### PR TITLE
python3pkgs: Add missing maintainers field

### DIFF
--- a/pkgs/development/python-modules/acme-tiny/default.nix
+++ b/pkgs/development/python-modules/acme-tiny/default.nix
@@ -44,5 +44,6 @@ buildPythonPackage rec {
     mainProgram = "acme-tiny";
     homepage = "https://github.com/diafygi/acme-tiny";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/aiofiles/default.nix
+++ b/pkgs/development/python-modules/aiofiles/default.nix
@@ -46,5 +46,6 @@ buildPythonPackage rec {
     description = "File support for asyncio";
     homepage = "https://github.com/Tinche/aiofiles";
     license = with licenses; [ asl20 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/aiohttp-swagger/default.nix
+++ b/pkgs/development/python-modules/aiohttp-swagger/default.nix
@@ -54,5 +54,6 @@ buildPythonPackage rec {
     description = "Swagger API Documentation builder for aiohttp";
     homepage = "https://github.com/cr0hn/aiohttp-swagger";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/aioresponses/default.nix
+++ b/pkgs/development/python-modules/aioresponses/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
     description = "Helper to mock/fake web requests in python aiohttp package";
     homepage = "https://github.com/pnuckowski/aioresponses";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/alabaster/default.nix
+++ b/pkgs/development/python-modules/alabaster/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/bitprophet/alabaster";
     description = "Sphinx theme";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/amqplib/default.nix
+++ b/pkgs/development/python-modules/amqplib/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/barryp/py-amqplib";
     description = "Python client for the Advanced Message Queuing Procotol (AMQP)";
     license = licenses.lgpl21;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ansi/default.nix
+++ b/pkgs/development/python-modules/ansi/default.nix
@@ -31,5 +31,6 @@ buildPythonPackage rec {
     description = "ANSI cursor movement and graphics";
     homepage = "https://github.com/tehmaze/ansi/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/appdirs/default.nix
+++ b/pkgs/development/python-modules/appdirs/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Python module for determining appropriate platform-specific dirs";
     homepage = "https://github.com/ActiveState/appdirs";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/area/default.nix
+++ b/pkgs/development/python-modules/area/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Calculate the area inside of any GeoJSON geometry. This is a port of Mapbox’s geojson-area for Python";
     homepage = "https://github.com/scisco/area";
     license = licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/argon2-cffi/default.nix
+++ b/pkgs/development/python-modules/argon2-cffi/default.nix
@@ -40,5 +40,6 @@ buildPythonPackage rec {
     description = "Secure Password Hashes for Python";
     homepage = "https://argon2-cffi.readthedocs.io/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/args/default.nix
+++ b/pkgs/development/python-modules/args/default.nix
@@ -17,5 +17,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Command Arguments for Humans";
     homepage = "https://github.com/kennethreitz/args";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/aspy-yaml/default.nix
+++ b/pkgs/development/python-modules/aspy-yaml/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "Few extensions to pyyaml";
     homepage = "https://github.com/asottile/aspy.yaml";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/async-timeout/default.nix
+++ b/pkgs/development/python-modules/async-timeout/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Timeout context manager for asyncio programs";
     homepage = "https://github.com/aio-libs/async_timeout/";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/audioread/default.nix
+++ b/pkgs/development/python-modules/audioread/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "Cross-platform audio decoding";
     homepage = "https://github.com/sampsyo/audioread";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/augeas/default.nix
+++ b/pkgs/development/python-modules/augeas/default.nix
@@ -38,6 +38,7 @@ buildPythonPackage rec {
     description = "Pure python bindings for augeas";
     homepage = "https://github.com/hercules-team/python-augeas";
     license = licenses.lgpl2Plus;
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/avro3k/default.nix
+++ b/pkgs/development/python-modules/avro3k/default.nix
@@ -31,5 +31,6 @@ buildPythonPackage rec {
     description = "Serialization and RPC framework";
     mainProgram = "avro";
     homepage = "https://pypi.python.org/pypi/avro3k/";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/backcall/default.nix
+++ b/pkgs/development/python-modules/backcall/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "Specifications for callback functions passed in to an API";
     homepage = "https://github.com/takluyver/backcall";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/basiciw/default.nix
+++ b/pkgs/development/python-modules/basiciw/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/enkore/basiciw";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/bcdoc/default.nix
+++ b/pkgs/development/python-modules/bcdoc/default.nix
@@ -27,6 +27,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/boto/bcdoc";
     license = licenses.asl20;
+    maintainers = [ ];
     description = "ReST document generation tools for botocore";
   };
 }

--- a/pkgs/development/python-modules/bech32/default.nix
+++ b/pkgs/development/python-modules/bech32/default.nix
@@ -19,5 +19,6 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://pypi.org/project/bech32/";
     license = with licenses; [ mit ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/betamax-serializers/default.nix
+++ b/pkgs/development/python-modules/betamax-serializers/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     homepage = "https://gitlab.com/betamax/serializers";
     description = "Set of third-party serializers for Betamax";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/bibtexparser/default.nix
+++ b/pkgs/development/python-modules/bibtexparser/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage rec {
       lgpl3Only # or
       bsd3
     ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/binaryornot/default.nix
+++ b/pkgs/development/python-modules/binaryornot/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/audreyr/binaryornot";
     description = "Ultra-lightweight pure Python package to check if a file is binary or text";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/bkcharts/default.nix
+++ b/pkgs/development/python-modules/bkcharts/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "High level chart types built on top of Bokeh";
     homepage = "https://github.com/bokeh/bkcharts";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/btchip-python/default.nix
+++ b/pkgs/development/python-modules/btchip-python/default.nix
@@ -39,5 +39,6 @@ buildPythonPackage rec {
     description = "Python communication library for Ledger Hardware Wallet products";
     homepage = "https://github.com/LedgerHQ/btchip-python";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/chai/default.nix
+++ b/pkgs/development/python-modules/chai/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Mocking, stubbing and spying framework for python";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/characteristic/default.nix
+++ b/pkgs/development/python-modules/characteristic/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
   meta = {
     description = "Python attributes without boilerplate";
     homepage = "https://characteristic.readthedocs.org";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/click-threading/default.nix
+++ b/pkgs/development/python-modules/click-threading/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/click-contrib/click-threading/";
     description = "Multithreaded Click apps made easy";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/clickclick/default.nix
+++ b/pkgs/development/python-modules/clickclick/default.nix
@@ -40,5 +40,6 @@ buildPythonPackage rec {
     description = "Click command line utilities";
     homepage = "https://github.com/hjacobs/python-clickclick/";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/cmdline/default.nix
+++ b/pkgs/development/python-modules/cmdline/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Utilities for consistent command line tools";
     homepage = "https://github.com/rca/cmdline";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/cock/default.nix
+++ b/pkgs/development/python-modules/cock/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pohmelie/cock";
     description = "Configuration file with click";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/colanderalchemy/default.nix
+++ b/pkgs/development/python-modules/colanderalchemy/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Autogenerate Colander schemas based on SQLAlchemy models";
     homepage = "https://github.com/stefanofontanelli/ColanderAlchemy";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/colorclass/default.nix
+++ b/pkgs/development/python-modules/colorclass/default.nix
@@ -20,6 +20,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/Robpol86/colorclass";
     license = licenses.mit;
+    maintainers = [ ];
     description = "Automatic support for console colors";
   };
 }

--- a/pkgs/development/python-modules/colour/default.nix
+++ b/pkgs/development/python-modules/colour/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     description = "Converts and manipulates common color representation (RGB, HSV, web, ...)";
     homepage = "https://github.com/vaab/colour";
     license = licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/commonmark/default.nix
+++ b/pkgs/development/python-modules/commonmark/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     mainProgram = "cmark";
     homepage = "https://github.com/rolandshoemaker/CommonMark-py";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/contexter/default.nix
+++ b/pkgs/development/python-modules/contexter/default.nix
@@ -14,5 +14,7 @@ buildPythonPackage rec {
     sha256 = "c730890b1a915051414a6350d8ea1cddca7d01d8f756badedb30b9bf305ea0a8";
   };
 
-  meta = with lib; { };
+  meta = with lib; {
+    maintainers = [ ];
+  };
 }

--- a/pkgs/development/python-modules/cookies/default.nix
+++ b/pkgs/development/python-modules/cookies/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     description = "Friendlier RFC 6265-compliant cookie parser/renderer";
     homepage = "https://github.com/sashahart/cookies";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/coverage/default.nix
+++ b/pkgs/development/python-modules/coverage/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     description = "Code coverage measurement for python";
     homepage = "https://coverage.readthedocs.io/";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/coveralls/default.nix
+++ b/pkgs/development/python-modules/coveralls/default.nix
@@ -63,5 +63,6 @@ buildPythonPackage rec {
     mainProgram = "coveralls";
     homepage = "https://github.com/coveralls-clients/coveralls-python";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/cppy/default.nix
+++ b/pkgs/development/python-modules/cppy/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "C++ headers for C extension development";
     homepage = "https://github.com/nucleic/cppy";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/crayons/default.nix
+++ b/pkgs/development/python-modules/crayons/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "TextUI colors for Python";
     homepage = "https://github.com/kennethreitz/crayons";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/crcmod/default.nix
+++ b/pkgs/development/python-modules/crcmod/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Python module for generating objects that compute the Cyclic Redundancy Check (CRC)";
     homepage = "https://crcmod.sourceforge.net/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/cssmin/default.nix
+++ b/pkgs/development/python-modules/cssmin/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     mainProgram = "cssmin";
     homepage = "https://github.com/zacharyvoase/cssmin";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/cycler/default.nix
+++ b/pkgs/development/python-modules/cycler/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     description = "Composable style cycles";
     homepage = "https://github.com/matplotlib/cycler";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/cython/0.nix
+++ b/pkgs/development/python-modules/cython/0.nix
@@ -98,5 +98,6 @@ buildPythonPackage rec {
     description = "Optimising static compiler for both the Python programming language and the extended Cython programming language";
     homepage = "https://cython.org";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/cytoolz/default.nix
+++ b/pkgs/development/python-modules/cytoolz/default.nix
@@ -48,5 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pytoolz/cytoolz/";
     description = "Cython implementation of Toolz: High performance functional utilities";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/daemonize/default.nix
+++ b/pkgs/development/python-modules/daemonize/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Library to enable your code run as a daemon process on Unix-like systems";
     homepage = "https://github.com/thesharp/daemonize";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/datashape/default.nix
+++ b/pkgs/development/python-modules/datashape/default.nix
@@ -72,5 +72,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ContinuumIO/datashape";
     description = "Data description language";
     license = lib.licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/dazl/default.nix
+++ b/pkgs/development/python-modules/dazl/default.nix
@@ -70,5 +70,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "High-level Ledger API client for Daml ledgers";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/deprecation/default.nix
+++ b/pkgs/development/python-modules/deprecation/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage rec {
     description = "Library to handle automated deprecations";
     homepage = "https://deprecation.readthedocs.io/";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/dicttoxml/default.nix
+++ b/pkgs/development/python-modules/dicttoxml/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Converts a Python dictionary or other native data type into a valid XML string";
     homepage = "https://github.com/quandyfactory/dicttoxml";
     license = lib.licenses.gpl2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/discid/default.nix
+++ b/pkgs/development/python-modules/discid/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     description = "Python binding of libdiscid";
     homepage = "https://python-discid.readthedocs.org/";
     license = licenses.lgpl3Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/dissononce/default.nix
+++ b/pkgs/development/python-modules/dissononce/default.nix
@@ -32,6 +32,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://pypi.org/project/dissononce/";
     license = licenses.mit;
+    maintainers = [ ];
     description = "Python implementation for Noise Protocol Framework";
   };
 }

--- a/pkgs/development/python-modules/django-colorful/default.nix
+++ b/pkgs/development/python-modules/django-colorful/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "Django extension that provides database and form color fields";
     homepage = "https://github.com/charettes/django-colorful";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-contrib-comments/default.nix
+++ b/pkgs/development/python-modules/django-contrib-comments/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/django/django-contrib-comments";
     description = "Code formerly known as django.contrib.comments";
     license = licenses.bsd0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-csp/default.nix
+++ b/pkgs/development/python-modules/django-csp/default.nix
@@ -44,5 +44,6 @@ buildPythonPackage rec {
     description = "Adds Content-Security-Policy headers to Django";
     homepage = "https://github.com/mozilla/django-csp";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-environ/default.nix
+++ b/pkgs/development/python-modules/django-environ/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Utilize environment variables to configure your Django application";
     homepage = "https://github.com/joke2k/django-environ/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -91,5 +91,6 @@ buildPythonPackage rec {
     description = "Collection of custom extensions for the Django Framework";
     homepage = "https://github.com/django-extensions/django-extensions";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-gravatar2/default.nix
+++ b/pkgs/development/python-modules/django-gravatar2/default.nix
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     description = "Essential Gravatar support for Django";
     homepage = "https://github.com/twaddington/django-gravatar";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-multiselectfield/default.nix
+++ b/pkgs/development/python-modules/django-multiselectfield/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "django-multiselectfield";
     homepage = "https://github.com/goinnn/django-multiselectfield";
     license = lib.licenses.lgpl3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-paintstore/default.nix
+++ b/pkgs/development/python-modules/django-paintstore/default.nix
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     description = "Django app that integrates jQuery ColorPicker with the Django admin";
     homepage = "https://github.com/gsiegman/django-paintstore";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-pglocks/default.nix
+++ b/pkgs/development/python-modules/django-pglocks/default.nix
@@ -15,6 +15,7 @@ buildPythonPackage rec {
     description = "PostgreSQL locking context managers and functions for Django";
     homepage = "https://github.com/Xof/django-pglocks";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/django-raster/default.nix
+++ b/pkgs/development/python-modules/django-raster/default.nix
@@ -45,5 +45,6 @@ buildPythonPackage rec {
     description = "Basic raster data integration for Django";
     homepage = "https://github.com/geodesign/django-raster";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-sesame/default.nix
+++ b/pkgs/development/python-modules/django-sesame/default.nix
@@ -45,5 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/aaugustin/django-sesame";
     changelog = "https://github.com/aaugustin/django-sesame/blob/${version}/docs/changelog.rst";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-sites/default.nix
+++ b/pkgs/development/python-modules/django-sites/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage rec {
     description = "Alternative implementation of django sites framework";
     homepage = "https://github.com/niwinz/django-sites";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
     # has not been updated for django>=4.0
     broken = lib.versionAtLeast django.version "4";
   };

--- a/pkgs/development/python-modules/django-soft-delete/default.nix
+++ b/pkgs/development/python-modules/django-soft-delete/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Soft delete models, managers, queryset for Django";
     homepage = "https://github.com/san4ezy/django_softdelete";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-tagging/default.nix
+++ b/pkgs/development/python-modules/django-tagging/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
   meta = {
     description = "Generic tagging application for Django projects";
     homepage = "https://github.com/Fantomas42/django-tagging";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/djmail/default.nix
+++ b/pkgs/development/python-modules/djmail/default.nix
@@ -17,6 +17,7 @@ buildPythonPackage rec {
     description = "Simple, powerfull and nonobstructive django email middleware";
     homepage = "https://github.com/bameda/djmail";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/docker-pycreds/default.nix
+++ b/pkgs/development/python-modules/docker-pycreds/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "Python bindings for the docker credentials store API";
     homepage = "https://github.com/shin-/dockerpy-creds";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/dockerpty/default.nix
+++ b/pkgs/development/python-modules/dockerpty/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Functionality needed to operate the pseudo-tty (PTY) allocated to a docker container";
     homepage = "https://github.com/d11wtq/dockerpty";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/docopt/default.nix
+++ b/pkgs/development/python-modules/docopt/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Pythonic argument parser, that will make you smile";
     homepage = "http://docopt.org/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/dot2tex/default.nix
+++ b/pkgs/development/python-modules/dot2tex/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage rec {
     mainProgram = "dot2tex";
     homepage = "https://github.com/kjellmf/dot2tex";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ds4drv/default.nix
+++ b/pkgs/development/python-modules/ds4drv/default.nix
@@ -40,5 +40,6 @@ buildPythonPackage rec {
     mainProgram = "ds4drv";
     homepage = "https://github.com/chrippa/ds4drv";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/dwdwfsapi/default.nix
+++ b/pkgs/development/python-modules/dwdwfsapi/default.nix
@@ -37,5 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/stephan192/dwdwfsapi";
     changelog = "https://github.com/stephan192/dwdwfsapi/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ mit ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/easydict/default.nix
+++ b/pkgs/development/python-modules/easydict/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/makinacorpus/easydict";
     license = licenses.lgpl3;
     description = "Access dict values as attributes (works recursively)";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ecdsa/default.nix
+++ b/pkgs/development/python-modules/ecdsa/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "ECDSA cryptographic signature library";
     homepage = "https://github.com/warner/python-ecdsa";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ecpy/default.nix
+++ b/pkgs/development/python-modules/ecpy/default.nix
@@ -31,5 +31,6 @@ buildPythonPackage rec {
     description = "Pure Pyhton Elliptic Curve Library";
     homepage = "https://github.com/ubinity/ECPy";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/eggdeps/default.nix
+++ b/pkgs/development/python-modules/eggdeps/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     mainProgram = "eggdeps";
     homepage = "http://thomas-lotze.de/en/software/eggdeps/";
     license = licenses.zpl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/enum34/default.nix
+++ b/pkgs/development/python-modules/enum34/default.nix
@@ -24,5 +24,6 @@ else
       homepage = "https://pypi.python.org/pypi/enum34";
       description = "Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4";
       license = licenses.bsd0;
+      maintainers = [ ];
     };
   }

--- a/pkgs/development/python-modules/enzyme/default.nix
+++ b/pkgs/development/python-modules/enzyme/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/Diaoul/enzyme";
     license = licenses.mit;
+    maintainers = [ ];
     description = "Python video metadata parser";
   };
 }

--- a/pkgs/development/python-modules/epc/default.nix
+++ b/pkgs/development/python-modules/epc/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     description = "EPC (RPC stack for Emacs Lisp) implementation in Python";
     homepage = "https://github.com/tkf/python-epc";
     license = licenses.gpl3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ethtool/default.nix
+++ b/pkgs/development/python-modules/ethtool/default.nix
@@ -53,5 +53,6 @@ buildPythonPackage rec {
     description = "Python bindings for the ethtool kernel interface";
     homepage = "https://github.com/fedora-python/python-ethtool";
     license = licenses.gpl2Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/extras/default.nix
+++ b/pkgs/development/python-modules/extras/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Useful extra bits for Python - things that should be in the standard library";
     homepage = "https://github.com/testing-cabal/extras";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/favicon/default.nix
+++ b/pkgs/development/python-modules/favicon/default.nix
@@ -42,5 +42,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/scottwernervt/favicon";
     changelog = "https://github.com/scottwernervt/favicon/blob/${version}/CHANGELOG.rst";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/fenics/default.nix
+++ b/pkgs/development/python-modules/fenics/default.nix
@@ -286,6 +286,7 @@ let
       homepage = "https://fenicsproject.org/";
       platforms = lib.platforms.all;
       license = lib.licenses.lgpl3;
+      maintainers = [ ];
     };
   };
 in

--- a/pkgs/development/python-modules/fixtures/default.nix
+++ b/pkgs/development/python-modules/fixtures/default.nix
@@ -40,5 +40,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.org/project/fixtures/";
     changelog = "https://github.com/testing-cabal/fixtures/blob/${version}/NEWS";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/flake8-future-import/default.nix
+++ b/pkgs/development/python-modules/flake8-future-import/default.nix
@@ -58,5 +58,6 @@ buildPythonPackage rec {
     description = "Flake8 extension to check for the imported __future__ modules to make it easier to have a consistent code base";
     homepage = "https://github.com/xZise/flake8-future-import";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/flaky/default.nix
+++ b/pkgs/development/python-modules/flaky/default.nix
@@ -37,5 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/box/flaky";
     description = "Plugin for nose or py.test that automatically reruns flaky tests";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/flask-common/default.nix
+++ b/pkgs/development/python-modules/flask-common/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     description = "Flask extension with lots of common time-savers";
     homepage = "https://github.com/kennethreitz/flask-common";
     license = licenses.asl20; # XXX: setup.py lists BSD but git repo has Apache 2.0 LICENSE
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/flask-mail/default.nix
+++ b/pkgs/development/python-modules/flask-mail/default.nix
@@ -43,5 +43,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pallets-eco/flask-mail";
     changelog = "https://github.com/pallets-eco/flask-mail/blob/${src.rev}/CHANGES.md";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/flit/default.nix
+++ b/pkgs/development/python-modules/flit/default.nix
@@ -59,5 +59,6 @@ buildPythonPackage rec {
     mainProgram = "flit";
     homepage = "https://github.com/pypa/flit";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/fluent-logger/default.nix
+++ b/pkgs/development/python-modules/fluent-logger/default.nix
@@ -42,5 +42,6 @@ buildPythonPackage rec {
     description = "Structured logger for Fluentd (Python)";
     homepage = "https://github.com/fluent/fluent-logger-python";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/fn/default.nix
+++ b/pkgs/development/python-modules/fn/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/kachayev/fn.py";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/funcparserlib/default.nix
+++ b/pkgs/development/python-modules/funcparserlib/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage rec {
     description = "Recursive descent parsing library based on functional combinators";
     homepage = "https://github.com/vlasovskikh/funcparserlib";
     license = licenses.mit;
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/fusepy/default.nix
+++ b/pkgs/development/python-modules/fusepy/default.nix
@@ -36,6 +36,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/terencehonles/fusepy";
     license = licenses.isc;
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/gdata/default.nix
+++ b/pkgs/development/python-modules/gdata/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/google/gdata-python-client";
     description = "Python client library for Google data APIs";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/genshi/default.nix
+++ b/pkgs/development/python-modules/genshi/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://genshi.edgewall.org/";
     license = licenses.bsd0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/genzshcomp/default.nix
+++ b/pkgs/development/python-modules/genzshcomp/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     mainProgram = "genzshcomp";
     homepage = "https://bitbucket.org/hhatto/genzshcomp/";
     license = licenses.bsd0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/gflags/default.nix
+++ b/pkgs/development/python-modules/gflags/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/google/python-gflags";
     description = "Module for command line handling, similar to Google's gflags for C++";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/github-webhook/default.nix
+++ b/pkgs/development/python-modules/github-webhook/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Framework for writing webhooks for GitHub";
     homepage = "https://github.com/bloomberg/python-github-webhook";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/globus-sdk/default.nix
+++ b/pkgs/development/python-modules/globus-sdk/default.nix
@@ -49,5 +49,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/globus/globus-sdk-python";
     changelog = "https://github.com/globus/globus-sdk-python/releases/tag/${version}";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/gmpy/default.nix
+++ b/pkgs/development/python-modules/gmpy/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     description = "GMP or MPIR interface to Python 2.4+ and 3.x";
     homepage = "https://github.com/aleaxit/gmpy/";
     license = lib.licenses.lgpl21Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/gnureadline/default.nix
+++ b/pkgs/development/python-modules/gnureadline/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     description = "Standard Python readline extension statically linked against the GNU readline library";
     homepage = "https://github.com/ludwigschwardt/python-gnureadline";
     license = licenses.gpl3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/greenlet/default.nix
+++ b/pkgs/development/python-modules/greenlet/default.nix
@@ -62,6 +62,7 @@ let
         psfl # src/greenlet/slp_platformselect.h & files in src/greenlet/platform/ directory
         mit
       ];
+      maintainers = [ ];
     };
   };
 in

--- a/pkgs/development/python-modules/gssapi/default.nix
+++ b/pkgs/development/python-modules/gssapi/default.nix
@@ -79,5 +79,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.python.org/pypi/gssapi";
     description = "Python GSSAPI Wrapper";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -55,5 +55,6 @@ buildPythonPackage rec {
     description = "Hierarchical Density-Based Spatial Clustering of Applications with Noise, a clustering algorithm with a scikit-learn compatible API";
     homepage = "https://github.com/scikit-learn-contrib/hdbscan";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/helpdev/default.nix
+++ b/pkgs/development/python-modules/helpdev/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Extracts information about the Python environment easily";
     mainProgram = "helpdev";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/helper/default.nix
+++ b/pkgs/development/python-modules/helper/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     description = "Development library for quickly writing configurable applications and daemons";
     homepage = "https://helper.readthedocs.org/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/hsaudiotag3k/default.nix
+++ b/pkgs/development/python-modules/hsaudiotag3k/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Pure Python library that lets one to read metadata from media files";
     homepage = "http://hg.hardcoded.net/hsaudiotag/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/httpretty/default.nix
+++ b/pkgs/development/python-modules/httpretty/default.nix
@@ -42,5 +42,6 @@ buildPythonPackage rec {
     homepage = "https://httpretty.readthedocs.org/";
     description = "HTTP client request mocking tool";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/httpx-ws/default.nix
+++ b/pkgs/development/python-modules/httpx-ws/default.nix
@@ -64,5 +64,6 @@ buildPythonPackage rec {
     description = "WebSocket support for HTTPX";
     homepage = "https://github.com/frankie567/httpx-ws";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/hug/default.nix
+++ b/pkgs/development/python-modules/hug/default.nix
@@ -60,6 +60,7 @@ buildPythonPackage rec {
     description = "Python framework that makes developing APIs as simple as possible, but no simpler";
     homepage = "https://github.com/hugapi/hug";
     license = licenses.mit;
+    maintainers = [ ];
     # Missing support for later falcon releases
     broken = true;
   };

--- a/pkgs/development/python-modules/hypchat/default.nix
+++ b/pkgs/development/python-modules/hypchat/default.nix
@@ -24,4 +24,8 @@ buildPythonPackage rec {
     six
     python-dateutil
   ];
+
+  meta = {
+    maintainers = [ ];
+  };
 }

--- a/pkgs/development/python-modules/i3-py/default.nix
+++ b/pkgs/development/python-modules/i3-py/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
     description = "Tools for i3 users and developers";
     homepage = "https://github.com/ziberna/i3-py";
     license = licenses.gpl3;
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/idna/default.nix
+++ b/pkgs/development/python-modules/idna/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/kjd/idna/releases/tag/v${version}";
     description = "Internationalized Domain Names in Applications (IDNA)";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/imagesize/default.nix
+++ b/pkgs/development/python-modules/imagesize/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Getting image size from png/jpeg/jpeg2000/gif file";
     homepage = "https://github.com/shibukawa/imagesize_py";
     license = with licenses; [ mit ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/inotify/default.nix
+++ b/pkgs/development/python-modules/inotify/default.nix
@@ -40,6 +40,7 @@ buildPythonPackage {
     homepage = "https://github.com/dsoprea/PyInotify";
     description = "Monitor filesystems events on Linux platforms with inotify";
     license = lib.licenses.gpl2;
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/iocapture/default.nix
+++ b/pkgs/development/python-modules/iocapture/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     description = "Capture stdout, stderr easily";
     homepage = "https://github.com/oinume/iocapture";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/iowait/default.nix
+++ b/pkgs/development/python-modules/iowait/default.nix
@@ -13,5 +13,6 @@ buildPythonPackage rec {
   meta = {
     description = "Platform-independent module for I/O completion events";
     homepage = "https://launchpad.net/python-iowait";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/iptools/default.nix
+++ b/pkgs/development/python-modules/iptools/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     description = "Utilities for manipulating IP addresses including a class that can be used to include CIDR network blocks in Django's INTERNAL_IPS setting";
     homepage = "https://github.com/bd808/python-iptools";
     license = licenses.bsd0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ipyparallel/default.nix
+++ b/pkgs/development/python-modules/ipyparallel/default.nix
@@ -63,5 +63,6 @@ buildPythonPackage rec {
     homepage = "https://ipyparallel.readthedocs.io/";
     changelog = "https://github.com/ipython/ipyparallel/blob/${version}/docs/source/changelog.md";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ipython-genutils/default.nix
+++ b/pkgs/development/python-modules/ipython-genutils/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     description = "Vestigial utilities from IPython";
     homepage = "https://ipython.org/";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ipywidgets/default.nix
+++ b/pkgs/development/python-modules/ipywidgets/default.nix
@@ -45,5 +45,6 @@ buildPythonPackage rec {
     description = "IPython HTML widgets for Jupyter";
     homepage = "https://github.com/jupyter-widgets/ipywidgets";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/isodate/default.nix
+++ b/pkgs/development/python-modules/isodate/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     description = "ISO 8601 date/time parser";
     homepage = "http://cheeseshop.python.org/pypi/isodate";
     license = licenses.bsd0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/itsdangerous/default.nix
+++ b/pkgs/development/python-modules/itsdangerous/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     description = "Safely pass data to untrusted environments and back";
     homepage = "https://itsdangerous.palletsprojects.com";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jaraco-classes/default.nix
+++ b/pkgs/development/python-modules/jaraco-classes/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage rec {
     description = "Utility functions for Python class constructs";
     homepage = "https://github.com/jaraco/jaraco.classes";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jaraco-itertools/default.nix
+++ b/pkgs/development/python-modules/jaraco-itertools/default.nix
@@ -43,5 +43,6 @@ buildPythonPackage rec {
     description = "Tools for working with iterables";
     homepage = "https://github.com/jaraco/jaraco.itertools";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jaraco-stream/default.nix
+++ b/pkgs/development/python-modules/jaraco-stream/default.nix
@@ -21,4 +21,8 @@ buildPythonPackage rec {
   doCheck = false;
   buildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ six ];
+
+  meta = {
+    maintainers = [ ];
+  };
 }

--- a/pkgs/development/python-modules/jaydebeapi/default.nix
+++ b/pkgs/development/python-modules/jaydebeapi/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/baztian/jaydebeapi";
     license = licenses.lgpl2;
+    maintainers = [ ];
     description = "Use JDBC database drivers from Python 2/3 or Jython with a DB-API";
   };
 }

--- a/pkgs/development/python-modules/jpype1/default.nix
+++ b/pkgs/development/python-modules/jpype1/default.nix
@@ -36,6 +36,7 @@ buildPythonPackage rec {
       binaryBytecode
     ];
     license = licenses.asl20;
+    maintainers = [ ];
     description = "Python to Java bridge";
   };
 }

--- a/pkgs/development/python-modules/jsondate/default.nix
+++ b/pkgs/development/python-modules/jsondate/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ilya-kolpakov/jsondate";
     description = "JSON with datetime handling";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jsondiff/default.nix
+++ b/pkgs/development/python-modules/jsondiff/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     mainProgram = "jdiff";
     homepage = "https://github.com/ZoomerAnalytics/jsondiff";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jsonpath-rw/default.nix
+++ b/pkgs/development/python-modules/jsonpath-rw/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     description = "Robust and significantly extended implementation of JSONPath for Python, with a clear AST for metaprogramming";
     mainProgram = "jsonpath.py";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jsonpickle/default.nix
+++ b/pkgs/development/python-modules/jsonpickle/default.nix
@@ -43,5 +43,6 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/jsonpickle/jsonpickle";
     homepage = "http://jsonpickle.github.io/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jsonpointer/default.nix
+++ b/pkgs/development/python-modules/jsonpointer/default.nix
@@ -19,5 +19,6 @@ buildPythonPackage rec {
     mainProgram = "jsonpointer";
     homepage = "https://github.com/stefankoegl/python-json-pointer";
     license = licenses.bsd2; # "Modified BSD license, says pypi"
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jupyter-packaging/default.nix
+++ b/pkgs/development/python-modules/jupyter-packaging/default.nix
@@ -68,5 +68,6 @@ buildPythonPackage rec {
     description = "Jupyter Packaging Utilities";
     homepage = "https://github.com/jupyter/jupyter-packaging";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jupyter-sphinx/default.nix
+++ b/pkgs/development/python-modules/jupyter-sphinx/default.nix
@@ -55,5 +55,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/jupyter/jupyter-sphinx/";
     changelog = "https://github.com/jupyter/jupyter-sphinx/releases/tag/${lib.removePrefix "refs/tags/" src.rev}";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jupyter/default.nix
+++ b/pkgs/development/python-modules/jupyter/default.nix
@@ -41,6 +41,7 @@ buildPythonPackage rec {
     description = "Installs all the Jupyter components in one go";
     homepage = "https://jupyter.org/";
     license = licenses.bsd3;
+    maintainers = [ ];
     priority = 100; # This is a metapackage which is unimportant
   };
 }

--- a/pkgs/development/python-modules/jupyterhub-ldapauthenticator/default.nix
+++ b/pkgs/development/python-modules/jupyterhub-ldapauthenticator/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Simple LDAP Authenticator Plugin for JupyterHub";
     homepage = "https://github.com/jupyterhub/ldapauthenticator";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/keepalive/default.nix
+++ b/pkgs/development/python-modules/keepalive/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     description = "HTTP handler for `urllib` that supports HTTP 1.1 and keepalive";
     homepage = "https://github.com/wikier/keepalive";
     license = licenses.lgpl21Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/keras-applications/default.nix
+++ b/pkgs/development/python-modules/keras-applications/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     description = "Reference implementations of popular deep learning models";
     homepage = "https://github.com/keras-team/keras-applications";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/keras-preprocessing/default.nix
+++ b/pkgs/development/python-modules/keras-preprocessing/default.nix
@@ -45,5 +45,6 @@ buildPythonPackage rec {
     description = "Easy data preprocessing and data augmentation for deep learning models";
     homepage = "https://github.com/keras-team/keras-preprocessing";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/kerberos/default.nix
+++ b/pkgs/development/python-modules/kerberos/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
     description = "Kerberos high-level interface";
     homepage = "https://pypi.org/project/kerberos/";
     license = licenses.asl20;
+    maintainers = [ ];
     knownVulnerabilities = [ "CVE-2015-3206" ];
   };
 }

--- a/pkgs/development/python-modules/langcodes/default.nix
+++ b/pkgs/development/python-modules/langcodes/default.nix
@@ -46,5 +46,6 @@ buildPythonPackage rec {
     description = "Python toolkit for working with and comparing the standardized codes for languages";
     homepage = "https://github.com/georgkrause/langcodes";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/latexcodec/default.nix
+++ b/pkgs/development/python-modules/latexcodec/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/mcmtroffaes/latexcodec";
     description = "Lexer and codec to work with LaTeX code in Python";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/lazr/config.nix
+++ b/pkgs/development/python-modules/lazr/config.nix
@@ -43,5 +43,6 @@ buildPythonPackage rec {
     homepage = "https://launchpad.net/lazr.config";
     changelog = "https://git.launchpad.net/lazr.config/tree/NEWS.rst?h=${version}";
     license = licenses.lgpl3Only;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/lazr/delegates.nix
+++ b/pkgs/development/python-modules/lazr/delegates.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     homepage = "https://launchpad.net/lazr.delegates";
     changelog = "https://git.launchpad.net/lazr.delegates/tree/NEWS.rst?h=${version}";
     license = licenses.lgpl3Only;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/lazy-object-proxy/default.nix
+++ b/pkgs/development/python-modules/lazy-object-proxy/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     description = "Fast and thorough lazy object proxy";
     homepage = "https://github.com/ionelmc/python-lazy-object-proxy";
     license = with licenses; [ bsd2 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/lazy/default.nix
+++ b/pkgs/development/python-modules/lazy/default.nix
@@ -18,6 +18,7 @@ buildPythonPackage rec {
   meta = {
     description = "Lazy attributes for Python objects";
     license = lib.licenses.bsd2;
+    maintainers = [ ];
     homepage = "https://github.com/stefanholek/lazy";
   };
 }

--- a/pkgs/development/python-modules/lcov-cobertura/default.nix
+++ b/pkgs/development/python-modules/lcov-cobertura/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     mainProgram = "lcov_cobertura";
     homepage = "https://eriwen.github.io/lcov-to-cobertura-xml/";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ldappool/default.nix
+++ b/pkgs/development/python-modules/ldappool/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
       lgpl21Plus
       gpl2Plus
     ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ledger-bitcoin/default.nix
+++ b/pkgs/development/python-modules/ledger-bitcoin/default.nix
@@ -37,5 +37,6 @@ buildPythonPackage rec {
     description = "Client library for Ledger Bitcoin application";
     homepage = "https://github.com/LedgerHQ/app-bitcoin-new/tree/develop/bitcoin_client/ledger_bitcoin";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ledgercomm/default.nix
+++ b/pkgs/development/python-modules/ledgercomm/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     mainProgram = "ledgercomm-send";
     homepage = "https://github.com/LedgerHQ/ledgercomm";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/libarchive-c/default.nix
+++ b/pkgs/development/python-modules/libarchive-c/default.nix
@@ -40,5 +40,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Changaco/python-libarchive-c";
     description = "Python interface to libarchive";
     license = licenses.cc0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/line-profiler/default.nix
+++ b/pkgs/development/python-modules/line-profiler/default.nix
@@ -59,5 +59,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pyutils/line_profiler";
     changelog = "https://github.com/pyutils/line_profiler/blob/v${version}/CHANGELOG.rst";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/linecache2/default.nix
+++ b/pkgs/development/python-modules/linecache2/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Backport of linecache to older supported Pythons";
     homepage = "https://github.com/testing-cabal/linecache2";
     license = licenses.psfl;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/linuxfd/default.nix
+++ b/pkgs/development/python-modules/linuxfd/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/FrankAbelbeck/linuxfd";
     platforms = lib.platforms.linux;
     license = with lib.licenses; [ lgpl3Plus ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/llvmlite/default.nix
+++ b/pkgs/development/python-modules/llvmlite/default.nix
@@ -58,5 +58,6 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/numba/llvmlite";
     homepage = "http://llvmlite.pydata.org/";
     license = lib.licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/lockfile/default.nix
+++ b/pkgs/development/python-modules/lockfile/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = "https://launchpad.net/pylockfile";
     description = "Platform-independent advisory file locking capability for Python applications";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/logster/default.nix
+++ b/pkgs/development/python-modules/logster/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
     description = "Parses log files, generates metrics for Graphite and Ganglia";
     mainProgram = "logster";
     license = licenses.gpl3Plus;
+    maintainers = [ ];
     homepage = "https://github.com/etsy/logster";
   };
 }

--- a/pkgs/development/python-modules/mailcap-fix/default.nix
+++ b/pkgs/development/python-modules/mailcap-fix/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Patched mailcap module that conforms to RFC 1524";
     homepage = "https://github.com/michael-lazar/mailcap_fix";
     license = licenses.unlicense;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mailchimp/default.nix
+++ b/pkgs/development/python-modules/mailchimp/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     description = "CLI client and Python API library for the MailChimp email platform";
     homepage = "http://apidocs.mailchimp.com/api/2.0/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/manuel/default.nix
+++ b/pkgs/development/python-modules/manuel/default.nix
@@ -37,5 +37,6 @@ buildPythonPackage rec {
     description = "Documentation builder";
     homepage = "https://pypi.python.org/pypi/manuel";
     license = licenses.zpl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/marisa-trie/default.nix
+++ b/pkgs/development/python-modules/marisa-trie/default.nix
@@ -68,5 +68,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/kmike/marisa-trie";
     changelog = "https://github.com/pytries/marisa-trie/blob/${version}/CHANGES.rst";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mecab-python3/default.nix
+++ b/pkgs/development/python-modules/mecab-python3/default.nix
@@ -42,5 +42,6 @@ buildPythonPackage rec {
       lgpl21
       bsd3
     ]; # any of the three
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/meinheld/default.nix
+++ b/pkgs/development/python-modules/meinheld/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     description = "High performance asynchronous Python WSGI Web Server";
     homepage = "https://meinheld.org/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/meld3/default.nix
+++ b/pkgs/development/python-modules/meld3/default.nix
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     description = "HTML/XML templating engine used by supervisor";
     homepage = "https://github.com/supervisor/meld3";
     license = licenses.free;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/memory-profiler/default.nix
+++ b/pkgs/development/python-modules/memory-profiler/default.nix
@@ -29,5 +29,6 @@ python.pkgs.buildPythonPackage rec {
     '';
     homepage = "https://pypi.python.org/pypi/memory_profiler";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mesonpep517/default.nix
+++ b/pkgs/development/python-modules/mesonpep517/default.nix
@@ -45,5 +45,6 @@ buildPythonPackage rec {
     description = "Create pep517 compliant packages from the meson build system";
     homepage = "https://gitlab.com/thiblahute/mesonpep517";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mmpython/default.nix
+++ b/pkgs/development/python-modules/mmpython/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Media Meta Data retrieval framework";
     homepage = "https://sourceforge.net/projects/mmpython/";
     license = licenses.gpl2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mock-open/default.nix
+++ b/pkgs/development/python-modules/mock-open/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/nivbend/mock-open";
     description = "Better mock for file I/O";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/modestmaps/default.nix
+++ b/pkgs/development/python-modules/modestmaps/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Library for building interactive maps";
     homepage = "http://modestmaps.com";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mongodict/default.nix
+++ b/pkgs/development/python-modules/mongodict/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "MongoDB-backed Python dict-like interface";
     homepage = "https://github.com/turicas/mongodict/";
     license = licenses.gpl3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/monotonic/default.nix
+++ b/pkgs/development/python-modules/monotonic/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     description = "Implementation of time.monotonic() for Python 2 & < 3.3";
     homepage = "https://github.com/atdt/monotonic";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/moretools/default.nix
+++ b/pkgs/development/python-modules/moretools/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://bitbucket.org/userzimmermann/python-moretools";
     license = licenses.gpl3Plus;
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/mplfinance/default.nix
+++ b/pkgs/development/python-modules/mplfinance/default.nix
@@ -31,5 +31,6 @@ buildPythonPackage rec {
     description = "Matplotlib utilities for the visualization, and visual analysis, of financial data";
     homepage = "https://github.com/matplotlib/mplfinance";
     license = [ licenses.bsd3 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mplleaflet/default.nix
+++ b/pkgs/development/python-modules/mplleaflet/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Convert Matplotlib plots into Leaflet web maps";
     homepage = "https://github.com/jwass/mplleaflet";
     license = with lib.licenses; [ bsd3 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/multi-key-dict/default.nix
+++ b/pkgs/development/python-modules/multi-key-dict/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "multi_key_dict";
     homepage = "https://github.com/formiaczek/multi_key_dict";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/multipledispatch/default.nix
+++ b/pkgs/development/python-modules/multipledispatch/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/mrocklin/multipledispatch/";
     description = "Relatively sane approach to multiple dispatch in Python";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/munch/default.nix
+++ b/pkgs/development/python-modules/munch/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Dot-accessible dictionary (a la JavaScript objects)";
     license = licenses.mit;
+    maintainers = [ ];
     homepage = "https://github.com/Infinidat/munch";
   };
 }

--- a/pkgs/development/python-modules/mwoauth/default.nix
+++ b/pkgs/development/python-modules/mwoauth/default.nix
@@ -40,5 +40,6 @@ buildPythonPackage rec {
     description = "Python library to perform OAuth handshakes with a MediaWiki installation";
     homepage = "https://github.com/mediawiki-utilities/python-mwoauth";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/nbclassic/default.nix
+++ b/pkgs/development/python-modules/nbclassic/default.nix
@@ -54,5 +54,6 @@ buildPythonPackage rec {
     description = "Jupyter lab environment notebook server extension";
     homepage = "https://github.com/jupyter/nbclassic";
     license = with licenses; [ bsd3 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/networkx/default.nix
+++ b/pkgs/development/python-modules/networkx/default.nix
@@ -75,5 +75,6 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/networkx/networkx";
     description = "Library for the creation, manipulation, and study of the structure, dynamics, and functions of complex networks";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/nevow/default.nix
+++ b/pkgs/development/python-modules/nevow/default.nix
@@ -46,5 +46,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/twisted/nevow";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/nidaqmx/default.nix
+++ b/pkgs/development/python-modules/nidaqmx/default.nix
@@ -50,5 +50,6 @@ buildPythonPackage rec {
   meta = {
     description = "API for interacting with the NI-DAQmx driver";
     license = [ lib.licenses.mit ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
     description = "Module for statistical learning on neuroimaging data";
     changelog = "https://github.com/nilearn/nilearn/releases/tag/${version}";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/nine/default.nix
+++ b/pkgs/development/python-modules/nine/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Let's write Python 3 right now!";
     homepage = "https://github.com/nandoflorestan/nine";
     license = licenses.free;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/nipy/default.nix
+++ b/pkgs/development/python-modules/nipy/default.nix
@@ -70,5 +70,6 @@ buildPythonPackage rec {
     description = "Software for structural and functional neuroimaging analysis";
     downloadPage = "https://github.com/nipy/nipy";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ntplib/default.nix
+++ b/pkgs/development/python-modules/ntplib/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Python NTP library";
     homepage = "http://code.google.com/p/ntplib/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/nuitka/default.nix
+++ b/pkgs/development/python-modules/nuitka/default.nix
@@ -48,6 +48,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python compiler with full language support and CPython compatibility";
     license = licenses.asl20;
+    maintainers = [ ];
     homepage = "https://nuitka.net/";
   };
 }

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -170,6 +170,7 @@ buildPythonPackage rec {
     description = "Compiling Python code using LLVM";
     homepage = "https://numba.pydata.org/";
     license = licenses.bsd2;
+    maintainers = [ ];
     mainProgram = "numba";
   };
 }

--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -202,5 +202,6 @@ buildPythonPackage rec {
     mainProgram = "f2py";
     homepage = "https://numpy.org/";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/numpydoc/default.nix
+++ b/pkgs/development/python-modules/numpydoc/default.nix
@@ -58,5 +58,6 @@ buildPythonPackage rec {
     mainProgram = "validate-docstrings";
     homepage = "https://github.com/numpy/numpydoc";
     license = lib.licenses.free;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/oauth/default.nix
+++ b/pkgs/development/python-modules/oauth/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     homepage = "https://code.google.com/archive/p/oauth/";
     description = "Library for OAuth version 1.0a";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/oauth2client/default.nix
+++ b/pkgs/development/python-modules/oauth2client/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     description = "Client library for OAuth 2.0";
     homepage = "https://github.com/google/oauth2client/";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/odfpy/default.nix
+++ b/pkgs/development/python-modules/odfpy/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Python API and tools to manipulate OpenDocument files";
     homepage = "https://github.com/eea/odfpy";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/offtrac/default.nix
+++ b/pkgs/development/python-modules/offtrac/default.nix
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     homepage = "http://fedorahosted.org/offtrac";
     description = "Trac xmlrpc library";
     license = licenses.gpl2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ofxclient/default.nix
+++ b/pkgs/development/python-modules/ofxclient/default.nix
@@ -39,5 +39,6 @@ buildPythonPackage rec {
     description = "OFX client for dowloading transactions from banks";
     mainProgram = "ofxclient";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ofxparse/default.nix
+++ b/pkgs/development/python-modules/ofxparse/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     homepage = "http://sites.google.com/site/ofxparse";
     description = "Tools for working with the OFX (Open Financial Exchange) file format";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ofxtools/default.nix
+++ b/pkgs/development/python-modules/ofxtools/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     description = "Library for working with Open Financial Exchange (OFX) formatted data used by financial institutions";
     mainProgram = "ofxget";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/onnxconverter-common/default.nix
+++ b/pkgs/development/python-modules/onnxconverter-common/default.nix
@@ -51,5 +51,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/microsoft/onnxconverter-common";
     changelog = "https://github.com/microsoft/onnxconverter-common/releases/tag/v${version}";
     license = with lib.licenses; [ mit ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/openant/default.nix
+++ b/pkgs/development/python-modules/openant/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage rec {
     description = "ANT and ANT-FS Python Library";
     mainProgram = "openant";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/openapi-spec-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-spec-validator/default.nix
@@ -66,5 +66,6 @@ buildPythonPackage rec {
     mainProgram = "openapi-spec-validator";
     homepage = "https://github.com/p1c2u/openapi-spec-validator";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
@@ -40,5 +40,6 @@ buildPythonPackage {
   meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-prometheus";
     description = "Prometheus Metric Exporter for OpenTelemetry";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage {
   meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions";
     description = "OpenTelemetry Semantic Conventions";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage {
   meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/tests/opentelemetry-test-utils";
     description = "Test utilities for OpenTelemetry unit tests";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/oset/default.nix
+++ b/pkgs/development/python-modules/oset/default.nix
@@ -19,5 +19,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Ordered set";
     license = licenses.psfl;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pamela/default.nix
+++ b/pkgs/development/python-modules/pamela/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "PAM interface using ctypes";
     homepage = "https://github.com/minrk/pamela";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pandocfilters/default.nix
+++ b/pkgs/development/python-modules/pandocfilters/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Python module for writing pandoc filters, with a collection of examples";
     homepage = "https://github.com/jgm/pandocfilters";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = "https://parso.readthedocs.io/en/latest/";
     changelog = "https://github.com/davidhalter/parso/blob/master/CHANGELOG.rst";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/partd/default.nix
+++ b/pkgs/development/python-modules/partd/default.nix
@@ -65,6 +65,7 @@ buildPythonPackage rec {
   meta = {
     description = "Appendable key-value storage";
     license = with lib.licenses; [ bsd3 ];
+    maintainers = [ ];
     homepage = "https://github.com/dask/partd/";
   };
 }

--- a/pkgs/development/python-modules/pdfkit/default.nix
+++ b/pkgs/development/python-modules/pdfkit/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.python.org/pypi/pdfkit";
     description = "Wkhtmltopdf python wrapper to convert html to pdf using the webkit rendering engine and qt";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pep517/default.nix
+++ b/pkgs/development/python-modules/pep517/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage rec {
   meta = {
     description = "Wrappers to build Python packages using PEP 517 hooks";
     license = lib.licenses.mit;
+    maintainers = [ ];
     homepage = "https://github.com/pypa/pep517";
   };
 }

--- a/pkgs/development/python-modules/pexif/default.nix
+++ b/pkgs/development/python-modules/pexif/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Module for editing JPEG EXIF data";
     homepage = "http://www.benno.id.au/code/pexif/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pgpdump/default.nix
+++ b/pkgs/development/python-modules/pgpdump/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Python library for parsing PGP packets";
     homepage = "https://github.com/toofishes/python-pgpdump";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pickleshare/default.nix
+++ b/pkgs/development/python-modules/pickleshare/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "Tiny 'shelve'-like database with concurrency support";
     homepage = "https://github.com/vivainio/pickleshare";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pid/default.nix
+++ b/pkgs/development/python-modules/pid/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     description = "Pidfile featuring stale detection and file-locking";
     homepage = "https://github.com/trbs/pid/";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pika-pool/default.nix
+++ b/pkgs/development/python-modules/pika-pool/default.nix
@@ -27,6 +27,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/bninja/pika-pool";
     license = licenses.bsdOriginal;
+    maintainers = [ ];
     description = "Pools for pikas";
   };
 }

--- a/pkgs/development/python-modules/pillowfight/default.nix
+++ b/pkgs/development/python-modules/pillowfight/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Eases the transition from PIL to Pillow for Python packages";
     homepage = "https://github.com/beanbaginc/pillowfight";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -113,6 +113,7 @@ let self = buildPythonPackage rec {
   meta = {
     description = "PyPA recommended tool for installing Python packages";
     license = with lib.licenses; [ mit ];
+    maintainers = [ ];
     homepage = "https://pip.pypa.io/";
     changelog = "https://pip.pypa.io/en/stable/news/#v${lib.replaceStrings [ "." ] [ "-" ] version}";
   };

--- a/pkgs/development/python-modules/pipetools/default.nix
+++ b/pkgs/development/python-modules/pipetools/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Library that enables function composition similar to using Unix pipes";
     homepage = "https://0101.github.io/pipetools/";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pkuseg/default.nix
+++ b/pkgs/development/python-modules/pkuseg/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage rec {
     description = "Toolkit for multi-domain Chinese word segmentation";
     homepage = "https://github.com/lancopku/pkuseg-python";
     license = licenses.unfree;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/plaster/default.nix
+++ b/pkgs/development/python-modules/plaster/default.nix
@@ -23,4 +23,8 @@ buildPythonPackage rec {
     pytest
     pytest-cov
   ];
+
+  meta = {
+    maintainers = [ ];
+  };
 }

--- a/pkgs/development/python-modules/plone-testing/default.nix
+++ b/pkgs/development/python-modules/plone-testing/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     description = "Testing infrastructure for Zope and Plone projects";
     homepage = "https://github.com/plone/plone.testing";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pluginbase/default.nix
+++ b/pkgs/development/python-modules/pluginbase/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/mitsuhiko/pluginbase";
     description = "Support library for building plugins sytems in Python";
     license = licenses.bsd3;
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/python-modules/ply/default.nix
+++ b/pkgs/development/python-modules/ply/default.nix
@@ -40,5 +40,6 @@ buildPythonPackage rec {
       not a large parsing framework or a component of some larger system.
     '';
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/plyvel/default.nix
+++ b/pkgs/development/python-modules/plyvel/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     platforms = platforms.unix;
     homepage = "https://github.com/wbolster/plyvel";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/podcats/default.nix
+++ b/pkgs/development/python-modules/podcats/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     mainProgram = "podcats";
     homepage = "https://github.com/jakubroztocil/podcats";
     license = lib.licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/polib/default.nix
+++ b/pkgs/development/python-modules/polib/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Library to manipulate gettext files (po and mo files)";
     homepage = "https://bitbucket.org/izi/polib/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/portend/default.nix
+++ b/pkgs/development/python-modules/portend/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     description = "Monitor TCP ports for bound or unbound states";
     homepage = "https://github.com/jaraco/portend";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/power/default.nix
+++ b/pkgs/development/python-modules/power/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Cross-platform system power status information";
     homepage = "https://github.com/Kentzo/Power";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/powerline/default.nix
+++ b/pkgs/development/python-modules/powerline/default.nix
@@ -53,5 +53,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/powerline/powerline";
     description = "Ultimate statusline/prompt utility";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/poyo/default.nix
+++ b/pkgs/development/python-modules/poyo/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/hackebrot/poyo";
     description = "Lightweight YAML Parser for Python";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/process-tests/default.nix
+++ b/pkgs/development/python-modules/process-tests/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     description = "Tools for testing processes";
     license = licenses.bsd2;
     homepage = "https://github.com/ionelmc/python-process-tests";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/proglog/default.nix
+++ b/pkgs/development/python-modules/proglog/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Logs and progress bars manager for Python";
     homepage = "https://github.com/Edinburgh-Genome-Foundry/Proglog";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ptest/default.nix
+++ b/pkgs/development/python-modules/ptest/default.nix
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     description = "Test classes and test cases using decorators, execute test cases by command line, and get clear reports";
     homepage = "https://pypi.python.org/pypi/ptest";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pushbullet-py/default.nix
+++ b/pkgs/development/python-modules/pushbullet-py/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
     description = "Simple python client for pushbullet.com";
     homepage = "https://github.com/randomchars/pushbullet.py";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pweave/default.nix
+++ b/pkgs/development/python-modules/pweave/default.nix
@@ -42,5 +42,6 @@ buildPythonPackage rec {
     description = "Scientific reports with embedded python computations with reST, LaTeX or markdown";
     homepage = "https://mpastell.com/pweave/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/py-stringmatching/default.nix
+++ b/pkgs/development/python-modules/py-stringmatching/default.nix
@@ -41,5 +41,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/anhaidgroup/py_stringmatching";
     changelog = "https://github.com/anhaidgroup/py_stringmatching/blob/v${version}/CHANGES.txt";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/py/default.nix
+++ b/pkgs/development/python-modules/py/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     description = "Library with cross-python path, ini-parsing, io, code, log facilities";
     homepage = "https://py.readthedocs.io/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/py3dns/default.nix
+++ b/pkgs/development/python-modules/py3dns/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Python 3 DNS library";
     homepage = "https://launchpad.net/py3dns";
     license = licenses.psfl;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyaes/default.nix
+++ b/pkgs/development/python-modules/pyaes/default.nix
@@ -17,6 +17,7 @@ buildPythonPackage rec {
   meta = {
     description = "Pure-Python AES";
     license = lib.licenses.mit;
+    maintainers = [ ];
     homepage = "https://github.com/ricmoo/pyaes";
   };
 }

--- a/pkgs/development/python-modules/pyalgotrade/default.nix
+++ b/pkgs/development/python-modules/pyalgotrade/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage rec {
     description = "Python Algorithmic Trading";
     homepage = "http://gbeced.github.io/pyalgotrade/";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyaudio/default.nix
+++ b/pkgs/development/python-modules/pyaudio/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Python bindings for PortAudio";
     homepage = "https://people.csail.mit.edu/hubert/pyaudio/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pybtex-docutils/default.nix
+++ b/pkgs/development/python-modules/pybtex-docutils/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     description = "Docutils backend for pybtex";
     homepage = "https://github.com/mcmtroffaes/pybtex-docutils";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pybtex/default.nix
+++ b/pkgs/development/python-modules/pybtex/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = "https://pybtex.org/";
     description = "BibTeX-compatible bibliography processor written in Python";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -51,6 +51,7 @@ buildPythonPackage rec {
       lgpl21Only
       mpl11
     ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/pkgs/development/python-modules/pycategories/infix.nix
+++ b/pkgs/development/python-modules/pycategories/infix.nix
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/borntyping/python-infix";
     description = "Decorator that allows functions to be used as infix functions";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pychart/default.nix
+++ b/pkgs/development/python-modules/pychart/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Library for creating high quality encapsulated Postscript, PDF, PNG, or SVG charts";
     homepage = "https://pypi.python.org/pypi/PyChart";
     license = licenses.gpl2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pycosat/default.nix
+++ b/pkgs/development/python-modules/pycosat/default.nix
@@ -19,5 +19,6 @@ buildPythonPackage rec {
     description = "Bindings to picosat SAT solver";
     homepage = "https://github.com/ContinuumIO/pycosat";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pycrypto/default.nix
+++ b/pkgs/development/python-modules/pycrypto/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     homepage = "https://www.pycrypto.org/";
     description = "Drop-in replacement for pycrypto using pycryptodome";
     platforms = pycryptodome.meta.platforms;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pycups/default.nix
+++ b/pkgs/development/python-modules/pycups/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     description = "Python bindings for libcups";
     homepage = "http://cyberelk.net/tim/software/pycups/";
     license = with licenses; [ gpl2Plus ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pydenticon/default.nix
+++ b/pkgs/development/python-modules/pydenticon/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/azaghal/pydenticon";
     description = "Library for generating identicons. Port of Sigil (https://github.com/cupcake/sigil) with enhancements";
     license = licenses.bsd0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pydispatcher/default.nix
+++ b/pkgs/development/python-modules/pydispatcher/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     homepage = "https://pydispatcher.sourceforge.net/";
     description = "Signal-registration and routing infrastructure for use in multiple contexts";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyechonest/default.nix
+++ b/pkgs/development/python-modules/pyechonest/default.nix
@@ -19,5 +19,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Tap into The Echo Nest's Musical Brain for the best music search, information, recommendations and remix tools on the web";
     homepage = "https://github.com/echonest/pyechonest";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyemd/default.nix
+++ b/pkgs/development/python-modules/pyemd/default.nix
@@ -44,5 +44,6 @@ buildPythonPackage rec {
     description = "Python wrapper for Ofir Pele and Michael Werman's implementation of the Earth Mover's Distance";
     homepage = "https://github.com/wmayner/pyemd";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyenchant/default.nix
+++ b/pkgs/development/python-modules/pyenchant/default.nix
@@ -44,5 +44,6 @@ buildPythonPackage rec {
     description = "pyenchant: Python bindings for the Enchant spellchecker";
     homepage = "https://github.com/pyenchant/pyenchant";
     license = licenses.lgpl21;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyfantom/default.nix
+++ b/pkgs/development/python-modules/pyfantom/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage {
     homepage = "https://pyfantom.ni.fr.eu.org/";
     description = "Wrapper for the LEGO Mindstorms Fantom Driver";
     license = licenses.gpl2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyfribidi/default.nix
+++ b/pkgs/development/python-modules/pyfribidi/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Simple wrapper around fribidi";
     homepage = "https://github.com/pediapress/pyfribidi";
     license = licenses.gpl2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyftgl/default.nix
+++ b/pkgs/development/python-modules/pyftgl/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python bindings for FTGL (FreeType for OpenGL)";
     license = licenses.gpl2Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyglet/default.nix
+++ b/pkgs/development/python-modules/pyglet/default.nix
@@ -110,6 +110,7 @@ buildPythonPackage rec {
     homepage = "http://www.pyglet.org/";
     description = "Cross-platform windowing and multimedia library";
     license = licenses.bsd3;
+    maintainers = [ ];
     inherit (mesa.meta) platforms;
   };
 }

--- a/pkgs/development/python-modules/pygments-markdown-lexer/default.nix
+++ b/pkgs/development/python-modules/pygments-markdown-lexer/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/jhermann/pygments-markdown-lexer";
     description = "Pygments Markdown Lexer – A Markdown lexer for Pygments to highlight Markdown code snippets";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pygreat/default.nix
+++ b/pkgs/development/python-modules/pygreat/default.nix
@@ -37,5 +37,6 @@ buildPythonPackage {
     description = "Python library for talking with libGreat devices";
     homepage = "https://greatscottgadgets.com/greatfet/";
     license = with licenses; [ bsd3 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pygtail/default.nix
+++ b/pkgs/development/python-modules/pygtail/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
     description = "Library for reading log file lines that have not been read";
     mainProgram = "pygtail";
     license = licenses.gpl2Plus;
+    maintainers = [ ];
     homepage = "https://github.com/bgreenlee/pygtail";
   };
 }

--- a/pkgs/development/python-modules/pyicu/default.nix
+++ b/pkgs/development/python-modules/pyicu/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     description = "Python extension wrapping the ICU C++ API";
     changelog = "https://gitlab.pyicu.org/main/pyicu/-/raw/v${version}/CHANGES";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyinotify/default.nix
+++ b/pkgs/development/python-modules/pyinotify/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/seb-m/pyinotify/wiki";
     description = "Monitor filesystems events on Linux platforms with inotify";
     license = licenses.mit;
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/pyinputevent/default.nix
+++ b/pkgs/development/python-modules/pyinputevent/default.nix
@@ -20,6 +20,7 @@ buildPythonPackage {
     homepage = "https://github.com/ntzrmtthihu777/pyinputevent";
     description = "Python interface to the Input Subsystem's input_event and uinput";
     license = licenses.bsd3;
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/pyjwkest/default.nix
+++ b/pkgs/development/python-modules/pyjwkest/default.nix
@@ -32,4 +32,8 @@ buildPythonPackage rec {
     requests
     six
   ];
+
+  meta = {
+    maintainers = [ ];
+  };
 }

--- a/pkgs/development/python-modules/pylibacl/default.nix
+++ b/pkgs/development/python-modules/pylibacl/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
   meta = {
     description = "Python extension module for POSIX ACLs, it can be used to query, list, add, and remove ACLs from files and directories under operating systems that support them";
     license = lib.licenses.lgpl21Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pylibconfig2/default.nix
+++ b/pkgs/development/python-modules/pylibconfig2/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/heinzK1X/pylibconfig2";
     description = "Pure python library for libconfig syntax";
     license = licenses.gpl3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyliblo/default.nix
+++ b/pkgs/development/python-modules/pyliblo/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     homepage = "https://das.nasophon.de/pyliblo/";
     description = "Python wrapper for the liblo OSC library";
     license = licenses.lgpl21Only;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pymacaroons/default.nix
+++ b/pkgs/development/python-modules/pymacaroons/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Macaroon library for Python";
     homepage = "https://github.com/ecordell/pymacaroons";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pympler/default.nix
+++ b/pkgs/development/python-modules/pympler/default.nix
@@ -56,5 +56,6 @@ buildPythonPackage rec {
     description = "Tool to measure, monitor and analyze memory behavior";
     homepage = "https://pythonhosted.org/Pympler/";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pymvglive/default.nix
+++ b/pkgs/development/python-modules/pymvglive/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     description = "get live-data from mvg-live.de";
     homepage = "https://github.com/pc-coholic/PyMVGLive";
     license = licenses.free;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pymysqlsa/default.nix
+++ b/pkgs/development/python-modules/pymysqlsa/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "PyMySQL dialect for SQL Alchemy";
     homepage = "https://pypi.python.org/pypi/pymysql_sa";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pynac/default.nix
+++ b/pkgs/development/python-modules/pynac/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage {
     homepage = "https://github.com/se-esss-litterbox/Pynac";
     description = "Python wrapper around the Dynac charged particle simulator";
     license = licenses.gpl3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pynamecheap/default.nix
+++ b/pkgs/development/python-modules/pynamecheap/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "Namecheap API client in Python";
     homepage = "https://github.com/Bemmu/PyNamecheap";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pynest2d/default.nix
+++ b/pkgs/development/python-modules/pynest2d/default.nix
@@ -38,6 +38,7 @@ buildPythonPackage rec {
     description = "Python bindings for libnest2d";
     homepage = "https://github.com/Ultimaker/pynest2d";
     license = licenses.lgpl3;
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -81,6 +81,7 @@ buildPythonPackage rec {
       liberal BSD-style Open-Source license.
     '';
     license = licenses.bsd3;
+    maintainers = [ ];
     inherit (mesa.meta) platforms;
   };
 }

--- a/pkgs/development/python-modules/pypeg2/default.nix
+++ b/pkgs/development/python-modules/pypeg2/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "PEG parser interpreter in Python";
     homepage = "http://fdik.org/pyPEG";
     license = licenses.gpl2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyphen/default.nix
+++ b/pkgs/development/python-modules/pyphen/default.nix
@@ -38,5 +38,6 @@ buildPythonPackage rec {
       lgpl21
       mpl20
     ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyplatec/default.nix
+++ b/pkgs/development/python-modules/pyplatec/default.nix
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     description = "Library to simulate plate tectonics with Python bindings";
     homepage = "https://github.com/Mindwerks/plate-tectonics";
     license = licenses.lgpl3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyproject-metadata/default.nix
+++ b/pkgs/development/python-modules/pyproject-metadata/default.nix
@@ -38,5 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/FFY00/python-pyproject-metadata";
     changelog = "https://github.com/FFY00/python-pyproject-metadata/blob/${version}/CHANGELOG.rst";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyptlib/default.nix
+++ b/pkgs/development/python-modules/pyptlib/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.org/project/pyptlib/";
     description = "Python implementation of the Pluggable Transports for Circumvention specification for Tor";
     license = licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyquery/default.nix
+++ b/pkgs/development/python-modules/pyquery/default.nix
@@ -64,5 +64,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/gawel/pyquery";
     changelog = "https://github.com/gawel/pyquery/blob/${version}/CHANGES.rst";
     license = licenses.bsd0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyrfc3339/default.nix
+++ b/pkgs/development/python-modules/pyrfc3339/default.nix
@@ -31,5 +31,6 @@ buildPythonPackage rec {
     description = "Generate and parse RFC 3339 timestamps";
     homepage = "https://github.com/kurtraschke/pyRFC3339";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pysftp/default.nix
+++ b/pkgs/development/python-modules/pysftp/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
     homepage = "https://bitbucket.org/dundeemt/pysftp";
     description = "Friendly face on SFTP";
     license = licenses.mit;
+    maintainers = [ ];
     longDescription = ''
       A simple interface to SFTP. The module offers high level abstractions
       and task based routines to handle your SFTP needs. Checkout the Cook

--- a/pkgs/development/python-modules/pysolr/default.nix
+++ b/pkgs/development/python-modules/pysolr/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     description = "Lightweight Python wrapper for Apache Solr";
     homepage = "https://github.com/toastdriven/pysolr/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pysrt/default.nix
+++ b/pkgs/development/python-modules/pysrt/default.nix
@@ -36,6 +36,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/byroot/pysrt";
     license = licenses.gpl3Only;
+    maintainers = [ ];
     description = "Python library used to edit or create SubRip files";
     mainProgram = "srt";
   };

--- a/pkgs/development/python-modules/pystemmer/default.nix
+++ b/pkgs/development/python-modules/pystemmer/default.nix
@@ -59,6 +59,7 @@ buildPythonPackage rec {
       bsd3
       mit
     ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/pytest-catchlog/default.nix
+++ b/pkgs/development/python-modules/pytest-catchlog/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     license = licenses.mit;
+    maintainers = [ ];
     homepage = "https://pypi.python.org/pypi/pytest-catchlog/";
     description = "py.test plugin to catch log messages. This is a fork of pytest-capturelog";
   };

--- a/pkgs/development/python-modules/pytest-cov/default.nix
+++ b/pkgs/development/python-modules/pytest-cov/default.nix
@@ -41,5 +41,6 @@ buildPythonPackage rec {
     description = "Plugin for coverage reporting with support for both centralised and distributed testing, including subprocesses and multiprocessing";
     homepage = "https://github.com/pytest-dev/pytest-cov";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-django/default.nix
+++ b/pkgs/development/python-modules/pytest-django/default.nix
@@ -55,5 +55,6 @@ buildPythonPackage rec {
     description = "Pytest plugin for testing of Django applications";
     homepage = "https://pytest-django.readthedocs.org/en/latest/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-expect/default.nix
+++ b/pkgs/development/python-modules/pytest-expect/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     description = "py.test plugin to store test expectations and mark tests based on them";
     homepage = "https://github.com/gsnedders/pytest-expect";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-flakes/default.nix
+++ b/pkgs/development/python-modules/pytest-flakes/default.nix
@@ -34,6 +34,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     license = licenses.mit;
+    maintainers = [ ];
     homepage = "https://pypi.python.org/pypi/pytest-flakes";
     description = "pytest plugin to check source code with pyflakes";
   };

--- a/pkgs/development/python-modules/pytest-raisesregexp/default.nix
+++ b/pkgs/development/python-modules/pytest-raisesregexp/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Simple pytest plugin to look for regex in Exceptions";
     homepage = "https://github.com/Walkman/pytest_raisesregexp";
     license = with licenses; [ mit ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-subtesthack/default.nix
+++ b/pkgs/development/python-modules/pytest-subtesthack/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "Terrible plugin to set up and tear down fixtures within the test function itself";
     homepage = "https://github.com/untitaker/pytest-subtesthack";
     license = licenses.publicDomain;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-tornado/default.nix
+++ b/pkgs/development/python-modules/pytest-tornado/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Py.test plugin providing fixtures and markers to simplify testing of asynchronous tornado applications";
     homepage = "https://github.com/eugeniy/pytest-tornado";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-warnings/default.nix
+++ b/pkgs/development/python-modules/pytest-warnings/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Plugin to list Python warnings in pytest report";
     homepage = "https://github.com/fschulze/pytest-warnings";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytestcache/default.nix
+++ b/pkgs/development/python-modules/pytestcache/default.nix
@@ -27,6 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     license = licenses.mit;
+    maintainers = [ ];
     homepage = "https://pypi.python.org/pypi/pytest-cache/";
     description = "pytest plugin with mechanisms for caching across test runs";
   };

--- a/pkgs/development/python-modules/python-ctags3/default.nix
+++ b/pkgs/development/python-modules/python-ctags3/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     inherit (src.meta) homepage;
     description = "Ctags indexing python bindings";
     license = licenses.lgpl3Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-editor/default.nix
+++ b/pkgs/development/python-modules/python-editor/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage {
     description = "Library that provides the `editor` module for programmatically";
     homepage = "https://github.com/fmoo/python-editor";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-etcd/default.nix
+++ b/pkgs/development/python-modules/python-etcd/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage {
     description = "Python client for Etcd";
     homepage = "https://github.com/jplana/python-etcd";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-ldap/default.nix
+++ b/pkgs/development/python-modules/python-ldap/default.nix
@@ -73,5 +73,6 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/python-ldap/python-ldap";
     homepage = "https://www.python-ldap.org/";
     license = licenses.psfl;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-linux-procfs/default.nix
+++ b/pkgs/development/python-modules/python-linux-procfs/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     mainProgram = "pflags";
     homepage = "https://git.kernel.org/pub/scm/libs/python/python-linux-procfs/python-linux-procfs.git/";
     license = licenses.gpl2Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-lzf/default.nix
+++ b/pkgs/development/python-modules/python-lzf/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
     description = "liblzf python bindings";
     homepage = "https://github.com/teepark/python-lzf";
     license = licenses.mit;
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/python-oauth2/default.nix
+++ b/pkgs/development/python-modules/python-oauth2/default.nix
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     description = "Framework that aims at making it easy to provide authentication via OAuth 2.0 within an application stack";
     homepage = "https://github.com/wndhydrnt/python-oauth2";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-simple-hipchat/default.nix
+++ b/pkgs/development/python-modules/python-simple-hipchat/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Easy peasy wrapper for HipChat's v1 API";
     homepage = "https://github.com/kurttheviking/simple-hipchat-py";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-wifi/default.nix
+++ b/pkgs/development/python-modules/python-wifi/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
       lgpl2Plus
       gpl2Plus
     ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python3-openid/default.nix
+++ b/pkgs/development/python-modules/python3-openid/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     description = "OpenID support for modern servers and consumers";
     homepage = "https://github.com/necaris/python3-openid";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pythondialog/default.nix
+++ b/pkgs/development/python-modules/pythondialog/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "Python interface to the UNIX dialog utility and mostly-compatible programs";
     homepage = "http://pythondialog.sourceforge.net/";
     license = licenses.lgpl3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytzdata/default.nix
+++ b/pkgs/development/python-modules/pytzdata/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Timezone database for Python";
     homepage = "https://github.com/sdispater/pytzdata";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pywatchman/default.nix
+++ b/pkgs/development/python-modules/pywatchman/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Watchman client for Python";
     homepage = "https://facebook.github.io/watchman/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pywavelets/default.nix
+++ b/pkgs/development/python-modules/pywavelets/default.nix
@@ -56,5 +56,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/PyWavelets/pywt";
     changelog = "https://github.com/PyWavelets/pywt/releases/tag/v${version}";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyx/default.nix
+++ b/pkgs/development/python-modules/pyx/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "Python package for the generation of PostScript, PDF, and SVG files";
     homepage = "https://pyx.sourceforge.net/";
     license = with licenses; [ gpl2 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyxattr/default.nix
+++ b/pkgs/development/python-modules/pyxattr/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python extension module which gives access to the extended attributes for filesystem objects available in some operating systems";
     license = licenses.lgpl21Plus;
+    maintainers = [ ];
     inherit (pkgs.attr.meta) platforms;
   };
 }

--- a/pkgs/development/python-modules/pyxlsb/default.nix
+++ b/pkgs/development/python-modules/pyxlsb/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     description = "Excel 2007-2010 Binary Workbook (xlsb) parser";
     homepage = "https://github.com/willtrnr/pyxlsb";
     license = licenses.lgpl3Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/qtpy/default.nix
+++ b/pkgs/development/python-modules/qtpy/default.nix
@@ -50,5 +50,6 @@ buildPythonPackage rec {
     mainProgram = "qtpy";
     homepage = "https://github.com/spyder-ide/qtpy";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/random2/default.nix
+++ b/pkgs/development/python-modules/random2/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = "http://pypi.python.org/pypi/random2";
     description = "Python 3 compatible Python 2 `random` Module";
     license = licenses.psfl;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/re-assert/default.nix
+++ b/pkgs/development/python-modules/re-assert/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
   meta = {
     description = "Show where your regex match assertion failed";
     license = lib.licenses.mit;
+    maintainers = [ ];
     homepage = "https://github.com/asottile/re-assert";
   };
 }

--- a/pkgs/development/python-modules/readthedocs-sphinx-ext/default.nix
+++ b/pkgs/development/python-modules/readthedocs-sphinx-ext/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     description = "Sphinx extension for Read the Docs overrides";
     homepage = "https://github.com/rtfd/readthedocs-sphinx-ext";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/recommonmark/default.nix
+++ b/pkgs/development/python-modules/recommonmark/default.nix
@@ -43,5 +43,6 @@ buildPythonPackage rec {
     description = "Docutils-compatibility bridge to CommonMark";
     homepage = "https://github.com/rtfd/recommonmark";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/recursive-pth-loader/default.nix
+++ b/pkgs/development/python-modules/recursive-pth-loader/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Enable recursive processing of pth files anywhere in sys.path";
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/redis/default.nix
+++ b/pkgs/development/python-modules/redis/default.nix
@@ -66,5 +66,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/redis/redis-py";
     changelog = "https://github.com/redis/redis-py/releases/tag/v${version}";
     license = with licenses; [ mit ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/reikna/default.nix
+++ b/pkgs/development/python-modules/reikna/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage rec {
     description = "GPGPU algorithms for PyCUDA and PyOpenCL";
     homepage = "https://github.com/fjarri/reikna";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/repocheck/default.nix
+++ b/pkgs/development/python-modules/repocheck/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Check the status of code repositories under a root directory";
     mainProgram = "repocheck";
     license = licenses.gpl3Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/requests-download/default.nix
+++ b/pkgs/development/python-modules/requests-download/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Download files using requests and save them to a target path";
     homepage = "https://www.github.com/takluyver/requests_download";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/restructuredtext-lint/default.nix
+++ b/pkgs/development/python-modules/restructuredtext-lint/default.nix
@@ -33,6 +33,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/twolfson/restructuredtext-lint";
     changelog = "https://github.com/twolfson/restructuredtext-lint/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.unlicense;
+    maintainers = [ ];
     mainProgram = "rst-lint";
   };
 }

--- a/pkgs/development/python-modules/rethinkdb/default.nix
+++ b/pkgs/development/python-modules/rethinkdb/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     description = "Python driver library for the RethinkDB database server";
     homepage = "https://github.com/RethinkDB/rethinkdb-python";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/retry-decorator/default.nix
+++ b/pkgs/development/python-modules/retry-decorator/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pnpnpn/retry-decorator";
     changelog = "https://github.com/pnpnpn/retry-decorator/releases/tag/v${version}";
     license = with licenses; [ asl20 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/retry/default.nix
+++ b/pkgs/development/python-modules/retry/default.nix
@@ -39,5 +39,6 @@ buildPythonPackage rec {
     description = "Easy to use retry decorator";
     homepage = "https://github.com/invl/retry";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/robot-detection/default.nix
+++ b/pkgs/development/python-modules/robot-detection/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "Library for detecting if a HTTP User Agent header is likely to be a bot";
     homepage = "https://github.com/rory/robot-detection";
     license = licenses.gpl3Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/robotframework-sshlibrary/default.nix
+++ b/pkgs/development/python-modules/robotframework-sshlibrary/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     description = "SSHLibrary is a Robot Framework test library for SSH and SFTP";
     homepage = "https://github.com/robotframework/SSHLibrary";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/robotsuite/default.nix
+++ b/pkgs/development/python-modules/robotsuite/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     description = "Python unittest test suite for Robot Framework";
     homepage = "https://github.com/collective/robotsuite/";
     license = licenses.gpl3Only;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/rocket-errbot/default.nix
+++ b/pkgs/development/python-modules/rocket-errbot/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/errbotio/rocket";
     description = "Modern, multi-threaded and extensible web server";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/roku/default.nix
+++ b/pkgs/development/python-modules/roku/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     description = "Screw remotes. Control your Roku with Python";
     homepage = "https://github.com/jcarbaugh/python-roku";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/roman/default.nix
+++ b/pkgs/development/python-modules/roman/default.nix
@@ -19,5 +19,6 @@ buildPythonPackage rec {
     description = "Integer to Roman numerals converter";
     homepage = "https://pypi.python.org/pypi/roman";
     license = licenses.psfl;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/rpdb/default.nix
+++ b/pkgs/development/python-modules/rpdb/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "pdb wrapper with remote access via tcp socket";
     homepage = "https://github.com/tamentis/rpdb";
     license = licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/rsa/default.nix
+++ b/pkgs/development/python-modules/rsa/default.nix
@@ -41,6 +41,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://stuvel.eu/rsa";
     license = licenses.asl20;
+    maintainers = [ ];
     description = "Pure-Python RSA implementation";
   };
 }

--- a/pkgs/development/python-modules/rtslib/default.nix
+++ b/pkgs/development/python-modules/rtslib/default.nix
@@ -30,6 +30,7 @@ buildPythonPackage rec {
     mainProgram = "targetctl";
     homepage = "https://github.com/open-iscsi/rtslib-fb";
     license = licenses.asl20;
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/seaborn/default.nix
+++ b/pkgs/development/python-modules/seaborn/default.nix
@@ -69,5 +69,6 @@ buildPythonPackage rec {
     homepage = "https://seaborn.pydata.org/";
     changelog = "https://github.com/mwaskom/seaborn/blob/master/doc/whatsnew/${src.rev}.rst";
     license = with licenses; [ bsd3 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sentinel/default.nix
+++ b/pkgs/development/python-modules/sentinel/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Create sentinel and singleton objects";
     homepage = "https://github.com/eddieantonio/sentinel";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sepaxml/default.nix
+++ b/pkgs/development/python-modules/sepaxml/default.nix
@@ -39,5 +39,6 @@ buildPythonPackage rec {
     description = "SEPA Direct Debit XML generation in python";
     homepage = "https://github.com/raphaelm/python-sepaxml/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/setuptools-git/default.nix
+++ b/pkgs/development/python-modules/setuptools-git/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     description = "Setuptools revision control system plugin for Git";
     homepage = "https://pypi.python.org/pypi/setuptools-git";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/simplebayes/default.nix
+++ b/pkgs/development/python-modules/simplebayes/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage {
     description = "Memory-based naive bayesian text classifier";
     homepage = "https://github.com/hickeroar/simplebayes";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/simplegeneric/default.nix
+++ b/pkgs/development/python-modules/simplegeneric/default.nix
@@ -19,5 +19,6 @@ buildPythonPackage rec {
     description = "Simple generic functions";
     homepage = "http://cheeseshop.python.org/pypi/simplegeneric";
     license = lib.licenses.zpl21;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/skl2onnx/default.nix
+++ b/pkgs/development/python-modules/skl2onnx/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
   meta = {
     description = "Convert scikit-learn models to ONNX";
     license = with lib.licenses; [ asl20 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sleekxmpp/default.nix
+++ b/pkgs/development/python-modules/sleekxmpp/default.nix
@@ -32,6 +32,7 @@ buildPythonPackage rec {
       (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) || stdenv.hostPlatform.isDarwin;
     description = "XMPP library for Python";
     license = licenses.mit;
+    maintainers = [ ];
     homepage = "http://sleekxmpp.com/";
   };
 }

--- a/pkgs/development/python-modules/slob/default.nix
+++ b/pkgs/development/python-modules/slob/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage {
     description = "Reference implementation of the slob (sorted list of blobs) format";
     mainProgram = "slob";
     license = licenses.gpl3Only;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sniffio/default.nix
+++ b/pkgs/development/python-modules/sniffio/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/python-trio/sniffio";
     license = licenses.asl20;
+    maintainers = [ ];
     description = "Sniff out which async library your code is running under";
   };
 }

--- a/pkgs/development/python-modules/snowballstemmer/default.nix
+++ b/pkgs/development/python-modules/snowballstemmer/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
     description = "16 stemmer algorithms (15 + Poerter English stemmer) generated from Snowball algorithms";
     homepage = "http://sigal.saimon.org/en/latest/index.html";
     license = licenses.bsd3;
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/socksipy-branch/default.nix
+++ b/pkgs/development/python-modules/socksipy-branch/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     homepage = "http://code.google.com/p/socksipy-branch/";
     description = "This Python module allows you to create TCP connections through a SOCKS proxy without any special effort";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sorl-thumbnail/default.nix
+++ b/pkgs/development/python-modules/sorl-thumbnail/default.nix
@@ -39,5 +39,6 @@ buildPythonPackage rec {
     description = "Thumbnails for Django";
     changelog = "https://github.com/jazzband/sorl-thumbnail/blob/${version}/CHANGES.rst";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -43,5 +43,6 @@ buildPythonPackage rec {
     description = "Play and Record Sound with Python";
     homepage = "http://python-sounddevice.rtfd.org/";
     license = with lib.licenses; [ mit ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage rec {
   meta = {
     description = "Audio library based on libsndfile, CFFI and NumPy";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
     homepage = "https://github.com/bastibe/python-soundfile";
   };
 }

--- a/pkgs/development/python-modules/sparqlwrapper/default.nix
+++ b/pkgs/development/python-modules/sparqlwrapper/default.nix
@@ -31,5 +31,6 @@ buildPythonPackage rec {
     mainProgram = "rqw";
     homepage = "http://rdflib.github.io/sparqlwrapper";
     license = licenses.w3c;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sphinx-rtd-theme/default.nix
+++ b/pkgs/development/python-modules/sphinx-rtd-theme/default.nix
@@ -54,5 +54,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/readthedocs/sphinx_rtd_theme";
     changelog = "https://github.com/readthedocs/sphinx_rtd_theme/blob/${version}/docs/changelog.rst";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sphinx-testing/default.nix
+++ b/pkgs/development/python-modules/sphinx-testing/default.nix
@@ -38,6 +38,7 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/sphinx-doc/sphinx-testing";
     license = lib.licenses.bsd2;
+    maintainers = [ ];
     description = "Testing utility classes and functions for Sphinx extensions";
   };
 }

--- a/pkgs/development/python-modules/sphinxcontrib-httpdomain/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-httpdomain/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Provides a Sphinx domain for describing RESTful HTTP APIs";
     homepage = "https://bitbucket.org/birkenfeld/sphinx-contrib";
     license = licenses.bsd0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sphinxcontrib-newsfeed/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-newsfeed/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     description = "Extension for adding a simple Blog, News or Announcements section to a Sphinx website";
     homepage = "https://github.com/prometheusresearch/sphinxcontrib-newsfeed";
     license = licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sphinxcontrib-websupport/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-websupport/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     description = "Sphinx API for Web Apps";
     homepage = "http://sphinx-doc.org/";
     license = lib.licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sqlalchemy-i18n/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-i18n/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/kvesteri/sqlalchemy-i18n";
     description = "Internationalization extension for SQLAlchemy models";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sqlalchemy/1_4.nix
+++ b/pkgs/development/python-modules/sqlalchemy/1_4.nix
@@ -105,5 +105,6 @@ buildPythonPackage rec {
     description = "Database Toolkit for Python";
     homepage = "https://github.com/sqlalchemy/sqlalchemy";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -117,5 +117,6 @@ buildPythonPackage rec {
     description = "Python SQL toolkit and Object Relational Mapper";
     homepage = "http://www.sqlalchemy.org/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sqlparse/default.nix
+++ b/pkgs/development/python-modules/sqlparse/default.nix
@@ -53,6 +53,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/andialbrecht/sqlparse";
     changelog = "https://github.com/andialbrecht/sqlparse/blob/${version}/CHANGELOG";
     license = licenses.bsd3;
+    maintainers = [ ];
     mainProgram = "sqlformat";
   };
 }

--- a/pkgs/development/python-modules/srsly/default.nix
+++ b/pkgs/development/python-modules/srsly/default.nix
@@ -49,5 +49,6 @@ buildPythonPackage rec {
     description = "Modern high-performance serialization utilities for Python";
     homepage = "https://github.com/explosion/srsly";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/statsmodels/default.nix
+++ b/pkgs/development/python-modules/statsmodels/default.nix
@@ -64,5 +64,6 @@ buildPythonPackage rec {
     homepage = "https://www.github.com/statsmodels/statsmodels";
     changelog = "https://github.com/statsmodels/statsmodels/releases/tag/v${version}";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/svgwrite/default.nix
+++ b/pkgs/development/python-modules/svgwrite/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     description = "Python library to create SVG drawings";
     homepage = "https://github.com/mozman/svgwrite";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/swagger-ui-bundle/default.nix
+++ b/pkgs/development/python-modules/swagger-ui-bundle/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     description = "bundled swagger-ui pip package";
     homepage = "https://github.com/dtkav/swagger_ui_bundle";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tabulate/default.nix
+++ b/pkgs/development/python-modules/tabulate/default.nix
@@ -39,5 +39,6 @@ buildPythonPackage rec {
     mainProgram = "tabulate";
     homepage = "https://github.com/astanin/python-tabulate";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/telegram/default.nix
+++ b/pkgs/development/python-modules/telegram/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/liluo/telegram";
     description = "Telegram APIs";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/termcolor/default.nix
+++ b/pkgs/development/python-modules/termcolor/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     description = "ANSI color formatting for output in terminal";
     homepage = "https://github.com/termcolor/termcolor";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/terminaltables/default.nix
+++ b/pkgs/development/python-modules/terminaltables/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Display simple tables in terminals";
     homepage = "https://github.com/Robpol86/terminaltables";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/termstyle/default.nix
+++ b/pkgs/development/python-modules/termstyle/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Console colouring for python";
     homepage = "https://pypi.python.org/pypi/python-termstyle/0.1.10";
     license = licenses.bsdOriginal;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/testpath/default.nix
+++ b/pkgs/development/python-modules/testpath/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Test utilities for code working with files and commands";
     license = licenses.mit;
+    maintainers = [ ];
     homepage = "https://github.com/jupyter/testpath";
   };
 }

--- a/pkgs/development/python-modules/testrepository/default.nix
+++ b/pkgs/development/python-modules/testrepository/default.nix
@@ -37,5 +37,6 @@ buildPythonPackage rec {
     mainProgram = "testr";
     homepage = "https://pypi.python.org/pypi/testrepository";
     license = licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/testresources/default.nix
+++ b/pkgs/development/python-modules/testresources/default.nix
@@ -38,5 +38,6 @@ buildPythonPackage rec {
     description = "Pyunit extension for managing expensive test resources";
     homepage = "https://launchpad.net/testresources";
     license = licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/testscenarios/default.nix
+++ b/pkgs/development/python-modules/testscenarios/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
     description = "Pyunit extension for dependency injection";
     homepage = "https://github.com/testing-cabal/testscenarios";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/testtools/default.nix
+++ b/pkgs/development/python-modules/testtools/default.nix
@@ -38,5 +38,6 @@ buildPythonPackage rec {
     description = "Set of extensions to the Python standard library's unit testing framework";
     homepage = "https://pypi.python.org/pypi/testtools";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/text-unidecode/default.nix
+++ b/pkgs/development/python-modules/text-unidecode/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "Most basic Text::Unidecode port";
     homepage = "https://github.com/kmike/text-unidecode";
     license = licenses.artistic1;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -67,5 +67,6 @@ buildPythonPackage rec {
     description = "Higher-level text processing, built on spaCy";
     homepage = "https://textacy.readthedocs.io/";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tflearn/default.nix
+++ b/pkgs/development/python-modules/tflearn/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage rec {
     description = "Deep learning library featuring a higher-level API for TensorFlow";
     homepage = "https://github.com/tflearn/tflearn";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/threadpool/default.nix
+++ b/pkgs/development/python-modules/threadpool/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     homepage = "https://chrisarndt.de/projects/threadpool/";
     description = "Easy to use object-oriented thread pool framework";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tiledb/default.nix
+++ b/pkgs/development/python-modules/tiledb/default.nix
@@ -77,6 +77,7 @@ buildPythonPackage rec {
     description = "Python interface to the TileDB storage manager";
     homepage = "https://github.com/TileDB-Inc/TileDB-Py";
     license = licenses.mit;
+    maintainers = [ ];
     # tiledb/core.cc:556:30: error: ‘struct std::array<long unsigned int, 2>’ has no member named ‘second’
     broken = true;
   };

--- a/pkgs/development/python-modules/tilestache/default.nix
+++ b/pkgs/development/python-modules/tilestache/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     description = "Tile server for rendered geographic data";
     homepage = "http://tilestache.org";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/timelib/default.nix
+++ b/pkgs/development/python-modules/timelib/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     description = "Parse english textual date descriptions";
     homepage = "https://github.com/pediapress/timelib/";
     license = licenses.zlib;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/timeout-decorator/default.nix
+++ b/pkgs/development/python-modules/timeout-decorator/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Timeout decorator";
     license = licenses.mit;
+    maintainers = [ ];
     homepage = "https://github.com/pnpnpn/timeout-decorator";
   };
 }

--- a/pkgs/development/python-modules/tlsh/default.nix
+++ b/pkgs/development/python-modules/tlsh/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     homepage = "https://tlsh.org/";
     changelog = "https://github.com/trendmicro/tlsh/releases/tag/${version}";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tlslite/default.nix
+++ b/pkgs/development/python-modules/tlslite/default.nix
@@ -17,5 +17,6 @@ buildPythonPackage rec {
     description = "Pure Python implementation of SSL and TLS";
     homepage = "https://pypi.python.org/pypi/tlslite";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tokenlib/default.nix
+++ b/pkgs/development/python-modules/tokenlib/default.nix
@@ -42,5 +42,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/mozilla-services/tokenlib";
     description = "Generic support library for signed-token-based auth schemes";
     license = licenses.mpl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/toolz/default.nix
+++ b/pkgs/development/python-modules/toolz/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pytoolz/toolz";
     description = "List processing tools and functional utilities";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tornado/4.nix
+++ b/pkgs/development/python-modules/tornado/4.nix
@@ -38,5 +38,6 @@ buildPythonPackage rec {
     description = "Web framework and asynchronous networking library";
     homepage = "https://www.tornadoweb.org/";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tornado/5.nix
+++ b/pkgs/development/python-modules/tornado/5.nix
@@ -38,5 +38,6 @@ buildPythonPackage rec {
     description = "Web framework and asynchronous networking library";
     homepage = "https://www.tornadoweb.org/";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -62,5 +62,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/tqdm/tqdm";
     changelog = "https://tqdm.github.io/releases/";
     license = with licenses; [ mit ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/traceback2/default.nix
+++ b/pkgs/development/python-modules/traceback2/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     description = "Backport of traceback to older supported Pythons";
     homepage = "https://pypi.python.org/pypi/traceback2/";
     license = licenses.psfl;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/traitlets/default.nix
+++ b/pkgs/development/python-modules/traitlets/default.nix
@@ -48,5 +48,6 @@ buildPythonPackage rec {
     description = "Traitlets Python config system";
     homepage = "https://github.com/ipython/traitlets";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tunigo/default.nix
+++ b/pkgs/development/python-modules/tunigo/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     description = "Python API for the browse feature of Spotify";
     homepage = "https://github.com/trygveaa/python-tunigo";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/twine/default.nix
+++ b/pkgs/development/python-modules/twine/default.nix
@@ -50,5 +50,6 @@ buildPythonPackage rec {
     mainProgram = "twine";
     homepage = "https://github.com/pypa/twine";
     license = lib.licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/u-msgpack-python/default.nix
+++ b/pkgs/development/python-modules/u-msgpack-python/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/vsergeev/u-msgpack-python";
     changelog = "https://github.com/vsergeev/u-msgpack-python/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/umalqurra/default.nix
+++ b/pkgs/development/python-modules/umalqurra/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Date Api that support Hijri Umalqurra calendar";
     homepage = "https://github.com/tytkal/python-hijiri-ummalqura";
     license = with licenses; [ publicDomain ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/unpaddedbase64/default.nix
+++ b/pkgs/development/python-modules/unpaddedbase64/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/matrix-org/python-unpaddedbase64";
     description = "Unpadded Base64";
     license = licenses.asl20;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/update-checker/default.nix
+++ b/pkgs/development/python-modules/update-checker/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     description = "Python module that will check for package updates";
     homepage = "https://github.com/bboe/update_checker";
     license = licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/update-copyright/default.nix
+++ b/pkgs/development/python-modules/update-copyright/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     mainProgram = "update-copyright.py";
     homepage = "http://blog.tremily.us/posts/update-copyright";
     license = licenses.gpl3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/vcversioner/default.nix
+++ b/pkgs/development/python-modules/vcversioner/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "take version numbers from version control";
     homepage = "https://github.com/habnabit/vcversioner";
     license = licenses.isc;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/vega-datasets/default.nix
+++ b/pkgs/development/python-modules/vega-datasets/default.nix
@@ -37,5 +37,6 @@ buildPythonPackage rec {
       homepage = "https://github.com/altair-viz/vega_datasets";
       changelog = "https://github.com/altair-viz/vega_datasets/blob/${tag}/CHANGES.md";
       license = lib.licenses.mit;
+      maintainers = [ ];
     };
 }

--- a/pkgs/development/python-modules/versiontools/default.nix
+++ b/pkgs/development/python-modules/versiontools/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     homepage = "https://launchpad.net/versiontools";
     description = "Smart replacement for plain tuple used in __version__";
     license = licenses.lgpl2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/veryprettytable/default.nix
+++ b/pkgs/development/python-modules/veryprettytable/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "Simple Python library for easily displaying tabular data in a visually appealing ASCII table format";
     homepage = "https://github.com/smeggingsmegger/VeryPrettyTable";
     license = licenses.free;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/virtualenvwrapper/default.nix
+++ b/pkgs/development/python-modules/virtualenvwrapper/default.nix
@@ -80,5 +80,6 @@ buildPythonPackage rec {
     description = "Enhancements to virtualenv";
     homepage = "https://pypi.python.org/pypi/virtualenvwrapper";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/vmprof/default.nix
+++ b/pkgs/development/python-modules/vmprof/default.nix
@@ -53,6 +53,7 @@ buildPythonPackage rec {
     description = "Vmprof client";
     mainProgram = "vmprofshow";
     license = licenses.mit;
+    maintainers = [ ];
     homepage = "https://vmprof.readthedocs.org/";
   };
 }

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -97,5 +97,6 @@ buildPythonPackage rec {
     mainProgram = "weasyprint";
     homepage = "https://weasyprint.org/";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/webencodings/default.nix
+++ b/pkgs/development/python-modules/webencodings/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "Character encoding aliases for legacy web content";
     homepage = "https://github.com/SimonSapin/python-webencodings";
     license = lib.licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/whichcraft/default.nix
+++ b/pkgs/development/python-modules/whichcraft/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pydanny/whichcraft";
     description = "Cross-platform cross-python shutil.which functionality";
     license = licenses.bsd3;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/widgetsnbextension/default.nix
+++ b/pkgs/development/python-modules/widgetsnbextension/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     description = "IPython HTML widgets for Jupyter";
     homepage = "https://github.com/jupyter-widgets/ipywidgets/tree/master/python/widgetsnbextension";
     license = ipywidgets.meta.license; # Build from same repo
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/wordfreq/default.nix
+++ b/pkgs/development/python-modules/wordfreq/default.nix
@@ -50,5 +50,6 @@ buildPythonPackage rec {
     description = "Library for looking up the frequencies of words in many languages, based on many sources of data";
     homepage = "https://github.com/rspeer/wordfreq/";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/xdot/default.nix
+++ b/pkgs/development/python-modules/xdot/default.nix
@@ -67,5 +67,6 @@ buildPythonPackage rec {
     mainProgram = "xdot";
     homepage = "https://github.com/jrfonseca/xdot.py";
     license = licenses.lgpl3Plus;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/xlrd/default.nix
+++ b/pkgs/development/python-modules/xlrd/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "Library for developers to extract data from Microsoft Excel (tm) spreadsheet files";
     mainProgram = "runxlrd.py";
     license = licenses.bsd0;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/yapsy/default.nix
+++ b/pkgs/development/python-modules/yapsy/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = "https://yapsy.sourceforge.net/";
     description = "Yet another plugin system";
     license = licenses.bsd2;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/z3c-checkversions/default.nix
+++ b/pkgs/development/python-modules/z3c-checkversions/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     description = "Find newer package versions on PyPI";
     mainProgram = "checkversions";
     license = licenses.zpl21;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zeep/default.nix
+++ b/pkgs/development/python-modules/zeep/default.nix
@@ -88,5 +88,6 @@ buildPythonPackage rec {
     description = "Python SOAP client";
     homepage = "http://docs.python-zeep.org";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zetup/default.nix
+++ b/pkgs/development/python-modules/zetup/default.nix
@@ -46,6 +46,7 @@ buildPythonPackage rec {
     description = "Zimmermann's Extensible Tools for Unified Project setups";
     homepage = "https://github.com/zimmermanncode/zetup";
     license = licenses.gpl3Plus;
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/zope-deferredimport/default.nix
+++ b/pkgs/development/python-modules/zope-deferredimport/default.nix
@@ -31,5 +31,6 @@ buildPythonPackage rec {
     description = "Allows you to perform imports names that will only be resolved when used in the code";
     homepage = "https://github.com/zopefoundation/zope.deferredimport";
     license = licenses.zpl21;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-hookable/default.nix
+++ b/pkgs/development/python-modules/zope-hookable/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     description = "Supports the efficient creation of “hookable” objects";
     homepage = "https://github.com/zopefoundation/zope.hookable";
     license = licenses.zpl21;
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
This pr aim to give more discoverability to packages that where missing `maintainers` meta's field, for bash expression such as `grep -rP "maintainers = \[ \];"` or [through github search](https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20maintainers%20%3D%20%5B%20%5D%3B&type=code).

It also remove ambiguity by showing a clear empty maintainer list, inviting for someone to put their name in.
I hope this may lead to an adoption of somes, previously invisible to interested maintainers.

Used the following command to edit each derivation, and either append the missing field or discard (some invalid scenoria where meta is inherited):

```
grep -rP "version\s+=\s+" pkgs/development/python-modules               \
    | nix run github:sigmanificient/filterpath                          \
    | grep ".nix" | uniq                                                \
    | xargs -i sh -c 'grep -P "maintainers" {} >/dev/null || echo "{}"' \
    | xargs -i nvim {}
```

If you are looking at this pr, consider taking a bit of time to see if anything interest you in this list

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
