### PR TITLE
mozillavpn: 2.21.0 → 2.23.1

### DIFF
--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -1,28 +1,29 @@
-{ buildGoModule
-, cargo
-, cmake
-, fetchFromGitHub
-, go
-, lib
-, libcap
-, libgcrypt
-, libgpg-error
-, libsecret
-, pkg-config
-, polkit
-, python3
-, qt5compat
-, qtbase
-, qtnetworkauth
-, qtsvg
-, qttools
-, qtwayland
-, qtwebsockets
-, rustPlatform
-, rustc
-, stdenv
-, wireguard-tools
-, wrapQtAppsHook
+{
+  buildGoModule,
+  cargo,
+  cmake,
+  fetchFromGitHub,
+  go,
+  lib,
+  libcap,
+  libgcrypt,
+  libgpg-error,
+  libsecret,
+  pkg-config,
+  polkit,
+  python3,
+  qt5compat,
+  qtbase,
+  qtnetworkauth,
+  qtsvg,
+  qttools,
+  qtwayland,
+  qtwebsockets,
+  rustPlatform,
+  rustc,
+  stdenv,
+  wireguard-tools,
+  wrapQtAppsHook,
 }:
 
 let
@@ -37,11 +38,17 @@ let
   };
   patches = [ ];
 
-  netfilterGoModules = (buildGoModule {
-    inherit pname version src patches;
-    modRoot = "linux/netfilter";
-    vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
-  }).goModules;
+  netfilterGoModules =
+    (buildGoModule {
+      inherit
+        pname
+        version
+        src
+        patches
+        ;
+      modRoot = "linux/netfilter";
+      vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
+    }).goModules;
 
   extensionBridgeDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
@@ -61,10 +68,14 @@ let
     preBuild = "cd qtglean";
     hash = "sha256-HFmRcfxCcc83IPPIovbf3jNftp0olKQ6RzV8vPpCYAM=";
   };
-
 in
 stdenv.mkDerivation {
-  inherit pname version src patches;
+  inherit
+    pname
+    version
+    src
+    patches
+    ;
 
   buildInputs = [
     libcap
@@ -144,8 +155,12 @@ stdenv.mkDerivation {
   ];
   dontFixCmake = true;
 
-  qtWrapperArgs =
-    [ "--prefix" "PATH" ":" (lib.makeBinPath [ wireguard-tools ]) ];
+  qtWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ wireguard-tools ])
+  ];
 
   meta = {
     description = "Client for the Mozilla VPN service";

--- a/pkgs/tools/networking/mozillavpn/default.nix
+++ b/pkgs/tools/networking/mozillavpn/default.nix
@@ -3,6 +3,7 @@
   cargo,
   cmake,
   fetchFromGitHub,
+  fetchpatch,
   go,
   lib,
   libcap,
@@ -28,15 +29,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mozillavpn";
-  version = "2.21.0";
+  version = "2.23.1";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-XBvKSgMuWgMuV+is2G028UNQ4hID7tKiHFuMdPOZcsI=";
+    hash = "sha256-NQM1ZII9owD9ek/Leo6WRfvNybZ5pUjDgvQGXQBrD+0=";
   };
-  patches = [ ];
+  patches = [
+    # Update cargo deps for "time"
+    (fetchpatch {
+      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/commit/31d5799a30fc02067ad31d86b6ef63294bb3c3b8.patch";
+      hash = "sha256-ECrIcfhhSuvbqQ/ExPdFkQ6b9Q767lhUKmwPdDz7yxI=";
+    })
+  ];
 
   netfilterGoModules =
     (buildGoModule {
@@ -50,23 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
       vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
     }).goModules;
 
-  extensionBridgeDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoTarball {
     inherit (finalAttrs) src patches;
-    name = "${finalAttrs.pname}-${finalAttrs.version}-extension-bridge";
-    preBuild = "cd extension/bridge";
-    hash = "sha256-1BXlp9AC9oQo/UzCtgNWVv8Er2ERoDLKdlTYXLzodMQ=";
-  };
-  signatureDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) src patches;
-    name = "${finalAttrs.pname}-${finalAttrs.version}-signature";
-    preBuild = "cd signature";
-    hash = "sha256-GtkDkeFdPsLuTpZh5UqIhFMpzW3HMkbz7npryOQkkGw=";
-  };
-  qtgleanDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) src patches;
-    name = "${finalAttrs.pname}-${finalAttrs.version}-qtglean";
-    preBuild = "cd qtglean";
-    hash = "sha256-HFmRcfxCcc83IPPIovbf3jNftp0olKQ6RzV8vPpCYAM=";
+    hash = "sha256-JIe6FQL0xm6FYYGoIwwnOxq21sC1y8xPsr8tYPF0Mzo=";
   };
 
   buildInputs = [
@@ -96,24 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
     wrapQtAppsHook
   ];
 
-  postUnpack = ''
-    pushd source/extension/bridge
-    cargoDeps='${finalAttrs.extensionBridgeDeps}' cargoSetupPostUnpackHook
-    extensionBridgeDepsCopy="$cargoDepsCopy"
-    popd
-
-    pushd source/signature
-    cargoDeps='${finalAttrs.signatureDeps}' cargoSetupPostUnpackHook
-    signatureDepsCopy="$cargoDepsCopy"
-    popd
-
-    pushd source/qtglean
-    cargoDeps='${finalAttrs.qtgleanDeps}' cargoSetupPostUnpackHook
-    qtgleanDepsCopy="$cargoDepsCopy"
-    popd
-  '';
-  dontCargoSetupPostUnpack = true;
-
   postPatch = ''
     substituteInPlace src/cmake/linux.cmake \
       --replace '/etc/xdg/autostart' "$out/etc/xdg/autostart" \
@@ -124,20 +99,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace '/etc' "$out/etc"
 
     ln -s '${finalAttrs.netfilterGoModules}' linux/netfilter/vendor
-
-    pushd extension/bridge
-    cargoDepsCopy="$extensionBridgeDepsCopy" cargoSetupPostPatchHook
-    popd
-
-    pushd signature
-    cargoDepsCopy="$signatureDepsCopy" cargoSetupPostPatchHook
-    popd
-
-    pushd qtglean
-    cargoDepsCopy="$qtgleanDepsCopy" cargoSetupPostPatchHook
-    popd
-
-    cargoSetupPostPatchHook() { true; }
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
## Description of changes

Upgrade the Mozilla VPN client from 2.21.0 to 2.23.1. Also add the upstream patch that fixes building with Rust 1.80.0 in staging-next (#332957).

https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.22.0
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.22.1
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.23.0
https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.23.1
https://github.com/mozilla-mobile/mozilla-vpn-client/compare/v2.21.0...v2.23.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
