### PR TITLE
nixos/renovate: set service type to simple

### DIFF
--- a/nixos/modules/services/misc/renovate.nix
+++ b/nixos/modules/services/misc/renovate.nix
@@ -100,12 +100,10 @@ in
       ] ++ cfg.runtimePackages;
 
       serviceConfig = {
-        Type = "oneshot";
         User = "renovate";
         Group = "renovate";
         DynamicUser = true;
         LoadCredential = lib.mapAttrsToList (name: value: "SECRET-${name}:${value}") cfg.credentials;
-        RemainAfterExit = false;
         Restart = "on-failure";
         CacheDirectory = "renovate";
         StateDirectory = "renovate";

--- a/nixos/tests/renovate.nix
+++ b/nixos/tests/renovate.nix
@@ -58,12 +58,12 @@ import ./make-test-python.nix (
       machine.succeed("git -C /tmp/kitty push origin")
 
       machine.succeed(f"echo '{accessToken}' > /etc/renovate-token")
-      machine.systemctl("start renovate.service")
+      machine.systemctl("start --wait renovate.service")
 
       machine.succeed("tea pulls list --repo meow/kitty | grep 'Configure Renovate'")
       machine.succeed("tea pulls merge --repo meow/kitty 1")
 
-      machine.systemctl("start renovate.service")
+      machine.systemctl("start --wait renovate.service")
     '';
   }
 )


### PR DESCRIPTION
## Description of changes

By setting `Type=oneshot` for longer running services like Renovate, the unit remains in the `activating` state during the whole lifetime of the main process.
This is probably desirable for short scripts/programs that run setup tasks for other services, like setting up network interfaces.
In those cases one can also make use of `RemainAfterExit` to treat the service as `active` once the main process exits.

In the case of Renovate we do not make use of `RemainAfterExit` and we have a longer running task, so `Type=simple` works better here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
