### PR TITLE
nrr: enable LTO by default

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -162,3 +162,6 @@ fc7a83f8b62e90de5679e993d4d49ca014ea013d
 
 # darwin.stdenv: format with nixfmt-rfc-style (#333962)
 93c10ac9e561c6594d3baaeaff2341907390d9b8
+
+# nrr: format with nixfmt-rfc-style (#334578)
+cffc27daf06c77c0d76bc35d24b929cb9d68c3c9

--- a/pkgs/by-name/nr/nrr/package.nix
+++ b/pkgs/by-name/nr/nrr/package.nix
@@ -1,14 +1,14 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, rustPlatform
-, darwin
-, pkg-config
-, libiconv
-, enableLTO ? true
-, nrxAlias ? true
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  darwin,
+  pkg-config,
+  libiconv,
+  enableLTO ? true,
+  nrxAlias ? true,
 }:
-
 rustPlatform.buildRustPackage rec {
   pname = "nrr";
   version = "0.9.4";
@@ -30,9 +30,7 @@ rustPlatform.buildRustPackage rec {
     libiconv
   ];
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs = [ pkg-config ];
 
   env = lib.optionalAttrs enableLTO {
     CARGO_PROFILE_RELEASE_LTO = "fat";

--- a/pkgs/by-name/nr/nrr/package.nix
+++ b/pkgs/by-name/nr/nrr/package.nix
@@ -43,6 +43,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Minimal, blazing fast npm scripts runner";
+    homepage = "https://github.com/ryanccn/nrr";
     maintainers = with maintainers; [ ryanccn ];
     license = licenses.gpl3Only;
     mainProgram = "nrr";

--- a/pkgs/by-name/nr/nrr/package.nix
+++ b/pkgs/by-name/nr/nrr/package.nix
@@ -5,12 +5,14 @@
 , darwin
 , pkg-config
 , libiconv
+, enableLTO ? true
 , nrxAlias ? true
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nrr";
   version = "0.9.4";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "ryanccn";
@@ -31,6 +33,11 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     pkg-config
   ];
+
+  env = lib.optionalAttrs enableLTO {
+    CARGO_PROFILE_RELEASE_LTO = "fat";
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+  };
 
   postInstall = lib.optionalString nrxAlias "ln -s $out/bin/nr{r,x}";
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Sets `CARGO_PROFILE_RELEASE_LTO="fat"` and `CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1"` in the build environment by default in order to enable LTO; also includes miscellaneous changes such as adding `meta.homepage` and reformatting with `nixfmt-rfc-style`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
