### PR TITLE
josh: 23.12.04 -> 24.08.14

### DIFF
--- a/pkgs/applications/version-management/josh/default.nix
+++ b/pkgs/applications/version-management/josh/default.nix
@@ -13,21 +13,21 @@
 let
   # josh-ui requires javascript dependencies, haven't tried to figure it out yet
   cargoFlags = [ "--workspace" "--exclude" "josh-ui" ];
+  version = "24.08.14";
 in
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "josh";
-  version = "23.12.04";
-  JOSH_VERSION = "r${version}";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "esrlabs";
     repo = "josh";
-    rev = JOSH_VERSION;
-    sha256 = "10fspcafqnv6if5c1h8z9pf9140jvvlrch88w62wsg4w2vhaii0v";
+    rev = "v${version}";
+    hash = "sha256-6U1nhERpPQAVgQm6xwRlHIhslYBLd65DomuGn5yRiSs=";
   };
 
-  cargoHash = "sha256-g4/Z3QUFBeWlqhnZ2VhmdAjya4A+vwXQa7QYZ+CgG8g=";
+  cargoHash = "sha256-s6+Bd4ucwUinrcbjNvlDsf9LhWc/U9SAvBRW7JAmxVA=";
 
   nativeBuildInputs = [
     pkg-config
@@ -43,6 +43,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = cargoFlags;
   cargoTestFlags = cargoFlags;
+
+  # used to teach josh itself about its version number
+  env.JOSH_VERSION = "r${version}";
 
   postInstall = ''
     wrapProgram "$out/bin/josh-proxy" --prefix PATH : "${git}/bin"


### PR DESCRIPTION
This bumps josh to the new release, which includes a fix for the Rust 1.80 compilation issue.

See https://github.com/NixOS/nixpkgs/issues/332957 for context.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
