### PR TITLE
nixos/teeworlds: add option `environmentFile` for injecting secrets

### DIFF
--- a/nixos/modules/services/games/teeworlds.nix
+++ b/nixos/modules/services/games/teeworlds.nix
@@ -418,7 +418,7 @@ in
             -i ${teeworldsConf} \
             -o /run/teeworlds/teeworlds.yaml
         '';
-        ExecStart = "${cfg.package}/bin/teeworlds_srv -f /run/teeworlds/teeworlds.yaml";
+        ExecStart = "${lib.getExe cfg.package} -f /run/teeworlds/teeworlds.yaml";
 
         # Hardening
         CapabilityBoundingSet = false;

--- a/nixos/modules/services/games/teeworlds.nix
+++ b/nixos/modules/services/games/teeworlds.nix
@@ -368,6 +368,33 @@ in
           '';
         };
       };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/var/lib/teeworlds/teeworlds.env";
+        description = ''
+          Environment file as defined in {manpage}`systemd.exec(5)`.
+
+          Secrets may be passed to the service without adding them to the world-readable
+          Nix store, by specifying placeholder variables as the option value in Nix and
+          setting these variables accordingly in the environment file.
+
+          ```
+            # snippet of teeworlds-related config
+            services.teeworlds.password = "$TEEWORLDS_PASSWORD";
+          ```
+
+          ```
+            # content of the environment file
+            TEEWORLDS_PASSWORD=verysecretpassword
+          ```
+
+          Note that this file needs to be available on the host on which
+          `teeworlds` is running.
+        '';
+      };
+
     };
   };
 
@@ -383,7 +410,15 @@ in
 
       serviceConfig = {
         DynamicUser = true;
-        ExecStart = "${cfg.package}/bin/teeworlds_srv -f ${teeworldsConf}";
+        RuntimeDirectory = "teeworlds";
+        RuntimeDirectoryMode = "0700";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
+        ExecStartPre = ''
+          ${pkgs.envsubst}/bin/envsubst \
+            -i ${teeworldsConf} \
+            -o /run/teeworlds/teeworlds.yaml
+        '';
+        ExecStart = "${cfg.package}/bin/teeworlds_srv -f /run/teeworlds/teeworlds.yaml";
 
         # Hardening
         CapabilityBoundingSet = false;


### PR DESCRIPTION
## Description of changes
Adds `environmentFile` which can be used to inject secrets, just like murmur, dendrite, etc. does it.

## Things done
I've tested this locally, and it works just fine.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
