### PR TITLE
chipsec: 1.10.6 -> 1.13.4

### DIFF
--- a/pkgs/tools/security/chipsec/fix-setup-copytree.diff
+++ b/pkgs/tools/security/chipsec/fix-setup-copytree.diff
@@ -1,0 +1,22 @@
+diff --git a/setup.py b/setup.py
+index de527199..341cdec6 100755
+--- a/setup.py
++++ b/setup.py
+@@ -29,7 +29,7 @@ import os
+ import platform
+ import logging
+ import subprocess
+-from shutil import rmtree
++from shutil import rmtree, copytree
+ from setuptools import setup, find_packages, Extension, __version__ as _sutver
+ 
+ if _sutver and int(_sutver.split('.')[0]) < 62:
+@@ -84,7 +84,7 @@ class build_ext(_build_ext):
+         build_driver = os.path.join(self.real_build_lib, 'drivers', 'linux')
+         ko_ext = os.path.join(build_driver, 'chipsec.ko')
+         # We copy the drivers extension to the build directory.
+-        self.copy_tree(os.path.join('drivers', 'linux'), build_driver)
++        copytree(os.path.join('drivers', 'linux'), build_driver)
+         # Run the makefile there.
+         subprocess.check_output(['make', '-C', build_driver])
+         # And copy the resulting .ko to the right place.

--- a/pkgs/tools/security/chipsec/ko-path.diff
+++ b/pkgs/tools/security/chipsec/ko-path.diff
@@ -1,13 +1,13 @@
 diff --git a/chipsec/helper/linux/linuxhelper.py b/chipsec/helper/linux/linuxhelper.py
-index 2fd65140..f3f26bcb 100644
+index 5c415124..8c65c1a0 100644
 --- a/chipsec/helper/linux/linuxhelper.py
 +++ b/chipsec/helper/linux/linuxhelper.py
-@@ -153,7 +153,7 @@ class LinuxHelper(Helper):
+@@ -132,7 +132,7 @@ class LinuxHelper(Helper):
              else:
                  a2 = f'a2=0x{phys_mem_access_prot}'
  
--        driver_path = os.path.join(chipsec.file.get_main_dir(), "chipsec", "helper", "linux", "chipsec.ko")
-+        driver_path = os.path.join(chipsec.file.get_main_dir(), "drivers", "linux", "chipsec.ko")
+-        driver_path = os.path.join(chipsec.library.file.get_main_dir(), "chipsec", "helper", "linux", "chipsec.ko")
++        driver_path = os.path.join(chipsec.library.file.get_main_dir(), "drivers", "linux", "chipsec.ko")
          if not os.path.exists(driver_path):
              driver_path += ".xz"
              if not os.path.exists(driver_path):


### PR DESCRIPTION
## Description of changes

Update chipsec to the latest version.

Tested on:
Lenovo Intel ThinkPads:
- X13 Gen5
- L16 Gen1
- T14 Gen5
- T16 Gen3
- L14 Gen5

The only errors are related to an Intel MTL bug: https://github.com/chipsec/chipsec/issues/2276

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
