### PR TITLE
olm: mark vulnerable

### DIFF
--- a/pkgs/development/libraries/olm/default.nix
+++ b/pkgs/development/libraries/olm/default.nix
@@ -27,5 +27,8 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.matrix.org/matrix-org/olm";
     license = licenses.asl20;
     maintainers = with maintainers; [ tilpner oxzi ];
+    knownVulnerabilities = [
+      "libolm has been deprecated and is affected by various security issues, that will not be fixed: https://soatok.blog/2024/08/14/security-issues-in-matrixs-olm-library/"
+    ];
   };
 }


### PR DESCRIPTION
https://soatok.blog/2024/08/14/security-issues-in-matrixs-olm-library/

## Description of changes

- chatty (†0.8.4)
- fluffychat-linux (†1.20.0)
- fluffychat-web (†1.20.0)
- go-neb-unstable (†2021-07-21)
- gomuks (†0.3.1)
- heisenbridge (†1.14.6)
- homeassistant-test-matrix (†2024.8.1)
- itinerary (†23.08.5)
- itinerary (†24.05.2)
- libquotient (†0.8.2)
- libquotient (†0.8.2)
- libquotient (†0.8.2)
- matrix-commander (†7.6.2)
- maubot (†0.4.2)
- mautrix-discord (†0.7.0)
- mautrix-googlechat (†0.5.1)
- mautrix-meta (†0.3.2)
- mautrix-signal (†0.6.3)
- mautrix-whatsapp (†0.10.9)
- mtxclient (†0.10.0)
- neochat (†23.08.5)
- neochat (†24.05.2)
- nheko (†0.12.0)
- olm (†3.2.16)
- pantalaimon (†0.10.5)
- pantalaimon (†0.10.5)
- purple-matrix-unstable (†2019-06-06)
- python3.11-matrix-nio (†0.24.0)
- python3.11-mautrix (†0.20.6)
- python3.11-mautrix (†0.20.6)
- python3.11-python-olm (†3.2.16)
- python3.11-zulip (†0.9.0)
- python3.12-matrix-nio (†0.24.0)
- python3.12-maubot (†0.4.2)
- python3.12-mautrix (†0.20.6)
- python3.12-mautrix (†0.20.6)
- python3.12-mautrix-facebook (†0.5.1)
- python3.12-mautrix-telegram (†0.15.2)
- python3.12-opsdroid (†0.30.0)
- python3.12-python-olm (†3.2.16)
- python3.12-weechat-matrix (†0.3.0)
- python3.12-zulip (†0.9.0)
- quaternion (†0.0.96.1)
- quaternion (†0.0.96.1)
- quaternion (†0.0.96.1)
- visidata (†3.0.2)
- weechat-matrix-bridge-unstable (†2018-11-19)
- zulip-term (†0.7.0)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
