### PR TITLE
k3s_1_28: 1.28.11+k3s2 -> 1.28.12+k3s1

### DIFF
--- a/nixos/tests/k3s/kubelet-config.nix
+++ b/nixos/tests/k3s/kubelet-config.nix
@@ -53,7 +53,7 @@ import ../make-test-python.nix (
       start_all()
       machine.wait_for_unit("k3s")
       # wait until the node is ready
-      machine.wait_until_succeeds(r"""kubectl wait --for='jsonpath={.status.conditions[?(@.type=="Ready")].status}=True' nodes/${nodeName}""")
+      machine.wait_until_succeeds(r"""kubectl get node ${nodeName} -ojson | jq -e '.status.conditions[] | select(.type == "Ready") | .status == "True"'""")
       # test whether the kubelet registered an inhibitor lock
       machine.succeed("systemd-inhibit --list --no-legend | grep \"kubelet.*k3s-server.*shutdown\"")
       # run kubectl proxy in the background, close stdout through redirection to not wait for the command to finish

--- a/pkgs/applications/networking/cluster/k3s/1_28/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_28/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.11%2Bk3s2/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "199nxfxwr52cddk2ljchhxaigyi0al3lzyc0jy2am4aljlm0jivy"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.12%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "0dhzkn5y3ng7blyxj4bwrhbq5qvl3hq1hzg0h9633h8swv0xbsss"
   },
   "airgap-images-arm": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.11%2Bk3s2/k3s-airgap-images-arm.tar.zst",
-    "sha256": "02riiiwwr0h3zhlxxmjn5p8ws354rr2gk44x3kz9d7sxqn17sz4w"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.12%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "1225nqsfg7p6iq7a7qibzf3d0r7iwn53hnd9w6l189dxqna97015"
   },
   "airgap-images-arm64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.11%2Bk3s2/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "0bs9wj33appb9xpsb2v1xz4xck4qq6g74flnc0mxf9warwr4988r"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.12%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "1lic564naj9323dkkq0z0y10n3j3yfmhixargqqs60syanfvj2p7"
   },
   "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.11%2Bk3s2/k3s-images.txt",
-    "sha256": "0245zra2h8756kq2v8nwl6gji749xlvy1y1bkab8vz5b0vpqhfxy"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.12%2Bk3s1/k3s-images.txt",
+    "sha256": "1my3lfs5rfazcnnpsc9dj84dfnxx88xydrl86z6yw5n5p84x4nif"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
@@ -1,12 +1,12 @@
 {
-  k3sVersion = "1.28.11+k3s2";
-  k3sCommit = "d076d9a78cb835279a04f12c816ff4404884862e";
-  k3sRepoSha256 = "1k1k3qmxc7n2h2i0g52ad4gnpq0qrvxnl7p2y0g9dss1ancgqwsd";
-  k3sVendorHash = "sha256-tzcMcsTmY8lG+9EyYkzYJm1YU/8tGpxpH7oZ4Jl/yNU=";
+  k3sVersion = "1.28.12+k3s1";
+  k3sCommit = "4717e2a58e04f0ba3d9f43d574a7eff01dea9146";
+  k3sRepoSha256 = "02wywlqqna0dj9cam6q3ykb3p5mi96f6lclrg5yhjky7jdvkffds";
+  k3sVendorHash = "sha256-RyUlaGQnfrCm4cB5FRs9IAeF+zn4LzAXmIViU3o30Z4=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
-  k3sRootVersion = "0.12.2";
-  k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";
+  k3sRootVersion = "0.14.0";
+  k3sRootSha256 = "15cs9faw3jishsb5nhgmb5ldjc47hkwf7hz2126fp8ahf80m0fcl";
   k3sCNIVersion = "1.4.0-k3s2";
   k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
   containerdVersion = "1.7.17-k3s1.28";


### PR DESCRIPTION
https://github.com/k3s-io/k3s/releases/tag/v1.28.12%2Bk3s1

## Description of changes

1 package updated:
k3s_1_28 (1.28.11+k3s2 → 1.28.12+k3s1)

1 package built:
k3s_1_28

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
