### PR TITLE
pagefind: update time crate, unbreak

### DIFF
--- a/pkgs/applications/misc/pagefind/default.nix
+++ b/pkgs/applications/misc/pagefind/default.nix
@@ -9,6 +9,7 @@
 , rustc
 , wasm-bindgen-cli
 , wasm-pack
+, fetchpatch
 }:
 
 let
@@ -32,7 +33,15 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-pcgcu9zylSTjj5rxNff+afFBWVpN5sGtlpadG1wb93M=";
   };
 
-  cargoHash = "sha256-E4gjG5GrVWkMKgjQiAvEiSy2/tx/yHKe+5isveMZ9tU=";
+  cargoPatches = [
+    (fetchpatch { # https://github.com/CloudCannon/pagefind/pull/680
+      name = "cargo-update-time.patch";
+      url = "https://github.com/CloudCannon/pagefind/commit/e6778572d225316803180db822f5cc12a936acd2.patch";
+      hash = "sha256-XHpHA1hPIe+wjDQ6LE9hn2jn3eMBOK9Yoo920jfH9do=";
+    })
+  ];
+
+  cargoHash = "sha256-KWWln7QCRo02cOgHy5JNERGS0CvvgsPISwkTZeeNEkg=";
 
   env.npmDeps_web_js = fetchNpmDeps {
     name = "npm-deps-web-js";


### PR DESCRIPTION
## Description of changes

upstream is being unresponsive, so [i bumped it myself](https://github.com/CloudCannon/pagefind/pull/680)

tracking: https://github.com/NixOS/nixpkgs/issues/332957

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
