### PR TITLE
python3Packages.locust: init at 2.31.2

### DIFF
--- a/pkgs/development/python-modules/locust/default.nix
+++ b/pkgs/development/python-modules/locust/default.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  buildPythonPackage,
+  python,
+  callPackage,
+  fetchFromGitHub,
+  poetry-core,
+  poetry-dynamic-versioning,
+  pytestCheckHook,
+  configargparse,
+  cryptography,
+  flask,
+  flask-cors,
+  flask-login,
+  gevent,
+  geventhttpclient,
+  msgpack,
+  psutil,
+  pyquery,
+  pyzmq,
+  requests,
+  retry,
+  tomli,
+  werkzeug,
+}:
+
+buildPythonPackage rec {
+  pname = "locust";
+  version = "2.31.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "locustio";
+    repo = "locust";
+    rev = "refs/tags/${version}";
+    hash = "sha256-xDquVQjkWVER9h0a6DHWRZH6KtRf0jsThycSojDEdh4=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'script = "pre_build.py"' ""
+
+    substituteInPlace locust/test/test_main.py \
+      --replace-fail '"locust"' '"${placeholder "out"}/bin/locust"'
+
+    substituteInPlace locust/test/test_log.py \
+      --replace-fail '"locust"' '"${placeholder "out"}/bin/locust"'
+  '';
+
+  webui = callPackage ./webui.nix {
+    inherit version;
+    src = "${src}/locust/webui";
+  };
+
+  preBuild = ''
+    mkdir -p $out/${python.sitePackages}/${pname}
+    ln -sf ${webui} $out/${python.sitePackages}/${pname}/webui
+  '';
+
+  build-system = [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
+
+  pythonRelaxDeps = [
+    # version 0.7.0.dev0 is not considered to be >= 0.6.3
+    "flask-login"
+  ];
+
+  dependencies = [
+    configargparse
+    flask
+    flask-cors
+    flask-login
+    gevent
+    geventhttpclient
+    msgpack
+    psutil
+    pyzmq
+    requests
+    tomli
+    werkzeug
+  ];
+
+  pythonImportsCheck = [ "locust" ];
+
+  nativeCheckInputs = [
+    cryptography
+    pyquery
+    pytestCheckHook
+    retry
+  ];
+
+  # locust's test suite is very flaky, due to heavy reliance on timing-based tests and access to the
+  # network.
+  doCheck = false;
+
+  meta = {
+    description = "Developer-friendly load testing framework";
+    homepage = "https://docs.locust.io/";
+    changelog = "https://github.com/locustio/locust/blob/${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jokatzke ];
+  };
+}

--- a/pkgs/development/python-modules/locust/webui.nix
+++ b/pkgs/development/python-modules/locust/webui.nix
@@ -1,0 +1,32 @@
+{
+  stdenv,
+  fetchYarnDeps,
+  yarnConfigHook,
+  yarnBuildHook,
+  nodejs,
+  version,
+  src,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "locust-ui";
+  inherit version src;
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-ek02mjB8DsBUOR28WSuqj6oVvxTq8EKTNXWFFI3OhuU=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+  ];
+
+  dontNpmPrune = true;
+  yarnBuildScript = "build";
+  postInstall = ''
+    mkdir -p $out/dist
+    cp -r dist/** $out/dist
+  '';
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7550,6 +7550,8 @@ self: super: with self; {
 
   lockfile = callPackage ../development/python-modules/lockfile { };
 
+  locust = callPackage ../development/python-modules/locust { };
+
   log-symbols = callPackage ../development/python-modules/log-symbols { };
 
   logbook = callPackage ../development/python-modules/logbook { };


### PR DESCRIPTION
## Description of changes

Add https://locust.io/, making #199746 redundant

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
  - [x] Using `--sandbox` flag of `nix build`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
