### PR TITLE
pdf-sign: Fix program name in help text

### DIFF
--- a/pkgs/by-name/pd/pdf-sign/package.nix
+++ b/pkgs/by-name/pd/pdf-sign/package.nix
@@ -38,8 +38,11 @@ stdenv.mkDerivation {
     runHook preInstall
 
     for exe in "pdf-sign" "pdf-create-empty" "pdf-from-text"; do
-      install -Dm755 $exe -t $out/bin
-      wrapProgram $out/bin/$exe --prefix PATH : ${binPath}
+      # Install wrapped programs into $out/lib so that they are not renamed.
+      # Renaming them, like wrapProgram does, would produce the wrong output
+      # from `--help`.
+      install -Dm755 $exe -t $out/lib
+      makeWrapper $out/lib/$exe $out/bin/$exe --prefix PATH : ${binPath}
     done
 
     runHook postInstall


### PR DESCRIPTION
## Description of changes
Use correct program name, rather than wrapped program, in usage text.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
