### PR TITLE
lib/types: add `record` (simplified submodule)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -71,6 +71,7 @@ let
       modules = callLibs ./modules.nix;
       options = callLibs ./options.nix;
       types = callLibs ./types.nix;
+      fields = callLibs ./fields.nix;
 
       # constants
       licenses = callLibs ./licenses.nix;
@@ -438,6 +439,7 @@ let
         revOrTag
         repoRevToName
         ;
+      inherit (self.fields) mkField;
       inherit (self.modules)
         evalModules
         setDefaultModuleLocation

--- a/lib/fields.nix
+++ b/lib/fields.nix
@@ -26,9 +26,8 @@
       internal ? null,
       # Whether the field shows up in the manual. Default: true. Use false to hide the field and any sub-options from submodules. Use "shallow" to hide only sub-options.
       visible ? null,
+      # Whether the field is omitted from the final record when undefined. Default false.
+      optional ? null,
     }@attrs:
-    assert lib.assertMsg (
-      (attrs.optional or false) -> (!attrs ? default)
-    ) "mkField: `optional` is true, but a `default` is provided";
     attrs // { _type = "field"; };
 }

--- a/lib/fields.nix
+++ b/lib/fields.nix
@@ -1,0 +1,34 @@
+{ lib }:
+{
+  /**
+    Creates a Field attribute set. mkField accepts an attribute set with the following keys:
+
+     Example:
+       mkField { }  // => { _type = "field"; }
+       mkField { default = "foo"; } // => { _type = "field"; default = "foo"; }
+       mkField { optional = true; } // => { _type = "field"; optional = true; }
+  */
+  mkField =
+    {
+      # Default value used when no definition is given in the configuration.
+      default ? null,
+      # Textual representation of the default, for the manual.
+      defaultText ? null,
+      # Example value used in the manual.
+      example ? null,
+      # String describing the field.
+      description ? null,
+      # Related packages used in the manual (see `genRelatedPackages` in ../nixos/lib/make-fields-doc/default.nix).
+      relatedPackages ? null,
+      # Option type, providing type-checking and value merging.
+      type ? null,
+      # Whether the field is for NixOS developers only.
+      internal ? null,
+      # Whether the field shows up in the manual. Default: true. Use false to hide the field and any sub-options from submodules. Use "shallow" to hide only sub-options.
+      visible ? null,
+    }@attrs:
+    assert lib.assertMsg (
+      (attrs.optional or false) -> (!attrs ? default)
+    ) "mkField: `optional` is true, but a `default` is provided";
+    attrs // { _type = "field"; };
+}

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -178,6 +178,14 @@ checkConfigOutput '^2016$' config.people.alice.nixerSince ./declare-record-wildc
 # record wildcard field
 checkConfigOutput '^true$' config.people.alice.mechKeyboard ./declare-record-wildcard.nix ./define-record-alice-prefs.nix
 
+# record definition without corresponding field
+checkConfigError 'A definition for option .people.mike. has an unknown field' config.people.mike.age ./declare-record.nix ./define-record-mike.nix
+# record optional field without definition
+checkConfigError "attribute 'age' in selection path 'config.people.alice.age' not found" config.people.alice.age ./declare-record-optional-field.nix ./define-record-alice.nix
+# record optional field with definition
+checkConfigOutput '^27$' config.people.mike.age ./declare-record-optional-field.nix ./define-record-mike.nix
+
+
 
 if false; then
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -169,7 +169,7 @@ checkConfigError 'define-record-mallory.nix.: "beginning of time"' config.people
 checkConfigOutput '^true$' config.people.bob.isCool ./declare-record.nix ./define-record-alice.nix ./define-record-bob.nix
 
 # record field bad default definition
-checkConfigError 'In .the default value of option people.mallory.: "yeah"' config.people.mallory.isCool ./declare-record-bad-default.nix ./define-record-mallory.nix
+checkConfigError 'In .the default value of field people.mallory.: "yeah"' config.people.mallory.isCool ./declare-record-bad-default.nix ./define-record-mallory.nix
 checkConfigError 'A definition for option .people.mallory.isCool. is not of type .boolean.. Definition values:' config.people.mallory.isCool ./declare-record-bad-default.nix ./define-record-mallory.nix
 
 # record field works in presence of wildcard
@@ -179,7 +179,7 @@ checkConfigOutput '^2016$' config.people.alice.nixerSince ./declare-record-wildc
 checkConfigOutput '^true$' config.people.alice.mechKeyboard ./declare-record-wildcard.nix ./define-record-alice-prefs.nix
 
 # record definition without corresponding field
-checkConfigError 'A definition for option .people.mike. has an unknown field' config.people.mike.age ./declare-record.nix ./define-record-mike.nix
+checkConfigError 'A definition for option .people.mike. has an unknown fields' config.people.mike.age ./declare-record.nix ./define-record-mike.nix
 # record optional field without definition
 checkConfigError "attribute 'age' in selection path 'config.people.alice.age' not found" config.people.alice.age ./declare-record-optional-field.nix ./define-record-alice.nix
 # record optional field with definition

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -185,6 +185,11 @@ checkConfigError "attribute 'age' in selection path 'config.people.alice.age' no
 # record optional field with definition
 checkConfigOutput '^27$' config.people.mike.age ./declare-record-optional-field.nix ./define-record-mike.nix
 
+#TODO:
+# - test empty definitions
+# - test neseted records
+# - test nested optional records
+# - etc?
 
 
 if false; then

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -157,6 +157,30 @@ checkConfigError() {
     fi
 }
 
+# record field
+checkConfigOutput '^"Alice"$' config.people.alice.name ./declare-record.nix ./define-record-alice.nix ./define-record-bob.nix
+checkConfigOutput '^2019$' config.people.bob.nixerSince ./declare-record.nix ./define-record-alice.nix ./define-record-bob.nix
+
+# record field type error
+checkConfigError 'A definition for option .people.mallory.nixerSince. is not of type .signed integer.. Definition values' config.people.mallory.nixerSince ./declare-record.nix ./define-record-mallory.nix
+checkConfigError 'define-record-mallory.nix.: "beginning of time"' config.people.mallory.nixerSince ./declare-record.nix ./define-record-mallory.nix
+
+# record field default
+checkConfigOutput '^true$' config.people.bob.isCool ./declare-record.nix ./define-record-alice.nix ./define-record-bob.nix
+
+# record field bad default definition
+checkConfigError 'In .the default value of option people.mallory.: "yeah"' config.people.mallory.isCool ./declare-record-bad-default.nix ./define-record-mallory.nix
+checkConfigError 'A definition for option .people.mallory.isCool. is not of type .boolean.. Definition values:' config.people.mallory.isCool ./declare-record-bad-default.nix ./define-record-mallory.nix
+
+# record field works in presence of wildcard
+checkConfigOutput '^2016$' config.people.alice.nixerSince ./declare-record-wildcard.nix ./define-record-alice-prefs.nix
+
+# record wildcard field
+checkConfigOutput '^true$' config.people.alice.mechKeyboard ./declare-record-wildcard.nix ./define-record-alice-prefs.nix
+
+
+if false; then
+
 # Shorthand meta attribute does not duplicate the config
 checkConfigOutput '^"one two"$' config.result ./shorthand-meta.nix
 
@@ -781,6 +805,8 @@ checkConfigError 'A definition for option .* is not of type .signed integer.*' c
 checkConfigOutput '^true$' config.v2checkedPass ./add-check.nix
 checkConfigError 'A definition for option .* is not of type .attribute set of signed integer.*' config.v2checkedFail ./add-check.nix
 
+
+fi
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules/declare-record-bad-default.nix
+++ b/lib/tests/modules/declare-record-bad-default.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+
+  person = types.record {
+    fields = {
+      nixerSince = mkOption { type = types.int; };
+      name = mkOption { type = types.str; };
+      isCool = mkOption {
+        type = types.bool;
+        default = "yeah";
+      };
+    };
+  };
+
+in
+{
+  options.people = mkOption { type = types.attrsOf person; };
+}

--- a/lib/tests/modules/declare-record-bad-default.nix
+++ b/lib/tests/modules/declare-record-bad-default.nix
@@ -1,13 +1,13 @@
 { lib, ... }:
 
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkField mkOption types;
 
   person = types.record {
     fields = {
-      nixerSince = mkOption { type = types.int; };
-      name = mkOption { type = types.str; };
-      isCool = mkOption {
+      nixerSince = mkField { type = types.int; };
+      name = mkField { type = types.str; };
+      isCool = mkField {
         type = types.bool;
         default = "yeah";
       };

--- a/lib/tests/modules/declare-record-optional-field.nix
+++ b/lib/tests/modules/declare-record-optional-field.nix
@@ -1,17 +1,18 @@
 { lib, ... }:
 
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkField mkOption types;
 
   person = types.record {
     fields = {
-      nixerSince = mkOption { type = types.int; };
-      name = mkOption { type = types.str; };
+      nixerSince = mkField { type = types.int; };
+      name = mkField { type = types.str; };
+      age = mkField {
+        type = types.ints.unsigned;
+        optional = true;
+      };
     };
-    optionalFields = {
-      age = mkOption { type = types.ints.unsigned; };
-    };
-    wildcard = mkOption { type = types.bool; };
+    freeformType = types.bool;
   };
 
 in

--- a/lib/tests/modules/declare-record-optional-field.nix
+++ b/lib/tests/modules/declare-record-optional-field.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+
+  person = types.record {
+    fields = {
+      nixerSince = mkOption { type = types.int; };
+      name = mkOption { type = types.str; };
+    };
+    optionalFields = {
+      age = mkOption { type = types.ints.unsigned; };
+    };
+    wildcard = mkOption { type = types.bool; };
+  };
+
+in
+{
+  options.people = mkOption { type = types.attrsOf person; };
+}

--- a/lib/tests/modules/declare-record-wildcard.nix
+++ b/lib/tests/modules/declare-record-wildcard.nix
@@ -1,14 +1,14 @@
 { lib, ... }:
 
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkField mkOption types;
 
   person = types.record {
     fields = {
-      nixerSince = mkOption { type = types.int; };
-      name = mkOption { type = types.str; };
+      nixerSince = mkField { type = types.int; };
+      name = mkField { type = types.str; };
     };
-    wildcard = mkOption { type = types.bool; };
+    freeformType = types.bool;
   };
 
 in

--- a/lib/tests/modules/declare-record-wildcard.nix
+++ b/lib/tests/modules/declare-record-wildcard.nix
@@ -1,0 +1,17 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+
+  person = types.record {
+    fields = {
+      nixerSince = mkOption { type = types.int; };
+      name = mkOption { type = types.str; };
+    };
+    wildcard = mkOption { type = types.bool; };
+  };
+
+in
+{
+  options.people = mkOption { type = types.attrsOf person; };
+}

--- a/lib/tests/modules/declare-record.nix
+++ b/lib/tests/modules/declare-record.nix
@@ -1,13 +1,13 @@
 { lib, ... }:
 
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkField mkOption types;
 
   person = types.record {
     fields = {
-      nixerSince = mkOption { type = types.int; };
-      name = mkOption { type = types.str; };
-      isCool = mkOption {
+      nixerSince = mkField { type = types.int; };
+      name = mkField { type = types.str; };
+      isCool = mkField {
         type = types.bool;
         default = true;
       };

--- a/lib/tests/modules/declare-record.nix
+++ b/lib/tests/modules/declare-record.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+
+  person = types.record {
+    fields = {
+      nixerSince = mkOption { type = types.int; };
+      name = mkOption { type = types.str; };
+      isCool = mkOption {
+        type = types.bool;
+        default = true;
+      };
+    };
+  };
+
+in
+{
+  options.people = mkOption { type = types.attrsOf person; };
+}

--- a/lib/tests/modules/define-record-alice-prefs.nix
+++ b/lib/tests/modules/define-record-alice-prefs.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+{
+  people.alice = {
+    nixerSince = 2016;
+    name = "Alice";
+    hiRes = true;
+    mechKeyboard = true;
+    spiders = false;
+  };
+}

--- a/lib/tests/modules/define-record-alice.nix
+++ b/lib/tests/modules/define-record-alice.nix
@@ -1,0 +1,6 @@
+{
+  people.alice = {
+    nixerSince = 2016;
+    name = "Alice";
+  };
+}

--- a/lib/tests/modules/define-record-bob.nix
+++ b/lib/tests/modules/define-record-bob.nix
@@ -1,0 +1,6 @@
+{
+  people.bob = {
+    nixerSince = 2019;
+    name = "Bob";
+  };
+}

--- a/lib/tests/modules/define-record-mallory.nix
+++ b/lib/tests/modules/define-record-mallory.nix
@@ -1,0 +1,6 @@
+{
+  people.mallory = {
+    nixerSince = "beginning of time";
+    name = "Bobby";
+  };
+}

--- a/lib/tests/modules/define-record-mike.nix
+++ b/lib/tests/modules/define-record-mike.nix
@@ -1,0 +1,7 @@
+{
+  people.mike = {
+    nixerSince = 2020;
+    name = "Mike";
+    age = 27;
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1632,7 +1632,7 @@ let
         merged = a.typeMerge b.functor;
       in
       if merged == null then setType "merge-error" { error = "Cannot merge types"; } else merged;
-  };
+  } // import ./types/record.nix { inherit lib; };
 
 in
 outer_types // outer_types.types

--- a/lib/types/record.nix
+++ b/lib/types/record.nix
@@ -1,0 +1,104 @@
+{ lib }:
+
+let
+  inherit (lib)
+    mapAttrs
+    zipAttrsWith
+    removeAttrs
+    attrNames
+    showOption
+    mergeDefinitions
+    mkOptionType
+    isAttrs
+    ;
+
+  record =
+    args@{
+      fields,
+      wildcard ? null,
+    }:
+    let
+      fields = mapAttrs (
+        name: value:
+        if value._type or null != "option" then
+          throw "Record field `${lib.escapeNixIdentifier name}` must be declared with `mkOption`."
+        else if value ? apply then
+          throw "In field ${lib.escapeNixIdentifier name} records do not support options with `apply`"
+        else if value ? readOnly then
+          throw "In field ${lib.escapeNixIdentifier name} records do not support options with `readOnly`"
+        else
+          value
+      ) args.fields;
+      wildcard =
+        if args.wildcard or null == null then
+          null
+        else if args.wildcard._type or null != "option" then
+          throw "Record wildcard must be declared with `mkOption`."
+        else if args.wildcard ? apply then
+          throw "Records do not support options with `apply`, but wildcard has `apply`."
+        else
+          args.wildcard;
+    in
+    mkOptionType {
+      name = "record";
+      description = if wildcard == null then "record" else "open record of ${wildcard.description}";
+      descriptionClass = if wildcard == null then "noun" else "composite";
+      check = isAttrs;
+      merge =
+        loc: defs:
+        let
+          data = zipAttrsWith (name: values: values) (
+            map (
+              def:
+              mapAttrs (_fieldName: fieldValue: {
+                inherit (def) file;
+                value = fieldValue;
+              }) def.value
+            ) defs
+          );
+          requiredFieldValues = mapAttrs (
+            fieldName: fieldOption:
+            builtins.addErrorContext ("while evaluating the field `${fieldName}' of option `${showOption loc}'")
+              (
+                (mergeDefinitions (loc ++ [ fieldName ]) fieldOption.type (
+                  data.${fieldName} or [ ]
+                  ++ (
+                    if fieldOption ? default then
+                      [
+                        {
+                          value = fieldOption.default;
+                          file = "the default value of option ${showOption loc}";
+                        }
+                      ]
+                    else
+                      [ ]
+                  )
+                )).mergedValue
+              )
+          ) fields;
+          extraData = removeAttrs data (attrNames fields);
+        in
+        if wildcard == null then
+          if extraData == { } then
+            requiredFieldValues
+          else
+            throw "A definition for option `${showOption loc}' has an unknown field."
+        else
+          requiredFieldValues
+          // mapAttrs (
+            fieldName: fieldDefs:
+            builtins.addErrorContext (
+              "while evaluating the wildcard field `${fieldName}' of option `${showOption loc}'"
+            ) ((mergeDefinitions (loc ++ [ fieldName ]) wildcard.type fieldDefs).mergedValue)
+          ) extraData;
+      nestedTypes = fields // {
+        # potential collision with `_wildcard` field
+        _wildcard = wildcard;
+      };
+    };
+
+in
+# public
+{
+  inherit record;
+}

--- a/lib/types/record.nix
+++ b/lib/types/record.nix
@@ -7,6 +7,7 @@ let
     removeAttrs
     attrNames
     showOption
+    optional
     mergeDefinitions
     mkOptionType
     isAttrs
@@ -61,17 +62,11 @@ let
             builtins.addErrorContext "while evaluating the field `${fieldName}' of option `${showOption loc}'" (
               (mergeDefinitions (loc ++ [ fieldName ]) fieldOption.type (
                 data.${fieldName} or [ ]
-                ++ (
-                  if fieldOption ? default then
-                    [
-                      {
-                        value = fieldOption.default;
-                        file = "the default value of option ${showOption loc}";
-                      }
-                    ]
-                  else
-                    [ ]
-                )
+                # FIXME: isn't this handled by `mergeDefinitions` already?
+                ++ optional (fieldOption ? default) {
+                  value = fieldOption.default;
+                  file = "the default value of option ${showOption loc}";
+                }
               )).mergedValue
             )
           ) fields;

--- a/lib/types/record.nix
+++ b/lib/types/record.nix
@@ -103,7 +103,10 @@ let
       nestedTypes = lib.optionalAttrs (freeformType != null) {
         inherit freeformType;
       };
-      # TODO: getSubOptions for documentation purposes, etc
+      # TODO: include `_freeformOptions`
+      getSubOptions = prefix: lib.mapAttrs (name: field:
+        mergeDefinitions (prefix ++ [ name ]) field.type [ ]
+      ) checkedFields;
     };
 
 in

--- a/lib/types/record.nix
+++ b/lib/types/record.nix
@@ -58,23 +58,22 @@ let
           );
           requiredFieldValues = mapAttrs (
             fieldName: fieldOption:
-            builtins.addErrorContext ("while evaluating the field `${fieldName}' of option `${showOption loc}'")
-              (
-                (mergeDefinitions (loc ++ [ fieldName ]) fieldOption.type (
-                  data.${fieldName} or [ ]
-                  ++ (
-                    if fieldOption ? default then
-                      [
-                        {
-                          value = fieldOption.default;
-                          file = "the default value of option ${showOption loc}";
-                        }
-                      ]
-                    else
-                      [ ]
-                  )
-                )).mergedValue
-              )
+            builtins.addErrorContext "while evaluating the field `${fieldName}' of option `${showOption loc}'" (
+              (mergeDefinitions (loc ++ [ fieldName ]) fieldOption.type (
+                data.${fieldName} or [ ]
+                ++ (
+                  if fieldOption ? default then
+                    [
+                      {
+                        value = fieldOption.default;
+                        file = "the default value of option ${showOption loc}";
+                      }
+                    ]
+                  else
+                    [ ]
+                )
+              )).mergedValue
+            )
           ) fields;
           extraData = removeAttrs data (attrNames fields);
         in
@@ -87,12 +86,13 @@ let
           requiredFieldValues
           // mapAttrs (
             fieldName: fieldDefs:
-            builtins.addErrorContext (
+            builtins.addErrorContext
               "while evaluating the wildcard field `${fieldName}' of option `${showOption loc}'"
-            ) ((mergeDefinitions (loc ++ [ fieldName ]) wildcard.type fieldDefs).mergedValue)
+              ((mergeDefinitions (loc ++ [ fieldName ]) wildcard.type fieldDefs).mergedValue)
           ) extraData;
       nestedTypes = fields // {
         # potential collision with `_wildcard` field
+        # TODO: should we prevent fields from having a wildcard?
         _wildcard = wildcard;
       };
     };

--- a/lib/types/record.nix
+++ b/lib/types/record.nix
@@ -3,11 +3,13 @@
 let
   inherit (lib)
     mapAttrs
-    zipAttrsWith
+    concatMapAttrs
+    zipAttrs
     removeAttrs
     attrNames
     showOption
     optional
+    optionalAttrs
     mergeDefinitions
     mkOptionType
     isAttrs
@@ -16,94 +18,77 @@ let
   record =
     {
       fields ? { },
-      optionalFields ? { },
       wildcard ? null,
     }@args:
-    # TODO: assert that at least one arg is provided, i.e. args != { }
     let
-      checkFields = mapAttrs (
-        name: value:
-        if value._type or null != "option" then
-          throw "Record field `${lib.escapeNixIdentifier name}` must be declared with `mkOption`."
-        else if value ? apply then
-          throw "In field ${lib.escapeNixIdentifier name} records do not support options with `apply`"
-        else if value ? readOnly then
-          throw "In field ${lib.escapeNixIdentifier name} records do not support options with `readOnly`"
+      checkField =
+        name: field:
+        if field._type or null != "field" then
+          throw "Record field `${lib.escapeNixIdentifier name}` must be declared with `mkField`."
         else
-          value
-      );
-      fields' = checkFields fields;
-      # TODO: should we also check optionalFields have no default?
-      optionalFields' = checkFields optionalFields;
-      wildcard =
-        if args.wildcard or null == null then
-          null
-        else if args.wildcard._type or null != "option" then
-          throw "Record wildcard must be declared with `mkOption`."
-        else if args.wildcard ? apply then
-          throw "Records do not support options with `apply`, but wildcard has `apply`."
-        else
-          args.wildcard;
+          field;
+      checkedFields = mapAttrs checkField fields;
+      # TODO: maybe specify a freeformType instead of a wildcard-field
+      wildcard = if args ? wildcard then checkField "wildcard" args.wildcard else null;
     in
     mkOptionType {
       name = "record";
-      description = if wildcard == null then "record" else "open record of ${wildcard.description}";
+      description = if wildcard == null then "record" else "open record of ${wildcard.type.description}";
       descriptionClass = if wildcard == null then "noun" else "composite";
       check = isAttrs;
       merge =
         loc: defs:
         let
-          data = zipAttrsWith (name: values: values) (
+          data = zipAttrs (
             map (
               def:
-              mapAttrs (_fieldName: fieldValue: {
+              mapAttrs (_: value: {
                 inherit (def) file;
-                value = fieldValue;
+                inherit value;
               }) def.value
             ) defs
           );
-          requiredFieldValues = mapAttrs (
-            fieldName: fieldOption:
-            builtins.addErrorContext "while evaluating the field `${fieldName}' of option `${showOption loc}'" (
-              (mergeDefinitions (loc ++ [ fieldName ]) fieldOption.type (
-                data.${fieldName} or [ ]
-                ++ optional (fieldOption ? default) {
-                  value = lib.mkOptionDefault fieldOption.default;
-                  file = "the default value of option ${showOption loc}";
-                }
-              )).mergedValue
-            )
-          ) fields';
-          optionalFieldValues = lib.concatMapAttrs (
-            fieldName: fieldOption:
+          fieldValues = concatMapAttrs (
+            fieldName: field:
             let
-              opt = mergeDefinitions (loc ++ [ fieldName ]) fieldOption.type (data.${fieldName} or [ ]);
+              fieldOption = mergeDefinitions (loc ++ [ fieldName ]) fieldOption.type (
+                data.${fieldName} or [ ]
+                ++ optional (field ? default) {
+                  value = lib.mkOptionDefault fieldOption.default;
+                  file = "the default value of field ${showOption loc}";
+                }
+              );
             in
-            builtins.addErrorContext
-              "while evaluating the optional field `${fieldName}' of option `${showOption loc}'"
-              (lib.optionalAttrs opt.isDefined { ${fieldName} = opt.mergedValue; })
-          ) optionalFields';
-          extraData = removeAttrs data (attrNames fields' ++ attrNames optionalFields');
-        in
-        if wildcard == null then
-          if extraData == { } then
-            requiredFieldValues
-          else
-            throw "A definition for option `${showOption loc}' has an unknown field."
-        else
-          requiredFieldValues
-          // optionalFieldValues
-          // mapAttrs (
+            builtins.addErrorContext "while evaluating the field `${fieldName}' of option `${showOption loc}'" (
+              optionalAttrs (!field.optional || fieldOption.isDefined) {
+                ${fieldName} = fieldOption.mergedValue;
+              }
+            )
+          ) checkedFields;
+          extraData = removeAttrs data (attrNames checkedFields);
+          extraValues = mapAttrs (
             fieldName: fieldDefs:
             builtins.addErrorContext
               "while evaluating the wildcard field `${fieldName}' of option `${showOption loc}'"
               ((mergeDefinitions (loc ++ [ fieldName ]) wildcard.type fieldDefs).mergedValue)
           ) extraData;
-      nestedTypes = fields' // {
+        in
+        if wildcard == null then
+          if extraData == { } then
+            fieldValues
+          else
+            # As per _module.check
+            throw ''
+              A definition for option `${showOption loc}' has an unknown fields:
+              ${lib.concatMapAttrsStringSep "\n" (name: defs: "`${name}'${lib.showDefs defs}") extraData}''
+        else
+          fieldValues // extraValues;
+      nestedTypes = checkedFields // {
         # potential collision with `_wildcard` field
         # TODO: should we prevent fields from having a wildcard?
         _wildcard = wildcard;
       };
+      # TODO: getSubOptions for documentation purposes, etc
     };
 
 in

--- a/nixos/doc/manual/development/freeform-modules.section.md
+++ b/nixos/doc/manual/development/freeform-modules.section.md
@@ -16,17 +16,17 @@ submodules.
 
 <!-- TODO: Link to more details on the record and submodule types -->
 
-Wildcard records can also be used to achieve the same thing, and may be
+Freeform records can also be used to achieve the same thing, and may be
 preferred in many scenarios due to their improved performance when
 compared to submodules and also the ability to declare "optional" fields.
 
-Wildcards records are used by simply passing `wildcard = types.anything`
+Freeform records are used by simply passing `freeformType = types.anything`
 to a record type definition.
 
-::: {#ex-wildcard-record .example}
-### Wildcard record
+::: {#ex-freeform-record .example}
+### Freeform record
 
-Most freeform submodules can also be represented as wildcard records.
+Most freeform submodules can also be represented as freeform records.
 
 The following example is equivalent to the first submodule example:
 
@@ -36,20 +36,16 @@ The following example is equivalent to the first submodule example:
   options.settings = lib.mkOption {
     type = lib.types.record {
 
-      wildcard = lib.types.str;
+      freeformType = lib.types.str;
 
       # We want this attribute to be checked for the correct type
-      fields.port = lib.mkOption {
-        type = lib.types.port;
-        # Declaring the option also allows defining a default value
-        default = 8080;
-      };
-
-      # We could use an "optional" field, instead of supplying a default
-      optionalFields.port = lib.mkOption {
-        type = lib.types.port;
-      };
-
+      fields = {
+        port = lib.mkField {
+          type = lib.types.port;
+          default = 8080;
+          # We could also set `optional = true` instead of setting a default:
+          # optional = true;
+        };
     };
   };
 }

--- a/nixos/doc/manual/development/freeform-modules.section.md
+++ b/nixos/doc/manual/development/freeform-modules.section.md
@@ -1,5 +1,7 @@
 # Freeform modules {#sec-freeform-modules}
 
+<!-- TODO: Consider re-writing this doc to favor `types.record` over `types.submodule` -->
+
 Freeform modules allow you to define values for option paths that have
 not been declared explicitly. This can be used to add attribute-specific
 types to what would otherwise have to be `attrsOf` options in order to
@@ -11,6 +13,47 @@ associated option will be merged using the freeform type and combined
 into the resulting `config` set. Since this feature nullifies name
 checking for entire option trees, it is only recommended for use in
 submodules.
+
+<!-- TODO: Link to more details on the record and submodule types -->
+
+Wildcard records can also be used to achieve the same thing, and may be
+preferred in many scenarios due to their improved performance when
+compared to submodules and also the ability to declare "optional" fields.
+
+Wildcards records are used by simply passing `wildcard = types.anything`
+to a record type definition.
+
+::: {#ex-wildcard-record .example}
+### Wildcard record
+
+Most freeform submodules can also be represented as wildcard records.
+
+The following example is equivalent to the first submodule example:
+
+```nix
+{ lib, config, ... }: {
+
+  options.settings = lib.mkOption {
+    type = lib.types.record {
+
+      wildcard = lib.types.str;
+
+      # We want this attribute to be checked for the correct type
+      fields.port = lib.mkOption {
+        type = lib.types.port;
+        # Declaring the option also allows defining a default value
+        default = 8080;
+      };
+
+      # We could use an "optional" field, instead of supplying a default
+      optionalFields.port = lib.mkOption {
+        type = lib.types.port;
+      };
+
+    };
+  };
+}
+```
 
 ::: {#ex-freeform-module .example}
 ### Freeform submodule

--- a/nixos/doc/manual/development/freeform-modules.section.md
+++ b/nixos/doc/manual/development/freeform-modules.section.md
@@ -16,9 +16,7 @@ submodules.
 
 <!-- TODO: Link to more details on the record and submodule types -->
 
-Freeform records can also be used to achieve the same thing, and may be
-preferred in many scenarios due to their improved performance when
-compared to submodules and also the ability to declare "optional" fields.
+A similar result can be achieved with `types.record` with a `wildcardType`. Whereas `submodule` is designed to host logic inside of it, `record` is just a data container, and that lets it implement optional fields.
 
 Freeform records are used by simply passing `freeformType = types.anything`
 to a record type definition.

--- a/nixos/doc/manual/development/freeform-modules.section.md
+++ b/nixos/doc/manual/development/freeform-modules.section.md
@@ -29,7 +29,8 @@ Most freeform submodules can also be represented as freeform records.
 The following example is equivalent to the first submodule example:
 
 ```nix
-{ lib, config, ... }: {
+{ lib, config, ... }:
+{
 
   options.settings = lib.mkOption {
     type = lib.types.record {
@@ -44,12 +45,12 @@ The following example is equivalent to the first submodule example:
           # We could also set `optional = true` instead of setting a default:
           # optional = true;
         };
+      };
     };
   };
 }
 ```
 
-::: {#ex-freeform-module .example}
 ### Freeform submodule
 
 The following shows a submodule assigning a freeform type that allows

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -239,9 +239,27 @@ merging is handled.
 :   A string wrapped using `lib.mkLuaInline`. Allows embedding lua expressions
     inline within generated lua. Multiple definitions cannot be merged.
 
-## Submodule types {#sec-option-types-submodule}
+## Record and module types {#sec-option-types-submodule}
 
-Submodules are detailed in [Submodule](#section-option-types-submodule).
+Records and submodules are detailed in [Record](#section-option-types-record) and [Submodule](#section-option-types-submodule) respectively.
+While submodules provide the full power of the module system, records are usually faster to evaluate and may be preferred in many scenarios.
+
+`types.record` { `fields` ? {}, `optionalFields` ? {}, `wildcard` ? null }.
+
+:   A set of sub options, represented as fields. A field can be almost
+    any option, including record or submodule type options.
+    It has parameters:
+
+    -   *`fields`* An attribute set of options that will be merged into
+        the final value.
+
+    -   *`optionalFields`* An attribute set of options that will only be
+        merged into the final value _if_ they are defined.
+
+    -   *`wildcard`* An option-type used to merge unknown field
+        definitions into the final value.
+
+        If null, definitions for unknown fields will throw an error.
 
 `types.submodule` *`o`*
 
@@ -469,6 +487,48 @@ Composed types are types that take a type as parameter. `listOf
     function *`f`* which takes an argument of type *`from`* and return a
     value of type *`to`*. Can be used to preserve backwards compatibility
     of an option if its type was changed.
+
+## Record {#section-option-types-record}
+
+<!-- TODO: Add some examples!! -->
+
+Records are a simpler alternative to [submodules](#section-option-types-submodule).
+Rather than merging fully-fledged modules, a record consists only of "field" sub-options and an optional "wildcard" type, similar to a submodule's `freeformType`.
+
+    ::: {.note}
+    Because records are not implemented using the full module system, they can usually be evaluated significantly faster than submodules.
+    :::
+
+### Record fields
+
+A record's sub-options are declared as `fields`. A field can be almost any option (restrictions listed below).
+You can also use other record or submodule options in a record's fields to implement "nested" options.
+
+#### Restrictions
+
+- Fields must be options (e.g. created using `lib.mkOption`)
+- Fields cannot have an `apply` function
+- Fields cannot be `readOnly`
+
+### Record optional fields
+
+In addition to _required_ fields, a record can contain "optional" fields. Optional fields are similar to wildcard or freeform types, in that they are only merged into the final value when defined.
+This contrasts "required" fields and submodule sub-options, which will still be merged into the final value when undefined as a stub value that throws a "used but not defined" error when read.
+
+Optional fields are a unique feature, not currently supported by submodules.
+
+### Restrictions
+- All the same restrictions for required fields apply
+- Additionally, optional fields cannot have a `default`
+
+### Record wildcard type
+
+Records can optionally be declared with a "wildcard" type, which can be used to allow definitions that do not match the explicitly declared "field" options.
+Any definition that does not match a field option will be checked against the "wildcard" type, for example you could set `wildcard = types.anything`.
+
+    ::: {.info}
+    A wildcard record with no fields can be thought of as equivialent to `types.attrsOf`!
+    :::
 
 ## Submodule {#section-option-types-submodule}
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -490,18 +490,18 @@ Composed types are types that take a type as parameter. `listOf
 <!-- TODO: Add some examples!! -->
 
 Records are a simpler alternative to [submodules](#section-option-types-submodule).
-Rather than merging fully-fledged modules, a record consists only of "field" sub-options and an optional "wildcard" type, similar to a submodule's `freeformType`.
+Rather than merging fully-fledged modules, a record consists only of "fields" and an optional `freeformType`.
 
     ::: {.note}
     Because records are not implemented using the full module system, they can usually be evaluated significantly faster than submodules.
     :::
 
-### Record fields
+### Record fields {#section-option-types-record-fields}
 
-A record's sub-options are declared as `fields`, using `lib.mkField`. A field is very similar to an option.
+A record's fields are declared using `lib.mkField`. A field is very similar to an option.
 You can also use record or submodule type fields to implement _nested_ options.
 
-### Record optional fields
+### Record optional fields {#section-option-types-record-optional-fields}
 
 Normally, options and fields will always be present in the final value. When undefined they are present as a value that **throws**.
 
@@ -512,7 +512,7 @@ This means you can do things like `config.recordOption ? optionalField`.
     Optional fields should not define a `default`.
     :::
 
-### Freeform Records
+### Freeform Records {#section-option-types-record-freeform}
 
 Records can optionally be declared with a freeformType, which can be used to allow definitions that do not match the explicitly declared fields.
 Any definition that does not match a field will be checked against the freeformType, for example you could set `freeformType = types.anything`.

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -244,7 +244,7 @@ merging is handled.
 Records and submodules are detailed in [Record](#section-option-types-record) and [Submodule](#section-option-types-submodule) respectively.
 While submodules provide the full power of the module system, records are usually faster to evaluate and may be preferred in many scenarios.
 
-`types.record` { `fields` ? {}, `wildcard` ? null }.
+`types.record` { `fields` ? {}, `freeformType` ? null }.
 
 :   A set of sub options, represented as fields. A field can be almost
     any option, including record or submodule type options.
@@ -253,10 +253,10 @@ While submodules provide the full power of the module system, records are usuall
     -   *`fields`* An attribute set of fields that will be merged into
         the final value.
 
-    -   *`wildcard`* An option-type used to merge unknown field
+    -   *`freeformType`* An option-type used to merge unknown field
         definitions into the final value.
 
-        If null, definitions for unknown fields will throw an error.
+        If not defined, definitions for unknown fields will throw an error.
 
 `types.submodule` *`o`*
 
@@ -512,13 +512,13 @@ This means you can do things like `config.recordOption ? optionalField`.
     Optional fields should not define a `default`.
     :::
 
-### Record wildcard type
+### Freeform Records
 
-Records can optionally be declared with a "wildcard" type, which can be used to allow definitions that do not match the explicitly declared fields.
-Any definition that does not match a field will be checked against the "wildcard" type, for example you could set `wildcard = types.anything`.
+Records can optionally be declared with a freeformType, which can be used to allow definitions that do not match the explicitly declared fields.
+Any definition that does not match a field will be checked against the freeformType, for example you could set `freeformType = types.anything`.
 
     ::: {.info}
-    A wildcard record with no fields can be thought of as equivialent to `types.attrsOf`!
+    A freeform record without fields is effectively equivialent to `types.attrsOf`.
     :::
 
 ## Submodule {#section-option-types-submodule}

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -244,17 +244,14 @@ merging is handled.
 Records and submodules are detailed in [Record](#section-option-types-record) and [Submodule](#section-option-types-submodule) respectively.
 While submodules provide the full power of the module system, records are usually faster to evaluate and may be preferred in many scenarios.
 
-`types.record` { `fields` ? {}, `optionalFields` ? {}, `wildcard` ? null }.
+`types.record` { `fields` ? {}, `wildcard` ? null }.
 
 :   A set of sub options, represented as fields. A field can be almost
     any option, including record or submodule type options.
     It has parameters:
 
-    -   *`fields`* An attribute set of options that will be merged into
+    -   *`fields`* An attribute set of fields that will be merged into
         the final value.
-
-    -   *`optionalFields`* An attribute set of options that will only be
-        merged into the final value _if_ they are defined.
 
     -   *`wildcard`* An option-type used to merge unknown field
         definitions into the final value.
@@ -501,30 +498,24 @@ Rather than merging fully-fledged modules, a record consists only of "field" sub
 
 ### Record fields
 
-A record's sub-options are declared as `fields`. A field can be almost any option (restrictions listed below).
-You can also use other record or submodule options in a record's fields to implement "nested" options.
-
-#### Restrictions
-
-- Fields must be options (e.g. created using `lib.mkOption`)
-- Fields cannot have an `apply` function
-- Fields cannot be `readOnly`
+A record's sub-options are declared as `fields`, using `lib.mkField`. A field is very similar to an option.
+You can also use record or submodule type fields to implement _nested_ options.
 
 ### Record optional fields
 
-In addition to _required_ fields, a record can contain "optional" fields. Optional fields are similar to wildcard or freeform types, in that they are only merged into the final value when defined.
-This contrasts "required" fields and submodule sub-options, which will still be merged into the final value when undefined as a stub value that throws a "used but not defined" error when read.
+Normally, options and fields will always be present in the final value. When undefined they are present as a value that **throws**.
 
-Optional fields are a unique feature, not currently supported by submodules.
+Unlike normal options, record fields can be marked as `optional`. Optional fields are only present in the final value when they are defined.
+This means you can do things like `config.recordOption ? optionalField`.
 
-### Restrictions
-- All the same restrictions for required fields apply
-- Additionally, optional fields cannot have a `default`
+    ::: {.note}
+    Optional fields should not define a `default`.
+    :::
 
 ### Record wildcard type
 
-Records can optionally be declared with a "wildcard" type, which can be used to allow definitions that do not match the explicitly declared "field" options.
-Any definition that does not match a field option will be checked against the "wildcard" type, for example you could set `wildcard = types.anything`.
+Records can optionally be declared with a "wildcard" type, which can be used to allow definitions that do not match the explicitly declared fields.
+Any definition that does not match a field will be checked against the "wildcard" type, for example you could set `wildcard = types.anything`.
 
     ::: {.info}
     A wildcard record with no fields can be thought of as equivialent to `types.attrsOf`!

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1771,6 +1771,18 @@
   "sec-option-types-composed": [
     "index.html#sec-option-types-composed"
   ],
+  "section-option-types-record": [
+    "index.html#section-option-types-record"
+  ],
+  "section-option-types-record-fields": [
+    "index.html#section-option-types-record-fields"
+  ],
+  "section-option-types-record-optional-fields": [
+    "index.html#section-option-types-record-optional-fields"
+  ],
+  "section-option-types-record-freeform": [
+    "index.html#section-option-types-record-freeform"
+  ],
   "section-option-types-submodule": [
     "index.html#section-option-types-submodule"
   ],
@@ -1842,6 +1854,9 @@
   ],
   "sec-freeform-modules": [
     "index.html#sec-freeform-modules"
+  ],
+  "ex-freeform-record": [
+    "index.html#ex-freeform-record"
   ],
   "ex-freeform-module": [
     "index.html#ex-freeform-module"


### PR DESCRIPTION
## Description of changes

Work in progress draft, based on #257511 by @roberth, but without `types.fix` and with additional support for optional fields.

Pushing an early draft, I'll polish up the changes and this description shortly.

The main TODO for me is to add additional test-cases to cover more exotic useage. I've added a few inline TODO comments regarding things I'm unsure of or plan to investigate.

More TODO from https://github.com/NixOS/nixpkgs/pull/257511/files#r1621120811:
- required fields can be returned without looking at their declarations, making it a bit more lazy, which is good for performance and robustness
- if we don't have optional or wildcard fields, we can return all the fields without even looking at the definitions
- it avoids having to partition the required and optional fields at runtime, which we'd then have to do; it's more efficient this way

---

- Fixes #158598
- Closes #333799
- Based on #257511
- See also #158594

cc @roberth @infinisil @GaetanLepage @traxys

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
