### PR TITLE
emacs: replace cd with pushd/popd in buildPhase of melpaBuild

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/melpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/melpa.nix
@@ -111,13 +111,15 @@ genericBuild ({
   buildPhase = ''
     runHook preBuild
 
-    cd "$NIX_BUILD_TOP"
+    pushd "$NIX_BUILD_TOP"
 
     emacs --batch -Q \
         -L "$NIX_BUILD_TOP/package-build" \
         -l "$melpa2nix" \
         -f melpa2nix-build-package \
         $ename $melpaVersion $commit
+
+    popd
 
     runHook postBuild
     '';

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lsp-bridge/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lsp-bridge/default.nix
@@ -77,7 +77,6 @@ melpaBuild {
   checkPhase = ''
     runHook preCheck
 
-    cd "$sourceRoot"
     mkfifo test.log
     cat < test.log &
     HOME=$(mktemp -d) python -m test.test

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -384,26 +384,6 @@ let
           };
         });
 
-        libgit = super.libgit.overrideAttrs(attrs: {
-          nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ [ pkgs.cmake ];
-          buildInputs = attrs.buildInputs ++ [ pkgs.libgit2 ];
-          dontUseCmakeBuildDir = true;
-          postPatch = ''
-            sed -i s/'add_subdirectory(libgit2)'// CMakeLists.txt
-          '';
-          postBuild = ''
-            pushd working/libgit
-            make
-            popd
-          '';
-          postInstall = (attrs.postInstall or "") + "\n" + ''
-            outd=$(echo $out/share/emacs/site-lisp/elpa/libgit-**)
-            mkdir $outd/build
-            install -m444 -t $outd/build ./source/src/libegit2.so
-            rm -r $outd/src $outd/Makefile $outd/CMakeLists.txt
-          '';
-        });
-
         evil-magit = buildWithGit super.evil-magit;
 
         eopengrok = buildWithGit super.eopengrok;

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -186,13 +186,13 @@ let
           buildInputs = old.buildInputs ++ [ pkgs.sqlite ];
 
           postBuild = ''
-            cd source/sqlite
+            pushd sqlite
             make
-            cd -
+            popd
           '';
 
           postInstall = (old.postInstall or "") + "\n" + ''
-            install -m=755 -D source/sqlite/emacsql-sqlite \
+            install -m=755 -D sqlite/emacsql-sqlite \
               $out/share/emacs/site-lisp/elpa/emacsql-${old.version}/sqlite/emacsql-sqlite
           '';
 
@@ -203,13 +203,13 @@ let
           buildInputs = old.buildInputs ++ [ pkgs.sqlite ];
 
           postBuild = ''
-            cd source/sqlite
+            pushd sqlite
             make
-            cd -
+            popd
           '';
 
           postInstall = (old.postInstall or "") + "\n" + ''
-            install -m=755 -D source/sqlite/emacsql-sqlite \
+            install -m=755 -D sqlite/emacsql-sqlite \
               $out/share/emacs/site-lisp/elpa/emacsql-sqlite-${old.version}/sqlite/emacsql-sqlite
           '';
 
@@ -296,7 +296,7 @@ let
           '';
 
           postInstall = (old.postInstall or "") + "\n" + ''
-            install source/hotfuzz-module.so $out/share/emacs/site-lisp/elpa/hotfuzz-*
+            install hotfuzz-module.so $out/share/emacs/site-lisp/elpa/hotfuzz-*
           '';
         });
 
@@ -304,17 +304,17 @@ let
           cmakeFlags = old.cmakeFlags or [ ] ++ [ "-DCMAKE_INSTALL_BINDIR=bin" ];
           env.NIX_CFLAGS_COMPILE = "-UCLANG_RESOURCE_DIR";
           preConfigure = ''
-            cd server
+            pushd server
           '';
           preBuild = ''
             make
             install -D bin/irony-server $out/bin/irony-server
-            cd ..
+            popd
           '';
           checkPhase = ''
-            cd source/server
+            pushd server
             make check
-            cd ../..
+            popd
           '';
           preFixup = ''
             rm -rf $out/share/emacs/site-lisp/elpa/*/server
@@ -343,18 +343,14 @@ let
           buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.enchant2 ];
 
           postBuild = ''
-            pushd working/jinx
             NIX_CFLAGS_COMPILE="$($PKG_CONFIG --cflags enchant-2) $NIX_CFLAGS_COMPILE"
             $CC -shared -o jinx-mod${libExt} jinx-mod.c -lenchant-2
-            popd
           '';
 
           postInstall = (old.postInstall or "") + "\n" + ''
-            pushd source
             outd=$(echo $out/share/emacs/site-lisp/elpa/jinx-*)
             install -m444 --target-directory=$outd jinx-mod${libExt}
             rm $outd/jinx-mod.c $outd/emacs-module.h
-            popd
           '';
 
           meta = old.meta // {
@@ -366,17 +362,13 @@ let
           buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.sqlite ];
 
           postBuild = ''
-            pushd working/sqlite3
             make
-            popd
           '';
 
           postInstall = (old.postInstall or "") + "\n" + ''
-            pushd source
             outd=$out/share/emacs/site-lisp/elpa/sqlite3-*
             install -m444 -t $outd sqlite3-api.so
             rm $outd/*.c $outd/*.h
-            popd
           '';
 
           meta = old.meta // {
@@ -539,14 +531,14 @@ let
           '';
 
           postBuild = ''
-            cd source/server
+            pushd server
             make
-            cd -
+            popd
           '';
 
           postInstall = (old.postInstall or "") + "\n" + ''
             mkdir -p $out/bin
-            install -m755 -Dt $out/bin ./source/server/telega-server
+            install -m755 -Dt $out/bin server/telega-server
           '';
         });
 
@@ -676,10 +668,8 @@ let
           # we need the proper out directory to exist, so we do this in the
           # postInstall instead of postBuild
           postInstall = (old.postInstall or "") + "\n" + ''
-            pushd source/build >/dev/null
             make
             install -m444 -t $out/share/emacs/site-lisp/elpa/vterm-** ../*.so
-            popd > /dev/null
             rm -rf $out/share/emacs/site-lisp/elpa/vterm-**/{CMake*,build,*.c,*.h}
           '';
         });
@@ -717,8 +707,7 @@ let
             buildInputs =
               old.buildInputs ++
               (with pkgs.darwin.apple_sdk.frameworks; [CoreServices Foundation]);
-            buildPhase = (old.buildPhase or "") + ''
-              cd source
+            postBuild = (old.postBuild or "") + ''
               $CXX -O3 -framework CoreServices -framework Foundation osx-dictionary.m -o osx-dictionary-cli
             '';
             postInstall = (old.postInstall or "") + "\n" + ''

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -717,7 +717,6 @@ let
             buildInputs =
               old.buildInputs ++
               (with pkgs.darwin.apple_sdk.frameworks; [CoreServices Foundation]);
-            dontUnpack = false;
             buildPhase = (old.buildPhase or "") + ''
               cd source
               $CXX -O3 -framework CoreServices -framework Foundation osx-dictionary.m -o osx-dictionary-cli


### PR DESCRIPTION
## Description of changes

It is better to not change the working directory.

One example showing the benefit is the rewriting[1] of lspce, where
the Rust build hook assumes the working directory is unchanged.

[1]: https://github.com/NixOS/nixpkgs/pull/334476


Due to the limitation of nix, this PR triggers rebuilds of all packages built with `melpaBuild`.  However, it only affects a small number of package which changes their working directory.  I use a heuristic way to find those packages: searching for `cd`, `source`, `packages`, `recipes`, `working`, `..`, `pushd` and `popd`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
