### PR TITLE
tinygo: disable build on hydra

### DIFF
--- a/pkgs/development/compilers/tinygo/default.nix
+++ b/pkgs/development/compilers/tinygo/default.nix
@@ -123,5 +123,6 @@ buildGoModule rec {
     description = "Go compiler for small places";
     license = licenses.bsd3;
     maintainers = with maintainers; [ Madouura muscaln ];
+    hydraPlatforms = [ ]; # src with submodules is 6.3G, hydra fails with "Output limit exceeded"
   };
 }


### PR DESCRIPTION
## Description of changes

- disable build on hydra

Since update to `0.31.1` `tinygo` does not build on hydra because of "Output limit exceeded" (`src` is too big):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.tinygo.x86_64-linux
https://hydra.nixos.org/build/268960641

Most likely this change to `lib/cmsis-svd` drastically increased submodule size between `0.30.0` and `0.31.1`:
https://github.com/tinygo-org/tinygo/pull/4007
https://github.com/tinygo-org/tinygo/pull/4030

Current `src` size on unstable:
```text
6.3G    /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source
6.3G    /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source/lib
5.6G    /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source/lib/cmsis-svd
5.6G    /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source/lib/cmsis-svd/data
280M    /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source/lib/CMSIS
274M    /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source/lib/CMSIS/CMSIS
179M    /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source/lib/stm32-svd
165M    /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source/lib/stm32-svd/svd
98M     /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source/lib/mingw-w64
71M     /nix/store/0qszq6dmvg1vd8gzjlmax73k5qynhpsb-source/lib/mingw-w64/mingw-w64-headers
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
