### PR TITLE
c3d: unstable-2021-09-14 -> 1.4.1-unstable-2024-08-07

### DIFF
--- a/pkgs/applications/graphics/c3d/default.nix
+++ b/pkgs/applications/graphics/c3d/default.nix
@@ -1,19 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, cmake, itk_5_2, Cocoa }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  itk,
+  Cocoa,
+}:
 
 stdenv.mkDerivation rec {
-  pname   = "c3d";
-  version = "unstable-2021-09-14";
+  pname = "c3d";
+  version = "1.4.1-unstable-2024-08-07";
 
   src = fetchFromGitHub {
     owner = "pyushkevich";
-    repo = pname;
-    rev = "cc06e6e2f04acd3d6faa3d8c9a66b499f02d4388";
-    sha256 = "sha256:1ql1y6694njsmdapywhppb54viyw8wdpaxxr1b3hm2rqhvwmhn52";
+    repo = "c3d";
+    rev = "9e6174153ab87eae014f5b802413478c8fbc9a1a";
+    hash = "sha256-s2/XRyKoiMnF6cRsxxNUSlNtksbOyKSlk8hAGxJELqw=";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ itk_5_2 ]
-    ++ lib.optional stdenv.isDarwin Cocoa;
+  buildInputs = [ itk ] ++ lib.optional stdenv.isDarwin Cocoa;
 
   cmakeFlags = [ "-DCONVERT3D_USE_ITK_REMOTE_MODULES=OFF" ];
 


### PR DESCRIPTION
## Description of changes

Routine update; apply `nixfmt`; unpin `itk_5_2` in favour of `itk`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
