### PR TITLE
nut: 2.8.0 -> 2.8.2

### DIFF
--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -7,6 +7,7 @@
 , freeipmi
 , gd
 , i2c-tools
+, libgpiod_1
 , libmodbus
 , libtool
 , libusb1
@@ -42,6 +43,7 @@ stdenv.mkDerivation rec {
       src = ./hardcode-paths.patch;
       avahi = "${avahi}/lib";
       freeipmi = "${freeipmi}/lib";
+      libgpiod = "${libgpiod_1}/lib";
       libusb = "${libusb1}/lib";
       neon = "${neon}/lib";
       libmodbus = "${libmodbus}/lib";
@@ -49,14 +51,13 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ neon libusb1 openssl udev avahi freeipmi libmodbus libtool i2c-tools net-snmp gd ];
+  buildInputs = [ neon libusb1 openssl udev avahi freeipmi libgpiod_1 libmodbus libtool i2c-tools net-snmp gd ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config makeWrapper ];
 
   configureFlags =
     [ "--with-all"
       "--with-ssl"
-      "--without-gpio"
       "--without-powerman" # Until we have it ...
       "--with-systemdsystemunitdir=$(out)/lib/systemd/system"
       "--with-systemdshutdowndir=$(out)/lib/systemd/system-shutdown"

--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nut";
-  version = "2.8.0";
+  version = "2.8.2";
 
   src = fetchurl {
     url = "https://networkupstools.org/source/${lib.versions.majorMinor version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-w+WnCNp5e3xwtlPTexIGoAD8tQO4VRn+TN9jU/eSv+U=";
+    sha256 = "sha256-5LSwy+fdObqQl75/fXh7sv/74132Tf9Ttf45PWWcWX0=";
   };
 
   patches = [
@@ -56,6 +56,7 @@ stdenv.mkDerivation rec {
   configureFlags =
     [ "--with-all"
       "--with-ssl"
+      "--without-gpio"
       "--without-powerman" # Until we have it ...
       "--with-systemdsystemunitdir=$(out)/lib/systemd/system"
       "--with-systemdshutdowndir=$(out)/lib/systemd/system-shutdown"
@@ -82,9 +83,6 @@ stdenv.mkDerivation rec {
 
     substituteInPlace $out/lib/systemd/system/nut-driver-enumerator.path \
       --replace "$out/etc/ups.conf" "/etc/nut/ups.conf"
-
-    # we don't need init.d scripts
-    rm -r $out/share/solaris-init
 
     # Suspicious/overly broad rule, remove it until we know better
     rm $out/etc/udev/rules.d/52-nut-ipmipsu.rules

--- a/pkgs/applications/misc/nut/hardcode-paths.patch
+++ b/pkgs/applications/misc/nut/hardcode-paths.patch
@@ -1,9 +1,9 @@
 --- a/common/common.c
 +++ b/common/common.c
-@@ -991,6 +991,12 @@ ssize_t select_write(const int fd, const void *buf, const size_t buflen, const t
+@@ -1990,6 +1990,12 @@ ssize_t select_write(serial_handler_t *fd, const void *buf, const size_t buflen,
   * communications media and/or vendor protocol.
   */
- static const char * search_paths[] = {
+ static const char * search_paths_builtin[] = {
 +	"@avahi@",
 +	"@freeipmi@",
 +	"@libusb@",
@@ -12,4 +12,4 @@
 +	"@netsnmp@",
  	/* Use the library path (and bitness) provided during ./configure first */
  	LIBDIR,
- 	"/usr"LIBDIR,
+ 	"/usr"LIBDIR,		/* Note: this can lead to bogus strings like */

--- a/pkgs/applications/misc/nut/hardcode-paths.patch
+++ b/pkgs/applications/misc/nut/hardcode-paths.patch
@@ -1,11 +1,12 @@
 --- a/common/common.c
 +++ b/common/common.c
-@@ -1990,6 +1990,12 @@ ssize_t select_write(serial_handler_t *fd, const void *buf, const size_t buflen,
+@@ -1990,6 +1990,13 @@ ssize_t select_write(serial_handler_t *fd, const void *buf, const size_t buflen,
   * communications media and/or vendor protocol.
   */
  static const char * search_paths_builtin[] = {
 +	"@avahi@",
 +	"@freeipmi@",
++	"@libgpiod@",
 +	"@libusb@",
 +	"@neon@",
 +	"@libmodbus@",


### PR DESCRIPTION
## Description of changes

* nut wants to build the new GPIO driver by default. Our libgpiod
  version isn't compatible and configure fails with

    checking for libgpiod version via pkg-config (1.0.0 minimum required)... 2.1.3 found
    checking for libgpiod cflags... -I/nix/store/igaf4d9zr8nmmk91icf7f2w0mw23238p-libgpiod-2.1.3/include
    checking for libgpiod ldflags... -L/nix/store/igaf4d9zr8nmmk91icf7f2w0mw23238p-libgpiod-2.1.3/lib -lgpiod
    checking for gpiod.h... yes
    checking for gpiod_chip_open_by_name... no
    checking for gpiod_chip_close... yes
    [...]
    configure: error: No supported GPIO library was found, required for GPIO driver

  So disable that for now.

* Refresh our search path patch.

* solaris-init doesn't exist in the output anymore, so we can remove the
  removal.

I tested this upgrade with my UPS on NixOS 24.05.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
