### PR TITLE
open-webui: Add `environmentFile` option

### DIFF
--- a/nixos/modules/services/misc/open-webui.nix
+++ b/nixos/modules/services/misc/open-webui.nix
@@ -60,6 +60,17 @@ in
         '';
       };
 
+      environmentFile = lib.mkOption {
+        description = ''
+          Environment file to be passed to the systemd service.
+          Useful for passing secrets to the service to prevent them from being
+          world-readable in the Nix store.
+        '';
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/var/lib/secrets/openWebuiSecrets";
+      };
+
       openFirewall = lib.mkOption {
         type = types.bool;
         default = false;
@@ -86,6 +97,7 @@ in
 
       serviceConfig = {
         ExecStart = "${lib.getExe cfg.package} serve --host ${cfg.host} --port ${toString cfg.port}";
+        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "open-webui";
         RuntimeDirectory = "open-webui";

--- a/nixos/tests/open-webui.nix
+++ b/nixos/tests/open-webui.nix
@@ -1,6 +1,7 @@
-{ lib, ... }:
+{ config, lib, ... }:
 let
   mainPort = "8080";
+  webuiName = "NixOS Test";
 in
 {
   name = "open-webui";
@@ -18,16 +19,31 @@ in
             # Requires network connection
             RAG_EMBEDDING_MODEL = "";
           };
+
+          # Test that environment variables can be
+          # overridden through a file.
+          environmentFile = config.node.pkgs.writeText "test.env" ''
+            WEBUI_NAME="${webuiName}"
+          '';
         };
       };
   };
 
   testScript = ''
+    import json
+
     machine.start()
 
     machine.wait_for_unit("open-webui.service")
     machine.wait_for_open_port(${mainPort})
 
     machine.succeed("curl http://127.0.0.1:${mainPort}")
+
+    # Load the Web UI config JSON and parse it.
+    webui_config_json = machine.succeed("curl http://127.0.0.1:${mainPort}/api/config")
+    webui_config = json.loads(webui_config_json)
+
+    # Check that the name was overridden via the environmentFile option.
+    assert webui_config["name"] == "${webuiName} (Open WebUI)"
   '';
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This option allows passing secrets to Open WebUI without directly exposing them in nix configuration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
