### PR TITLE
tea: Install shell completions for bash, zsh and fish

### DIFF
--- a/pkgs/by-name/te/tea/package.nix
+++ b/pkgs/by-name/te/tea/package.nix
@@ -30,6 +30,10 @@ buildGoModule rec {
     mainProgram = "tea";
   };
 
+  ldflags = [
+    "-X code.gitea.io/tea/cmd.Version=${version}"
+  ];
+
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''

--- a/pkgs/by-name/te/tea/package.nix
+++ b/pkgs/by-name/te/tea/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitea,
+  installShellFiles,
 }:
 
 buildGoModule rec {
@@ -28,4 +29,16 @@ buildGoModule rec {
     ];
     mainProgram = "tea";
   };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd tea \
+      --bash <($out/bin/tea completion bash) \
+      --fish <($out/bin/tea completion fish) \
+      --zsh <($out/bin/tea completion zsh)
+
+    mkdir $out/share/powershell/ -p
+    $out/bin/tea completion pwsh > $out/share/powershell/tea.Completion.ps1
+  '';
 }


### PR DESCRIPTION
## Description of changes

The `tea` tool comes with shell completions for bash, zsh, fish and ps: https://gitea.com/gitea/tea/src/branch/main/contrib. This change installs the completions for bash and zsh. Currently, there is no simple way to get the fish completion script since it is generated at runtime and directly written on disk. Maybe someone who knows better can add the fish completion later.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## TODO

- [x] Install fish completion from `XDG_CONFIG_HOME` (my attempts failed with "undefined variable" errors)
- [x] Patch or Update bash and ZSH completions to set `PROG`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
