### PR TITLE
weblate: 5.6.2 -> 5.7

### DIFF
--- a/nixos/modules/services/web-apps/weblate.nix
+++ b/nixos/modules/services/web-apps/weblate.nix
@@ -42,9 +42,10 @@ let
       SESSION_COOKIE_SECURE = ENABLE_HTTPS
       DATA_DIR = "${dataDir}"
       CACHE_DIR = f"{DATA_DIR}/cache"
-      STATIC_ROOT = "${finalPackage.static}/static"
+      STATIC_ROOT = "${finalPackage.static}"
       MEDIA_ROOT = "/var/lib/weblate/media"
-      COMPRESS_ROOT = "${finalPackage.static}/compressor-cache"
+      COMPRESS_ROOT = "${finalPackage.static}"
+      COMPRESS_OFFLINE = True
       DEBUG = False
 
       DATABASES = {
@@ -85,6 +86,13 @@ let
       CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 
       VCS_BACKENDS = ("weblate.vcs.git.GitRepository",)
+
+      SITE_URL = "https://{}".format(SITE_DOMAIN)
+
+      # WebAuthn
+      OTP_WEBAUTHN_RP_NAME = SITE_TITLE
+      OTP_WEBAUTHN_RP_ID = SITE_DOMAIN.split(":")[0]
+      OTP_WEBAUTHN_ALLOWED_ORIGINS = [SITE_URL]
 
     ''
     + lib.optionalString cfg.smtp.enable ''
@@ -205,8 +213,7 @@ in
 
         locations = {
           "= /favicon.ico".alias = "${finalPackage}/${python.sitePackages}/weblate/static/favicon.ico";
-          "/static/".alias = "${finalPackage.static}/static/";
-          "/static/CACHE/".alias = "${finalPackage.static}/compressor-cache/CACHE/";
+          "/static/".alias = "${finalPackage.static}/";
           "/media/".alias = "/var/lib/weblate/media/";
           "/".proxyPass = "http://unix:///run/weblate.socket";
         };

--- a/pkgs/by-name/we/weblate/package.nix
+++ b/pkgs/by-name/we/weblate/package.nix
@@ -34,7 +34,7 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "weblate";
-  version = "5.6.2";
+  version = "5.7";
 
   pyproject = true;
 
@@ -47,7 +47,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "WeblateOrg";
     repo = "weblate";
     rev = "weblate-${version}";
-    sha256 = "sha256-t/hnigsKjdWCkUd8acNWhYVFmZ7oGn74+12347MkFgM=";
+    sha256 = "sha256-h5+0lOMD+H0ehtZ0bngA9bI5va1I5KjZH9boaEtXJPo=";
   };
 
   patches = [
@@ -55,27 +55,15 @@ python.pkgs.buildPythonApplication rec {
     ./cache.lock.patch
   ];
 
-  # Relax dependency constraints
-  # mistletoe: https://github.com/WeblateOrg/weblate/commit/50df46a25dda2b7b39de86d4c65ecd7a685f62e6
-  # borgbackup: https://github.com/WeblateOrg/weblate/commit/355c81c977c59948535a98a35a5c05d7e6909703
-  # django-crispy-forms: https://github.com/WeblateOrg/weblate/commit/7b341c523ed9b3b41ecfbc5c92dd6156992e4f32
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace '"mistletoe>=1.3.0,<1.4"' '"mistletoe>=1.3.0,<1.5"' \
-      --replace '"borgbackup>=1.2.5,<1.3"' '"borgbackup>=1.2.5,<1.5"' \
-      --replace '"django-crispy-forms>=2.1,<2.3"' '"django-crispy-forms>=2.1,<2.4"'
-  '';
-
   build-system = with python.pkgs; [ setuptools ];
 
   # Build static files into a separate output
   postBuild =
     let
       staticSettings = writeText "static_settings.py" ''
-        STATIC_ROOT = os.environ["static"] + "/static"
-        COMPRESS_ENABLED = True
+        DEBUG = False
+        STATIC_ROOT = os.environ["static"]
         COMPRESS_OFFLINE = True
-        COMPRESS_ROOT = os.environ["static"] + "/compressor-cache"
         # So we don't need postgres dependencies
         DATABASES = {}
       '';
@@ -99,6 +87,7 @@ python.pkgs.buildPythonApplication rec {
     cryptography
     cssselect
     cython
+    cyrtranslit
     diff-match-patch
     django-appconf
     django-celery-beat
@@ -107,6 +96,8 @@ python.pkgs.buildPythonApplication rec {
     django-crispy-forms
     django-filter
     django-redis
+    django-otp
+    django-otp-webauthn
     django
     djangorestframework
     filelock
@@ -117,7 +108,6 @@ python.pkgs.buildPythonApplication rec {
     iniparse
     jsonschema
     lxml
-    misaka
     mistletoe
     nh3
     openpyxl
@@ -131,6 +121,7 @@ python.pkgs.buildPythonApplication rec {
     pyparsing
     python-dateutil
     python-redis-lock
+    qrcode
     rapidfuzz
     redis
     requests

--- a/pkgs/development/python-modules/cyrtranslit/default.nix
+++ b/pkgs/development/python-modules/cyrtranslit/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  unittestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "cyrtranslit";
+  version = "1.1.1";
+  pyproject = true;
+
+  # Pypi tarball doesn't contain tests/
+  src = fetchFromGitHub {
+    owner = "opendatakosovo";
+    repo = "cyrillic-transliteration";
+    rev = "v${version}";
+    sha256 = "sha256-t8UTOmjGqjmxU7+Po0/HmOPWAvcgZibaUC9dMlttA/0=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  pythonImportsCheck = [ "cyrtranslit" ];
+
+  meta = with lib; {
+    description = "Transliterate Cyrillic script to Latin script and vice versa";
+    homepage = "https://github.com/opendatakosovo/cyrillic-transliteration";
+    license = licenses.mit;
+    maintainers = with maintainers; [ erictapen ];
+  };
+
+}

--- a/pkgs/development/python-modules/django-otp-webauthn/default.nix
+++ b/pkgs/development/python-modules/django-otp-webauthn/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  django,
+  django-otp,
+  djangorestframework,
+  webauthn,
+}:
+
+buildPythonPackage rec {
+  pname = "django-otp-webauthn";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "django_otp_webauthn";
+    sha256 = "sha256-+Y46/PDeXL9zayoZykaU63faQmnLHzYPmqJJeRBx+hs=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    django
+    django-otp
+    djangorestframework
+    webauthn
+  ];
+
+  # Tests are on the roadmap, but not yet implemented
+
+  pythonImportsCheck = [ "django_otp_webauthn" ];
+
+  meta = with lib; {
+    description = "Passkey support for Django";
+    homepage = "https://github.com/Stormbase/django-otp-webauthn";
+    changelog = "https://github.com/Stormbase/django-otp-webauthn/blob/main/CHANGELOG.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ erictapen ];
+  };
+
+}

--- a/pkgs/development/python-modules/django-otp/default.nix
+++ b/pkgs/development/python-modules/django-otp/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "django-otp";
-  version = "1.5.0";
+  version = "1.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "django-otp";
     repo = "django-otp";
     rev = "v${version}";
-    hash = "sha256-c0Yr41S1LFBzcDIK2etOP3rYcCPaThDs+XGiw4WP/ks=";
+    hash = "sha256-1tatp4CQowaHZ5w9IPiKZ3rT5jREXZnwK9iSAYaUhis=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3395,6 +3395,8 @@ self: super: with self; {
 
   django-otp = callPackage ../development/python-modules/django-otp { };
 
+  django-otp-webauthn = callPackage ../development/python-modules/django-otp-webauthn { };
+
   django-paintstore = callPackage ../development/python-modules/django-paintstore { };
 
   django-parler = callPackage ../development/python-modules/django-parler { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2761,6 +2761,8 @@ self: super: with self; {
 
   cypherpunkpay = callPackage ../development/python-modules/cypherpunkpay { };
 
+  cyrtranslit = callPackage ../development/python-modules/cyrtranslit { };
+
   cysignals = callPackage ../development/python-modules/cysignals { };
 
   cython = callPackage ../development/python-modules/cython { };


### PR DESCRIPTION
## Description of changes

First update to the new Weblate package and module. Builds and deploys on my [test instance](https://weblate.erictapen.name).

Changelogs:

- [weblate: 5.6.2 -> 5.7](https://github.com/WeblateOrg/weblate/releases/tag/weblate-5.7)
- [python3Packages.django-otp: 1.5.0 -> 1.5.1](https://github.com/django-otp/django-otp/blob/master/CHANGES.rst#v151---july-23-2024---admin-search-fields)

New packages:
- python3Packages.cyrtranslit
- python3Packages.django-otp-webauthn

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
