### PR TITLE
nixos/binfmt: Add option to use static emulators when available

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -277,25 +277,6 @@ let
       let
         selectEmulator = pkgs:
           let
-            qemu-user = pkgs.qemu.override {
-              smartcardSupport = false;
-              spiceSupport = false;
-              openGLSupport = false;
-              virglSupport = false;
-              vncSupport = false;
-              gtkSupport = false;
-              sdlSupport = false;
-              alsaSupport = false;
-              pulseSupport = false;
-              pipewireSupport = false;
-              jackSupport = false;
-              smbdSupport = false;
-              seccompSupport = false;
-              tpmSupport = false;
-              capstoneSupport = false;
-              enableDocs = false;
-              hostCpuTargets = [ "${final.qemuArch}-linux-user" ];
-            };
             wine = (pkgs.winePackagesFor "wine${toString final.parsed.cpu.bits}").minimal;
           in
           # Note: we guarantee that the return value is either `null` or a path
@@ -306,7 +287,7 @@ let
           else if final.isWindows
           then "${wine}/bin/wine${optionalString (final.parsed.cpu.bits == 64) "64"}"
           else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux && final.qemuArch != null
-          then "${qemu-user}/bin/qemu-${final.qemuArch}"
+          then "${pkgs.qemu-user}/bin/qemu-${final.qemuArch}"
           else if final.isWasi
           then "${pkgs.wasmtime}/bin/wasmtime"
           else if final.isMmix

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -296,6 +296,10 @@ let
       in {
         emulatorAvailable = pkgs: (selectEmulator pkgs) != null;
 
+        # whether final.emulator pkgs.pkgsStatic works
+        staticEmulatorAvailable = pkgs: final.emulatorAvailable pkgs
+          && (final.isLinux || final.isWasi || final.isMmix);
+
         emulator = pkgs:
           if (final.emulatorAvailable pkgs)
           then selectEmulator pkgs

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -96,6 +96,7 @@ lib.runTests (
         canExecute = null;
         emulator = null;
         emulatorAvailable = null;
+        staticEmulatorAvailable = null;
         isCompatible = null;
       }?${platformAttrName};
     };

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -94,10 +94,9 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ sigtool ]
     ++ lib.optionals (!userOnly) [ dtc ];
 
-  buildInputs = [ zlib glib pixman
-    vde2 lzo snappy libtasn1
-    gnutls nettle curl libslirp
-  ]
+  buildInputs = [ glib zlib ]
+    ++ lib.optionals (!minimal) [ dtc pixman vde2 lzo snappy libtasn1 gnutls nettle libslirp ]
+    ++ lib.optionals (!userOnly) [ curl ]
     ++ lib.optionals ncursesSupport [ ncurses ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices Cocoa Hypervisor Kernel rez setfile vmnet ]
     ++ lib.optionals seccompSupport [ libseccomp ]
@@ -112,8 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals smartcardSupport [ libcacard ]
     ++ lib.optionals spiceSupport [ spice-protocol spice ]
     ++ lib.optionals usbredirSupport [ usbredir ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ libcap_ng libcap attr ]
-    ++ lib.optionals (stdenv.hostPlatform.isLinux && !userOnly) [ libaio ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && !userOnly) [ libcap_ng libcap attr libaio ]
     ++ lib.optionals xenSupport [ xen ]
     ++ lib.optionals cephSupport [ ceph ]
     ++ lib.optionals glusterfsSupport [ glusterfs libuuid ]
@@ -124,8 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals smbdSupport [ samba ]
     ++ lib.optionals uringSupport [ liburing ]
     ++ lib.optionals canokeySupport [ canokey-qemu ]
-    ++ lib.optionals capstoneSupport [ capstone ]
-    ++ lib.optionals (!userOnly) [ dtc ];
+    ++ lib.optionals capstoneSupport [ capstone ];
 
   dontUseMesonConfigure = true; # meson's configurePhase isn't compatible with qemu build
   dontAddStaticConfigureFlags = true;


### PR DESCRIPTION
## Motivation
This PR makes running binaries via `boot.binfmt.emulatedSystems` in chroots "just work", at the cost of adding/setting a single option.

The goal is to change
```
$ uname -m
x86_64
$ docker run --rm -ti --platform linux/arm alpine uname -m
exec /bin/uname: no such file or directory
```
into
```
$ docker run --rm -ti --platform linux/arm alpine uname -m
armv7l
```


The other prominent use-case is to `nixos-enter`/`chroot` into a broken linux install mounted to `/mnt` of an other machine for debugging, where that linux install is for a different platform (e.g. a raspi).

## Description of changes

* Add an option `boot.binfmt.preferStaticEmulators`, which changes `boot.binfmt.registrations.*.interpreter` to an executable from `pkgsStatic` where possible.
* Add a test for the option
* Some misc related cleanup

## Things I'd like advice on

Note how the error message in the motivational examples is abysmal? `/bin/uname` exists in both examples. What's not being found is `/run/binfmt/armv7l-linux`.

Instead of making this an option, would it be conceivable to make this always-on?

## Notes

This is the third attempt to land this in nixpkgs. Related PRs/issues:
* Original Issue: #160300
* First PR: #160802
  (abandoned)
* Second PR: #300070 
  (abandoned)
* Third PR: #314998
  (only made `pkgsStatic.qemu.override { userOnly = true; }` work)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
