### PR TITLE
nixos/ollama: move `loadModels` script into a separate service

### DIFF
--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) literalExpression types mkBefore;
+  inherit (lib) literalExpression types;
 
   cfg = config.services.ollama;
   ollamaPackage = cfg.package.override { inherit (cfg) acceleration; };
@@ -50,7 +50,6 @@ in
           The user will automatically be created, if this option is set to a non-null value.
         '';
       };
-
       group = lib.mkOption {
         type = with types; nullOr str;
         default = cfg.user;
@@ -71,7 +70,6 @@ in
           The home directory that the ollama service is started in.
         '';
       };
-
       models = lib.mkOption {
         type = types.str;
         default = "${cfg.home}/models";
@@ -98,6 +96,7 @@ in
           Which port the ollama server listens to.
         '';
       };
+
       acceleration = lib.mkOption {
         type = types.nullOr (
           types.enum [
@@ -136,6 +135,7 @@ in
           ) for details.
         '';
       };
+
       environmentVariables = lib.mkOption {
         type = types.attrsOf types.str;
         default = { };
@@ -155,7 +155,10 @@ in
         type = types.listOf types.str;
         default = [ ];
         description = ''
-          The models to download as soon as the service starts.
+          Download these models using `ollama pull` as soon as `ollama.service` has started.
+
+          This creates a systemd unit `ollama-model-loader.service`.
+
           Search for models of your choice from: https://ollama.com/library
         '';
       };
@@ -164,6 +167,7 @@ in
         default = false;
         description = ''
           Whether to open the firewall for ollama.
+
           This adds `services.ollama.port` to `networking.firewall.allowedTCPPorts`.
         '';
       };
@@ -200,6 +204,7 @@ in
           Group = cfg.group;
         }
         // {
+          Type = "exec";
           DynamicUser = true;
           ExecStart = "${lib.getExe ollamaPackage} serve";
           WorkingDirectory = cfg.home;
@@ -255,13 +260,50 @@ in
           ];
           UMask = "0077";
         };
-      postStart = mkBefore ''
-        set -x
-        export OLLAMA_HOST=${lib.escapeShellArg cfg.host}:${builtins.toString cfg.port}
-        for model in ${lib.escapeShellArgs cfg.loadModels}
-        do
-          ${lib.escapeShellArg (lib.getExe ollamaPackage)} pull "$model"
+    };
+
+    systemd.services.ollama-model-loader = lib.mkIf (cfg.loadModels != [ ]) {
+      description = "Download ollama models in the background";
+      wantedBy = [
+        "multi-user.target"
+        "ollama.service"
+      ];
+      after = [ "ollama.service" ];
+      bindsTo = [ "ollama.service" ];
+      environment = config.systemd.services.ollama.environment;
+      serviceConfig = {
+        Type = "exec";
+        DynamicUser = true;
+        Restart = "on-failure";
+        # bounded exponential backoff
+        RestartSec = "1s";
+        RestartMaxDelaySec = "2h";
+        RestartSteps = "10";
+      };
+
+      script = ''
+        total=${toString (builtins.length cfg.loadModels)}
+        failed=0
+
+        for model in ${lib.escapeShellArgs cfg.loadModels}; do
+          '${lib.getExe ollamaPackage}' pull "$model" &
         done
+
+        for job in $(jobs -p); do
+          set +e
+          wait $job
+          exit_code=$?
+          set -e
+
+          if [ $exit_code != 0 ]; then
+            failed=$((failed + 1))
+          fi
+        done
+
+        if [ $failed != 0 ]; then
+          echo "error: $failed out of $total attempted model downloads failed" >&2
+          exit 1
+        fi
       '';
     };
 


### PR DESCRIPTION
## Description of changes

Due to the large size of models, the script can run for a long time, which can cause timeouts, since the startup phase has a time limit.

`loadModels` was originally introduced in #313606. These changes are in response to [this comment](https://github.com/NixOS/nixpkgs/commit/f6727a9e3ee8365e1af3f94931f113fb0c6d37d6#commitcomment-144864206).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] manually tested service functionality
  - [x] `nix build -f pkgs/top-level/release.nix release-checks`
  - [x] `nix build -f default.nix ollama.tests`
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix run nixpkgs#nixpkgs-review -- rev HEAD`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
