### PR TITLE
vfkit: init at 0.5.1

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -33,6 +33,7 @@
 , aardvark-dns
 , netavark
 , passt
+, vfkit
 , testers
 , podman
 }:
@@ -44,6 +45,8 @@ let
     util-linux
     iptables
     iproute2
+  ] ++ lib.optionals stdenv.isDarwin [
+    vfkit
   ] ++ extraPackages);
 
   helpersBin = symlinkJoin {

--- a/pkgs/by-name/vf/vfkit/package.nix
+++ b/pkgs/by-name/vf/vfkit/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  fetchurl,
+  stdenvNoCC,
+  testers,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "vfkit";
+  version = "0.5.1";
+
+  src = fetchurl {
+    url = "https://github.com/crc-org/vfkit/releases/download/v${finalAttrs.version}/vfkit";
+    hash = "sha256-at+KsvsKO359d4VUvcSuio2ej5hM6//U4Mj/jqXwhEc=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/vfkit
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion { package = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "Simple command line tool to start VMs through the macOS Virtualization framework";
+    homepage = "https://github.com/crc-org/vfkit";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sarcasticadmin ];
+    platforms = lib.platforms.darwin;
+    # Source build will be possible after darwin SDK 12.0 bump
+    # https://github.com/NixOS/nixpkgs/pull/229210
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "vfkit";
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes: #306179 #305868

init `vfkit` using the prebuilt universal macOS binary from the upstream project (suggested in https://github.com/NixOS/nixpkgs/issues/306179#issuecomment-2119521348). This isn't ideal but it looks like there are existing issues getting `vfkit` to build. Recent attempt: #306438 This seems to be related to work that's `in-progress` for the macOS SDK in nixpkgs: #229210 I figure it's better to have `vfkit` in nixpkgs and working with `podman` on macOS than for it to be broken until there's a better path forward.

Additionally, I've add `vfkit` to the PATH for `podman`.

prior to having `vfkit`:

```
$ podman machine start
Starting machine "podman-machine-default"
ERRO[0000] process 67230 has not ended
Error: exec: "vfkit": executable file not found in $PATH
```

Running `podman` with `vfkit`:

```
$ ./result/bin/podman machine start
Starting machine "podman-machine-default"

This machine is currently configured in rootless mode. If your containers
require root permissions (e.g. ports < 1024), or if you run into compatibility
issues with non-podman clients, you can switch using the following command:

        podman machine set --rootful

API forwarding listening on: /var/folders/r0/k849jt6s5ss4222ll7t21vc40000gn/T/podman/podman-machine-default-api.sock
You can still connect Docker API clients by setting DOCKER_HOST using the
following command in your terminal session:

        export DOCKER_HOST='unix:///var/folders/r0/k849jt6s5ss4222ll7t21vc40000gn/T/podman/podman-machine-default-api.sock'

Machine "podman-machine-default" started successfully
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
