### PR TITLE
trivial-builders: init addTmateBreakpoint

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1,4 +1,4 @@
-{ lib, config, stdenv, stdenvNoCC, jq, lndir, runtimeShell, shellcheck-minimal }:
+{ lib, config, stdenv, stdenvNoCC, jq, lndir, unixtools, tmate, runtimeShell, shellcheck-minimal }:
 
 let
   inherit (lib)
@@ -602,6 +602,46 @@ rec {
     ln -s ${lib.getBin drv}/bin $out/bin
   '';
 
+  /*
+    Adds a hook to the nativeBuildInputs of a derivation which will provide an
+    SSH session via tmate to the build environment, for interactive
+    debugging
+
+    Example:
+
+    # Spawn a tmate session after the `buildPhase` of the `hello` derivation
+    addTmateBreakpoint (pkgs.hello.overrideAttrs { buildPhase = "exit 1;"; })
+  */
+  addTmateBreakpoint = let
+    tmateWrapper = writeShellScript "tmate" "${tmate}/bin/tmate -F";
+    flags = if stdenv.hostPlatform.isDarwin then "-qeF ./tmpfile" else "-qefc";
+    warningMessage = "addTmateBreakpoint in use, ignore the sha256 warning and do not leak these build logs, otherwise unauthorized ssh access to the build sandbox may occur";
+    hook = lib.warn warningMessage (makeSetupHook {} (writeTextFile {
+      name = "hook.sh";
+      text = ''
+        breakpointHookTmate() {
+          local red='\033[0;31m'
+          local no_color='\033[0m'
+
+          echo -e "''${red}build failed in ''${curPhase} with exit code ''${exitCode}''${no_color}"
+          echo -e "''${red}### WARNING ###''${no_color}"
+          echo -e "''${red}${warningMessage}''${no_color}"
+
+          printf "To attach using tmate:\n\n"
+          ${unixtools.script}/bin/script ${flags} "${tmateWrapper}"
+        }
+        failureHooks+=(breakpointHookTmate)
+      '';
+    }));
+  in drv: drv.overrideAttrs (old: {
+    name = "${drv.name}-addTmateBreakpoint-${builtins.unsafeDiscardStringContext (lib.substring 0 12 (baseNameOf drv.drvPath))}";
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      hook
+    ];
+    outputHash = "";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  });
 
   # Docs in doc/build-helpers/special/makesetuphook.section.md
   # See https://nixos.org/manual/nixpkgs/unstable/#sec-pkgs.makeSetupHook

--- a/pkgs/build-support/trivial-builders/test/addTmateBreakpoint.nix
+++ b/pkgs/build-support/trivial-builders/test/addTmateBreakpoint.nix
@@ -1,0 +1,1 @@
+{ addTmateBreakpoint, hello }: (addTmateBreakpoint hello).overrideAttrs { postPatch = "exit 1"; }

--- a/pkgs/build-support/trivial-builders/test/default.nix
+++ b/pkgs/build-support/trivial-builders/test/default.nix
@@ -33,4 +33,7 @@ recurseIntoAttrs {
     inherit (references) samples;
   };
   writeTextFile = callPackage ./write-text-file.nix {};
+  manualTesting = lib.dontRecurseIntoAttrs {
+    addTmateBreakpoint = callPackage ./addTmateBreakpoint.nix {};
+  };
 }

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -114,7 +114,7 @@ let
       inherit lib;
       inherit (self) config;
       inherit (self) runtimeShell stdenv stdenvNoCC;
-      inherit (self.pkgsBuildHost) jq shellcheck-minimal;
+      inherit (self.pkgsBuildHost) jq shellcheck-minimal unixtools tmate;
       inherit (self.pkgsBuildHost.xorg) lndir;
     };
 


### PR DESCRIPTION
## Description of changes

Testable with `nix-build -A tests.trivial-builders.manualTesting.addTmateBreakpoint`

This adds a function to Nixpkgs that allows you to wrap a derivation and insert a hook that creates an ssh session with tmate, allowing you to enter the derivation at the exact point it went wrong, regardless of whether the derivation is being built on a remote-builder. 

```
{ addTmateBreakpoint, hello }:
(addTmateBreakpoint hello).overrideAttrs { postPatch = "exit 1"; }
```

Will result in the following

```
❯ nix-build -A tests.trivial-builders.addTmateBreakpoint
evaluation warning: addTmateBreakpoint in use, ignore the sha256 warning and do not leak these build logs, otherwise unauthorized ssh access to the build sandbox may occur
evaluation warning: calling makeSetupHook without passing a name is deprecated.
warning: found empty hash, assuming 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
this derivation will be built:
  /nix/store/ryf52zzfkk1h7m9w5w1r8m2s7gb45vlw-hello-2.12.1.drv
resolved derivation: '/nix/store/ryf52zzfkk1h7m9w5w1r8m2s7gb45vlw-hello-2.12.1.drv' -> '/nix/store/lbx9yvrzmkjn8s892lc6hgr74d2sia7x-hello-2.12.1.drv'...
building '/nix/store/lbx9yvrzmkjn8s892lc6hgr74d2sia7x-hello-2.12.1.drv'...
Using versionCheckHook
Running phase: unpackPhase
unpacking source archive /nix/store/pa10z4ngm0g83kx9mssrqzz30s84vq7k-hello-2.12.1.tar.gz
source root is hello-2.12.1
setting SOURCE_DATE_EPOCH to timestamp 1653865426 of file hello-2.12.1/ChangeLog
Running phase: patchPhase
build failed in patchPhase with exit code 1
### WARNING ###
addTmateBreakpoint in use, ignore the sha256 warning and do not leak these build logs, otherwise unauthorized ssh access to the build sandbox may occur
To attach using tmate:

To connect to the session locally, run: tmate -S /tmp/tmate-1000/Q1zzAv attach
Connecting to ssh.tmate.io...
web session read only: https://tmate.io/t/ro-VvJLT6c7tz5k9gD9gbjrDgScx
ssh session read only: ssh ro-VvJLT6c7tz5k9gD9gbjrDgScx@lon1.tmate.io
web session: https://tmate.io/t/uxxQTYbdBQ47ECELbM4BNAgQN
ssh session: ssh uxxQTYbdBQ47ECELbM4BNAgQN@lon1.tmate.io
``` 

There's is a potential issue issue that this hook can introduce new and unexpected build failure, just by the fact that it provides internet access to a build that previously didn't have it, which can limit its usefulness in certain contexts. But nonetheless, I've found it very useful in practice

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
