### PR TITLE
super-productivity: 11.1.2 -> 11.1.3, build from source

### DIFF
--- a/pkgs/by-name/su/super-productivity/package.nix
+++ b/pkgs/by-name/su/super-productivity/package.nix
@@ -1,51 +1,137 @@
-{ stdenv , lib , fetchurl , appimageTools , makeWrapper , electron }:
+{
+  buildNpmPackage,
+  copyDesktopItems,
+  electron,
+  fetchFromGitHub,
+  lib,
+  makeDesktopItem,
+  nix-update-script,
+  npm-lockfile-fix,
+  python3,
+  stdenv,
+}:
 
-stdenv.mkDerivation rec {
+buildNpmPackage rec {
   pname = "super-productivity";
-  version = "11.1.2";
+  version = "11.1.3";
 
-  src = fetchurl {
-    url = "https://github.com/johannesjo/super-productivity/releases/download/v${version}/superProductivity-x86_64.AppImage";
-    sha256 = "sha256-AtN7x0Vt0wWxNoXwRc78drFE8UfMpssFBYZ83w1QgbU=";
-    name = "${pname}-${version}.AppImage";
+  src = fetchFromGitHub {
+    owner = "johannesjo";
+    repo = "super-productivity";
+    tag = "v${version}";
+    hash = "sha256-GWpKz1q3pmAozlzawi2ITxo3KH0MSrJCszVQdGTeOXA=";
+
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} -r $out/package-lock.json
+    '';
   };
 
-  appimageContents = appimageTools.extractType2 {
-    inherit pname version src;
+  npmDepsHash = "sha256-iP1op4R7OUA7cSW/dJCBBGcb5r6icSbx/X7mYogiMkA=";
+  npmFlags = [ "--legacy-peer-deps" ];
+  makeCacheWritable = true;
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    CHROMEDRIVER_SKIP_DOWNLOAD = "true";
+    CSC_IDENTITY_AUTO_DISCOVERY = "false";
   };
 
-  dontUnpack = true;
-  dontConfigure = true;
-  dontBuild = true;
+  nativeBuildInputs =
+    [ copyDesktopItems ]
+    ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+      (python3.withPackages (ps: [ ps.setuptools ]))
+    ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  # package.json does not include `core-js` and the comment suggests
+  # it is only needed on some mobile platforms
+  postPatch = ''
+    substituteInPlace electron-builder.yaml \
+      --replace-fail "notarize: true" "notarize: false"
+    substituteInPlace src/polyfills.ts \
+      --replace-fail "import 'core-js/es/object';" ""
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # electronDist needs to be modifiable on Darwin
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    npm run buildFrontend:prod:es6
+    npm run electron:build
+    npm exec electron-builder -- --dir \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/share/${pname} $out/share/applications
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          mkdir -p $out/Applications
+          cp -r "app-builds/mac"*"/Super Productivity.app" "$out/Applications"
+          makeWrapper "$out/Applications/Super Productivity.app/Contents/MacOS/Super Productivity" "$out/bin/super-productivity"
+        ''
+      else
+        ''
+          mkdir -p $out/share/super-productivity/{app,defaults,static/plugins,static/resources/plugins}
+          cp -r app-builds/*-unpacked/{locales,resources{,.pak}} "$out/share/super-productivity/app"
 
-    cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
-    cp -a ${appimageContents}/superproductivity.desktop $out/share/applications/${pname}.desktop
-    cp -a ${appimageContents}/usr/share/icons $out/share
+          for size in 16 32 48 64 128 256 512 1024; do
+            local sizexsize="''${size}x''${size}"
+            mkdir -p $out/share/icons/hicolor/$sizexsize/apps
+            cp -v build/icons/$sizexsize.png \
+              $out/share/icons/hicolor/$sizexsize/apps/super-productivity.png
+          done
 
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
+          makeWrapper '${lib.getExe electron}' "$out/bin/super-productivity" \
+            --add-flags "$out/share/super-productivity/app/resources/app.asar" \
+            --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+            --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+            --inherit-argv0
+        ''
+    }
 
     runHook postInstall
   '';
 
-  postFixup = ''
-    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
-      --add-flags $out/share/${pname}/resources/app.asar
-  '';
+  # copied from deb file
+  desktopItems = [
+    (makeDesktopItem {
+      name = "super-productivity";
+      desktopName = "superProductivity";
+      exec = "super-productivity %u";
+      terminal = false;
+      type = "Application";
+      icon = "super-productivity";
+      startupWMClass = "superProductivity";
+      comment = builtins.replaceStrings [ "\n" ] [ " " ] meta.longDescription;
+      categories = [ "Utility" ];
+    })
+  ];
 
-  meta = with lib; {
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
     description = "To Do List / Time Tracker with Jira Integration";
+    longDescription = ''
+      Experience the best ToDo app for digital professionals and get more done!
+      Super Productivity comes with integrated time-boxing and time tracking capabilities
+      and you can load your task from your calendars and from
+      Jira, Gitlab, GitHub, Open Project and others all into a single ToDo list.
+    '';
     homepage = "https://super-productivity.com";
-    license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ offline ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      offline
+      pineapplehunter
+    ];
     mainProgram = "super-productivity";
   };
 }


### PR DESCRIPTION
Builds super-productivity from source and updates to 11.0.3.

## Description of changes

This PR does a number of things.

- Builds package from source
- Updates the package from version to 11.0.3
- ~~Moved files to pkgs/by-name~~
- Adds support for aarch64-linux (only checked build)

~~Because the upstream package-lock.json is out of sync, the package-lock.json is manually generated. If the generated lock file is too big (this seems to be a significant issue #327064), I have opened another PR before which only updates the appimage file #332671.~~ Edit: this is not relevant because it uses npm-lockfile-fix now. I'll keep the appimage version #332671 so we can update before the review of this PR.

@offlinehacker  ~~This does make this package a bit harder to maintain (although I don't think it would be too hard to make a update script) so I would like to know your opinion.~~ Edit: added an update script

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
