### PR TITLE
tauon: 7.8.0 -> 7.8.1

### DIFF
--- a/pkgs/applications/audio/tauon/default.nix
+++ b/pkgs/applications/audio/tauon/default.nix
@@ -19,6 +19,7 @@
   mpg123,
   opusfile,
   pango,
+  pipewire,
   wavpack,
   ffmpeg,
   pulseaudio,
@@ -27,13 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tauon";
-  version = "7.8.0";
+  version = "7.8.2";
 
   src = fetchFromGitHub {
     owner = "Taiko2k";
-    repo = "TauonMusicBox";
+    repo = "Tauon";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-8UnUcEvG206tPwyD+WqxcJgDvQlYvTJ6v+sm0u30Z3k=";
+    hash = "sha256-fVp3RWRNIBSeALbYNRIYjyWNH9An+YnS7neQt0x33yI=";
   };
 
   postUnpack = ''
@@ -54,15 +55,16 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'libopenmpt.so' '${lib.getLib libopenmpt}/lib/libopenmpt.so'
 
     substituteInPlace t_modules/t_phazor.py \
-      --replace-fail 'lib/libphazor.so' '../../lib/libphazor.so'
+      --replace-fail 'lib/libphazor' '../../lib/libphazor'
 
-    substituteInPlace compile-phazor.sh --replace-fail 'gcc' '${stdenv.cc.targetPrefix}cc'
+    substituteInPlace compile-phazor*.sh --replace-fail 'gcc' '${stdenv.cc.targetPrefix}cc'
 
     substituteInPlace extra/tauonmb.desktop --replace-fail 'Exec=/opt/tauon-music-box/tauonmb.sh' 'Exec=${placeholder "out"}/bin/tauon'
   '';
 
   postBuild = ''
     bash ./compile-phazor.sh
+    bash ./compile-phazor-pipewire.sh
   '';
 
   nativeBuildInputs = [
@@ -84,6 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     mpg123
     opusfile
     pango
+    pipewire
     wavpack
   ];
 
@@ -92,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       beautifulsoup4
       dbus-python
-      isounidecode
+      unidecode
       jxlpy
       musicbrainzngs
       mutagen

--- a/pkgs/applications/audio/tauon/default.nix
+++ b/pkgs/applications/audio/tauon/default.nix
@@ -23,7 +23,7 @@
   wavpack,
   ffmpeg,
   pulseaudio,
-  withDiscordRPC ? false,
+  withDiscordRPC ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
## Description of changes
Main change is adding pipewire support.

### To discuss:
 Perhaps we should make discord RPC support not optional, or at least on by default, so users don't have to recompile the C libraries if they want to enable it, and so we match upstream's defaults.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
