### PR TITLE
nixos/ayatana-indicators: Split ayatana and lomiri indicators

### DIFF
--- a/nixos/modules/services/desktops/ayatana-indicators.nix
+++ b/nixos/modules/services/desktops/ayatana-indicators.nix
@@ -20,11 +20,12 @@ in
       example = lib.literalExpression "with pkgs; [ ayatana-indicator-messages ]";
       description = ''
         List of packages containing Ayatana Indicator services
-        that should be brought up by the SystemD "ayatana-indicators" user target.
+        that should be brought up by a SystemD "ayatana-indicators" user target.
 
         Packages specified here must have passthru.ayatana-indicators set correctly.
 
         If, how, and where these indicators are displayed will depend on your DE.
+        Which target they will be brought up by depends on the packages' passthru.ayatana-indicators.
       '';
     };
   };
@@ -39,16 +40,36 @@ in
     # libayatana-common's ayatana-indicators.target with explicit Wants & Before to bring up requested indicator services
     systemd.user.targets =
       let
-        indicatorServices = lib.lists.flatten (
-          map (pkg: (map (ind: "${ind}.service") pkg.passthru.ayatana-indicators)) cfg.packages
-        );
+        namesToServices = map (indicator: "${indicator}.service");
+        indicatorServices =
+          target:
+          lib.lists.flatten (
+            map (
+              pkg:
+              if lib.isList pkg.passthru.ayatana-indicators then
+                # Old format, add to every target
+                (lib.warn "${pkg.name} is using the old passthru.ayatana-indicators format, please update it!" (
+                  namesToServices pkg.passthru.ayatana-indicators
+                ))
+              else
+                # New format, filter by target being mentioned
+                (namesToServices (
+                  builtins.filter (
+                    service:
+                    builtins.any (
+                      targetPrefix: "${targetPrefix}-indicators" == target
+                    ) pkg.passthru.ayatana-indicators.${service}
+                  ) (builtins.attrNames pkg.passthru.ayatana-indicators)
+                ))
+            ) cfg.packages
+          );
       in
       lib.attrsets.mapAttrs
-        (_: desc: {
+        (name: desc: {
           description = "Target representing the lifecycle of the ${desc}. Each indicator should be bound to it in its individual service file";
           partOf = [ "graphical-session.target" ];
-          wants = indicatorServices;
-          before = indicatorServices;
+          wants = indicatorServices name;
+          before = indicatorServices name;
         })
         {
           ayatana-indicators = "Ayatana Indicators";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -141,7 +141,7 @@ in {
   authelia = handleTest ./authelia.nix {};
   avahi = handleTest ./avahi.nix {};
   avahi-with-resolved = handleTest ./avahi.nix { networkd = true; };
-  ayatana-indicators = handleTest ./ayatana-indicators.nix {};
+  ayatana-indicators = runTest ./ayatana-indicators.nix;
   babeld = handleTest ./babeld.nix {};
   bazarr = handleTest ./bazarr.nix {};
   bcachefs = handleTestOn ["x86_64-linux" "aarch64-linux"] ./bcachefs.nix {};

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -1,116 +1,133 @@
-import ./make-test-python.nix ({ pkgs, lib, ... }: let
+{ pkgs, lib, ... }:
+let
   user = "alice";
-in {
+in
+{
   name = "ayatana-indicators";
 
   meta = {
     maintainers = lib.teams.lomiri.members;
   };
 
-  nodes.machine = { config, ... }: {
-    imports = [
-      ./common/auto.nix
-      ./common/user-account.nix
-    ];
+  nodes.machine =
+    { config, ... }:
+    {
+      imports = [
+        ./common/auto.nix
+        ./common/user-account.nix
+      ];
 
-    test-support.displayManager.auto = {
-      enable = true;
-      inherit user;
+      test-support.displayManager.auto = {
+        enable = true;
+        inherit user;
+      };
+
+      services.xserver = {
+        enable = true;
+        desktopManager.mate.enable = true;
+      };
+      services.displayManager.defaultSession = lib.mkForce "mate";
+
+      services.ayatana-indicators = {
+        enable = true;
+        packages =
+          with pkgs;
+          [
+            ayatana-indicator-datetime
+            ayatana-indicator-display
+            ayatana-indicator-messages
+            ayatana-indicator-power
+            ayatana-indicator-session
+            ayatana-indicator-sound
+          ]
+          ++ (with pkgs.lomiri; [
+            lomiri-indicator-network
+            telephony-service
+          ]);
+      };
+
+      # Setup needed by some indicators
+
+      services.accounts-daemon.enable = true; # messages
+
+      hardware.pulseaudio.enable = true; # sound
+
+      # Lomiri-ish setup for Lomiri indicators
+      # TODO move into a Lomiri module, once the package set is far enough for the DE to start
+
+      networking.networkmanager.enable = true; # lomiri-network-indicator
+      # TODO potentially urfkill for lomiri-network-indicator?
+
+      services.dbus.packages = with pkgs.lomiri; [ libusermetrics ];
+
+      environment.systemPackages = with pkgs.lomiri; [ lomiri-schemas ];
+
+      services.telepathy.enable = true;
+
+      users.users.usermetrics = {
+        group = "usermetrics";
+        home = "/var/lib/usermetrics";
+        createHome = true;
+        isSystemUser = true;
+      };
+
+      users.groups.usermetrics = { };
     };
-
-    services.xserver = {
-      enable = true;
-      desktopManager.mate.enable = true;
-    };
-    services.displayManager.defaultSession = lib.mkForce "mate";
-
-    services.ayatana-indicators = {
-      enable = true;
-      packages = with pkgs; [
-        ayatana-indicator-datetime
-        ayatana-indicator-display
-        ayatana-indicator-messages
-        ayatana-indicator-power
-        ayatana-indicator-session
-        ayatana-indicator-sound
-      ] ++ (with pkgs.lomiri; [
-        lomiri-indicator-network
-        telephony-service
-      ]);
-    };
-
-    # Setup needed by some indicators
-
-    services.accounts-daemon.enable = true; # messages
-
-    hardware.pulseaudio.enable = true; # sound
-
-    # Lomiri-ish setup for Lomiri indicators
-    # TODO move into a Lomiri module, once the package set is far enough for the DE to start
-
-    networking.networkmanager.enable = true; # lomiri-network-indicator
-    # TODO potentially urfkill for lomiri-network-indicator?
-
-    services.dbus.packages = with pkgs.lomiri; [
-      libusermetrics
-    ];
-
-    environment.systemPackages = with pkgs.lomiri; [
-      lomiri-schemas
-    ];
-
-    services.telepathy.enable = true;
-
-    users.users.usermetrics = {
-      group = "usermetrics";
-      home = "/var/lib/usermetrics";
-      createHome = true;
-      isSystemUser = true;
-    };
-
-    users.groups.usermetrics = { };
-  };
 
   # TODO session indicator starts up in a semi-broken state, but works fine after a restart. maybe being started before graphical session is truly up & ready?
-  testScript = { nodes, ... }: let
-    runCommandOverServiceList = list: command:
-      lib.strings.concatMapStringsSep "\n" command list;
+  testScript =
+    { nodes, ... }:
+    let
+      runCommandOverServiceList = list: command: lib.strings.concatMapStringsSep "\n" command list;
 
-    runCommandOverAyatanaIndicators = runCommandOverServiceList
-      (builtins.filter
-        (service: !(lib.strings.hasPrefix "lomiri" service || lib.strings.hasPrefix "telephony-service" service))
-        nodes.machine.systemd.user.targets."ayatana-indicators".wants);
+      runCommandOverAyatanaIndicators = runCommandOverServiceList (
+        builtins.filter (
+          service:
+          !(lib.strings.hasPrefix "lomiri" service || lib.strings.hasPrefix "telephony-service" service)
+        ) nodes.machine.systemd.user.targets."ayatana-indicators".wants
+      );
 
-    runCommandOverAllIndicators = runCommandOverServiceList
-      nodes.machine.systemd.user.targets."ayatana-indicators".wants;
-  in ''
-    start_all()
-    machine.wait_for_x()
+      runCommandOverAllIndicators =
+        runCommandOverServiceList
+          nodes.machine.systemd.user.targets."ayatana-indicators".wants;
+    in
+    ''
+      start_all()
+      machine.wait_for_x()
 
-    # Desktop environment should reach graphical-session.target
-    machine.wait_for_unit("graphical-session.target", "${user}")
+      # Desktop environment should reach graphical-session.target
+      machine.wait_for_unit("graphical-session.target", "${user}")
 
-    # MATE relies on XDG autostart to bring up the indicators.
-    # Not sure *when* XDG autostart fires them up, and awaiting pgrep success seems to misbehave?
-    machine.sleep(10)
+      # MATE relies on XDG autostart to bring up the indicators.
+      # Not sure *when* XDG autostart fires them up, and awaiting pgrep success seems to misbehave?
+      machine.sleep(10)
 
-    # Now check if all indicators were brought up successfully, and kill them for later
-  '' + (runCommandOverAyatanaIndicators (service: let serviceExec = builtins.replaceStrings [ "." ] [ "-" ] service; in ''
-    machine.wait_until_succeeds("pgrep -u ${user} -f ${serviceExec}")
-    machine.succeed("pkill -f ${serviceExec}")
-  '')) + ''
+      # Now check if all indicators were brought up successfully, and kill them for later
+    ''
+    + (runCommandOverAyatanaIndicators (
+      service:
+      let
+        serviceExec = builtins.replaceStrings [ "." ] [ "-" ] service;
+      in
+      ''
+        machine.wait_until_succeeds("pgrep -u ${user} -f ${serviceExec}")
+        machine.succeed("pkill -f ${serviceExec}")
+      ''
+    ))
+    + ''
 
-    # Ayatana target is the preferred way of starting up indicators on SystemD session, the graphical session is responsible for starting this if it supports them.
-    # Mate currently doesn't do this, so start it manually for checking (https://github.com/mate-desktop/mate-indicator-applet/issues/63)
-    machine.systemctl("start ayatana-indicators.target", "${user}")
-    machine.wait_for_unit("ayatana-indicators.target", "${user}")
+      # Ayatana target is the preferred way of starting up indicators on SystemD session, the graphical session is responsible for starting this if it supports them.
+      # Mate currently doesn't do this, so start it manually for checking (https://github.com/mate-desktop/mate-indicator-applet/issues/63)
+      machine.systemctl("start ayatana-indicators.target", "${user}")
+      machine.wait_for_unit("ayatana-indicators.target", "${user}")
 
-    # Let all indicator services do their startups, potential post-launch crash & restart cycles so we can properly check for failures
-    # Not sure if there's a better way of awaiting this without false-positive potential
-    machine.sleep(10)
+      # Let all indicator services do their startups, potential post-launch crash & restart cycles so we can properly check for failures
+      # Not sure if there's a better way of awaiting this without false-positive potential
+      machine.sleep(10)
 
-    # Now check if all indicator services were brought up successfully
-  '' + runCommandOverAllIndicators (service: ''
-    machine.wait_for_unit("${service}", "${user}")
-  '');
-})
+      # Now check if all indicator services were brought up successfully
+    ''
+    + runCommandOverAllIndicators (service: ''
+      machine.wait_for_unit("${service}", "${user}")
+    '');
+}

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -80,12 +80,8 @@ in
     let
       runCommandOverServiceList = list: command: lib.strings.concatMapStringsSep "\n" command list;
 
-      runCommandOverAyatanaIndicators = runCommandOverServiceList (
-        builtins.filter (
-          service:
-          !(lib.strings.hasPrefix "lomiri" service || lib.strings.hasPrefix "telephony-service" service)
-        ) nodes.machine.systemd.user.targets."ayatana-indicators".wants
-      );
+      runCommandOverAyatanaIndicators = runCommandOverServiceList
+        nodes.machine.systemd.user.targets.ayatana-indicators.wants;
 
       runCommandOverLomiriIndicators = runCommandOverServiceList nodes.machine.systemd.user.targets.lomiri-indicators.wants;
     in

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -38,6 +38,13 @@ in
       testScript =
         { nodes, ... }:
         ''
+          def wait_for_text(text):
+              """
+              Wait for on-screen text, and try to optimise retry count for slow hardware.
+              """
+              machine.sleep(10)
+              machine.wait_for_text(text)
+
           start_all()
           machine.wait_for_unit("multi-user.target")
 
@@ -47,12 +54,12 @@ in
               machine.wait_until_succeeds("pgrep -u lightdm -f 'lomiri --mode=greeter'")
 
               # Start page shows current time
-              machine.wait_for_text(r"(AM|PM)")
+              wait_for_text(r"(AM|PM)")
               machine.screenshot("lomiri_greeter_launched")
 
               # Advance to login part
               machine.send_key("ret")
-              machine.wait_for_text("${description}")
+              wait_for_text("${description}")
               machine.screenshot("lomiri_greeter_login")
 
               # Login
@@ -62,16 +69,16 @@ in
               # Output rendering from Lomiri has started when it starts printing performance diagnostics
               machine.wait_for_console_text("Last frame took")
               # Look for datetime's clock, one of the last elements to load
-              machine.wait_for_text(r"(AM|PM)")
+              wait_for_text(r"(AM|PM)")
               machine.screenshot("lomiri_launched")
         '';
     }
   );
 
-  desktop = makeTest (
+  desktop-basics = makeTest (
     { pkgs, lib, ... }:
     {
-      name = "lomiri-desktop";
+      name = "lomiri-desktop-basics";
 
       meta = {
         maintainers = lib.teams.lomiri.members;
@@ -89,8 +96,6 @@ in
 
           users.users.${user} = {
             inherit description password;
-            # polkit agent test
-            extraGroups = [ "wheel" ];
           };
 
           test-support.displayManager.auto = {
@@ -128,15 +133,7 @@ in
               };
             };
 
-            variables = {
-              # So we can test what content-hub is working behind the scenes
-              CONTENT_HUB_LOGGING_LEVEL = "2";
-            };
-
             systemPackages = with pkgs; [
-              # For a convenient way of kicking off content-hub peer collection
-              lomiri.content-hub.examples
-
               # Forcing alacritty to run as an X11 app when opened from the starter menu
               (symlinkJoin {
                 name = "x11-${alacritty.name}";
@@ -205,6 +202,230 @@ in
       testScript =
         { nodes, ... }:
         ''
+          def wait_for_text(text):
+              """
+              Wait for on-screen text, and try to optimise retry count for slow hardware.
+              """
+              machine.sleep(10)
+              machine.wait_for_text(text)
+
+          def mouse_click(xpos, ypos):
+              """
+              Move the mouse to a screen location and hit left-click.
+              """
+
+              # Need to reset to top-left, --absolute doesn't work?
+              machine.execute("ydotool mousemove -- -10000 -10000")
+              machine.sleep(2)
+
+              # Move
+              machine.execute(f"ydotool mousemove -- {xpos} {ypos}")
+              machine.sleep(2)
+
+              # Click (C0 - left button: down & up)
+              machine.execute("ydotool click 0xC0")
+              machine.sleep(2)
+
+          def open_starter():
+              """
+              Open the starter, and ensure it's opened.
+              """
+
+              # Using the keybind has a chance of instantly closing the menu again? Just click the button
+              mouse_click(20, 30)
+
+          start_all()
+          machine.wait_for_unit("multi-user.target")
+
+          # The session should start, and not be stuck in i.e. a crash loop
+          with subtest("lomiri starts"):
+              machine.wait_until_succeeds("pgrep -u ${user} -f 'lomiri --mode=full-shell'")
+              # Output rendering from Lomiri has started when it starts printing performance diagnostics
+              machine.wait_for_console_text("Last frame took")
+              # Look for datetime's clock, one of the last elements to load
+              wait_for_text(r"(AM|PM)")
+              machine.screenshot("lomiri_launched")
+
+          # Working terminal keybind is good
+          with subtest("terminal keybind works"):
+              machine.send_key("ctrl-alt-t")
+              wait_for_text(r"(${user}|machine)")
+              machine.screenshot("terminal_opens")
+
+              # lomiri-terminal-app has a separate VM test to test its basic functionality
+
+              machine.send_key("alt-f4")
+
+          # We want the ability to launch applications
+          with subtest("starter menu works"):
+              open_starter()
+              machine.screenshot("starter_opens")
+
+              # Just try the terminal again, we know that it should work
+              machine.send_chars("Terminal\n")
+              wait_for_text(r"(${user}|machine)")
+              machine.send_key("alt-f4")
+
+          # We want support for X11 apps
+          with subtest("xwayland support works"):
+              open_starter()
+              machine.send_chars("Alacritty\n")
+              wait_for_text(r"(${user}|machine)")
+              machine.screenshot("alacritty_opens")
+              machine.send_key("alt-f4")
+
+          # Morph is how we go online
+          with subtest("morph browser works"):
+              open_starter()
+              machine.send_chars("Morph\n")
+              wait_for_text(r"(Bookmarks|address|site|visited any)")
+              machine.screenshot("morph_open")
+
+              # morph-browser has a separate VM test to test its basic functionalities
+
+              machine.send_key("alt-f4")
+
+          # LSS provides DE settings
+          with subtest("system settings open"):
+              open_starter()
+              machine.send_chars("System Settings\n")
+              wait_for_text("Rotation Lock")
+              machine.screenshot("settings_open")
+
+              # lomiri-system-settings has a separate VM test to test its basic functionalities
+
+              machine.send_key("alt-f4")
+        '';
+    }
+  );
+
+  desktop-appinteractions = makeTest (
+    { pkgs, lib, ... }:
+    {
+      name = "lomiri-desktop-appinteractions";
+
+      meta = {
+        maintainers = lib.teams.lomiri.members;
+      };
+
+      nodes.machine =
+        { config, ... }:
+        {
+          imports = [
+            ./common/auto.nix
+            ./common/user-account.nix
+          ];
+
+          virtualisation.memorySize = 2047;
+
+          users.users.${user} = {
+            inherit description password;
+            # polkit agent test
+            extraGroups = [ "wheel" ];
+          };
+
+          test-support.displayManager.auto = {
+            enable = true;
+            inherit user;
+          };
+
+          # To control mouse via scripting
+          programs.ydotool.enable = true;
+
+          services.desktopManager.lomiri.enable = lib.mkForce true;
+          services.displayManager.defaultSession = lib.mkForce "lomiri";
+
+          # Help with OCR
+          fonts.packages = [ pkgs.inconsolata ];
+
+          environment = {
+            # Help with OCR
+            etc."xdg/alacritty/alacritty.yml".text = lib.generators.toYAML { } {
+              font = rec {
+                normal.family = "Inconsolata";
+                bold.family = normal.family;
+                italic.family = normal.family;
+                bold_italic.family = normal.family;
+                size = 16;
+              };
+              colors = rec {
+                primary = {
+                  foreground = "0x000000";
+                  background = "0xffffff";
+                };
+                normal = {
+                  green = primary.foreground;
+                };
+              };
+            };
+
+            variables = {
+              # So we can test what content-hub is working behind the scenes
+              CONTENT_HUB_LOGGING_LEVEL = "2";
+            };
+
+            systemPackages = with pkgs; [
+              # For a convenient way of kicking off content-hub peer collection
+              lomiri.content-hub.examples
+            ];
+          };
+
+          # Help with OCR
+          systemd.tmpfiles.settings =
+            let
+              white = "255, 255, 255";
+              black = "0, 0, 0";
+              colorSection = color: {
+                Color = color;
+                Bold = true;
+                Transparency = false;
+              };
+              terminalColors = pkgs.writeText "customized.colorscheme" (
+                lib.generators.toINI { } {
+                  Background = colorSection white;
+                  Foreground = colorSection black;
+                  Color2 = colorSection black;
+                  Color2Intense = colorSection black;
+                }
+              );
+              terminalConfig = pkgs.writeText "terminal.ubports.conf" (
+                lib.generators.toINI { } {
+                  General = {
+                    colorScheme = "customized";
+                    fontSize = "16";
+                    fontStyle = "Inconsolata";
+                  };
+                }
+              );
+              confBase = "${config.users.users.${user}.home}/.config";
+              userDirArgs = {
+                mode = "0700";
+                user = user;
+                group = "users";
+              };
+            in
+            {
+              "10-lomiri-test-setup" = {
+                "${confBase}".d = userDirArgs;
+                "${confBase}/terminal.ubports".d = userDirArgs;
+                "${confBase}/terminal.ubports/customized.colorscheme".L.argument = "${terminalColors}";
+                "${confBase}/terminal.ubports/terminal.ubports.conf".L.argument = "${terminalConfig}";
+              };
+            };
+        };
+
+      enableOCR = true;
+
+      testScript =
+        { nodes, ... }:
+        ''
+          def wait_for_text(text):
+              """
+              Wait for on-screen text, and try to optimise retry count for slow hardware.
+              """
+              machine.sleep(10)
+              machine.wait_for_text(text)
+
           def toggle_maximise():
               """
               Maximise the current window.
@@ -252,20 +473,20 @@ in
               # Output rendering from Lomiri has started when it starts printing performance diagnostics
               machine.wait_for_console_text("Last frame took")
               # Look for datetime's clock, one of the last elements to load
-              machine.wait_for_text(r"(AM|PM)")
+              wait_for_text(r"(AM|PM)")
               machine.screenshot("lomiri_launched")
 
           # Working terminal keybind is good
           with subtest("terminal keybind works"):
               machine.send_key("ctrl-alt-t")
-              machine.wait_for_text(r"(${user}|machine)")
+              wait_for_text(r"(${user}|machine)")
               machine.screenshot("terminal_opens")
 
               # lomiri-terminal-app has a separate VM test to test its basic functionality
 
               # for the LSS content-hub test to work reliably, we need to kick off peer collecting
               machine.send_chars("content-hub-test-importer\n")
-              machine.wait_for_text(r"(/build/source|hub.cpp|handler.cpp|void|virtual|const)") # awaiting log messages from content-hub
+              wait_for_text(r"(/build/source|hub.cpp|handler.cpp|void|virtual|const)") # awaiting log messages from content-hub
               machine.send_key("ctrl-c")
 
               # Doing this here, since we need an in-session shell & separately starting a terminal again wastes time
@@ -282,40 +503,11 @@ in
 
               machine.send_key("alt-f4")
 
-          # We want the ability to launch applications
-          with subtest("starter menu works"):
-              open_starter()
-              machine.screenshot("starter_opens")
-
-              # Just try the terminal again, we know that it should work
-              machine.send_chars("Terminal\n")
-              machine.wait_for_text(r"(${user}|machine)")
-              machine.send_key("alt-f4")
-
-          # We want support for X11 apps
-          with subtest("xwayland support works"):
-              open_starter()
-              machine.send_chars("Alacritty\n")
-              machine.wait_for_text(r"(${user}|machine)")
-              machine.screenshot("alacritty_opens")
-              machine.send_key("alt-f4")
-
-          # Morph is how we go online
-          with subtest("morph browser works"):
-              open_starter()
-              machine.send_chars("Morph\n")
-              machine.wait_for_text(r"(Bookmarks|address|site|visited any)")
-              machine.screenshot("morph_open")
-
-              # morph-browser has a separate VM test, there isn't anything new we could test here
-
-              machine.send_key("alt-f4")
-
           # LSS provides DE settings
           with subtest("system settings open"):
               open_starter()
               machine.send_chars("System Settings\n")
-              machine.wait_for_text("Rotation Lock")
+              wait_for_text("Rotation Lock")
               machine.screenshot("settings_open")
 
               # lomiri-system-settings has a separate VM test, only test Lomiri-specific content-hub functionalities here
@@ -331,7 +523,7 @@ in
               machine.send_key("tab")
               machine.send_key("tab")
               machine.send_key("ret")
-              machine.wait_for_text("Background image")
+              wait_for_text("Background image")
 
               # Try to load custom background
               machine.send_key("shift-tab")
@@ -343,14 +535,14 @@ in
               machine.send_key("ret")
 
               # Peers should be loaded
-              machine.wait_for_text("Morph") # or Gallery, but Morph is already packaged
+              wait_for_text("Morph") # or Gallery, but Morph is already packaged
               machine.screenshot("settings_content-hub_peers")
 
               # Select Morph as content source
               mouse_click(370, 100)
 
               # Expect Morph to be brought into the foreground, with its Downloads page open
-              machine.wait_for_text("No downloads")
+              wait_for_text("No downloads")
 
               # If content-hub encounters a problem, it may have crashed the original application issuing the request.
               # Check that it's still alive
@@ -403,6 +595,8 @@ in
 
           # Help with OCR
           fonts.packages = [ pkgs.inconsolata ];
+
+          environment.systemPackages = with pkgs; [ qt5.qttools ];
         };
 
       enableOCR = true;
@@ -410,6 +604,13 @@ in
       testScript =
         { nodes, ... }:
         ''
+          def wait_for_text(text):
+              """
+              Wait for on-screen text, and try to optimise retry count for slow hardware.
+              """
+              machine.sleep(10)
+              machine.wait_for_text(text)
+
           def mouse_click(xpos, ypos):
               """
               Move the mouse to a screen location and hit left-click.
@@ -436,14 +637,14 @@ in
               # Output rendering from Lomiri has started when it starts printing performance diagnostics
               machine.wait_for_console_text("Last frame took")
               # Look for datetime's clock, one of the last elements to load
-              machine.wait_for_text(r"(AM|PM)")
+              wait_for_text(r"(AM|PM)")
               machine.screenshot("lomiri_launched")
 
           # The ayatana indicators are an important part of the experience, and they hold the only graphical way of exiting the session.
           # There's a test app we could use that also displays their contents, but it's abit inconsistent.
           with subtest("ayatana indicators work"):
               mouse_click(735, 0) # the cog in the top-right, for the session indicator
-              machine.wait_for_text(r"(Notifications|Rotation|Battery|Sound|Time|Date|System)")
+              wait_for_text(r"(Notifications|Rotation|Battery|Sound|Time|Date|System)")
               machine.screenshot("indicators_open")
 
               # Indicator order within the menus *should* be fixed based on per-indicator order setting
@@ -457,32 +658,32 @@ in
 
               with subtest("ayatana indicator display works"):
                   # We start on this, don't go right
-                  machine.wait_for_text("Lock")
+                  wait_for_text("Lock")
                   machine.screenshot("indicators_display")
 
               with subtest("lomiri indicator network works"):
                   machine.send_key("right")
-                  machine.wait_for_text(r"(Flight|Wi-Fi)")
+                  wait_for_text(r"(Flight|Wi-Fi)")
                   machine.screenshot("indicators_network")
 
               with subtest("ayatana indicator sound works"):
                   machine.send_key("right")
-                  machine.wait_for_text(r"(Silent|Volume)")
+                  wait_for_text(r"(Silent|Volume)")
                   machine.screenshot("indicators_sound")
 
               with subtest("ayatana indicator power works"):
                   machine.send_key("right")
-                  machine.wait_for_text(r"(Charge|Battery settings)")
+                  wait_for_text(r"(Charge|Battery settings)")
                   machine.screenshot("indicators_power")
 
               with subtest("ayatana indicator datetime works"):
                   machine.send_key("right")
-                  machine.wait_for_text("Time and Date Settings")
+                  wait_for_text("Time and Date Settings")
                   machine.screenshot("indicators_timedate")
 
               with subtest("ayatana indicator session works"):
                   machine.send_key("right")
-                  machine.wait_for_text("Log Out")
+                  wait_for_text("Log Out")
                   machine.screenshot("indicators_session")
 
                   # We should be able to log out and return to the greeter

--- a/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
@@ -1,29 +1,30 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, gitUpdater
-, nixosTests
-, ayatana-indicator-messages
-, cmake
-, dbus
-, dbus-test-runner
-, evolution-data-server
-, glib
-, gst_all_1
-, gtest
-, intltool
-, libaccounts-glib
-, libayatana-common
-, libical
-, libnotify
-, libuuid
-, lomiri
-, pkg-config
-, properties-cpp
-, python3
-, systemd
-, tzdata
-, wrapGAppsHook3
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  nixosTests,
+  ayatana-indicator-messages,
+  cmake,
+  dbus,
+  dbus-test-runner,
+  evolution-data-server,
+  glib,
+  gst_all_1,
+  gtest,
+  intltool,
+  libaccounts-glib,
+  libayatana-common,
+  libical,
+  libnotify,
+  libuuid,
+  lomiri,
+  pkg-config,
+  properties-cpp,
+  python3,
+  systemd,
+  tzdata,
+  wrapGAppsHook3,
 }:
 
 let
@@ -36,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "ayatana-indicator-datetime";
-    rev = finalAttrs.version;
+    rev = "refs/tags/${finalAttrs.version}";
     hash = "sha256-lY49v2uZ7BawQoN/hmN6pbetHlSGjMHbS6S8Wl1bDmQ=";
   };
 
@@ -61,34 +62,35 @@ stdenv.mkDerivation (finalAttrs: {
     wrapGAppsHook3
   ];
 
-  buildInputs = [
-    ayatana-indicator-messages
-    evolution-data-server
-    glib
-    libaccounts-glib
-    libayatana-common
-    libical
-    libnotify
-    libuuid
-    properties-cpp
-    systemd
-  ] ++ (with gst_all_1; [
-    gstreamer
-    gst-plugins-base
-    gst-plugins-good
-  ]) ++ (with lomiri; [
-    cmake-extras
-    lomiri-schemas
-    lomiri-sounds
-    lomiri-url-dispatcher
-  ]);
+  buildInputs =
+    [
+      ayatana-indicator-messages
+      evolution-data-server
+      glib
+      libaccounts-glib
+      libayatana-common
+      libical
+      libnotify
+      libuuid
+      properties-cpp
+      systemd
+    ]
+    ++ (with gst_all_1; [
+      gstreamer
+      gst-plugins-base
+      gst-plugins-good
+    ])
+    ++ (with lomiri; [
+      cmake-extras
+      lomiri-schemas
+      lomiri-sounds
+      lomiri-url-dispatcher
+    ]);
 
   nativeCheckInputs = [
     dbus
     dbus-test-runner
-    (python3.withPackages (ps: with ps; [
-      python-dbusmock
-    ]))
+    (python3.withPackages (ps: with ps; [ python-dbusmock ]))
     tzdata
   ];
 
@@ -109,13 +111,15 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelChecking = false;
 
   preCheck = ''
-    export XDG_DATA_DIRS=${lib.strings.concatStringsSep ":" [
-      # org.ayatana.common schema
-      (glib.passthru.getSchemaDataDirPath libayatana-common)
+    export XDG_DATA_DIRS=${
+      lib.strings.concatStringsSep ":" [
+        # org.ayatana.common schema
+        (glib.passthru.getSchemaDataDirPath libayatana-common)
 
-      # loading EDS engines to handle ICS-loading
-      edsDataDir
-    ]}
+        # loading EDS engines to handle ICS-loading
+        edsDataDir
+      ]
+    }
   '';
 
   # schema is already added automatically by wrapper, EDS needs to be added explicitly
@@ -126,16 +130,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    ayatana-indicators = [
-      "ayatana-indicator-datetime"
-    ];
+    ayatana-indicators = [ "ayatana-indicator-datetime" ];
     tests = {
       inherit (nixosTests) ayatana-indicators;
     };
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Ayatana Indicator providing clock and calendar";
     longDescription = ''
       This Ayatana Indicator provides a combined calendar, clock, alarm and
@@ -143,8 +145,8 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime";
     changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-datetime/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
@@ -130,7 +130,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    ayatana-indicators = [ "ayatana-indicator-datetime" ];
+    ayatana-indicators = {
+      ayatana-indicator-datetime = [
+        "ayatana"
+        "lomiri"
+      ];
+    };
     tests = {
       inherit (nixosTests) ayatana-indicators;
     };

--- a/pkgs/by-name/ay/ayatana-indicator-display/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-display/package.nix
@@ -1,30 +1,31 @@
-{ stdenv
-, lib
-, gitUpdater
-, fetchFromGitHub
-, nixosTests
-, accountsservice
-, cmake
-, cppcheck
-, dbus
-, geoclue2
-, glib
-, gsettings-desktop-schemas
-, gtest
-, intltool
-, libayatana-common
-, libgudev
-, libqtdbusmock
-, libqtdbustest
-, libsForQt5
-, lomiri
-, mate
-, pkg-config
-, properties-cpp
-, python3
-, systemd
-, wrapGAppsHook3
-, xsct
+{
+  stdenv,
+  lib,
+  gitUpdater,
+  fetchFromGitHub,
+  nixosTests,
+  accountsservice,
+  cmake,
+  cppcheck,
+  dbus,
+  geoclue2,
+  glib,
+  gsettings-desktop-schemas,
+  gtest,
+  intltool,
+  libayatana-common,
+  libgudev,
+  libqtdbusmock,
+  libqtdbustest,
+  libsForQt5,
+  lomiri,
+  mate,
+  pkg-config,
+  properties-cpp,
+  python3,
+  systemd,
+  wrapGAppsHook3,
+  xsct,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -60,29 +61,30 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # TODO Can we get around requiring every desktop's schemas just to avoid segfaulting on some systems?
-  buildInputs = [
-    accountsservice
-    geoclue2
-    gsettings-desktop-schemas # gnome schemas
-    glib
-    libayatana-common
-    libgudev
-    libsForQt5.qtbase
-    systemd
-  ] ++ (with lomiri; [
-    cmake-extras
-    lomiri-schemas # lomiri schema
-  ]) ++ (with mate; [
-    mate.marco # marco schema
-    mate.mate-settings-daemon # mate mouse schema
-  ]);
+  buildInputs =
+    [
+      accountsservice
+      geoclue2
+      gsettings-desktop-schemas # gnome schemas
+      glib
+      libayatana-common
+      libgudev
+      libsForQt5.qtbase
+      systemd
+    ]
+    ++ (with lomiri; [
+      cmake-extras
+      lomiri-schemas # lomiri schema
+    ])
+    ++ (with mate; [
+      mate.marco # marco schema
+      mate.mate-settings-daemon # mate mouse schema
+    ]);
 
   nativeCheckInputs = [
     cppcheck
     dbus
-    (python3.withPackages (ps: with ps; [
-      python-dbusmock
-    ]))
+    (python3.withPackages (ps: with ps; [ python-dbusmock ]))
   ];
 
   checkInputs = [
@@ -109,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Ayatana Indicator for Display configuration";
     longDescription = ''
       This Ayatana Indicator is designed to be placed on the right side of a
@@ -117,8 +119,8 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-display";
     changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-display/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ay/ayatana-indicator-display/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-display/package.nix
@@ -106,7 +106,12 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   passthru = {
-    ayatana-indicators = [ "ayatana-indicator-display" ];
+    ayatana-indicators = {
+      ayatana-indicator-display = [
+        "ayatana"
+        "lomiri"
+      ];
+    };
     tests.vm = nixosTests.ayatana-indicators;
     updateScript = gitUpdater { };
   };

--- a/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
@@ -1,26 +1,27 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, gitUpdater
-, nixosTests
-, testers
-, accountsservice
-, cmake
-, dbus-test-runner
-, withDocumentation ? true
-, docbook_xsl
-, docbook_xml_dtd_45
-, glib
-, gobject-introspection
-, gtest
-, gtk-doc
-, intltool
-, lomiri
-, pkg-config
-, python3
-, systemd
-, vala
-, wrapGAppsHook3
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  nixosTests,
+  testers,
+  accountsservice,
+  cmake,
+  dbus-test-runner,
+  withDocumentation ? true,
+  docbook_xsl,
+  docbook_xml_dtd_45,
+  glib,
+  gobject-introspection,
+  gtest,
+  gtk-doc,
+  intltool,
+  lomiri,
+  pkg-config,
+  python3,
+  systemd,
+  vala,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,49 +31,51 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "ayatana-indicator-messages";
-    rev = finalAttrs.version;
+    rev = "refs/tags/${finalAttrs.version}";
     hash = "sha256-D1181eD2mAVXEa7RLXXC4b2tVGrxbh0WWgtbC1anHH0=";
   };
 
   outputs = [
     "out"
     "dev"
-  ] ++ lib.optionals withDocumentation [
-    "devdoc"
-  ];
+  ] ++ lib.optionals withDocumentation [ "devdoc" ];
 
-  postPatch = ''
-    # Uses pkg_get_variable, cannot substitute prefix with that
-    substituteInPlace data/CMakeLists.txt \
-      --replace "\''${SYSTEMD_USER_DIR}" "$out/lib/systemd/user"
+  postPatch =
+    ''
+      # Uses pkg_get_variable, cannot substitute prefix with that
+      substituteInPlace data/CMakeLists.txt \
+        --replace "\''${SYSTEMD_USER_DIR}" "$out/lib/systemd/user"
 
-    # Bad concatenation
-    substituteInPlace libmessaging-menu/messaging-menu.pc.in \
-      --replace "\''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@" '@CMAKE_INSTALL_FULL_LIBDIR@' \
-      --replace "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" '@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+      # Bad concatenation
+      substituteInPlace libmessaging-menu/messaging-menu.pc.in \
+        --replace "\''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@" '@CMAKE_INSTALL_FULL_LIBDIR@' \
+        --replace "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" '@CMAKE_INSTALL_FULL_INCLUDEDIR@'
 
-    # Fix tests with gobject-introspection 1.80 not installing GLib introspection data
-    substituteInPlace tests/CMakeLists.txt \
-      --replace-fail 'GI_TYPELIB_PATH=\"' 'GI_TYPELIB_PATH=\"$GI_TYPELIB_PATH$\{GI_TYPELIB_PATH\:+\:\}'
-  '' + lib.optionalString (!withDocumentation) ''
-    sed -i CMakeLists.txt \
-      '/add_subdirectory(doc)/d'
-  '';
+      # Fix tests with gobject-introspection 1.80 not installing GLib introspection data
+      substituteInPlace tests/CMakeLists.txt \
+        --replace-fail 'GI_TYPELIB_PATH=\"' 'GI_TYPELIB_PATH=\"$GI_TYPELIB_PATH$\{GI_TYPELIB_PATH\:+\:\}'
+    ''
+    + lib.optionalString (!withDocumentation) ''
+      sed -i CMakeLists.txt \
+        '/add_subdirectory(doc)/d'
+    '';
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    glib # For glib-compile-schemas
-    intltool
-    pkg-config
-    vala
-    wrapGAppsHook3
-  ] ++ lib.optionals withDocumentation [
-    docbook_xsl
-    docbook_xml_dtd_45
-    gtk-doc
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      glib # For glib-compile-schemas
+      intltool
+      pkg-config
+      vala
+      wrapGAppsHook3
+    ]
+    ++ lib.optionals withDocumentation [
+      docbook_xsl
+      docbook_xml_dtd_45
+      gtk-doc
+    ];
 
   buildInputs = [
     accountsservice
@@ -83,10 +86,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeCheckInputs = [
-    (python3.withPackages (ps: with ps; [
-      pygobject3
-      python-dbusmock
-    ]))
+    (python3.withPackages (
+      ps: with ps; [
+        pygobject3
+        python-dbusmock
+      ]
+    ))
   ];
 
   checkInputs = [
@@ -133,9 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    ayatana-indicators = [
-      "ayatana-indicator-messages"
-    ];
+    ayatana-indicators = [ "ayatana-indicator-messages" ];
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       vm = nixosTests.ayatana-indicators;
@@ -143,18 +146,16 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Ayatana Indicator Messages Applet";
     longDescription = ''
       The -messages Ayatana System Indicator is the messages menu indicator for Unity7, MATE and Lomiri (optionally for
       others, e.g. XFCE, LXDE).
     '';
     homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-messages";
-    license = licenses.gpl3Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ OPNA2608 ];
-    pkgConfigModules = [
-      "messaging-menu"
-    ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    pkgConfigModules = [ "messaging-menu" ];
   };
 })

--- a/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
@@ -138,7 +138,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    ayatana-indicators = [ "ayatana-indicator-messages" ];
+    ayatana-indicators = {
+      ayatana-indicator-messages = [
+        "ayatana"
+        "lomiri"
+      ];
+    };
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       vm = nixosTests.ayatana-indicators;

--- a/pkgs/by-name/ay/ayatana-indicator-power/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-power/package.nix
@@ -1,22 +1,23 @@
-{ stdenv
-, lib
-, gitUpdater
-, fetchFromGitHub
-, nixosTests
-, cmake
-, dbus
-, dbus-test-runner
-, glib
-, gtest
-, intltool
-, libayatana-common
-, libnotify
-, librda
-, lomiri
-, pkg-config
-, python3
-, systemd
-, wrapGAppsHook3
+{
+  stdenv,
+  lib,
+  gitUpdater,
+  fetchFromGitHub,
+  nixosTests,
+  cmake,
+  dbus,
+  dbus-test-runner,
+  glib,
+  gtest,
+  intltool,
+  libayatana-common,
+  libnotify,
+  librda,
+  lomiri,
+  pkg-config,
+  python3,
+  systemd,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,24 +51,24 @@ stdenv.mkDerivation (finalAttrs: {
     wrapGAppsHook3
   ];
 
-  buildInputs = [
-    glib
-    libayatana-common
-    libnotify
-    librda
-    systemd
-  ] ++ (with lomiri; [
-    cmake-extras
-    deviceinfo
-    lomiri-schemas
-    lomiri-sounds
-  ]);
+  buildInputs =
+    [
+      glib
+      libayatana-common
+      libnotify
+      librda
+      systemd
+    ]
+    ++ (with lomiri; [
+      cmake-extras
+      deviceinfo
+      lomiri-schemas
+      lomiri-sounds
+    ]);
 
   nativeCheckInputs = [
     dbus
-    (python3.withPackages (ps: with ps; [
-      python-dbusmock
-    ]))
+    (python3.withPackages (ps: with ps; [ python-dbusmock ]))
   ];
 
   checkInputs = [
@@ -92,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Ayatana Indicator showing power state";
     longDescription = ''
       This Ayatana Indicator displays current power management information and
@@ -100,8 +101,8 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-power";
     changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-power/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ay/ayatana-indicator-power/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-power/package.nix
@@ -88,7 +88,12 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   passthru = {
-    ayatana-indicators = [ "ayatana-indicator-power" ];
+    ayatana-indicators = {
+      ayatana-indicator-power = [
+        "ayatana"
+        "lomiri"
+      ];
+    };
     tests.vm = nixosTests.ayatana-indicators;
     updateScript = gitUpdater { };
   };

--- a/pkgs/by-name/ay/ayatana-indicator-session/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-session/package.nix
@@ -1,22 +1,23 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, gitUpdater
-, nixosTests
-, cmake
-, dbus
-, glib
-, gnome
-, gsettings-desktop-schemas
-, gtest
-, intltool
-, libayatana-common
-, librda
-, lomiri
-, mate
-, pkg-config
-, systemd
-, wrapGAppsHook3
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  nixosTests,
+  cmake,
+  dbus,
+  glib,
+  gnome,
+  gsettings-desktop-schemas,
+  gtest,
+  intltool,
+  libayatana-common,
+  librda,
+  lomiri,
+  mate,
+  pkg-config,
+  systemd,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "ayatana-indicator-session";
-    rev = finalAttrs.version;
+    rev = "refs/tags/${finalAttrs.version}";
     hash = "sha256-p4nu7ZgnEjnnxNqyZIg//YcssnQcCY7GFDbpGIu1dz0=";
   };
 
@@ -61,13 +62,9 @@ stdenv.mkDerivation (finalAttrs: {
     mate.mate-settings-daemon
   ];
 
-  nativeCheckInputs = [
-    dbus
-  ];
+  nativeCheckInputs = [ dbus ];
 
-  checkInputs = [
-    gtest
-  ];
+  checkInputs = [ gtest ];
 
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
@@ -86,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Ayatana Indicator showing session management, status and user switching";
     longDescription = ''
       This Ayatana Indicator is designed to be placed on the right side of a
@@ -98,8 +95,8 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-session";
     changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-session/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ay/ayatana-indicator-session/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-session/package.nix
@@ -78,7 +78,12 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelChecking = false;
 
   passthru = {
-    ayatana-indicators = [ "ayatana-indicator-session" ];
+    ayatana-indicators = {
+      ayatana-indicator-session = [
+        "ayatana"
+        "lomiri"
+      ];
+    };
     tests.vm = nixosTests.ayatana-indicators;
     updateScript = gitUpdater { };
   };

--- a/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
@@ -1,30 +1,31 @@
-{ stdenv
-, lib
-, gitUpdater
-, fetchFromGitHub
-, nixosTests
-, accountsservice
-, cmake
-, dbus
-, dbus-test-runner
-, glib
-, gobject-introspection
-, gtest
-, intltool
-, libayatana-common
-, libgee
-, libnotify
-, libpulseaudio
-, libqtdbusmock
-, libqtdbustest
-, libsForQt5
-, libxml2
-, lomiri
-, pkg-config
-, python3
-, systemd
-, vala
-, wrapGAppsHook3
+{
+  stdenv,
+  lib,
+  gitUpdater,
+  fetchFromGitHub,
+  nixosTests,
+  accountsservice,
+  cmake,
+  dbus,
+  dbus-test-runner,
+  glib,
+  gobject-introspection,
+  gtest,
+  intltool,
+  libayatana-common,
+  libgee,
+  libnotify,
+  libpulseaudio,
+  libqtdbusmock,
+  libqtdbustest,
+  libsForQt5,
+  libxml2,
+  lomiri,
+  pkg-config,
+  python3,
+  systemd,
+  vala,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -61,27 +62,27 @@ stdenv.mkDerivation (finalAttrs: {
     wrapGAppsHook3
   ];
 
-  buildInputs = [
-    accountsservice
-    glib
-    gobject-introspection
-    libayatana-common
-    libgee
-    libnotify
-    libpulseaudio
-    libxml2
-    systemd
-  ] ++ (with lomiri; [
-    cmake-extras
-    lomiri-api
-    lomiri-schemas
-  ]);
+  buildInputs =
+    [
+      accountsservice
+      glib
+      gobject-introspection
+      libayatana-common
+      libgee
+      libnotify
+      libpulseaudio
+      libxml2
+      systemd
+    ]
+    ++ (with lomiri; [
+      cmake-extras
+      lomiri-api
+      lomiri-schemas
+    ]);
 
   nativeCheckInputs = [
     dbus
-    (python3.withPackages (ps: with ps; [
-      python-dbusmock
-    ]))
+    (python3.withPackages (ps: with ps; [ python-dbusmock ]))
   ];
 
   checkInputs = [
@@ -110,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Ayatana Indicator for managing system sound";
     longDescription = ''
       Ayatana Indicator Sound that provides easy control of the PulseAudio
@@ -118,8 +119,8 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-sound";
     changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-sound/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
@@ -106,7 +106,12 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   passthru = {
-    ayatana-indicators = [ "ayatana-indicator-sound" ];
+    ayatana-indicators = {
+      ayatana-indicator-sound = [
+        "ayatana"
+        "lomiri"
+      ];
+    };
     tests.vm = nixosTests.ayatana-indicators;
     updateScript = gitUpdater { };
   };

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -263,7 +263,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
-      inherit (nixosTests.lomiri) greeter desktop desktop-ayatana-indicators;
+      inherit (nixosTests.lomiri)
+        greeter
+        desktop-basics
+        desktop-appinteractions
+        desktop-ayatana-indicators
+        ;
     };
     updateScript = gitUpdater { };
     greeter = linkFarm "lomiri-greeter" [

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  fetchpatch,
   gitUpdater,
   nixosTests,
   testers,
@@ -45,6 +46,16 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
     "doc"
+  ];
+
+  patches = [
+    # Move to new lomiri-indicators target
+    # Remove when version > 1.0.2
+    (fetchpatch {
+      name = "0001-lomiri-indicator-network-lomiri-indicators-target.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-indicator-network/-/commit/b1e1f7da4b298964eba3caea37b1dace7a6182e9.patch";
+      hash = "sha256-pZKpEn2OJtB1pG/U+6IjtPGiOchRDhdbBHEZbTW7Lx0=";
+    })
   ];
 
   postPatch = ''
@@ -106,7 +117,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    ayatana-indicators = [ "lomiri-indicator-network" ];
+    ayatana-indicators = {
+      lomiri-indicator-network = [ "lomiri" ];
+    };
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       vm = nixosTests.ayatana-indicators;

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -1,32 +1,33 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, gitUpdater
-, nixosTests
-, testers
-, cmake
-, cmake-extras
-, coreutils
-, dbus
-, doxygen
-, gettext
-, glib
-, gmenuharness
-, gtest
-, intltool
-, libsecret
-, libqofono
-, libqtdbusmock
-, libqtdbustest
-, lomiri-api
-, lomiri-url-dispatcher
-, networkmanager
-, ofono
-, pkg-config
-, python3
-, qtdeclarative
-, qtbase
-, validatePkgConfig
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  nixosTests,
+  testers,
+  cmake,
+  cmake-extras,
+  coreutils,
+  dbus,
+  doxygen,
+  gettext,
+  glib,
+  gmenuharness,
+  gtest,
+  intltool,
+  libsecret,
+  libqofono,
+  libqtdbusmock,
+  libqtdbustest,
+  lomiri-api,
+  lomiri-url-dispatcher,
+  networkmanager,
+  ofono,
+  pkg-config,
+  python3,
+  qtdeclarative,
+  qtbase,
+  validatePkgConfig,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -78,11 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtbase
   ];
 
-  nativeCheckInputs = [
-    (python3.withPackages (ps: with ps; [
-      python-dbusmock
-    ]))
-  ];
+  nativeCheckInputs = [ (python3.withPackages (ps: with ps; [ python-dbusmock ])) ];
 
   checkInputs = [
     gmenuharness
@@ -109,9 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    ayatana-indicators = [
-      "lomiri-indicator-network"
-    ];
+    ayatana-indicators = [ "lomiri-indicator-network" ];
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       vm = nixosTests.ayatana-indicators;
@@ -119,15 +114,13 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Ayatana indiator exporting the network settings menu through D-Bus";
     homepage = "https://gitlab.com/ubports/development/core/lomiri-indicator-network";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-indicator-network/-/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.gpl3Only;
-    maintainers = teams.lomiri.members;
-    platforms = platforms.linux;
-    pkgConfigModules = [
-      "lomiri-connectivity-qt1"
-    ];
+    license = lib.licenses.gpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
+    pkgConfigModules = [ "lomiri-connectivity-qt1" ];
   };
 })

--- a/pkgs/desktops/lomiri/services/telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/telephony-service/default.nix
@@ -1,42 +1,45 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, fetchpatch
-, gitUpdater
-, nixosTests
-, ayatana-indicator-messages
-, bash
-, cmake
-, dbus
-, dbus-glib
-, dbus-test-runner
-, dconf
-, gettext
-, glib
-, gnome-keyring
-, history-service
-, libnotify
-, libphonenumber
-, libpulseaudio
-, libusermetrics
-, lomiri-url-dispatcher
-, makeWrapper
-, pkg-config
-, protobuf
-, python3
-, qtbase
-, qtdeclarative
-, qtfeedback
-, qtmultimedia
-, qtpim
-, telepathy
-, telepathy-glib
-, telepathy-mission-control
-, xvfb-run
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  nixosTests,
+  ayatana-indicator-messages,
+  bash,
+  cmake,
+  dbus,
+  dbus-glib,
+  dbus-test-runner,
+  dconf,
+  gettext,
+  glib,
+  gnome-keyring,
+  history-service,
+  libnotify,
+  libphonenumber,
+  libpulseaudio,
+  libusermetrics,
+  lomiri-url-dispatcher,
+  makeWrapper,
+  pkg-config,
+  protobuf,
+  python3,
+  qtbase,
+  qtdeclarative,
+  qtfeedback,
+  qtmultimedia,
+  qtpim,
+  telepathy,
+  telepathy-glib,
+  telepathy-mission-control,
+  xvfb-run,
 }:
 
 let
-  replaceDbusService = pkg: name: "--replace \"\\\${DBUS_SERVICES_DIR}/${name}\" \"${pkg}/share/dbus-1/services/${name}\"";
+  replaceDbusService =
+    pkg: name:
+    "--replace-fail \"\\\${DBUS_SERVICES_DIR}/${name}\" \"${pkg}/share/dbus-1/services/${name}\"";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "telephony-service";
@@ -65,23 +68,25 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  postPatch = ''
-    # Queries qmake for the QML installation path, which returns a reference to Qt5's build directory
-    # Patch out failure if QMake is not found, since we don't use it
-    substituteInPlace CMakeLists.txt \
-      --replace "\''${QMAKE_EXECUTABLE} -query QT_INSTALL_QML" "echo $out/${qtbase.qtQmlPrefix}" \
-      --replace-fail 'QMAKE_EXECUTABLE STREQUAL "QMAKE_EXECUTABLE-NOTFOUND"' 'FALSE'
+  postPatch =
+    ''
+      # Queries qmake for the QML installation path, which returns a reference to Qt5's build directory
+      # Patch out failure if QMake is not found, since we don't use it
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "\''${QMAKE_EXECUTABLE} -query QT_INSTALL_QML" "echo $out/${qtbase.qtQmlPrefix}" \
+        --replace-fail 'QMAKE_EXECUTABLE STREQUAL "QMAKE_EXECUTABLE-NOTFOUND"' 'FALSE'
 
-  '' + lib.optionalString finalAttrs.finalPackage.doCheck ''
-    substituteInPlace tests/common/dbus-services/CMakeLists.txt \
-      ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.MissionControl5.service"} \
-      ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.AccountManager.service"} \
-      ${replaceDbusService dconf "ca.desrt.dconf.service"}
+    ''
+    + lib.optionalString finalAttrs.finalPackage.doCheck ''
+      substituteInPlace tests/common/dbus-services/CMakeLists.txt \
+        ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.MissionControl5.service"} \
+        ${replaceDbusService telepathy-mission-control "org.freedesktop.Telepathy.AccountManager.service"} \
+        ${replaceDbusService dconf "ca.desrt.dconf.service"}
 
-    substituteInPlace cmake/modules/GenerateTest.cmake \
-      --replace '/usr/lib/dconf' '${lib.getLib dconf}/libexec' \
-      --replace '/usr/lib/telepathy' '${lib.getLib telepathy-mission-control}/libexec'
-  '';
+      substituteInPlace cmake/modules/GenerateTest.cmake \
+        --replace-fail '/usr/lib/dconf' '${lib.getLib dconf}/libexec' \
+        --replace-fail '/usr/lib/telepathy' '${lib.getLib telepathy-mission-control}/libexec'
+    '';
 
   strictDeps = true;
 
@@ -106,10 +111,12 @@ stdenv.mkDerivation (finalAttrs: {
     libusermetrics
     lomiri-url-dispatcher
     protobuf
-    (python3.withPackages (ps: with ps; [
-      dbus-python
-      pygobject3
-    ]))
+    (python3.withPackages (
+      ps: with ps; [
+        dbus-python
+        pygobject3
+      ]
+    ))
     qtbase
     qtdeclarative
     qtfeedback
@@ -134,22 +141,27 @@ stdenv.mkDerivation (finalAttrs: {
     # These rely on libphonenumber reformatting inputs to certain results
     # Seem to be broken for a small amount of numbers, maybe libphonenumber version change?
     (lib.cmakeBool "SKIP_QML_TESTS" true)
-    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
-      # Exclude tests
-      "-E" (lib.strings.escapeShellArg "(${lib.concatStringsSep "|" [
-        # Flaky, randomly failing to launch properly & stuck until test timeout
-        # https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/issues/70
-        "^HandlerTest"
-        "^OfonoAccountEntryTest"
-        "^TelepathyHelperSetupTest"
-        "^AuthHandlerTest"
-        "^ChatManagerTest"
-        "^AccountEntryTest"
-        "^AccountEntryFactoryTest"
-        "^PresenceRequestTest"
-        "^CallEntryTest"
-      ]})")
-    ]))
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (
+      lib.concatStringsSep ";" [
+        # Exclude tests
+        "-E"
+        (lib.strings.escapeShellArg "(${
+          lib.concatStringsSep "|" [
+            # Flaky, randomly failing to launch properly & stuck until test timeout
+            # https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/issues/70
+            "^HandlerTest"
+            "^OfonoAccountEntryTest"
+            "^TelepathyHelperSetupTest"
+            "^AuthHandlerTest"
+            "^ChatManagerTest"
+            "^AccountEntryTest"
+            "^AccountEntryFactoryTest"
+            "^PresenceRequestTest"
+            "^CallEntryTest"
+          ]
+        })")
+      ]
+    ))
   ];
 
   env.NIX_CFLAGS_COMPILE = toString ([
@@ -165,7 +177,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   preCheck = ''
     export QT_QPA_PLATFORM=minimal
-    export QT_PLUGIN_PATH=${lib.makeSearchPathOutput "bin" qtbase.qtPluginPrefix [ qtbase qtpim ]}
+    export QT_PLUGIN_PATH=${
+      lib.makeSearchPathOutput "bin" qtbase.qtPluginPrefix [
+        qtbase
+        qtpim
+      ]
+    }
   '';
 
   postInstall = ''
@@ -173,20 +190,25 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Still missing getprop from libhybris, we don't have it packaged (yet?)
     wrapProgram $out/bin/ofono-setup \
-      --prefix PATH : ${lib.makeBinPath [ dbus dconf gettext glib telepathy-mission-control ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          dbus
+          dconf
+          gettext
+          glib
+          telepathy-mission-control
+        ]
+      }
 
     # These SystemD services are referenced by the installed D-Bus services, but not part of the installation. Why?
     for service in telephony-service-{approver,indicator}; do
       install -Dm644 ../debian/telephony-service."$service".user.service $out/lib/systemd/user/"$service".service
 
-      # ofono-setup.service would be rovided by ubuntu-touch-session, we don't plan to package it
+      # ofono-setup.service would be provided by ubuntu-touch-session, we don't plan to package it
       substituteInPlace $out/lib/systemd/user/"$service".service \
-        --replace '/usr' "$out" \
-        --replace 'Requires=ofono-setup.service' "" \
-        --replace 'After=ofono-setup.service' "" \
-
-      sed -i $out/lib/systemd/user/"$service".service \
-        -e '/ofono-setup.service/d'
+        --replace-fail '/usr' "$out" \
+        --replace-warn 'Requires=ofono-setup.service' "" \
+        --replace-warn 'After=ofono-setup.service' ""
     done
 
     # Parses the call & SMS indicator desktop files & tries to find its own executable in PATH
@@ -195,19 +217,17 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    ayatana-indicators = [
-      "telephony-service-indicator"
-    ];
+    ayatana-indicators = [ "telephony-service-indicator" ];
     tests.vm = nixosTests.ayatana-indicators;
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Backend dispatcher service for various mobile phone related operations";
     homepage = "https://gitlab.com/ubports/development/core/telephony-service";
     changelog = "https://gitlab.com/ubports/development/core/telephony-service/-/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.gpl3Only;
-    maintainers = teams.lomiri.members;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/desktops/lomiri/services/telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/telephony-service/default.nix
@@ -205,10 +205,12 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 ../debian/telephony-service."$service".user.service $out/lib/systemd/user/"$service".service
 
       # ofono-setup.service would be provided by ubuntu-touch-session, we don't plan to package it
+      # Doesn't make sense to provide on non-Lomiri
       substituteInPlace $out/lib/systemd/user/"$service".service \
         --replace-fail '/usr' "$out" \
         --replace-warn 'Requires=ofono-setup.service' "" \
-        --replace-warn 'After=ofono-setup.service' ""
+        --replace-warn 'After=ofono-setup.service' "" \
+        --replace-warn 'WantedBy=ayatana-indicators.target' 'WantedBy=lomiri-indicators.target'
     done
 
     # Parses the call & SMS indicator desktop files & tries to find its own executable in PATH
@@ -217,7 +219,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    ayatana-indicators = [ "telephony-service-indicator" ];
+    ayatana-indicators = {
+      telephony-service-indicator = [ "lomiri" ];
+    };
     tests.vm = nixosTests.ayatana-indicators;
     updateScript = gitUpdater { };
   };


### PR DESCRIPTION
## Description of changes

The Ayatana & Lomiri upstreams have adapted a new strategy for using the Ayatana Indicators system, without bloating non-Lomiri desktops with Lomiri-specific, otherwise-broken services: Just make a new target for Lomiri.

Examples:
- https://github.com/AyatanaIndicators/ayatana-indicator-datetime/commit/43c8d3662f3396d74f67585daab41d287ffca393
- https://gitlab.com/ubports/development/core/lomiri-indicator-network/-/commit/b1e1f7da4b298964eba3caea37b1dace7a6182e9

Handle this by:
1. Changing the format of `<package>.passthru.ayatana-indicators` from a simple list to an attrset of `service = [ target1 target2 ... ]`
    The code constructing the final targets' after & wanted lists continues to support the old format, in case of out-of-tree users
2. Move all in-tree indicators to the new format, marking what targets they should be brought up by (more or less what's in their `WantedBy` fields
3. Adjust the test to check both targets

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
