### PR TITLE
emacs: make melpaBuild accept recipe content as a string

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/melpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/melpa.nix
@@ -63,11 +63,10 @@ libBuildHelper.extendMkDerivation' genericBuild (finalAttrs:
   /*
     recipe: Optional MELPA recipe.
     Default: a minimally functional recipe
+    This can be a path of a recipe file, a string of the recipe content or an empty string.
+    The default value is used if it is an empty string.
   */
-, recipe ? (writeText "${finalAttrs.pname}-recipe" ''
-    (${finalAttrs.ename} :fetcher git :url ""
-              ${lib.optionalString (finalAttrs.files != null) ":files ${finalAttrs.files}"})
-  '')
+, recipe ? ""
 , preUnpack ? ""
 , postUnpack ? ""
 , meta ? {}
@@ -98,9 +97,21 @@ libBuildHelper.extendMkDerivation' genericBuild (finalAttrs:
 
   preUnpack = ''
     mkdir -p "$NIX_BUILD_TOP/recipes"
-    if [ -n "$recipe" ]; then
-      cp "$recipe" "$NIX_BUILD_TOP/recipes/$ename"
+    recipeFile="$NIX_BUILD_TOP/recipes/$ename"
+    if [ -r "$recipe" ]; then
+      ln -s "$recipe" "$recipeFile"
+      nixInfoLog "link recipe"
+    elif [ -n "$recipe" ]; then
+      printf "%s" "$recipe" > "$recipeFile"
+      nixInfoLog "write recipe"
+    else
+      cat > "$recipeFile" <<'EOF'
+(${finalAttrs.ename} :fetcher git :url "" ${lib.optionalString (finalAttrs.files != null) ":files ${finalAttrs.files}"})
+EOF
+      nixInfoLog "use default recipe"
     fi
+    nixInfoLog "recipe content:" "$(< $recipeFile)"
+    unset -v recipeFile
 
     ln -s "$packageBuild" "$NIX_BUILD_TOP/package-build"
 


### PR DESCRIPTION
This is the first part of https://github.com/NixOS/nixpkgs/issues/334888.  (I probably won't do the second part, i.e., changing the code for generating MELPA index).

Presumably, this PR does not change the built packages.  I have rebeased the commit onto master and verified that the content of `urweb-mode` (default recipe) and `flycheck` (file path as recipe) does not change.  However, duo to the limitation of nix, this triggers rebuilds of all packages built with `melpaBuild`.

I have also tested three possible branches.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
