### PR TITLE
hyper: mark as broken

### DIFF
--- a/pkgs/applications/terminal-emulators/hyper/default.nix
+++ b/pkgs/applications/terminal-emulators/hyper/default.nix
@@ -54,5 +54,6 @@ stdenv.mkDerivation rec {
     license     = licenses.mit;
     platforms   = [ "x86_64-linux" ];
     mainProgram = "hyper";
+    broken = true; # Error: 'node-pty' failed to load
   };
 }


### PR DESCRIPTION
## Description of changes

Marks `hyper` as broken because of runtime error.
<details> 

<summary>Log</summary>

```text
innerError Error: Cannot find module '../build/Debug/pty.node'
Require stack:
- /nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/node_modules/node-pty/lib/unixTerminal.js
- /nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/node_modules/node-pty/lib/index.js
- /nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/session.js
- /nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/ui/window.js
- /nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/index.js
-
    at Module._resolveFilename (node:internal/modules/cjs/loader:940:15)
    at n._resolveFilename (node:electron/js2c/browser_init:245:1105)
    at Module._load (node:internal/modules/cjs/loader:785:27)
    at c._load (node:electron/js2c/asar_bundle:5:13343)
    at Function._load (/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/plugins.js:103:37)
    at Module.require (node:internal/modules/cjs/loader:1012:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/node_modules/node-pty/lib/unixTerminal.js:30:15)
    at Module._compile (node:internal/modules/cjs/loader:1120:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1175:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/node_modules/node-pty/lib/unixTerminal.js',
    '/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/node_modules/node-pty/lib/index.js',
    '/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/session.js',
    '/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/ui/window.js',
    '/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/index.js',
    undefined
  ]
}
A JavaScript error occurred in the main process
Uncaught Exception:
Error: `node-pty` failed to load. Typically this means that it was built incorrectly. Please check the `readme.md` to more info.
    at createNodePtyError (/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/session.js:39:34)
    at Object.<anonymous> (/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/session.js:46:11)
    at Module._compile (node:internal/modules/cjs/loader:1120:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1175:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Module._load (node:internal/modules/cjs/loader:829:12)
    at c._load (node:electron/js2c/asar_bundle:5:13343)
    at Function._load (/nix/store/s6fcai3kfzf3a6ds7zdvgfc79g8xins5-hyper-3.4.1/opt/Hyper/resources/app.asar/plugins.js:103:37)
    at Module.require (node:internal/modules/cjs/loader:1012:19)
    at require (node:internal/modules/cjs/helpers:102:18)
```

</details>

Fixes test timeout `nixos.tests.terminal-emulators.hyper`:
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.terminal-emulators.hyper.x86_64-linux

According to that test error started from `hyper` build on `2023-04-12`:
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.terminal-emulators.hyper.x86_64-linux/all?page=15
https://hydra.nixos.org/build/215757444
Last good run:
https://hydra.nixos.org/build/215468671
First bad run:
https://hydra.nixos.org/build/215718591

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
