### PR TITLE
python3Packages.tensorflow-bin: Use CUDA 12, add Jetson support

### DIFF
--- a/pkgs/development/python-modules/geoip2/default.nix
+++ b/pkgs/development/python-modules/geoip2/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "geoip2" ];
 
   disabledTests =
-    lib.optionals (pythonAtLeast "3.11") [
+    lib.optionals (pythonAtLeast "3.10") [
       # https://github.com/maxmind/GeoIP2-python/pull/136
       "TestAsyncClient"
     ]

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -107,6 +107,7 @@ buildPythonPackage {
     pushd dist
 
     for f in tensorflow-*+nv*.whl; do
+      # e.g. *nv24.07* -> *nv24.7*
       mv "$f" "$(sed -E 's/(nv[0-9]+)\.0*([0-9]+)/\1.\2/' <<< "$f")"
     done
 

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -95,7 +95,8 @@ buildPythonPackage {
   build-system = [
     distutils
     wheel
-  ] ++ lib.optionals cudaSupport [ addDriverRunpath ];
+  ] ++ lib.optionals cudaSupport ([ addDriverRunpath ]
+    ++ lib.optionals cudaPackages.cudaFlags.isJetsonBuild [ cudaPackages.autoAddCudaCompatRunpath ]);
 
   preConfigure = ''
     unset SOURCE_DATE_EPOCH

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -51,7 +51,7 @@ let
   packages = import ./binary-hashes.nix;
   inherit (cudaPackages) cudatoolkit cudnn;
 in
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "tensorflow" + lib.optionalString cudaSupport "-gpu";
   version = packages."${"version" + lib.optionalString (cudaSupport && cudaPackages.cudaFlags.isJetsonBuild) "_jetson"}";
   format = "wheel";

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -140,12 +140,11 @@ buildPythonPackage rec {
   postFixup =
     let
       # rpaths we only need to add if CUDA is enabled.
-      cudapaths = lib.optionals cudaSupport ([
+      cudapaths = lib.optionals cudaSupport [
         cudatoolkit.out
         cudatoolkit.lib
-      ] ++ lib.optionals (!cudaPackages.cudaFlags.isJetsonBuild) [
         cudnn
-      ]);
+      ];
 
       libpaths = [
         stdenv.cc.cc.lib

--- a/pkgs/development/python-modules/tensorflow/binary-hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/binary-hashes.nix
@@ -1,5 +1,6 @@
 {
   version = "2.17.0";
+  version_jetson = "2.16.1+nv24.07";
   x86_64-linux_39 = {
     url = "https://storage.googleapis.com/tensorflow/versions/2.17.0/tensorflow_cpu-2.17.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
     sha256 = "1aacn68b88bnnmpl1q0irih0avzm2lfyhwr3wldg144n5zljlrbx";
@@ -47,6 +48,10 @@
   aarch64-linux_312 = {
     url = "https://storage.googleapis.com/tensorflow/versions/2.17.0/tensorflow-2.17.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl";
     sha256 = "1zrscms9qkfpiscnl8c7ibfipwpw8jrdfvwh4wb69p9rxvqgxbbj";
+  };
+  aarch64-linux_310_jetson = {
+    url = "https://developer.download.nvidia.com/compute/redist/jp/v60/tensorflow/tensorflow-2.16.1+nv24.07-cp310-cp310-linux_aarch64.whl";
+    sha256 = "1ymdknl5v41z6z0wg068diici30am8vysg6b6sqxr8w6yk4aib42";
   };
   aarch64-darwin_39 = {
     url = "https://storage.googleapis.com/tensorflow/versions/2.17.0/tensorflow-2.17.0-cp39-cp39-macosx_12_0_arm64.whl";

--- a/pkgs/development/python-modules/tensorflow/prefetcher.sh
+++ b/pkgs/development/python-modules/tensorflow/prefetcher.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 version="2.17.0"
+version_jetson="2.16.1+nv24.07"
 
 bucket="https://storage.googleapis.com/tensorflow/versions/${version}"
+bucket_jetson="https://developer.download.nvidia.com/compute/redist/jp/v60/tensorflow"
 
 # List of binary wheels for Tensorflow.  The most recent versions can be found
 # on the following page:
@@ -20,6 +22,7 @@ url_and_key_list=(
 "aarch64-linux_310 $bucket/tensorflow-${version}-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
 "aarch64-linux_311 $bucket/tensorflow-${version}-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
 "aarch64-linux_312 $bucket/tensorflow-${version}-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+"aarch64-linux_310_jetson $bucket_jetson/tensorflow-${version_jetson}-cp310-cp310-linux_aarch64.whl"
 "aarch64-darwin_39 $bucket/tensorflow-${version}-cp39-cp39-macosx_12_0_arm64.whl"
 "aarch64-darwin_310 $bucket/tensorflow-${version}-cp310-cp310-macosx_12_0_arm64.whl"
 "aarch64-darwin_311 $bucket/tensorflow-${version}-cp311-cp311-macosx_12_0_arm64.whl"
@@ -30,6 +33,7 @@ hashfile=binary-hashes.nix
 rm -f $hashfile
 echo "{" >> $hashfile
 echo "version = \"$version\";" >> $hashfile
+echo "version_jetson = \"$version_jetson\";" >> $hashfile
 
 for url_and_key in "${url_and_key_list[@]}"; do
   key=$(echo "$url_and_key" | cut -d' ' -f1)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15392,7 +15392,7 @@ self: super: with self; {
   tensorflow-bin = callPackage ../development/python-modules/tensorflow/bin.nix {
     inherit (pkgs.config) cudaSupport;
     # https://www.tensorflow.org/install/source#gpu
-    cudaPackages = pkgs.cudaPackages_11;
+    cudaPackages = pkgs.cudaPackages_12;
   };
 
   tensorflow-build = let


### PR DESCRIPTION
## Description of changes

NVIDIA provide prebuilt copies of TensorFlow for Jetsons, and these can be used with the existing `tensorflow-bin` package. Unfortunately, only Python 3.10 builds are available.

No TensorRT support for now. No JAX either, though I'm not sure why that's a dependency in the first place.

`tensorflow-bin` has also been changed to use CUDA 12 for all platforms, as this is what versions >= 2.15.0 expect (https://www.tensorflow.org/install/source#gpu).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@NixOS/cuda-maintainers @jyp @abbradar