### PR TITLE
python3Packages.array-api-compat: init at 1.8

### DIFF
--- a/pkgs/development/python-modules/array-api-compat/default.nix
+++ b/pkgs/development/python-modules/array-api-compat/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  numpy,
+  jaxlib,
+  jax,
+  torch,
+  dask,
+  sparse,
+  array-api-strict,
+  config,
+  cudaSupport ? config.cudaSupport,
+  cupy,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "array-api-compat";
+  version = "1.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "data-apis";
+    repo = "array-api-compat";
+    rev = "refs/tags/${version}";
+    hash = "sha256-DZs51yWgeMX7lmzR6jily0S3MRD4AVlk7BP8aU99Zp8=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+    jaxlib
+    jax
+    torch
+    dask
+    sparse
+    array-api-strict
+  ] ++ lib.optionals cudaSupport [ cupy ];
+
+  pythonImportsCheck = [ "array_api_compat" ];
+
+  # CUDA (used via cupy) is not available in the testing sandbox
+  checkPhase = ''
+    runHook preCheck
+    python -m pytest -k 'not cupy'
+    runHook postCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://data-apis.org/array-api-compat";
+    changelog = "https://github.com/data-apis/array-api-compat/releases/tag/${version}";
+    description = "Compatibility layer for NumPy to support the Python array API";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ berquist ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -779,6 +779,8 @@ self: super: with self; {
 
   arnparse = callPackage ../development/python-modules/arnparse { };
 
+  array-api-compat = callPackage ../development/python-modules/array-api-compat { };
+
   array-api-strict = callPackage ../development/python-modules/array-api-strict { };
 
   array-record = callPackage ../development/python-modules/array-record { };


### PR DESCRIPTION
## Description of changes

This Python package is a transitive dependency for https://github.com/scverse/anndata, a part of https://github.com/NixOS/nixpkgs/issues/313389.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - done but no dependents
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - no binaries
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
