### PR TITLE
cc-wrapper: disable incompatible hardening options in cpu bit size cross

### DIFF
--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -108,54 +108,54 @@ rec {
   types.cpuType = enum (attrValues cpuTypes);
 
   cpuTypes = let inherit (significantBytes) bigEndian littleEndian; in setTypes types.openCpuType {
-    arm      = { bits = 32; significantByte = littleEndian; family = "arm"; };
-    armv5tel = { bits = 32; significantByte = littleEndian; family = "arm"; version = "5"; arch = "armv5t"; };
-    armv6m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "6"; arch = "armv6-m"; };
-    armv6l   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "6"; arch = "armv6"; };
-    armv7a   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; arch = "armv7-a"; };
-    armv7r   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; arch = "armv7-r"; };
-    armv7m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; arch = "armv7-m"; };
-    armv7l   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; arch = "armv7"; };
-    armv8a   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; arch = "armv8-a"; };
-    armv8r   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; arch = "armv8-a"; };
-    armv8m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; arch = "armv8-m"; };
-    aarch64  = { bits = 64; significantByte = littleEndian; family = "arm"; version = "8"; arch = "armv8-a"; };
+    arm      = { bits = 32; significantByte = littleEndian; family = "arm"; as64bit = "aarch64"; };
+    armv5tel = { bits = 32; significantByte = littleEndian; family = "arm"; version = "5"; arch = "armv5t"; as64bit = "aarch64"; };
+    armv6m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "6"; arch = "armv6-m"; as64bit = "aarch64"; };
+    armv6l   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "6"; arch = "armv6"; as64bit = "aarch64"; };
+    armv7a   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; arch = "armv7-a"; as64bit = "aarch64"; };
+    armv7r   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; arch = "armv7-r"; as64bit = "aarch64"; };
+    armv7m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; arch = "armv7-m"; as64bit = "aarch64"; };
+    armv7l   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; arch = "armv7"; as64bit = "aarch64"; };
+    armv8a   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; arch = "armv8-a"; as64bit = "aarch64"; };
+    armv8r   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; arch = "armv8-a"; as64bit = "aarch64"; };
+    armv8m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; arch = "armv8-m"; as64bit = "aarch64"; };
+    aarch64  = { bits = 64; significantByte = littleEndian; family = "arm"; version = "8"; arch = "armv8-a"; as32bit = "arm"; };
     aarch64_be = { bits = 64; significantByte = bigEndian; family = "arm"; version = "8";  arch = "armv8-a"; };
 
-    i386     = { bits = 32; significantByte = littleEndian; family = "x86"; arch = "i386"; };
-    i486     = { bits = 32; significantByte = littleEndian; family = "x86"; arch = "i486"; };
-    i586     = { bits = 32; significantByte = littleEndian; family = "x86"; arch = "i586"; };
-    i686     = { bits = 32; significantByte = littleEndian; family = "x86"; arch = "i686"; };
-    x86_64   = { bits = 64; significantByte = littleEndian; family = "x86"; arch = "x86-64"; };
+    i386     = { bits = 32; significantByte = littleEndian; family = "x86"; arch = "i386"; as64bit = "x86_64"; };
+    i486     = { bits = 32; significantByte = littleEndian; family = "x86"; arch = "i486"; as64bit = "x86_64"; };
+    i586     = { bits = 32; significantByte = littleEndian; family = "x86"; arch = "i586"; as64bit = "x86_64"; };
+    i686     = { bits = 32; significantByte = littleEndian; family = "x86"; arch = "i686"; as64bit = "x86_64"; };
+    x86_64   = { bits = 64; significantByte = littleEndian; family = "x86"; arch = "x86-64"; as32bit = "i686"; };
 
     microblaze   = { bits = 32; significantByte = bigEndian;    family = "microblaze"; };
     microblazeel = { bits = 32; significantByte = littleEndian; family = "microblaze"; };
 
-    mips     = { bits = 32; significantByte = bigEndian;    family = "mips"; };
-    mipsel   = { bits = 32; significantByte = littleEndian; family = "mips"; };
-    mips64   = { bits = 64; significantByte = bigEndian;    family = "mips"; };
-    mips64el = { bits = 64; significantByte = littleEndian; family = "mips"; };
+    mips     = { bits = 32; significantByte = bigEndian;    family = "mips"; as64bit = "mips64"; };
+    mipsel   = { bits = 32; significantByte = littleEndian; family = "mips"; as64bit = "mips64el"; };
+    mips64   = { bits = 64; significantByte = bigEndian;    family = "mips"; as32bit = "mips"; };
+    mips64el = { bits = 64; significantByte = littleEndian; family = "mips"; as32bit = "mipsel"; };
 
     mmix     = { bits = 64; significantByte = bigEndian;    family = "mmix"; };
 
     m68k     = { bits = 32; significantByte = bigEndian; family = "m68k"; };
 
-    powerpc  = { bits = 32; significantByte = bigEndian;    family = "power"; };
-    powerpc64 = { bits = 64; significantByte = bigEndian; family = "power"; };
-    powerpc64le = { bits = 64; significantByte = littleEndian; family = "power"; };
-    powerpcle = { bits = 32; significantByte = littleEndian; family = "power"; };
+    powerpc  = { bits = 32; significantByte = bigEndian;    family = "power"; as64bit = "powerpc64"; };
+    powerpc64 = { bits = 64; significantByte = bigEndian; family = "power"; as32bit = "powerpc"; };
+    powerpc64le = { bits = 64; significantByte = littleEndian; family = "power"; as32bit = "powerpcle"; };
+    powerpcle = { bits = 32; significantByte = littleEndian; family = "power"; as64bit = "powerpc64le"; };
 
-    riscv32  = { bits = 32; significantByte = littleEndian; family = "riscv"; };
-    riscv64  = { bits = 64; significantByte = littleEndian; family = "riscv"; };
+    riscv32  = { bits = 32; significantByte = littleEndian; family = "riscv"; as64bit = "riscv64"; };
+    riscv64  = { bits = 64; significantByte = littleEndian; family = "riscv"; as32bit = "riscv32"; };
 
-    s390     = { bits = 32; significantByte = bigEndian; family = "s390"; };
-    s390x    = { bits = 64; significantByte = bigEndian; family = "s390"; };
+    s390     = { bits = 32; significantByte = bigEndian; family = "s390"; as64bit = "s390x"; };
+    s390x    = { bits = 64; significantByte = bigEndian; family = "s390"; as32bit = "s390"; };
 
-    sparc    = { bits = 32; significantByte = bigEndian;    family = "sparc"; };
-    sparc64  = { bits = 64; significantByte = bigEndian;    family = "sparc"; };
+    sparc    = { bits = 32; significantByte = bigEndian;    family = "sparc"; as64bit = "sparc64"; };
+    sparc64  = { bits = 64; significantByte = bigEndian;    family = "sparc"; as32bit = "sparc"; };
 
-    wasm32   = { bits = 32; significantByte = littleEndian; family = "wasm"; };
-    wasm64   = { bits = 64; significantByte = littleEndian; family = "wasm"; };
+    wasm32   = { bits = 32; significantByte = littleEndian; family = "wasm"; as64bit = "wasm64"; };
+    wasm64   = { bits = 64; significantByte = littleEndian; family = "wasm"; as32bit = "wasm32"; };
 
     alpha    = { bits = 64; significantByte = littleEndian; family = "alpha"; };
 


### PR DESCRIPTION
## Description of changes

As the title says, this disables incompatible hardening options when cross compiling between the same ISA but different bit size. This prevents the issue of the `zerocallregs` hardening option from being used when using clang to build Linux and Linux is building for aarch64 but builds vdso32.

@K900 initially suggested the idea that we prevent that behavior inside of the cc-wrapper instead of hardcoding derivations to disable the `zerocallregs` hardening option altogether inside of the Linux kernel derivation.

Can be tested by building `pkgsLLVM.linux` on aarch64-linux.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
