### PR TITLE
nix-melt: bump deps harder to fix rust 1.80 build

### DIFF
--- a/pkgs/tools/nix/nix-melt/0001-fix-build-for-rust-1.80.patch
+++ b/pkgs/tools/nix/nix-melt/0001-fix-build-for-rust-1.80.patch
@@ -1,17 +1,58 @@
-From 472d60ff5d0f7e1cbfe4ec92cf7e985eefb68a92 Mon Sep 17 00:00:00 2001
+From b85cef7cd9a3d7367c41b7deca8264652e88014a Mon Sep 17 00:00:00 2001
 From: Bryan Lai <bryanlais@gmail.com>
-Date: Wed, 14 Aug 2024 14:23:10 +0800
+Date: Fri, 16 Aug 2024 20:14:28 +0800
 Subject: [PATCH] deps: bump `time`, fix build for rust 1.80
 
+With: cargo update time --recursive
+
+Note that `cargo update` without the `--recursive` flag would be
+executed "conservatively". Basically, `cargo update time` will try
+its best to _not_ bump the dependencies of `time`. This restricts
+the amount that `time` itself can be updated.
+
+To really get the latest version, one has to add a `--recursive` flag.
+Only by doing this can we ensure that time is updated to the latest
+semver compatible version. In our case,
+
+- without `--recursive`, time only gets updated to 0.3.26
+- with `--recursive`, time gets updated to the latest 0.3.36,
+  with a couple of other dependencies updated
 ---
- Cargo.lock | 22 ++++++++++++++++------
- 1 file changed, 16 insertions(+), 6 deletions(-)
+ Cargo.lock | 84 +++++++++++++++++++++++++++++++++++-------------------
+ 1 file changed, 55 insertions(+), 29 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 5bd0f35..dabe0d1 100644
+index 5bd0f35..a7c7cf8 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -372,6 +372,15 @@ dependencies = [
+@@ -200,7 +200,7 @@ dependencies = [
+  "heck",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.74",
+ ]
+ 
+ [[package]]
+@@ -317,7 +317,7 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "scratch",
+- "syn 2.0.15",
++ "syn 2.0.74",
+ ]
+ 
+ [[package]]
+@@ -334,7 +334,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.74",
+ ]
+ 
+ [[package]]
+@@ -372,6 +372,16 @@ dependencies = [
   "syn 1.0.109",
  ]
  
@@ -21,46 +62,195 @@ index 5bd0f35..dabe0d1 100644
 +source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 +dependencies = [
++ "powerfmt",
 + "serde",
 +]
 +
  [[package]]
  name = "errno"
  version = "0.3.1"
-@@ -1041,10 +1050,11 @@ dependencies = [
+@@ -511,9 +521,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "itoa"
+-version = "1.0.6"
++version = "1.0.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
++checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+ 
+ [[package]]
+ name = "js-sys"
+@@ -532,9 +542,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.142"
++version = "0.2.156"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
++checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
+ 
+ [[package]]
+ name = "link-cplusplus"
+@@ -618,6 +628,12 @@ dependencies = [
+  "time",
+ ]
+ 
++[[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
+ [[package]]
+ name = "num-integer"
+ version = "0.1.45"
+@@ -639,9 +655,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "num_threads"
+-version = "0.1.6"
++version = "0.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
++checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+ dependencies = [
+  "libc",
+ ]
+@@ -722,20 +738,26 @@ version = "0.2.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+ 
++[[package]]
++name = "powerfmt"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
++
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.56"
++version = "1.0.86"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
++checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+ dependencies = [
+  "unicode-ident",
+ ]
+ 
+ [[package]]
+ name = "quote"
+-version = "1.0.26"
++version = "1.0.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
++checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -837,22 +859,22 @@ checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+ 
+ [[package]]
+ name = "serde"
+-version = "1.0.160"
++version = "1.0.208"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
++checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+ dependencies = [
+  "serde_derive",
+ ]
+ 
+ [[package]]
+ name = "serde_derive"
+-version = "1.0.160"
++version = "1.0.208"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
++checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.74",
+ ]
+ 
+ [[package]]
+@@ -981,9 +1003,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "syn"
+-version = "2.0.15"
++version = "2.0.74"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
++checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -1026,7 +1048,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.15",
++ "syn 2.0.74",
+ ]
+ 
+ [[package]]
+@@ -1041,13 +1063,16 @@ dependencies = [
  
  [[package]]
  name = "time"
 -version = "0.3.20"
-+version = "0.3.26"
++version = "0.3.36"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
-+checksum = "a79d09ac6b08c1ab3906a2f7cc2e81a0e27c7ae89c63812df75e52bef0751e07"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
  dependencies = [
 + "deranged",
   "itoa",
   "libc",
++ "num-conv",
   "num_threads",
-@@ -1055,15 +1065,15 @@ dependencies = [
++ "powerfmt",
+  "serde",
+  "time-core",
+  "time-macros",
+@@ -1055,16 +1080,17 @@ dependencies = [
  
  [[package]]
  name = "time-core"
 -version = "0.1.0"
-+version = "0.1.1"
++version = "0.1.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
++checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
  
  [[package]]
  name = "time-macros"
 -version = "0.2.8"
-+version = "0.2.12"
++version = "0.2.18"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
-+checksum = "75c65469ed6b3a4809d987a41eb1dc918e9bc1d92211cbad7ae82931846f7451"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
  dependencies = [
++ "num-conv",
   "time-core",
  ]
+ 
+@@ -1121,9 +1147,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "unicode-ident"
+-version = "1.0.8"
++version = "1.0.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
++checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+ 
+ [[package]]
+ name = "unicode-segmentation"
 -- 
 2.45.2
 

--- a/pkgs/tools/nix/nix-melt/default.nix
+++ b/pkgs/tools/nix/nix-melt/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     ./0001-fix-build-for-rust-1.80.patch
   ];
 
-  cargoHash = "sha256-SzBsSr8bpzhc0GIcTkm9LZgJ66LEBe3QA8I7NdaJ0T8=";
+  cargoHash = "sha256-oEZTBb9dwnZvByULtgCm17KbWc9hjURLB0KDkqRRCr0=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
## Description of changes

This one is a follow-up of #334556 as that actually didn't work... Sorry for the miss.

It turns out that in this case a simple `cargo update time` is not enough to fix the build; one also needs to ~~increment the semver spec in `Cargo.toml`, or~~ do a `cargo update time --recursive`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
