### PR TITLE
lib.systems.doubles: add aarch64-windows double

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -55,7 +55,7 @@ let
     "wasm64-wasi" "wasm32-wasi"
 
     # Windows
-    "x86_64-windows" "i686-windows"
+    "aarch64-windows" "x86_64-windows" "i686-windows"
   ];
 
   allParsed = map parse.mkSystemFromString all;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -325,6 +325,13 @@ rec {
     libc = "ucrt"; # This distinguishes the mingw (non posix) toolchain
   };
 
+  # LLVM-based mingw-w64 for ARM
+  ucrtAarch64 = {
+    config = "aarch64-w64-mingw32";
+    libc = "ucrt";
+    useLLVM = true;
+  };
+
   # BSDs
 
   x86_64-freebsd = {

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -60,7 +60,7 @@ lib.runTests (
   testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "loongarch64-linux" "m68k-linux" "microblaze-linux" "microblazeel-linux" "mips-linux" "mips64-linux" "mips64el-linux" "mipsel-linux" "powerpc64-linux" "powerpc64le-linux" "riscv32-linux" "riscv64-linux" "s390-linux" "s390x-linux" "x86_64-linux" ];
   testnetbsd = mseteq netbsd [ "aarch64-netbsd" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd" "i686-netbsd" "m68k-netbsd" "mipsel-netbsd" "powerpc-netbsd" "riscv32-netbsd" "riscv64-netbsd" "x86_64-netbsd" ];
   testopenbsd = mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ];
-  testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "i686-windows" "x86_64-windows" ];
+  testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "aarch64-windows" "i686-windows" "x86_64-windows" ];
   testunix = mseteq unix (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ cygwin ++ redox);
 })
 

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -41,8 +41,8 @@ let
   # use clean up the `cmakeFlags` rats nest below.
   haveLibcxx = stdenv.cc.libcxx != null;
   isDarwinStatic = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isStatic && lib.versionAtLeast release_version "16";
-  inherit (stdenv.hostPlatform) isMusl isAarch64;
-  noSanitizers = !haveLibc || bareMetal || isMusl || isDarwinStatic;
+  inherit (stdenv.hostPlatform) isMusl isAarch64 isWindows;
+  noSanitizers = !haveLibc || bareMetal || isMusl || isDarwinStatic || isWindows;
 
   baseName = "compiler-rt";
   pname = baseName + lib.optionalString (haveLibc) "-libc";

--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -61,7 +61,8 @@ let
   ]) ++ lib.optionals stdenv.hostPlatform.isWasm [
     "-DLIBCXXABI_ENABLE_THREADS=OFF"
     "-DLIBCXXABI_ENABLE_EXCEPTIONS=OFF"
-  ] ++ lib.optionals (!enableShared) [
+  ] ++ lib.optionals (!enableShared || stdenv.hostPlatform.isWindows) [
+    # Required on Windows due to https://github.com/llvm/llvm-project/issues/55245
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
   ];
 
@@ -91,6 +92,9 @@ let
     "-DLIBCXX_ENABLE_THREADS=OFF"
     "-DLIBCXX_ENABLE_FILESYSTEM=OFF"
     "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
+  ] ++ lib.optionals stdenv.hostPlatform.isWindows [
+    # https://github.com/llvm/llvm-project/issues/55245
+    "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON"
   ] ++ lib.optionals (!enableShared) [
     "-DLIBCXX_ENABLE_SHARED=OFF"
   ] ++ lib.optionals (cxxabi != null && cxxabi.libName == "cxxrt") [

--- a/pkgs/os-specific/windows/cygwin-setup/default.nix
+++ b/pkgs/os-specific/windows/cygwin-setup/default.nix
@@ -1,5 +1,17 @@
-{ lib, stdenv, fetchcvs, autoconf, automake, libtool, flex, bison, pkg-config
-, zlib, bzip2, xz, libgcrypt
+{
+  lib,
+  stdenv,
+  fetchcvs,
+  autoconf,
+  automake,
+  libtool,
+  flex,
+  bison,
+  pkg-config,
+  zlib,
+  bzip2,
+  xz,
+  libgcrypt,
 }:
 
 stdenv.mkDerivation rec {
@@ -13,16 +25,30 @@ stdenv.mkDerivation rec {
     sha256 = "024wxaaxkf7p1i78bh5xrsqmfz7ss2amigbfl2r5w9h87zqn9aq3";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool flex bison pkg-config ];
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    flex
+    bison
+    pkg-config
+  ];
 
-  buildInputs = let
-    mkStatic = lib.flip lib.overrideDerivation (o: {
-      dontDisableStatic = true;
-      configureFlags = lib.toList (o.configureFlags or []) ++ [ "--enable-static" ];
-      buildInputs = map mkStatic (o.buildInputs or []);
-      propagatedBuildInputs = map mkStatic (o.propagatedBuildInputs or []);
-    });
-  in map mkStatic [ zlib bzip2 xz libgcrypt ];
+  buildInputs =
+    let
+      mkStatic = lib.flip lib.overrideDerivation (o: {
+        dontDisableStatic = true;
+        configureFlags = lib.toList (o.configureFlags or [ ]) ++ [ "--enable-static" ];
+        buildInputs = map mkStatic (o.buildInputs or [ ]);
+        propagatedBuildInputs = map mkStatic (o.propagatedBuildInputs or [ ]);
+      });
+    in
+    map mkStatic [
+      zlib
+      bzip2
+      xz
+      libgcrypt
+    ];
 
   configureFlags = [ "--disable-shared" ];
 

--- a/pkgs/os-specific/windows/default.nix
+++ b/pkgs/os-specific/windows/default.nix
@@ -1,46 +1,52 @@
-{ lib, stdenv, buildPackages
-, newScope, overrideCC, stdenvNoLibc, libcCross
+{
+  lib,
+  stdenv,
+  buildPackages,
+  newScope,
+  overrideCC,
+  stdenvNoLibc,
+  libcCross,
 }:
 
-lib.makeScope newScope (self: with self; {
+lib.makeScope newScope (
+  self: with self; {
 
-  cygwinSetup = callPackage ./cygwin-setup { };
+    cygwinSetup = callPackage ./cygwin-setup { };
 
-  dlfcn = callPackage ./dlfcn { };
+    dlfcn = callPackage ./dlfcn { };
 
-  w32api = callPackage ./w32api { };
+    w32api = callPackage ./w32api { };
 
-  mingwrt = callPackage ./mingwrt { };
-  mingw_runtime = mingwrt;
+    mingwrt = callPackage ./mingwrt { };
+    mingw_runtime = mingwrt;
 
-  mingw_w64 = callPackage ./mingw-w64 {
-    stdenv = stdenvNoLibc;
-  };
+    mingw_w64 = callPackage ./mingw-w64 {
+      stdenv = stdenvNoLibc;
+    };
 
-  # FIXME untested with llvmPackages_16 was using llvmPackages_8
-  crossThreadsStdenv = overrideCC stdenvNoLibc
-    (if stdenv.hostPlatform.useLLVM or false
-     then buildPackages.llvmPackages.clangNoLibcxx
-     else buildPackages.gccWithoutTargetLibc.override (old: {
-       bintools = old.bintools.override {
-         libc = libcCross;
-       };
-       libc = libcCross;
-     }));
+    # FIXME untested with llvmPackages_16 was using llvmPackages_8
+    crossThreadsStdenv = overrideCC stdenvNoLibc (
+      if stdenv.hostPlatform.useLLVM or false then
+        buildPackages.llvmPackages.clangNoLibcxx
+      else
+        buildPackages.gccWithoutTargetLibc.override (old: {
+          bintools = old.bintools.override {
+            libc = libcCross;
+          };
+          libc = libcCross;
+        })
+    );
 
-  mingw_w64_headers = callPackage ./mingw-w64/headers.nix { };
+    mingw_w64_headers = callPackage ./mingw-w64/headers.nix { };
 
-  mingw_w64_pthreads = callPackage ./mingw-w64/pthreads.nix {
-    stdenv = crossThreadsStdenv;
-  };
+    mingw_w64_pthreads = callPackage ./mingw-w64/pthreads.nix { stdenv = crossThreadsStdenv; };
 
-  mcfgthreads = callPackage ./mcfgthreads {
-    stdenv = crossThreadsStdenv;
-  };
+    mcfgthreads = callPackage ./mcfgthreads { stdenv = crossThreadsStdenv; };
 
-  npiperelay = callPackage ./npiperelay { };
+    npiperelay = callPackage ./npiperelay { };
 
-  pthreads = callPackage ./pthread-w32 { };
+    pthreads = callPackage ./pthread-w32 { };
 
-  libgnurx = callPackage ./libgnurx { };
-})
+    libgnurx = callPackage ./libgnurx { };
+  }
+)

--- a/pkgs/os-specific/windows/dlfcn/default.nix
+++ b/pkgs/os-specific/windows/dlfcn/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, lib, fetchFromGitHub, cmake }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+}:
 
 stdenv.mkDerivation rec {
   pname = "dlfcn";

--- a/pkgs/os-specific/windows/libgnurx/default.nix
+++ b/pkgs/os-specific/windows/libgnurx/default.nix
@@ -1,8 +1,13 @@
-{ lib, stdenv, fetchurl }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
 
 let
   version = "2.5.1";
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "libgnurx";
   inherit version;
   src = fetchurl {

--- a/pkgs/os-specific/windows/mcfgthreads/default.nix
+++ b/pkgs/os-specific/windows/mcfgthreads/default.nix
@@ -1,7 +1,8 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, autoreconfHook
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -15,11 +16,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-FrmeaQhwLrNewS0HDlbWgCvVQ5U1l0jrw0YVuQdt9Ck=";
   };
 
-  outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    autoreconfHook
+  outputs = [
+    "out"
+    "dev"
   ];
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = {
     description = "Threading support library for Windows 7 and above";

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -4,7 +4,13 @@
   windows,
   autoreconfHook,
   mingw_w64_headers,
+  crt ? stdenv.hostPlatform.libc,
 }:
+
+assert lib.assertOneOf "crt" crt [
+  "msvcrt"
+  "ucrt"
+];
 
 stdenv.mkDerivation {
   pname = "mingw-w64";
@@ -18,7 +24,8 @@ stdenv.mkDerivation {
   configureFlags = [
     "--enable-idl"
     "--enable-secure-api"
-  ] ++ lib.optionals (stdenv.targetPlatform.libc == "ucrt") [ "--with-default-msvcrt=ucrt" ];
+    "--with-default-msvcrt=${crt}"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -25,6 +25,11 @@ stdenv.mkDerivation {
     (lib.enableFeature true "idl")
     (lib.enableFeature true "secure-api")
     (lib.withFeatureAs true "default-msvcrt" crt)
+
+    # Including other architectures causes errors with invalid asm
+    (lib.enableFeature stdenv.hostPlatform.isi686 "lib32")
+    (lib.enableFeature stdenv.hostPlatform.isx86_64 "lib64")
+    (lib.enableFeature stdenv.hostPlatform.isAarch64 "libarm64")
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -22,9 +22,9 @@ stdenv.mkDerivation {
   ];
 
   configureFlags = [
-    "--enable-idl"
-    "--enable-secure-api"
-    "--with-default-msvcrt=${crt}"
+    (lib.enableFeature true "idl")
+    (lib.enableFeature true "secure-api")
+    (lib.withFeatureAs true "default-msvcrt" crt)
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -1,26 +1,31 @@
-{ lib
-, stdenv
-, windows
-, autoreconfHook
-, mingw_w64_headers
+{
+  lib,
+  stdenv,
+  windows,
+  autoreconfHook,
+  mingw_w64_headers,
 }:
 
 stdenv.mkDerivation {
   pname = "mingw-w64";
   inherit (mingw_w64_headers) version src meta;
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   configureFlags = [
     "--enable-idl"
     "--enable-secure-api"
-  ] ++ lib.optionals (stdenv.targetPlatform.libc == "ucrt") [
-    "--with-default-msvcrt=ucrt"
-  ];
+  ] ++ lib.optionals (stdenv.targetPlatform.libc == "ucrt") [ "--with-default-msvcrt=ucrt" ];
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ windows.mingw_w64_headers ];
-  hardeningDisable = [ "stackprotector" "fortify" ];
+  hardeningDisable = [
+    "stackprotector"
+    "fortify"
+  ];
 }

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -1,4 +1,8 @@
-{ lib, stdenvNoCC, fetchurl }:
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mingw_w64-headers";

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mingw_w64-headers";
-  version = "11.0.1";
+  version = "12.0.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/mingw-w64/mingw-w64-v${finalAttrs.version}.tar.bz2";
-    hash = "sha256-P2a84Gnui+10OaGhPafLkaXmfqYXDyExesf1eUYl7hA=";
+    hash = "sha256-zEGJiqxLbo3Vz/1zMbnZUVuRLfRCCjphK16ilVu+7S8=";
   };
 
   preConfigure = ''

--- a/pkgs/os-specific/windows/mingw-w64/pthreads.nix
+++ b/pkgs/os-specific/windows/mingw-w64/pthreads.nix
@@ -1,14 +1,17 @@
-{ stdenv, mingw_w64_headers }:
+{
+  lib,
+  stdenv,
+  mingw_w64_headers,
+  # Rustc require 'libpthread.a' when targeting 'x86_64-pc-windows-gnu'.
+  # Enabling this makes it work out of the box instead of failing.
+  withStatic ? true,
+}:
 
 stdenv.mkDerivation {
   pname = "mingw_w64-pthreads";
   inherit (mingw_w64_headers) version src meta;
 
-  configureFlags = [
-    # Rustc require 'libpthread.a' when targeting 'x86_64-pc-windows-gnu'.
-    # Enabling this makes it work out of the box instead of failing.
-    "--enable-static"
-  ];
+  configureFlags = [ (lib.enableFeature withStatic "static") ];
 
   preConfigure = ''
     cd mingw-w64-libraries/winpthreads

--- a/pkgs/os-specific/windows/mingwrt/default.nix
+++ b/pkgs/os-specific/windows/mingwrt/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, lib, fetchurl }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+}:
 
 stdenv.mkDerivation rec {
   pname = "mingwrt";
@@ -14,5 +18,8 @@ stdenv.mkDerivation rec {
   };
 
   dontStrip = true;
-  hardeningDisable = [ "stackprotector" "fortify" ];
+  hardeningDisable = [
+    "stackprotector"
+    "fortify"
+  ];
 }

--- a/pkgs/os-specific/windows/npiperelay/default.nix
+++ b/pkgs/os-specific/windows/npiperelay/default.nix
@@ -1,4 +1,8 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
 
 buildGoModule rec {
   pname = "npiperelay";

--- a/pkgs/os-specific/windows/pthread-w32/default.nix
+++ b/pkgs/os-specific/windows/pthread-w32/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchzip }:
+{
+  lib,
+  stdenv,
+  fetchzip,
+}:
 
 stdenv.mkDerivation {
   pname = "pthreads-w32";
@@ -9,7 +13,10 @@ stdenv.mkDerivation {
     sha256 = "1s8iny7g06z289ahdj0kzaxj0cd3wvjbd8j3bh9xlg7g444lhy9w";
   };
 
-  makeFlags = [ "CROSS=${stdenv.cc.targetPrefix}" "GC-static" ];
+  makeFlags = [
+    "CROSS=${stdenv.cc.targetPrefix}"
+    "GC-static"
+  ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/os-specific/windows/w32api/default.nix
+++ b/pkgs/os-specific/windows/w32api/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, lib }:
+{
+  stdenv,
+  fetchurl,
+  lib,
+}:
 
 stdenv.mkDerivation rec {
   pname = "w32api";


### PR DESCRIPTION
## Description of changes

This introduces initial support for cross compiling to Windows on Arm in nixpkgs

It adds a new example system (and `pkgsCross` target) in `ucrtAarch64`. It is modeled after MSYS2's CLANGARM64 [environment](https://www.msys2.org/docs/environments/#overview), which is based on LLVM. Windows-specific fixes for a few LLVM packages have been applied due to this

Currently `stdenv.cc` builds but doesn't seem to work all too well -- `hello` errors out early, reporting `C compiler cannot create executables`. Help would be appreciated here!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
