### PR TITLE
Positron: init at 2024.08.0-31

### DIFF
--- a/pkgs/by-name/po/positron/package.nix
+++ b/pkgs/by-name/po/positron/package.nix
@@ -1,8 +1,10 @@
 {
   stdenv,
   lib,
+  autoPatchelfHook,
   dpkg,
-  fetchurl,
+  pkgs,
+  fetchurl
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +23,28 @@ stdenv.mkDerivation rec {
     hash = "sha256-8LckYQ++uv8fOHOBLaPAJfcJM0/Fc6YMKhAsXHFI/nY=";
   };
 
-  nativeBuildInputs = [ dpkg ];
+  buildInputs = with pkgs; [
+    stdenv.cc.cc
+    libkrb5 xorg.libX11
+    xorg.libxkbfile
+    xorg.libXcomposite
+    xorg.libXdamage
+    libxkbcommon
+    libdrm
+    gtk3
+    nss
+    mesa
+    alsa-lib
+    musl
+    expat
+    pango
+    cairo
+    openssl
+    xorg.libXfixes
+    xorg.libXrandr
+  ];
+
+  nativeBuildInputs = [ dpkg autoPatchelfHook ];
 
   unpackPhase = "
     runHook preUnpack

--- a/pkgs/by-name/po/positron/package.nix
+++ b/pkgs/by-name/po/positron/package.nix
@@ -1,0 +1,57 @@
+{
+  stdenv,
+  lib,
+  dpkg,
+  fetchurl,
+}:
+
+stdenv.mkDerivation rec {
+
+  pname = "positron";
+  version = "2024.08.0-31";
+  POSITRON_VERSION_MAJOR = lib.versions.major version;
+  POSITRON_VERSION_MINOR = lib.versions.minor version;
+  POSITRON_VERSION_PATCH = lib.versions.patch version;
+  POSITRON_VERSION_SUFFIX = "+" + toString (lib.tail (lib.splitString "+" version));
+
+  outputs = [ "out" ];
+
+  src = fetchurl {
+    url = "https://github.com/posit-dev/positron/releases/download/${version}/Positron-${version}.deb";
+    hash = "sha256-8LckYQ++uv8fOHOBLaPAJfcJM0/Fc6YMKhAsXHFI/nY=";
+  };
+
+  nativeBuildInputs = [ dpkg ];
+
+  unpackPhase = "
+    runHook preUnpack
+
+    # The deb file contains a setuid binary, so 'dpkg -x' doesn't work here
+    dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
+    runHook postUnpack
+    ";
+
+  installPhase = "
+    runHook preInstall
+
+    mkdir -p $out $out/bin $out/share
+
+    mv usr/share/* $out/share/
+
+    ln -s $out/share/positron/bin/positron $out/bin/positron
+
+    runHook postInstall
+    ";
+
+  meta = {
+    description = "Positron, a next-generation data science IDE";
+    longDescription = ''
+      Positron is an extensible, polyglot IDE built by Posit PBC.
+    '';
+    homepage = "https://github.com/posit-dev/positron";
+    license = lib.licenses.elastic20;
+    maintainers = with lib.maintainers; [ b-rodrigues ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Positron is a new IDE made by Posit (formerly known as RStudio) forked from VS Code and with a focus on data science. 
I used the `.deb` package as source. I tested this in a nix-shell on non-NixOS with R and Python interpreters, basic functionality seems to be working well:

```
nix-shell -I nixpkgs=. -p positron R rPackages.dplyr python312 python312Packages.ipykernel python312Packages.polars
```

I leave this as a draft for now, as I'm sure this expression could be improved. 

Also, would we need a positronWrapper as we have a rstudioWrapper?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
