### PR TITLE
Update gauge plugins and add tests

### DIFF
--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -3,6 +3,7 @@ lib.makeScope pkgs.newScope (final: let
   inherit (final) callPackage;
 in {
   makeGaugePlugin = callPackage ./make-gauge-plugin.nix { };
+  testGaugePlugins = callPackage ./test-gauge-plugins.nix { };
   dotnet = callPackage ./dotnet { };
   html-report = callPackage ./html-report { };
   java = callPackage ./java { };

--- a/pkgs/development/tools/gauge/plugins/java/data.json
+++ b/pkgs/development/tools/gauge/plugins/java/data.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.10.3",
+  "version": "0.11.0",
   "aarch64-darwin": {
-    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.10.3/gauge-java-0.10.3-darwin.arm64.zip",
-    "hash": "sha256-Hs9ZNupj0s7YRjRZibphr7m5YjOj3MTgx/hqAbWyY6I="
+    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.11.0/gauge-java-0.11.0-darwin.arm64.zip",
+    "hash": "sha256-o7viYih6oghPipGmpsdGZXxtML4++Ux7Qul8pRzkdUc="
   },
   "x86_64-darwin": {
-    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.10.3/gauge-java-0.10.3-darwin.x86_64.zip",
-    "hash": "sha256-Hj/Lkwsx/RvyMiJO8dI6vFpIvvyhOA2Un5deC1syYY4="
+    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.11.0/gauge-java-0.11.0-darwin.x86_64.zip",
+    "hash": "sha256-wTXVuyXU9mfVxAc/l0mgvKt3c/jinffILBUhe/tikgs="
   },
   "aarch64-linux": {
-    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.10.3/gauge-java-0.10.3-linux.arm64.zip",
-    "hash": "sha256-XJqP2eew+aI1jFaDzsJhfML8Ft+adFJrHURF8F391Pc="
+    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.11.0/gauge-java-0.11.0-linux.arm64.zip",
+    "hash": "sha256-CsEzoNseWllbNtN5mOYVCPvTPlm60fd7eSXuTpxbRx8="
   },
   "x86_64-linux": {
-    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.10.3/gauge-java-0.10.3-linux.x86_64.zip",
-    "hash": "sha256-sMyWhAGo6oa7MsqK8xApdrwhZo8NkSTIRbsCu5LW3ls="
+    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.11.0/gauge-java-0.11.0-linux.x86_64.zip",
+    "hash": "sha256-zig+Wq6uyBl8fKfjcpKCRFtHBZ/xFeDaUrUqvx1ails="
   }
 }

--- a/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
+++ b/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation (finalAttrs: (lib.recursiveUpdate {
     stripRoot = false;
   };
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optional stdenvNoCC.hostPlatform.isLinux autoPatchelfHook;
 
   installPhase = ''
     mkdir -p "$out/share/gauge-plugins/${pname}/${finalAttrs.version}"

--- a/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
+++ b/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
@@ -71,7 +71,7 @@ stdenvNoCC.mkDerivation (finalAttrs: (lib.recursiveUpdate {
         hash=$(nix-prefetch-url --type sha256 $url --unpack)
         sriHash="$(nix hash to-sri --type sha256 $hash)"
 
-        yq -iPoj '. + { "$system": { "url": "$url", "hash": "$sriHash" } }' "$tempfile"
+        yq -iPoj ". + { \"$system\": { \"url\": \"$url\", \"hash\": \"$sriHash\" } }" "$tempfile"
     }
 
     updateSingle() {
@@ -81,7 +81,7 @@ stdenvNoCC.mkDerivation (finalAttrs: (lib.recursiveUpdate {
         hash=$(nix-prefetch-url --type sha256 $url --unpack)
         sriHash="$(nix hash to-sri --type sha256 $hash)"
 
-        yq -iPoj '. + { "url": "$url", "hash": "$sriHash" }' "$tempfile"
+        yq -iPoj ". + { \"url\": \"$url\", \"hash\": \"$sriHash\" }" "$tempfile"
     }
 
     baseUrl="https://github.com/${repo}/releases/download/$latestTag/${releasePrefix}$latestVersion"

--- a/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
+++ b/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
@@ -3,6 +3,7 @@
 , lib
 , writeScript
 , autoPatchelfHook
+, testGaugePlugins
 }:
 
 { pname
@@ -41,57 +42,60 @@ stdenvNoCC.mkDerivation (finalAttrs: (lib.recursiveUpdate {
     cp -r . "$out/share/gauge-plugins/${pname}/${finalAttrs.version}"
   '';
 
-  passthru.updateScript = writeScript "update-${finalAttrs.pname}" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl nix-prefetch yq-go
+  passthru = {
+    tests.loadPlugin = testGaugePlugins { plugins = [ finalAttrs.finalPackage ]; };
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl nix-prefetch yq-go
 
-    set -e
+      set -e
 
-    dirname="pkgs/development/tools/gauge/plugins/${pname}"
+      dirname="pkgs/development/tools/gauge/plugins/${pname}"
 
-    currentVersion=$(nix eval --raw -f default.nix gaugePlugins.${pname}.version)
+      currentVersion=$(nix eval --raw -f default.nix gaugePlugins.${pname}.version)
 
-    latestTag=$(curl -s ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/${repo}/releases/latest | yq ".tag_name")
-    latestVersion="$(expr $latestTag : 'v\(.*\)')"
+      latestTag=$(curl -s ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/${repo}/releases/latest | yq ".tag_name")
+      latestVersion="$(expr $latestTag : 'v\(.*\)')"
 
-    tempfile=$(mktemp)
+      tempfile=$(mktemp)
 
-    if [[ "$FORCE_UPDATE" != "true" && "$currentVersion" == "$latestVersion" ]]; then
-        echo "gauge-${pname} is up-to-date: ''${currentVersion}"
-        exit 0
-    fi
+      if [[ "$FORCE_UPDATE" != "true" && "$currentVersion" == "$latestVersion" ]]; then
+          echo "gauge-${pname} is up-to-date: ''${currentVersion}"
+          exit 0
+      fi
 
-    yq -iPoj "{ \"version\": \"$latestVersion\" }" "$tempfile"
+      yq -iPoj "{ \"version\": \"$latestVersion\" }" "$tempfile"
 
-    updateSystem() {
-        system=$1
-        url=$2
+      updateSystem() {
+          system=$1
+          url=$2
 
-        echo "Fetching hash for $system"
-        hash=$(nix-prefetch-url --type sha256 $url --unpack)
-        sriHash="$(nix hash to-sri --type sha256 $hash)"
+          echo "Fetching hash for $system"
+          hash=$(nix-prefetch-url --type sha256 $url --unpack)
+          sriHash="$(nix hash to-sri --type sha256 $hash)"
 
-        yq -iPoj ". + { \"$system\": { \"url\": \"$url\", \"hash\": \"$sriHash\" } }" "$tempfile"
-    }
+          yq -iPoj ". + { \"$system\": { \"url\": \"$url\", \"hash\": \"$sriHash\" } }" "$tempfile"
+      }
 
-    updateSingle() {
-        url=$1
+      updateSingle() {
+          url=$1
 
-        echo "Fetching hash"
-        hash=$(nix-prefetch-url --type sha256 $url --unpack)
-        sriHash="$(nix hash to-sri --type sha256 $hash)"
+          echo "Fetching hash"
+          hash=$(nix-prefetch-url --type sha256 $url --unpack)
+          sriHash="$(nix hash to-sri --type sha256 $hash)"
 
-        yq -iPoj ". + { \"url\": \"$url\", \"hash\": \"$sriHash\" }" "$tempfile"
-    }
+          yq -iPoj ". + { \"url\": \"$url\", \"hash\": \"$sriHash\" }" "$tempfile"
+      }
 
-    baseUrl="https://github.com/${repo}/releases/download/$latestTag/${releasePrefix}$latestVersion"
+      baseUrl="https://github.com/${repo}/releases/download/$latestTag/${releasePrefix}$latestVersion"
 
-    ${if isCrossArch then
-        "updateSingle \${baseUrl}.zip"
-      else
-        lib.concatStringsSep "\n" (map (platform: ''updateSystem "${platform}" "''${baseUrl}-${systemMap.${platform}}.zip"'') meta.platforms)
-    }
+      ${if isCrossArch then
+          "updateSingle \${baseUrl}.zip"
+        else
+          lib.concatStringsSep "\n" (map (platform: ''updateSystem "${platform}" "''${baseUrl}-${systemMap.${platform}}.zip"'') meta.platforms)
+      }
 
-    mv "$tempfile" "$dirname/data.json"
-  '';
+      mv "$tempfile" "$dirname/data.json"
+    '';
+  };
 } otherArgs))

--- a/pkgs/development/tools/gauge/plugins/ruby/data.json
+++ b/pkgs/development/tools/gauge/plugins/ruby/data.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.8.0",
+  "version": "0.9.2",
   "aarch64-darwin": {
-    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.8.0/gauge-ruby-0.8.0-darwin.arm64.zip",
-    "hash": "sha256-HQ7reuC7dQUMbhEzUBiEelPmFBsFJBHe42lmFufkZJY="
+    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.9.2/gauge-ruby-0.9.2-darwin.arm64.zip",
+    "hash": "sha256-QPwqgQ+Qd+eHbw445GstcPqEODoKcvvt+YJxsJqxtPc="
   },
   "x86_64-darwin": {
-    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.8.0/gauge-ruby-0.8.0-darwin.x86_64.zip",
-    "hash": "sha256-poxT9wYgs21GRx/eVvD7jA1T0VBDEHgH0Zv941pZcKA="
+    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.9.2/gauge-ruby-0.9.2-darwin.x86_64.zip",
+    "hash": "sha256-AWe5S8QXkps6eV1+1GZbHY/S+kY/QQoiG/gbddZHZdk="
   },
   "aarch64-linux": {
-    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.8.0/gauge-ruby-0.8.0-linux.arm64.zip",
-    "hash": "sha256-SAEHPaWScux6C05jQBfDuLBN2J22Df9eKVM46kWawiU="
+    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.9.2/gauge-ruby-0.9.2-linux.arm64.zip",
+    "hash": "sha256-7d6FETLrd7OePiWWRu+5OMKKH9t9H+ZnQCqqYTsuRrk="
   },
   "x86_64-linux": {
-    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.8.0/gauge-ruby-0.8.0-linux.x86_64.zip",
-    "hash": "sha256-aXLDK/7phdsX0CmIuxfK39mdrjGo2IpwYBL7uolP5Mk="
+    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.9.2/gauge-ruby-0.9.2-linux.x86_64.zip",
+    "hash": "sha256-iPHQ5Tx3iCb/e3RoF5P2grCbNBFuagezQrABK7snFvw="
   }
 }

--- a/pkgs/development/tools/gauge/plugins/screenshot/data.json
+++ b/pkgs/development/tools/gauge/plugins/screenshot/data.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "x86_64-darwin": {
-    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.2.0/screenshot-0.2.0-darwin.x86_64.zip",
-    "hash": "sha256-7bFuInEYAQ+fN12HTazQNfqpz5DAkYNCjUJbaj0DYb4="
+    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.3.0/screenshot-0.3.0-darwin.x86_64.zip",
+    "hash": "sha256-2PL0WrIpfDCK5+aKH1rtNVBTiIPYHU4f81UZpv9M2sQ="
   },
   "aarch64-darwin": {
-    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.2.0/screenshot-0.2.0-darwin.arm64.zip",
-    "hash": "sha256-Ly6iHBc2PfeFkKkZIkyD2JD5+EpFNL4SDjzG1oMpKfA="
+    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.3.0/screenshot-0.3.0-darwin.arm64.zip",
+    "hash": "sha256-QfpylVGxE/qKiN57ni4aJsh8Dfg/VIN9vfd1nHX2QO0="
   },
   "aarch64-linux": {
-    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.2.0/screenshot-0.2.0-linux.arm64.zip",
-    "hash": "sha256-Pzfnhs4H0MmeBIhrZElFmvC+PuabLNU/pftVdIu4+LI="
+    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.3.0/screenshot-0.3.0-linux.arm64.zip",
+    "hash": "sha256-HfO2KjK1xSp6xw9F38JjkrUs7JfxkrdltRr6j5/5Cw8="
   },
   "x86_64-linux": {
-    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.2.0/screenshot-0.2.0-linux.x86_64.zip",
-    "hash": "sha256-Wpuq3aSgbIhd4WuJx4SMv+NbEZMVIpAOUMdKV2xxd7c="
+    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.3.0/screenshot-0.3.0-linux.x86_64.zip",
+    "hash": "sha256-2EEUI2jBmEC2JfeJizFqNzINZtYy/y1c+B70hE1hCQk="
   }
 }

--- a/pkgs/development/tools/gauge/plugins/test-gauge-plugins.nix
+++ b/pkgs/development/tools/gauge/plugins/test-gauge-plugins.nix
@@ -1,0 +1,35 @@
+{
+  runCommand,
+  gauge,
+  lib,
+}:
+
+/**
+  Creates a gauge install with all given plugins and makes sure every plugin is loaded.
+*/
+{ plugins }:
+
+let
+  gaugeWithPlugins = gauge.withPlugins (_: plugins);
+in
+
+runCommand "gauge-test" { nativeBuildInputs = [ gaugeWithPlugins ]; } ''
+  mkdir $out
+  echo $(gauge install || true) > $out/output.txt
+
+  function checkPlugin() {
+    plugin="$1"
+    version="$2"
+
+    echo Checking for plugin $plugin version $version
+    if ! grep "$plugin ($version)" $out/output.txt
+    then
+      echo "Couldn't find plugin $plugin version $version"
+      exit 1
+    fi
+  }
+
+  ${lib.concatMapStringsSep "\n" (
+    p: "checkPlugin '${lib.removePrefix "gauge-plugin-" p.pname}' '${p.version}'"
+  ) plugins}
+''

--- a/pkgs/development/tools/gauge/wrapper.nix
+++ b/pkgs/development/tools/gauge/wrapper.nix
@@ -6,6 +6,7 @@
 , xorg
 , gaugePlugins
 , plugins ? []
+, runCommand
 }:
 
 stdenvNoCC.mkDerivation {
@@ -53,6 +54,8 @@ stdenvNoCC.mkDerivation {
         requiredPlugins = with manifest; [ Language ] ++ Plugins;
         manifestPlugins = plugins: map (name: plugins.${name} or (throw "Gauge plugin ${name} is not available!")) requiredPlugins;
       in gauge.withPlugins manifestPlugins;
+    # Builds gauge with all plugins and checks for successful installation
+    tests.allPlugins = gaugePlugins.testGaugePlugins { plugins = lib.filter lib.isDerivation (lib.attrValues gaugePlugins); };
   };
 
   inherit (gauge-unwrapped) meta;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/getgauge/gauge-java/releases/tag/v0.11.0
https://github.com/getgauge/gauge_screenshot/releases/tag/v0.3.0
https://github.com/getgauge/gauge-ruby/releases/tag/v0.9.0
https://github.com/getgauge/gauge-ruby/releases/tag/v0.9.1
https://github.com/getgauge/gauge-ruby/releases/tag/v0.9.2

Also adds tests to make sure all plugins get loaded correctly, and fixes the updateScript for plugins.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
