### PR TITLE
check-meta: warn about misinterpreted *Array variables

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -452,11 +452,15 @@ let
       { valid = "warn"; reason = "maintainerless"; errormsg = "has no maintainers"; }
     else if unstructuredArrays attrs != [] then
       let
-        variables = builtins.concatStringsSep ", " (unstructuredArrays attrs);
+        quote = s: ''"${s}"'';
+        variables = unstructuredArrays attrs;
+        variablesStr = builtins.concatStringsSep ", " (map quote variables);
+        usePlural = variables != [(builtins.head variables)];
+        plural = optionalString usePlural "s";
       in
       { valid = "warn";
         reason = "unstructured-arrays";
-        errormsg = "The following variables will be misinterpreted as single element bash arrays because __structuredAttrs is not set: ${variables}";
+        errormsg = "The variable${plural} ${variablesStr} will be misinterpreted as single element bash array${plural} because __structuredAttrs is not set";
       }
     # -----
     else validYes;

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -141,7 +141,7 @@ let
     };
 
     showDerivationWarnings = mkOption {
-      type = types.listOf (types.enum [ "maintainerless" ]);
+      type = types.listOf (types.enum [ "maintainerless" "unstructured-arrays" ]);
       default = [];
       description = ''
         Which warnings to display for potentially dangerous

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -142,7 +142,7 @@ let
 
     showDerivationWarnings = mkOption {
       type = types.listOf (types.enum [ "maintainerless" "unstructured-arrays" ]);
-      default = [];
+      default = [ "unstructured-arrays" ];
       description = ''
         Which warnings to display for potentially dangerous
         or deprecated values passed into `stdenv.mkDerivation`.


### PR DESCRIPTION
## Description of changes

As per https://github.com/NixOS/nixpkgs/pull/334973#discussion_r1719124296. The issue originally noted in https://github.com/NixOS/nixpkgs/pull/318614#issuecomment-2289078713.

~~I never worked with `check-meta` before, I observe that the warning isn't actually displayed by default, but changing `"warn"` to `validity "no"` does produce the expected effect~~

I also realize that Nix is expected to be painfully slow and that we may not want to extend `check-meta` without a good reason lest we inflate the eval times

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
