### PR TITLE
python312Packages.python-linkplay: 0.0.6 -> 0.0.8

### DIFF
--- a/pkgs/development/python-modules/python-linkplay/default.nix
+++ b/pkgs/development/python-modules/python-linkplay/default.nix
@@ -1,8 +1,11 @@
 {
+  aiofiles,
   aiohttp,
+  appdirs,
   async-timeout,
   async-upnp-client,
   buildPythonPackage,
+  deprecated,
   fetchFromGitHub,
   lib,
   pytest-asyncio,
@@ -12,22 +15,27 @@
 
 buildPythonPackage rec {
   pname = "python-linkplay";
-  version = "0.0.6";
+  version = "0.0.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Velleman";
     repo = "python-linkplay";
     rev = "refs/tags/v${version}";
-    hash = "sha256-GUpotQLs+xzsMV3i52YtWYm9IoQLyyw8EY9VhG+uT8o=";
+    hash = "sha256-Ju4fubZPOVreu7YGhAPfSepXzaXDa7ZpvsAxoSHWLqo=";
   };
 
   build-system = [ setuptools ];
 
+  pythonRelaxDeps = [ "aiofiles" ];
+
   dependencies = [
+    aiofiles
     aiohttp
+    appdirs
     async-timeout
     async-upnp-client
+    deprecated
   ];
 
   pythonImportsCheck = [ "linkplay" ];
@@ -38,6 +46,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/Velleman/python-linkplay/releases/tag/v${version}";
     description = "Python Library for Seamless LinkPlay Device Control";
     homepage = "https://github.com/Velleman/python-linkplay";
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/python-linkplay/default.nix
+++ b/pkgs/development/python-modules/python-linkplay/default.nix
@@ -3,7 +3,7 @@
   async-timeout,
   async-upnp-client,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   lib,
   pytest-asyncio,
   pytestCheckHook,
@@ -15,10 +15,11 @@ buildPythonPackage rec {
   version = "0.0.6";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "python_linkplay";
-    inherit version;
-    hash = "sha256-mChlhJt2p77KWXWNZztrEA8Z2BmYkPLYPdv9Gw7p5/I=";
+  src = fetchFromGitHub {
+    owner = "Velleman";
+    repo = "python-linkplay";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-GUpotQLs+xzsMV3i52YtWYm9IoQLyyw8EY9VhG+uT8o=";
   };
 
   build-system = [ setuptools ];
@@ -35,10 +36,6 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ];
-
-  # no tests on PyPI, no tags on GitHub
-  # https://github.com/Velleman/python-linkplay/issues/23
-  doCheck = false;
 
   meta = {
     description = "Python Library for Seamless LinkPlay Device Control";


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/Velleman/python-linkplay/compare/refs/tags/v0.0.6...v0.0.8

Changelog: 
https://github.com/Velleman/python-linkplay/releases/tag/v0.0.7
           https://github.com/Velleman/python-linkplay/releases/tag/v0.0.8
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
