### PR TITLE
python312Packages.howdoi: remove broken mark on darwin and remove one bad test case

### DIFF
--- a/pkgs/development/python-modules/howdoi/default.nix
+++ b/pkgs/development/python-modules/howdoi/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   appdirs,
   buildPythonPackage,
@@ -7,6 +6,7 @@
   colorama,
   cssselect,
   fetchFromGitHub,
+  fetchpatch,
   keep,
   lxml,
   pygments,
@@ -30,6 +30,16 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-u0k+h7Sp2t/JUnfPqRzDpEA+vNXB7CpyZ/SRvk+B9t0=";
   };
+
+  patches = [
+    # Bad test case fix: comparing hardcoded string to internet search result
+    # PR merged: https://github.com/gleitz/howdoi/pull/497
+    # Please remove on the next release
+    (fetchpatch {
+      url = "https://github.com/gleitz/howdoi/commit/7d24e9e1c87811a6e66d60f504381383cf1ac3fd.patch";
+      sha256 = "sha256-AFQMnMEijaExqiimbNaVeIRmZJ4Yj0nGUOEjfsvBLh8=";
+    })
+  ];
 
   propagatedBuildInputs = [
     appdirs
@@ -55,7 +65,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "howdoi" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     changelog = "https://github.com/gleitz/howdoi/blob/v${version}/CHANGES.txt";
     description = "Instant coding answers via the command line";
     homepage = "https://github.com/gleitz/howdoi";


### PR DESCRIPTION
## Description of changes

- This package is about getting answer using search engine from terminal. One test case is doing by comparing a hardcoded string to the answer fetched by the search engine which can be changing anytime.
- Remove broken from darwin as i already tested and working fine.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
