### PR TITLE
versionCheckHook: ignore echoed store paths

### DIFF
--- a/pkgs/by-name/ve/versionCheckHook/hook.sh
+++ b/pkgs/by-name/ve/versionCheckHook/hook.sh
@@ -5,6 +5,7 @@ _handleCmdOutput(){
         --argv0="$(basename "$1")" \
         --ignore-environment \
         "$@" 2>&1 \
+        | sed -e 's|@storeDir@/[^/ ]*/|{{storeDir}}/|g' \
         || true)"
     if [[ "$versionOutput" =~ "$version" ]]; then
         echoPrefix="Successfully managed to"

--- a/pkgs/by-name/ve/versionCheckHook/hook.sh
+++ b/pkgs/by-name/ve/versionCheckHook/hook.sh
@@ -1,6 +1,11 @@
 _handleCmdOutput(){
     local versionOutput
-    versionOutput="$(env --chdir=/ --argv0="$(basename "$1")" --ignore-environment "$@" 2>&1 || true)"
+    versionOutput="$(env \
+        --chdir=/ \
+        --argv0="$(basename "$1")" \
+        --ignore-environment \
+        "$@" 2>&1 \
+        || true)"
     if [[ "$versionOutput" =~ "$version" ]]; then
         echoPrefix="Successfully managed to"
     else

--- a/pkgs/by-name/ve/versionCheckHook/package.nix
+++ b/pkgs/by-name/ve/versionCheckHook/package.nix
@@ -5,6 +5,9 @@
 
 makeSetupHook {
   name = "version-check-hook";
+  substitutions = {
+    storeDir = builtins.storeDir;
+  };
   meta = {
     description = "Lookup for $version in the output of --help and --version";
     maintainers = with lib.maintainers; [ doronbehar ];

--- a/pkgs/development/compilers/c3c/default.nix
+++ b/pkgs/development/compilers/c3c/default.nix
@@ -8,7 +8,7 @@
   libxml2,
   libffi,
   xar,
-  testers,
+  versionCheckHook,
 }:
 
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
@@ -48,9 +48,8 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     runHook postCheck
   '';
 
-  passthru.tests = {
-    version = testers.testVersion { package = finalAttrs.finalPackage; };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Compiler for the C3 language";


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
