### PR TITLE
xcursor-pro: init at 2.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11617,6 +11617,12 @@
     github = "lachrymaLF";
     githubId = 13716477;
   };
+  lactose = {
+    name = "lactose";
+    email = "lactose@allthingslinux.com";
+    github = "juuyokka";
+    githubId = 15185244;
+  };
   lafrenierejm = {
     email = "joseph@lafreniere.xyz";
     github = "lafrenierejm";

--- a/pkgs/by-name/xc/xcursor-pro/package.nix
+++ b/pkgs/by-name/xc/xcursor-pro/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchurl,
+  variants ? [ ],
+}:
+
+let
+  sources = import ./sources.nix;
+  knownVariants = builtins.attrNames sources;
+  selectedVariants =
+    if (variants == [ ]) then
+      knownVariants
+    else
+      let
+        unknownVariants = lib.subtractLists knownVariants variants;
+      in
+      if (unknownVariants != [ ]) then
+        throw "Unknown variant(s): ${lib.concatStringsSep unknownVariants}"
+      else
+        variants;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "xcursor-pro";
+  version = "2.0.2";
+  srcs = map (variant: fetchurl { inherit (sources.${variant}) url sha256; }) selectedVariants;
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    for theme in XCursor-Pro-{${lib.concatStringsSep "," selectedVariants}}; do
+      mkdir -p $out/share/icons/$theme/cursors
+      cp -a $theme/cursors/* $out/share/icons/$theme/cursors/
+      install -m644 $theme/index.theme $out/share/icons/$theme/index.theme
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    homepage = "https://github.com/ful1e5/XCursor-pro";
+    description = "Modern XCursors";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      lactose
+      midirhee12
+    ];
+  };
+})

--- a/pkgs/by-name/xc/xcursor-pro/sources.nix
+++ b/pkgs/by-name/xc/xcursor-pro/sources.nix
@@ -1,0 +1,15 @@
+{
+  Dark = {
+    url = "https://github.com/ful1e5/XCursor-pro/releases/download/v2.0.2/XCursor-Pro-Dark.tar.xz";
+    sha256 = "12r7b2wygasl5yk0k5m6b640q4b23k072myzpz8s5jkyvnp3p84n";
+  };
+  Light = {
+    url = "https://github.com/ful1e5/XCursor-pro/releases/download/v2.0.2/XCursor-Pro-Light.tar.xz";
+    sha256 = "19vddq8ajdxxzl3fnvac7p4lmb2hvyszpl25f5nmpm84xwp1kdla";
+  };
+  Red = {
+    url = "https://github.com/ful1e5/XCursor-pro/releases/download/v2.0.2/XCursor-Pro-Red.tar.xz";
+    sha256 = "00rhqmcfczy3nvk95rgy22mi6yqpp7ggbxck1z0ay2qv6cfics9m";
+  };
+}
+# old version was 2.0.1

--- a/pkgs/by-name/xc/xcursor-pro/update.sh
+++ b/pkgs/by-name/xc/xcursor-pro/update.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p nix-prefetch jq
+
+latest_release=$(curl --silent https://api.github.com/repos/ful1e5/XCursor-pro/releases/latest)
+version=$(jq -r '.tag_name' <<<"$latest_release")
+version="${version#*v}"
+
+dirname="$(dirname "$0")"
+if [ "$UPDATE_NIX_OLD_VERSION" = "$version" ]; then
+    printf 'No new version available, current: %s\n' $version
+    exit 0
+else
+    printf 'Updated to version %s\n' $version
+    sed -i "s/version = \"$UPDATE_NIX_OLD_VERSION\"/version = \"$version\"/" "$dirname/package.nix"
+fi
+
+printf '{\n' > "$dirname/sources.nix"
+
+while
+  read -r name
+  read -r url
+do
+    variant="${name#*-*-}"
+    variant="${variant%%.*}"
+
+    {
+        printf '  %s = {\n' "$variant"
+        printf '    url = \"%s\";\n' "$url"
+        printf '    sha256 = \"%s\";\n' "$(nix-prefetch-url "$url")"
+        printf '  };\n'
+    } >> "$dirname/sources.nix"
+done < <(jq -r '.assets[] |
+                select(.name | endswith(".tar.xz") and (contains("all") | not)) |
+                .name, .browser_download_url' <<<"$latest_release")
+
+printf '}\n' >> "$dirname/sources.nix"


### PR DESCRIPTION
## Description of changes

XCursor Pro is modern, simple and elegant cursor theme.
https://github.com/ful1e5/XCursor-pro

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
