### PR TITLE
[24.05] olm: mark as vulnerable

### DIFF
--- a/pkgs/applications/networking/instant-messengers/cinny/default.nix
+++ b/pkgs/applications/networking/instant-messengers/cinny/default.nix
@@ -10,6 +10,7 @@
 , pango
 , stdenv
 , darwin
+, olm
 , conf ? { }
 }:
 
@@ -63,5 +64,6 @@ buildNpmPackage rec {
     maintainers = with maintainers; [ abbe ashkitten ];
     license = licenses.agpl3Only;
     platforms = platforms.all;
+    inherit (olm.meta) knownVulnerabilities;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
@@ -8,6 +8,7 @@
 , pulseaudio
 , makeDesktopItem
 , gnome
+, olm
 
 , targetFlutterPlatform ? "linux"
 }:
@@ -44,6 +45,7 @@ flutter319.buildFlutterApplication (rec {
     maintainers = with maintainers; [ mkg20001 gilice ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
     sourceProvenance = [ sourceTypes.fromSource ];
+    inherit (olm.meta) knownVulnerabilities;
   };
 } // lib.optionalAttrs (targetFlutterPlatform == "linux") {
   nativeBuildInputs = [ imagemagick ];

--- a/pkgs/development/libraries/olm/default.nix
+++ b/pkgs/development/libraries/olm/default.nix
@@ -51,6 +51,12 @@ stdenv.mkDerivation rec {
 
       For further information, see:
 
+      * The CVE records for the known vulnerabilities:
+
+        * CVE-2024-45191
+        * CVE-2024-45192
+        * CVE-2024-45193
+
       * The libolm deprecation notice:
         <https://gitlab.matrix.org/matrix-org/olm/-/blob/6d4b5b07887821a95b144091c8497d09d377f985/README.md#important-libolm-is-now-deprecated>
 
@@ -60,8 +66,9 @@ stdenv.mkDerivation rec {
       * The blog post disclosing the details of the known vulnerabilities:
         <https://soatok.blog/2024/08/14/security-issues-in-matrixs-olm-library/>
 
-      * The Matrix.org project lead’s response to the disclosure:
-        <https://news.ycombinator.com/item?id=41249371>
+      * The announcement in This Week in Matrix from the Matrix.org
+        project lead:
+        <https://matrix.org/blog/2024/08/16/this-week-in-matrix-2024-08-16/#dept-of-encryption-closed-lock-with-key>
 
       * A (likely incomplete) aggregation of client tracking issue links:
         <https://github.com/NixOS/nixpkgs/pull/334638#issuecomment-2289025802>

--- a/pkgs/development/libraries/olm/default.nix
+++ b/pkgs/development/libraries/olm/default.nix
@@ -27,5 +27,44 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.matrix.org/matrix-org/olm";
     license = licenses.asl20;
     maintainers = with maintainers; [ tilpner oxzi ];
+    knownVulnerabilities = [ ''
+      The libolm end‐to‐end encryption library used in many Matrix
+      clients and Jitsi Meet has been deprecated upstream, and relies
+      on a cryptography library that has known side‐channel issues and
+      disclaims that its implementations are not cryptographically secure
+      and should not be used when cryptographic security is required.
+
+      It is not known that the issues can be exploited over the network in
+      practical conditions. Upstream has stated that the library should
+      not be used going forwards, and there are no plans to move to a
+      another cryptography implementation or otherwise further maintain
+      the library at all.
+
+      You should make an informed decision about whether to override this
+      security warning, especially if you critically rely on end‐to‐end
+      encryption. If you don’t care about that, or don’t use the Matrix
+      functionality of a multi‐protocol client depending on libolm,
+      then there should be no additional risk.
+
+      Some clients are investigating migrating away from libolm to maintained
+      libraries without known vulnerabilities.
+
+      For further information, see:
+
+      * The libolm deprecation notice:
+        <https://gitlab.matrix.org/matrix-org/olm/-/blob/6d4b5b07887821a95b144091c8497d09d377f985/README.md#important-libolm-is-now-deprecated>
+
+      * The warning from the cryptography code used by libolm:
+        <https://gitlab.matrix.org/matrix-org/olm/-/blob/6d4b5b07887821a95b144091c8497d09d377f985/lib/crypto-algorithms/README.md>
+
+      * The blog post disclosing the details of the known vulnerabilities:
+        <https://soatok.blog/2024/08/14/security-issues-in-matrixs-olm-library/>
+
+      * The Matrix.org project lead’s response to the disclosure:
+        <https://news.ycombinator.com/item?id=41249371>
+
+      * A (likely incomplete) aggregation of client tracking issue links:
+        <https://github.com/NixOS/nixpkgs/pull/334638#issuecomment-2289025802>
+    '' ];
   };
 }

--- a/pkgs/development/libraries/olm/default.nix
+++ b/pkgs/development/libraries/olm/default.nix
@@ -34,11 +34,11 @@ stdenv.mkDerivation rec {
       disclaims that its implementations are not cryptographically secure
       and should not be used when cryptographic security is required.
 
-      It is not known that the issues can be exploited over the network in
-      practical conditions. Upstream has stated that the library should
-      not be used going forwards, and there are no plans to move to a
-      another cryptography implementation or otherwise further maintain
-      the library at all.
+      It is not known if the issues can be exploited over the network in
+      practical conditions. Upstream does not believe such an attack is
+      feasible, but has stated that the library should not be used going
+      forward, and there are no plans to move to a another cryptography
+      implementation or otherwise further maintain the library at all.
 
       You should make an informed decision about whether to override this
       security warning, especially if you critically rely on end‐to‐end
@@ -66,9 +66,9 @@ stdenv.mkDerivation rec {
       * The blog post disclosing the details of the known vulnerabilities:
         <https://soatok.blog/2024/08/14/security-issues-in-matrixs-olm-library/>
 
-      * The announcement in This Week in Matrix from the Matrix.org
-        project lead:
-        <https://matrix.org/blog/2024/08/16/this-week-in-matrix-2024-08-16/#dept-of-encryption-closed-lock-with-key>
+      * The statement about the deprecation and vulnerabilities from the
+        Matrix.org Foundation:
+        <https://matrix.org/blog/2024/08/libolm-deprecation/>
 
       * A (likely incomplete) aggregation of client tracking issue links:
         <https://github.com/NixOS/nixpkgs/pull/334638#issuecomment-2289025802>

--- a/pkgs/servers/web-apps/jitsi-meet/default.nix
+++ b/pkgs/servers/web-apps/jitsi-meet/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, nixosTests }:
+{ lib, stdenv, fetchurl, nixosTests, olm }:
 
 stdenv.mkDerivation rec {
   pname = "jitsi-meet";
@@ -34,5 +34,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = teams.jitsi.members;
     platforms = platforms.all;
+    inherit (olm.meta) knownVulnerabilities;
   };
 }


### PR DESCRIPTION
## Description of changes

Manual backport of https://github.com/NixOS/nixpkgs/pull/334638.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
