### PR TITLE
lesspipe: 2.11 -> 2.14

### DIFF
--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -16,17 +16,18 @@
 , gnutar
 , iconv
 , ncurses
+, squashfsTools
 }:
 
 stdenv.mkDerivation rec {
   pname = "lesspipe";
-  version = "2.11";
+  version = "2.14";
 
   src = fetchFromGitHub {
     owner = "wofr06";
     repo = "lesspipe";
     rev = "v${version}";
-    hash = "sha256-jJrKiRdrargk0JzcPWxBZGyOpMfTIONHG8HNRecazVo=";
+    hash = "sha256-SEFyiKxfKC2Rx5tQ2OK8zEiCBFex2kZUY/vnnDsdCoc=";
   };
 
   nativeBuildInputs = [ perl makeWrapper ];
@@ -61,19 +62,22 @@ stdenv.mkDerivation rec {
         iconv
         procps
         ncurses
+        squashfsTools
       ];
       keep = [ "$prog" "$c1" "$c2" "$c3" "$c4" "$c5" "$cmd" "$colorizer" "$HOME" ];
       fake = {
         # script guards usage behind has_cmd test function, it's safe to leave these external and optional
         external = [
-          "cpio" "isoinfo" "cabextract" "bsdtar" "rpm2cpio" "bsdtar" "unzip" "ar" "unrar" "rar" "7zr" "7za" "isoinfo"
-          "gzip" "bzip2" "lzip" "lzma" "xz" "brotli" "compress" "zstd" "lz4"
-          "archive_color" "bat" "batcat" "pygmentize" "source-highlight" "vimcolor" "code2color"
-
-          "w3m" "lynx" "elinks" "html2text" "dtc" "pdftotext" "pdftohtml" "pdfinfo" "ps2ascii" "procyon" "ccze"
-          "mdcat" "pandoc" "docx2txt" "libreoffice" "pptx2md" "mdcat" "xlscat" "odt2txt" "wvText" "antiword" "catdoc"
-          "broken_catppt" "sxw2txt" "groff" "mandoc" "unrtf" "dvi2tty" "pod2text" "perldoc" "h5dump" "ncdump" "matdump"
-          "djvutxt" "openssl" "gpg" "plistutil" "plutil" "id3v2" "csvlook" "jq" "zlib-flate" "lessfilter"
+          "7z" "7za" "7zr" "7zz" "antiword" "ar" "archive_color" "bat" "batcat" "broken_catppt" "brotli" "bsdtar" "bzip2"
+          "cabextract" "catdoc" "ccze" "code2color" "column" "compress" "cpio" "csvlook" "csvtable"
+          "djvutxt" "docx2txt" "dtc" "dvi2tty" "elinks" "excel2csv" "exiftool" "gpg" "groff" "gzip"
+          "h5dump" "html2text" "id3v2" "identify" "in2csv" "isoinfo" "jq"
+          "lessfilter" "libreoffice" "lynx" "lz4" "lzip" "lzma"
+          "man" "mandoc" "matdump" "mdcat" "mediainfo" "ncdump" "odt2txt" "openssl"
+          "pandoc" "pdfinfo" "pdftohtml" "pdftotext" "perldoc" "plistutil" "plutil"
+          "pod2text" "pptx2md" "procyon" "ps2ascii" "pygmentize" "rar" "rpm" "rpm2cpio" "snap" "source-highlight"
+          "sxw2txt" "tput" "unrar" "unrtf" "unsquashfs" "unzip" "vimcolor" "w3m" "wvText"
+          "xls2csv" "xlscat" "xmq" "xz" "zlib-flate" "zstd"
         ] ++ lib.optional (stdenv.isDarwin || stdenv.isFreeBSD) [
           # resholve only identifies this on darwin/bsd
           # call site is guarded by || so it's safe to leave dynamic


### PR DESCRIPTION
## Description of changes

lesspipe 2.14 (c.f. [changelog](https://github.com/wofr06/lesspipe/blob/lesspipe/ChangeLog), [releases](https://github.com/wofr06/lesspipe/releases)). it builds, tho i'm not too familiar with testing lesspipe.
i added a few programs to `fake` as i'm not confident they're packaged, including [xmq](https://github.com/libxmq/xmq), [csvtable](https://github.com/wofr06/csvtable) (from the creator of lesspipe), and snap.
2.14 would also add `nvimpager`, tho the build somehow did not seem to require it in `resholve`'s `fake` somehow.

/cc @martijnvermaat

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
