### PR TITLE
python312Packages.torchrl: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/torchrl/default.nix
+++ b/pkgs/development/python-modules/torchrl/default.nix
@@ -3,13 +3,20 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
+
+  # build-system
   ninja,
   setuptools,
-  wheel,
   which,
+
+  # dependencies
   cloudpickle,
   numpy,
+  packaging,
+  tensordict,
   torch,
+
+  # optional-dependencies
   ale-py,
   gym,
   pygame,
@@ -30,19 +37,20 @@
   hydra-core,
   tensorboard,
   wandb,
-  packaging,
-  tensordict,
+
+  # checks
   imageio,
   pytest-rerunfailures,
   pytestCheckHook,
   pyyaml,
   scipy,
+
   stdenv,
 }:
 
 buildPythonPackage rec {
   pname = "torchrl";
-  version = "0.4.0";
+  version = "0.5.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -51,13 +59,12 @@ buildPythonPackage rec {
     owner = "pytorch";
     repo = "rl";
     rev = "refs/tags/v${version}";
-    hash = "sha256-8wSyyErqveP9zZS/UGvWVBYyylu9BuA447GEjXIzBIk=";
+    hash = "sha256-uDpOdOuHTqKFKspHOpl84kD9adEKZjvO2GnYuL27H5c=";
   };
 
   build-system = [
     ninja
     setuptools
-    wheel
     which
   ];
 
@@ -69,7 +76,7 @@ buildPythonPackage rec {
     torch
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     atari = [
       ale-py
       gym
@@ -117,6 +124,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs =
     [
+      h5py
       gymnasium
       imageio
       pytest-rerunfailures
@@ -125,9 +133,9 @@ buildPythonPackage rec {
       scipy
       torchvision
     ]
-    ++ passthru.optional-dependencies.atari
-    ++ passthru.optional-dependencies.gym-continuous
-    ++ passthru.optional-dependencies.rendering;
+    ++ optional-dependencies.atari
+    ++ optional-dependencies.gym-continuous
+    ++ optional-dependencies.rendering;
 
   disabledTests = [
     # mujoco.FatalError: an OpenGL platform library has not been loaded into this process, this most likely means that a valid OpenGL context has not been created before mjr_makeContext was called
@@ -155,7 +163,7 @@ buildPythonPackage rec {
     "test_distributed_collector_updatepolicy"
     "test_timeit"
 
-    # On a 24
+    # On a 24 threads system
     # assert torch.get_num_threads() == max(1, init_threads - 3)
     # AssertionError: assert 23 == 21
     "test_auto_num_threads"
@@ -168,6 +176,5 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     # ~3k tests fail with: RuntimeError: internal error
-    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
## Description of changes

- **python312Packages.tensordict: 0.4.0 -> 0.5.0** (https://github.com/pytorch/tensordict/releases/tag/v0.5.0)
- **python312Packages.torchrl: 0.4.0 -> 0.5.0** (https://github.com/pytorch/rl/releases/tag/v0.5.0)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
