### PR TITLE
tinyxxd: init at 1.3.5, use as default xxd

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -417,6 +417,8 @@
 
 - The `shadowstack` hardening flag has been added, though disabled by default.
 
+- `xxd` is now provided by the `tinyxxd` package, rather than `vim.xxd`, to reduce closure size and vulnerability impact. Since it has the same options and semantics as Vim's `xxd` utility, there is no user impact. Vim's `xxd` remains available as the `vim.xxd` package.
+
 - `restic` module now has an option for inhibiting system sleep while backups are running, defaulting to off (not inhibiting sleep), available as [`services.restic.backups.<name>.inhibitsSleep`](#opt-services.restic.backups._name_.inhibitsSleep).
 
 - Support for *runner registration tokens* has been [deprecated](https://gitlab.com/gitlab-org/gitlab/-/issues/380872)

--- a/pkgs/by-name/ti/tinyxxd/package.nix
+++ b/pkgs/by-name/ti/tinyxxd/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  vim,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tinyxxd";
+  version = "1.3.5";
+
+  src = fetchFromGitHub {
+    repo = "tinyxxd";
+    owner = "xyproto";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-W7BrQga98ACrhTHF3UlGQMRmcdJaxgorDP6FpD5mr2A=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    installManPage tinyxxd.1
+
+    # Allow using `tinyxxd` as `xxd`. This is similar to the Arch packaging.
+    # https://gitlab.archlinux.org/archlinux/packaging/packages/tinyxxd/-/blob/main/PKGBUILD
+    ln -s $out/bin/{tiny,}xxd
+    ln -s $out/share/man/man1/{tiny,}xxd.1.gz
+  '';
+
+  meta = {
+    homepage = "https://github.com/xyproto/tinyxxd";
+    description = "Drop-in replacement and standalone version of the hex dump utility that comes with ViM";
+    license = [
+      lib.licenses.mit # or
+      lib.licenses.gpl2Only
+    ];
+    mainProgram = "tinyxxd";
+    maintainers = with lib.maintainers; [
+      emily
+      philiptaron
+    ];
+    platforms = lib.platforms.unix;
+
+    # If the two `xxd` providers are present, choose this one.
+    priority = (vim.xxd.meta.priority or lib.meta.defaultPriority) - 1;
+  };
+})

--- a/pkgs/top-level/unixtools.nix
+++ b/pkgs/top-level/unixtools.nix
@@ -224,9 +224,9 @@ let
       darwin = pkgs.darwin.basic_cmds;
     };
     xxd = {
-      linux = pkgs.vim.xxd;
-      darwin = pkgs.vim.xxd;
-      freebsd = pkgs.vim.xxd;
+      linux = pkgs.tinyxxd;
+      darwin = pkgs.tinyxxd;
+      freebsd = pkgs.tinyxxd;
     };
   };
 


### PR DESCRIPTION
## Motivation for change

- https://github.com/NixOS/nixpkgs/pull/335213
- https://github.com/NixOS/nixpkgs/pull/335269

Vim is a complex and vulnerability-prone beast. `xxd` is just a little guy. Sad to couple the two of them. So `tinyxxd` was invented by @xyproto. Let's use it.

## Description of changes

- [x] Make `tinyxxd`
- [x] Make `tinyxxd.xxd` (which exposes `tinyxxd` as `xxd` for drop-in purposes)
- [x] Document it
- [x] Yolo it [just like Arch does](https://gitlab.archlinux.org/archlinux/packaging/packages/tinyxxd/-/blob/main/PKGBUILD?ref_type=heads)

@emilazy told me to put `xxd` in the main derivation ~but I didn't do that~ so I did that.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).