### PR TITLE
nix: 2.18 -> 2.24

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -8,6 +8,14 @@
   Starting with release 25.05, the minimum supported version will be macOS Big Sur 11, and we cannot guarantee that packages will continue to work on older versions of macOS.
   Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
   If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports back to Mac OS X Snow Leopard 10.6.
+- Nix was updated to 2.24, which brings a lot of improvements and fixes. See the release notes for
+    [2.19](https://nix.dev/manual/nix/latest/release-notes/rl-2.19),
+    [2.20](https://nix.dev/manual/nix/latest/release-notes/rl-2.20),
+    [2.21](https://nix.dev/manual/nix/latest/release-notes/rl-2.21),
+    [2.22](https://nix.dev/manual/nix/latest/release-notes/rl-2.22),
+    [2.23](https://nix.dev/manual/nix/latest/release-notes/rl-2.23),
+    [2.24](https://nix.dev/manual/nix/latest/release-notes/rl-2.24).
+  Notable changes include improvements to Git fetching, documentation comment support in `nix-repl> :doc`, as well as many quality of life improvements.
 
 - Convenience options for `amdgpu`, open source driver for Radeon cards, is now available under `hardware.amdgpu`.
 

--- a/nixos/modules/installer/tools/nix-fallback-paths.nix
+++ b/nixos/modules/installer/tools/nix-fallback-paths.nix
@@ -1,7 +1,8 @@
 {
-  x86_64-linux = "/nix/store/f409bhlpp0xkzvdz95qr2yvfjfi8r9jc-nix-2.18.5";
-  i686-linux = "/nix/store/ra39jzrxq3bcpf55aahwv5037akvylf5-nix-2.18.5";
-  aarch64-linux = "/nix/store/xiw8a4jbnw18svgdb04hyqzg5bsjspqf-nix-2.18.5";
-  x86_64-darwin = "/nix/store/k2gzx7i90x3h2c8g6xdi1jkwbl6ic895-nix-2.18.5";
-  aarch64-darwin = "/nix/store/rqwymbndaqxma6p8s5brcl9k32n5xx54-nix-2.18.5";
+  x86_64-linux = "/nix/store/b9kk9p6ankg080wh70smhg44dyan78kn-nix-2.24.2";
+  i686-linux = "/nix/store/nin0kajw977j8hhbyamgv5mkclssr03x-nix-2.24.2";
+  aarch64-linux = "/nix/store/pghw4m535hnrwkdlm7bamxca6lbx6n7z-nix-2.24.2";
+  riscv64-linux = "/nix/store/jcva3mcba7qn4waxkmv77w2r44q7wmq0-nix-riscv64-unknown-linux-gnu-2.24.2";
+  x86_64-darwin = "/nix/store/fkvinbdryqr854hk9i9hpdcqqaqln39m-nix-2.24.2";
+  aarch64-darwin = "/nix/store/z9j3va2vs4ycl9nxxph335c3jf47l27h-nix-2.24.2";
 }

--- a/nixos/modules/installer/tools/nix-fallback-paths.nix
+++ b/nixos/modules/installer/tools/nix-fallback-paths.nix
@@ -1,8 +1,8 @@
 {
-  x86_64-linux = "/nix/store/b9kk9p6ankg080wh70smhg44dyan78kn-nix-2.24.2";
-  i686-linux = "/nix/store/nin0kajw977j8hhbyamgv5mkclssr03x-nix-2.24.2";
-  aarch64-linux = "/nix/store/pghw4m535hnrwkdlm7bamxca6lbx6n7z-nix-2.24.2";
-  riscv64-linux = "/nix/store/jcva3mcba7qn4waxkmv77w2r44q7wmq0-nix-riscv64-unknown-linux-gnu-2.24.2";
-  x86_64-darwin = "/nix/store/fkvinbdryqr854hk9i9hpdcqqaqln39m-nix-2.24.2";
-  aarch64-darwin = "/nix/store/z9j3va2vs4ycl9nxxph335c3jf47l27h-nix-2.24.2";
+  x86_64-linux = "/nix/store/fmfy9zigxns8f1wfb4v2arf1jmfdjpjc-nix-2.24.6";
+  i686-linux = "/nix/store/bl95c09pcihf2fdqpzjyjk4bdq0bsizm-nix-2.24.6";
+  aarch64-linux = "/nix/store/2sbzgmvas19iq3nhg8xbnd8k0khahk34-nix-2.24.6";
+  riscv64-linux = "/nix/store/7yy1x9sx83wm77mjawd953d6a6wb669q-nix-riscv64-unknown-linux-gnu-2.24.6";
+  x86_64-darwin = "/nix/store/vs6bbxkwxqr828q8rj1xlbmsbnx1ry6z-nix-2.24.6";
+  aarch64-darwin = "/nix/store/d88r5b1qv1fvz2j9qndz8sr31mqgz45x-nix-2.24.6";
 }

--- a/pkgs/development/libraries/nix-plugins/default.nix
+++ b/pkgs/development/libraries/nix-plugins/default.nix
@@ -2,18 +2,21 @@
 
 stdenv.mkDerivation rec {
   pname = "nix-plugins";
-  version = "14.0.0";
+  version = "15.0.0";
 
   src = fetchFromGitHub {
     owner = "shlevy";
     repo = "nix-plugins";
     rev = version;
-    hash = "sha256-RDKAuLwcZ3Pbn5JUDmGBcfD0xbM6Jud2ouXh/YKpfS8=";
+    hash = "sha256-C4VqKHi6nVAHuXVhqvTRRyn0Bb619ez4LzgUWPH1cbM=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ nix boost ];
+  buildInputs = [
+    nix
+    boost
+  ];
 
   meta = {
     description = "Collection of miscellaneous plugins for the nix expression language";

--- a/pkgs/tools/package-management/nix-doc/default.nix
+++ b/pkgs/tools/package-management/nix-doc/default.nix
@@ -6,7 +6,7 @@
 , nix
 , pkg-config
 # Whether to build the nix-doc plugin for Nix
-, withPlugin ? true
+, withPlugin ? false # no longer needed for nix 2.24
 }:
 
 let

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -85,6 +85,7 @@ in
 
   # passthru tests
 , pkgsi686Linux
+, pkgsStatic
 , runCommand
 , pkgs
 }: let
@@ -260,6 +261,8 @@ self = stdenv.mkDerivation {
 
     tests = {
       nixi686 = pkgsi686Linux.nixVersions.${self_attribute_name};
+      nixStatic = pkgsStatic.nixVersions.${self_attribute_name};
+
       # Basic smoke test that needs to pass when upgrading nix.
       # Note that this test does only test the nixVersions.stable attribute.
       misc = nixosTests.nix-misc.default;

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -86,6 +86,7 @@ in
   # passthru tests
 , pkgsi686Linux
 , runCommand
+, pkgs
 }: let
 self = stdenv.mkDerivation {
   pname = "nix";
@@ -278,6 +279,12 @@ self = stdenv.mkDerivation {
         fi
         touch $out
       '';
+
+      /** Intended to test `lib`, but also a good smoke test for Nix */
+      nixpkgs-lib = import ../../../../lib/tests/test-with-nix.nix {
+        inherit lib pkgs;
+        nix = self;
+      };
     };
   };
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -115,7 +115,9 @@ let
         runCommand "test-nix-fallback-paths-version-equals-nix-stable" {
           paths = lib.concatStringsSep "\n" (builtins.attrValues (import ../../../../nixos/modules/installer/tools/nix-fallback-paths.nix));
         } ''
-          if [[ "" != $(grep -v 'nix-${pkg.version}$' <<< "$paths") ]]; then
+          # NOTE: name may contain cross compilation details between the pname
+          #       and version this is permitted thanks to ([^-]*-)*
+          if [[ "" != $(grep -vE 'nix-([^-]*-)*${lib.strings.replaceStrings ["."] ["\\."] pkg.version}$' <<< "$paths") ]]; then
             echo "nix-fallback-paths not up to date with nixVersions.stable (nix-${pkg.version})"
             echo "The following paths are not up to date:"
             grep -v 'nix-${pkg.version}$' <<< "$paths"

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -241,7 +241,7 @@ in lib.makeExtensible (self: ({
     else
       nix;
 
-  stable = addFallbackPathsCheck self.nix_2_18;
+  stable = addFallbackPathsCheck self.nix_2_24;
 } // lib.optionalAttrs config.allowAliases (
   lib.listToAttrs (map (
     minor:


### PR DESCRIPTION
## Description of changes

- Deliver new features and fixes to regular users
- Add the `lib` test suite to passthru. I think it already runs for `nix` aka stable as part of the normal CI, but this makes it easier to run by hand

Depends on https://github.com/NixOS/nixpkgs/pull/335458

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
