### PR TITLE
Init g-golf at 0.8.0-rc.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17169,6 +17169,12 @@
     name = "Roland Conybeare";
     keys = [ { fingerprint = "bw5Cr/4ul1C2UvxopphbZbFI1i5PCSnOmPID7mJ/Ogo"; } ];
   };
+  rc-zb = {
+    name = "rczb";
+    email = "rc-zb@outlook.com";
+    github = "rc-zb";
+    githubId = 161540043;
+  };
   rdnetto = {
     email = "rdnetto@gmail.com";
     github = "rdnetto";

--- a/pkgs/by-name/g-/g-golf/package.nix
+++ b/pkgs/by-name/g-/g-golf/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  autoconf,
+  automake,
+  texinfo,
+  guile,
+  glib,
+  gobject-introspection,
+  guile-lib,
+  gtk3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "g-golf";
+  version = "0.8.0-rc.5";
+
+  src = fetchurl {
+    url = "http://ftp.gnu.org/gnu/g-golf/g-golf-${finalAttrs.version}.tar.gz";
+    hash = "sha256-pF7ORAr1c56J+Sv9BIDlk0JrhWrfGsAc0OAfm3r3gVk=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoconf
+    automake
+    texinfo
+  ];
+
+  buildInputs = [
+    guile
+    glib
+    gobject-introspection
+  ];
+
+  checkInputs = [
+    guile-lib
+    gtk3
+  ];
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+        --replace 'SITEDIR="$datadir/g-golf"' \
+            'SITEDIR="$prefix/${guile.siteDir}"' \
+        --replace 'SITECCACHEDIR="$libdir/g-golf/guile/$GUILE_EFFECTIVE_VERSION/site-ccache"' \
+            'SITECCACHEDIR="$prefix/${guile.siteCcacheDir}"'
+  '';
+
+  makeFlags = [ "GUILE_AUTO_COMPILE=0" ];
+
+  preBuild = ''
+    export GUILE_EXTENSIONS_PATH="${
+      lib.strings.makeLibraryPath [
+        glib
+        gobject-introspection
+      ]
+    }''${GUILE_EXTENSIONS_PATH:+:$GUILE_EXTENSIONS_PATH}"
+  '';
+
+  # TODO: Check fails.
+  doCheck = false;
+
+  installTargets = "install install-info";
+
+  meta = {
+    description = "Guile Object Library for GNOME";
+    homepage = "https://www.gnu.org/software/g-golf/";
+    changlog = "https://git.savannah.gnu.org/cgit/g-golf.git/tree/NEWS?h=v${finalAttrs.version}";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ rc-zb ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

Add [GNU G-Golf](https://www.gnu.org/software/g-golf/), a [Guile](http://www.gnu.org/software/guile/) Object Library for [GNOME](https://www.gnome.org/).

And add myself to the maintainer list of Nixpkgs as well as this package.

### Status

- [ ] Make sure its functionality in real world
    - Guile-C FFIs do not work out-of-box for Nixpkgs.
- [ ] Pass the upstream test suite

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
