### PR TITLE
_86Box: darwin support, add maintainer, derivation cleanup (`with lib;` and RFC format)

### DIFF
--- a/pkgs/applications/emulators/86box/darwin.patch
+++ b/pkgs/applications/emulators/86box/darwin.patch
@@ -1,0 +1,15 @@
+diff --git a/src/qt/qt_platform.cpp b/src/qt/qt_platform.cpp
+index 824f71023..1f38e4b5f 100644
+--- a/src/qt/qt_platform.cpp
++++ b/src/qt/qt_platform.cpp
+@@ -673,6 +673,10 @@ plat_init_rom_paths(void)
+         rom_add_path(QDir(path).filePath("86Box/roms").toUtf8().constData());
+ #endif
+     }
++
++    #ifdef __APPLE__
++    rom_add_path("@out@/share/86Box/roms/");
++    #endif
+ }
+ 
+ void

--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -49,27 +49,34 @@ stdenv.mkDerivation (finalAttrs: {
     substituteAllInPlace src/qt/qt_platform.cpp
   '';
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-    makeWrapper
-    qt5.wrapQtAppsHook
-  ] ++ lib.optionals enableWayland [ extra-cmake-modules wayland-scanner ];
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+      makeWrapper
+      qt5.wrapQtAppsHook
+    ]
+    ++ lib.optionals enableWayland [
+      extra-cmake-modules
+      wayland-scanner
+    ];
 
-  buildInputs = [
-    freetype
-    fluidsynth
-    SDL2
-    glib
-    openal
-    rtmidi
-    pcre2
-    jack2
-    libpcap
-    libslirp
-    qt5.qtbase
-    qt5.qttools
-  ] ++ lib.optional stdenv.isLinux alsa-lib
+  buildInputs =
+    [
+      freetype
+      fluidsynth
+      SDL2
+      glib
+      openal
+      rtmidi
+      pcre2
+      jack2
+      libpcap
+      libslirp
+      qt5.qtbase
+      qt5.qttools
+    ]
+    ++ lib.optional stdenv.isLinux alsa-lib
     ++ lib.optional enableWayland wayland
     ++ lib.optional enableVncRenderer libvncserver
     ++ lib.optional stdenv.isDarwin darwin.apple_sdk_11_0.libs.xpc;
@@ -120,7 +127,9 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Emulator of x86-based machines based on PCem";
     mainProgram = "86Box";
     homepage = "https://86box.net/";
-    license = with lib.licenses; [ gpl2Only ] ++ lib.optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
+    license =
+      with lib.licenses;
+      [ gpl2Only ] ++ lib.optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
     maintainers = with lib.maintainers; [ jchw ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };

--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -1,5 +1,6 @@
 {
   stdenv,
+  darwin,
   lib,
   fetchFromGitHub,
   cmake,
@@ -42,6 +43,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ioE0EVIXv/biXXvLqwhmtZ/RJM0nLqcE+i+CU+WXBY4=";
   };
 
+  patches = [ ./darwin.patch ];
+
+  postPatch = ''
+    substituteAllInPlace src/qt/qt_platform.cpp
+  '';
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -64,7 +71,8 @@ stdenv.mkDerivation (finalAttrs: {
     qt5.qttools
   ] ++ lib.optional stdenv.isLinux alsa-lib
     ++ lib.optional enableWayland wayland
-    ++ lib.optional enableVncRenderer libvncserver;
+    ++ lib.optional enableVncRenderer libvncserver
+    ++ lib.optional stdenv.isDarwin darwin.apple_sdk_11_0.libs.xpc;
 
   cmakeFlags =
     lib.optional stdenv.isDarwin "-DCMAKE_MACOSX_BUNDLE=OFF"
@@ -114,6 +122,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://86box.net/";
     license = with licenses; [ gpl2Only ] ++ optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
     maintainers = [ maintainers.jchw ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 })

--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -130,7 +130,10 @@ stdenv.mkDerivation (finalAttrs: {
     license =
       with lib.licenses;
       [ gpl2Only ] ++ lib.optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
-    maintainers = with lib.maintainers; [ jchw ];
+    maintainers = with lib.maintainers; [
+      jchw
+      matteopacini
+    ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -116,12 +116,12 @@ stdenv.mkDerivation (finalAttrs: {
       makeWrapperArgs+=(--prefix ${libPathVar} : "${libPath}")
     '';
 
-  meta = with lib; {
+  meta = {
     description = "Emulator of x86-based machines based on PCem";
     mainProgram = "86Box";
     homepage = "https://86box.net/";
-    license = with licenses; [ gpl2Only ] ++ optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
-    maintainers = [ maintainers.jchw ];
-    platforms = platforms.linux ++ platforms.darwin;
+    license = with lib.licenses; [ gpl2Only ] ++ lib.optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
+    maintainers = with lib.maintainers; [ jchw ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
## Description of changes

- Added better support for Darwin
    - Added `$out/share/86Box/roms` as an additional ROM path, so ROMs - if present - are picked up automatically
- Cleaned up `meta` as per #208242 
- Formatted the derivation with `nixfmt-rfc-style`.
- Added myself as a maintainer for Darwin

To test this with ROMs (on Darwin):
- Checkout my branch and cd into it
- Run `NIX_PATH="nixpkgs=$PWD" NIXPKGS_ALLOW_UNFREE=1 nix-shell -p _86Box-with-roms`
- Once built and inside the Nix shell, run `86Box` - it should launch the GUI if it can find the roms within the Nix Store.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
