### PR TITLE
[24.05] cudnn: Fix referring to deprecated alias

### DIFF
--- a/pkgs/development/cuda-modules/generic-builders/multiplex.nix
+++ b/pkgs/development/cuda-modules/generic-builders/multiplex.nix
@@ -127,6 +127,8 @@ let
             inherit pname;
             redistName = pname;
             inherit (shims) redistribRelease featureRelease;
+            # get `autoAddDriverRunpath` from pkgs instead of cudaPackages' alias to avoid warning
+            inherit (final.callPackage ({ pkgs }: pkgs) { }) autoAddDriverRunpath;
           };
           fixedDrv = drv.overrideAttrs (overrideAttrsFixupFn final package);
         in


### PR DESCRIPTION
Similar to commit

    ae5074ef cudaPackages: fix an annoying warning caused by alias

CC @wrvsrx @niklaskorz @drupol from https://github.com/NixOS/nixpkgs/pull/316594

Can be verified with:

    NIX_ABORT_ON_WARN=true NIXPKGS_ALLOW_UNFREE=1 NIX_PATH=nixpkgs=. nix-instantiate -A cudaPackages.cudnn

Without this change, it prints

```
trace: warning: cudaPackages.autoAddDriverRunpath is deprecated, use pkgs.autoAddDriverRunpath instead
```

for `cudnn` and any package that depends on it.

Not necessary on `master` because commit https://github.com/NixOS/nixpkgs/pull/331017/commits/bb429ba52d3b1a99c20dd0a67af1e5868500cdaf already removed the alias in PR:

* #331017

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Eval-only change.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
