### PR TITLE
mmsd-tng: 1.12.1 -> 2.6.1

### DIFF
--- a/pkgs/tools/networking/mmsd-tng/default.nix
+++ b/pkgs/tools/networking/mmsd-tng/default.nix
@@ -1,26 +1,28 @@
-{ lib, stdenv
-, fetchFromGitLab
-, c-ares
-, dbus
-, glib
-, libphonenumber
-, libsoup
-, meson
-, mobile-broadband-provider-info
-, modemmanager
-, ninja
-, pkg-config
-, protobuf
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  c-ares,
+  dbus,
+  glib,
+  libphonenumber,
+  libsoup,
+  meson,
+  mobile-broadband-provider-info,
+  modemmanager,
+  ninja,
+  pkg-config,
+  protobuf,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mmsd-tng";
   version = "1.12.1";
 
   src = fetchFromGitLab {
     owner = "kop316";
     repo = "mmsd";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-fhbiTJWmQwJpuMaVX2qWyWwJ/2Y/Vczo//+0T0b6jhA=";
   };
 
@@ -43,12 +45,12 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Multimedia Messaging Service Daemon - The Next Generation";
     homepage = "https://gitlab.com/kop316/mmsd";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ julm ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ julm ];
+    platforms = lib.platforms.linux;
     mainProgram = "mmsdtng";
   };
-}
+})

--- a/pkgs/tools/networking/mmsd-tng/default.nix
+++ b/pkgs/tools/networking/mmsd-tng/default.nix
@@ -6,7 +6,7 @@
   dbus,
   glib,
   libphonenumber,
-  libsoup,
+  libsoup_3,
   meson,
   mobile-broadband-provider-info,
   modemmanager,
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mmsd-tng";
-  version = "1.12.1";
+  version = "2.6.1";
 
   src = fetchFromGitLab {
     owner = "kop316";
     repo = "mmsd";
     rev = finalAttrs.version;
-    hash = "sha256-fhbiTJWmQwJpuMaVX2qWyWwJ/2Y/Vczo//+0T0b6jhA=";
+    hash = "sha256-XornJvKudVeibc40GOQpX/4hINoJTqj3M3WeBEqdLe4=";
   };
 
   nativeBuildInputs = [
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     dbus
     glib
     libphonenumber
-    libsoup
+    libsoup_3
     mobile-broadband-provider-info
     modemmanager
     protobuf


### PR DESCRIPTION
## Description of changes

Updates the outdated `mmsd-tng` so it works with [Chatty](https://gitlab.gnome.org/World/Chatty) on the PinePhone

Changelog: https://gitlab.com/kop316/mmsd/-/tags

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
