### PR TITLE
python3Packages.llvmlite: make it statically link to llvm

### DIFF
--- a/pkgs/development/python-modules/llvmlite/default.nix
+++ b/pkgs/development/python-modules/llvmlite/default.nix
@@ -6,12 +6,14 @@
   isPyPy,
   pythonAtLeast,
 
-  # build-system
-  llvm,
   setuptools,
 
   # tests
   pytestCheckHook,
+  llvm,
+  libxml2,
+
+  withStaticLLVM ? true,
 }:
 
 buildPythonPackage rec {
@@ -28,24 +30,19 @@ buildPythonPackage rec {
     hash = "sha256-5QBSRDb28Bui9IOhGofj+c7Rk7J5fNv5nPksEPY/O5o=";
   };
 
-  nativeBuildInputs = [
-    llvm
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
-  postPatch = ''
-    substituteInPlace llvmlite/tests/test_binding.py \
-      --replace-fail "test_linux" "nope"
+  buildInputs = [ llvm ] ++ lib.optionals withStaticLLVM [ libxml2.dev ];
+
+  postPatch = lib.optionalString withStaticLLVM ''
+    substituteInPlace ffi/build.py --replace-fail "--system-libs --libs all" "--system-libs --libs --link-static all"
   '';
 
   # Set directory containing llvm-config binary
-  preConfigure = ''
-    export LLVM_CONFIG=${llvm.dev}/bin/llvm-config
-  '';
+  env.LLVM_CONFIG = "${llvm.dev}/bin/llvm-config";
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
   # https://github.com/NixOS/nixpkgs/issues/255262
   preCheck = ''
     cd $out
@@ -53,7 +50,7 @@ buildPythonPackage rec {
 
   __impureHostDeps = lib.optionals stdenv.isDarwin [ "/usr/lib/libm.dylib" ];
 
-  passthru.llvm = llvm;
+  passthru = lib.optionalAttrs (!withStaticLLVM) { inherit llvm; };
 
   meta = {
     changelog = "https://github.com/numba/llvmlite/blob/v${version}/CHANGE_LOG";


### PR DESCRIPTION
## Description of changes

Llvmlite doc says that they link to llvm statically, but it's not. Check

- https://github.com/numba/llvmlite/issues/1027.
- https://github.com/numba/llvmlite/blob/ca123c3ae2a6f7db865661ae509862277ec5d692/docs/source/faqs.rst#why-static-linking-to-llvm

This behavior causes problems when python uses another version of llvm, for example, mesa llvmpipe. This PR force llvmlite statically link to llvm.

Besides, this PR also use llvm as buildInputs rather than nativeBuildInputs since it's a library that llvmlite use rather than a part of build system.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
