### PR TITLE
Fix: neovim treesitter grammar error

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -226,23 +226,6 @@ let
       ''
         mkdir -p "$out/parser"
         ln -s "${grammar}/parser" "$out/parser/${name}.so"
-
-        mkdir -p "$out/queries/${name}"
-        if [ -d "${grammar}/queries/${name}" ]; then
-          echo "moving queries from neovim queries dir"
-          for file in "${grammar}/queries/${name}"*; do
-            ln -s "$file" "$out/queries/${name}/$(basename "$file")"
-          done
-        else
-          if [ -d "${grammar}/queries" ]; then
-            echo "moving queries from standard queries dir"
-            for file in "${grammar}/queries/"*; do
-              ln -s "$file" "$out/queries/${name}/$(basename "$file")"
-            done
-          else
-            echo "missing queries for ${name}"
-          fi
-        fi
       '');
 
   /*


### PR DESCRIPTION
Addresses issue https://github.com/NixOS/nixpkgs/issues/332580

Revert to https://github.com/NixOS/nixpkgs/pull/321550

It was finding the queries before this change was made.

Adding them to where you would expect throws an error.

Removing them again afterwards during the build process fixes the error.

It is weird, but that at least seems pretty clear to me. I would very much like to know how it currently is finding the ones that we have right now before trying to copy them in somewhere that causes issues.

Opening this as a draft so that if the decision is made to revert, all that needs to be done is accept it. 