### PR TITLE
virtualisation.oci-containers: Add new `imageStream` option

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -304,10 +304,10 @@ let
     };
   in {
     wantedBy = [] ++ optional (container.autoStart) "multi-user.target";
-    wants = lib.optional (container.imageFile == null)  "network-online.target";
+    wants = lib.optional (container.imageFile == null && container.imageStream == null)  "network-online.target";
     after = lib.optionals (cfg.backend == "docker") [ "docker.service" "docker.socket" ]
-            # if imageFile is not set, the service needs the network to download the image from the registry
-            ++ lib.optionals (container.imageFile == null) [ "network-online.target" ]
+            # if imageFile or imageStream is not set, the service needs the network to download the image from the registry
+            ++ lib.optionals (container.imageFile == null && container.imageStream == null) [ "network-online.target" ]
             ++ dependsOn;
     requires = dependsOn;
     environment = proxy_env;

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -36,7 +36,7 @@ let
         imageStream = mkOption {
           type = with types; nullOr package;
           default = null;
-          description = lib.mdDoc ''
+          description = ''
             Path to a script that streams the desired image on standard output.
 
             This option is mainly intended for use with

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -419,15 +419,13 @@ in {
       assertions =
         let
           toAssertion = _: { imageFile, imageStream, ... }:
-            { assertion =
-                config.imageFile == null || config.imageStream == null;
+            { assertion = imageFile == null || imageStream == null;
 
-              message =
-                "You can only define one of imageFile and imageStream";
+              message = "You can only define one of imageFile and imageStream";
             };
 
         in
-          lib.mapAttrsToList toAssertion config.virtualisation.oci-containers;
+          lib.mapAttrsToList toAssertion cfg.containers;
     }
     (lib.mkIf (cfg.backend == "podman") {
       virtualisation.podman.enable = true;

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -8,7 +8,7 @@ let
   defaultBackend = options.virtualisation.oci-containers.backend.default;
 
   containerOptions =
-    { config, ... }: {
+    { ... }: {
 
       options = {
 

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -295,7 +295,7 @@ let
           ${cfg.backend} load -i ${container.imageFile}
         ''}
         ${optionalString (container.imageStream != null) ''
-          ${cfg.backend} load < $(${lib.getExe container.imageStream})
+          ${container.imageStream} | ${cfg.backend} load
         ''}
         ${optionalString (cfg.backend == "podman") ''
           rm -f /run/podman-${escapedName}.ctr-id

--- a/nixos/tests/cntr.nix
+++ b/nixos/tests/cntr.nix
@@ -18,7 +18,7 @@ let
             inherit backend;
             containers.nginx = {
               image = "nginx-container";
-              imageFile = pkgs.dockerTools.examples.nginx;
+              imageStream = pkgs.dockerTools.examples.nginxStream;
               ports = [ "8181:80" ];
             };
           };

--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -20,7 +20,7 @@ let
           inherit backend;
           containers.nginx = {
             image = "nginx-container";
-            imageFile = pkgs.dockerTools.examples.nginx;
+            imageStream = pkgs.dockerTools.examples.nginxStream;
             ports = ["8181:80"];
           };
         };

--- a/nixos/tests/traefik.nix
+++ b/nixos/tests/traefik.nix
@@ -23,7 +23,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             "traefik.http.routers.nginx.rule=Host(`nginx.traefik.test`)"
           ];
           image = "nginx-container";
-          imageFile = pkgs.dockerTools.examples.nginx;
+          imageStream = pkgs.dockerTools.examples.nginxStream;
         };
       };
 


### PR DESCRIPTION
This adds a new `imageStream` option that can be used in conjunction with `pkgs.dockerTools.streamLayeredImage` so that the image archive never needs to be materialized in the `/nix/store`.  This greatly improves the disk utilization for systems that use container images built using Nix because they only need to store image layers instead of the full image.  Additionally, when deploying the new system only new layers need to be built/copied.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note that I updated tests to reflect this change but haven't personally run them yet because I don't have access to an `x86_64-linux` system at the moment.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
