### PR TITLE
freebsd: Fix obscure c++98 interaction used by gbenchmark

### DIFF
--- a/pkgs/development/libraries/gbenchmark/default.nix
+++ b/pkgs/development/libraries/gbenchmark/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     description = "Microbenchmark support library";
     homepage = "https://github.com/google/benchmark";
     license = licenses.asl20;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.linux ++ platforms.darwin ++ platforms.freebsd;
     maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/patches/14.1/sys-cdefs-static-assert.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.1/sys-cdefs-static-assert.patch
@@ -1,0 +1,41 @@
+From 22cdafe197ac960c5ce839ef6ec699b59f4b0080 Mon Sep 17 00:00:00 2001
+From: Warner Losh <imp@FreeBSD.org>
+Date: Sat, 20 Jul 2024 09:57:53 -0600
+Subject: cdefs.h: Don't define fallback for _Static_assert
+
+Remove pre 4.6 code to define _Static_assert in terms of _COUNTER.  We
+no longer need to support compilers this old (in fact support for all
+pre gcc 10 compilers has been removed in -current). This is a partial
+MFC of that work because removing this fixes a bug that's oft reported
+with -pedantic-errors and C++98 compilations.
+
+PR: 280382, 276738
+Sponsored by:		Netflix
+
+This is a direct commit to stable/14.
+---
+ sys/sys/cdefs.h | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/sys/sys/cdefs.h b/sys/sys/cdefs.h
+index 19b7d8fe427d..a52864c5db9d 100644
+--- a/sys/sys/cdefs.h
++++ b/sys/sys/cdefs.h
+@@ -277,15 +277,6 @@
+ #if (defined(__cplusplus) && __cplusplus >= 201103L) || \
+     __has_extension(cxx_static_assert)
+ #define	_Static_assert(x, y)	static_assert(x, y)
+-#elif __GNUC_PREREQ__(4,6) && !defined(__cplusplus)
+-/* Nothing, gcc 4.6 and higher has _Static_assert built-in */
+-#elif defined(__COUNTER__)
+-#define	_Static_assert(x, y)	__Static_assert(x, __COUNTER__)
+-#define	__Static_assert(x, y)	___Static_assert(x, y)
+-#define	___Static_assert(x, y)	typedef char __assert_ ## y[(x) ? 1 : -1] \
+-				__unused
+-#else
+-#define	_Static_assert(x, y)	struct __hack
+ #endif
+ #endif
+ 
+-- 
+cgit v1.2.3


### PR DESCRIPTION
## Description of changes

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276738#c12

Using _Static_assert under -std=c++98 -pedantic-errors will fail in FreeBSD 14.1. This fixes that, allowing software like gbenchmark to run its tests against legacy c++ standards. This patch is pending for FreeBSD 14.2, and should be removed for that release.

I have included this patch in-tree since there is not a convenient way to apply unvendored patches to the entire FreeBSD source tree.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
