### PR TITLE
rain-bittorrent: init at 1.12.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12764,6 +12764,12 @@
     githubId = 26458780;
     name = "Matthew Croughan";
   };
+  matthewdargan = {
+    email = "matthewdargan57@gmail.com";
+    githubId = 18505904;
+    github = "matthewdargan";
+    name = "Matthew Dargan";
+  };
   matthew-levan = {
     email = "matthew@coeli.network";
     github = "matthew-levan";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10365,6 +10365,11 @@
     githubId = 7183441;
     name = "Justin Lovinger";
   };
+  justinrubek = {
+    github = "justinrubek";
+    githubId = 25621857;
+    name = "Justin Rubek";
+  };
   justinwoo = {
     email = "moomoowoo@gmail.com";
     github = "justinwoo";

--- a/pkgs/by-name/ra/rain-bittorrent/package.nix
+++ b/pkgs/by-name/ra/rain-bittorrent/package.nix
@@ -4,24 +4,27 @@
   fetchFromGitHub,
 }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "rain";
-  version = "1.30.0";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "cenkalti";
     repo = "rain";
-    rev = "v1.13.0";
-    sha256 = "sha256-pz20vhr3idXja7wYIdVr1dosSpqYiQfeho66rqd718I=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-pz20vhr3idXja7wYIdVr1dosSpqYiQfeho66rqd718I=";
   };
 
   vendorHash = "sha256-40DK0D9TRJDfrMbBJNpcNzvjKb/uXN/Yz5Bb7oXBh+E=";
 
-  meta = with lib; {
+  meta = {
     description = "BitTorrent client and library in Go";
     homepage = "https://github.com/cenkalti/rain";
-    license = licenses.mit;
-    maintainers = with maintainers; [ justinrubek ];
+    license = lib.licenses.mit;
     mainProgram = "rain";
+    maintainers = with lib.maintainers; [
+      justinrubek
+      matthewdargan
+    ];
   };
 }

--- a/pkgs/by-name/ra/rain-bittorrent/package.nix
+++ b/pkgs/by-name/ra/rain-bittorrent/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule {
+  pname = "rain";
+  version = "1.30.0";
+
+  src = fetchFromGitHub {
+    owner = "cenkalti";
+    repo = "rain";
+    rev = "v1.13.0";
+    sha256 = "sha256-pz20vhr3idXja7wYIdVr1dosSpqYiQfeho66rqd718I=";
+  };
+
+  vendorHash = "sha256-40DK0D9TRJDfrMbBJNpcNzvjKb/uXN/Yz5Bb7oXBh+E=";
+
+  meta = with lib; {
+    description = "BitTorrent client and library in Go";
+    homepage = "https://github.com/cenkalti/rain";
+    license = licenses.mit;
+    maintainers = with maintainers; [ justinrubek ];
+    mainProgram = "rain";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added package https://github.com/cenkalti/rain

This package is a bittorrent client. It provides an RPC server that other applications can connect to in order to initiate a download as well as a command-line client in the same binary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
