### PR TITLE
python3Packages.pym3u8downloader: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/pycolorecho/default.nix
+++ b/pkgs/development/python-modules/pycolorecho/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pycolorecho";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "coldsofttech";
+    repo = "pycolorecho";
+    rev = version;
+    hash = "sha256-h/7Wi0x8iLMZpPYekK6W9LTM+2nYJTaKClNtRTzbmdg=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pycolorecho" ];
+
+  meta = {
+    description = "Simple Python package for colorized terminal output";
+    homepage = "https://github.com/coldsofttech/pycolorecho";
+    changelog = "https://github.com/coldsofttech/pycolorecho/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/development/python-modules/pyloggermanager/default.nix
+++ b/pkgs/development/python-modules/pyloggermanager/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  pycolorecho,
+}:
+
+buildPythonPackage rec {
+  pname = "pyloggermanager";
+  version = "0.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "coldsofttech";
+    repo = "pyloggermanager";
+    rev = version;
+    hash = "sha256-1hfcmMLH2d71EV71ExKqjZ7TMcqVd1AQrEwJhmEWOVU=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pycolorecho ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pyloggermanager" ];
+
+  meta = {
+    description = "Logging framework for Python applications";
+    homepage = "https://github.com/coldsofttech/pyloggermanager";
+    changelog = "https://github.com/coldsofttech/pyloggermanager/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/development/python-modules/pym3u8downloader/default.nix
+++ b/pkgs/development/python-modules/pym3u8downloader/default.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  pyloggermanager,
+  requests,
+  pym3u8downloader, # For package tests
+}:
+
+buildPythonPackage rec {
+  pname = "pym3u8downloader";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "coldsofttech";
+    repo = "pym3u8downloader";
+    rev = version;
+    hash = "sha256-Kcvtl4jP2pSiETTKUmuiBsysxaFfd4K/E2/nXY8Vlw8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyloggermanager
+    requests
+  ];
+
+  pythonImportsCheck = [ "pym3u8downloader" ];
+
+  doCheck = false;
+
+  passthru = {
+    tests = {
+      pytest = pym3u8downloader.overridePythonAttrs (previousPythonAttrs: {
+        TEST_SERVER_PORT = "8000";
+
+        postPatch =
+          previousPythonAttrs.postPatch or ""
+          + ''
+            # Patch test data location
+            substituteInPlace tests/commonclass.py \
+              --replace-fail \
+                "f'https://raw.githubusercontent.com/coldsofttech/pym3u8downloader/{branch_name}/tests/files'" \
+                "'http://localhost:$TEST_SERVER_PORT/tests/files'"
+            # Patch the `is_internet_connected()` method
+            substituteInPlace pym3u8downloader/__main__.py \
+              --replace-fail "'http://www.github.com'" "'http://localhost:$TEST_SERVER_PORT'"
+          '';
+
+        doCheck = true;
+
+        nativeCheckInputs = [ pytestCheckHook ];
+
+        preCheck =
+          previousPythonAttrs.preCheck or ""
+          + ''
+            python3 -m http.server "$TEST_SERVER_PORT" &
+            TEST_SERVER_PID="$!"
+          '';
+
+        postCheck =
+          previousPythonAttrs.postCheck or ""
+          + ''
+            kill -s TERM "$TEST_SERVER_PID"
+          '';
+      });
+    };
+  };
+
+  meta = {
+    description = "Python class to download and concatenate video files from M3U8 playlists";
+    longDescription = ''
+      M3U8 Downloader is a Python class designed to
+      download and concatenate video files from M3U8 playlists.
+      This class provides functionality to handle M3U8 playlist files,
+      download video segments,
+      concatenate them into a single video file,
+      and manage various error conditions.
+    '';
+    homepage = "https://github.com/coldsofttech/pym3u8downloader";
+    changelog = "https://github.com/coldsofttech/pym3u8downloader/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10308,6 +10308,8 @@ self: super: with self; {
 
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };
 
+  pycolorecho = callPackage ../development/python-modules/pycolorecho { };
+
   pycomm3 = callPackage ../development/python-modules/pycomm3 { };
 
   pycompliance = callPackage ../development/python-modules/pycompliance { };
@@ -11734,6 +11736,8 @@ self: super: with self; {
 
   py-libzfs = callPackage ../development/python-modules/py-libzfs { };
 
+  pyloggermanager = callPackage ../development/python-modules/pyloggermanager { };
+
   py-lru-cache = callPackage ../development/python-modules/py-lru-cache { };
 
   pylnk3 = callPackage ../development/python-modules/pylnk3 { };
@@ -11765,6 +11769,8 @@ self: super: with self; {
   pylxd = callPackage ../development/python-modules/pylxd { };
 
   pylzma = callPackage ../development/python-modules/pylzma { };
+
+  pym3u8downloader = callPackage ../development/python-modules/pym3u8downloader { };
 
   pymacaroons = callPackage ../development/python-modules/pymacaroons { };
 


### PR DESCRIPTION
## Description of changes

This pull request packages `pyhon3Packages.pym3u8downloader` and its dependencies.

`python3Packages.pym3u8downloader` has its pytest test cases run in `passthru.tests.pytest`, which makes the tests runnable without network connections, by patching the URLs for the test cases and network connection checks and starts a simple HTTP server before running `pytest`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
