### PR TITLE
librealsense: 2.54.2 -> 2.55.1

### DIFF
--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -2,9 +2,9 @@
 , config
 , lib
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , libusb1
+, nlohmann_json
 , ninja
 , pkg-config
 , gcc
@@ -23,7 +23,7 @@ assert enablePython -> pythonPackages != null;
 
 stdenv.mkDerivation rec {
   pname = "librealsense";
-  version = "2.54.2";
+  version = "2.55.1";
 
   outputs = [ "out" "dev" ];
 
@@ -31,12 +31,13 @@ stdenv.mkDerivation rec {
     owner = "IntelRealSense";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-EbnIHnsUgsqN/SVv4m9H7K8gfwni+u82+M55QBstAGI=";
+    sha256 = "sha256-MNHvfWk58WRtu6Xysfvn+lx8J1+HlNw5AmmgaTAzuok=";
   };
 
   buildInputs = [
     libusb1
     gcc.cc.lib
+    nlohmann_json
   ] ++ lib.optional cudaSupport cudaPackages.cudatoolkit
     ++ lib.optionals enablePython (with pythonPackages; [ python pybind11 ])
     ++ lib.optionals enableGUI [ mesa gtk3 glfw libGLU curl ];
@@ -44,13 +45,15 @@ stdenv.mkDerivation rec {
   patches = [
     ./py_pybind11_no_external_download.patch
     ./install-presets.patch
-    # https://github.com/IntelRealSense/librealsense/pull/11917
-    (fetchpatch {
-      name = "fix-gcc13-missing-cstdint.patch";
-      url = "https://github.com/IntelRealSense/librealsense/commit/b59b13671658910fc453a4a6bbd61f13ba6e83cc.patch";
-      hash = "sha256-zaW8HG8rfsApI5S/3x+x9Fx8xhyTIPNn/fJVFtkmlEA=";
-    })
   ];
+
+  postPatch = ''
+    # use nixpkgs nlohmann_json instead of fetching it
+    substituteInPlace third-party/CMakeLists.txt \
+      --replace-fail \
+        'include(CMake/external_json.cmake)' \
+        'find_package(nlohmann_json 3.11.3 REQUIRED)'
+  '';
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     libusb1
     gcc.cc.lib
     nlohmann_json
-  ] ++ lib.optional cudaSupport cudaPackages.cudatoolkit
+  ] ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
     ++ lib.optionals enablePython (with pythonPackages; [ python pybind11 ])
     ++ lib.optionals enableGUI [ mesa gtk3 glfw libGLU curl ];
 
@@ -59,6 +59,8 @@ stdenv.mkDerivation rec {
     cmake
     ninja
     pkg-config
+  ] ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/IntelRealSense/librealsense/compare/v2.54.2...v2.55.1


![Screenshot from 2024-08-18 02-02-59](https://github.com/user-attachments/assets/9b24a2c6-11c9-47af-bb31-0a769a6fbead)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
