### PR TITLE
npmFixupHook: extract from npmInstallHook

### DIFF
--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -55,6 +55,8 @@
 , npmBuildHook ? null
   # Custom npmInstallHook
 , npmInstallHook ? null
+  # Custom npmFixupHook
+, npmFixupHook ? null
 , ...
 } @ args:
 
@@ -74,6 +76,7 @@ stdenv.mkDerivation (args // {
       (if npmConfigHook != null then npmConfigHook else npmHooks.npmConfigHook)
       (if npmBuildHook != null then npmBuildHook else npmHooks.npmBuildHook)
       (if npmInstallHook != null then npmInstallHook else npmHooks.npmInstallHook)
+      (if npmFixupHook != null then npmFixupHook else npmHooks.npmFixupHook)
       nodejs.python
     ]
     ++ lib.optionals stdenv.isDarwin [ cctools ];

--- a/pkgs/build-support/node/build-npm-package/hooks/default.nix
+++ b/pkgs/build-support/node/build-npm-package/hooks/default.nix
@@ -45,4 +45,12 @@
         jq = "${jq}/bin/jq";
       };
     } ./npm-install-hook.sh;
+
+  npmFixupHook = makeSetupHook
+    {
+      name = "npm-fixup-hook";
+      substitutions = {
+        jq = "${jq}/bin/jq";
+      };
+    } ./npm-fixup-hook.sh;
 }

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-fixup-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-fixup-hook.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+
+npmFixupHook() {
+    echo "Executing npmFixupHook"
+
+    runHook preFixup
+
+    local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' package.json)"
+    local -r nodeModulesPath="$packageOut/node_modules"
+
+    if [ -d "$nodeModulesPath" ]; then
+        pushd "$packageOut"
+
+        if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} $npmPruneFlags "${npmPruneFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+          echo
+          echo
+          echo "ERROR: npm prune step failed"
+          echo
+          echo 'If npm tried to download additional dependencies above, try setting `dontNpmPrune = true`.'
+          echo
+
+          exit 1
+        fi
+
+        find node_modules -maxdepth 1 -type d -empty -delete
+
+        popd
+    fi
+
+    runHook postFixup
+
+    echo "Finished npmFixupHook"
+}
+
+# keep dontNpmPrune for backwards compatibility
+if [ -z "${dontNpmPrune-}" ] && [ -z "${dontNpmFixup-}" ] && [ -z "${fixupPhase-}" ]; then
+    fixupPhase=npmFixupHook
+fi

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -43,21 +43,6 @@ npmInstallHook() {
     local -r nodeModulesPath="$packageOut/node_modules"
 
     if [ ! -d "$nodeModulesPath" ]; then
-        if [ -z "${dontNpmPrune-}" ]; then
-            if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} $npmPruneFlags "${npmPruneFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
-              echo
-              echo
-              echo "ERROR: npm prune step failed"
-              echo
-              echo 'If npm tried to download additional dependencies above, try setting `dontNpmPrune = true`.'
-              echo
-
-              exit 1
-            fi
-        fi
-
-        find node_modules -maxdepth 1 -type d -empty -delete
-
         cp -r node_modules "$nodeModulesPath"
     fi
 


### PR DESCRIPTION
`npmInstallHook` currently performs a prune step to remove unnecessary dependencies from node_modules. 
This behavior makes more sense as the `fixupPhase`, filling a similar role to stripping binary files.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
