### PR TITLE
spade: enable build on darwin

### DIFF
--- a/pkgs/by-name/sp/spade/package.nix
+++ b/pkgs/by-name/sp/spade/package.nix
@@ -41,6 +41,7 @@ rustPlatform.buildRustPackage rec {
     '')
   ];
 
+  buildInputs = lib.optionals stdenv.isDarwin [ python312 ];
   env.NIX_CFLAGS_LINK = lib.optionals stdenv.isDarwin "-L${python312}/lib/python3.12/config-3.12-darwin -lpython3.12";
 
   meta = with lib; {

--- a/pkgs/by-name/sp/spade/package.nix
+++ b/pkgs/by-name/sp/spade/package.nix
@@ -5,6 +5,7 @@
 , nix-update
 , writeScript
 , git
+, python312
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -39,6 +40,8 @@ rustPlatform.buildRustPackage rec {
     '')
   ];
 
+  env.NIX_CFLAGS_LINK = lib.optionals stdenv.isDarwin "-L${python312}/lib/python3.12/config-3.12-darwin -lpython3.12";
+
   meta = with lib; {
     description = "Better hardware description language";
     homepage = "https://gitlab.com/spade-lang/spade";
@@ -47,6 +50,5 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ eupl12 asl20 mit ];
     maintainers = with maintainers; [ pbsds ];
     mainProgram = "spade";
-    broken = stdenv.isDarwin; # ld: symbol(s) not found for architecture ${system}
   };
 }

--- a/pkgs/by-name/sp/spade/package.nix
+++ b/pkgs/by-name/sp/spade/package.nix
@@ -1,11 +1,12 @@
-{ lib
-, rustPlatform
-, fetchFromGitLab
-, stdenv
-, nix-update
-, writeScript
-, git
-, python312
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  stdenv,
+  nix-update,
+  writeScript,
+  git,
+  python312,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -47,7 +48,11 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://gitlab.com/spade-lang/spade";
     changelog = "https://gitlab.com/spade-lang/spade/-/blob/${src.rev}/CHANGELOG.md";
     # compiler is eupl12, spade-lang stdlib is both asl20 and mit
-    license = with licenses; [ eupl12 asl20 mit ];
+    license = with licenses; [
+      eupl12
+      asl20
+      mit
+    ];
     maintainers = with maintainers; [ pbsds ];
     mainProgram = "spade";
   };


### PR DESCRIPTION
## Description of changes

when building on darwin, the build would fail when compiling `spade-tests` with linker errors like the following:

```
error: linking with `/nix/store/gj5jfkr5y5s95vhgvh5hzq70p8dzhw57-clang-wrapper-16.0.6/bin/cc` failed: exit status: 1

...

  = note: Undefined symbols for architecture arm64:
            "_PyBaseObject_Type", referenced from:
                pyo3::pyclass::create_type_object::create_type_object::h32bb09bb3b93c8f8 (.llvm.6562022786284816598) in spade.spade.ed1a311ee7cc6dbd-cgu.2.rcgu.o
...
```

these missing symbols are all provided by the CPython object files. the solution is thus to add the folder containing `libpython3.12.a` to the linker's search paths via `-L` and the `lpython3.12` library to the linking process via `-l`. these flags are passed to the linker via the `NIX_CFLAGS_LINK` variable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
