### PR TITLE
yarnInstallHook: init

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/default.nix
+++ b/pkgs/build-support/node/build-npm-package/hooks/default.nix
@@ -43,6 +43,27 @@
       substitutions = {
         hostNode = "${nodejs}/bin/node";
         jq = "${jq}/bin/jq";
+        prunePart = /* bash */ ''
+          if [ -z "''${dontNpmPrune-}" ]; then
+              if ! npm prune \
+                --omit=dev \
+                --no-save \
+                ''${npmWorkspace+--workspace=$npmWorkspace} \
+                $npmPruneFlags \
+                "''${npmPruneFlagsArray[@]}" \
+                $npmFlags \
+                "''${npmFlagsArray[@]}"; then
+                echo
+                echo
+                echo "ERROR: npm prune step failed"
+                echo
+                echo 'If npm tried to download additional dependencies above, try setting `dontNpmPrune = true`.'
+                echo
+
+                exit 1
+              fi
+          fi
+        '';
       };
     } ./npm-install-hook.sh;
 }

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -58,29 +58,7 @@ npmInstallHook() {
     local -r nodeModulesPath="$packageOut/node_modules"
 
     if [ ! -d "$nodeModulesPath" ]; then
-        if [ -z "${dontNpmPrune-}" ]; then
-            if ! npm prune \
-              --omit=dev \
-              --no-save \
-              ''${npmWorkspace+--workspace=$npmWorkspace} \
-              $npmPruneFlags \
-              "${npmPruneFlagsArray[@]}" \
-              $npmFlags \
-              "${npmFlagsArray[@]}"; then
-              echo
-              echo
-              echo "ERROR: npm prune step failed"
-              echo
-              echo 'If npm tried to download additional dependencies above, try setting `dontNpmPrune = true`.'
-              echo
-
-              exit 1
-            fi
-        fi
-
-        find node_modules -maxdepth 1 -type d -empty -delete
-
-        cp -r node_modules "$nodeModulesPath"
+        @prunePart@
     fi
 
     runHook postInstall

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -12,7 +12,22 @@ npmInstallHook() {
         local dest="$packageOut/$(dirname "$file")"
         mkdir -p "$dest"
         cp "${npmWorkspace-.}/$file" "$dest"
-    done < <(@jq@ --raw-output '.[0].files | map(.path | select(. | startswith("node_modules/") | not)) | join("\n")' <<< "$(npm_config_cache="$HOME/.npm" npm pack --json --dry-run --loglevel=warn --no-foreground-scripts ${npmWorkspace+--workspace=$npmWorkspace} $npmPackFlags "${npmPackFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}")")
+    done < <(@jq@ --raw-output \
+        '.[0].files
+            | map(.path | select(. | startswith("node_modules/") | not))
+            | join("\n")
+        ' <<< "$(npm_config_cache="$HOME/.npm" npm pack \
+            --json \
+            --dry-run \
+            --loglevel=warn \
+            --no-foreground-scripts \
+            ${npmWorkspace+--workspace=$npmWorkspace} \
+            $npmPackFlags \
+            "${npmPackFlagsArray[@]}" \
+            $npmFlags \
+            "${npmFlagsArray[@]}" \
+        )" \
+    )
 
     # Based on code from Python's buildPythonPackage wrap.sh script, for
     # supporting both the case when makeWrapperArgs is an array and a
@@ -44,7 +59,14 @@ npmInstallHook() {
 
     if [ ! -d "$nodeModulesPath" ]; then
         if [ -z "${dontNpmPrune-}" ]; then
-            if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} $npmPruneFlags "${npmPruneFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+            if ! npm prune \
+              --omit=dev \
+              --no-save \
+              ''${npmWorkspace+--workspace=$npmWorkspace} \
+              $npmPruneFlags \
+              "${npmPruneFlagsArray[@]}" \
+              $npmFlags \
+              "${npmFlagsArray[@]}"; then
               echo
               echo
               echo "ERROR: npm prune step failed"

--- a/pkgs/by-name/po/postlight-parser/package.nix
+++ b/pkgs/by-name/po/postlight-parser/package.nix
@@ -5,7 +5,7 @@
 , yarnConfigHook
 , yarnBuildHook
 , nodejs
-, npmHooks
+, yarnInstallHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     yarnConfigHook
     yarnBuildHook
+    yarnInstallHook
     nodejs
-    npmHooks.npmInstallHook
   ];
   # Upstream doesn't include a script in package.json that only builds without
   # testing, and tests fail because they need to access online websites. Hence
@@ -39,8 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
   postBuild = ''
     yarn --offline run rollup -c
   '';
-  # Tries to download stuff from the internet in this phase.
-  dontNpmPrune = true;
 
   meta = {
     changelog = "https://github.com/postlight/parser/blob/${finalAttrs.src.rev}/CHANGELOG.md";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -977,6 +977,7 @@ with pkgs;
     prefetch-yarn-deps
     yarnConfigHook
     yarnBuildHook
+    yarnInstallHook
     fetchYarnDeps;
 
   find-cursor = callPackage ../tools/X11/find-cursor { };


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
