### PR TITLE
hatch: clean, format and fix build

### DIFF
--- a/pkgs/by-name/ha/hatch/package.nix
+++ b/pkgs/by-name/ha/hatch/package.nix
@@ -1,29 +1,36 @@
-{ lib
-, stdenv
-, fetchPypi
-, python3
-, cargo
-, git
-, uv
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  uv,
+  git,
+  cargo,
+  stdenv,
+  darwin,
+  nix-update-script,
+  testers,
+  hatch,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "hatch";
   version = "1.12.0";
-  format = "pyproject";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-roBHjRAxLfK0TWWck7wu1NM67N3OS3Y3gjG9+ByL9q0=";
+  src = fetchFromGitHub {
+    owner = "pypa";
+    repo = "hatch";
+    rev = "refs/tags/hatch-v${version}";
+    hash = "sha256-HW2vDVsFrdFRRaPNuGDg9DZpJd8OuYDIqA3KQRa3m9o=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [
     hatchling
     hatch-vcs
     uv
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     click
     hatchling
     httpx
@@ -41,51 +48,88 @@ python3.pkgs.buildPythonApplication rec {
     zstandard
   ];
 
-  nativeCheckInputs = [
-    cargo
-  ] ++ (with python3.pkgs; [
-    binary
-    git
-    pytestCheckHook
-    pytest-mock
-    pytest-xdist
-    setuptools
-  ]);
+  nativeCheckInputs =
+    with python3.pkgs;
+    [
+      binary
+      git
+      pytestCheckHook
+      pytest-mock
+      pytest-xdist
+      setuptools
+    ]
+    ++ [ cargo ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.ps
+    ];
 
   preCheck = ''
     export HOME=$(mktemp -d);
   '';
 
-  disabledTests = [
-    # AssertionError: assert (1980, 1, 2, 0, 0, 0) == (2020, 2, 2, 0, 0, 0)
-    "test_default"
-    # Loosen hatchling runtime version dependency
-    "test_core"
-    # New failing
-    "test_guess_variant"
-    "test_open"
-    "test_no_open"
-    "test_uv_env"
-    "test_pyenv"
-    "test_pypirc"
-  ] ++ lib.optionals stdenv.isDarwin [
-    # https://github.com/NixOS/nixpkgs/issues/209358
-    "test_scripts_no_environment"
+  disabledTests =
+    [
+      # AssertionError: assert (1980, 1, 2, 0, 0, 0) == (2020, 2, 2, 0, 0, 0)
+      "test_default"
+      "test_editable_default"
+      "test_editable_default_extra_dependencies"
+      "test_editable_default_force_include"
+      "test_editable_default_force_include_option"
+      "test_editable_default_symlink"
+      "test_editable_exact"
+      "test_editable_exact_extra_dependencies"
+      "test_editable_exact_force_include"
+      "test_editable_exact_force_include_build_data_precedence"
+      "test_editable_exact_force_include_option"
+      "test_editable_pth"
+      "test_explicit_path"
 
-    # This test assumes it is running on macOS with a system shell on the PATH.
-    # It is not possible to run it in a nix build using a /nix/store shell.
-    # See https://github.com/pypa/hatch/pull/709 for the relevant code.
-    "test_populate_default_popen_kwargs_executable"
-  ] ++ lib.optionals stdenv.isAarch64 [
-    "test_resolve"
+      # Loosen hatchling runtime version dependency
+      "test_core"
+      # New failing
+      "test_guess_variant"
+      "test_open"
+      "test_no_open"
+      "test_uv_env"
+      "test_pyenv"
+      "test_pypirc"
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      # https://github.com/NixOS/nixpkgs/issues/209358
+      "test_scripts_no_environment"
+
+      # This test assumes it is running on macOS with a system shell on the PATH.
+      # It is not possible to run it in a nix build using a /nix/store shell.
+      # See https://github.com/pypa/hatch/pull/709 for the relevant code.
+      "test_populate_default_popen_kwargs_executable"
+
+      # Those tests fail because the final wheel is named '...2-macosx_11_0_arm64.whl' instead of
+      # '...2-macosx_14_0_arm64.whl'
+      "test_macos_archflags"
+      "test_macos_max_compat"
+    ]
+    ++ lib.optionals stdenv.isAarch64 [ "test_resolve" ];
+
+  disabledTestPaths = lib.optionals stdenv.isDarwin [
+    # AssertionError: assert [call('test h...2p32/bin/sh')] == [call('test h..., shell=True)]
+    # At index 0 diff:
+    #    call('test hatch-test.py3.10', shell=True, executable='/nix/store/b34ianga4diikh0kymkpqwmvba0mmzf7-bash-5.2p32/bin/sh')
+    # != call('test hatch-test.py3.10', shell=True)
+    "tests/cli/fmt/test_fmt.py"
+    "tests/cli/test/test_test.py"
   ];
 
-  meta = with lib; {
+  passthru = {
+    tests.version = testers.testVersion { package = hatch; };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
     description = "Modern, extensible Python project manager";
-    mainProgram = "hatch";
     homepage = "https://hatch.pypa.io/latest/";
     changelog = "https://github.com/pypa/hatch/blob/hatch-v${version}/docs/history/hatch.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ onny ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ onny ];
+    mainProgram = "hatch";
   };
 }


### PR DESCRIPTION
## Description of changes

cc @onny

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
