### PR TITLE
nixos/streamcontroller: init, streamcontroller: init at 1.5.0-beta.6-unstable-2024-08-13, pythonPackages.usb-monitor: init at 1.21

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -286,6 +286,7 @@
   ./programs/ssh.nix
   ./programs/starship.nix
   ./programs/steam.nix
+  ./programs/streamcontroller.nix
   ./programs/streamdeck-ui.nix
   ./programs/sysdig.nix
   ./programs/system-config-printer.nix

--- a/nixos/modules/programs/streamcontroller.nix
+++ b/nixos/modules/programs/streamcontroller.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.streamcontroller;
+in
+{
+  options.programs.streamcontroller = {
+    enable = lib.mkEnableOption "StreamController";
+    package = lib.mkPackageOption pkgs "streamcontroller" { default = [ "streamcontroller" ]; };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ sifmelcara ];
+}

--- a/pkgs/by-name/st/streamcontroller/package.nix
+++ b/pkgs/by-name/st/streamcontroller/package.nix
@@ -1,0 +1,190 @@
+{
+  stdenv,
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  copyDesktopItems,
+  makeDesktopItem,
+  wrapGAppsHook4,
+  gobject-introspection,
+  libadwaita,
+  libportal,
+  libportal-gtk4,
+  xdg-desktop-portal,
+  xdg-desktop-portal-gtk,
+}:
+stdenv.mkDerivation rec {
+  pname = "streamcontroller";
+
+  # Note that the latest tagged version (1.5.0-beta.6) includes a python dependency
+  # that doesn't exist anymore, so we package an unstable version instead.
+  version = "1.5.0-beta.6-unstable-2024-08-13";
+
+  src = fetchFromGitHub {
+    repo = "StreamController";
+    owner = "StreamController";
+    rev = "dbb6460a69137af192db09d504224ae9f1127cbd";
+    hash = "sha256-+YYzHLRU5MNjF3iaKIDj9k4PVg+vnEZhbc3ZmNI7xyw=";
+  };
+
+  # The installation method documented upstream
+  # (https://streamcontroller.github.io/docs/latest/installation/) is to clone the repo,
+  # run `pip install`, then run `python3 main.py` to launch the program.
+  # Due to how the code is structured upstream, it's infeasible to use `buildPythonApplication`.
+
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/usr/lib/streamcontroller
+    cp -r ./* $out/usr/lib/streamcontroller/
+
+    mkdir -p $out/bin/
+
+    # Note that the implementation of main.py assumes
+    # working directory to be at the root of the project's source code
+    makeWrapper \
+      ${python3Packages.python.interpreter} \
+      $out/bin/streamcontroller \
+      --add-flags main.py \
+      --chdir $out/usr/lib/streamcontroller \
+      --prefix PYTHONPATH : "$PYTHONPATH"
+
+    mkdir -p "$out/etc/udev/rules.d"
+    cp ./udev.rules $out/etc/udev/rules.d/70-streamcontroller.rules
+
+    install -D ./flatpak/icon_256.png $out/share/icons/hicolor/256x256/apps/streamcontroller.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "StreamController";
+      desktopName = "StreamController";
+      exec = "streamcontroller";
+      icon = "streamcontroller";
+      comment = "Control your Elgato Stream Decks";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    wrapGAppsHook4
+    gobject-introspection
+  ];
+
+  buildInputs =
+    [
+      libadwaita
+      libportal
+      libportal-gtk4
+      xdg-desktop-portal
+      xdg-desktop-portal-gtk
+    ]
+    ++ (with python3Packages; [
+      annotated-types
+      async-lru
+      cairocffi
+      cairosvg
+      certifi
+      cffi
+      charset-normalizer
+      click
+      colorama
+      contourpy
+      cssselect2
+      cycler
+      dbus-python
+      decorator
+      defusedxml
+      distlib
+      dnspython
+      evdev
+      filelock
+      fonttools
+      fuzzywuzzy
+      gcodepy
+      get-video-properties
+      gitdb
+      idna
+      imageio
+      imageio-ffmpeg
+      indexed-bzip2
+      jinja2
+      joblib
+      kiwisolver
+      levenshtein
+      linkify-it-py
+      loguru
+      markdown-it-py
+      markupsafe
+      matplotlib
+      mdit-py-plugins
+      mdurl
+      meson
+      meson-python
+      natsort
+      nltk
+      numpy
+      opencv4
+      packaging
+      pillow
+      platformdirs
+      plumbum
+      proglog
+      psutil
+      pulsectl
+      pycairo
+      pyclip
+      pycparser
+      pydantic
+      pydantic-core
+      pyenchant
+      pygments
+      pygobject3
+      pymongo
+      pyparsing
+      pyperclip
+      pyproject-metadata
+      pyro5
+      pyspellchecker
+      python-dateutil
+      pyudev
+      pyusb
+      pyyaml
+      rapidfuzz
+      regex
+      requests
+      requirements-parser
+      rich
+      rpyc
+      serpent
+      setproctitle
+      six
+      smmap
+      speedtest-cli
+      streamcontroller-plugin-tools
+      streamdeck
+      textual
+      tinycss2
+      tqdm
+      types-setuptools
+      typing-extensions
+      uc-micro-py
+      urllib3
+      usb-monitor
+      webencodings
+      websocket-client
+    ]);
+
+  meta = with lib; {
+    description = "Elegant Linux app for the Elgato Stream Deck with support for plugins";
+    homepage = "https://core447.com/";
+    license = licenses.gpl3;
+    mainProgram = "streamcontroller";
+    maintainers = with maintainers; [ sifmelcara ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/streamcontroller-plugin-tools/default.nix
+++ b/pkgs/development/python-modules/streamcontroller-plugin-tools/default.nix
@@ -1,0 +1,33 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  loguru,
+  rpyc,
+}:
+buildPythonPackage rec {
+  pname = "streamcontroller-plugin-tools";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "StreamController";
+    repo = "streamcontroller-plugin-tools";
+    rev = version;
+    hash = "sha256-dQZPRSzHhI3X+Pf7miwJlECGFgUfp68PtvwXAmpq5/s=";
+  };
+
+  dependencies = [
+    loguru
+    rpyc
+  ];
+
+  pythonImportsCheck = [ "streamcontroller_plugin_tools" ];
+
+  meta = with lib; {
+    description = "StreamController plugin tools";
+    homepage = "https://github.com/StreamController/streamcontroller-plugin-tools";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ sifmelcara ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/usb-monitor/default.nix
+++ b/pkgs/development/python-modules/usb-monitor/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  pyudev,
+}:
+
+buildPythonPackage rec {
+  pname = "usb-monitor";
+  version = "1.21";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "usb_monitor";
+    hash = "sha256-M+BUmbNxQWcULFECexTnp55EZiJ6y3bYCEtSwqKldAk=";
+  };
+
+  dependencies = [ pyudev ];
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "usbmonitor" ];
+
+  meta = {
+    description = "Cross-platform library for USB device monitoring";
+    homepage = "https://github.com/Eric-Canas/USBMonitor";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sifmelcara ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17146,6 +17146,8 @@ self: super: with self; {
 
   usb-devices = callPackage ../development/python-modules/usb-devices { };
 
+  usb-monitor = callPackage ../development/python-modules/usb-monitor { };
+
   usbrelay-py = callPackage ../os-specific/linux/usbrelay/python.nix { };
 
   usbtmc = callPackage ../development/python-modules/usbtmc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15152,6 +15152,8 @@ self: super: with self; {
 
   strct = callPackage ../development/python-modules/strct { };
 
+  streamcontroller-plugin-tools = callPackage ../development/python-modules/streamcontroller-plugin-tools { };
+
   streamdeck = callPackage ../development/python-modules/streamdeck { };
 
   streaming-form-data = callPackage ../development/python-modules/streaming-form-data { };


### PR DESCRIPTION
## Description of changes

Closes #333746

Package [StreamController/StreamController: An elegant Linux app for the Elgato Stream Deck with support for plugins](https://github.com/StreamController/StreamController), its dependency, and added a service for udev files.

StreamController is a replacement of streamdeck-ui , see https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/discussions/203 for more detail.

Tested features (all works): plugins (tested clocks, speedtest), icon packs, background wallpaper, CPU monitor, memory monitor, spawning external commands, pages, brightness, volumes, media info, hyprland integration for detecting focus and auto change pages. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
