### PR TITLE
haskellPackages.quickspec: Unmark broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3091,4 +3091,14 @@ self: super: {
     safe-coloured-text-terminfo = unmarkBroken self.safe-coloured-text-terminfo_0_3_0_0;
   })));
 
+  quickcheck-state-machine = overrideCabal (drv: {
+    # 2024-08-18: Remove a test which fails to build due to API changes.
+    #   This is fixed in quickcheck-state-machine-0.10.0.
+    postPatch = assert drv.version == "0.8.0"; ''
+      sed -i '/SQLite/d' quickcheck-state-machine.cabal
+      sed -i -e '/import.*SQLite/d' -e 's/\[.*prop_parallel_sqlite/[/' test/Spec.hs
+      ${drv.postPatch or ""}
+     '';
+  }) super.quickcheck-state-machine;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -4873,7 +4873,6 @@ broken-packages:
   - quickcheck-property-monad # failure in job https://hydra.nixos.org/build/233228775 at 2023-09-02
   - quickcheck-rematch # failure in job https://hydra.nixos.org/build/233205449 at 2023-09-02
   - quickcheck-report # failure in job https://hydra.nixos.org/build/233214523 at 2023-09-02
-  - quickcheck-state-machine # failure in job https://hydra.nixos.org/build/252730381 at 2024-03-16
   - QuickCheckVariant # failure in job https://hydra.nixos.org/build/233239276 at 2023-09-02
   - quickcheck-webdriver # failure in job https://hydra.nixos.org/build/233228000 at 2023-09-02
   - quickjs-hs # failure in job https://hydra.nixos.org/build/233248440 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -4883,7 +4883,6 @@ broken-packages:
   - quickset # failure in job https://hydra.nixos.org/build/233236904 at 2023-09-02
   - Quickson # failure in job https://hydra.nixos.org/build/233195101 at 2023-09-02
   - quickson # failure in job https://hydra.nixos.org/build/233216697 at 2023-09-02
-  - quickspec # failure in job https://hydra.nixos.org/build/233196573 at 2023-09-02
   - quickwebapp # failure in job https://hydra.nixos.org/build/233208251 at 2023-09-02
   - quipper-core # failure in job https://hydra.nixos.org/build/233200962 at 2023-09-02
   - quiver # failure in job https://hydra.nixos.org/build/233230395 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -462,7 +462,6 @@ dont-distribute-packages:
  - aivika-distributed
  - alg
  - algebra-checkers
- - algebra-driven-design
  - algebra-sql
  - algebraic
  - algebraic-graphs-io
@@ -3314,7 +3313,6 @@ dont-distribute-packages:
  - reddit
  - redis-io
  - rediscaching-haxl
- - reduce-equations
  - refh
  - reflex-animation
  - reflex-backend-wai


### PR DESCRIPTION
This is for merging into `haskell-updates` (PR #331380).

- `quickspec` is no longer broken, so remove it from `broken.yaml`.
- `quickcheck-state-machine` has a SQLite example/test case. Version 0.8.0 has developed an incompatibility with `persistent-sqlite` (2.13.3.0). Easiest solution is to chop out the offending test module.
- `quickcheck-state-machine_0_10_0` is not broken.

The following packages now build on `x86_64-linux`:
- `haskellPackages.quickspec`
- `haskellPackages.quickcheck-state-machine`
- `haskellPackages.quickcheck-state-machine_0_10_0`

