### PR TITLE
python312Packages.sismic: init at 1.6.6

### DIFF
--- a/pkgs/development/python-modules/sismic/default.nix
+++ b/pkgs/development/python-modules/sismic/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  behave,
+  ruamel-yaml,
+  schema,
+  pytestCheckHook,
+  pytest-mock,
+}:
+
+let
+  version = "1.6.6";
+in
+buildPythonPackage {
+  pname = "sismic";
+  inherit version;
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  src = fetchFromGitHub {
+    owner = "AlexandreDecan";
+    repo = "sismic";
+    rev = "refs/tags/${version}";
+    hash = "sha256-MvJyyERH0l5547cVmpxnHXRf9q1ylK9/ZfyLYBQfsbY=";
+  };
+
+  pythonRelaxDeps = [ "behave" ];
+
+  dependencies = [
+    behave
+    ruamel-yaml
+    schema
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  pythonImportsCheck = [ "sismic" ];
+
+  pytestFlagsArray = [ "tests/" ];
+
+  disabledTests = [
+    # Time related tests, might lead to flaky tests on slow/busy machines
+    "test_clock"
+  ];
+
+  meta = {
+    changelog = "https://github.com/AlexandreDecan/sismic/releases/tag/${version}";
+    description = "Sismic Interactive Statechart Model Interpreter and Checker";
+    homepage = "https://github.com/AlexandreDecan/sismic";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14484,6 +14484,8 @@ self: super: with self; {
 
   sipyco = callPackage ../development/python-modules/sipyco { };
 
+  sismic = callPackage ../development/python-modules/sismic { };
+
   sisyphus-control = callPackage ../development/python-modules/sisyphus-control { };
 
   siuba = callPackage ../development/python-modules/siuba { };


### PR DESCRIPTION
Create statecharts diagrams from YAML files with [Sismic](https://github.com/AlexandreDecan/sismic).

Tested with [`elevator.yaml`](https://github.com/AlexandreDecan/sismic/blob/master/docs/examples/elevator/elevator.yaml)

```shell
$ nix build .#python312Packages.sismic
$ ./result/bin/sismic-plantuml elevator.yaml
@startuml
title Elevator
state "active" as active {
  state "floorListener" as floorListener {
    [*] --> floorSelecting
    state "floorSelecting" as floorSelecting {
      floorSelecting --> floorSelecting : floorSelected / destination = event.floor
    }
  }
  --
  state "movingElevator" as movingElevator {
    [*] --> doorsOpen
    state "moving" as moving {
      moving --> doorsOpen : [destination == current] / doors_open = True
      state "movingDown" as movingDown {
        movingDown : **entry** / current = current - 1
        movingDown --> movingDown : [destination < current]
      }
      state "movingUp" as movingUp {
        movingUp : **entry** / current = current + 1
        movingUp --> movingUp : [destination > current]
      }
    }
    state "doorsClosed" as doorsClosed {
      doorsClosed --> movingUp : [destination > current]
      doorsClosed --> movingDown : [destination < current and destination >= 0]
    }
    state "doorsOpen" as doorsOpen {
      doorsOpen --> doorsClosed : [destination != current] / doors_open = False
      doorsOpen --> doorsClosed : [after(10) and current > 0] / destination = 0; doors_open = False
    }
  }
}
@enduml
```

Result: [SVG](https://planttext.com/api/plantuml/svg/bPHDJyCm38Rl_HLc9oWgRDT1gqbyd90um4xJXABLGvMoP4go8eJwtqdIB4tQZez3fUMr_VfnwcuX5H7giAE9gXH5UA1O4yL5edM5C24RLTKu0IAX_GbV2O0BRYddugcI2XaAcnCfDXLWbQuXouesze8KjGzxjw7GnqSw8oyv9-ZBGrkOXmAMS0qbIXqXgk8CSi0QcRgoETQpITedoxgvThpMLiUhi3onr9kir6RoUOyi7Agj28hz4EuOLMhkLGIQm-OWX6PTcn5CsXitUJcyYWCwfwZLFVzWGJjpz2qX5EUGfjfOVAQfzdPjm3U436PZPOOtSec0Rpslgst669VxW72v7_1fwJUwom6TBkhOh4D4LeoJDU7BiXTyHxd4qW86PyyOQl_gDrxuuoK2OMMqk4KEq_K9RhC_7RNTfeZPAdxR74YlyzdfVNiaLE9V_CXMeJYVJIyi_N6IGeCFliBfpQaUxVVO90jafVbR-WO0)

CC @AlexandreDecan @TomMens

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
