### PR TITLE
make-startupitem: fix {prepend,append}ExtraArgs for Exec without arguments

### DIFF
--- a/pkgs/build-support/make-startupitem/default.nix
+++ b/pkgs/build-support/make-startupitem/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     target=${name}.desktop
     cp ${package}/share/applications/${srcPrefix}${name}.desktop $target
     ${lib.optionalString (prependExtraArgs != [] || appendExtraArgs != []) ''
-      sed -i -r "s/(Exec=)([^ ]*) (.*)/\1\2 ${prependArgs}\3${appendArgs}/" $target
+      sed -i -r "s/(Exec=)([^ \n]*) *(.*)/\1\2 ${prependArgs}\3${appendArgs}/" $target
     ''}
     chmod +rw $target
     echo "X-KDE-autostart-phase=${phase}" >> $target


### PR DESCRIPTION
## Description of changes

Fixes `prependExtraArgs` & `appendExtraArgs` that were introduced in #284161.

The previous implementation worked for `Exec` lines with arguments, like:
`Exec=/nix/store/[...]/bin/signal-desktop --no-sandbox %U`

However many desktop files have no arguments, e.g. as is the case for `trayscale`: `Exec=trayscale`
In these cases `prependExtraArgs` & `appendExtraArgs` don't work and the `Exec` line remains unchanged.

I've updated the regular expression to accommodate for this case.

The following commands can be used with `nix repl .` to validate the correct behavior:

```console
nix-repl> :b pkgs.makeAutostartItem { name = "signal-desktopo"]; package = pkgs.signal-desktop; prependExtraArgs = ["--start" "--two"]; appendExtraArgs = ["--end"]; }
nix-repl> :b pkgs.makeAutostartItem { name = "dev.deedles.Trayscale"; package = pkgs.trayscale; prependExtraArgs = ["--start" "--two"]; appendExtraArgs = ["--end"]; }
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
