### PR TITLE
wlx-overlay-s: add required libraries

### DIFF
--- a/pkgs/by-name/wl/wlx-overlay-s/package.nix
+++ b/pkgs/by-name/wl/wlx-overlay-s/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   fontconfig,
   lib,
+  libGL,
+  libuuid,
   libX11,
   libXext,
   libXrandr,
@@ -19,6 +21,7 @@
   shaderc,
   stdenv,
   testers,
+  vulkan-loader,
   wayland,
   wlx-overlay-s,
 }:
@@ -76,7 +79,11 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     patchelf $out/bin/wlx-overlay-s \
       --add-needed ${lib.getLib wayland}/lib/libwayland-client.so.0 \
-      --add-needed ${lib.getLib libxkbcommon}/lib/libxkbcommon.so.0
+      --add-needed ${lib.getLib libxkbcommon}/lib/libxkbcommon.so.0 \
+      --add-needed ${lib.getLib libGL}/lib/libEGL.so.1 \
+      --add-needed ${lib.getLib libGL}/lib/libGL.so.1 \
+      --add-needed ${lib.getLib vulkan-loader}/lib/libvulkan.so.1 \
+      --add-needed ${lib.getLib libuuid}/lib/libuuid.so.1
   '';
 
   passthru = {


### PR DESCRIPTION
## Description of changes

With my setup (Gnome X11, NVIDIA dGPU, SteamVR, ALVR) the current derivation complains of missing libraries, e.g.:

```console
$ ./result/bin/wlx-overlay-s
Logging to: /tmp/wlx.log
INFO [wlx_overlay_s] Welcome to wlx-overlay-s version 0.4.4 (Cargo)!
INFO [wlx_overlay_s] It is Sun Aug 18 15:40:42 2024.
Error [GENERAL | xrEnumerateInstanceExtensionProperties | OpenXR-Loader] : RuntimeInterface::LoadRuntime skipping manifest file /home/justinas/.config/openxr/1/active_runtime.json, failed to load with message "libGL.so.1: cannot open shared object file: No such file or directory"
Error [GENERAL | xrEnumerateInstanceExtensionProperties | OpenXR-Loader] : RuntimeInterface::LoadRuntimes - failed to load a runtime
Error [GENERAL | xrEnumerateInstanceExtensionProperties | OpenXR-Loader] : Failed to find default runtime with RuntimeInterface::LoadRuntime()
Error [GENERAL | xrEnumerateInstanceExtensionProperties | OpenXR-Loader] : Failed querying extension properties
WARN [wlx_overlay_s::backend::openxr] Will not use OpenXR: Failed to enumerate OpenXR extensions.
WARN [wlx_overlay_s::backend::openvr] Will not use OpenVR: Context init failed
ERROR [wlx_overlay_s] No more backends to try
```

This patch seems to fix the errors on my machine, and I'm able to stream my displays.

As a workaround, using `steam-run wlx-overlay-s` also works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
