### PR TITLE
python31{2,1}Packages.lammps: init at 2Aug2023_update3

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit extraBuildInputs;
   };
   cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
   ]
   ++ (builtins.map (p: "-DPKG_${p}=ON") (builtins.attrNames (lib.filterAttrs (n: v: v) packages)))
   ++ (lib.mapAttrsToList (n: v: "-D${n}=${v}") extraCmakeFlags)

--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
   ]
-  ++ (builtins.map (p: "-DPKG_${p}=ON") (builtins.attrNames (lib.filterAttrs (n: v: v) packages)))
+  ++ (lib.mapAttrsToList (n: v: lib.cmakeBool "PKG_${n}" v) packages)
   ++ (lib.mapAttrsToList (n: v: "-D${n}=${v}") extraCmakeFlags)
   ;
 

--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/share/vim-plugins/lammps $out/share/nvim/site
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Classical Molecular Dynamics simulation code";
     longDescription = ''
       LAMMPS is a classical molecular dynamics simulation code designed to
@@ -109,13 +109,16 @@ stdenv.mkDerivation (finalAttrs: {
       under the terms of the GNU Public License (GPL).
       '';
     homepage = "https://www.lammps.org";
-    license = licenses.gpl2Only;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
     # compiling lammps with 64 bit support blas and lapack might cause runtime
     # segfaults. In anycase both blas and lapack should have the same #bits
     # support.
     broken = (blas.isILP64 && lapack.isILP64);
-    maintainers = [ maintainers.costrouc maintainers.doronbehar ];
+    maintainers = with lib.maintainers; [
+      costrouc
+      doronbehar
+    ];
     mainProgram = "lmp";
   };
 })

--- a/pkgs/development/python-modules/lammps/default.nix
+++ b/pkgs/development/python-modules/lammps/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  lammps,
+  stdenv,
+  buildPythonPackage,
+}:
+
+let
+  LAMMPS_SHARED_LIB = "${lib.getLib lammps}/lib/liblammps${stdenv.hostPlatform.extensions.library}";
+in
+buildPythonPackage {
+  inherit (lammps) pname version src;
+
+  env = {
+    inherit LAMMPS_SHARED_LIB;
+  };
+  preConfigure = ''
+    cd python
+    # Upstream assumes that the shared library is located in the same directory
+    # as the core.py file. We want to separate the shared library (built by
+    # cmake) and the Python library, so we perform this substitution:
+    substituteInPlace lammps/core.py \
+      --replace-fail \
+        "from inspect import getsourcefile" \
+        "getsourcefile = lambda f: \"${LAMMPS_SHARED_LIB}\""
+  '';
+
+  pythonImportsCheck = [
+    "lammps"
+    "lammps.pylammps"
+  ];
+
+  # We could potentially run other examples, but some of them are so old that
+  # they don't run with nowadays' LAMMPS. This one is simple enough and recent
+  # enough and it works.
+  checkPhase = ''
+    python examples/mc.py examples/in.mc
+  '';
+
+  meta = {
+    description = "Python Bindings for LAMMPS";
+    homepage = "https://docs.lammps.org/Python_head.html";
+    inherit (lammps.meta) license;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6734,6 +6734,10 @@ self: super: with self; {
 
   lakeside = callPackage ../development/python-modules/lakeside { };
 
+  lammps = callPackage ../development/python-modules/lammps {
+    inherit (pkgs) lammps;
+  };
+
   lancedb = callPackage ../development/python-modules/lancedb { };
 
   langchain = callPackage ../development/python-modules/langchain { };


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
