### PR TITLE
beidconnect: init at 2.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10097,6 +10097,12 @@
     githubId = 15893072;
     name = "Josh van Leeuwen";
   };
+  jovandeginste = {
+    email = "jo.vandeginste@gmail.com";
+    github = "jovandeginste";
+    githubId = 3170771;
+    name = "Jo Vandeginste";
+  };
   jpagex = {
     name = "Jérémy Pagé";
     email = "contact@jeremypage.me";

--- a/pkgs/by-name/be/beidconnect/package.nix
+++ b/pkgs/by-name/be/beidconnect/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pcsclite,
+  boost,
+  pkg-config,
+  testers,
+  beidconnect,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "beidconnect";
+  version = "2.10";
+
+  src = fetchFromGitHub {
+    owner = "Fedict";
+    repo = "fts-beidconnect";
+    rev = finalAttrs.version;
+    hash = "sha256-xkBldXOlgLMgrvzm7ajXzJ92mpXrxHD1RX4DeBxU3kk=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    pcsclite.dev
+    boost
+  ];
+
+  strictDeps = true;
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail '$(DESTDIR)/usr/bin' '$(DESTDIR)/bin'
+  '';
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+  sourceRoot = "${finalAttrs.src.name}/linux";
+
+  postInstall = ''
+    install -d \
+      $out/etc/chromium/native-messaging-hosts \
+      $out/etc/opt/chrome/native-messaging-hosts/ \
+      $out/etc/opt/edge/native-messaging-hosts/ \
+      $out/etc/opt/vivaldi/native-messaging-hosts/ \
+      $out/etc/opt/brave/native-messaging-hosts/ \
+      $out/lib/mozilla/native-messaging-hosts \
+
+    $out/bin/beidconnect -setup $out/bin \
+      $out/etc/chromium/native-messaging-hosts \
+      $out/lib/mozilla/native-messaging-hosts
+
+    # Chrome
+    install $out/etc/chromium/native-messaging-hosts/be.bosa.beidconnect.json $out/etc/opt/chrome/native-messaging-hosts/
+
+    # Edge
+    install $out/etc/chromium/native-messaging-hosts/be.bosa.beidconnect.json $out/etc/opt/edge/native-messaging-hosts/
+
+    # Vivaldi
+    install $out/etc/chromium/native-messaging-hosts/be.bosa.beidconnect.json $out/etc/opt/vivaldi/native-messaging-hosts/
+
+    # Brave
+    install $out/etc/chromium/native-messaging-hosts/be.bosa.beidconnect.json $out/etc/opt/brave/native-messaging-hosts/
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = beidconnect;
+    command = "${beidconnect}/bin/beidconnect -version";
+  };
+
+  meta = {
+    description = "BeIDConnect native messaging component";
+    longDescription = ''
+      The beidconnect is a program to help implementing digital signing services
+      and/or an identity service using the Belgian eID card. It provides
+      services to webbrowsers to read data from cards, and is intended to work
+      together with a WebExtension in the browser.
+
+      This package contains the native code. For the WebExtension, see your
+      webbrowser's extension store.
+    '';
+    homepage = "https://github.com/Fedict/fts-beidconnect/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jovandeginste ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

beidconnect is a native messaging component for browsers to perform digital signing with Belgian eID cards.

It consists of a binary and a json file per browser.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
