### PR TITLE
Init Mobsql, Mobroute and Transito, and update Mepo

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -210,6 +210,12 @@
 
 - `zammad` has had its support for MySQL removed, since it was never working correctly and is now deprecated upstream. Check the [migration guide](https://docs.zammad.org/en/latest/appendix/migrate-to-postgresql.html) for how to convert your database to PostgreSQL.
 
+- `mepo` was updated to version 1.3.3.  The manual page was removed,
+  a new JSON API was introduced to replace Mepolang for configuration,
+  and a few default key bindings were changed.
+  See the [1.3.0 changelog](https://git.sr.ht/~mil/mepo/refs/1.3.0)
+  for more details.
+
 - The `earlyoom` service is now using upstream systemd service, which enables
   hardening and filesystem isolation by default. If you need filesystem write
   access or want to access home directory via `killHook`, hardening setting can

--- a/pkgs/by-name/me/mepo/package.nix
+++ b/pkgs/by-name/me/mepo/package.nix
@@ -8,33 +8,33 @@
   SDL2_ttf,
   busybox,
   curl,
-  findutils,
   geoclue2-with-demo-agent,
   gpsd,
   jq,
   makeWrapper,
+  mobroute,
   ncurses,
   pkg-config,
   util-linux,
   xwininfo,
   zenity,
-  zig_0_12,
+  zig_0_13,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mepo";
-  version = "1.2.1";
+  version = "1.3.3";
 
   src = fetchFromSourcehut {
     owner = "~mil";
     repo = "mepo";
     rev = finalAttrs.version;
-    hash = "sha256-Ii5E9TgUxzlVIdkKS/6RtasOETeclMm1yoU86gs4hB8=";
+    hash = "sha256-hEsQpTrj2WCoRgNWdhcUnQRzhI/6BydcbG9kRePstgg=";
   };
 
   nativeBuildInputs = [
     pkg-config
-    zig_0_12.hook
+    zig_0_13.hook
     makeWrapper
   ];
 
@@ -51,8 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   postInstall = ''
-    install -d $out/share/man/man1
-    $out/bin/mepo -docman > $out/share/man/man1/mepo.1
+    install -d $out/share/doc/mepo
+    $out/bin/mepo -docmd > $out/share/doc/mepo/documentation.md
   '';
 
   postFixup = ''
@@ -67,9 +67,9 @@ stdenv.mkDerivation (finalAttrs: {
           lib.makeBinPath ([
             busybox
             curl
-            findutils
             gpsd
             jq
+            mobroute
             ncurses
             util-linux
             xwininfo
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://mepo.milesalan.com";
+    homepage = "https://mepo.lrdu.org";
     description = "Fast, simple, and hackable OSM map viewer";
     longDescription = ''
       Mepo is a fast, simple, and hackable OSM map viewer for desktop & mobile
@@ -90,9 +90,9 @@ stdenv.mkDerivation (finalAttrs: {
       desktop X, and desktop Wayland. Mepo works both offline and online,
       features a minimalist both touch/mouse and keyboard compatible interface,
       and offers a UNIX-philosophy inspired underlying design, exposing a
-      powerful command language called Mepolang capable of being scripted to
-      provide things like custom bounding-box search scripts, bookmarks, and
-      more.
+      powerful JSON API to allow the user to change & add functionality
+      such as adding their own search & routing scripts,
+      add arbitrary buttons/keybindings to the UI, and more.
     '';
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/mo/mobroute/package.nix
+++ b/pkgs/by-name/mo/mobroute/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromSourcehut,
+  sqlite,
+  stdenv,
+}:
+
+buildGoModule rec {
+  pname = "mobroute";
+  version = "0.9.0";
+
+  src = fetchFromSourcehut {
+    owner = "~mil";
+    repo = "mobroute";
+    rev = "v${version}";
+    hash = "sha256-eMLn9Px6jO88CQWpwFF7JK1UPHoEbhDXoU2G1aYe2dw=";
+  };
+  vendorHash = "sha256-fMIa9HCfK6YDb0V0RhzomwuSqPhlwLBHJRjQV96cY8g=";
+
+  buildInputs = [ sqlite ];
+  tags = [
+    "libsqlite3"
+    "sqlite_math_functions"
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  postInstall = ''
+    mv $out/bin/{cli,mobroute}
+  '';
+
+  meta = with lib; {
+    description = "General purpose public transportation router based on GTFS";
+    longDescription = ''
+      Mobroute is a general purpose public transportation router
+      (e.g. trip planner) Go library and CLI that works
+      by directly ingesting timetable (GTFS) data from transit agencies
+      (sourced from the Mobility Database).  After data has been fetched,
+      routing calculations can be run offline.
+
+      Overall, Mobroute aims to offer an opensource framework
+      for integrating data-provider-agnostic GTFS public transit capabilities
+      (integrated GTFS ETL, GTFS multisource support, and routing algorithm)
+      into applications to get users from point-a to point-b via public transit
+      without comprising privacy or user freedoms.
+    '';
+    homepage = "https://git.sr.ht/~mil/mobroute";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.McSinyx ];
+    mainProgram = "mobroute";
+    platforms = platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+}

--- a/pkgs/by-name/mo/mobsql/package.nix
+++ b/pkgs/by-name/mo/mobsql/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromSourcehut,
+  sqlite,
+}:
+
+buildGoModule rec {
+  pname = "mobsql";
+  version = "0.9.0";
+
+  src = fetchFromSourcehut {
+    owner = "~mil";
+    repo = "mobsql";
+    rev = "v${version}";
+    hash = "sha256-7zrM2vmaikyClNgHHO8OXmATNpJtH85/CDv/86vwzZU=";
+  };
+  vendorHash = "sha256-YqduGY9c4zRQscjqze3ZOAB8EYj+0/6V7NceRwLe3DY=";
+
+  buildInputs = [ sqlite ];
+
+  buildPhase = ''
+    runHook preBuild
+    go build -o $GOPATH/bin/mobsql\
+      -tags=sqlite_math_functions,libsqlite3 cli/*.go
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    HOME=$TMPDIR go test -tags=sqlite_math_functions,libsqlite3 ./...
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "GTFS to SQLite import utility";
+    longDescription = ''
+      Mobsql is a Go library and command-line application
+      which facilitates loading one or multiple Mobility Database
+      source GTFS feed archives into a SQLite database.
+      Its internal SQLite schema mirrors GTFS's spec but adds a feed_id field
+      to each table (thus allowing multiple feeds to be loaded
+      to the database simulatenously).
+    '';
+    homepage = "https://git.sr.ht/~mil/mobsql";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.McSinyx ];
+    mainProgram = "mobsql";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/tr/transito/package.nix
+++ b/pkgs/by-name/tr/transito/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromSourcehut,
+  pkg-config,
+  vulkan-headers,
+  libxkbcommon,
+  wayland,
+  xorg,
+  libGL,
+  sqlite,
+}:
+
+buildGoModule rec {
+  pname = "transito";
+  version = "0.9.1";
+
+  src = fetchFromSourcehut {
+    owner = "~mil";
+    repo = "transito";
+    rev = "v${version}";
+    hash = "sha256-5aG/hmpUAN2qYxpqMKLl2WnYgR/sPdtAwLGkFXVyrNs=";
+  };
+  vendorHash = "sha256-7QMO+/f+yc5GfxvDLIXuf+QT2cAmbgI6iQqWmQIkMMA=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    vulkan-headers
+    libxkbcommon
+    wayland
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXfixes
+    libGL
+    sqlite
+  ];
+
+  tags = [ "sqlite_math_functions" ];
+  ldflags = [ "-X git.sr.ht/~mil/transito/src/uipages/pageconfig.Commit=${version}" ];
+
+  postInstall = ''
+    install -Dm644 -t $out/share/applications assets/transito.desktop
+    install -Dm644 -t $out/share/pixmaps assets/transito.png
+    for icon in assets/transito_*.png
+    do
+      name=$(basename $icon .png)
+      install -Dm644 -t $out/share/icons/hicolor/''${name#transito_}/apps $icon
+    done
+  '';
+
+  doCheck = false; # no test
+
+  meta = with lib; {
+    description = "Data-provider-agnostic (GTFS) public transportation app";
+    longDescription = ''
+      Transito is a data-provider-agnostic public transportation app
+      that let's you route between locations using openly available
+      public GTFS feeds.  Utilizing the Mobroute library,
+      the Transito app lets you performs routing calculations offline
+      (no network calls once data is initially fetched).
+
+      Overall, Transito aims to be an opensource alternative
+      to proprietary routing apps to get users from point A to point B
+      via public transit without comprising privacy or user freedoms.
+      It works in many well-connected metros which have publicly available
+      GTFS data, to name a few: Lisbon, NYC, Brussels, Krakow, and Bourges.
+    '';
+    homepage = "https://git.sr.ht/~mil/transito";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.McSinyx ];
+    mainProgram = "transito";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

New 1.3 release of Mepo optionally requires Mobroute for navigation.  Changelogs: [1.3.0](https://git.sr.ht/~mil/mepo/refs/1.3.0) and [others](https://git.sr.ht/~mil/mepo/refs).

Mobsql and Transito are tightly coupled with [Mobroute](https://sr.ht/~mil/mobroute).  Technically, Mobsql is a dependency of Mobroute, which in turns is a dependency of Transito (but since Go modules are vendored in nixpkgs it is not reflected in the build recipes).  Major changes to the three are usually released together.

This supersedes GH-319598, and I'm also taking over as a maintainer as due to @trungtruong1's lack of availability in the foreseeable future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc