### PR TITLE
surrealist: 2.0.6 -> 2.1.6

### DIFF
--- a/pkgs/by-name/su/surrealist/0001-Cargo.patch
+++ b/pkgs/by-name/su/surrealist/0001-Cargo.patch
@@ -1,0 +1,148 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 55f480a8..a69f9ed9 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1839,6 +1839,22 @@ dependencies = [
+  "tower-service",
+ ]
+ 
++[[package]]
++name = "hyper-tls"
++version = "0.6.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
++dependencies = [
++ "bytes",
++ "http-body-util",
++ "hyper",
++ "hyper-util",
++ "native-tls",
++ "tokio",
++ "tokio-native-tls",
++ "tower-service",
++]
++
+ [[package]]
+ name = "hyper-util"
+ version = "0.1.3"
+@@ -2302,6 +2318,23 @@ dependencies = [
+  "windows-sys 0.52.0",
+ ]
+ 
++[[package]]
++name = "native-tls"
++version = "0.2.12"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
++dependencies = [
++ "libc",
++ "log",
++ "openssl",
++ "openssl-probe",
++ "openssl-sys",
++ "schannel",
++ "security-framework",
++ "security-framework-sys",
++ "tempfile",
++]
++
+ [[package]]
+ name = "ndk"
+ version = "0.7.0"
+@@ -2511,6 +2544,12 @@ dependencies = [
+  "syn 2.0.50",
+ ]
+ 
++[[package]]
++name = "openssl-probe"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
++
+ [[package]]
+ name = "openssl-src"
+ version = "300.2.3+3.2.1"
+@@ -3416,6 +3455,15 @@ dependencies = [
+  "winapi-util",
+ ]
+ 
++[[package]]
++name = "schannel"
++version = "0.1.23"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
++dependencies = [
++ "windows-sys 0.52.0",
++]
++
+ [[package]]
+ name = "schemars"
+ version = "0.8.19"
+@@ -3460,6 +3508,29 @@ version = "4.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+ 
++[[package]]
++name = "security-framework"
++version = "2.10.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
++dependencies = [
++ "bitflags 1.3.2",
++ "core-foundation",
++ "core-foundation-sys",
++ "libc",
++ "security-framework-sys",
++]
++
++[[package]]
++name = "security-framework-sys"
++version = "2.11.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
++dependencies = [
++ "core-foundation-sys",
++ "libc",
++]
++
+ [[package]]
+ name = "selectors"
+ version = "0.22.0"
+@@ -3847,6 +3918,7 @@ name = "surrealist"
+ version = "0.0.0"
+ dependencies = [
+  "dirs",
++ "hyper-tls",
+  "log",
+  "openssl",
+  "portpicker",
+@@ -4563,6 +4635,16 @@ dependencies = [
+  "windows-sys 0.48.0",
+ ]
+ 
++[[package]]
++name = "tokio-native-tls"
++version = "0.3.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
++dependencies = [
++ "native-tls",
++ "tokio",
++]
++
+ [[package]]
+ name = "tokio-rustls"
+ version = "0.25.0"
+diff --git a/Cargo.toml b/Cargo.toml
+index 3e3ab7ee..b6612f95 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -28,6 +28,8 @@ time = { version = "0.3", default-features = false}
+ log = "^0.4"
+ url = "2"
+ 
++hyper-tls = "0.6.0"
++
+ [target.'cfg(target_os = "linux")'.dependencies]
+ openssl = { version = "0.10.64", features = ["vendored"] }
+ 

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -5,9 +5,10 @@
 , esbuild
 , fetchFromGitHub
 , gdk-pixbuf
+, glib-networking
 , gobject-introspection
 , lib
-, libsoup
+, libsoup_3
 , makeBinaryWrapper
 , nodejs
 , openssl
@@ -18,12 +19,30 @@
 , rustPlatform
 , stdenv
 , stdenvNoCC
-, webkitgtk
+, webkitgtk_4_1
 }:
 
 let
 
-  esbuild-20-2 = let version = "0.20.2";
+  cargo-tauri_2 = let
+    version = "2.0.0-rc.3";
+    src = fetchFromGitHub {
+      owner = "tauri-apps";
+      repo = "tauri";
+      rev = "tauri-v${version}";
+      hash = "sha256-PV8m/MzYgbY4Hv71dZrqVbrxmxrwFfOAraLJIaQk6FQ=";
+    };
+  in cargo-tauri.overrideAttrs (drv: {
+    inherit src version;
+    cargoDeps = drv.cargoDeps.overrideAttrs (lib.const {
+      inherit src;
+      name = "tauri-${version}-vendor.tar.gz";
+      outputHash = "sha256-BrIH0JkGMp68O+4B+0g7X3lSdNSPXo+otlBgslCzPZE=";
+    });
+  });
+
+  esbuild_21-5 = let
+    version = "0.21.5";
   in esbuild.override {
     buildGoModule = args:
       buildGoModule (args // {
@@ -32,7 +51,7 @@ let
           owner = "evanw";
           repo = "esbuild";
           rev = "v${version}";
-          hash = "sha256-h/Vqwax4B4nehRP9TaYbdixAZdb1hx373dNxNHvDrtY=";
+          hash = "sha256-FpvXWIlt67G8w3pBKZo/mcp57LunxDmRUaCU/Ne89B8=";
         };
         vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
       });
@@ -40,16 +59,26 @@ let
 
 in stdenv.mkDerivation (finalAttrs: {
   pname = "surrealist";
-  version = "2.0.6";
+  version = "2.1.6";
 
   src = fetchFromGitHub {
     owner = "surrealdb";
     repo = "surrealist";
     rev = "surrealist-v${finalAttrs.version}";
-    hash = "sha256-5OiVqn+ujssxXZXC6pnGiG1Nw8cAhoDU5IIl9skywBw=";
+    hash = "sha256-jOjOdrVOcGPenFW5mkkXKA64C6c+/f9KzlvtUmw6vXc=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src-tauri";
+
+  # HACK: A dependency (surrealist -> tauri -> **reqwest**) contains hyper-tls
+  # as an actually optional dependency. It ends up in the `Cargo.lock` file of
+  # tauri, but not in the one of surrealist. We apply a patch to `Cargo.toml`
+  # and `Cargo.lock` to ensure that we have it in our vendor archive. This may
+  # be a result of the following bug:
+  # https://github.com/rust-lang/cargo/issues/10801
+  patches = [
+    ./0001-Cargo.patch
+  ];
 
   ui = stdenvNoCC.mkDerivation {
     inherit (finalAttrs) src version;
@@ -57,17 +86,17 @@ in stdenv.mkDerivation (finalAttrs: {
 
     pnpmDeps = pnpm.fetchDeps {
       inherit (finalAttrs) pname version src;
-      hash = "sha256-apvU7nanzueaF7PEQL7EKjVT5z1M6I7PZpEIJxfKuCQ=";
+      hash = "sha256-zGs1MWJ8TEFuHOoekCNIKQo2PBnp95xLz+R8mzeJXh8=";
     };
 
-    ESBUILD_BINARY_PATH = "${lib.getExe esbuild-20-2}";
+    ESBUILD_BINARY_PATH = lib.getExe esbuild_21-5;
 
     nativeBuildInputs = [ nodejs pnpm.configHook ];
 
     buildPhase = ''
       runHook preBuild
 
-      pnpm build
+      pnpm build:desktop
 
       runHook postBuild
     '';
@@ -82,22 +111,29 @@ in stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) src sourceRoot version;
+    inherit (finalAttrs) patches src sourceRoot version;
     name = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-uE4r0smgSbl4l77/MsHtn1Ar5fqspsYcLC/u8TUrcu8=";
+    hash = "sha256-LtQS0kH+2P4odV7BJYiH6T51+iZHAM9W9mV96rNfNWs=";
   };
 
   nativeBuildInputs = [
     cargo
-    cargo-tauri
+    cargo-tauri_2
+    gobject-introspection
     makeBinaryWrapper
     pkg-config
     rustc
     rustPlatform.cargoSetupHook
   ];
 
-  buildInputs =
-    [ cairo gdk-pixbuf gobject-introspection libsoup openssl pango webkitgtk ];
+  buildInputs = [
+    cairo
+    gdk-pixbuf
+    libsoup_3
+    openssl
+    pango
+    webkitgtk_4_1
+  ];
 
   env = {
     OPENSSL_NO_VENDOR = 1;
@@ -105,8 +141,8 @@ in stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace ./tauri.conf.json \
-      --replace-fail '"distDir": "../dist",' '"distDir": "${finalAttrs.ui}",' \
-      --replace-fail '"beforeBuildCommand": "pnpm build",' '"beforeBuildCommand": "",'
+      --replace-fail '"frontendDist": "../dist",' '"frontendDist": "${finalAttrs.ui}",' \
+      --replace-fail '"beforeBuildCommand": "pnpm build:desktop",' '"beforeBuildCommand": "",'
   '';
 
   postBuild = ''
@@ -114,12 +150,14 @@ in stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall = ''
-    install -Dm555 target/release/bundle/deb/surrealist_${finalAttrs.version}_*/data/usr/bin/surrealist -t $out/bin
-    cp -r target/release/bundle/deb/surrealist_${finalAttrs.version}_*/data/usr/share $out
+    install -Dm555 target/release/bundle/deb/Surrealist_${finalAttrs.version}_*/data/usr/bin/surrealist -t $out/bin
+    cp -r target/release/bundle/deb/Surrealist_${finalAttrs.version}_*/data/usr/share $out
   '';
 
   postFixup = ''
-    wrapProgram "$out/bin/surrealist" --set WEBKIT_DISABLE_COMPOSITING_MODE 1
+    wrapProgram "$out/bin/surrealist" \
+      --set GIO_EXTRA_MODULES ${glib-networking}/lib/gio/modules \
+      --set WEBKIT_DISABLE_COMPOSITING_MODE 1
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

- Closes: https://github.com/NixOS/nixpkgs/issues/339056
- [Changelog](https://github.com/surrealdb/surrealist/releases/tag/surrealist-v2.1.6)
- [Diff](https://github.com/surrealdb/surrealist/compare/surrealist-v2.0.6...surrealist-v2.1.6)

I had to apply a patch to `Cargo.toml` and `Cargo.lock` to ensure that `hyper-tls` and the transitive dependencies are in the vendor archive. This was necessary because [surrealist does not have it](https://github.com/surrealdb/surrealist/blob/surrealist-v2.1.6/src-tauri/Cargo.lock), but [tauri does](https://github.com/tauri-apps/tauri/blob/tauri-v2.0.0-beta.23/Cargo.lock#L1457).

fixes #339056

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
