### PR TITLE
gaphor: 2.8.2 -> 2.26.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -949,6 +949,12 @@
     github = "Alexnortung";
     githubId = 1552267;
   };
+  alex-nt = {
+    email = "nix@azuremyst.org";
+    github = "alex-nt";
+    githubId = 12470950;
+    name = "AN";
+  };
   alexoundos = {
     email = "alexoundos@gmail.com";
     github = "AleXoundOS";

--- a/pkgs/development/python-modules/better-exceptions/default.nix
+++ b/pkgs/development/python-modules/better-exceptions/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "better-exceptions";
+  version = "0.3.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "better_exceptions";
+    inherit version;
+    hash = "sha256-5Oa8GERNXwTm6JSxA4Hl6SHT1UQkBBgWLH21fp6zRTs=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "better_exceptions" ];
+
+  # As noted by @WolfangAukang, some check files need to be disabled because of various errors, same with some tests.
+  # After disabling and running the build, no tests are collected.
+  doCheck = false;
+
+  meta = {
+    description = "Pretty and more helpful exceptions in Python, automatically";
+    homepage = "https://github.com/qix-/better-exceptions";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.alex-nt ];
+  };
+}

--- a/pkgs/tools/misc/gaphor/default.nix
+++ b/pkgs/tools/misc/gaphor/default.nix
@@ -4,16 +4,23 @@
 , copyDesktopItems
 , gobject-introspection
 , poetry-core
-, wrapGAppsHook3
-, gtksourceview4
+, wrapGAppsHook4
+, gtksourceview5
+, libadwaita
 , pango
 , gaphas
 , generic
 , jedi
 , pycairo
+, pillow
+, dulwich
+, pydot
+, defusedxml
+, better-exceptions
+, babel
 , pygobject3
 , tinycss2
-, gtk3
+, gtk4
 , librsvg
 , makeDesktopItem
 , python
@@ -21,34 +28,43 @@
 
 buildPythonApplication rec {
   pname = "gaphor";
-  version = "2.8.2";
-
-  format = "pyproject";
+  version = "2.26.0";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-+qqsSLjdY2I19fxdfkOEQ9DhTTHccUDll4O5yqtLiz0=";
+    hash = "sha256-e0K5bfgPqlJh8qrAz40c/w3ANzkfa/6txuqzQDJYXfE=";
   };
+
+  pythonRelaxDeps = [ "defusedxml" ];
 
   nativeBuildInputs = [
     copyDesktopItems
     gobject-introspection
-    poetry-core
-    wrapGAppsHook3
+    wrapGAppsHook4
   ];
 
   buildInputs = [
-    gtksourceview4
+    gtksourceview5
     pango
+    libadwaita
   ];
 
-  propagatedBuildInputs = [
-    gaphas
-    generic
-    jedi
+  build-system = [ poetry-core ];
+
+  dependencies = [
     pycairo
     pygobject3
+    gaphas
+    generic
     tinycss2
+    babel
+    jedi
+    better-exceptions
+    pydot
+    pillow
+    defusedxml
+    dulwich
   ];
 
   desktopItems = makeDesktopItem {
@@ -59,7 +75,7 @@ buildPythonApplication rec {
     desktopName = "Gaphor";
   };
 
-  # Disable automatic wrapGAppsHook3 to prevent double wrapping
+  # Disable automatic wrapGAppsHook4 to prevent double wrapping
   dontWrapGApps = true;
 
   postInstall = ''
@@ -69,7 +85,7 @@ buildPythonApplication rec {
   preFixup = ''
     makeWrapperArgs+=(
       "''${gappsWrapperArgs[@]}" \
-      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+      --prefix XDG_DATA_DIRS : "${gtk4}/share/gsettings-schemas/${gtk4.name}/" \
       --set GDK_PIXBUF_MODULE_FILE "${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     )
   '';
@@ -79,6 +95,6 @@ buildPythonApplication rec {
     maintainers = [ ];
     homepage = "https://github.com/gaphor/gaphor";
     license = licenses.asl20;
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1562,6 +1562,8 @@ self: super: with self; {
 
   betamax-serializers = callPackage ../development/python-modules/betamax-serializers { };
 
+  better-exceptions = callPackage ../development/python-modules/better-exceptions { };
+
   betterproto = callPackage ../development/python-modules/betterproto { };
 
   beziers = callPackage ../development/python-modules/beziers { };


### PR DESCRIPTION
## Description of changes

`gaphor` no longer builds, this will update it to `2.26.0`.

## Things done

* Added [better-exceptions](https://pypi.org/project/better-exceptions/) as it was the only missing package needed in latest `gaphor`
* Added all the new dependencies `gaphor` has

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
