### PR TITLE
cvc5: add patches for CVE-2024-37794 & CVE-2024-37795

### DIFF
--- a/pkgs/applications/science/logic/cvc5/1.1.2-CVE-2024-37794-CVE-2024-37795.part-1.patch
+++ b/pkgs/applications/science/logic/cvc5/1.1.2-CVE-2024-37794-CVE-2024-37795.part-1.patch
@@ -1,0 +1,163 @@
+Based on upstream 3f1ed7bbaff5dfb7b32217ba3c11e9d9a697045b, adjusted to
+apply to 1.1.2
+
+diff --git a/src/api/cpp/cvc5.cpp b/src/api/cpp/cvc5.cpp
+index 2c946b59b..6cc20167c 100644
+--- a/src/api/cpp/cvc5.cpp
++++ b/src/api/cpp/cvc5.cpp
+@@ -5113,9 +5113,23 @@ Term Solver::mkRealOrIntegerFromStrHelper(const std::string& s,
+   //////// all checks before this line
+   try
+   {
+-    internal::Rational r = s.find('/') != std::string::npos
+-                               ? internal::Rational(s)
+-                               : internal::Rational::fromDecimal(s);
++    internal::Rational r;
++    size_t spos = s.find('/');
++    if (spos != std::string::npos)
++    {
++      // Ensure the denominator contains a non-zero digit. We catch this here to
++      // avoid a floating point exception in GMP. This exception will be caught
++      // and given the standard error message below.
++      if (s.find_first_not_of('0', spos + 1) == std::string::npos)
++      {
++        throw std::invalid_argument("Zero denominator encountered");
++      }
++      r = internal::Rational(s);
++    }
++    else
++    {
++      r = internal::Rational::fromDecimal(s);
++    }
+     return Solver::mkRationalValHelper(d_nm, r, isInt);
+   }
+   catch (const std::invalid_argument& e)
+@@ -5123,8 +5137,8 @@ Term Solver::mkRealOrIntegerFromStrHelper(const std::string& s,
+     /* Catch to throw with a more meaningful error message. To be caught in
+      * enclosing CVC5_API_TRY_CATCH_* block to throw CVC5ApiException. */
+     std::stringstream message;
+-    message << "Cannot construct Real or Int from string argument '" << s << "'"
+-            << std::endl;
++    message << "Cannot construct Real or Int from string argument '" << s
++            << "'";
+     throw std::invalid_argument(message.str());
+   }
+ }
+diff --git a/src/parser/smt2/smt2_term_parser.cpp b/src/parser/smt2/smt2_term_parser.cpp
+index aae036996..725b3050b 100644
+--- a/src/parser/smt2/smt2_term_parser.cpp
++++ b/src/parser/smt2/smt2_term_parser.cpp
+@@ -992,17 +992,21 @@ uint32_t Smt2TermParser::parseIntegerNumeral()
+ uint32_t Smt2TermParser::tokenStrToUnsigned()
+ {
+   // forbid leading zeroes if in strict mode
++  std::string token = d_lex.tokenStr();
+   if (d_lex.isStrict())
+   {
+-    std::string token = d_lex.tokenStr();
+     if (token.size() > 1 && token[0] == '0')
+     {
+-      d_lex.parseError("Numeral with leading zeroes are forbidden");
++      d_lex.parseError("Numerals with leading zeroes are forbidden");
+     }
+   }
++  if (token.size() > 1 && token[0] == '-')
++  {
++    d_lex.parseError("Negative numerals are forbidden in indices");
++  }
+   uint32_t result;
+   std::stringstream ss;
+-  ss << d_lex.tokenStr();
++  ss << token;
+   ss >> result;
+   return result;
+ }
+diff --git a/test/regress/cli/CMakeLists.txt b/test/regress/cli/CMakeLists.txt
+index c32123851..e72e34701 100644
+--- a/test/regress/cli/CMakeLists.txt
++++ b/test/regress/cli/CMakeLists.txt
+@@ -1118,6 +1118,8 @@ set(regress_0_tests
+   regress0/parser/get-model-sort-constructor.smt2
+   regress0/parser/get-value-empty-err.smt2
+   regress0/parser/global-dec-cli.smt2
++  regress0/parser/issue10813-1.smt2
++  regress0/parser/issue10813-2.smt2
+   regress0/parser/issue5163.smt2
+   regress0/parser/issue6908-get-value-uc.smt2
+   regress0/parser/issue7274.smt2
+diff --git a/test/regress/cli/regress0/parser/issue10813-1.smt2 b/test/regress/cli/regress0/parser/issue10813-1.smt2
+new file mode 100644
+index 000000000..af415225a
+--- /dev/null
++++ b/test/regress/cli/regress0/parser/issue10813-1.smt2
+@@ -0,0 +1,11 @@
++; DISABLE-TESTER: dump
++; SCRUBBER: grep -o 'Cannot construct Real or Int from string argument'
++; EXPECT: Cannot construct Real or Int from string argument
++; EXIT: 1
++(set-logic QF_LRA)
++(declare-const x Real)
++(declare-const y Real)
++(assert (> x 1.5))
++(assert (< y 3.5))
++(assert (= (+ x y) 5/0))
++(check-sat)
+diff --git a/test/regress/cli/regress0/parser/issue10813-2.smt2 b/test/regress/cli/regress0/parser/issue10813-2.smt2
+new file mode 100644
+index 000000000..971492d86
+--- /dev/null
++++ b/test/regress/cli/regress0/parser/issue10813-2.smt2
+@@ -0,0 +1,9 @@
++; DISABLE-TESTER: dump
++; SCRUBBER: grep -o 'Negative numerals are forbidden in indices'
++; EXPECT: Negative numerals are forbidden in indices
++; EXIT: 1
++(set-logic QF_BV)
++(declare-const x (_ BitVec 32))
++(declare-const y (_ BitVec 32))
++(assert (= (bvadd x y) (_ bv10 -2)))
++(check-sat)
+diff --git a/test/unit/api/cpp/term_black.cpp b/test/unit/api/cpp/term_black.cpp
+index 83ff3a9f1..01b7896d4 100644
+--- a/test/unit/api/cpp/term_black.cpp
++++ b/test/unit/api/cpp/term_black.cpp
+@@ -846,6 +846,9 @@ TEST_F(TestApiBlackTerm, getReal)
+   ASSERT_EQ("18446744073709551617/1", real9.getRealValue());
+ 
+   ASSERT_EQ("23432343/10000", real10.getRealValue());
++
++  ASSERT_THROW(d_tm.mkReal("1/0"), CVC5ApiException);
++  ASSERT_THROW(d_tm.mkReal("2/0000"), CVC5ApiException);
+ }
+ 
+ TEST_F(TestApiBlackTerm, getConstArrayBase)
+diff --git a/test/unit/api/java/TermTest.java b/test/unit/api/java/TermTest.java
+index a99ea79b9..5fc113de8 100644
+--- a/test/unit/api/java/TermTest.java
++++ b/test/unit/api/java/TermTest.java
+@@ -812,6 +812,9 @@ class TermTest
+     assertEquals("1/18446744073709551617", Utils.getRational(real8.getRealValue()));
+     assertEquals("18446744073709551617/1", Utils.getRational(real9.getRealValue()));
+     assertEquals("23432343/10000", Utils.getRational(real10.getRealValue()));
++
++    assertThrows(CVC5ApiException.class, () -> d_tm.mkReal("1/0"));
++    assertThrows(CVC5ApiException.class, () -> d_tm.mkReal("2/0000"));
+   }
+ 
+   @Test
+diff --git a/test/unit/api/python/test_term.py b/test/unit/api/python/test_term.py
+index ae7740a59..7be763df1 100644
+--- a/test/unit/api/python/test_term.py
++++ b/test/unit/api/python/test_term.py
+@@ -1210,6 +1210,11 @@ def test_get_real(solver):
+     assert Fraction("0.3") == real_decimal.getRealValue()
+     assert Fraction(0.3) == Fraction(5404319552844595, 18014398509481984)
+     assert Fraction(0.3) != real_decimal.getRealValue()
++    
++    with pytest.raises(RuntimeError):
++        tm.mkReal("1/0")
++    with pytest.raises(RuntimeError):
++        tm.mkReal("2/0000")
+ 
+ 
+ def test_get_boolean(solver):

--- a/pkgs/applications/science/logic/cvc5/default.nix
+++ b/pkgs/applications/science/logic/cvc5/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, flex, cadical, symfpu, gmp, python3, gtest, libantlr3c, antlr3_4, boost, jdk }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, cmake, flex, cadical, symfpu, gmp, python3, gtest, libantlr3c, antlr3_4, boost, jdk }:
 
 stdenv.mkDerivation rec {
   pname = "cvc5";
@@ -10,6 +10,15 @@ stdenv.mkDerivation rec {
     rev    = "cvc5-${version}";
     hash  = "sha256-v+3/2IUslQOySxFDYgTBWJIDnyjbU2RPdpfLcIkEtgQ=";
   };
+
+  patches = [
+    ./1.1.2-CVE-2024-37794-CVE-2024-37795.part-1.patch
+    (fetchpatch {
+      name = "CVE-2024-37794-CVE-2024-37795.part-2.patch";
+      url = "https://github.com/cvc5/cvc5/commit/a2c2f5e971916d947e9efa41e22036db8a0a7956.patch";
+      hash  = "sha256-kvqHiAF/C66if0Pkr2jAXFmAcUPv0TeZBMYLKQ1INPw=";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config cmake flex ];
   buildInputs = [


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-37794
https://nvd.nist.gov/vuln/detail/CVE-2024-37795

Addressed in unstable by bump to 1.2.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
