### PR TITLE
treewide: `default.nix` -> `package.nix` in pkgs/by-name

### DIFF
--- a/pkgs/by-name/az/azure-cli/README.md
+++ b/pkgs/by-name/az/azure-cli/README.md
@@ -2,7 +2,7 @@
 
 ## Updating the CLI
 
-- Update `version` and `src.hash` in default.nix
+- Update `version` and `src.hash` in package.nix
 - Check out the changes made to the azure-cli [setup.py](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/setup.py) since the last release
 - Try build the CLI, will likely fail with `ModuleNotFoundError`, for example
   ```

--- a/pkgs/by-name/fl/fluxcd/update.sh
+++ b/pkgs/by-name/fl/fluxcd/update.sh
@@ -17,7 +17,7 @@ if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
     SPEC_SHA256=$(nix hash to-sri --type sha256 $SPEC_SHA256)
 
     setKV () {
-        sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${FLUXCD_PATH}/default.nix"
+        sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${FLUXCD_PATH}/package.nix"
     }
 
     setKV version ${LATEST_VERSION}
@@ -40,7 +40,7 @@ if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
     # `git` flag here is to be used by local maintainers to speed up the bump process
     if [ $# -eq 1 ] && [ "$1" = "git" ]; then
         git switch -c "package-fluxcd-${LATEST_VERSION}"
-        git add "$FLUXCD_PATH"/default.nix
+        git add "$FLUXCD_PATH"/package.nix
         git commit -m "fluxcd: ${OLD_VERSION} -> ${LATEST_VERSION}
 
 Release: https://github.com/fluxcd/flux2/releases/tag/v${LATEST_VERSION}"

--- a/pkgs/by-name/lo/localsend/update.sh
+++ b/pkgs/by-name/lo/localsend/update.sh
@@ -14,13 +14,13 @@ if [[ "$currentVersion" == "$latestVersion" ]]; then
   exit 0
 fi
 
-sed -i "s/version = \".*\"/version = \"${latestVersion}\"/" "$ROOT/default.nix"
+sed -i "s/version = \".*\"/version = \"${latestVersion}\"/" "$ROOT/package.nix"
 
 DARWIN_x64_URL="https://github.com/localsend/localsend/releases/download/v${latestVersion}/LocalSend-${latestVersion}.dmg"
 DARWIN_X64_SHA=$(nix hash to-sri --type sha256 $(nix-prefetch-url ${DARWIN_x64_URL}))
-sed -i "/darwin/,/hash/{s|hash = \".*\"|hash = \"${DARWIN_X64_SHA}\"|}" "$ROOT/default.nix"
+sed -i "/darwin/,/hash/{s|hash = \".*\"|hash = \"${DARWIN_X64_SHA}\"|}" "$ROOT/package.nix"
 
 GIT_SRC_URL="https://github.com/localsend/localsend/archive/refs/tags/v${latestVersion}.tar.gz"
 GIT_SRC_SHA=$(nix hash to-sri --type sha256 $(nix-prefetch-url --unpack ${GIT_SRC_URL}))
-sed -i "/linux/,/hash/{s|hash = \".*\"|hash = \"${GIT_SRC_SHA}\"|}" "$ROOT/default.nix"
+sed -i "/linux/,/hash/{s|hash = \".*\"|hash = \"${GIT_SRC_SHA}\"|}" "$ROOT/package.nix"
 curl https://raw.githubusercontent.com/localsend/localsend/v${latestVersion}/app/pubspec.lock | yq . > $ROOT/pubspec.lock.json


### PR DESCRIPTION
We need to remember to go over all the update scripts once the mass-by-name migration has happened

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
