### PR TITLE
xen-guest-agent: remove unneeded environment variable, install systemd service

### DIFF
--- a/pkgs/by-name/xe/xen-guest-agent/package.nix
+++ b/pkgs/by-name/xe/xen-guest-agent/package.nix
@@ -27,10 +27,18 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ xen-slim ];
 
+  postInstall =
+    # Install the sample systemd service.
+    ''
+      mkdir --parents $out/lib/systemd/system
+      cp $src/startup/xen-guest-agent.service $out/lib/systemd/system
+      substituteInPlace $out/lib/systemd/system/xen-guest-agent.service \
+        --replace-fail "/usr/sbin/xen-guest-agent" "$out/bin/xen-guest-agent"
+    '';
 
-  postFixup = ''
-    patchelf $out/bin/xen-guest-agent --add-rpath ${xen-slim.out}/lib
-  '';
+  postFixup =
+    # Add the Xen libraries in the runpath so the guest agent can find libxenstore.
+    "patchelf $out/bin/xen-guest-agent --add-rpath ${xen-slim.out}/lib";
 
   meta = {
     description = "Xen agent running in Linux/BSDs (POSIX) VMs";

--- a/pkgs/by-name/xe/xen-guest-agent/package.nix
+++ b/pkgs/by-name/xe/xen-guest-agent/package.nix
@@ -20,13 +20,13 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-E6QKh4FFr6sLAByU5n6sLppFwPHSKtKffhQ7FfdXAu4=";
 
   nativeBuildInputs = [
+    rustPlatform.bindgenHook
     llvmPackages.clang
     pkg-config
   ];
 
   buildInputs = [ xen-slim ];
 
-  env.LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
   postFixup = ''
     patchelf $out/bin/xen-guest-agent --add-rpath ${xen-slim.out}/lib


### PR DESCRIPTION
## Description of changes

- Removes an unnecessary `clang` environment library by adding `bindgenHook`. (As recommended [here](https://github.com/NixOS/nixpkgs/pull/332306#discussion_r1720934312))
- Installs the minimal systemd service provided by upstream from `$src/startup` to `$out/lib/systemd/system`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - No automated tests, as `xen-guest-agent` must be ran inside a Xen domU.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 335641"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Change is minor, so no changelog.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
