### PR TITLE
nixos/lubelogger: init

### DIFF
--- a/nixos/modules/services/web-apps/lubelogger.nix
+++ b/nixos/modules/services/web-apps/lubelogger.nix
@@ -1,0 +1,93 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.lubelogger;
+in
+{
+  options = {
+    services.lubelogger = {
+      enable = mkEnableOption "Lubelogger, a self-hosted, open-source, web-based vehicle maintenance and fuel milage tracker";
+
+      package = mkPackageOption pkgs "lubelogger" { };
+
+      dataDir = mkOption {
+        description = "Path to Lubelogger config and metadata inside of /var/lib.";
+        default = "lubelogger";
+        type = types.str;
+      };
+
+      port = mkOption {
+        description = "The TCP port Lubelogger will listen on.";
+        default = 5000;
+        readOnly = true; # Lubelogger does not allow you to configure the port it runs on
+        type = types.port;
+      };
+
+      user = mkOption {
+        description = "User account under which Lubelogger runs.";
+        default = "audiobookshelf";
+        type = types.str;
+      };
+
+      group = mkOption {
+        description = "Group under which Lubelogger runs.";
+        default = "lubelogger";
+        type = types.str;
+      };
+
+      openFirewall = mkOption {
+        description = "Open ports in the firewall for the Lubelogger web interface.";
+        default = false;
+        type = types.bool;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.lubelogger = {
+      description = "Lubeloger is a self-hosted vehicle maintenance and fuel mileage tracker";
+
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment.DOTNET_CONTENTROOT = "/var/lib/${cfg.dataDir}";
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = cfg.dataDir;
+        WorkingDirectory = "/var/lib/${cfg.dataDir}";
+        ExecStart = "${lib.getExe cfg.package}";
+        Restart = "on-failure";
+
+        ExecStartPre = pkgs.writeShellScript "lubelogger-prestart" ''
+          cd $STATE_DIRECTORY
+          if [ ! -e .nixos-lubelogger-contentroot-copied ]; then
+            cp -r ${cfg.package}/lib/lubelogger/* .
+            chmod -R 744 .
+            touch .nixos-lubelogger-contentroot-copied
+          fi
+        '';
+      };
+    };
+
+    users.users = mkIf (cfg.user == "lubelogger") {
+      lubelogger = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = "/var/lib/${cfg.dataDir}";
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "lubelogger") {
+      lubelogger = { };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+}

--- a/nixos/modules/services/web-apps/lubelogger.nix
+++ b/nixos/modules/services/web-apps/lubelogger.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
@@ -82,12 +87,8 @@ in
       };
     };
 
-    users.groups = mkIf (cfg.group == "lubelogger") {
-      lubelogger = { };
-    };
+    users.groups = mkIf (cfg.group == "lubelogger") { lubelogger = { }; };
 
-    networking.firewall = mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.port ];
-    };
+    networking.firewall = mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.port ]; };
   };
 }

--- a/pkgs/by-name/lu/lubelogger/package.nix
+++ b/pkgs/by-name/lu/lubelogger/package.nix
@@ -22,7 +22,7 @@ buildDotnetModule rec {
   dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
 
   makeWrapperArgs = [
-    "--set DOTNET_CONTENTROOT ${placeholder "out"}/lib/lubelogger"
+    "--set-default DOTNET_CONTENTROOT ${placeholder "out"}/lib/lubelogger"
   ];
 
   executables = [ "CarCareTracker" ]; # This wraps "$out/lib/$pname/foo" to `$out/bin/foo`.


### PR DESCRIPTION
## Description of changes

Adds a module for Lubelogger. Also removes myself as maintainer from the lubelogger package, as I no longer use this package. I have been doing simple testing of lubelogger for updates, but would like for someone to take it over.

Closes #333954

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
