### PR TITLE
containers.*.config.nixpkgs: use `host.pkgs.stdenv.hostPlatform`

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -488,7 +488,9 @@ in
                       extraConfig = { options, ... }: {
                         _file = "module at ${__curPos.file}:${toString __curPos.line}";
                         config = {
-                          nixpkgs = if options.nixpkgs?hostPlatform && host.options.nixpkgs.hostPlatform.isDefined
+                          nixpkgs = if options.nixpkgs?pkgs && host.options.nixpkgs.pkgs.isDefined
+                                    then { inherit (host.config.nixpkgs) pkgs; }
+                                    else if options.nixpkgs?hostPlatform && host.options.nixpkgs.hostPlatform.isDefined
                                     then { inherit (host.config.nixpkgs) hostPlatform; }
                                     else { inherit (host.config.nixpkgs) localSystem; }
                           ;

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -488,12 +488,7 @@ in
                       extraConfig = { options, ... }: {
                         _file = "module at ${__curPos.file}:${toString __curPos.line}";
                         config = {
-                          nixpkgs = if options.nixpkgs?pkgs && host.options.nixpkgs.pkgs.isDefined
-                                    then { inherit (host.config.nixpkgs) pkgs; }
-                                    else if options.nixpkgs?hostPlatform && host.options.nixpkgs.hostPlatform.isDefined
-                                    then { inherit (host.config.nixpkgs) hostPlatform; }
-                                    else { inherit (host.config.nixpkgs) localSystem; }
-                          ;
+                          nixpkgs = { inherit (host.pkgs.stdenv) hostPlatform; };
                           boot.isContainer = true;
                           networking.hostName = mkDefault name;
                           networking.useDHCP = false;

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -488,7 +488,11 @@ in
                       extraConfig = { options, ... }: {
                         _file = "module at ${__curPos.file}:${toString __curPos.line}";
                         config = {
-                          nixpkgs = { inherit (host.pkgs.stdenv) hostPlatform; };
+                          nixpkgs =
+                            if options.nixpkgs?hostPlatform
+                            then { inherit (host.pkgs.stdenv) hostPlatform; }
+                            else { localSystem = host.pkgs.stdenv.hostPlatform; }
+                          ;
                           boot.isContainer = true;
                           networking.hostName = mkDefault name;
                           networking.useDHCP = false;


### PR DESCRIPTION
The minimum reproduction for the problem I'm trying to solve is that the following NixOS test with a trivial NixOS container:

```nix
{ inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/24.05";

    flake-utils.url = "github:numtide/flake-utils/v1.0.0";
  };

  outputs = { flake-utils, nixpkgs, self, ... }:
    flake-utils.lib.eachDefaultSystem (system: {
      checks.default = nixpkgs.legacyPackages."${system}".nixosTest {
        name = "test";

        nodes.machine.containers.tutorial.config = { };

        testScript = "";
      };
    });
}
```

… fails with the following error message:

```
error: Neither nodes.machine.nixpkgs.hostPlatform nor the legacy option nodes.machine.nixpkgs.system has been set.
You can set nodes.machine.nixpkgs.hostPlatform in hardware-configuration.nix by re-running
a recent version of nixos-generate-config.
The option nodes.machine.nixpkgs.system is still fully supported for NixOS 22.05 interoperability,
but will be deprecated in the future, so we recommend to set nodes.machine.nixpkgs.hostPlatform.
```

The root of the problem appears to be that in
`nixos/modules/virtualisation/nixos-containers.nix` there is support for deriving the guest's `nixpkgs.hostPlatform` or `nixpkgs.localSystem` from the corresponding host's values, but this doesn't work if the host sets `nixpkgs.pkgs` instead of one of those values.  In fact, this is what happens when using `pkgs.nixosTest` (which sets `nixpkgs.pkgs` in
`pkgs/build-support/testers/default.nix`).

The solution I went with was to forward the `nixpkgs.pkgs` setting from the host to the guest, but only if it is defined (matching the same treatment as `nixpkgs.hostPlatform` and `nixpkgs.localSystem`).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
