### PR TITLE
simgrid: use `lib.cmakeBool/cmakeFeature`

### DIFF
--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -12,10 +12,6 @@
 , withoutBin ? false
 }:
 
-let
-  optionOnOff = option: if option then "on" else "off";
-in
-
 stdenv.mkDerivation rec {
   pname = "simgrid";
   version = "3.35";
@@ -42,31 +38,32 @@ stdenv.mkDerivation rec {
 
   # "Release" does not work. non-debug mode is Debug compiled with optimization
   cmakeBuildType = "Debug";
-  cmakeFlags = [
-    "-Denable_documentation=${optionOnOff buildDocumentation}"
-    "-Denable_java=${optionOnOff buildJavaBindings}"
-    "-Denable_python=${optionOnOff buildPythonBindings}"
-    "-DSIMGRID_PYTHON_LIBDIR=./" # prevents CMake to install in ${python3} dir
-    "-Denable_msg=${optionOnOff buildJavaBindings}"
-    "-Denable_fortran=${optionOnOff fortranSupport}"
-    "-Denable_model-checking=${optionOnOff modelCheckingSupport}"
-    "-Denable_ns3=off"
-    "-Denable_lua=off"
-    "-Denable_lib_in_jar=off"
-    "-Denable_maintainer_mode=off"
-    "-Denable_mallocators=on"
-    "-Denable_debug=on"
-    "-Denable_smpi=on"
-    "-Dminimal-bindings=${optionOnOff minimalBindings}"
-    "-Denable_smpi_ISP_testsuite=${optionOnOff moreTests}"
-    "-Denable_smpi_MPICH3_testsuite=${optionOnOff moreTests}"
-    "-Denable_compile_warnings=off"
-    "-Denable_compile_optimizations=${optionOnOff optimize}"
-    "-Denable_lto=${optionOnOff optimize}"
 
+  cmakeFlags = [
+    (lib.cmakeBool "enable_documentation" buildDocumentation)
+    (lib.cmakeBool "enable_java" buildJavaBindings)
+    (lib.cmakeBool "enable_python" buildPythonBindings)
+    (lib.cmakeFeature "SIMGRID_PYTHON_LIBDIR" "./") # prevents CMake to install in ${python3} dir
+    (lib.cmakeBool "enable_msg" buildJavaBindings)
+    (lib.cmakeBool "enable_fortran" fortranSupport)
+    (lib.cmakeBool "enable_model-checking" modelCheckingSupport)
+    (lib.cmakeBool "enable_ns3" false)
+    (lib.cmakeBool "enable_lua" false)
+    (lib.cmakeBool "enable_lib_in_jar" false)
+    (lib.cmakeBool "enable_maintainer_mode" false)
+    (lib.cmakeBool "enable_mallocators" true)
+    (lib.cmakeBool "enable_debug" true)
+    (lib.cmakeBool "enable_smpi" true)
+    (lib.cmakeBool "minimal-bindings" minimalBindings)
+    (lib.cmakeBool "enable_smpi_ISP_testsuite" moreTests)
+    (lib.cmakeBool "enable_smpi_MPICH3_testsuite" moreTests)
+    (lib.cmakeBool "enable_compile_warnings" false)
+    (lib.cmakeBool "enable_compile_optimizations" optimize)
+    (lib.cmakeBool "enable_lto" optimize)
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" optimize)
   ];
+
   makeFlags = lib.optional debug "VERBOSE=1";
 
   # needed to run tests and to ensure correct shabangs in output scripts


### PR DESCRIPTION
## Description of changes

use `lib.cmakeBool/cmakeFeature`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
