### PR TITLE
treewide: support structuredAttrs in setup hooks (part 2)

### DIFF
--- a/pkgs/build-support/setup-hooks/autoreconf.sh
+++ b/pkgs/build-support/setup-hooks/autoreconf.sh
@@ -4,8 +4,11 @@ autoreconfPhase() {
     runHook preAutoreconf
 
     local flagsArray=()
-    : "${autoreconfFlags:=--install --force --verbose}"
-    concatTo flagsArray autoreconfFlags
+    if [[ -v autoreconfFlags ]]; then
+        concatTo flagsArray autoreconfFlags
+    else
+        flagsArray+=(--install --force --verbose)
+    fi
 
     autoreconf "${flagsArray[@]}"
     runHook postAutoreconf

--- a/pkgs/by-name/bm/bmake/setup-hook.sh
+++ b/pkgs/by-name/bm/bmake/setup-hook.sh
@@ -14,9 +14,8 @@ bmakeBuildPhase() {
     local flagsArray=(
         ${enableParallelBuilding:+-j${NIX_BUILD_CORES}}
         SHELL="$SHELL"
-        $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
-        $buildFlags ${buildFlagsArray+"${buildFlagsArray[@]}"}
     )
+    concatTo flagsArray makeFlags makeFlagsArray buildFlags buildFlagsArray
 
     echoCmd 'build flags' "${flagsArray[@]}"
     bmake ${makefile:+-f $makefile} "${flagsArray[@]}"
@@ -42,11 +41,8 @@ bmakeCheckPhase() {
         local flagsArray=(
             ${enableParallelChecking:+-j${NIX_BUILD_CORES}}
             SHELL="$SHELL"
-            # Old bash empty array hack
-            $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
-            ${checkFlags:-VERBOSE=y} ${checkFlagsArray+"${checkFlagsArray[@]}"}
-            ${checkTarget}
         )
+        concatTo flagsArray makeFlags makeFlagsArray checkFlags=VERBOSE=y checkFlagsArray checkTarget
 
         echoCmd 'check flags' "${flagsArray[@]}"
         bmake ${makefile:+-f $makefile} "${flagsArray[@]}"
@@ -65,11 +61,8 @@ bmakeInstallPhase() {
     local flagsArray=(
         ${enableParallelInstalling:+-j${NIX_BUILD_CORES}}
         SHELL="$SHELL"
-        # Old bash empty array hack
-        $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
-        $installFlags ${installFlagsArray+"${installFlagsArray[@]}"}
-        ${installTargets:-install}
     )
+    concatTo flagsArray makeFlags makeFlagsArray installFlags installFlagsArray installTargets=install
 
     echoCmd 'install flags' "${flagsArray[@]}"
     bmake ${makefile:+-f $makefile} "${flagsArray[@]}"
@@ -84,10 +77,8 @@ bmakeDistPhase() {
         mkdir -p "$prefix"
     fi
 
-    # Old bash empty array hack
-    local flagsArray=(
-        $distFlags ${distFlagsArray+"${distFlagsArray[@]}"} ${distTarget:-dist}
-    )
+    local flagsArray=()
+    concatTo flagsArray distFlags distFlagsArray distTarget=dist
 
     echo 'dist flags: %q' "${flagsArray[@]}"
     bmake ${makefile:+-f $makefile} "${flagsArray[@]}"

--- a/pkgs/by-name/ju/just/setup-hook.sh
+++ b/pkgs/by-name/ju/just/setup-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 justBuildPhase() {
     runHook preBuild
 
@@ -15,7 +17,7 @@ justCheckPhase() {
 
     if [ -z "${checkTarget:-}" ]; then
         if just -n test >/dev/null 2>&1; then
-            checkTarget=test
+            checkTarget="test"
         fi
     fi
 
@@ -44,14 +46,14 @@ justInstallPhase() {
     runHook postInstall
 }
 
-if [ -z "${dontUseJustBuild-}" -a -z "${buildPhase-}" ]; then
+if [ -z "${dontUseJustBuild-}" ] && [ -z "${buildPhase-}" ]; then
     buildPhase=justBuildPhase
 fi
 
-if [ -z "${dontUseJustCheck-}" -a -z "${checkPhase-}" ]; then
+if [ -z "${dontUseJustCheck-}" ] && [ -z "${checkPhase-}" ]; then
     checkPhase=justCheckPhase
 fi
 
-if [ -z "${dontUseJustInstall-}" -a -z "${installPhase-}" ]; then
+if [ -z "${dontUseJustInstall-}" ] && [ -z "${installPhase-}" ]; then
     installPhase=justInstallPhase
 fi

--- a/pkgs/by-name/ju/just/setup-hook.sh
+++ b/pkgs/by-name/ju/just/setup-hook.sh
@@ -1,7 +1,8 @@
 justBuildPhase() {
     runHook preBuild
 
-    local flagsArray=($justFlags "${justFlagsArray[@]}")
+    local flagsArray=()
+    concatTo flagsArray justFlags justFlagsArray
 
     echoCmd 'build flags' "${flagsArray[@]}"
     just "${flagsArray[@]}"
@@ -21,10 +22,8 @@ justCheckPhase() {
     if [ -z "${checkTarget:-}" ]; then
         echo "no test target found in just, doing nothing"
     else
-        local flagsArray=(
-            $justFlags "${justFlagsArray[@]}"
-            $checkTarget
-        )
+        local flagsArray=()
+        concatTo flagsArray justFlags justFlagsArray checkTarget
 
         echoCmd 'check flags' "${flagsArray[@]}"
         just "${flagsArray[@]}"
@@ -36,8 +35,8 @@ justCheckPhase() {
 justInstallPhase() {
     runHook preInstall
 
-    # shellcheck disable=SC2086
-    local flagsArray=($justFlags "${justFlagsArray[@]}" ${installTargets:-install})
+    local flagsArray=()
+    concatTo flagsArray justFlags justFlagsArray installTargets=install
 
     echoCmd 'install flags' "${flagsArray[@]}"
     just "${flagsArray[@]}"

--- a/pkgs/by-name/ni/ninja/setup-hook.sh
+++ b/pkgs/by-name/ni/ninja/setup-hook.sh
@@ -65,8 +65,7 @@ ninjaInstallPhase() {
     local flagsArray=(
         "-j$buildCores"
     )
-    : "${installTargets:=install}"
-    concatTo flagsArray ninjaFlags ninjaFlagsArray installTargets
+    concatTo flagsArray ninjaFlags ninjaFlagsArray installTargets=install
 
     echoCmd 'install flags' "${flagsArray[@]}"
     TERM=dumb ninja "${flagsArray[@]}"

--- a/pkgs/by-name/sc/scons/setup-hook.sh
+++ b/pkgs/by-name/sc/scons/setup-hook.sh
@@ -61,7 +61,7 @@ sconsCheckPhase() {
         local flagsArray=(
             ${enableParallelChecking:+-j${NIX_BUILD_CORES}}
         )
-        concatTo flagsArray sconsFlags sconsFlagsArray checkFlagsArray
+        concatTo flagsArray sconsFlags sconsFlagsArray checkFlagsArray checkTarget
 
         echoCmd 'scons check flags' "${flagsArray[@]}"
         scons "${flagsArray[@]}"

--- a/pkgs/by-name/sc/scons/setup-hook.sh
+++ b/pkgs/by-name/sc/scons/setup-hook.sh
@@ -8,14 +8,13 @@ sconsBuildPhase() {
     fi
 
     if [ -z "${dontAddPrefix:-}" ] && [ -n "$prefix" ]; then
-        buildFlags="${prefixKey:-prefix=}$prefix $buildFlags"
+        prependToVar buildFlags "${prefixKey:-prefix=}$prefix"
     fi
 
     local flagsArray=(
       ${enableParallelBuilding:+-j${NIX_BUILD_CORES}}
-      $sconsFlags ${sconsFlagsArray[@]}
-      $buildFlags ${buildFlagsArray[@]}
     )
+    concatTo flagsArray sconsFlags sconsFlagsArray buildFlags buildFlagsArray
 
     echoCmd 'scons build flags' "${flagsArray[@]}"
     scons "${flagsArray[@]}"
@@ -31,15 +30,13 @@ sconsInstallPhase() {
     fi
 
     if [ -z "${dontAddPrefix:-}" ] && [ -n "$prefix" ]; then
-        installFlags="${prefixKey:-prefix=}$prefix $installFlags"
+        prependToVar installFlags "${prefixKey:-prefix=}$prefix"
     fi
 
     local flagsArray=(
         ${enableParallelInstalling:+-j${NIX_BUILD_CORES}}
-        $sconsFlags ${sconsFlagsArray[@]}
-        $installFlags ${installFlagsArray[@]}
-        ${installTargets:-install}
     )
+    concatTo flagsArray sconsFlags sconsFlagsArray installFlags installFlagsArray installTargets=install
 
     echoCmd 'scons install flags' "${flagsArray[@]}"
     scons "${flagsArray[@]}"
@@ -63,9 +60,8 @@ sconsCheckPhase() {
     else
         local flagsArray=(
             ${enableParallelChecking:+-j${NIX_BUILD_CORES}}
-            $sconsFlags ${sconsFlagsArray[@]}
-            ${checkFlagsArray[@]}
         )
+        concatTo flagsArray sconsFlags sconsFlagsArray checkFlagsArray
 
         echoCmd 'scons check flags' "${flagsArray[@]}"
         scons "${flagsArray[@]}"

--- a/pkgs/by-name/wa/waf/setup-hook.sh
+++ b/pkgs/by-name/wa/waf/setup-hook.sh
@@ -16,11 +16,8 @@ wafConfigurePhase() {
       export PKGCONFIG="${PKG_CONFIG}"
     fi
 
-    local flagsArray=(
-        $prefixFlag
-        $wafConfigureFlags "${wafConfigureFlagsArray[@]}"
-        ${wafConfigureTargets:-configure}
-    )
+    local flagsArray=( $prefixFlag )
+    concatTo flagsArray wafConfigureFlags wafConfigureFlagsArray wafConfigureTargets=configure
 
     echoCmd 'waf configure flags' "${flagsArray[@]}"
     python "$wafPath" "${flagsArray[@]}"
@@ -41,15 +38,8 @@ wafConfigurePhase() {
 wafBuildPhase () {
     runHook preBuild
 
-    # set to empty if unset
-    : "${wafFlags=}"
-
-    local flagsArray=(
-      ${enableParallelBuilding:+-j ${NIX_BUILD_CORES}}
-      $wafFlags ${wafFlagsArray[@]}
-      $wafBuildFlags ${wafBuildFlagsArray[@]}
-      ${wafBuildTargets:-build}
-    )
+    local flagsArray=( ${enableParallelBuilding:+-j ${NIX_BUILD_CORES}} )
+    concatTo flagsArray wafFlags wafFlagsArray wafBuildFlags wafBuildFlagsArray wafBuildTargets=build
 
     echoCmd 'waf build flags' "${flagsArray[@]}"
     python "$wafPath" "${flagsArray[@]}"
@@ -64,12 +54,8 @@ wafInstallPhase() {
         mkdir -p "$prefix"
     fi
 
-    local flagsArray=(
-        ${enableParallelInstalling:+-j ${NIX_BUILD_CORES}}
-        $wafFlags ${wafFlagsArray[@]}
-        $wafInstallFlags ${wafInstallFlagsArray[@]}
-        ${wafInstallTargets:-install}
-    )
+    local flagsArray=( ${enableParallelInstalling:+-j ${NIX_BUILD_CORES}} )
+    concatTo flagsArray wafFlags wafFlagsArray wafInstallFlags wafInstallFlagsArray wafInstallTargets=install
 
     echoCmd 'waf install flags' "${flagsArray[@]}"
     python "$wafPath" "${flagsArray[@]}"

--- a/pkgs/development/compilers/zig/0.10/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.10/setup-hook.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash disable=SC2154,SC2086
+# shellcheck shell=bash
 
 # shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
@@ -53,6 +53,7 @@ function zigInstallPhase {
     runHook postInstall
 }
 
+# shellcheck disable=SC2154
 addEnvHooks "$targetOffset" zigSetGlobalCacheDir
 
 if [ -z "${dontUseZigBuild-}" ] && [ -z "${buildPhase-}" ]; then

--- a/pkgs/development/compilers/zig/0.10/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.10/setup-hook.sh
@@ -1,5 +1,6 @@
 # shellcheck shell=bash disable=SC2154,SC2086
 
+# shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
 
 function zigSetGlobalCacheDir {
@@ -10,10 +11,9 @@ function zigSetGlobalCacheDir {
 function zigBuildPhase {
     runHook preBuild
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray
 
     echoCmd 'zig build flags' "${flagsArray[@]}"
     zig build "${flagsArray[@]}"
@@ -24,10 +24,9 @@ function zigBuildPhase {
 function zigCheckPhase {
     runHook preCheck
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigCheckFlags "${zigCheckFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigCheckFlags zigCheckFlagsArray
 
     echoCmd 'zig check flags' "${flagsArray[@]}"
     zig build test "${flagsArray[@]}"
@@ -38,11 +37,10 @@ function zigCheckPhase {
 function zigInstallPhase {
     runHook preInstall
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-        $zigInstallFlags "${zigInstallFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray \
+        zigInstallFlags zigInstallFlagsArray
 
     if [ -z "${dontAddPrefix-}" ]; then
         # Zig does not recognize `--prefix=/dir/`, only `--prefix /dir/`

--- a/pkgs/development/compilers/zig/0.11/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.11/setup-hook.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash disable=SC2154,SC2086
+# shellcheck shell=bash
 
 # shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
@@ -53,6 +53,7 @@ function zigInstallPhase {
     runHook postInstall
 }
 
+# shellcheck disable=SC2154
 addEnvHooks "$targetOffset" zigSetGlobalCacheDir
 
 if [ -z "${dontUseZigBuild-}" ] && [ -z "${buildPhase-}" ]; then

--- a/pkgs/development/compilers/zig/0.11/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.11/setup-hook.sh
@@ -1,5 +1,6 @@
 # shellcheck shell=bash disable=SC2154,SC2086
 
+# shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
 
 function zigSetGlobalCacheDir {
@@ -10,10 +11,9 @@ function zigSetGlobalCacheDir {
 function zigBuildPhase {
     runHook preBuild
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray
 
     echoCmd 'zig build flags' "${flagsArray[@]}"
     zig build "${flagsArray[@]}"
@@ -24,10 +24,9 @@ function zigBuildPhase {
 function zigCheckPhase {
     runHook preCheck
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigCheckFlags "${zigCheckFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigCheckFlags zigCheckFlagsArray
 
     echoCmd 'zig check flags' "${flagsArray[@]}"
     zig build test "${flagsArray[@]}"
@@ -38,11 +37,10 @@ function zigCheckPhase {
 function zigInstallPhase {
     runHook preInstall
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-        $zigInstallFlags "${zigInstallFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray \
+        zigInstallFlags zigInstallFlagsArray
 
     if [ -z "${dontAddPrefix-}" ]; then
         # Zig does not recognize `--prefix=/dir/`, only `--prefix /dir/`

--- a/pkgs/development/compilers/zig/0.12/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.12/setup-hook.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash disable=SC2154,SC2086
+# shellcheck shell=bash
 
 # shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
@@ -53,6 +53,7 @@ function zigInstallPhase {
     runHook postInstall
 }
 
+# shellcheck disable=SC2154
 addEnvHooks "$targetOffset" zigSetGlobalCacheDir
 
 if [ -z "${dontUseZigBuild-}" ] && [ -z "${buildPhase-}" ]; then

--- a/pkgs/development/compilers/zig/0.12/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.12/setup-hook.sh
@@ -1,5 +1,6 @@
 # shellcheck shell=bash disable=SC2154,SC2086
 
+# shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
 
 function zigSetGlobalCacheDir {
@@ -10,10 +11,9 @@ function zigSetGlobalCacheDir {
 function zigBuildPhase {
     runHook preBuild
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray
 
     echoCmd 'zig build flags' "${flagsArray[@]}"
     zig build "${flagsArray[@]}"
@@ -24,10 +24,9 @@ function zigBuildPhase {
 function zigCheckPhase {
     runHook preCheck
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigCheckFlags "${zigCheckFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigCheckFlags zigCheckFlagsArray
 
     echoCmd 'zig check flags' "${flagsArray[@]}"
     zig build test "${flagsArray[@]}"
@@ -38,11 +37,10 @@ function zigCheckPhase {
 function zigInstallPhase {
     runHook preInstall
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-        $zigInstallFlags "${zigInstallFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray \
+        zigInstallFlags zigInstallFlagsArray
 
     if [ -z "${dontAddPrefix-}" ]; then
         # Zig does not recognize `--prefix=/dir/`, only `--prefix /dir/`

--- a/pkgs/development/compilers/zig/0.13/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.13/setup-hook.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash disable=SC2154,SC2086
+# shellcheck shell=bash
 
 # shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
@@ -53,6 +53,7 @@ function zigInstallPhase {
     runHook postInstall
 }
 
+# shellcheck disable=SC2154
 addEnvHooks "$targetOffset" zigSetGlobalCacheDir
 
 if [ -z "${dontUseZigBuild-}" ] && [ -z "${buildPhase-}" ]; then

--- a/pkgs/development/compilers/zig/0.13/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.13/setup-hook.sh
@@ -1,5 +1,6 @@
 # shellcheck shell=bash disable=SC2154,SC2086
 
+# shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
 
 function zigSetGlobalCacheDir {
@@ -10,10 +11,9 @@ function zigSetGlobalCacheDir {
 function zigBuildPhase {
     runHook preBuild
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray
 
     echoCmd 'zig build flags' "${flagsArray[@]}"
     zig build "${flagsArray[@]}"
@@ -24,10 +24,9 @@ function zigBuildPhase {
 function zigCheckPhase {
     runHook preCheck
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigCheckFlags "${zigCheckFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigCheckFlags zigCheckFlagsArray
 
     echoCmd 'zig check flags' "${flagsArray[@]}"
     zig build test "${flagsArray[@]}"
@@ -38,11 +37,10 @@ function zigCheckPhase {
 function zigInstallPhase {
     runHook preInstall
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-        $zigInstallFlags "${zigInstallFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray \
+        zigInstallFlags zigInstallFlagsArray
 
     if [ -z "${dontAddPrefix-}" ]; then
         # Zig does not recognize `--prefix=/dir/`, only `--prefix /dir/`

--- a/pkgs/development/compilers/zig/0.9/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.9/setup-hook.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash disable=SC2154,SC2086
+# shellcheck shell=bash
 
 # shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
@@ -53,6 +53,7 @@ function zigInstallPhase {
     runHook postInstall
 }
 
+# shellcheck disable=SC2154
 addEnvHooks "$targetOffset" zigSetGlobalCacheDir
 
 if [ -z "${dontUseZigBuild-}" ] && [ -z "${buildPhase-}" ]; then

--- a/pkgs/development/compilers/zig/0.9/setup-hook.sh
+++ b/pkgs/development/compilers/zig/0.9/setup-hook.sh
@@ -1,5 +1,6 @@
 # shellcheck shell=bash disable=SC2154,SC2086
 
+# shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
 
 function zigSetGlobalCacheDir {
@@ -10,10 +11,9 @@ function zigSetGlobalCacheDir {
 function zigBuildPhase {
     runHook preBuild
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray
 
     echoCmd 'zig build flags' "${flagsArray[@]}"
     zig build "${flagsArray[@]}"
@@ -24,10 +24,9 @@ function zigBuildPhase {
 function zigCheckPhase {
     runHook preCheck
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigCheckFlags "${zigCheckFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigCheckFlags zigCheckFlagsArray
 
     echoCmd 'zig check flags' "${flagsArray[@]}"
     zig build test "${flagsArray[@]}"
@@ -38,11 +37,10 @@ function zigCheckPhase {
 function zigInstallPhase {
     runHook preInstall
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-        $zigInstallFlags "${zigInstallFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray \
+        zigInstallFlags zigInstallFlagsArray
 
     if [ -z "${dontAddPrefix-}" ]; then
         # Zig does not recognize `--prefix=/dir/`, only `--prefix /dir/`

--- a/pkgs/development/compilers/zig/setup-hook.sh
+++ b/pkgs/development/compilers/zig/setup-hook.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash disable=SC2154,SC2086
+# shellcheck shell=bash
 
 # shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
@@ -53,6 +53,7 @@ function zigInstallPhase {
     runHook postInstall
 }
 
+# shellcheck disable=SC2154
 addEnvHooks "$targetOffset" zigSetGlobalCacheDir
 
 if [ -z "${dontUseZigBuild-}" ] && [ -z "${buildPhase-}" ]; then

--- a/pkgs/development/compilers/zig/setup-hook.sh
+++ b/pkgs/development/compilers/zig/setup-hook.sh
@@ -1,5 +1,6 @@
 # shellcheck shell=bash disable=SC2154,SC2086
 
+# shellcheck disable=SC2034
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
 
 function zigSetGlobalCacheDir {
@@ -10,10 +11,9 @@ function zigSetGlobalCacheDir {
 function zigBuildPhase {
     runHook preBuild
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray
 
     echoCmd 'zig build flags' "${flagsArray[@]}"
     zig build "${flagsArray[@]}"
@@ -24,10 +24,9 @@ function zigBuildPhase {
 function zigCheckPhase {
     runHook preCheck
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigCheckFlags "${zigCheckFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigCheckFlags zigCheckFlagsArray
 
     echoCmd 'zig check flags' "${flagsArray[@]}"
     zig build test "${flagsArray[@]}"
@@ -38,11 +37,10 @@ function zigCheckPhase {
 function zigInstallPhase {
     runHook preInstall
 
-    local flagsArray=(
-        "${zigDefaultFlagsArray[@]}"
-        $zigBuildFlags "${zigBuildFlagsArray[@]}"
-        $zigInstallFlags "${zigInstallFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray zigDefaultFlagsArray \
+        zigBuildFlags zigBuildFlagsArray \
+        zigInstallFlags zigInstallFlagsArray
 
     if [ -z "${dontAddPrefix-}" ]; then
         # Zig does not recognize `--prefix=/dir/`, only `--prefix /dir/`

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -1,40 +1,36 @@
 . @fix_qmake_libtool@
 
-qmakeFlags=( ${qmakeFlags-} )
-
 qmakePrePhase() {
-    qmakeFlags_orig=( "${qmakeFlags[@]}" )
-
     # These flags must be added _before_ the flags specified in the derivation.
-    qmakeFlags=( \
-        "PREFIX=$out" \
-        "NIX_OUTPUT_OUT=$out" \
-        "NIX_OUTPUT_DEV=${!outputDev}" \
-        "NIX_OUTPUT_BIN=${!outputBin}" \
-        "NIX_OUTPUT_DOC=${!outputDev}/${qtDocPrefix:?}" \
-        "NIX_OUTPUT_QML=${!outputBin}/${qtQmlPrefix:?}" \
-        "NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?}" \
-    )
+    prependToVar qmakeFlags \
+      "PREFIX=$out" \
+      "NIX_OUTPUT_OUT=$out" \
+      "NIX_OUTPUT_DEV=${!outputDev}" \
+      "NIX_OUTPUT_BIN=${!outputBin}" \
+      "NIX_OUTPUT_DOC=${!outputDev}/${qtDocPrefix:?}" \
+      "NIX_OUTPUT_QML=${!outputBin}/${qtQmlPrefix:?}" \
+      "NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?}"
 
     if [ -n "@debug@" ]; then
-        qmakeFlags+=( "CONFIG+=debug" )
+        prependToVar qmakeFlags "CONFIG+=debug"
     else
-        qmakeFlags+=( "CONFIG+=release" )
+        prependToVar qmakeFlags "CONFIG+=release"
     fi
 
     # do the stripping ourselves (needed for separateDebugInfo)
-    qmakeFlags+=( "CONFIG+=nostrip" )
-
-    qmakeFlags+=( "${qmakeFlags_orig[@]}" )
+    prependToVar qmakeFlags "CONFIG+=nostrip"
 }
 prePhases+=" qmakePrePhase"
 
 qmakeConfigurePhase() {
     runHook preConfigure
 
+    local flagsArray=()
+    concatTo flagsArray qmakeFlags
+
     echo "QMAKEPATH=$QMAKEPATH"
-    echo qmake "${qmakeFlags[@]}"
-    qmake "${qmakeFlags[@]}"
+    echo qmake "${flagsArray[@]}"
+    qmake "${flagsArray[@]}"
 
     if ! [[ -v enableParallelBuilding ]]; then
         enableParallelBuilding=1

--- a/pkgs/development/libraries/qt-5/hooks/qttools-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qttools-setup-hook.sh
@@ -1,1 +1,1 @@
-qmakeFlags+=( "QMAKE_LRELEASE=@dev@/bin/lrelease" )
+appendToVar qmakeFlags "QMAKE_LRELEASE=@dev@/bin/lrelease"

--- a/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
@@ -1,33 +1,29 @@
 . @fix_qmake_libtool@
 
-qmakeFlags=(${qmakeFlags-})
-
 qmakePrePhase() {
-    qmakeFlags_orig=("${qmakeFlags[@]}")
-
     # These flags must be added _before_ the flags specified in the derivation.
     # TODO: these flags also need a patch which isn't applied
     # can we either remove these flags or update the qt5 patch?
     # "NIX_OUTPUT_DOC=${!outputDev}/${qtDocPrefix:?}" \
-    qmakeFlags=(
-        "PREFIX=$out"
-        "NIX_OUTPUT_OUT=$out"
-        "NIX_OUTPUT_DEV=${!outputDev}"
-        "NIX_OUTPUT_BIN=${!outputBin}"
-        "NIX_OUTPUT_QML=${!outputBin}/${qtQmlPrefix:?}"
-        "NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?}"
-    )
-
-    qmakeFlags+=("${qmakeFlags_orig[@]}")
+    prependToVar qmakeFlags \
+      "PREFIX=$out" \
+      "NIX_OUTPUT_OUT=$out" \
+      "NIX_OUTPUT_DEV=${!outputDev}" \
+      "NIX_OUTPUT_BIN=${!outputBin}" \
+      "NIX_OUTPUT_QML=${!outputBin}/${qtQmlPrefix:?}" \
+      "NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?}"
 }
 prePhases+=" qmakePrePhase"
 
 qmakeConfigurePhase() {
     runHook preConfigure
 
+    local flagsArray=()
+    concatTo flagsArray qmakeFlags
+
     echo "QMAKEPATH=$QMAKEPATH"
-    echo qmake "${qmakeFlags[@]}"
-    qmake "${qmakeFlags[@]}"
+    echo qmake "${flagsArray[@]}"
+    qmake "${flagsArray[@]}"
 
     if ! [[ -v enableParallelBuilding ]]; then
         enableParallelBuilding=1

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -23,7 +23,10 @@ preConfigure() {
         fi
     done
 
-    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
+    local flagsArray=()
+    concatTo flagsArray makeMakerFlags
+
+    perl Makefile.PL PREFIX=$out INSTALLDIRS=site "${flagsArray[@]}" PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
 }
 
 if test -n "$perlPreHook"; then

--- a/pkgs/development/tools/build-managers/build2/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/build2/setup-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 build2ConfigurePhase() {
     runHook preConfigure
 
@@ -19,6 +21,7 @@ build2ConfigurePhase() {
     )
     concatTo flagsArray build2ConfigureFlags build2ConfigureFlagsArray
 
+    # shellcheck disable=SC2157
     if [ -n "@isTargetDarwin@" ]; then
         flagsArray+=("config.bin.ld=ld64-lld")
         flagsArray+=("config.cc.loptions+=-fuse-ld=lld")
@@ -52,7 +55,7 @@ build2CheckPhase() {
 
     echo 'check flags' "${flagsArray[@]}"
 
-    b test ${build2Dir:-.} "${flagsArray[@]}"
+    b test "${build2Dir:-.}" "${flagsArray[@]}"
 
     runHook postCheck
 }
@@ -69,19 +72,20 @@ build2InstallPhase() {
     runHook postInstall
 }
 
-if [ -z "${dontUseBuild2Configure-}" -a -z "${configurePhase-}" ]; then
+if [ -z "${dontUseBuild2Configure-}" ] && [ -z "${configurePhase-}" ]; then
+    # shellcheck disable=SC2034
     setOutputFlags=
     configurePhase=build2ConfigurePhase
 fi
 
-if [ -z "${dontUseBuild2Build-}" -a -z "${buildPhase-}" ]; then
+if [ -z "${dontUseBuild2Build-}" ] && [ -z "${buildPhase-}" ]; then
     buildPhase=build2BuildPhase
 fi
 
-if [ -z "${dontUseBuild2Check-}" -a -z "${checkPhase-}" ]; then
+if [ -z "${dontUseBuild2Check-}" ] && [ -z "${checkPhase-}" ]; then
     checkPhase=build2CheckPhase
 fi
 
-if [ -z "${dontUseBuild2Install-}" -a -z "${installPhase-}" ]; then
+if [ -z "${dontUseBuild2Install-}" ] && [ -z "${installPhase-}" ]; then
     installPhase=build2InstallPhase
 fi

--- a/pkgs/development/tools/build-managers/build2/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/build2/setup-hook.sh
@@ -16,8 +16,8 @@ build2ConfigurePhase() {
         "config.install.man=${!outputDoc}/share/man"
         "config.install.sbin=${!outputBin}/sbin"
         "config.install.bin.mode=755"
-        $build2ConfigureFlags "${build2ConfigureFlagsArray[@]}"
     )
+    concatTo flagsArray build2ConfigureFlags build2ConfigureFlagsArray
 
     if [ -n "@isTargetDarwin@" ]; then
         flagsArray+=("config.bin.ld=ld64-lld")
@@ -35,9 +35,8 @@ build2ConfigurePhase() {
 build2BuildPhase() {
     runHook preBuild
 
-    local flagsArray=(
-        $build2BuildFlags "${build2BuildFlagsArray[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray build2BuildFlags build2BuildFlagsArray
 
     echo 'build flags' "${flagsArray[@]}"
     b "${flagsArray[@]}"
@@ -48,9 +47,8 @@ build2BuildPhase() {
 build2CheckPhase() {
     runHook preCheck
 
-    local flagsArray=(
-        $build2CheckFlags "${build2CheckFlags[@]}"
-    )
+    local flagsArray=()
+    concatTo flagsArray build2CheckFlags build2CheckFlags
 
     echo 'check flags' "${flagsArray[@]}"
 
@@ -62,10 +60,8 @@ build2CheckPhase() {
 build2InstallPhase() {
     runHook preInstall
 
-    local flagsArray=(
-        $build2InstallFlags "${build2InstallFlagsArray[@]}"
-        ${installTargets:-}
-    )
+    local flagsArray=()
+    concatTo flagsArray build2InstallFlags build2InstallFlagsArray installTargets
 
     echo 'install flags' "${flagsArray[@]}"
     b install "${flagsArray[@]}"

--- a/pkgs/development/tools/build-managers/gn/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/gn/setup-hook.sh
@@ -1,9 +1,12 @@
 gnConfigurePhase() {
     runHook preConfigure
 
-    echo "gn flags: $gnFlags ${gnFlagsArray[@]}"
+    local flagsArray=()
+    concatTo flagsArray gnFlags gnFlagsArray
 
-    gn gen out/Release --args="$gnFlags ${gnFlagsArray[@]}"
+    echoCmd 'gn flags' "${flagsArray[@]}"
+
+    gn gen out/Release --args="${flagsArray[*]}"
     cd out/Release/
 
     runHook postConfigure

--- a/pkgs/development/tools/build-managers/gn/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/gn/setup-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 gnConfigurePhase() {
     runHook preConfigure
 
@@ -7,11 +9,12 @@ gnConfigurePhase() {
     echoCmd 'gn flags' "${flagsArray[@]}"
 
     gn gen out/Release --args="${flagsArray[*]}"
+    # shellcheck disable=SC2164
     cd out/Release/
 
     runHook postConfigure
 }
 
-if [ -z "${dontUseGnConfigure-}" -a -z "${configurePhase-}" ]; then
+if [ -z "${dontUseGnConfigure-}" ] && [ -z "${configurePhase-}" ]; then
     configurePhase=gnConfigurePhase
 fi

--- a/pkgs/development/tools/misc/premake/setup-hook.sh
+++ b/pkgs/development/tools/misc/premake/setup-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 premakeConfigurePhase() {
     runHook preConfigure
 

--- a/pkgs/development/tools/misc/premake/setup-hook.sh
+++ b/pkgs/development/tools/misc/premake/setup-hook.sh
@@ -3,9 +3,8 @@ premakeConfigurePhase() {
 
     local flagsArray=(
         ${premakefile:+--file=$premakefile}
-        $premakeFlags ${premakeFlagsArray[@]}
-        ${premakeBackend:-gmake}
     )
+    concatTo flagsArray premakeFlags premakeFlagsArray premakeBackend=gmake
 
     echoCmd 'configure flags' "${flagsArray[@]}"
 

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -109,21 +109,30 @@ let
           declare -A associativeArray=(["X"]="Y")
           [[ $(concatTo nowhere associativeArray 2>&1) =~ "trying to use" ]] || (echo "concatTo did not throw concatenating associativeArray" && false)
 
+          empty_array=()
+          empty_string=""
+
           declare -a flagsArray
-          concatTo flagsArray string list
+          concatTo flagsArray string list notset=e=f empty_array=g empty_string=h
           declare -p flagsArray
           [[ "''${flagsArray[0]}" == "a" ]] || (echo "'\$flagsArray[0]' was not 'a'" && false)
           [[ "''${flagsArray[1]}" == "b" ]] || (echo "'\$flagsArray[1]' was not 'b'" && false)
           [[ "''${flagsArray[2]}" == "c" ]] || (echo "'\$flagsArray[2]' was not 'c'" && false)
           [[ "''${flagsArray[3]}" == "d" ]] || (echo "'\$flagsArray[3]' was not 'd'" && false)
+          [[ "''${flagsArray[4]}" == "e=f" ]] || (echo "'\$flagsArray[4]' was not 'e=f'" && false)
+          [[ "''${flagsArray[5]}" == "g" ]] || (echo "'\$flagsArray[5]' was not 'g'" && false)
+          [[ "''${flagsArray[6]}" == "h" ]] || (echo "'\$flagsArray[6]' was not 'h'" && false)
 
           # test concatenating to unset variable
-          concatTo nonExistant string list
+          concatTo nonExistant string list notset=e=f empty_array=g empty_string=h
           declare -p nonExistant
           [[ "''${nonExistant[0]}" == "a" ]] || (echo "'\$nonExistant[0]' was not 'a'" && false)
           [[ "''${nonExistant[1]}" == "b" ]] || (echo "'\$nonExistant[1]' was not 'b'" && false)
           [[ "''${nonExistant[2]}" == "c" ]] || (echo "'\$nonExistant[2]' was not 'c'" && false)
           [[ "''${nonExistant[3]}" == "d" ]] || (echo "'\$nonExistant[3]' was not 'd'" && false)
+          [[ "''${nonExistant[4]}" == "e=f" ]] || (echo "'\$nonExistant[4]' was not 'e=f'" && false)
+          [[ "''${nonExistant[5]}" == "g" ]] || (echo "'\$nonExistant[5]' was not 'g'" && false)
+          [[ "''${nonExistant[6]}" == "h" ]] || (echo "'\$nonExistant[6]' was not 'h'" && false)
 
           eval "$extraTest"
 


### PR DESCRIPTION
## Description of changes

This is a follow up to #318614, which had a lot more commits initially. After merging the basic changes for stdenv's appendTo, prependTo and new concatTo functions there, I now come back to apply those in more setup hooks.

I intentionally only took a part of long tail of commits I still have for this, so there will be more after this PR. All commits in this PR have one thing in common: I was able to test each of them by building the respective package mentioned in the commit message with `__structuredAttrs` turned on, similar to how I did it in #318614: The build for this package would fail on master, but succeed on this branch.

For some of the other setup hooks it's not that easy to find examples in nixpkgs, which actually fail with structuredAttrs turned on, so hard to prove the fix works. Thus I left them out for the moment and will bring them back once we have merged this set of changes, increasing the confidence in the general pattern of how the transition to `concatTo` works.

CC @emilazy @philiptaron @SomeoneSerge @tie 

Since the changed setup hooks won't trigger ofborg to mention the maintainers:
- bmake: @thoughtpolice @AndersonTorres 
- just: @xrelkd @06kellyjac 
- waf: @AndersonTorres 
- zig: @andrewrk @figsoda 
- build2: @vale981 @r-burns 
- scons: @AndersonTorres 
- premake: @bjornfor 
- gn: @stesie @matthewbauer @primeos 
- qt5: @qknight @ttuegel @periklis @bkchr 
- qt6: @milahu @NickCao 
- perl: @edolstra 

Quick recap for those not involved in #318614: That PR added a new function `concatTo` to allow merging of flags arrays / lists in either string or bash array format. Together with the already existing `appendTo` and `prependTo`, this allows to transparently support both building with and without `structuredAttrs` turned on, **without** putting checks whether structuredAttrs are enabled or not all over nixpkgs.

Making all the setup hooks support structuredAttrs is the first step to making this the default eventually.

## Things done

Of course I built the respective packages themselves - but since the setup hook is not a part of the derivation, those still work. As mentioned above, I built another package for each of the setup hooks, which uses that hook in the build process.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
