### PR TITLE
gitea: fix passthru.data-compressed

### DIFF
--- a/pkgs/build-support/compress-drv/default.nix
+++ b/pkgs/build-support/compress-drv/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  xorg,
-  runCommand,
-}:
+{ lib, runCommand }:
 /**
   Compresses files of a given derivation, and returns a new derivation with
   compressed files
@@ -72,7 +68,11 @@ let
 in
 runCommand "${drv.name}-compressed" { } ''
   mkdir $out
-  (cd $out; ${xorg.lndir}/bin/lndir ${drv})
+
+  # cannot use lndir here, because it also symlinks directories,
+  # which we do not need; we only need to symlink files.
+  (cd ${drv}; find -L -type d -exec mkdir -p $out/{} ';')
+  (cd ${drv}; find -L -type f -exec ln -s ${drv}/{} $out/{} ';')
 
   ${lib.concatStringsSep "\n\n" (lib.mapAttrsToList mkCmd compressors)}
 ''

--- a/pkgs/by-name/gi/gitea/package.nix
+++ b/pkgs/by-name/gi/gitea/package.nix
@@ -88,7 +88,7 @@ in buildGoModule rec {
   '';
 
   passthru = {
-    data-compressed = lib.warn "gitea.passthru.data-compressed is deprecated. Use \"compressDrvWeb gitea.data\"." (compressDrvWeb gitea.data);
+    data-compressed = lib.warn "gitea.passthru.data-compressed is deprecated. Use \"compressDrvWeb gitea.data\"." (compressDrvWeb gitea.data {});
 
     tests = nixosTests.gitea;
   };


### PR DESCRIPTION
Fixes two bugs:
- pass a forgotten `{}` to `compressDrv`.
- remove incorrect usage of `lndir` in `compressDrv`. I added a brief comment on why, see [this comment][1] for more details.

Tested with:

```
$ nix build .#legacyPackages.x86_64-linux.gitea.passthru.data-compressed
$ ls -lh result/public/assets/licenses.txt*
lrwxrwxrwx 1 root root  90 Jan  1  1970 result/public/assets/licenses.txt -> /nix/store/p21irsr57hckd3x3ym18aa0cr9zmm3an-gitea-1.22.1-data/./public/assets/licenses.txt
-r--r--r-- 1 root root 30K Jan  1  1970 result/public/assets/licenses.txt.br
-r--r--r-- 1 root root 82K Jan  1  1970 result/public/assets/licenses.txt.gz
```

[1]: https://github.com/NixOS/nixpkgs/pull/332752#discussion_r1721043286

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
