### PR TITLE
nixosTest.nix-upgrade: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -672,6 +672,7 @@ in {
   nix-config = handleTest ./nix-config.nix {};
   nix-ld = handleTest ./nix-ld.nix {};
   nix-misc = handleTest ./nix/misc.nix {};
+  nix-upgrade = handleTest ./nix/upgrade.nix {inherit (pkgs) nixVersions;};
   nix-required-mounts = runTest ./nix-required-mounts;
   nix-serve = handleTest ./nix-serve.nix {};
   nix-serve-ssh = handleTest ./nix-serve-ssh.nix {};

--- a/nixos/tests/nix/upgrade.nix
+++ b/nixos/tests/nix/upgrade.nix
@@ -8,12 +8,13 @@ let
     }'';
 
   inputDrv = import ../.. {
-    configuration =
-      {
-        imports = [ nixos-module ];
-        nix.package = nixVersions.latest;
-        boot.isContainer = true;
-      };
+    configuration = {
+      imports = [ nixos-module ];
+      nix.package = nixVersions.latest;
+      boot.isContainer = true;
+
+      users.users.alice.isNormalUser = true;
+    };
     system = pkgs.system;
   };
 
@@ -76,7 +77,7 @@ pkgs.testers.nixosTest {
         if not match: raise Exception("Couldn't find new version in output: " + result)
 
     with subtest("nix-build-with-mismatch-daemon"):
-        machine.succeed("nix build --expr 'derivation {name =\"test\"; system = \"${pkgs.system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
+        machine.succeed("runuser -u alice -- nix build --expr 'derivation {name =\"test\"; system = \"${pkgs.system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
 
 
     with subtest("remove-new-nix"):
@@ -99,6 +100,6 @@ pkgs.testers.nixosTest {
         if not match: raise Exception("Couldn't find new version in output: " + result)
 
     with subtest("nix-build-with-new-daemon"):
-        machine.succeed("nix build --expr 'derivation {name =\"test-new\"; system = \"${pkgs.system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
+        machine.succeed("runuser -u alice -- nix build --expr 'derivation {name =\"test-new\"; system = \"${pkgs.system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
   '';
 }

--- a/nixos/tests/nix/upgrade.nix
+++ b/nixos/tests/nix/upgrade.nix
@@ -101,5 +101,8 @@ pkgs.testers.nixosTest {
 
     with subtest("nix-build-with-new-daemon"):
         machine.succeed("runuser -u alice -- nix build --expr 'derivation {name =\"test-new\"; system = \"${pkgs.system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
+
+    with subtest("nix-collect-garbage-with-old-nix"):
+        machine.succeed("${nixVersions.stable}/bin/nix-collect-garbage")
   '';
 }

--- a/nixos/tests/nix/upgrade.nix
+++ b/nixos/tests/nix/upgrade.nix
@@ -1,0 +1,104 @@
+{ pkgs, nixVersions, ... }:
+let
+  lib = pkgs.lib;
+
+  fallback-paths-external = pkgs.writeTextDir "fallback-paths.nix" ''
+    {
+      ${pkgs.system} = "${nixVersions.latest}";
+    }'';
+
+  inputDrv = import ../.. {
+    configuration =
+      {
+        imports = [ nixos-module ];
+        nix.package = nixVersions.latest;
+        boot.isContainer = true;
+      };
+    system = pkgs.system;
+  };
+
+  nixos-module = builtins.toFile "nixos-module.nix" ''
+    { lib, pkgs, modulesPath, ... }:
+    {
+      imports = [
+        (modulesPath + "/profiles/minimal.nix")
+        (modulesPath + "/testing/test-instrumentation.nix")
+      ];
+
+      hardware.enableAllFirmware = lib.mkForce false;
+
+      nix.settings.substituters = lib.mkForce [];
+      nix.settings.hashed-mirrors = null;
+      nix.settings.connect-timeout = 1;
+      nix.extraOptions = "experimental-features = nix-command";
+
+      environment.localBinInPath = true;
+      users.users.alice = {
+        isNormalUser = true;
+        packages = [ pkgs.nixVersions.latest ];
+      };
+      documentation.enable = false;
+    }
+  '';
+in
+
+pkgs.testers.nixosTest {
+  name = "nix-upgrade-${nixVersions.stable.version}-${nixVersions.latest.version}";
+  meta.maintainers = with lib.maintainers; [ tomberek ];
+
+  nodes.machine = {
+    imports = [ nixos-module ];
+
+    nix.package = nixVersions.stable;
+    system.extraDependencies = [
+      fallback-paths-external
+      inputDrv.system
+    ];
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("nix-current"):
+        # Create a profile to pretend we are on non-NixOS
+
+        print(machine.succeed("nix --version"))
+        print(machine.succeed("nix-env -i /run/current-system/sw/bin/nix -p /root/.local"))
+
+    with subtest("nix-upgrade"):
+        print(machine.succeed("nix upgrade-nix --nix-store-paths-url file://${fallback-paths-external}/fallback-paths.nix --profile /root/.local"))
+        result = machine.succeed("nix --version")
+        print(result)
+
+        import re
+        match = re.match(r".*${nixVersions.latest.version}$",result)
+        if not match: raise Exception("Couldn't find new version in output: " + result)
+
+    with subtest("nix-build-with-mismatch-daemon"):
+        machine.succeed("nix build --expr 'derivation {name =\"test\"; system = \"${pkgs.system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
+
+
+    with subtest("remove-new-nix"):
+        machine.succeed("rm -rf /root/.local")
+
+        result = machine.succeed("nix --version")
+        print(result)
+
+        import re
+        match = re.match(r".*${nixVersions.stable.version}$",result)
+
+    with subtest("upgrade-via-switch-to-configuration"):
+        # not using nixos-rebuild due to nix-instantiate being called and forcing all drv's to be rebuilt
+        print(machine.succeed("${inputDrv.system.outPath}/bin/switch-to-configuration switch"))
+        result = machine.succeed("nix --version")
+        print(result)
+
+        import re
+        match = re.match(r".*${nixVersions.latest.version}$",result)
+        if not match: raise Exception("Couldn't find new version in output: " + result)
+
+    with subtest("nix-build-with-new-daemon"):
+        machine.succeed("nix build --expr 'derivation {name =\"test-new\"; system = \"${pkgs.system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
+  '';
+}

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -65,6 +65,7 @@ in
 , mdbook-linkcheck
 , nlohmann_json
 , nixosTests
+, nixVersions
 , openssl
 , perl
 , pkg-config
@@ -260,6 +261,7 @@ self = stdenv.mkDerivation {
       # Basic smoke test that needs to pass when upgrading nix.
       # Note that this test does only test the nixVersions.stable attribute.
       misc = nixosTests.nix-misc.default;
+      upgrade = nixosTests.nix-upgrade;
 
       srcVersion = runCommand "nix-src-version" {
         inherit version;


### PR DESCRIPTION
Test out both nix upgrade-nix and a NixOS upgrade.

Inject a fake fallback-paths.nix assuming a stable -> latest upgrade.

The NixOS upgrade does not use nixos-rebuild switch due to the cost+annoyance of the instantiation needing
system.includeBuildDependencies.

@Mic92 

@RossComputerGuy (I removed the includeBuildDependencies and call the activation directly instead of using nixos-rebuild)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
