### PR TITLE
hatch: fix tests on Darwin

### DIFF
--- a/pkgs/by-name/ha/hatch/package.nix
+++ b/pkgs/by-name/ha/hatch/package.nix
@@ -4,6 +4,7 @@
 , python3
 , cargo
 , git
+, ps
 , uv
 }:
 
@@ -50,7 +51,7 @@ python3.pkgs.buildPythonApplication rec {
     pytest-mock
     pytest-xdist
     setuptools
-  ]);
+  ]) ++ lib.optionals stdenv.isDarwin [ ps ];
 
   preCheck = ''
     export HOME=$(mktemp -d);


### PR DESCRIPTION
I still get 49 failures like the following.
```
___________________________ TestFilters.test_python ____________________________
[gw6] darwin -- Python 3.12.4 /nix/store/xnm9sbp02pp2704dvx4kb8g0yxn263pn-python3-3.12.4/bin/python3.12

self = <tests.cli.test.test_test.TestFilters object at 0x10a745f70>
hatch = <tests.conftest.CliRunner object at 0x109fa6ab0>
temp_dir = Path('/private/tmp/nix-build-hatch-1.12.0.drv-0/tmpitkbokcn')
config_file = <hatch.config.user.ConfigFile object at 0x109bffe00>
helpers = <module 'tests.helpers.helpers' from '/private/tmp/nix-build-hatch-1.12.0.drv-0/hatch-1.12.0/tests/helpers/helpers.py'>
env_run = <MagicMock name='run' id='4458529184'>
mocker = <pytest_mock.plugin.MockerFixture object at 0x109bfc0e0>

    def test_python(self, hatch, temp_dir, config_file, helpers, env_run, mocker):
        config_file.model.template.plugins['default']['tests'] = False
        config_file.save()
    
        project_name = 'My.App'
    
        with temp_dir.as_cwd():
            result = hatch('new', project_name)
    
        assert result.exit_code == 0, result.output
    
        project_path = temp_dir / 'my-app'
        data_path = temp_dir / 'data'
        data_path.mkdir()
    
        project = Project(project_path)
        config = dict(project.raw_config)
        config['tool']['hatch']['envs'] = {
            'hatch-test': {
                'matrix': [{'python': ['3.12', '3.10', '3.8']}],
                'scripts': {
                    'run': 'test {env_name}',
                    'run-cov': 'test with coverage',
                    'cov-combine': 'combine coverage',
                    'cov-report': 'show coverage',
                },
            }
        }
        project.save_config(config)
    
        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
            result = hatch('test', '-py', '3.10')
    
        assert result.exit_code == 0, result.output
        assert result.output == helpers.dedent(
            """
            ──────────────────────────────────────── hatch-test.py3.10 ─────────────────────────────────────────
            """
        )
    
>       assert env_run.call_args_list == [
            mocker.call('test hatch-test.py3.10', shell=True),
        ]
E       AssertionError: assert [call('test h...2p32/bin/sh')] == [call('test h..., shell=True)]
E         
E         At index 0 diff: call('test hatch-test.py3.10', shell=True, executable='/nix/store/b34ianga4diikh0kymkpqwmvba0mmzf7-bash-5.2p32/bin/sh') != call('test hatch-test.py3.10', shell=True)
E         Use -v to get more diff

/private/tmp/nix-build-hatch-1.12.0.drv-0/hatch-1.12.0/tests/cli/test/test_test.py:1080: AssertionError
```
Any idea?

## Description of changes
fixes https://github.com/NixOS/nixpkgs/issues/335561
cc @zubieta
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
