### PR TITLE
cmake: setup-hook.sh: split out `cmakeDefaultFlags`

### DIFF
--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -37,37 +37,7 @@ cmakeConfigurePhase() {
         : ${cmakeDir:=.}
     fi
 
-    if [ -z "${dontAddPrefix-}" ]; then
-        prependToVar cmakeFlags "-DCMAKE_INSTALL_PREFIX=$prefix"
-    fi
-
-    # We should set the proper `CMAKE_SYSTEM_NAME`.
-    # http://www.cmake.org/Wiki/CMake_Cross_Compiling
-    #
-    # Unfortunately cmake seems to expect absolute paths for ar, ranlib, and
-    # strip. Otherwise they are taken to be relative to the source root of the
-    # package being built.
-    prependToVar cmakeFlags "-DCMAKE_CXX_COMPILER=$CXX"
-    prependToVar cmakeFlags "-DCMAKE_C_COMPILER=$CC"
-    prependToVar cmakeFlags "-DCMAKE_AR=$(command -v $AR)"
-    prependToVar cmakeFlags "-DCMAKE_RANLIB=$(command -v $RANLIB)"
-    prependToVar cmakeFlags "-DCMAKE_STRIP=$(command -v $STRIP)"
-
-    # on macOS we want to prefer Unix-style headers to Frameworks
-    # because we usually do not package the framework
-    prependToVar cmakeFlags "-DCMAKE_FIND_FRAMEWORK=LAST"
-
-    # correctly detect our clang compiler
-    prependToVar cmakeFlags "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
-
-    # This installs shared libraries with a fully-specified install
-    # name. By default, cmake installs shared libraries with just the
-    # basename as the install name, which means that, on Darwin, they
-    # can only be found by an executable at runtime if the shared
-    # libraries are in a system path or in the same directory as the
-    # executable. This flag makes the shared library accessible from its
-    # nix/store directory.
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_NAME_DIR=${!outputLib}/lib"
+    declare -ga cmakeDefaultFlags=()
 
     # The docdir flag needs to include PROJECT_NAME as per GNU guidelines,
     # try to extract it from CMakeLists.txt.
@@ -87,40 +57,74 @@ cmakeConfigurePhase() {
         fi
     fi
 
-    # This ensures correct paths with multiple output derivations
-    # It requires the project to use variables from GNUInstallDirs module
-    # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_BINDIR=${!outputBin}/bin"
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_SBINDIR=${!outputBin}/sbin"
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_INCLUDEDIR=${!outputInclude}/include"
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_MANDIR=${!outputMan}/share/man"
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_INFODIR=${!outputInfo}/share/info"
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName}"
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_LIBDIR=${!outputLib}/lib"
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_LIBEXECDIR=${!outputLib}/libexec"
-    prependToVar cmakeFlags "-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale"
+    cmakeDefaultFlags+=(
+        # We should set the proper `CMAKE_SYSTEM_NAME`.
+        # http://www.cmake.org/Wiki/CMake_Cross_Compiling
+        #
+        # Unfortunately cmake seems to expect absolute paths for ar, ranlib, and
+        # strip. Otherwise they are taken to be relative to the source root of the
+        # package being built.
+        "-DCMAKE_CXX_COMPILER=$CXX"
+        "-DCMAKE_C_COMPILER=$CC"
+        "-DCMAKE_AR=$(command -v $AR)"
+        "-DCMAKE_RANLIB=$(command -v $RANLIB)"
+        "-DCMAKE_STRIP=$(command -v $STRIP)"
+
+        # on macOS we want to prefer Unix-style headers to Frameworks
+        # because we usually do not package the framework
+        "-DCMAKE_FIND_FRAMEWORK=LAST"
+
+        # correctly detect our clang compiler
+        "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
+
+        # This installs shared libraries with a fully-specified install
+        # name. By default, cmake installs shared libraries with just the
+        # basename as the install name, which means that, on Darwin, they
+        # can only be found by an executable at runtime if the shared
+        # libraries are in a system path or in the same directory as the
+        # executable. This flag makes the shared library accessible from its
+        # nix/store directory.
+        "-DCMAKE_INSTALL_NAME_DIR=${!outputLib}/lib"
+
+        # This ensures correct paths with multiple output derivations
+        # It requires the project to use variables from GNUInstallDirs module
+        # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+        "-DCMAKE_INSTALL_BINDIR=${!outputBin}/bin"
+        "-DCMAKE_INSTALL_SBINDIR=${!outputBin}/sbin"
+        "-DCMAKE_INSTALL_INCLUDEDIR=${!outputInclude}/include"
+        "-DCMAKE_INSTALL_MANDIR=${!outputMan}/share/man"
+        "-DCMAKE_INSTALL_INFODIR=${!outputInfo}/share/info"
+        "-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName}"
+        "-DCMAKE_INSTALL_LIBDIR=${!outputLib}/lib"
+        "-DCMAKE_INSTALL_LIBEXECDIR=${!outputLib}/libexec"
+        "-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale"
+
+        # Always build Release, to ensure optimisation flags
+        "-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release}"
+
+        # Disable user package registry to avoid potential side effects
+        # and unecessary attempts to access non-existent home folder
+        # https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#disabling-the-package-registry
+        "-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON"
+        "-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF"
+        "-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF"
+    )
+
+    if [ -z "${dontAddPrefix-}" ]; then
+        cmakeDefaultFlags+=("-DCMAKE_INSTALL_PREFIX=$prefix")
+    fi
 
     # Don’t build tests when doCheck = false
     if [ -z "${doCheck-}" ]; then
-        prependToVar cmakeFlags "-DBUILD_TESTING=OFF"
+        cmakeDefaultFlags+=("-DBUILD_TESTING=OFF")
     fi
 
-    # Always build Release, to ensure optimisation flags
-    prependToVar cmakeFlags "-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release}"
-
-    # Disable user package registry to avoid potential side effects
-    # and unecessary attempts to access non-existent home folder
-    # https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#disabling-the-package-registry
-    prependToVar cmakeFlags "-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON"
-    prependToVar cmakeFlags "-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF"
-    prependToVar cmakeFlags "-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF"
-
     if [ "${buildPhase-}" = ninjaBuildPhase ]; then
-        prependToVar cmakeFlags "-GNinja"
+        cmakeDefaultFlags+=("-GNinja")
     fi
 
     local flagsArray=()
-    concatTo flagsArray cmakeFlags cmakeFlagsArray
+    concatTo flagsArray cmakeDefaultFlags cmakeFlags cmakeFlagsArray
 
     echoCmd 'cmake flags' "${flagsArray[@]}"
 

--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -9,7 +9,7 @@ fixCmakeFiles() {
     echo "fixing cmake files..."
     find "$1" -type f \( -name "*.cmake" -o -name "*.cmake.in" -o -name CMakeLists.txt \) -print |
         while read fn; do
-            sed -e 's^/usr\([ /]\|$\)^/var/empty\1^g' -e 's^/opt\([ /]\|$\)^/var/empty\1^g' < "$fn" > "$fn.tmp"
+            sed -e 's^/usr\([ /]\|$\)^/var/empty\1^g' -e 's^/opt\([ /]\|$\)^/var/empty\1^g' <"$fn" >"$fn.tmp"
             mv "$fn.tmp" "$fn"
         done
 }
@@ -74,7 +74,7 @@ cmakeConfigurePhase() {
     if [[ -z "$shareDocName" ]]; then
         local cmakeLists="${cmakeDir}/CMakeLists.txt"
         if [[ -f "$cmakeLists" ]]; then
-            local shareDocName="$(grep --only-matching --perl-regexp --ignore-case '\bproject\s*\(\s*"?\K([^[:space:]")]+)' < "$cmakeLists" | head -n1)"
+            local shareDocName="$(grep --only-matching --perl-regexp --ignore-case '\bproject\s*\(\s*"?\K([^[:space:]")]+)' <"$cmakeLists" | head -n1)"
         fi
         # The argument sometimes contains garbage or variable interpolation.
         # When that is the case, let’s fall back to the derivation name.


### PR DESCRIPTION
## Description of changes

This PR extracts the default CMake flags pretending code into its own Bash function `genCmakeDefaultFlags()`. Instead of pretending the flags to `cmakeFlags`, it collects them into a global Bash array `cmakeDefaultFlags`.

Original discussions:
https://github.com/NixOS/nixpkgs/pull/318614#issuecomment-2214801613
https://github.com/NixOS/nixpkgs/pull/299622#issuecomment-2295022373

Cc: @AndersonTorres @jtojnar @wolfgangwalther

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (built `cmakeMinimal`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
