### PR TITLE
cmake: lint setuphooks with ShellCheck

### DIFF
--- a/pkgs/by-name/cm/cmake/check-pc-files-hook.sh
+++ b/pkgs/by-name/cm/cmake/check-pc-files-hook.sh
@@ -1,3 +1,11 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2016
+
+# shellcheck source=../../../stdenv/generic/setup.sh
+source /dev/null
+# shellcheck source=../../../build-support/setup-hooks/multiple-outputs.sh
+source /dev/null
+
 cmakePcfileCheckPhase() {
     while IFS= read -rd $'\0' file; do
         grepout=$(grep --line-number '}//nix/store' "$file" || true)

--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -1,14 +1,21 @@
+# shellcheck shell=bash
+
+# shellcheck source=../../../stdenv/generic/setup.sh
+source /dev/null
+# shellcheck source=../../../build-support/setup-hooks/multiple-outputs.sh
+source /dev/null
+
 addCMakeParams() {
     # NIXPKGS_CMAKE_PREFIX_PATH is like CMAKE_PREFIX_PATH except cmake
     # will not search it for programs
-    addToSearchPath NIXPKGS_CMAKE_PREFIX_PATH $1
+    addToSearchPath NIXPKGS_CMAKE_PREFIX_PATH "$1"
 }
 
 fixCmakeFiles() {
     # Replace occurences of /usr and /opt by /var/empty.
     echo "fixing cmake files..."
     find "$1" -type f \( -name "*.cmake" -o -name "*.cmake.in" -o -name CMakeLists.txt \) -print |
-        while read fn; do
+        while read -r fn; do
             sed -e 's^/usr\([ /]\|$\)^/var/empty\1^g' -e 's^/opt\([ /]\|$\)^/var/empty\1^g' < "$fn" > "$fn.tmp"
             mv "$fn.tmp" "$fn"
         done
@@ -18,26 +25,26 @@ cmakeConfigurePhase() {
     runHook preConfigure
 
     # default to CMake defaults if unset
-    : ${cmakeBuildDir:=build}
+    : "${cmakeBuildDir:=build}"
 
     export CTEST_OUTPUT_ON_FAILURE=1
-    if [ -n "${enableParallelChecking-1}" ]; then
+    if [[ -n "${enableParallelChecking-1}" ]]; then
         export CTEST_PARALLEL_LEVEL=$NIX_BUILD_CORES
     fi
 
-    if [ -z "${dontFixCmake-}" ]; then
+    if [[ -z "${dontFixCmake-}" ]]; then
         fixCmakeFiles .
     fi
 
-    if [ -z "${dontUseCmakeBuildDir-}" ]; then
+    if [[ -z "${dontUseCmakeBuildDir-}" ]]; then
         mkdir -p "$cmakeBuildDir"
-        cd "$cmakeBuildDir"
-        : ${cmakeDir:=..}
+        cd "$cmakeBuildDir" || return 1
+        : "${cmakeDir:=..}"
     else
-        : ${cmakeDir:=.}
+        : "${cmakeDir:=.}"
     fi
 
-    if [ -z "${dontAddPrefix-}" ]; then
+    if [[ -z "${dontAddPrefix-}" ]]; then
         prependToVar cmakeFlags "-DCMAKE_INSTALL_PREFIX=$prefix"
     fi
 
@@ -49,9 +56,9 @@ cmakeConfigurePhase() {
     # package being built.
     prependToVar cmakeFlags "-DCMAKE_CXX_COMPILER=$CXX"
     prependToVar cmakeFlags "-DCMAKE_C_COMPILER=$CC"
-    prependToVar cmakeFlags "-DCMAKE_AR=$(command -v $AR)"
-    prependToVar cmakeFlags "-DCMAKE_RANLIB=$(command -v $RANLIB)"
-    prependToVar cmakeFlags "-DCMAKE_STRIP=$(command -v $STRIP)"
+    prependToVar cmakeFlags "-DCMAKE_AR=$(command -v "$AR")"
+    prependToVar cmakeFlags "-DCMAKE_RANLIB=$(command -v "$RANLIB")"
+    prependToVar cmakeFlags "-DCMAKE_STRIP=$(command -v "$STRIP")"
 
     # on macOS we want to prefer Unix-style headers to Frameworks
     # because we usually do not package the framework
@@ -77,7 +84,8 @@ cmakeConfigurePhase() {
     if [[ -z "$shareDocName" ]]; then
         local cmakeLists="${cmakeDir}/CMakeLists.txt"
         if [[ -f "$cmakeLists" ]]; then
-            local shareDocName="$(grep --only-matching --perl-regexp --ignore-case '\bproject\s*\(\s*"?\K([^[:space:]")]+)' < "$cmakeLists" | head -n1)"
+            local shareDocName
+            shareDocName="$(grep --only-matching --perl-regexp --ignore-case '\bproject\s*\(\s*"?\K([^[:space:]")]+)' < "$cmakeLists" | head -n1)"
         fi
         # The argument sometimes contains garbage or variable interpolation.
         # When that is the case, let’s fall back to the derivation name.
@@ -85,6 +93,7 @@ cmakeConfigurePhase() {
             if [[ -n "${pname-}" ]]; then
                 shareDocName="$pname"
             else
+                # shellcheck disable=SC2001
                 shareDocName="$(echo "$name" | sed 's/-[^a-zA-Z].*//')"
             fi
         fi
@@ -105,7 +114,7 @@ cmakeConfigurePhase() {
     prependToVar cmakeFlags "-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale"
 
     # Don’t build tests when doCheck = false
-    if [ -z "${doCheck-}" ]; then
+    if [[ -z "${doCheck-}" ]]; then
         prependToVar cmakeFlags "-DBUILD_TESTING=OFF"
     fi
 
@@ -119,7 +128,7 @@ cmakeConfigurePhase() {
     prependToVar cmakeFlags "-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF"
     prependToVar cmakeFlags "-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF"
 
-    if [ "${buildPhase-}" = ninjaBuildPhase ]; then
+    if [[ "${buildPhase-}" = ninjaBuildPhase ]]; then
         prependToVar cmakeFlags "-GNinja"
     fi
 
@@ -143,7 +152,7 @@ cmakeConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "${dontUseCmakeConfigure-}" -a -z "${configurePhase-}" ]; then
+if [[ -z "${dontUseCmakeConfigure-}" ]] && [[ -z "${configurePhase-}" ]]; then
     setOutputFlags=
     configurePhase=cmakeConfigurePhase
 fi


### PR DESCRIPTION
## Description of changes

This pull reques lints the setup hooks of `cmake` with ShellCheck, making them more resilient to edge cases such as strings containing white spaces.

Split from #299622

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (built `cmakeMinimal`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
