### PR TITLE
xautocfg: init at 1.2

### DIFF
--- a/pkgs/by-name/xa/xautocfg/package.nix
+++ b/pkgs/by-name/xa/xautocfg/package.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Automatic keyboard repeat rate configuration for new keyboards";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ jceb ];
+    mainProgram = "xautocfg";
   };
 })

--- a/pkgs/by-name/xa/xautocfg/package.nix
+++ b/pkgs/by-name/xa/xautocfg/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libX11,
+  libXi,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xautocfg";
+  version = "1.2";
+  src = fetchFromGitHub {
+    owner = "SFTtech";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-NxfuBknNRicmEAPBeMaNb57gpM0y0t+JmNMKpSNzlQM=";
+  };
+
+  buildInputs = [
+    libX11
+    libXi
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "MANPREFIX=$(out)"
+  ];
+
+  meta = {
+    homepage = "https://github.com/SFTtech/xautocfg";
+    description = "Automatic keyboard repeat rate configuration for new keyboards";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jceb ];
+  };
+}

--- a/pkgs/by-name/xa/xautocfg/package.nix
+++ b/pkgs/by-name/xa/xautocfg/package.nix
@@ -6,13 +6,14 @@
   libXi,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xautocfg";
   version = "1.2";
+
   src = fetchFromGitHub {
     owner = "SFTtech";
-    repo = pname;
-    rev = "v${version}";
+    repo = "xautocfg";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-NxfuBknNRicmEAPBeMaNb57gpM0y0t+JmNMKpSNzlQM=";
   };
 
@@ -32,4 +33,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ jceb ];
   };
-}
+})

--- a/pkgs/by-name/xa/xautocfg/package.nix
+++ b/pkgs/by-name/xa/xautocfg/package.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   makeFlags = [
-    "PREFIX=$(out)"
-    "MANPREFIX=$(out)"
+    "PREFIX=${placeholder "out"}"
+    "MANPREFIX=${placeholder "out"}"
   ];
 
   meta = {

--- a/pkgs/by-name/xa/xautocfg/package.nix
+++ b/pkgs/by-name/xa/xautocfg/package.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ jceb ];
     mainProgram = "xautocfg";
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
## Description of changes

Add xautocfg, a tool to automatically configure the repeat rate for new keyboards.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
