### PR TITLE
backintime: 1.4.3 -> 1.5.2

### DIFF
--- a/pkgs/applications/networking/sync/backintime/common.nix
+++ b/pkgs/applications/networking/sync/backintime/common.nix
@@ -7,13 +7,13 @@ let
   apps = lib.makeBinPath [ openssh python' cron rsync sshfs-fuse encfs ];
 in stdenv.mkDerivation rec {
   pname = "backintime-common";
-  version = "1.4.3";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "bit-team";
     repo = "backintime";
     rev = "v${version}";
-    sha256 = "sha256-2q2Q4rnxXwVnfH1YEBwY35B2ctG9+qpOIAHqPOjjArg=";
+    sha256 = "sha256-yfCSTzCmhXDBC1vYqwgVjsYUtc5VO1VW74BmIB0hHfE=";
   };
 
   nativeBuildInputs = [ makeWrapper gettext ];
@@ -24,6 +24,7 @@ in stdenv.mkDerivation rec {
   configureFlags = [ "--python=${lib.getExe python'}" ];
 
   preConfigure = ''
+    patchShebangs --build updateversion.sh
     cd common
     substituteInPlace configure \
       --replace-fail "/.." "" \

--- a/pkgs/applications/networking/sync/backintime/common.nix
+++ b/pkgs/applications/networking/sync/backintime/common.nix
@@ -26,10 +26,10 @@ in stdenv.mkDerivation rec {
   preConfigure = ''
     cd common
     substituteInPlace configure \
-      --replace "/.." "" \
-      --replace "share/backintime" "${python'.sitePackages}/backintime"
+      --replace-fail "/.." "" \
+      --replace-fail "share/backintime" "${python'.sitePackages}/backintime"
     substituteInPlace "backintime" \
-      --replace "share" "${python'.sitePackages}"
+      --replace-fail "share" "${python'.sitePackages}"
   '';
 
   dontAddPrefix = true;
@@ -44,10 +44,11 @@ in stdenv.mkDerivation rec {
     description = "Simple backup tool for Linux";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ stephen-huan ];
-    platforms = lib.platforms.all;
+    platforms = lib.platforms.linux;
+    mainProgram = "backintime";
     longDescription = ''
       Back In Time is a simple backup tool (on top of rsync) for Linux
-      inspired from “flyback project” and “TimeVault”. The backup is
+      inspired from "flyback project" and "TimeVault". The backup is
       done by taking snapshots of a specified set of directories.
     '';
   };

--- a/pkgs/applications/networking/sync/backintime/common.nix
+++ b/pkgs/applications/networking/sync/backintime/common.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
     substituteInPlace configure \
       --replace-fail "/.." "" \
       --replace-fail "share/backintime" "${python'.sitePackages}/backintime"
-    substituteInPlace "backintime" \
+    substituteInPlace "backintime" "backintime-askpass" \
       --replace-fail "share" "${python'.sitePackages}"
   '';
 

--- a/pkgs/applications/networking/sync/backintime/qt.nix
+++ b/pkgs/applications/networking/sync/backintime/qt.nix
@@ -24,23 +24,23 @@ mkDerivation {
       --prefix PATH : "${lib.getBin backintime-common}/bin:$PATH"
 
     substituteInPlace "$out/share/polkit-1/actions/net.launchpad.backintime.policy" \
-      --replace "/usr/bin/backintime-qt" "$out/bin/backintime-qt"
+      --replace-fail "/usr/bin/backintime-qt" "$out/bin/backintime-qt"
 
     substituteInPlace "$out/share/applications/backintime-qt-root.desktop" \
-      --replace "/usr/bin/backintime-qt" "backintime-qt"
+      --replace-fail "/usr/bin/backintime-qt" "backintime-qt"
 
     substituteInPlace "$out/share/backintime/qt/serviceHelper.py" \
-      --replace "'which'" "'${lib.getBin which}/bin/which'" \
-      --replace "/bin/su" "${lib.getBin su}/bin/su" \
-      --replace "/usr/bin/backintime" "${lib.getBin backintime-common}/bin/backintime" \
-      --replace "/usr/bin/nice" "${lib.getBin coreutils}/bin/nice" \
-      --replace "/usr/bin/ionice" "${lib.getBin util-linux}/bin/ionice"
+      --replace-fail "'which'" "'${lib.getExe which}'" \
+      --replace-fail "/bin/su" "${lib.getBin su}/bin/su" \
+      --replace-fail "/usr/bin/backintime" "${lib.getExe backintime-common}" \
+      --replace-fail "/usr/bin/nice" "${lib.getBin coreutils}/bin/nice" \
+      --replace-fail "/usr/bin/ionice" "${lib.getBin util-linux}/bin/ionice"
 
     substituteInPlace "$out/share/dbus-1/system-services/net.launchpad.backintime.serviceHelper.service" \
-      --replace "/usr/share/backintime" "$out/share/backintime"
+      --replace-fail "/usr/share/backintime" "$out/share/backintime"
 
     substituteInPlace "$out/bin/backintime-qt_polkit" \
-      --replace "/usr/bin/backintime-qt" "$out/bin/backintime-qt"
+      --replace-fail "/usr/bin/backintime-qt" "$out/bin/backintime-qt"
 
     wrapProgram "$out/bin/backintime-qt_polkit" \
       --prefix PATH : "${lib.getBin polkit}/bin:$PATH"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29415,7 +29415,7 @@ with pkgs;
 
   backintime-common = callPackage ../applications/networking/sync/backintime/common.nix { };
 
-  backintime-qt = libsForQt5.callPackage ../applications/networking/sync/backintime/qt.nix { };
+  backintime-qt = qt6.callPackage ../applications/networking/sync/backintime/qt.nix { };
 
   backintime = backintime-qt;
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog:
- https://github.com/bit-team/backintime/releases/tag/v1.5.0
- https://github.com/bit-team/backintime/releases/tag/v1.5.1
- https://github.com/bit-team/backintime/releases/tag/v1.5.2

Tested by using `backintime-common` to make a backup but not `backintime-qt`.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>backintime</li>
    <li>backintime-common</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
