### PR TITLE
nixos/timesyncd: allow NTP servers advertised by DHCP to be used

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -448,6 +448,10 @@
 
 - The hooks `yarnConfigHook` and `yarnBuildHook` were added. These should replace `yarn2nix.mkYarnPackage` and other `yarn2nix` related tools. The motivation to get rid of `yarn2nix` tools is the fact that they are too complex and hard to maintain, and they rely upon too much Nix evaluation which is problematic if import-from-derivation is not allowed (see more details at [#296856](https://github.com/NixOS/nixpkgs/issues/296856). The transition from `mkYarnPackage` to `yarn{Config,Build}Hook` is tracked at [#324246](https://github.com/NixOS/nixpkgs/issues/324246).
 
+- `services.timesyncd.servers` now defaults to `null`, allowing systemd-timesyncd to use NTP servers advertised by DHCP.
+
+- `services.timesyncd.fallbackServers` was added and defaults to `networking.timeServers`.
+
 - Cinnamon has been updated to 6.2, please check [upstream announcement](https://www.linuxmint.com/rel_wilma_whatsnew.php) for more details.
   Following Mint 22 defaults, the Cinnamon module no longer ships geary and hexchat by default.
 

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -19,8 +19,7 @@ in
         '';
       };
       servers = mkOption {
-        default = config.networking.timeServers;
-        defaultText = literalExpression "config.networking.timeServers";
+        default = null;
         type = nullOr (listOf str);
         description = ''
           The set of NTP servers from which to synchronise.
@@ -28,6 +27,20 @@ in
           Setting this option to an empty list will write `NTP=` to the
           `timesyncd.conf` file as opposed to setting this option to null which
           will remove `NTP=` entirely.
+
+          See man:timesyncd.conf(5) for details.
+        '';
+      };
+      fallbackServers = mkOption {
+        default = config.networking.timeServers;
+        defaultText = literalExpression "config.networking.timeServers";
+        type = nullOr (listOf str);
+        description = ''
+          The set of fallback NTP servers from which to synchronise.
+
+          Setting this option to an empty list will write `FallbackNTP=` to the
+          `timesyncd.conf` file as opposed to setting this option to null which
+          will remove `FallbackNTP=` entirely.
 
           See man:timesyncd.conf(5) for details.
         '';
@@ -91,6 +104,9 @@ in
     ''
     + optionalString (cfg.servers != null) ''
       NTP=${concatStringsSep " " cfg.servers}
+    ''
+    + optionalString (cfg.fallbackServers != null) ''
+      FallbackNTP=${concatStringsSep " " cfg.fallbackServers}
     ''
     + cfg.extraConfig;
 

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -2,6 +2,9 @@
 
 with lib;
 
+let
+  cfg = config.services.timesyncd;
+in
 {
 
   options = {
@@ -41,7 +44,7 @@ with lib;
     };
   };
 
-  config = mkIf config.services.timesyncd.enable {
+  config = mkIf cfg.enable {
 
     systemd.additionalUpstreamSystemUnits = [ "systemd-timesyncd.service" ];
 
@@ -82,8 +85,8 @@ with lib;
 
     environment.etc."systemd/timesyncd.conf".text = ''
       [Time]
-      NTP=${concatStringsSep " " config.services.timesyncd.servers}
-      ${config.services.timesyncd.extraConfig}
+      NTP=${concatStringsSep " " cfg.servers}
+      ${cfg.extraConfig}
     '';
 
     users.users.systemd-timesync = {

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -9,11 +9,11 @@ in
 
   options = {
 
-    services.timesyncd = {
+    services.timesyncd = with types; {
       enable = mkOption {
         default = !config.boot.isContainer;
         defaultText = literalExpression "!config.boot.isContainer";
-        type = types.bool;
+        type = bool;
         description = ''
           Enables the systemd NTP client daemon.
         '';
@@ -21,7 +21,7 @@ in
       servers = mkOption {
         default = config.networking.timeServers;
         defaultText = literalExpression "config.networking.timeServers";
-        type = types.listOf types.str;
+        type = listOf str;
         description = ''
           The set of NTP servers from which to synchronise.
           Note if this is set to an empty list, the defaults systemd itself is
@@ -31,7 +31,7 @@ in
       };
       extraConfig = mkOption {
         default = "";
-        type = types.lines;
+        type = lines;
         example = ''
           PollIntervalMaxSec=180
         '';


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
