### PR TITLE
ogen: init at 1.4.1

### DIFF
--- a/pkgs/by-name/og/ogen/modify-version-handling.patch
+++ b/pkgs/by-name/og/ogen/modify-version-handling.patch
@@ -1,0 +1,16 @@
+diff --git a/internal/ogenversion/ogenversion.go b/internal/ogenversion/ogenversion.go
+index 5db622d3..fe71f95e 100644
+--- a/internal/ogenversion/ogenversion.go
++++ b/internal/ogenversion/ogenversion.go
+@@ -17,9 +17,9 @@ var getOnce struct {
+ 
+ func getOgenVersion(m *debug.Module) (string, bool) {
+ 	if m == nil || m.Path != "github.com/ogen-go/ogen" {
+-		return "", false
++		return "1.4.1", true
+ 	}
+-	return m.Version, true
++	return "1.4.1", true
+ }
+ 
+ func getInfo() (Info, bool) {

--- a/pkgs/by-name/og/ogen/package.nix
+++ b/pkgs/by-name/og/ogen/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "ogen";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "ogen-go";
+    repo = "ogen";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-SwJY9VQafclAxEQ/cbRJALvMLlnSIItIOz92XzuCoCk=";
+  };
+
+  vendorHash = "sha256-IxG7y0Zy0DerCh5DRdSWSaD643BG/8Wj2wuYvkn+XzE=";
+
+  patches = [ ./modify-version-handling.patch ];
+
+  subPackages = [
+    "cmd/ogen"
+    "cmd/jschemagen"
+  ];
+
+  meta = {
+    description = "OpenAPI v3 Code Generator for Go";
+    homepage = "https://github.com/ogen-go/ogen";
+    changelog = "https://github.com/ogen-go/ogen/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ seanrmurphy ];
+    mainProgram = "ogen";
+  };
+}


### PR DESCRIPTION
## Description of changes

- add ogen package - https://github.com/ogen-go/ogen
  - OpenAPI v3 Code Generator for Go.
- release notes for v1.4.1 - https://github.com/ogen-go/ogen/releases/tag/v1.4.1
- note that I added a patch which hardcodes the version number - this is because this tool takes the version info from git via the go build system - if the source is obtained using `fetchFromGithub`, the build does not take place inside a git repo and hence no version info can be inferred
  - would be particularly interested in thoughts on whether this is a good/sensible approach

Also note that #299164 did focus on this but I closed it as @dz0ny indicated that he could not progress it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
