### PR TITLE
cockroachdb-bin: Remove maintainer neosimsim

### DIFF
--- a/pkgs/servers/sql/cockroachdb/cockroachdb-bin.nix
+++ b/pkgs/servers/sql/cockroachdb/cockroachdb-bin.nix
@@ -41,6 +41,6 @@ buildFHSEnv {
     description = "Scalable, survivable, strongly-consistent SQL database";
     license = licenses.bsl11;
     platforms = [ "aarch64-linux" "x86_64-linux" ];
-    maintainers = with maintainers; [ rushmorem thoughtpolice neosimsim ];
+    maintainers = with maintainers; [ rushmorem thoughtpolice ];
   };
 }


### PR DESCRIPTION
Since we stopped using CockroachDB with NixOS, I'm not interested in maintainig this package anymore.