### PR TITLE
nautilus-typeahead: init at 46.2

### DIFF
--- a/pkgs/by-name/na/nautilus-typeahead/package.nix
+++ b/pkgs/by-name/na/nautilus-typeahead/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  nautilus,
+  callPackage,
+}:
+
+nautilus.overrideAttrs (
+  finalAttrs:
+  _prevAttrs@{
+    patches ? [ ],
+    passthru ? { },
+    meta ? { },
+    ...
+  }:
+  {
+    pname = "nautilus-typeahead";
+    passthru = passthru // {
+      updateScript = ./update.sh;
+      typeaheadPatch = (callPackage ./patch.nix { });
+    };
+
+    patches = [ finalAttrs.passthru.typeaheadPatch ] ++ patches;
+
+    meta = meta // {
+      description = meta.description + " - patched to bring back 'typeahead find'";
+      maintainers = with lib.maintainers; [ bryango ];
+    };
+  }
+)

--- a/pkgs/by-name/na/nautilus-typeahead/package.nix
+++ b/pkgs/by-name/na/nautilus-typeahead/package.nix
@@ -10,6 +10,7 @@ nautilus.overrideAttrs (
     patches ? [ ],
     passthru ? { },
     meta ? { },
+    version ? "",
     ...
   }:
   {
@@ -18,6 +19,16 @@ nautilus.overrideAttrs (
       updateScript = ./update.sh;
       typeaheadPatch = (callPackage ./patch.nix { });
     };
+
+    version =
+      let
+        inherit (finalAttrs.passthru.typeaheadPatch) pkgver;
+      in
+      lib.warnIf (pkgver != version) ''
+        ${finalAttrs.pname}: Nautilus version for the AUR patch "${pkgver}"
+        is not the same as Nixpkgs Nautilus version "${version}"!
+        This may lead to patch failures.
+      '' version;
 
     patches = [ finalAttrs.passthru.typeaheadPatch ] ++ patches;
 

--- a/pkgs/by-name/na/nautilus-typeahead/patch.nix
+++ b/pkgs/by-name/na/nautilus-typeahead/patch.nix
@@ -3,15 +3,16 @@
   stdenvNoCC,
   git,
   cacert,
-  nautilus,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
 
   pname = "nautilus-typeahead";
-  version = "46.1-1"; # labeled by the AUR package version
+  pkgver = "46.1"; # base nautilus version for the AUR patch, not necessary the same as nixpkgs `nautilus.version`
+  pkgrel = "1"; # revision number for the AUR package
+  version = "${finalAttrs.pkgver}-${finalAttrs.pkgrel}";
   rev = "f5f593bf36c41756a29d5112a10cf7ec70b8eafb";
-  outputHash = "sha256-z+JX8z/NCrGeizghYfLMpoXCoSjnUzRKjM7vVA1J/zM=";
+  outputHash = "sha256-bOPW7wRbEk+GMg29AKEGdlTyiYXg3r/tzTTYBkkK1r8=";
 
   name = "${finalAttrs.pname}-${finalAttrs.version}.patch";
 
@@ -29,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       https://gitlab.gnome.org/GNOME/nautilus.git
 
     git fetch --filter=blob:none --tags upstream
-    git format-patch "${nautilus.version}".."${finalAttrs.rev}" --output="$out"
+    git format-patch "${finalAttrs.pkgver}".."${finalAttrs.rev}" --no-signature --output="$out"
 
     set +x
   '';
@@ -37,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "AUR patch for the nautilus-typeahead package";
     homepage = "https://aur.archlinux.org/packages/nautilus-typeahead";
-    changelog = "https://gitlab.gnome.org/albertvaka/nautilus/-/compare/${nautilus.version}...${finalAttrs.rev}";
+    changelog = "https://gitlab.gnome.org/albertvaka/nautilus/-/compare/${finalAttrs.pkgver}...${finalAttrs.rev}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ bryango ];
   };

--- a/pkgs/by-name/na/nautilus-typeahead/patch.nix
+++ b/pkgs/by-name/na/nautilus-typeahead/patch.nix
@@ -8,11 +8,11 @@
 stdenvNoCC.mkDerivation (finalAttrs: {
 
   pname = "nautilus-typeahead";
-  pkgver = "46.1"; # base nautilus version for the AUR patch, not necessary the same as nixpkgs `nautilus.version`
+  pkgver = "46.2"; # base nautilus version for the AUR patch, not necessary the same as nixpkgs `nautilus.version`
   pkgrel = "1"; # revision number for the AUR package
   version = "${finalAttrs.pkgver}-${finalAttrs.pkgrel}";
-  rev = "f5f593bf36c41756a29d5112a10cf7ec70b8eafb";
-  outputHash = "sha256-bOPW7wRbEk+GMg29AKEGdlTyiYXg3r/tzTTYBkkK1r8=";
+  rev = "840ff0c85188a15fd7e5e726a2ad2bb5531add83";
+  outputHash = "sha256-Ov+9VpS4AHUpWqhApQhLUwKko0yMWEBghHGSFQYouaw=";
 
   name = "${finalAttrs.pname}-${finalAttrs.version}.patch";
 

--- a/pkgs/by-name/na/nautilus-typeahead/patch.nix
+++ b/pkgs/by-name/na/nautilus-typeahead/patch.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenvNoCC,
+  git,
+  cacert,
+  nautilus,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+
+  pname = "nautilus-typeahead";
+  version = "46.1-1"; # labeled by the AUR package version
+  rev = "f5f593bf36c41756a29d5112a10cf7ec70b8eafb";
+  outputHash = "sha256-z+JX8z/NCrGeizghYfLMpoXCoSjnUzRKjM7vVA1J/zM=";
+
+  name = "${finalAttrs.pname}-${finalAttrs.version}.patch";
+
+  nativeBuildInputs = [ git ];
+  env.GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  buildCommand = ''
+    set -x
+
+    git clone --filter=blob:none --single-branch \
+      https://gitlab.gnome.org/albertvaka/nautilus.git
+
+    cd nautilus
+    git fetch origin "${finalAttrs.rev}"
+    git remote add upstream \
+      https://gitlab.gnome.org/GNOME/nautilus.git
+
+    git fetch --filter=blob:none --tags upstream
+    git format-patch "${nautilus.version}".."${finalAttrs.rev}" --output="$out"
+
+    set +x
+  '';
+
+  meta = {
+    description = "AUR patch for the nautilus-typeahead package";
+    homepage = "https://aur.archlinux.org/packages/nautilus-typeahead";
+    changelog = "https://gitlab.gnome.org/albertvaka/nautilus/-/compare/${nautilus.version}...${finalAttrs.rev}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ bryango ];
+  };
+
+})

--- a/pkgs/by-name/na/nautilus-typeahead/update.sh
+++ b/pkgs/by-name/na/nautilus-typeahead/update.sh
@@ -31,7 +31,6 @@ read_src_info() {
 pkgver=$(read_src_info pkgver | head -1)
 pkgrel=$(read_src_info pkgrel | head -1)
 
-version="$pkgver-$pkgrel"
 rev=$(read_src_info source \
   | sed --silent -E "s|.*albertvaka/nautilus.*commit=($REGEX_REV)$|\1|p" \
   | head -1)
@@ -40,7 +39,8 @@ rm -rf "$tmp_dir"
 cd "$init_dir"
 
 new_file=$(sed -E "
-  s/(^\s*version\s*=\s*\")(.*)(\".*)$/\1$version\3/;
+  s/(^\s*pkgver\s*=\s*\")(.*)(\".*)$/\1$pkgver\3/;
+  s/(^\s*pkgrel\s*=\s*\")(.*)(\".*)$/\1$pkgrel\3/;
   s/(^\s*rev\s*=\s*\")($REGEX_REV)(\".*)$/\1$rev\3/;
   s/(^\s*outputHash\s*=)(.*)$/\1 lib.fakeHash;/;
 " patch.nix)
@@ -56,7 +56,8 @@ package=$(package_expr "$new_file")
 test_instantiate() {
   nix-instantiate --eval --expr "$package" --attr "$@"
 }
-[[ $(test_instantiate "version") == "\"$version\"" ]]
+[[ $(test_instantiate "pkgver") == "\"$pkgver\"" ]]
+[[ $(test_instantiate "pkgrel") == "\"$pkgrel\"" ]]
 [[ $(test_instantiate "rev") == "\"$rev\"" ]]
 
 test_build=$(nix-build --expr "$package" 2>&1 || true)

--- a/pkgs/by-name/na/nautilus-typeahead/update.sh
+++ b/pkgs/by-name/na/nautilus-typeahead/update.sh
@@ -1,0 +1,84 @@
+#! /usr/bin/env nix-shell
+#! nix-shell --pure -i bash --packages cacert git pacman nix
+# shellcheck shell=bash
+##
+## Automatic `updateScript` for `patch.nix` of `nautilus-typeahead`
+##
+## Available flag:
+##   `--dry-run`: do not write to the actual file, only print to stdout
+##
+
+set -eo pipefail
+set -x
+
+REGEX_REV='[a-f0-9]+'
+
+init_dir=$(realpath "$(dirname "$0")")
+tmp_dir=$(mktemp -d)
+cd "$tmp_dir"
+
+git clone --filter=blob:none https://aur.archlinux.org/nautilus-typeahead.git
+cd nautilus-typeahead
+
+## pacman's `makepkg` generates normalized source info
+## from the package definitions
+makepkg --printsrcinfo > .SRCINFO
+
+read_src_info() {
+  local key=$1
+  sed --silent -E s/$'\t'"$key = (.*)$/\1/p" .SRCINFO
+}
+pkgver=$(read_src_info pkgver | head -1)
+pkgrel=$(read_src_info pkgrel | head -1)
+
+version="$pkgver-$pkgrel"
+rev=$(read_src_info source \
+  | sed --silent -E "s|.*albertvaka/nautilus.*commit=($REGEX_REV)$|\1|p" \
+  | head -1)
+
+rm -rf "$tmp_dir"
+cd "$init_dir"
+
+new_file=$(sed -E "
+  s/(^\s*version\s*=\s*\")(.*)(\".*)$/\1$version\3/;
+  s/(^\s*rev\s*=\s*\")($REGEX_REV)(\".*)$/\1$rev\3/;
+  s/(^\s*outputHash\s*=)(.*)$/\1 lib.fakeHash;/;
+" patch.nix)
+
+set +x -v
+
+package_expr() {
+  local pkg=$1
+  echo "with import <nixpkgs> {}; callPackage ($pkg) {}"
+}
+package=$(package_expr "$new_file")
+
+test_instantiate() {
+  nix-instantiate --eval --expr "$package" --attr "$@"
+}
+[[ $(test_instantiate "version") == "\"$version\"" ]]
+[[ $(test_instantiate "rev") == "\"$rev\"" ]]
+
+test_build=$(nix-build --expr "$package" 2>&1 || true)
+echo "$test_build" >&2
+
+set +v
+outputHash=$(
+  sed --silent -E 's/.*got:\s*(sha256-.*=)\s*$/\1/p' <<< "$test_build" \
+  | head -1
+)
+echo "outputHash: $outputHash" >&2
+
+hashed_file=$(sed -E "
+  s|(^\s*outputHash\s*=)(.*)$|\1 \"$outputHash\";|
+" <<< "$new_file")
+## ^ note that here we must use `s|..|..|` instead of `s/../../`
+## because "$outputHash" may contain `/`
+
+nix-build --expr "$(package_expr "$hashed_file")" --no-out-link
+
+if [[ "$1" == "--dry-run" ]]; then
+  echo "$hashed_file"
+else
+  echo "$hashed_file" > patch.nix
+fi


### PR DESCRIPTION
## Description of changes

- AUR package: https://aur.archlinux.org/packages/nautilus-typeahead
- Also, this revives: #8704 but for gtk4

This package provides a popular variant of the Nautilus file browser that restores the removed "typeahead"-find feature.

In newer versions of Nautilus, typing in the files view will trigger a recursive search under the current directory, which may be rather slow and unintuitive. `nautilus-typeahead` restores the traditional behavior, where typing simply focuses on a matching file under the current view.

This package is an unofficial fork of the official GNOME Nautilus app, published in the Arch User Repository (AUR). To maximize coherence and auditability, we first generate a human-readable patch against the official source, and then apply the patch by overriding the official nautilus package in nixpkgs. More specially,

- `patch.nix` is a fixed output derivation to generate a small, human-readable patch between the nixpkgs nautilus source and the AUR fork.
- `package.nix` applies the patch to the official source by overriding the `nautilus` derivation.
- `update.sh` is used as `passthru.updateScript` to automate the update process.

As an unofficial package, `nautilus-typeahead` is obviously prone to breakages due to upstream API changes. I have hence set myself as the sole maintainer of this package. In particular, gnome and nautilus maintainers need not be responsible for possible (likely) future breakages of this package. However, due to its popularity, I do believe it would be nice to have it in nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
