### PR TITLE
darling: disable build on hydra

### DIFF
--- a/pkgs/applications/emulators/darling/default.nix
+++ b/pkgs/applications/emulators/darling/default.nix
@@ -230,5 +230,6 @@ in stdenv.mkDerivation {
     maintainers = with maintainers; [ zhaofengli ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "darling";
+    hydraPlatforms = [ ]; # src with submodules is 3.3G, hydra fails with "Output limit exceeded"
   };
 }


### PR DESCRIPTION
## Description of changes

- disable build on hydra

Since at least version `unstable-2023-11-07` (after `2023-11-25`) builds on hydra fail with "Output limit exceeded":
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.darling.x86_64-linux
https://hydra.nixos.org/build/242152891

`src` size (3512428168) is beyond current hydra limit (3421225472):
```text
nix path-info /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source --size
/nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source       3512428168

du -lh --apparent-size /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/ --max-depth=3 | sort -hk 1 -r| head -n 20
3.3G    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src
3.3G    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/
3.2G    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external
585M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/openjdk
351M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/perl
218M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/python_modules
201M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/WebCore
169M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/libarchive
152M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/libmalloc
149M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/icu
114M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/JavaScriptCore
99M     /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/ruby
78M     /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/python
65M     /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/security
62M     /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/xnu
52M     /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/vim
52M     /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/Heimdal
52M     /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/BerkeleyDB
47M     /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/bind9
37M     /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/libxml2
```

CC `darling` maintainers:
@zhaofengli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
