### PR TITLE
nixos/frr_exporter: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1030,6 +1030,7 @@
   ./services/networking/freeradius.nix
   ./services/networking/frp.nix
   ./services/networking/frr.nix
+  ./services/networking/frr_exporter.nix
   ./services/networking/gateone.nix
   ./services/networking/gdomap.nix
   ./services/networking/ghostunnel.nix

--- a/nixos/modules/services/networking/frr_exporter.nix
+++ b/nixos/modules/services/networking/frr_exporter.nix
@@ -1,0 +1,107 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.frr_exporter;
+in
+{
+  options.services.frr_exporter = {
+    enable = lib.mkEnableOption "FRR Exporter";
+
+    package = lib.mkPackageOption pkgs "prometheus-frr-exporter" { };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 9342;
+      description = "Port for FRR Exporter to run on";
+    };
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open ports in the firewall for the exporter.";
+    };
+
+    collectors = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          bfd = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Enable the bfd collector";
+          };
+          bgp = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Enable the bgp collector";
+          };
+          bgp6 = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Enable the bgp6 collector";
+          };
+          bgpl2vpn = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Enable the bgpl2vpn collector";
+          };
+          ospf = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Enable the ospf collector";
+          };
+          pim = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Enable the pim collector";
+          };
+          vrrp = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Enable the vrrp collector";
+          };
+        };
+      };
+      description = "Collectors that should be enabled";
+      default = { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.groups.frrvty = { };
+
+    users.users.frr_exporter = {
+      description = "FRR exporter user";
+      isSystemUser = true;
+      group = "frrvty";
+    };
+
+    systemd.services.frr_exporter = {
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "network.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        User = "frr_exporter";
+        Group = "frrvty";
+
+        ExecStart = ''
+          ${cfg.package}/bin/frr_exporter \
+            --web.listen-address=:${toString cfg.port} \
+            --${lib.optionalString (!cfg.collectors.bfd) "no-"}collector.bfd \
+            --${lib.optionalString (!cfg.collectors.bgp) "no-"}collector.bgp \
+            --${lib.optionalString (!cfg.collectors.bgp6) "no-"}collector.bgp6 \
+            --${lib.optionalString (!cfg.collectors.bgpl2vpn) "no-"}collector.bgpl2vpn \
+            --${lib.optionalString (!cfg.collectors.ospf) "no-"}collector.ospf \
+            --${lib.optionalString (!cfg.collectors.pim) "no-"}collector.pim \
+            --${lib.optionalString (!cfg.collectors.vrrp) "no-"}collector.vrrp
+        '';
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf (cfg.openFirewall) [ cfg.port ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Used the same group as `frr` https://github.com/NixOS/nixpkgs/blob/c3aa7b8938b17aebd2deecf7be0636000d62a2b9/nixos/modules/services/networking/frr.nix#L174-L175

Collector default values are from `frr_exporter` https://github.com/tynany/frr_exporter/blob/c86b14d3c0970ac63b00070959e5673213ac377e/README.md?plain=1#L52-L58

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
