### PR TITLE
nixosTests.systemd-boot.memtest86: only run when `memtest86plus` is available

### DIFF
--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -269,7 +269,7 @@ in
     '';
   };
 
-  memtest86 = with pkgs.lib; mkIf (meta.availableOn { inherit system; } pkgs.memtest86plus) (makeTest {
+  memtest86 = with pkgs.lib; optionalAttrs (meta.availableOn { inherit system; } pkgs.memtest86plus) (makeTest {
     name = "systemd-boot-memtest86";
     meta.maintainers = with maintainers; [ julienmalka ];
 

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -269,7 +269,7 @@ in
     '';
   };
 
-  memtest86 = makeTest {
+  memtest86 = pkgs.lib.mkIf (system == "x86_64-linux") (makeTest {
     name = "systemd-boot-memtest86";
     meta.maintainers = with pkgs.lib.maintainers; [ julienmalka ];
 
@@ -282,7 +282,7 @@ in
       machine.succeed("test -e /boot/loader/entries/memtest86.conf")
       machine.succeed("test -e /boot/efi/memtest86/memtest.efi")
     '';
-  };
+  });
 
   netbootxyz = makeTest {
     name = "systemd-boot-netbootxyz";

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -269,9 +269,9 @@ in
     '';
   };
 
-  memtest86 = pkgs.lib.mkIf (system == "x86_64-linux") (makeTest {
+  memtest86 = with pkgs.lib; mkIf (meta.availableOn { inherit system; } pkgs.memtest86plus) (makeTest {
     name = "systemd-boot-memtest86";
-    meta.maintainers = with pkgs.lib.maintainers; [ julienmalka ];
+    meta.maintainers = with maintainers; [ julienmalka ];
 
     nodes.machine = { pkgs, lib, ... }: {
       imports = [ common ];


### PR DESCRIPTION
## Description of changes

Made `nixosTests.systemd-boot.memtest86` conditional on `system`, resolving an [evaluation error] which seems to be currently blocking the `nixos-unstable` channel.

[evaluation error]: https://gist.github.com/nbraud/8820dda48156922f998bba987eb229c6

## Things done

- Built on platform(s)
  - [x] aarch64-linux
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) `systemd-boot.memtest86`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
