### PR TITLE
nixos/bind: Fix cacheNetworks option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -900,7 +900,9 @@
 
 - `freecad` now supports addons and custom configuration in nix-way, which can be used by calling `freecad.customize`.
 
-## Detailed Migration Information {#sec-release-24.11-migration}
+- `bind.cacheNetworks` now only controls access for recursive queries, where it previously controlled access for all queries.
+
+## Detailed migration information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}
 

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -38,9 +38,6 @@ let
         description = ''
           List of address ranges allowed to query this zone. Instead of the address(es), this may instead
           contain the single string "any".
-
-          NOTE: This overrides the global-level `allow-query` setting, which is set to the contents
-          of `cachenetworks`.
         '';
         default = [ "any" ];
       };
@@ -65,7 +62,7 @@ let
       options {
         listen-on { ${lib.concatMapStrings (entry: " ${entry}; ") cfg.listenOn} };
         listen-on-v6 { ${lib.concatMapStrings (entry: " ${entry}; ") cfg.listenOnIpv6} };
-        allow-query { cachenetworks; };
+        allow-query-cache { cachenetworks; };
         blackhole { badnetworks; };
         forward ${cfg.forward};
         forwarders { ${lib.concatMapStrings (entry: " ${entry}; ") cfg.forwarders} };


### PR DESCRIPTION
## Description of changes

services.bind.cacheNetworks should only apply to recursive queryies, as per the option documentation:
> Note that this is for recursive queries – all networks are allowed to
> query zones configured with the zones option by default [...].

This would correspond to the `allow-query-cache` option in named.conf, as per the BIND docs[1]:
> Specifies which hosts (an IP address list) can access this server’s
> cache and thus effectively controls recursion.

And not `allow-query`, which restricts all requests (including requests where the server has authority) [2]:
> Specifies which hosts (an IP address list) are allowed to send queries
> to this resolver.
> [...]
> Note:
> `allow-query-cache` is used to specify access to the cache.

[1]: https://bind9.readthedocs.io/en/v9.20.0/reference.html#namedconf-statement-allow-query-cache
[2]: https://bind9.readthedocs.io/en/v9.20.0/reference.html#namedconf-statement-allow-query

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
