### PR TITLE
bees: expose drv metadata, simplify wrapper

### DIFF
--- a/pkgs/tools/filesystems/bees/bees-service-wrapper
+++ b/pkgs/tools/filesystems/bees/bees-service-wrapper
@@ -1,7 +1,3 @@
-#!@bash@/bin/bash
-PATH=@bash@/bin:@coreutils@/bin:@utillinux@/bin:@btrfsProgs@/bin:$PATH
-beesd_bin=@bees@/lib/bees/bees
-# PLEASE KEEP NIX-ISMS ABOVE THIS LINE TO EASE UPSTREAM MERGE
 #!/usr/bin/env bash
 
 shopt -s extglob

--- a/pkgs/tools/filesystems/bees/default.nix
+++ b/pkgs/tools/filesystems/bees/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, runCommand
 , fetchFromGitHub
 , bash
 , btrfs-progs
@@ -10,73 +9,65 @@
 , nixosTests
 }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "bees";
+  version = "0.10";
 
-  bees = stdenv.mkDerivation rec {
-    pname = "bees";
-    version = "0.10";
-
-    src = fetchFromGitHub {
-      owner = "Zygo";
-      repo = "bees";
-      rev = "v${version}";
-      hash = "sha256-f3P3BEd8uO6QOZ1/2hBzdcuOSggYvHxW3g9pGftKO8g=";
-    };
-
-    buildInputs = [
-      btrfs-progs # for btrfs/ioctl.h
-      util-linux # for uuid.h
-    ];
-
-    nativeBuildInputs = [
-      python3Packages.markdown # documentation build
-    ];
-
-    preBuild = ''
-      git() { if [[ $1 = describe ]]; then echo ${version}; else command git "$@"; fi; }
-      export -f git
-    '';
-
-    postBuild = ''
-      unset -f git
-    '';
-
-    buildFlags = [
-      "ETC_PREFIX=/var/run/bees/configs"
-    ];
-
-    makeFlags = [
-      "SHELL=bash"
-      "PREFIX=$(out)"
-      "ETC_PREFIX=$(out)/etc"
-      "BEES_VERSION=${version}"
-      "SYSTEMD_SYSTEM_UNIT_DIR=$(out)/etc/systemd/system"
-    ];
-
-    meta = with lib; {
-      homepage = "https://github.com/Zygo/bees";
-      description = "Block-oriented BTRFS deduplication service";
-      longDescription = "Best-Effort Extent-Same: bees finds not just identical files, but also identical extents within files that differ";
-      license = licenses.gpl3;
-      platforms = platforms.linux;
-      maintainers = with maintainers; [ chaduffy ];
-    };
+  src = fetchFromGitHub {
+    owner = "Zygo";
+    repo = "bees";
+    rev = "v${version}";
+    hash = "sha256-f3P3BEd8uO6QOZ1/2hBzdcuOSggYvHxW3g9pGftKO8g=";
   };
 
-in
+  buildInputs = [
+    btrfs-progs # for btrfs/ioctl.h
+    util-linux # for uuid.h
+  ];
 
-(runCommand "bees-service"
-  {
-    inherit bash bees coreutils;
-    utillinux = util-linux; # needs to be a valid shell variable name
-    btrfsProgs = btrfs-progs; # needs to be a valid shell variable name
-  } ''
-  mkdir -p -- "$out/bin"
-  substituteAll ${./bees-service-wrapper} "$out"/bin/bees-service-wrapper
-  chmod +x "$out"/bin/bees-service-wrapper
-  ln -s ${bees}/bin/beesd "$out"/bin/beesd
-'').overrideAttrs {
+  nativeBuildInputs = [
+    python3Packages.markdown # documentation build
+  ];
+
+  preBuild = ''
+    git() { if [[ $1 = describe ]]; then echo ${version}; else command git "$@"; fi; }
+    export -f git
+  '';
+
+  postBuild = ''
+    unset -f git
+  '';
+
+  inherit bash bees coreutils;
+  utillinux = util-linux;
+  btrfsProgs = btrfs-progs;
+  postInstall = ''
+    substituteAll ${./bees-service-wrapper} "$out"/bin/bees-service-wrapper
+    chmod +x "$out"/bin/bees-service-wrapper
+  '';
+
+  buildFlags = [
+    "ETC_PREFIX=/var/run/bees/configs"
+  ];
+
+  makeFlags = [
+    "SHELL=bash"
+    "PREFIX=$(out)"
+    "ETC_PREFIX=$(out)/etc"
+    "BEES_VERSION=${version}"
+    "SYSTEMD_SYSTEM_UNIT_DIR=$(out)/etc/systemd/system"
+  ];
+
   passthru.tests = {
     smoke-test = nixosTests.bees;
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/Zygo/bees";
+    description = "Block-oriented BTRFS deduplication service";
+    longDescription = "Best-Effort Extent-Same: bees finds not just identical files, but also identical extents within files that differ";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ chaduffy ];
   };
 }

--- a/pkgs/tools/filesystems/bees/default.nix
+++ b/pkgs/tools/filesystems/bees/default.nix
@@ -1,12 +1,16 @@
 { lib
-, stdenv
 , fetchFromGitHub
-, bash
-, btrfs-progs
-, coreutils
-, python3Packages
-, util-linux
+, makeWrapper
 , nixosTests
+
+, stdenv
+# Build inputs
+, btrfs-progs
+, util-linux
+, python3Packages
+# bees-service-wrapper
+, bash
+, coreutils
 }:
 
 stdenv.mkDerivation rec {
@@ -26,6 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    makeWrapper
     python3Packages.markdown # documentation build
   ];
 
@@ -38,12 +43,10 @@ stdenv.mkDerivation rec {
     unset -f git
   '';
 
-  inherit bash bees coreutils;
-  utillinux = util-linux;
-  btrfsProgs = btrfs-progs;
   postInstall = ''
-    substituteAll ${./bees-service-wrapper} "$out"/bin/bees-service-wrapper
-    chmod +x "$out"/bin/bees-service-wrapper
+    makeWrapper ${./bees-service-wrapper} "$out"/bin/bees-service-wrapper \
+      --prefix PATH : ${lib.makeBinPath [ bash coreutils util-linux btrfs-progs ]} \
+      --set beesd_bin "$out"/lib/bees/bees
   '';
 
   buildFlags = [


### PR DESCRIPTION
## Description of changes

In `bees`:
- [x] flatten derivation to expose metadata: previously, `pkgs.bees` did not have a `meta` attribute etc.
- [ ] define an `updateScript`  
  I don't think that would have been (easily) possible previously, due to the `runCommand` wrapper not defining the `src` attribute.
- [x] replace use of `substituteAll` with `makeWrapper`
  - `bees-service-wrapper` does not need nix-specific modifications
  - for drawbacks of `substituteAll` in general, see #237216

cc @charles-dyfis-net

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
