### PR TITLE
lomiri.libusermetrics: 1.3.2 -> 1.3.3

### DIFF
--- a/pkgs/desktops/lomiri/development/libusermetrics/default.nix
+++ b/pkgs/desktops/lomiri/development/libusermetrics/default.nix
@@ -1,28 +1,29 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, fetchpatch
-, gitUpdater
-, testers
-, cmake
-, cmake-extras
-, dbus
-, doxygen
-, glibcLocales
-, gsettings-qt
-, gtest
-, intltool
-, json-glib
-, libapparmor
-, libqtdbustest
-, pkg-config
-, qdjango
-, qtbase
-, qtdeclarative
-, qtxmlpatterns
-, ubports-click
-, validatePkgConfig
-, wrapQtAppsHook
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  testers,
+  cmake,
+  cmake-extras,
+  dbus,
+  doxygen,
+  glibcLocales,
+  gsettings-qt,
+  gtest,
+  intltool,
+  json-glib,
+  libapparmor,
+  libqtdbustest,
+  pkg-config,
+  qdjango,
+  qtbase,
+  qtdeclarative,
+  qtxmlpatterns,
+  ubports-click,
+  validatePkgConfig,
+  wrapQtAppsHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/desktops/lomiri/development/libusermetrics/default.nix
+++ b/pkgs/desktops/lomiri/development/libusermetrics/default.nix
@@ -1,12 +1,14 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, fetchpatch
 , gitUpdater
 , testers
 , cmake
 , cmake-extras
 , dbus
 , doxygen
+, glibcLocales
 , gsettings-qt
 , gtest
 , intltool
@@ -25,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libusermetrics";
-  version = "1.3.2";
+  version = "1.3.3";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/libusermetrics";
     rev = finalAttrs.version;
-    hash = "sha256-jmJH5vByBnBqgQfyb7HNVe+eS/jHcU64R2dnvuLbqss=";
+    hash = "sha256-V4vxNyHMs2YYBILkpco79FN9xnooULgB+z2Kf3V0790=";
   };
 
   outputs = [
@@ -41,21 +43,21 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # Not submitted yet, waiting for decision on how CMake testing should be handled
-    ./2001-Remove-custom-check-target.patch
-
-    # Due to https://gitlab.com/ubports/development/core/libusermetrics/-/issues/8, we require knowledge about AppArmor availability at launch time
-    # Custom patch to launch a module-defined service that can handle this
-    ./2002-Launch-module-created-systemd-service.patch
+    # Remove when https://gitlab.com/ubports/development/core/libusermetrics/-/merge_requests/17 merged & in release
+    (fetchpatch {
+      name = "0001-libusermetrics-BUILD_TESTING.patch";
+      url = "https://gitlab.com/ubports/development/core/libusermetrics/-/commit/c1e4847601cc4522034a766755ce491d48132d77.patch";
+      hash = "sha256-UWc9/ngpuiSm0Rd6eBK/R3N/NwDRtMxie78seN3+y/8=";
+    })
   ];
 
   postPatch = ''
     # Tries to query QMake for QT_INSTALL_QML variable, would return broken paths into /build/qtbase-<commit> even if qmake was available
     substituteInPlace src/modules/UserMetrics/CMakeLists.txt \
-      --replace 'query_qmake(QT_INSTALL_QML QT_IMPORTS_DIR)' 'set(QT_IMPORTS_DIR "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}")'
+      --replace-fail 'query_qmake(QT_INSTALL_QML QT_IMPORTS_DIR)' 'set(QT_IMPORTS_DIR "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}")'
 
     substituteInPlace doc/CMakeLists.txt \
-      --replace "\''${CMAKE_INSTALL_DATAROOTDIR}/doc/libusermetrics-doc" "\''${CMAKE_INSTALL_DOCDIR}"
+      --replace-fail "\''${CMAKE_INSTALL_FULL_DATAROOTDIR}/doc/libusermetrics-doc" "\''${CMAKE_INSTALL_DOCDIR}"
   '';
 
   strictDeps = true;
@@ -82,8 +84,12 @@ stdenv.mkDerivation (finalAttrs: {
     qtbase
   ];
 
+  # Tests need to be able to check locale
+  LC_ALL = lib.optionalString finalAttrs.finalPackage.doCheck "en_US.UTF-8";
+
   nativeCheckInputs = [
     dbus
+    glibcLocales
   ];
 
   checkInputs = [
@@ -96,14 +102,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
     (lib.cmakeBool "GSETTINGS_COMPILE" true)
     (lib.cmakeBool "ENABLE_CLICK" true)
-    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
-    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
-      # Exclude tests
-      "-E" (lib.strings.escapeShellArg "(${lib.concatStringsSep "|" [
-        # Flaky, randomly failing in UserMetricsImplTest.AddTranslatedData (data not ready when signal is emitted?)
-        "^usermetricsoutput-unit-tests"
-      ]})")
-    ]))
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
@@ -118,13 +116,13 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Enables apps to locally store interesting numerical data for later presentation";
     homepage = "https://gitlab.com/ubports/development/core/libusermetrics";
     changelog = "https://gitlab.com/ubports/development/core/libusermetrics/-/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.lgpl3Only;
-    maintainers = teams.lomiri.members;
-    platforms = platforms.linux;
+    license = lib.licenses.lgpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
     mainProgram = "usermetricsinput";
     pkgConfigModules = [
       "libusermetricsinput-1"


### PR DESCRIPTION
## Description of changes

https://gitlab.com/ubports/development/core/libusermetrics/-/blob/1.3.3/ChangeLog?ref_type=tags

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
