### PR TITLE
python312Packages.pyzx: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/pyzx/default.nix
+++ b/pkgs/development/python-modules/pyzx/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  pythonRelaxDepsHook,
+  pytestCheckHook,
+  setuptools,
+  ipywidgets,
+  lark,
+  numpy,
+  pyperclip,
+  tqdm,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "pyzx";
+  version = "0.8.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "zxcalc";
+    repo = "pyzx";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-4yc4P2v2L/F/A1A9z41ow2KA0aUA+3SJyC+wyMWzhwM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    ipywidgets
+    lark
+    numpy
+    pyperclip
+    tqdm
+    typing-extensions
+  ];
+
+  pythonRelaxDeps = [ "ipywidgets" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  disabledTestPaths = [
+    # too expensive, and print results instead of reporting failures:
+    "tests/long_scalar_test.py"
+    "tests/long_test.py"
+  ];
+
+  pythonImportsCheck = [
+    "pyzx"
+    "pyzx.circuit"
+    "pyzx.graph"
+    "pyzx.routing"
+    "pyzx.local_search"
+    "pyzx.scripts"
+  ];
+
+  meta = {
+    description = "Library for quantum circuit rewriting and optimisation using the ZX-calculus";
+    homepage = "https://github.com/zxcalc/pyzx";
+    changelog = "https://github.com/zxcalc/pyzx/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13312,6 +13312,8 @@ self: super: with self; {
 
   pyzmq = callPackage ../development/python-modules/pyzmq { };
 
+  pyzx = callPackage ../development/python-modules/pyzx { };
+
   qbittorrent-api = callPackage ../development/python-modules/qbittorrent-api { };
 
   qasync = callPackage ../development/python-modules/qasync { };


### PR DESCRIPTION
## Description of changes

Init `pyzx`, a [Python library for quantum circuit rewriting and optimisation](https://github.com/zxcalc/pyzx).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
