### PR TITLE
nixos/tests/atop: fix version regex, add timeout

### DIFF
--- a/nixos/tests/atop.nix
+++ b/nixos/tests/atop.nix
@@ -24,7 +24,7 @@ let assertions = rec {
 
     with subtest("binary should report the correct version"):
         pkgver = "${pkgs.atop.version}"
-        ver = re.sub(r'(?s)^Version: (\d\.\d\.\d).*', r'\1', machine.succeed("atop -V"))
+        ver = re.sub(r'(?s)^Version: (\d+\.\d+\.\d+).*', r'\1', machine.succeed("atop -V"))
         assert ver == pkgver, f"Version is `{ver}`, expected `{pkgver}`"
   '';
   atoprc = contents:
@@ -103,6 +103,9 @@ let assertions = rec {
           machine.fail("type -p atopgpud")
     '';
 };
+meta = {
+  timeout = 600;
+};
 in
 {
   justThePackage = makeTest {
@@ -120,6 +123,7 @@ in
       (netatop false)
       (atopgpu false)
     ];
+    inherit meta;
   };
   defaults = makeTest {
     name = "atop-defaults";
@@ -138,6 +142,7 @@ in
       (netatop false)
       (atopgpu false)
     ];
+    inherit meta;
   };
   minimal = makeTest {
     name = "atop-minimal";
@@ -159,6 +164,7 @@ in
       (netatop false)
       (atopgpu false)
     ];
+    inherit meta;
   };
   netatop = makeTest {
     name = "atop-netatop";
@@ -178,6 +184,7 @@ in
       (netatop true)
       (atopgpu false)
     ];
+    inherit meta;
   };
   atopgpu = makeTest {
     name = "atop-atopgpu";
@@ -197,6 +204,7 @@ in
       (netatop false)
       (atopgpu true)
     ];
+    inherit meta;
   };
   everything = makeTest {
     name = "atop-everything";
@@ -222,5 +230,6 @@ in
       (netatop true)
       (atopgpu true)
     ];
+    inherit meta;
   };
 }


### PR DESCRIPTION
## Description of changes

- fix version regex to handle more than 1 digit in each part between dots (`X.X.X`)
- add 10 minutes timeout instead of default 1 hour

Fixes 6 `atop` tests:
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.atop.atopgpu.x86_64-linux/all
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.atop.defaults.x86_64-linux/all
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.atop.everything.x86_64-linux/all
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.atop.justThePackage.x86_64-linux/all
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.atop.minimal.x86_64-linux/all
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.atop.netatop.x86_64-linux/all

All tests broke after `atop` update to `2.10.0` on `2024-07-13`:
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.atop.x86_64-linux/all

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
