### PR TITLE
hwinfo: several improvements

### DIFF
--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -21,9 +21,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-YAhsnE1DJ5UlYAuhDxS/5IpfIJB6DrhCT3E0YiKENjU=";
   };
 
-  nativeBuildInputs = [
-    flex
-  ];
+  nativeBuildInputs = [ flex ];
 
   buildInputs = [
     libuuid

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
+    # Replace /usr paths with Nix store paths
     substituteInPlace Makefile \
       --replace-fail "/sbin" "/bin" \
       --replace-fail "/usr/" "/"
@@ -44,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/isdn/cdb/cdb_hwdb.h \
       --replace-fail "/usr/share" "$out/share"
 
-    # replace absolute paths with relative, we will prefix PATH later
+    # Replace /sbin and /usr/bin paths with Nix store paths
     substituteInPlace src/hd/hd_int.h \
       --replace-fail "/sbin/modprobe" "${kmod}/bin/modprobe" \
       --replace-fail "/sbin/rmmod" "${kmod}/bin/rmmod" \

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -66,5 +66,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/openSUSE/hwinfo";
     maintainers = with maintainers; [ bobvanderlinden ];
     platforms = platforms.linux;
+    mainProgram = "hwinfo";
   };
 })

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -8,6 +8,7 @@
   perl,
   kmod,
   systemdMinimal,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -59,6 +60,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installFlags = [ "DESTDIR=$(out)" ];
+
+  passthru.tests = {
+    version = testers.testVersion { package = finalAttrs.finalPackage; };
+  };
 
   meta = with lib; {
     description = "Hardware detection tool from openSUSE";

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -10,14 +10,14 @@
   systemdMinimal,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hwinfo";
   version = "23.2";
 
   src = fetchFromGitHub {
     owner = "opensuse";
     repo = "hwinfo";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-YAhsnE1DJ5UlYAuhDxS/5IpfIJB6DrhCT3E0YiKENjU=";
   };
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # VERSION and changelog are usually generated using Git
     # unless HWINFO_VERSION is defined (see Makefile)
-    export HWINFO_VERSION="${version}"
+    export HWINFO_VERSION="${finalAttrs.version}"
     sed -i 's|^\(TARGETS\s*=.*\)\<changelog\>\(.*\)$|\1\2|g' Makefile
 
     substituteInPlace Makefile --replace "/sbin" "/bin" --replace "/usr/" "/"
@@ -65,4 +65,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ bobvanderlinden ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -12,6 +12,7 @@
   binutils,
   writeText,
   runCommand,
+  validatePkgConfig,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -25,7 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-YAhsnE1DJ5UlYAuhDxS/5IpfIJB6DrhCT3E0YiKENjU=";
   };
 
-  nativeBuildInputs = [ flex ];
+  nativeBuildInputs = [
+    flex
+    validatePkgConfig
+  ];
 
   buildInputs = [
     libuuid
@@ -62,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests = {
     version = testers.testVersion { package = finalAttrs.finalPackage; };
+    pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
     no-usr = testers.testEqualContents {
       assertion = "There should be no /usr/ paths in the binaries";
       # There is a bash script that refers to lshal, which is deprecated and not available in Nixpkgs.
@@ -82,5 +87,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ bobvanderlinden ];
     platforms = platforms.linux;
     mainProgram = "hwinfo";
+    pkgConfigModules = [ "hwinfo" ];
   };
 })

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "lex isdn_cdb.lex" "flex isdn_cdb.lex"
     substituteInPlace hwinfo.pc.in \
       --replace-fail "prefix=/usr" "prefix=$out"
+    substituteInPlace src/isdn/cdb/cdb_hwdb.h \
+      --replace-fail "/usr/share" "$out/share"
 
     # replace absolute paths with relative, we will prefix PATH later
     substituteInPlace src/hd/hd_int.h \

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -30,11 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    # VERSION and changelog are usually generated using Git
-    # unless HWINFO_VERSION is defined (see Makefile)
-    export HWINFO_VERSION="${finalAttrs.version}"
-    sed -i 's|^\(TARGETS\s*=.*\)\<changelog\>\(.*\)$|\1\2|g' Makefile
-
     substituteInPlace Makefile --replace "/sbin" "/bin" --replace "/usr/" "/"
     substituteInPlace src/isdn/cdb/Makefile --replace "lex isdn_cdb.lex" "flex isdn_cdb.lex"
     substituteInPlace hwinfo.pc.in --replace "prefix=/usr" "prefix=$out"
@@ -54,7 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
     fi
   '';
 
-  makeFlags = [ "LIBDIR=/lib" ];
+  makeFlags = [
+    "LIBDIR=/lib"
+    "HWINFO_VERSION=${finalAttrs.version}"
+  ];
 
   installFlags = [ "DESTDIR=$(out)" ];
 

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -30,9 +30,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    substituteInPlace Makefile --replace "/sbin" "/bin" --replace "/usr/" "/"
-    substituteInPlace src/isdn/cdb/Makefile --replace "lex isdn_cdb.lex" "flex isdn_cdb.lex"
-    substituteInPlace hwinfo.pc.in --replace "prefix=/usr" "prefix=$out"
+    substituteInPlace Makefile \
+      --replace-fail "/sbin" "/bin" \
+      --replace-fail "/usr/" "/"
+    substituteInPlace src/isdn/cdb/Makefile \
+      --replace-fail "lex isdn_cdb.lex" "flex isdn_cdb.lex"
+    substituteInPlace hwinfo.pc.in \
+      --replace-fail "prefix=/usr" "prefix=$out"
 
     # replace absolute paths with relative, we will prefix PATH later
     substituteInPlace src/hd/hd_int.h \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8813,8 +8813,6 @@ with pkgs;
 
   humanfriendly = with python3Packages; toPythonApplication humanfriendly;
 
-  hwinfo = callPackage ../tools/system/hwinfo { };
-
   hw-probe = perlPackages.callPackage ../tools/system/hw-probe { };
 
   hybridreverb2 = callPackage ../applications/audio/hybridreverb2 { };


### PR DESCRIPTION
## Description of changes

Follow-up from https://github.com/NixOS/nixpkgs/pull/334633#pullrequestreview-2244309876

This PR includes several improvements to the hwinfo package.
See the individual commits for more details.

The newly introduced tests pass.
The updater seems to be working.

This also fixes another possible use of `/usr/bin/`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
