### PR TITLE
Re-upgrade erofs-utils to 1.8

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -143,6 +143,7 @@ let
           --transform 'flags=rSh;s|/nix/store/||' \
           --files-from ${hostPkgs.closureInfo { rootPaths = [ config.system.build.toplevel regInfo ]; }}/store-paths \
           | ${hostPkgs.erofs-utils}/bin/mkfs.erofs \
+            --quiet \
             --force-uid=0 \
             --force-gid=0 \
             -L ${nixStoreFilesystemLabel} \

--- a/pkgs/tools/filesystems/erofs-utils/default.nix
+++ b/pkgs/tools/filesystems/erofs-utils/default.nix
@@ -1,29 +1,50 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, fuse, util-linux, lz4, xz, zlib, libselinux
-, fuseSupport ? stdenv.isLinux
-, selinuxSupport ? false
-, lzmaSupport ? false
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoreconfHook,
+  pkg-config,
+  fuse,
+  util-linux,
+  lz4,
+  xz,
+  zlib,
+  libselinux,
+  fuseSupport ? stdenv.isLinux,
+  selinuxSupport ? false,
+  lzmaSupport ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "erofs-utils";
   version = "1.8.1";
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchurl {
-    url =
-      "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${finalAttrs.version}.tar.gz";
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${finalAttrs.version}.tar.gz";
     hash = "sha256-Xb97SS92gkYrl6dxIdQ8p2Cc2Q5l+MlpMa78ggpvDaM=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ util-linux lz4 zlib ]
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs =
+    [
+      util-linux
+      lz4
+      zlib
+    ]
     ++ lib.optionals fuseSupport [ fuse ]
     ++ lib.optionals selinuxSupport [ libselinux ]
     ++ lib.optionals lzmaSupport [ xz ];
 
-  configureFlags = [
-    "MAX_BLOCK_SIZE=4096"
-  ] ++ lib.optional fuseSupport "--enable-fuse"
+  configureFlags =
+    [ "MAX_BLOCK_SIZE=4096" ]
+    ++ lib.optional fuseSupport "--enable-fuse"
     ++ lib.optional selinuxSupport "--with-selinux"
     ++ lib.optional lzmaSupport "--enable-lzma";
 
@@ -32,7 +53,11 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Userspace utilities for linux-erofs file system";
     changelog = "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/tree/ChangeLog?h=v${version}";
     license = with licenses; [ gpl2Plus ];
-    maintainers = with maintainers; [ ehmry nikstur jmbaur ];
+    maintainers = with maintainers; [
+      ehmry
+      nikstur
+      jmbaur
+    ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/tools/filesystems/erofs-utils/default.nix
+++ b/pkgs/tools/filesystems/erofs-utils/default.nix
@@ -4,15 +4,15 @@
 , lzmaSupport ? false
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "erofs-utils";
-  version = "1.7.1";
+  version = "1.8.1";
   outputs = [ "out" "man" ];
 
   src = fetchurl {
     url =
-      "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${version}.tar.gz";
-    hash = "sha256-GWCD1j5eIx+1eZ586GqUS7ylZNqrzj3pIlqKyp3K/xU=";
+      "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Xb97SS92gkYrl6dxIdQ8p2Cc2Q5l+MlpMa78ggpvDaM=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -35,4 +35,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ehmry nikstur ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/tools/filesystems/erofs-utils/default.nix
+++ b/pkgs/tools/filesystems/erofs-utils/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Userspace utilities for linux-erofs file system";
     changelog = "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/tree/ChangeLog?h=v${version}";
     license = with licenses; [ gpl2Plus ];
-    maintainers = with maintainers; [ ehmry nikstur ];
+    maintainers = with maintainers; [ ehmry nikstur jmbaur ];
     platforms = platforms.unix;
   };
 })


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/335611 

So the nixos VM tests run the `startVM` script in a Popen call (see https://github.com/nixos/nixpkgs/blob/6ebe64bfe00e71b619578b3539fcba7a28cd1c8c/nixos/lib/test-driver/test_driver/machine.py#L203), which is loaded with output from the erofs-utils upgrade to 1.8.1.

Reproducer:

```python
import subprocess

print(subprocess.Popen(
    "/nix/store/k11rxbj9mvpgfk15rriqjn97by18r2xk-gnutar-1.35/bin/tar --create --absolute-names --verbatim-files-from --transform 'flags=rSh;s|/nix/store/||' --files-from /nix/store/aldmf8b535b09w0fq5r7vr3rzrcxbdaz-closure-info/store-paths | /nix/store/3jgkw8wylsg0hzzdwaifz6qds8mhdri3-erofs-utils-1.8.1/bin/mkfs.erofs --force-uid=0 --force-gid=0 -L nix-store -U eb176051-bd15-49b7-9e6b-462e0b467019 -T 0 --tar=f /tmp/store.img",
    # "/nix/store/k11rxbj9mvpgfk15rriqjn97by18r2xk-gnutar-1.35/bin/tar --create --absolute-names --verbatim-files-from --transform 'flags=rSh;s|/nix/store/||' --files-from /nix/store/aldmf8b535b09w0fq5r7vr3rzrcxbdaz-closure-info/store-paths | /nix/store/3jgkw8wylsg0hzzdwaifz6qds8mhdri3-erofs-utils-1.8.1/bin/mkfs.erofs --quiet --force-uid=0 --force-gid=0 -L nix-store -U eb176051-bd15-49b7-9e6b-462e0b467019 -T 0 --tar=f /tmp/store.img",
    # "/nix/store/k11rxbj9mvpgfk15rriqjn97by18r2xk-gnutar-1.35/bin/tar --create --absolute-names --verbatim-files-from --transform 'flags=rSh;s|/nix/store/||' --files-from /nix/store/aldmf8b535b09w0fq5r7vr3rzrcxbdaz-closure-info/store-paths | /nix/store/878azf6g0a60vq07j4r8qvz7x6jd8jai-erofs-utils-1.7.1/bin/mkfs.erofs --force-uid=0 --force-gid=0 -L nix-store -U eb176051-bd15-49b7-9e6b-462e0b467019 -T 0 --tar=f /tmp/store.img",
    stdin=subprocess.PIPE,
    stdout=subprocess.PIPE,
    shell=True,
    encoding="utf-8",
).communicate()[0])
```

In the first call, Popen hangs too long for my patience. In the second, Popen finishes after ~12 seconds

```
$ time nix run nixpkgs#python3 /tmp/test.py

nix run nixpkgs#python3 /tmp/test.py  2.65s user 12.68s system 108% cpu 14.163 total
```

And in the third, it finishes in ~14 seconds

```
$ time nix run nixpkgs#python3 /tmp/test.py
mkfs.erofs 1.7.1

Build completed.
------
Filesystem UUID: eb176051-bd15-49b7-9e6b-462e0b467019
Filesystem total blocks: 1235942 (of 4096-byte blocks)
Filesystem total inodes: 327519
Filesystem total metadata blocks: 91269
Filesystem total deduplicated bytes (of source files): 0

nix run nixpkgs#python3 /tmp/test.py  2.81s user 14.19s system 87% cpu 19.526 total
```

Even with the lowest log level for mkfs.erofs 1.8.1 (`-d0`), there is still a lot of output, so it seems suppressing all output is the simplest way to go.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
