### PR TITLE
nixos/dnsmasq: remove deprecated option "extraConfig"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -438,6 +438,8 @@
 
 - The `openlens` package got removed, suggested replacment `lens-desktop`
 
+- The `services.dnsmasq.extraConfig` option has been removed, as it had been deprecated for over 2 years. This option has been replaced by `services.dnsmasq.settings`.
+
 - The NixOS installation media no longer support the ReiserFS or JFS file systems by default.
 
 - Minimal installer ISOs are no longer built on the small channel.

--- a/nixos/modules/services/networking/dnsmasq.nix
+++ b/nixos/modules/services/networking/dnsmasq.nix
@@ -20,13 +20,7 @@ let
     listsAsDuplicateKeys = true;
   };
 
-  # Because formats.generate is outputting a file, we use of conf-file. Once
-  # `extraConfig` is deprecated we can just use
-  # `dnsmasqConf = format.generate "dnsmasq.conf" cfg.settings`
-  dnsmasqConf = pkgs.writeText "dnsmasq.conf" ''
-    conf-file=${settingsFormat.generate "dnsmasq.conf" cfg.settings}
-    ${cfg.extraConfig}
-  '';
+  dnsmasqConf = settingsFormat.generate "dnsmasq.conf" cfg.settings;
 
 in
 
@@ -34,6 +28,7 @@ in
 
   imports = [
     (lib.mkRenamedOptionModule [ "services" "dnsmasq" "servers" ] [ "services" "dnsmasq" "settings" "server" ])
+    (lib.mkRemovedOptionModule [ "services" "dnsmasq" "extraConfig" ] "This option has been replaced by `services.dnsmasq.settings`")
   ];
 
   ###### interface
@@ -104,17 +99,6 @@ in
         '';
       };
 
-      extraConfig = lib.mkOption {
-        type = lib.types.lines;
-        default = "";
-        description = ''
-          Extra configuration directives that should be added to
-          `dnsmasq.conf`.
-
-          This option is deprecated, please use {option}`settings` instead.
-        '';
-      };
-
     };
 
   };
@@ -123,8 +107,6 @@ in
   ###### implementation
 
   config = lib.mkIf cfg.enable {
-
-    warnings = lib.optional (cfg.extraConfig != "") "Text based config is deprecated, dnsmasq now supports `services.dnsmasq.settings` for an attribute-set based config";
 
     services.dnsmasq.settings = {
       dhcp-leasefile = lib.mkDefault "${stateDir}/dnsmasq.leases";

--- a/nixos/modules/services/networking/nixops-dns.nix
+++ b/nixos/modules/services/networking/nixops-dns.nix
@@ -68,10 +68,10 @@ in
       servers = [
         "/${cfg.domain}/127.0.0.1#5300"
       ];
-      extraConfig = ''
-        bind-interfaces
-        listen-address=127.0.0.1
-      '';
+      settings = {
+        bind-interfaces = true;
+        listen-address = "127.0.0.1";
+      };
     };
 
   };


### PR DESCRIPTION
## Description of changes

Remove deprecated option https://github.com/NixOS/nixpkgs/blob/f02fa2f654c7bcc45f0e815c29d093da7f1245b4/nixos/doc/manual/release-notes/rl-2305.section.md?plain=1#L417-L420

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
