### PR TITLE
lazyjj: init at 0.3.1

### DIFF
--- a/pkgs/by-name/la/lazyjj/package.nix
+++ b/pkgs/by-name/la/lazyjj/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  jujutsu,
+  rustPlatform,
+  testers,
+  lazyjj,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "lazyjj";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Cretezy";
+    repo = "lazyjj";
+    rev = "v${version}";
+    hash = "sha256-VlGmOdF/XsrZ/9vQ14UuK96LIK8NIkPZk4G4mbS8brg=";
+  };
+
+  cargoHash = "sha256-TAq9FufGsNVsmqCE41REltYRSSLihWJwTMoj0bTxdFc=";
+
+  postInstall = ''
+    wrapProgram $out/bin/lazyjj \
+      --prefix PATH : ${lib.makeBinPath [ jujutsu ]}
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  nativeCheckInputs = [ jujutsu ];
+
+  passthru.tests.version = testers.testVersion { package = lazyjj; };
+
+  meta = with lib; {
+    description = "TUI for Jujutsu/jj";
+    homepage = "https://github.com/Cretezy/lazyjj";
+    mainProgram = "lazyjj";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [`lazyjj`: "TUI for Jujutsu/jj"](https://github.com/Cretezy/lazyjj)

license: Apache 2

(which is a TUI for `jj`: [`jj` is awesome](https://martinvonz.github.io/jj/latest/), forgive the RESF-ism, but if you are a nix-er that likes other rust-y looks, you might give this pair a look. `jj` is good stuff.)

The `binutils-unwrapped` bit is cargo-culted. Not sure if needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
