### PR TITLE
oama: init at 0.14

### DIFF
--- a/pkgs/by-name/oa/oama/generated-package.nix
+++ b/pkgs/by-name/oa/oama/generated-package.nix
@@ -1,0 +1,94 @@
+# This file has been autogenerate with cabal2nix.
+# Update via ./update.sh
+{
+  mkDerivation,
+  aeson,
+  base,
+  bytestring,
+  containers,
+  directory,
+  fetchgit,
+  hsyslog,
+  http-conduit,
+  lib,
+  mtl,
+  network,
+  network-uri,
+  optparse-applicative,
+  pretty-simple,
+  process,
+  streaming-commons,
+  string-qq,
+  strings,
+  text,
+  time,
+  twain,
+  unix,
+  utf8-string,
+  warp,
+  yaml,
+}:
+mkDerivation {
+  pname = "oama";
+  version = "0.14";
+  src = fetchgit {
+    url = "https://github.com/pdobsan/oama.git";
+    sha256 = "1hdhkc6hh4nvx31vkaii7hd2rxlwqrsvr6i1i0a9r1xlda05ffq0";
+    rev = "4e1ffd3001034771d284678f0160060c1871707c";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson
+    base
+    bytestring
+    containers
+    directory
+    hsyslog
+    http-conduit
+    mtl
+    network
+    network-uri
+    optparse-applicative
+    pretty-simple
+    process
+    streaming-commons
+    string-qq
+    strings
+    text
+    time
+    twain
+    unix
+    utf8-string
+    warp
+    yaml
+  ];
+  executableHaskellDepends = [
+    aeson
+    base
+    bytestring
+    containers
+    directory
+    hsyslog
+    http-conduit
+    mtl
+    network
+    network-uri
+    optparse-applicative
+    pretty-simple
+    process
+    streaming-commons
+    string-qq
+    strings
+    text
+    time
+    twain
+    unix
+    utf8-string
+    warp
+    yaml
+  ];
+  license = lib.licenses.bsd3;
+  mainProgram = "oama";
+}

--- a/pkgs/by-name/oa/oama/package.nix
+++ b/pkgs/by-name/oa/oama/package.nix
@@ -1,0 +1,29 @@
+{
+  haskell,
+  haskellPackages,
+  lib,
+}:
+let
+  inherit (haskell.lib.compose) overrideCabal justStaticExecutables;
+
+  overrides = {
+    description = "OAuth credential MAnager";
+    homepage = "https://github.com/pdobsan/oama";
+    maintainers = with lib.maintainers; [ aidalgol ];
+
+    passthru.updateScript = ./update.sh;
+  };
+
+  raw-pkg = (haskellPackages.callPackage ./generated-package.nix { }).overrideScope (
+    final: prev: {
+      # Dependency twain requires an older version of http2, and we cannot mix
+      # versions of transitive dependencies.
+      http2 = final.http2_3_0_3;
+      warp = final.warp_3_3_30;
+    }
+  );
+in
+lib.pipe raw-pkg [
+  (overrideCabal overrides)
+  justStaticExecutables
+]

--- a/pkgs/by-name/oa/oama/update.sh
+++ b/pkgs/by-name/oa/oama/update.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p cabal2nix curl jq nixfmt-rfc-style
+
+set -euo pipefail
+
+# This is the directory of this update.sh script.
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+derivation_file="${script_dir}/generated-package.nix"
+latest_version="$(curl --silent https://api.github.com/repos/pdobsan/oama/releases/latest | jq --raw-output '.tag_name')"
+
+echo "Updating oama to version ${latest_version}."
+echo "Running cabal2nix and outputting to ${derivation_file}..."
+
+cat > "${derivation_file}" << EOF
+# This file has been autogenerate with cabal2nix.
+# Update via ./update.sh
+EOF
+
+cabal2nix --revision "${latest_version}" https://github.com/pdobsan/oama.git >> "${derivation_file}"
+nixfmt "${derivation_file}"
+
+echo "Finished."

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -921,6 +921,7 @@ mapAliases ({
 
   ma1sd = throw "ma1sd was dropped as it is unmaintained"; # Added 2024-07-10
   MACS2 = macs2; # Added 2023-06-12
+  mailctl = throw "mailctl has been renamed to oama"; # Added 2024-08-19
   mailman-rss = throw "The mailman-rss package was dropped since it was unmaintained."; # Added 2024-06-21
   mariadb_104 = throw "mariadb_104 has been removed from nixpkgs, please switch to another version like mariadb_106"; # Added 2023-09-11
   mariadb_1010 = throw "mariadb_1010 has been removed from nixpkgs, please switch to another version like mariadb_1011"; # Added 2023-11-14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2644,13 +2644,6 @@ with pkgs;
 
   mainsail = callPackage ../applications/misc/mainsail { };
 
-  mailctl = (haskellPackages.callPackage ../tools/networking/mailctl {}).overrideScope (final: prev: {
-    # Dependency twain requires an older version of http2, and we cannot mix
-    # versions of transitive dependencies.
-    http2 = final.http2_3_0_3;
-    warp = final.warp_3_3_30;
-  });
-
   mame = libsForQt5.callPackage ../applications/emulators/mame { };
 
   mame-tools = lib.addMetaAttrs {


### PR DESCRIPTION
## Description of changes
Adds `oama` and remove `mailctl`, because `mailctl` upstream has been replaced by `oama`.
https://github.com/pdobsan/oama/discussions/26

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
