### PR TITLE
Add customPath support for non-standard PyPI directory structures

### DIFF
--- a/pkgs/build-support/fetchpypi/default.nix
+++ b/pkgs/build-support/fetchpypi/default.nix
@@ -1,28 +1,80 @@
 # `fetchPypi` function for fetching artifacts from PyPI.
-{ fetchurl
-, makeOverridable
+{
+  fetchurl,
+  makeOverridable,
+  lib,
 }:
 
 let
-  computeUrl = {format ? "setuptools", ... } @attrs: let
-    computeWheelUrl = {pname, version, dist ? "py2.py3", python ? "py2.py3", abi ? "none", platform ? "any"}:
-    # Fetch a wheel. By default we fetch an universal wheel.
-    # See https://www.python.org/dev/peps/pep-0427/#file-name-convention for details regarding the optional arguments.
-      "https://files.pythonhosted.org/packages/${dist}/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}-${python}-${abi}-${platform}.whl";
+  computeUrl =
+    {
+      format ? "setuptools",
+      customPath ? null,
+      pname,
+      version,
+      dist ? "py2.py3",
+      python ? "py2.py3",
+      abi ? "none",
+      platform ? "any",
+      extension ? "tar.gz",
+    }:
+    let
+      computeWheelUrl =
+        {
+          pname,
+          version,
+          python,
+          abi,
+          platform,
+          customPath,
+        }:
+        let
+          # Use customPath if provided, otherwise default to pname-based path
+          pathPart = if customPath != null then customPath else "${builtins.substring 0 1 pname}/${pname}";
+        in
+        # Fetch a wheel. By default, we fetch a universal wheel.
+        # See https://www.python.org/dev/peps/pep-0427/#file-name-convention for details regarding the optional arguments.
+        "https://files.pythonhosted.org/packages/${pathPart}/${pname}-${version}-${python}-${abi}-${platform}.whl";
 
-    computeSourceUrl = {pname, version, extension ? "tar.gz"}:
-    # Fetch a source tarball.
-      "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}.${extension}";
-
-    compute = (if format == "wheel" then computeWheelUrl
-      else if format == "setuptools" then computeSourceUrl
-      else throw "Unsupported format ${format}");
-
-  in compute (builtins.removeAttrs attrs ["format"]);
-
-in makeOverridable( {format ? "setuptools", sha256 ? "", hash ? "", ... } @attrs:
+      computeSourceUrl =
+        {
+          pname,
+          version,
+          extension,
+        }:
+        # Fetch a source tarball.
+        "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}.${extension}";
+    in
+    if format == "wheel" then
+      computeWheelUrl {
+        inherit
+          pname
+          version
+          python
+          abi
+          platform
+          customPath
+          ;
+      }
+    else if format == "setuptools" then
+      computeSourceUrl { inherit pname version extension; }
+    else
+      throw "Unsupported format ${format}";
+in
+makeOverridable (
+  {
+    format ? "setuptools",
+    sha256 ? "",
+    hash ? "",
+    ...
+  }@attrs:
   let
-    url = computeUrl (builtins.removeAttrs attrs ["sha256" "hash"]) ;
-  in fetchurl {
-    inherit url sha256 hash;
-  })
+    url = computeUrl (
+      builtins.removeAttrs attrs [
+        "sha256"
+        "hash"
+      ]
+    );
+  in
+  fetchurl { inherit url sha256 hash; }
+)


### PR DESCRIPTION
## Description of changes

This PR improves the `fetchPypi` function to support custom URL paths. A `customPath` attribute is included to allow users to manually specify a path to a package to avoid issues with automatic path generation that can lead to incorrect URLs. For example when using: https://pypi.org/project/verilogae/ with `fetchPypi` which does not work.

The existing fetchPypi function is designed to generate URLs for fetching Python packages from PyPI based on standard patterns, using attributes like pname, version and dist. But, this approach can fail when dealing with packages hosted in non-standard or hash-based directories which somtimes occurs on PyPI. 

For example, a package might be stored at a URL like:  https://files.pythonhosted.org/packages/aa/a6/9daea00745844faba44c2917c66838adfc315269f38518ecca49e6eb5fb5/verilogae-1.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl

The current fetchPypi logic generates a URL that incorrectly duplicates path segments or misinterprets the directory structure, causing a 404 error during fetch. The `customPath` attribute allows a URL path to be specified which bypasses the automatic path construction that may not always work.

Usage:
```nix
 src = fetchPypi {
    inherit pname version;
    python = "cp311";
    abi = "cp311";
    platform = "manylinux_2_17_x86_64.manylinux2014_x86_64";
    format = "wheel";
    customPath = "aa/a6/9daea00745844faba44c2917c66838adfc315269f38518ecca49e6eb5fb5";
    sha256 = "QsEVq/4c44xCkovOhXOj8Zh6rp4Ipq+NGjbTW25Fd6E=";
  };
```

Please see [PEP427](https://peps.python.org/pep-0427/), [PEP 503](https://peps.python.org/pep-0503/) and [PyPI's own documentation](https://warehouse.pypa.io/api-reference/integration-guide.html#predictable-urls) on URL schemes for additional info. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
