### PR TITLE
duckstation-bin: init at 0.1-7294

### DIFF
--- a/pkgs/by-name/du/duckstation-bin/package.nix
+++ b/pkgs/by-name/du/duckstation-bin/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "duckstation-bin";
+  version = "0.1-7294";
+
+  src = fetchurl {
+    url = "https://github.com/stenzek/duckstation/releases/download/v${finalAttrs.version}/duckstation-mac-release.zip";
+    hash = "sha256-33aipZjYJOquQBbe8Ve9KRfLGW29v9xoztUsaY8LAjw=";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r DuckStation.app $out/Applications/DuckStation.app
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    homepage = "https://github.com/stenzek/duckstation";
+    description = "Fast PlayStation 1 emulator for x86-64/AArch32/AArch64";
+    changelog = "https://github.com/stenzek/duckstation/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ matteopacini ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/du/duckstation-bin/update.sh
+++ b/pkgs/by-name/du/duckstation-bin/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq gnused
+
+set -euo pipefail
+
+cd "$(dirname "$0")" || exit 1
+
+# Grab latest version, ignoring "latest" and "preview" tags
+LATEST_VER="$(curl --fail -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/stenzek/duckstation/releases" | jq -r '.[].tag_name' | grep '^v' | head -n 1 | sed 's/^v//')"
+CURRENT_VER="$(grep -oP 'version = "\K[^"]+' package.nix)"
+
+if [[ "$LATEST_VER" == "$CURRENT_VER" ]]; then
+    echo "duckstation-bin is up-to-date"
+    exit 0
+fi
+
+HASH="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "https://github.com/stenzek/duckstation/releases/download/v${LATEST_VER}/duckstation-mac-release.zip")")"
+
+sed -i "s#hash = \".*\"#hash = \"$HASH\"#g" package.nix
+sed -i "s#version = \".*\";#version = \"$LATEST_VER\";#g" package.nix


### PR DESCRIPTION
## Description of changes

- Added a new derivation for the binary distribution of `DuckStation`, as this cannot be compiled from source on Darwin (requires compilation of Metal shaders, that in turn requires Xcode).
- Also added a `r-ryantm` bot friendly update script

Same approach that has been adopted for `pcsx2` - `pcsx2` is the Linux version, built from source, and `pcsx2-bin` is the Darwin version (binary redist). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
