### PR TITLE
electron: 29.4.5 -> 29.4.6, 30.3.1 -> 30.4.0

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,14 +45,14 @@
     },
     "30": {
         "hashes": {
-            "aarch64-darwin": "9d7b31185ef61628e6f3abda32517953518f68d9f71a8fa29f2a0a17b9d3b9bb",
-            "aarch64-linux": "5f2326631080cc4a5f6231a83e492d8d75d9ccdd3bd41f56f6a1090e790d2a2a",
-            "armv7l-linux": "ef7be229a610cee357cba2f790618b239aab82fc2b26e0645c4cf4600dffb1c4",
-            "headers": "1s6cl0am8rv262s7ycixv3rjwry0s1ssimm109fh5xn2m808swn9",
-            "x86_64-darwin": "a66dbe01006fee9319f19c16ef08d4d72ecbb79bd35fffece32b36b8afe2ea47",
-            "x86_64-linux": "94d7470d9dae2dd2376612c804068ea6514e5efe342de8946f49f93bf0ed50de"
+            "aarch64-darwin": "2238c45a85b2c78aed00aeaf15bbfa2f64b4d13e48cc6b9bc330f24c4d214595",
+            "aarch64-linux": "aa422122373b84f4eb8ce937937b1b6fe8fb3975c3edafb9df85f7fba449afd4",
+            "armv7l-linux": "3643857e1eec3037ad6f07e755bffc64f033a7196307ff0386bf67c9cc3ec31e",
+            "headers": "1zpl51g8d0j6xw4h2pw1wy6qlwgxj37x4lsj377kg27y809rf5ah",
+            "x86_64-darwin": "6e633bf87be9f8bf46dff9733cfd0d611e018ae5df75f30735747721f91fcf43",
+            "x86_64-linux": "b365aac23c61dc0b18002c60937c4842e814cbe6d8e6a34e4dc211774ebaec01"
         },
-        "version": "30.3.1"
+        "version": "30.4.0"
     },
     "31": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -34,14 +34,14 @@
     },
     "29": {
         "hashes": {
-            "aarch64-darwin": "c4b1024ef77d3a6380541b3ae3b6cc60748ebdbeed17277cc2dc4b72944c1ddc",
-            "aarch64-linux": "b27d87b8d0da41cab3c683ac7fa71af84492fe5f9bcd5970da0c73901d18c5f8",
-            "armv7l-linux": "1f8681870ffda20a4f45afffd850619a55e711b3f6a033a5ac4a659540f7b339",
-            "headers": "0yzwc2d8hfrsrpg4m7234cyvcx9ch3psx9rsywbli1avzb8rkjdi",
-            "x86_64-darwin": "e3cf8e623049f18a0d7a7871fb5f14a9150352d7b1c5d59dca8388b3a9b42cb1",
-            "x86_64-linux": "b81bac1ffa3b0d82837d05212e988854ca9db0350c571857e0851f34443a5ecd"
+            "aarch64-darwin": "077c7abc2c8f1117863141fb5662684fc1320823e0e0aab6c42ad97bcfcceace",
+            "aarch64-linux": "14d5b54ef561cea2ca28c55a877bc1a1a3e360ca2f9e69ab3aa719054eca8552",
+            "armv7l-linux": "9007e44a5cb5b7645455e7895d2039d3264cab2eb0ecf8dbb4295344d392ca74",
+            "headers": "0swfh30yilw6w0qi6cl6ccm3rdvdmpr5s2vaxy5bbmizc88a4jkv",
+            "x86_64-darwin": "9f367006b67a923903e27b0be72a1a578b97936ca36cd91856adf4a278076d67",
+            "x86_64-linux": "2346338e2ffa12276f5b3bc6d63ff357c39f42d260ad45f19471ef7bbf18a389"
         },
-        "version": "29.4.5"
+        "version": "29.4.6"
     },
     "30": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -12,14 +12,14 @@
     },
     "30": {
         "hashes": {
-            "aarch64-darwin": "65621c6968832b604d1b81b65c2a4fdc56baafe167e76d22c55afa4c67c840f1",
-            "aarch64-linux": "c7767da210b8d4f084576e308570fcf15268c7f6a1182a621ce90788fe45d458",
-            "armv7l-linux": "509197b47830f31b715f3ab8940279c5b2c7f473c2059148efd86dffb58b895d",
-            "headers": "1s6cl0am8rv262s7ycixv3rjwry0s1ssimm109fh5xn2m808swn9",
-            "x86_64-darwin": "28001491af5805d8975f59edcee644f93e425b7e59f1fe94915ce9a286f7cd9e",
-            "x86_64-linux": "f4f6a66323b1180045321c779eacb88b48c8969e3ddf95d1d0aab92eb26ff071"
+            "aarch64-darwin": "3e432bd550279c2d58c6a02b0bda048fa2a9a89aef9752e22c39a518a83fe96f",
+            "aarch64-linux": "338f2a361448e78aa8c319cd582f2dd6d891d6c0c66b676c628e50511c27514f",
+            "armv7l-linux": "8cffae19618fe5f0eaff40378c40084e18f9747bbbe2d87390203a3012c98367",
+            "headers": "1zpl51g8d0j6xw4h2pw1wy6qlwgxj37x4lsj377kg27y809rf5ah",
+            "x86_64-darwin": "4d38f40ec33955dd0aef5cc0053b2b07c4744abb9f2614a44780280c4678aca9",
+            "x86_64-linux": "7ff1b75defc522f327c0f1bf6f4d13938b041cf5de1d7417b9dc5d1e7026e93c"
         },
-        "version": "30.3.1"
+        "version": "30.4.0"
     },
     "31": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -1,14 +1,14 @@
 {
     "29": {
         "hashes": {
-            "aarch64-darwin": "d2d4874957d6cf5b27168d9d1c96ef15cf333799b010dbee3bb6f64c16c228fb",
-            "aarch64-linux": "5bef9d44e32b853c31a11140c46304cfe2ba821e403beb55f14b9aa875ae1488",
-            "armv7l-linux": "128b6312f8677da8e133fc7878c7a476bd80f89d7002968e5f3d5946979c33a9",
-            "headers": "0yzwc2d8hfrsrpg4m7234cyvcx9ch3psx9rsywbli1avzb8rkjdi",
-            "x86_64-darwin": "f01ce2d13f6d3cdd957c06c90fc81ff1deb24b5d9084864bc0147acecaba2ea1",
-            "x86_64-linux": "4b305c3b0ce7b67316143162ba78bf217a95aa255c0cc847b2553551b0296790"
+            "aarch64-darwin": "8a100f4e7a84862847ab0804446ee805fbba0a68657420b369f80db417c1c87a",
+            "aarch64-linux": "232c375e4789b887a7f8712a64ac5849cf41904808b9aa00f6f6fbbf6621105d",
+            "armv7l-linux": "2c639a32c9436f135ef69db9640dcf4489b2dea30e865a0f63a87bb92d9ccf88",
+            "headers": "0swfh30yilw6w0qi6cl6ccm3rdvdmpr5s2vaxy5bbmizc88a4jkv",
+            "x86_64-darwin": "4364c264c932099d09fe67cc0072e6071739ad67ca1fecf5bfd7e8c1fdcc8671",
+            "x86_64-linux": "1c2b450b99929b49269a56db2dc60920f027ec92ae01a4620fa3f64473539caa"
         },
-        "version": "29.4.5"
+        "version": "29.4.6"
     },
     "30": {
         "hashes": {

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -47,10 +47,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-CKDvVP0S2g4CIPzMXPLe5C8rqeWvF/0gaXam8bDynuw=",
+                "hash": "sha256-NwkTCKyqn9JpRZrL8gHzqe/GJIj7Vc5y7q49bVGzV/E=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v29.4.5"
+                "rev": "v29.4.6"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -902,7 +902,7 @@
         "electron_yarn_hash": "0w41mjfnrhmkf2qy4lk5zwhc7afkaiqypxs4379s4ay1r6zpvf6q",
         "modules": "121",
         "node": "20.9.0",
-        "version": "29.4.5"
+        "version": "29.4.6"
     },
     "30": {
         "chrome": "124.0.6367.243",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -952,10 +952,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-C0PIpx72aRo/SVD17axkAVA36DICGjbzD++ns3KSUYo=",
+                "hash": "sha256-SUwtnpYQbPRCIzTQcJnoW9sI597LP1BvqNrhcb2NNfk=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v30.3.1"
+                "rev": "v30.4.0"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -1819,7 +1819,7 @@
         "electron_yarn_hash": "0vq12z09hcm6xdrd34b01vx1c47r4zdaqrkw9db6r612xrp2xi0c",
         "modules": "123",
         "node": "20.15.1",
-        "version": "30.3.1"
+        "version": "30.4.0"
     },
     "31": {
         "chrome": "126.0.6478.234",


### PR DESCRIPTION
## Description of changes
### Electron 29
- Changelog: https://github.com/electron/electron/releases/tag/v29.4.6
- Diff: https://github.com/electron/electron/compare/refs/tags/v29.4.5...v29.4.6
- Fixes CVE-2024-6772
- Fixes CVE-2024-6773
- Fixes CVE-2024-6774
- Fixes CVE-2024-6775
- Fixes CVE-2024-6776
- Fixes CVE-2024-6777
- Fixes CVE-2024-6778
- Fixes CVE-2024-6779
- Fixes CVE-2024-6989
- Fixes CVE-2024-6991

This is the last release before reaching end-of-life. Cleanup will be handled in #335850.

### Electron 30
- Changelog: https://github.com/electron/electron/releases/tag/v30.4.0
- Diff: https://github.com/electron/electron/compare/refs/tags/v30.3.1...v30.4.0
- Fixes CVE-2024-6772
- Fixes CVE-2024-6773
- Fixes CVE-2024-6774
- Fixes CVE-2024-6775
- Fixes CVE-2024-6776
- Fixes CVE-2024-6777
- Fixes CVE-2024-6778
- Fixes CVE-2024-6779
- Fixes CVE-2024-6989
- Fixes CVE-2024-6991
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
