### PR TITLE
nixpkgs-manual: fix build

### DIFF
--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -91,7 +91,7 @@ To obtain the hash without external tools, set `vendorHash = lib.fakeHash;` and 
 }
 ```
 
-### Overriding `goModules` (#buildGoModule-goModules-override)
+### Overriding `goModules` {#buildGoModule-goModules-override}
 
 Overriding `<pkg>.goModules` by calling `goModules.overrideAttrs` is unsupported. Still, it is possible to override the `vendorHash` (`goModules`'s `outputHash`) and the `pre`/`post` hooks for both the build and patch phases of the primary and `goModules` derivation. Alternatively, the primary derivation provides an overridable `passthru.overrideModAttrs` function to store the attribute overlay implicitly taken by `goModules.overrideAttrs`. Here's an example usage of `overrideModAttrs`:
 


### PR DESCRIPTION
## Description of changes

This was accidentally introduced in #225051.

## Things done

- [x] `nix-build -A nixpkgs-manual`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).