### PR TITLE
git: re-enable a few tests that are fixed upstream

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -325,8 +325,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace t/test-lib.sh \
       --replace "test_set_prereq POSIXPERM" ""
     # TODO: Investigate while these still fail (without POSIXPERM):
+    # Tested to fail: 2.46.0
     disable_test t0001-init 'shared overrides system'
+    # Tested to fail: 2.46.0
     disable_test t0001-init 'init honors global core.sharedRepository'
+    # Tested to fail: 2.46.0
     disable_test t1301-shared-repo
     # /build/git-2.44.0/contrib/completion/git-completion.bash: line 452: compgen: command not found
     disable_test t9902-completion
@@ -337,24 +340,12 @@ stdenv.mkDerivation (finalAttrs: {
     # Disable sendmail tests
     disable_test t9001-send-email
   '' + ''
-    # XXX: I failed to understand why this one fails.
-    # Could someone try to re-enable it on the next release ?
-    # Tested to fail: 2.18.0 and 2.19.0
-    disable_test t1700-split-index "null sha1"
-
     # Flaky tests:
-    disable_test t5319-multi-pack-index
     disable_test t6421-merge-partial-clone
 
     # Fails reproducibly on ZFS on Linux with formD normalization
     disable_test t0021-conversion
     disable_test t3910-mac-os-precompose
-
-  '' + lib.optionalString (!perlSupport) ''
-    # request-pull is a Bash script that invokes Perl, so it is not available
-    # when NO_PERL=1, and the test should be skipped, but the test suite does
-    # not check for the Perl prerequisite.
-    disable_test t5150-request-pull
   '' + lib.optionalString stdenv.isDarwin ''
     # XXX: Some tests added in 2.24.0 fail.
     # Please try to re-enable on the next release.


### PR DESCRIPTION
## Description of changes

This PR re-introduces the changes from the now-closed PR #335817, which mass-pinged.

Original text of PR from @miallo:

> When fiddling a bit with the git source-code I realized that the following tests have been fixed upstream and can be re-enabled here:
>
> - t5150: now has the proper perl prerequisite check: https://git.kernel.org/pub/scm/git/git.git/tree/t/t5150-request-pull.sh?h=v2.43.0#n10
> - t5319: flake was fixed: https://git.kernel.org/pub/scm/git/git.git/commit/?id=152923b132d57e1dbd693a8cb9a8bc1827405674
> - t1700: no idea what did the fix, but it is working again

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).