### PR TITLE
pict-rs_0_3: drop

### DIFF
--- a/nixos/modules/services/web-apps/pict-rs.nix
+++ b/nixos/modules/services/web-apps/pict-rs.nix
@@ -3,9 +3,6 @@
 let
   cfg = config.services.pict-rs;
   inherit (lib) maintainers mkOption types;
-
-  is03 = lib.versionOlder cfg.package.version "0.4.0";
-
 in
 {
   meta.maintainers = with maintainers; [ happysalada ];
@@ -61,38 +58,62 @@ in
 
   config = lib.mkIf cfg.enable {
     services.pict-rs.package = lib.mkDefault (
-      # An incompatible db change happened in the transition from 0.3 to 0.4.
       if lib.versionAtLeast config.system.stateVersion "23.11"
       then pkgs.pict-rs
-      else pkgs.pict-rs_0_3
+      else throw ''
+        pict-rs made changes to the database schema between 0.3 and 0.4. It
+        will apply these automatically on the first run of 0.4, but the old
+        version will no longer work after that.
+
+        Your configuration is currently using the old default of pict-rs
+        0.3. Unfortunately, 0.3 no longer builds due to the Rust 1.80 update,
+        and has been removed. pict-rs has already been updated to 0.5 in
+        Nixpkgs, which has another schema change but removes the migration
+        logic for 0.3.
+
+        You will need to migrate to 0.4 first, and then to 0.5. As 0.4 is
+        no longer present in Nixpkgs, the recommended migration path is:
+
+        * Import a separate Nixpkgs old enough to contain 0.4, temporarily
+          set `services.pict-rs.package` to its pict-rs, set the
+          `PICTRS__OLD_DB__PATH` environment variable for the migration, and
+          activate your configuration to start it. The following configuration
+          snippet should work:
+
+              services.pict-rs.package =
+                (import (builtins.fetchTarball {
+                  url = "https://github.com/NixOS/nixpkgs/archive/9b19f5e77dd906cb52dade0b7bd280339d2a1f3d.tar.gz";
+                  sha256 = "sha256:0939vbhln9d33xkqw63nsk908k03fxihj85zaf70i3il9z42q8mc";
+                }) pkgs.config).pict-rs;
+
+              systemd.services.pict-rs.environment.PICTRS__OLD_DB__PATH = config.services.pict-rs.dataDir;
+
+        * After the migration to 0.4 completes, remove the package and
+          environment variable overrides, set `services.pict-rs.package` to
+          the current `pkgs.pict-rs` instead, and activate your configuration
+          to begin the migration to 0.5.
+
+        For more information, see:
+
+        * <https://git.asonix.dog/asonix/pict-rs/src/tag/v0.4.8#0-3-to-0-4-migration-guide>
+        * <https://git.asonix.dog/asonix/pict-rs/src/tag/v0.5.16#0-4-to-0-5-migration-guide>
+
+        The NixOS module will handle the configuration changes for you,
+        at least.
+      ''
     );
 
-    # Account for config differences between 0.3 and 0.4
-    assertions = [
-      {
-        assertion = !is03 || (cfg.repoPath == null && cfg.storePath == null);
-        message = ''
-          Using `services.pict-rs.repoPath` or `services.pict-rs.storePath` with pict-rs 0.3 or older has no effect.
-        '';
-      }
-    ];
-
     systemd.services.pict-rs = {
-      # Pict-rs split it's database and image storage paths in 0.4.0.
-      environment =
-        if is03 then {
-          PICTRS__PATH = cfg.dataDir;
-          PICTRS__ADDR = "${cfg.address}:${toString cfg.port}";
-        } else {
-          PICTRS__REPO__PATH = if cfg.repoPath != null then cfg.repoPath else "${cfg.dataDir}/sled-repo";
-          PICTRS__STORE__PATH = if cfg.storePath != null then cfg.storePath else "${cfg.dataDir}/files";
-          PICTRS__SERVER__ADDRESS = "${cfg.address}:${toString cfg.port}";
-        };
+      environment = {
+        PICTRS__REPO__PATH = if cfg.repoPath != null then cfg.repoPath else "${cfg.dataDir}/sled-repo";
+        PICTRS__STORE__PATH = if cfg.storePath != null then cfg.storePath else "${cfg.dataDir}/files";
+        PICTRS__SERVER__ADDRESS = "${cfg.address}:${toString cfg.port}";
+      };
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         DynamicUser = true;
         StateDirectory = "pict-rs";
-        ExecStart = if is03 then "${lib.getBin cfg.package}/bin/pict-rs" else "${lib.getBin cfg.package}/bin/pict-rs run";
+        ExecStart = "${lib.getBin cfg.package}/bin/pict-rs run";
       };
     };
   };

--- a/nixos/modules/services/web-apps/pict-rs.nix
+++ b/nixos/modules/services/web-apps/pict-rs.nix
@@ -86,7 +86,7 @@ in
         } else {
           PICTRS__REPO__PATH = if cfg.repoPath != null then cfg.repoPath else "${cfg.dataDir}/sled-repo";
           PICTRS__STORE__PATH = if cfg.storePath != null then cfg.storePath else "${cfg.dataDir}/files";
-          PICTRS__SERVER__ADDR = "${cfg.address}:${toString cfg.port}";
+          PICTRS__SERVER__ADDRESS = "${cfg.address}:${toString cfg.port}";
         };
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1146,6 +1146,7 @@ mapAliases ({
   picom-allusive = throw "picom-allusive was renamed to compfy and is being abandoned by upstream"; # Added 2024-02-13
   picom-jonaburg = throw "picom-jonaburg was removed because it is unmaintained by upstream"; # Added 2024-02-13
   picom-next = picom; # Added 2024-02-13
+  pict-rs_0_3 = throw "pict-rs_0_3 has been removed, as it was an outdated version and no longer compiled"; # Added 2024-08-20
 
   # Obsolete PHP version aliases
   php80 = throw "php80 has been dropped due to the lack of maintenance from upstream for future releases"; # Added 2023-06-21

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25417,11 +25417,6 @@ with pkgs;
 
   pict-rs = callPackage ../servers/web-apps/pict-rs { };
 
-  pict-rs_0_3 = callPackage ../servers/web-apps/pict-rs/0.3.nix {
-    inherit (darwin.apple_sdk.frameworks) Security;
-    ffmpeg = ffmpeg_4;
-  };
-
   popa3d = callPackage ../servers/mail/popa3d { };
 
   postfix = callPackage ../servers/mail/postfix { };


### PR DESCRIPTION
## Description of changes

This was broken by the Rust 1.80 upgrade, and is an old version that we’d have to patch to keep working.

We have already done the 0.4 → 0.5 update without keeping around the old version or adding in any additional `stateVersion` logic in <https://github.com/NixOS/nixpkgs/pull/280221>. As a result, migration for 0.3 users is going to be a little awkward. I’ve done my best to provide comprehensive instructions for anyone who hasn’t already bumped to 0.4.

It is probably a footgun to add `stateVersion` logic for any package that makes backwards‐incompatible schema changes and only supports migration from the immediately previous version. Users won’t get migrated by default and we have to either package and maintain an endlessly growing list of old versions or add complicated instructions like this. It’s not really practical for us to support a significantly better migration story than upstream does.

cc @happysalada
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
