### PR TITLE
tagspaces: init at 5.9.2

### DIFF
--- a/pkgs/by-name/ta/tagspaces/package.nix
+++ b/pkgs/by-name/ta/tagspaces/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  makeWrapper,
+  electron,
+  autoPatchelfHook,
+  libgcc,
+  glib,
+  nss,
+  at-spi2-atk,
+  cups,
+  libdrm,
+  gtk3,
+  mesa,
+  alsa-lib,
+  libGL,
+  libnotify,
+  libsecret,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tagspaces";
+  version = "5.9.2";
+
+  src = fetchurl {
+    url = "https://github.com/tagspaces/tagspaces/releases/download/v${version}/tagspaces-linux-amd64-${version}.deb";
+    hash = "sha256-0D9ZXWaaFcKyySTAfGxA3svjSKPKD1EVPR9yoa35Nes=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    dpkg
+  ] ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    libgcc.libgcc
+    glib
+    nss
+    at-spi2-atk
+    cups
+    libdrm
+    gtk3
+    mesa
+    alsa-lib
+    libGL
+  ];
+
+  runtimeDependencies = lib.optionals stdenv.isLinux [
+    libGL
+    libnotify
+    libsecret
+  ];
+
+  dontAutoPatchelf = true;
+
+  unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/opt $out/share
+    cp -R opt/TagSpaces $out/opt/
+    cp -R usr/share/{applications,icons} $out/share
+    substituteInPlace $out/share/applications/tagspaces.desktop \
+      --replace-fail "/opt/TagSpaces/tagspaces" "$out/bin/tagspaces"
+
+    makeWrapper ${electron}/bin/electron $out/bin/tagspaces \
+      --add-flags $out/opt/TagSpaces/resources/app.asar \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  fixupPhase = lib.optionalString stdenv.isLinux ''
+    runHook preFixup
+
+    autoPatchelf $out/opt/TagSpaces/resources
+
+    runHook postFixup
+  '';
+
+  meta = {
+    description = "Free, no vendor lock-in, open source application for managing local files with the help of tags";
+    changelog = "https://github.com/tagspaces/tagspaces/blob/develop/CHANGELOG.md";
+    homepage = "https://www.tagspaces.org";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ gador ];
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    mainProgram = "tagspaces";
+  };
+}


### PR DESCRIPTION
## Description of changes

Init `tagspaces`, a "privacy aware file manager with tagging and note-taking capabilities". 

Homepage: https://www.tagspaces.org/

I tried for some time to build it by source and failed.

<details>

<summary>If someone wants to pick up where I left of</summary>

My problem was that the upstream build scripts are quite elaborate and there are two sources of `package-lock.json`. These needed to be combined to provide an offline source for `npmDeps`. 
I managed to do that with a complete custom `configure` step (by using the same cache, but using `prefetchNpmDeps`  two times and after each time running `npm ci`) but it then failed to find `electron`. Even though building `electron` with `npm` succeeded, the custom scripts failed to find it.  

</details>


fixes #296744

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
