### PR TITLE
python3Packages.pcbnewtransition: fix Python 3.12 build

### DIFF
--- a/pkgs/development/python-modules/pcbnewtransition/default.nix
+++ b/pkgs/development/python-modules/pcbnewtransition/default.nix
@@ -1,22 +1,23 @@
 {
   pythonOlder,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   lib,
   kicad,
   versioneer,
 }:
 buildPythonPackage rec {
   pname = "pcbnewtransition";
-  version = "0.4.1";
+  version = "0.4.1-unstable-2024-06-05"; # There hasn't been a release yet with Python 3.12 support: https://github.com/yaqwsx/pcbnewTransition/issues/7
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    pname = "pcbnewTransition";
-    inherit version;
-    hash = "sha256-+mRExuDuEYxSSlrkEjSyPK+RRJZo+YJH7WnUVfjblRQ=";
+  src = fetchFromGitHub {
+    owner = "yaqwsx";
+    repo = "pcbnewTransition";
+    rev = "c01829807de18cddc6d735d04bab5fafa67dd95f";
+    hash = "sha256-1iub9t5YILtaSQdmUmVNYzPdvfjPlt7LQNxM7wRqas4=";
   };
 
   propagatedBuildInputs = [ kicad ];


### PR DESCRIPTION
Before this change, pcbnewtransition couldn't build. It would fail with this issue already reported (and fixed!) upstream: https://github.com/yaqwsx/pcbnewTransition/issues/6

Unfortunately, there hasn't been a release of pcbnewtransition with the fix yet, so I've opted to pull the latest commit from GitHub. I filed an issue upstream asking for a proper pypi release:
https://github.com/yaqwsx/pcbnewTransition/issues/7.

This is a blocker to get kikit building on Python 3.12: https://github.com/NixOS/nixpkgs/issues/325220

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).