### PR TITLE
Revert "auth0-cli: 1.4.0 -> 1.5.0"

### DIFF
--- a/pkgs/tools/admin/auth0-cli/default.nix
+++ b/pkgs/tools/admin/auth0-cli/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "auth0-cli";
-  version = "1.5.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "auth0";
     repo = "auth0-cli";
     rev = "refs/tags/v${version}";
-    hash = "sha256-C4zKWMrWGrnamlcugrOUUUdCUwYDgiD6XKdBQ3bBWFI=";
+    hash = "sha256-j7HT57/4rrrVkx9Zz+XuWD6UL0spdej+U5gWtFo1FSI=";
   };
 
-  vendorHash = "sha256-VeH7EDMNrdJSWHioz2O29NiGtC59IdWYww3WoABO4LY=";
+  vendorHash = "sha256-bWAneCRsQbPRxEM/3jr1/Lov6NV67MRycOgrlj3bKF8=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Reverts NixOS/nixpkgs#334453

See https://github.com/NixOS/nixpkgs/pull/334453#issuecomment-2299410418

Closes https://github.com/NixOS/nixpkgs/issues/336122