### PR TITLE
nixos/tests/vscode-remote-ssh: fix ocr, add timeout

### DIFF
--- a/nixos/tests/vscode-remote-ssh.nix
+++ b/nixos/tests/vscode-remote-ssh.nix
@@ -14,7 +14,11 @@ import ./make-test-python.nix ({ lib, ... }@args: let
   inherit (pkgs.vscode.passthru) rev vscodeServer;
 in {
   name = "vscode-remote-ssh";
-  meta.maintainers = [ ];
+
+  meta = {
+    maintainers = [ ];
+    timeout = 600;
+  };
 
   nodes = let
     serverAddress = "192.168.0.2";
@@ -70,7 +74,11 @@ in {
       client.succeed("sudo -u alice code --remote=ssh-remote+root@server /root")
       client.wait_for_window("Visual Studio Code")
 
-      client.wait_for_text("Do you trust the authors" if should_succeed else "Disconnected from SSH")
+      if should_succeed:
+        ocr_text = "Do you trust"
+      else:
+        ocr_text = "Could not establish connection"
+      client.wait_for_text(ocr_text)
       client.screenshot(screenshot)
 
       if should_succeed:


### PR DESCRIPTION
## Description of changes

- fix ocr text
- add 10 minutes timeout instead of default 1 hour

Fixes `nixosTests.vscode-remote-ssh` test timing out since `2024-07-07`:
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.vscode-remote-ssh.x86_64-linux
https://hydra.nixos.org/build/269984263

Log:
```text
(finished: must succeed: xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d', in 0.03 seconds)
(finished: waiting for a window to appear, in 6.35 seconds)
client: waiting for Disconnected from SSH to appear on screen
```
"Disconnected from SSH" at the bottom left of vscode window was no longer recognized.

For future reference - OCR tests are not very reliable.
This time they appear to work with just text change, but may break in the future again.
At least now it would timeout after 10 minutes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
