### PR TITLE
openrw: unstable-2021-10-14 -> 0-unstable-2024-04-20

### DIFF
--- a/pkgs/games/openrw/default.nix
+++ b/pkgs/games/openrw/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, ninja
 , sfml
 , libGLU
 , libGL
@@ -11,31 +12,37 @@
 , openal
 , SDL2
 , boost
-, ffmpeg_4
+, ffmpeg_6
 , Cocoa
 , OpenAL }:
 
 stdenv.mkDerivation {
-  version = "unstable-2021-10-14";
+  version = "0-unstable-2024-04-20";
   pname = "openrw";
 
   src = fetchFromGitHub {
     owner = "rwengine";
     repo = "openrw";
-    rev = "0f83c16f6518c427a4f156497c3edc843610c402";
-    sha256 = "0i6nx9g0xb8sziak5swi8636fszcjjx8n2jwgz570izw2fl698ff";
+    rev = "f10a5a8f7abc79a0728847e9a10ee104a1216047";
+    hash = "sha256-4ydwPh/pCzuZNNOyZuEEeX4wzI+dqTtAxUyXOXz76zk=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # SoundSource.cpp: return AVERROR_EOF when buffer is empty
+    # https://github.com/rwengine/openrw/pull/747
+    ./fix-ffmpeg-6.patch
+  ];
 
   postPatch = lib.optional (stdenv.cc.isClang && (lib.versionAtLeast stdenv.cc.version "9"))''
     substituteInPlace cmake_configure.cmake \
       --replace 'target_link_libraries(rw_interface INTERFACE "stdc++fs")' ""
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ninja ];
 
   buildInputs = [
-    sfml libGLU libGL bullet glm libmad openal SDL2 boost ffmpeg_4
+    sfml libGLU libGL bullet glm libmad openal SDL2 boost ffmpeg_6
   ] ++ lib.optionals stdenv.isDarwin [ OpenAL Cocoa ];
 
   meta = with lib; {

--- a/pkgs/games/openrw/fix-ffmpeg-6.patch
+++ b/pkgs/games/openrw/fix-ffmpeg-6.patch
@@ -1,0 +1,22 @@
+From ad7be040894661b708f9c861696499640ac7f9dc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tomi=20L=C3=A4hteenm=C3=A4ki?= <lihis@lihis.net>
+Date: Fri, 1 Dec 2023 16:01:59 +0200
+Subject: [PATCH] SoundSource.cpp: return AVERROR_EOF when buffer is empty
+
+---
+ rwengine/src/audio/SoundSource.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rwengine/src/audio/SoundSource.cpp b/rwengine/src/audio/SoundSource.cpp
+index c93376e73..d355cab74 100644
+--- a/rwengine/src/audio/SoundSource.cpp
++++ b/rwengine/src/audio/SoundSource.cpp
+@@ -55,7 +55,7 @@ int read_packet(void* opaque, uint8_t* buf, int buf_size) {
+     memcpy(buf, input->ptr, buf_size);
+     input->ptr += buf_size;
+     input->size -= buf_size;
+-    return buf_size;
++    return buf_size <= 0 ? AVERROR_EOF : buf_size;
+ }
+ }  // namespace
+ 


### PR DESCRIPTION
## Description of changes

Includes fixes for FFmpeg 6.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
