### PR TITLE
nixos/tests/enlightenment: mark broken

### DIFF
--- a/nixos/tests/enlightenment.nix
+++ b/nixos/tests/enlightenment.nix
@@ -4,6 +4,9 @@ import ./make-test-python.nix ({ pkgs, ...} :
 
   meta = with pkgs.lib.maintainers; {
     maintainers = [ romildo ];
+    timeout = 600;
+    # OCR tests are flaky
+    broken = true;
   };
 
   nodes.machine = { ... }:


### PR DESCRIPTION
## Description of changes
- mark test broken
- add 10 minute timeout, in case it is fixed in the future

Fixes `nixosTests.enlightenment` timing out.
Test does not build and times out after 1 hour since `2022-01-03`:
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.enlightenment.x86_64-linux/all
https://hydra.nixos.org/build/269979633

Last successful run:
https://hydra.nixos.org/build/162950780


Most OCR tests inside fail.
Seems to be related to default wallpaper change for `enlightenment`
Current one most likely reduces OCR accuracy because patterns look a lot like symbols to recognize:
https://www.enlightenment.org/_media/aa/shot-2021-12-13_17-47-19.png
From screenshots in successful test in 2022 wallpaper was just grey dots and font for text was different:
```bash
nix-store --realise /nix/store/rz92xp0lr8pmyf7hzjmbw7z1rib4f1ic-vm-test-run-enlightenment
xdg-open /nix/store/rz92xp0lr8pmyf7hzjmbw7z1rib4f1ic-vm-test-run-enlightenment/wizard1.png
```


Listed test maintainer:
@romildo

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
