### PR TITLE
treewide: change `${pname}` to string literal

### DIFF
--- a/pkgs/by-name/ad/adwaita-icon-theme/package.nix
+++ b/pkgs/by-name/ad/adwaita-icon-theme/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "46.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/adwaita-icon-theme/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/adwaita-icon-theme/${lib.versions.major version}/adwaita-icon-theme-${version}.tar.xz";
     hash = "sha256-S8tTm9ddZNo4XW+gjLqp3erOtqyOgrhbpsQRF79bpk4=";
   };
 

--- a/pkgs/by-name/al/alp/package.nix
+++ b/pkgs/by-name/al/alp/package.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
   buildPhase = ''
     runHook preBuild
 
-    go build -o $GOPATH/bin/${pname} main.go
+    go build -o $GOPATH/bin/alp main.go
 
     runHook postBuild
   '';

--- a/pkgs/by-name/al/alsa-oss/package.nix
+++ b/pkgs/by-name/al/alsa-oss/package.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.1.8";
 
   src = fetchurl {
-    url = "mirror://alsa/oss-lib/${pname}-${version}.tar.bz2";
+    url = "mirror://alsa/oss-lib/alsa-oss-${version}.tar.bz2";
     sha256 = "13nn6n6wpr2sj1hyqx4r9nb9bwxnhnzw8r2f08p8v13yjbswxbb4";
   };
 

--- a/pkgs/by-name/al/alsa-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-plugins/package.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.2.12";
 
   src = fetchurl {
-    url = "mirror://alsa/plugins/${pname}-${version}.tar.bz2";
+    url = "mirror://alsa/plugins/alsa-plugins-${version}.tar.bz2";
     hash = "sha256-e9ioPTBOji2GoliV2Nyw7wJFqN8y4nGVnNvcavObZvI=";
   };
 

--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.2.11";
 
   src = fetchurl {
-    url = "mirror://alsa/lib/${pname}-${version}.tar.bz2";
+    url = "mirror://alsa/lib/alsa-ucm-conf-${version}.tar.bz2";
     hash = "sha256-OHwBzzDioWdte49ysmgc8hmrynDdHsKp4zrdW/P+roE=";
   };
 

--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   version = "1.2.10";
 
   src = fetchurl {
-    url = "mirror://alsa/utils/${pname}-${version}.tar.bz2";
+    url = "mirror://alsa/utils/alsa-utils-${version}.tar.bz2";
     sha256 = "sha256-EEti7H8Cp84WynefSBVhbfHMIZM1A3g6kQe1lE+DBjo=";
   };
   patches = [

--- a/pkgs/by-name/an/anyrun/package.nix
+++ b/pkgs/by-name/an/anyrun/package.nix
@@ -59,7 +59,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   postInstall = ''
-    install -Dm444 anyrun/res/style.css examples/config.ron -t $out/share/doc/${pname}/examples/
+    install -Dm444 anyrun/res/style.css examples/config.ron -t $out/share/doc/anyrun/examples/
   '';
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/by-name/as/assemblyscript/package.nix
+++ b/pkgs/by-name/as/assemblyscript/package.nix
@@ -9,7 +9,7 @@ buildNpmPackage rec {
 
   src = fetchFromGitHub {
     owner = "AssemblyScript";
-    repo = pname;
+    repo = "assemblyscript";
     rev = "v${version}";
     sha256 = "sha256-Jhjq+kLRzDesTPHHonImCnuzt1Ay04n7+O9aK4knb5g=";
   };
@@ -17,7 +17,7 @@ buildNpmPackage rec {
   npmDepsHash = "sha256-mWRQPQVprM+9SCYd8M7NMDtiwDjSH5cr4Xlr5VP9eHo=";
 
   meta = with lib; {
-    homepage = "https://github.com/AssemblyScript/${pname}";
+    homepage = "https://github.com/AssemblyScript/assemblyscript";
     description = "TypeScript-like language for WebAssembly";
     license = licenses.asl20;
     maintainers = with maintainers; [ lucperkins ];

--- a/pkgs/by-name/au/audiobookshelf/package.nix
+++ b/pkgs/by-name/au/audiobookshelf/package.nix
@@ -20,13 +20,13 @@ let
 
   src = fetchFromGitHub {
     owner = "advplyr";
-    repo = pname;
+    repo = "audiobookshelf";
     rev = "refs/tags/v${source.version}";
     inherit (source) hash;
   };
 
   client = buildNpmPackage {
-    pname = "${pname}-client";
+    pname = "audiobookshelf-client";
     inherit (source) version;
 
     src = runCommand "cp-source" { } ''
@@ -74,13 +74,13 @@ buildNpmPackage {
   installPhase = ''
     mkdir -p $out/opt/client
     cp -r index.js server package* node_modules $out/opt/
-    cp -r ${client}/lib/node_modules/${pname}-client/dist $out/opt/client/dist
+    cp -r ${client}/lib/node_modules/audiobookshelf-client/dist $out/opt/client/dist
     mkdir $out/bin
 
-    echo '${wrapper}' > $out/bin/${pname}
-    echo "  exec ${nodejs}/bin/node $out/opt/index.js" >> $out/bin/${pname}
+    echo '${wrapper}' > $out/bin/audiobookshelf
+    echo "  exec ${nodejs}/bin/node $out/opt/index.js" >> $out/bin/audiobookshelf
 
-    chmod +x $out/bin/${pname}
+    chmod +x $out/bin/audiobookshelf
   '';
 
   passthru = {

--- a/pkgs/by-name/ba/baobab/package.nix
+++ b/pkgs/by-name/ba/baobab/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   version = "46.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/baobab/${lib.versions.major version}/baobab-${version}.tar.xz";
     hash = "sha256-zk3vXILQVnGlAJ9768+FrJhnXZ2BYNKK2RgbJppy43w=";
   };
 
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "baobab";
     };
   };
 

--- a/pkgs/by-name/br/braa/package.nix
+++ b/pkgs/by-name/br/braa/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "0.82";
 
   src = fetchzip {
-    url = "http://s-tech.elsat.net.pl/${pname}/${pname}-${version}.tar.gz";
+    url = "http://s-tech.elsat.net.pl/braa/braa-${version}.tar.gz";
     hash = "sha256-GS3kk432BdGx/sLzzjXvotD9Qn4S3U4XtMmM0fWMhGA=";
   };
 

--- a/pkgs/by-name/br/brill/package.nix
+++ b/pkgs/by-name/br/brill/package.nix
@@ -14,8 +14,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     install -Dm644 *.ttf          -t $out/share/fonts/truetype
-    install -Dm644 *agreement.pdf -t $out/share/licenses/${pname}
-    install -Dm644 *use.pdf       -t $out/share/doc/${pname}
+    install -Dm644 *agreement.pdf -t $out/share/licenses/brill
+    install -Dm644 *use.pdf       -t $out/share/doc/brill
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ce/centrifugo/package.nix
+++ b/pkgs/by-name/ce/centrifugo/package.nix
@@ -43,7 +43,7 @@ buildGoModule rec {
       inherit (nixosTests) centrifugo;
       version = testers.testVersion {
         package = centrifugo;
-        command = "${pname} version";
+        command = "centrifugo version";
         version = "v${version}";
       };
     };

--- a/pkgs/by-name/ch/cheese/package.nix
+++ b/pkgs/by-name/ch/cheese/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "man" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/cheese/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/cheese/${lib.versions.major version}/cheese-${version}.tar.xz";
     sha256 = "XyGFxMmeVN3yuLr2DIKBmVDlSVLhMuhjmHXz7cv49o4=";
   };
 

--- a/pkgs/by-name/cl/cljfmt/package.nix
+++ b/pkgs/by-name/cl/cljfmt/package.nix
@@ -11,7 +11,7 @@ buildGraalvmNativeImage rec {
   version = "0.12.0";
 
   src = fetchurl {
-    url = "https://github.com/weavejester/${pname}/releases/download/${version}/${pname}-${version}-standalone.jar";
+    url = "https://github.com/weavejester/cljfmt/releases/download/${version}/cljfmt-${version}-standalone.jar";
     sha256 = "sha256-JdrMsRmTT8U8RZDI2SnQxM5WGMpo1pL2CQ5BqLxcf5M=";
   };
 

--- a/pkgs/by-name/co/coppwr/package.nix
+++ b/pkgs/by-name/co/coppwr/package.nix
@@ -63,7 +63,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   postFixup = ''
-    patchelf $out/bin/${pname} \
+    patchelf $out/bin/coppwr \
       --add-rpath ${lib.makeLibraryPath [ libGL libxkbcommon wayland ]}
   '';
 

--- a/pkgs/by-name/co/cosmic-edit/package.nix
+++ b/pkgs/by-name/co/cosmic-edit/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "pop-os";
-    repo = pname;
+    repo = "cosmic-edit";
     rev = "epoch-${version}";
     hash = "sha256-ZG5Ctyp2crTDS0WxhQqwN4T6WR5qW79HTbICMlOA3P8=";
   };
@@ -93,7 +93,7 @@ rustPlatform.buildRustPackage rec {
 
   # LD_LIBRARY_PATH can be removed once tiny-xlib is bumped above 0.2.2
   postInstall = ''
-    wrapProgram "$out/bin/${pname}" \
+    wrapProgram "$out/bin/cosmic-edit" \
       --suffix XDG_DATA_DIRS : "${cosmic-icons}/share" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr vulkan-loader libxkbcommon wayland

--- a/pkgs/by-name/co/cosmic-files/package.nix
+++ b/pkgs/by-name/co/cosmic-files/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "pop-os";
-    repo = pname;
+    repo = "cosmic-files";
     rev = "epoch-${version}";
     hash = "sha256-UwQwZRzOyMvLRRmU2noxGrqblezkR8J2PNMVoyG0M0w=";
   };
@@ -68,7 +68,7 @@ rustPlatform.buildRustPackage rec {
 
   # LD_LIBRARY_PATH can be removed once tiny-xlib is bumped above 0.2.2
   postInstall = ''
-    wrapProgram "$out/bin/${pname}" \
+    wrapProgram "$out/bin/cosmic-files" \
       --suffix XDG_DATA_DIRS : "${cosmic-icons}/share" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ xorg.libX11 xorg.libXcursor xorg.libXrandr xorg.libXi wayland ]}
   '';

--- a/pkgs/by-name/co/cosmic-store/package.nix
+++ b/pkgs/by-name/co/cosmic-store/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "pop-os";
-    repo = pname;
+    repo = "cosmic-store";
     rev = "epoch-${version}";
     hash = "sha256-RuqWO2/sqMMd9xMRClAy7cwv7iCTEC15TZ7JLBZ2zwM=";
     fetchSubmodules = true;
@@ -77,7 +77,7 @@ rustPlatform.buildRustPackage rec {
 
   # LD_LIBRARY_PATH can be removed once tiny-xlib is bumped above 0.2.2
   postInstall = ''
-    wrapProgram "$out/bin/${pname}" \
+    wrapProgram "$out/bin/cosmic-store" \
       --suffix XDG_DATA_DIRS : "${cosmic-icons}/share" \
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [

--- a/pkgs/by-name/co/cosmic-term/package.nix
+++ b/pkgs/by-name/co/cosmic-term/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "pop-os";
-    repo = pname;
+    repo = "cosmic-term";
     rev = "epoch-${version}";
     hash = "sha256-dY4QGQXJFL+yjCYRGCg3NfMLMjlEBSEmxHn68PvhCAQ=";
   };
@@ -95,7 +95,7 @@ rustPlatform.buildRustPackage rec {
 
   # LD_LIBRARY_PATH can be removed once tiny-xlib is bumped above 0.2.2
   postInstall = ''
-    wrapProgram "$out/bin/${pname}" \
+    wrapProgram "$out/bin/cosmic-term" \
       --suffix XDG_DATA_DIRS : "${cosmic-icons}/share" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         libxkbcommon

--- a/pkgs/by-name/cr/crate2nix/package.nix
+++ b/pkgs/by-name/cr/crate2nix/package.nix
@@ -15,12 +15,12 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "nix-community";
-    repo = pname;
+    repo = "crate2nix";
     rev = version;
     hash = "sha256-esWhRnt7FhiYq0CcIxw9pvH+ybOQmWBfHYMtleaMhBE=";
   };
 
-  sourceRoot = "${src.name}/${pname}";
+  sourceRoot = "${src.name}/crate2nix";
 
   cargoHash = "sha256-nQ1VUCFMmpWZWvKFbyJFIZUJ24N9ZPY8JCHWju385NE=";
 
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   postInstall = ''
-    wrapProgram $out/bin/${pname} \
+    wrapProgram $out/bin/crate2nix \
       --prefix PATH ":" ${
         lib.makeBinPath [
           cargo
@@ -44,8 +44,8 @@ rustPlatform.buildRustPackage rec {
 
       for shell in bash zsh fish
       do
-        $out/bin/${pname} completions -s $shell
-        installShellCompletion ${pname}.$shell || installShellCompletion --$shell _${pname}
+        $out/bin/crate2nix completions -s $shell
+        installShellCompletion crate2nix.$shell || installShellCompletion --$shell _crate2nix
       done
   '';
 

--- a/pkgs/by-name/cu/cups-kyocera-3500-4500/package.nix
+++ b/pkgs/by-name/cu/cups-kyocera-3500-4500/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     # for lib/cups/filter/kyofilter_pre_H
     wrapPythonProgramsIn $out/lib/cups/filter "$propagatedBuildInputs"
 
-    install -Dm444 usr/share/doc/kyodialog/copyright $out/share/doc/${pname}/copyright
+    install -Dm444 usr/share/doc/kyodialog/copyright $out/share/doc/cups-kyocera-3500-4500/copyright
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/db/dbqn/package.nix
+++ b/pkgs/by-name/db/dbqn/package.nix
@@ -48,11 +48,11 @@ stdenv.mkDerivation rec {
   '' + (if buildNativeImage then ''
     mv dbqn $out/bin
   '' else ''
-    mkdir -p $out/share/${pname}
-    mv BQN.jar $out/share/${pname}/
+    mkdir -p $out/share/dbqn
+    mv BQN.jar $out/share/dbqn/
 
     makeWrapper "${lib.getBin jdk}/bin/java" "$out/bin/dbqn" \
-      --add-flags "-jar $out/share/${pname}/BQN.jar"
+      --add-flags "-jar $out/share/dbqn/BQN.jar"
   '') + ''
     ln -s $out/bin/dbqn $out/bin/bqn
 

--- a/pkgs/by-name/dc/dconf-editor/package.nix
+++ b/pkgs/by-name/dc/dconf-editor/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   version = "45.0.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/dconf-editor/${lib.versions.major version}/dconf-editor-${version}.tar.xz";
     sha256 = "sha256-EYApdnju2uYhfMUUomOMGH0vHR7ycgy5B5t0DEKZQd0=";
   };
 
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "dconf-editor";
     };
   };
 

--- a/pkgs/by-name/de/devhelp/package.nix
+++ b/pkgs/by-name/de/devhelp/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/devhelp/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/devhelp/${lib.versions.major version}/devhelp-${version}.tar.xz";
     sha256 = "Y87u/QU5LgIESIHvHs1yQpNVPaVzW378CCstE/6F3QQ=";
   };
 

--- a/pkgs/by-name/dm/dmarc-report-converter/package.nix
+++ b/pkgs/by-name/dm/dmarc-report-converter/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
   ];
 
   passthru.tests = {
-    simple = runCommand "${pname}-test" { } ''
+    simple = runCommand "dmarc-report-converter-test" { } ''
       ${dmarc-report-converter}/bin/dmarc-report-converter -h > $out
     '';
   };

--- a/pkgs/by-name/en/engage/package.nix
+++ b/pkgs/by-name/en/engage/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitLab {
     domain = "gitlab.computer.surgery";
     owner = "charles";
-    repo = pname;
+    repo = "engage";
     rev = "v${version}";
     hash = "sha256-niXh63xTpXSp9Wqwfi8hUBKJSClOUSvB+TPCTaqHfZk=";
   };
@@ -27,11 +27,11 @@ rustPlatform.buildRustPackage {
   ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) (
-    "installShellCompletion --cmd ${pname} "
+    "installShellCompletion --cmd engage "
     + builtins.concatStringsSep
       " "
       (builtins.map
-        (shell: "--${shell} <($out/bin/${pname} completions ${shell})")
+        (shell: "--${shell} <($out/bin/engage completions ${shell})")
         [
           "bash"
           "fish"

--- a/pkgs/by-name/eo/eog/package.nix
+++ b/pkgs/by-name/eo/eog/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/eog/${lib.versions.major version}/eog-${version}.tar.xz";
     sha256 = "sha256-tQ8yHHCsZK97yqW0Rg3GdbPKYP2tOFYW86x7dw4GZv4=";
   };
 
@@ -111,7 +111,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "eog";
     };
   };
 

--- a/pkgs/by-name/ev/evolution-data-server/package.nix
+++ b/pkgs/by-name/ev/evolution-data-server/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/evolution-data-server-${version}.tar.xz";
     hash = "sha256-GzaoOdscjYmAZuGb54uZWTCgovKohvFJ5PZOF1XwZPc=";
   };
 
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     substitute ${./hardcode-gsettings.patch} hardcode-gsettings.patch \
-      --subst-var-by EDS ${glib.makeSchemaPath "$out" "${pname}-${version}"} \
+      --subst-var-by EDS ${glib.makeSchemaPath "$out" "evolution-data-server-${version}"} \
       --subst-var-by GDS ${glib.getSchemaPath gsettings-desktop-schemas}
     patches="$patches $PWD/hardcode-gsettings.patch"
   '';
@@ -149,7 +149,7 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = lib.optionalString stdenv.isDarwin ''
-    ln -s $out/lib/${pname}/*.dylib $out/lib/
+    ln -s $out/lib/evolution-data-server/*.dylib $out/lib/
   '';
 
   passthru = {

--- a/pkgs/by-name/fi/find-billy/package.nix
+++ b/pkgs/by-name/fi/find-billy/package.nix
@@ -43,10 +43,10 @@ stdenv.mkDerivation rec {
     ln -s ${godot3-export-templates}/share/godot/templates $HOME/.local/share/godot
 
     mkdir -p $out/share/find-billy
-    godot3-headless --export-pack 'Linux/X11' $out/share/${pname}/${pname}.pck
-    makeWrapper ${godot3}/bin/godot3 $out/bin/${pname} \
+    godot3-headless --export-pack 'Linux/X11' $out/share/find-billy/find-billy.pck
+    makeWrapper ${godot3}/bin/godot3 $out/bin/find-billy \
       --add-flags "--main-pack" \
-      --add-flags "$out/share/${pname}/${pname}.pck"
+      --add-flags "$out/share/find-billy/find-billy.pck"
 
     runHook postBuild
   '';
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     just build-icons
-    install -D ${pname}.desktop -t $out/share/applications
+    install -D find-billy.desktop -t $out/share/applications
 
     runHook postInstall
   '';

--- a/pkgs/by-name/fi/firefly-iii/package.nix
+++ b/pkgs/by-name/fi/firefly-iii/package.nix
@@ -76,7 +76,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   postInstall = ''
-    mv $out/share/php/${pname}/* $out/
+    mv $out/share/php/firefly-iii/* $out/
     rm -R $out/share $out/storage $out/bootstrap/cache $out/node_modules
     ln -s ${dataDir}/storage $out/storage
     ln -s ${dataDir}/cache $out/bootstrap/cache

--- a/pkgs/by-name/fu/fuchsia-cursor/package.nix
+++ b/pkgs/by-name/fu/fuchsia-cursor/package.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "ful1e5";
-    repo = pname;
+    repo = "fuchsia-cursor";
     rev = "v${version}";
     hash = "sha256-WnDtUsjRXT7bMppgwU5BIDqphP69DmPzQM/0qXES5tM=";
   };

--- a/pkgs/by-name/ge/geary/package.nix
+++ b/pkgs/by-name/ge/geary/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   version = "46.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/geary/${lib.versions.major version}/geary-${version}.tar.xz";
     sha256 = "r60VEwKBfd8Ji15BbnrH8tXupWejuAu5C9PGKv0TuaE=";
   };
 
@@ -142,7 +142,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "geary";
     };
   };
 

--- a/pkgs/by-name/gh/ghex/package.nix
+++ b/pkgs/by-name/gh/ghex/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/ghex/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/ghex/${lib.versions.major version}/ghex-${version}.tar.xz";
     hash = "sha256-ocRvMCDLNYuDIwJds6U5yX2ZSkxG9wH0jtxjV/f7y9E=";
   };
 

--- a/pkgs/by-name/gi/gitg/package.nix
+++ b/pkgs/by-name/gi/gitg/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   version = "44";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gitg/${lib.versions.majorMinor version}/gitg-${version}.tar.xz";
     hash = "sha256-NCoxaE2rlnHNNBvT485mWtzuBGDCoIHdxJPNvAMTJTA=";
   };
 
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "gitg";
     };
   };
 

--- a/pkgs/by-name/gl/glasskube/package.nix
+++ b/pkgs/by-name/gl/glasskube/package.nix
@@ -51,7 +51,7 @@ in buildGoModule rec {
     "-X github.com/glasskube/glasskube/internal/config.Commit=${src.rev}"
   ];
 
-  subPackages = [ "cmd/${pname}" "cmd/package-operator" ];
+  subPackages = [ "cmd/glasskube" "cmd/package-operator" ];
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/gn/gnome-autoar/package.nix
+++ b/pkgs/by-name/gn/gnome-autoar/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-autoar/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-autoar/${lib.versions.majorMinor version}/gnome-autoar-${version}.tar.xz";
     sha256 = "wK++MzvPPLFEGh9XTMjsexuBl3eRRdTt7uKJb9rPw8I=";
   };
 

--- a/pkgs/by-name/gn/gnome-calculator/package.nix
+++ b/pkgs/by-name/gn/gnome-calculator/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   version = "46.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-calculator/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-calculator/${lib.versions.major version}/gnome-calculator-${version}.tar.xz";
     hash = "sha256-LTZ1CnOJAIYSLPPwyD5oUXiRWFYVFlMG+hWWqRhmgkc=";
   };
 

--- a/pkgs/by-name/gn/gnome-calendar/package.nix
+++ b/pkgs/by-name/gn/gnome-calendar/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   version = "46.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-calendar/${lib.versions.major version}/gnome-calendar-${version}.tar.xz";
     hash = "sha256-mGH/e4q9W3sgaQulXrdULH7FNLVmJp4ptbHoWMFhCJc=";
   };
 
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "gnome-calendar";
     };
   };
 

--- a/pkgs/by-name/gn/gnome-common/package.nix
+++ b/pkgs/by-name/gn/gnome-common/package.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3.18.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-common/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-common/${lib.versions.majorMinor version}/gnome-common-${version}.tar.xz";
     sha256 = "22569e370ae755e04527b76328befc4c73b62bfd4a572499fde116b8318af8cf";
   };
 

--- a/pkgs/by-name/gn/gnome-dictionary/package.nix
+++ b/pkgs/by-name/gn/gnome-dictionary/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   version = "40.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-dictionary/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-dictionary/${lib.versions.major version}/gnome-dictionary-${version}.tar.xz";
     sha256 = "1d8dhcfys788vv27v34i3s3x3jdvdi2kqn2a5p8c937a9hm0qr9f";
   };
 

--- a/pkgs/by-name/gn/gnome-disk-utility/package.nix
+++ b/pkgs/by-name/gn/gnome-disk-utility/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   version = "46.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-disk-utility/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-disk-utility/${lib.versions.major version}/gnome-disk-utility-${version}.tar.xz";
     hash = "sha256-RkZJFIxtZ3HxrC6/5DpOUZIFsRwtkUoJ8qABgh0GlX0=";
   };
 

--- a/pkgs/by-name/gn/gnome-font-viewer/package.nix
+++ b/pkgs/by-name/gn/gnome-font-viewer/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   version = "46.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-font-viewer/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-font-viewer/${lib.versions.major version}/gnome-font-viewer-${version}.tar.xz";
     hash = "sha256-WS9AHkhdAswETUh7tcjgTJYdpoViFnaKWfH/mL0tU3w=";
   };
 

--- a/pkgs/by-name/gn/gnome-keyring/package.nix
+++ b/pkgs/by-name/gn/gnome-keyring/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-keyring/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-keyring/${lib.versions.major version}/gnome-keyring-${version}.tar.xz";
     hash = "sha256-vybJZriot/MoXsyLs+RnucIPlTW5TcRRycVZ3c/2GSU=";
   };
 

--- a/pkgs/by-name/gn/gnome-screenshot/package.nix
+++ b/pkgs/by-name/gn/gnome-screenshot/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   version = "41.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-screenshot/${lib.versions.major version}/gnome-screenshot-${version}.tar.xz";
     sha256 = "Stt97JJkKPdCY9V5ZnPPFC5HILbnaPVGio0JM/mMlZc=";
   };
 
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "gnome-screenshot";
     };
   };
 

--- a/pkgs/by-name/gn/gnome-system-monitor/package.nix
+++ b/pkgs/by-name/gn/gnome-system-monitor/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   version = "46.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-system-monitor/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-system-monitor/${lib.versions.major version}/gnome-system-monitor-${version}.tar.xz";
     hash = "sha256-U3YkgVjGhsMIJVRy6MKp5MFyVWQsFJ/HGYxtA05UdZk=";
   };
 

--- a/pkgs/by-name/gn/gnucap/package.nix
+++ b/pkgs/by-name/gn/gnucap/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {
-    url = "https://git.savannah.gnu.org/cgit/gnucap.git/snapshot/${pname}-${version}.tar.gz";
+    url = "https://git.savannah.gnu.org/cgit/gnucap.git/snapshot/gnucap-${version}.tar.gz";
     hash = "sha256-MUCtGw3BxGWgXgUwzklq5T1y9kjBTnFBa0/GK0hhl0E=";
   };
 

--- a/pkgs/by-name/go/goredo/package.nix
+++ b/pkgs/by-name/go/goredo/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   version = "2.6.0";
 
   src = fetchurl {
-    url = "http://www.goredo.cypherpunks.ru/download/${pname}-${version}.tar.zst";
+    url = "http://www.goredo.cypherpunks.ru/download/goredo-${version}.tar.zst";
     hash = "sha256-XTL/otfCKC55TsUBBVors2kgFpOFh+6oekOOafOhcUs=";
   };
 

--- a/pkgs/by-name/gu/guile-semver/package.nix
+++ b/pkgs/by-name/gu/guile-semver/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   version = "0.1.1";
 
   src = fetchurl {
-    url = "https://files.ngyro.com/guile-semver/${pname}-${version}.tar.gz";
+    url = "https://files.ngyro.com/guile-semver/guile-semver-${version}.tar.gz";
     hash = "sha256-T3kJGTdf6yBKjqLtqSopHZu03kyOscZ3Z4RYmoYlN4E=";
   };
 

--- a/pkgs/by-name/ha/halo/package.nix
+++ b/pkgs/by-name/ha/halo/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   pname = "halo";
   version = "2.18.0";
   src = fetchurl {
-    url = "https://github.com/halo-dev/halo/releases/download/v${version}/${pname}-${version}.jar";
+    url = "https://github.com/halo-dev/halo/releases/download/v${version}/halo-${version}.jar";
     hash = "sha256-XFV+cdqtBJID/s0I3Z6TBfeyzN/e9euUoQVTWy64NYM=";
   };
 

--- a/pkgs/by-name/in/intiface-central/package.nix
+++ b/pkgs/by-name/in/intiface-central/package.nix
@@ -14,7 +14,7 @@ flutterPackages.v3_19.buildFlutterApplication rec {
   version = "2.6.0";
   src = fetchFromGitHub {
     owner = "intiface";
-    repo = pname;
+    repo = "intiface-central";
     rev = "v${version}";
     hash = "sha256-7+rw0cD8MJPFOkgmfHD6y+EojTGQhb15o1mn2p14eoE=";
   };

--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   version = "1.2405.17-jammy";
 
   src = fetchurl {
-    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/i/${pname}/${pname}_${version}_amd64.deb";
+    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/i/intune-portal/intune-portal_${version}_amd64.deb";
     hash = "sha256-WpVPWzh8jN092MaY2rMXhLfpVXsflMl9hOY9nNGJlLk=";
   };
 

--- a/pkgs/by-name/is/iscc/package.nix
+++ b/pkgs/by-name/is/iscc/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
     cp -r ./app/* "$out/bin"
 
-    cat << 'EOF' > "$out/bin/${pname}"
+    cat << 'EOF' > "$out/bin/iscc"
     #!${runtimeShell}
     export PATH=${wineWow64Packages.stable}/bin:$PATH
     export WINEDLLOVERRIDES="mscoree=" # disable mono
@@ -44,10 +44,10 @@ stdenv.mkDerivation rec {
     ${wineWow64Packages.stable}/bin/wine "$out/bin/ISCC.exe" "$wineInputFile"
     EOF
 
-    substituteInPlace $out/bin/${pname} \
+    substituteInPlace $out/bin/iscc \
       --replace "\$out" "$out"
 
-    chmod +x "$out/bin/${pname}"
+    chmod +x "$out/bin/iscc"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/je/jetbrains-toolbox/package.nix
+++ b/pkgs/by-name/je/jetbrains-toolbox/package.nix
@@ -22,7 +22,7 @@ let
       nativeBuildInputs = [ appimageTools.appimage-exec ];
     }
     ''
-      appimage-exec.sh -x $out ${src}/${pname}-${version}/${pname}
+      appimage-exec.sh -x $out ${src}/jetbrains-toolbox-${version}/jetbrains-toolbox
 
       # JetBrains ship a broken desktop file. Despite registering a custom
       # scheme handler for jetbrains:// URLs, they never mark the command as
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -Dm644 ${appimageContents}/.DirIcon $out/share/icons/hicolor/scalable/apps/jetbrains-toolbox.svg
-    makeWrapper ${appimage}/bin/${pname} $out/bin/${pname} \
+    makeWrapper ${appimage}/bin/jetbrains-toolbox $out/bin/jetbrains-toolbox \
       --append-flags "--update-failed" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [icu]}
 

--- a/pkgs/by-name/jn/jnr-posix/package.nix
+++ b/pkgs/by-name/jn/jnr-posix/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -D target/${pname}-${version}.jar $out/share/java/${pname}-${version}.jar
+    install -D target/jnr-posix-${version}.jar $out/share/java/jnr-posix-${version}.jar
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ke/keymapp/package.nix
+++ b/pkgs/by-name/ke/keymapp/package.nix
@@ -49,8 +49,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -m755 -D keymapp "$out/bin/${pname}"
-    install -Dm644 icon.png "$out/share/pixmaps/${pname}.png"
+    install -m755 -D keymapp "$out/bin/keymapp"
+    install -Dm644 icon.png "$out/share/pixmaps/keymapp.png"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/li/libation/package.nix
+++ b/pkgs/by-name/li/libation/package.nix
@@ -73,7 +73,7 @@ buildDotnetModule rec {
 
   preFixup = ''
     # remove binaries for other platform, like upstream does
-    pushd $out/lib/${pname}
+    pushd $out/lib/libation
     rm -f *.x86.dll *.x64.dll
     ${lib.optionalString (stdenv.system != "x86_64-linux") "rm -f *.x64.so"}
     ${lib.optionalString (stdenv.system != "aarch64-linux") "rm -f *.arm64.so"}
@@ -81,9 +81,9 @@ buildDotnetModule rec {
     ${lib.optionalString (stdenv.system != "aarch64-darwin") "rm -f *.arm64.dylib"}
     popd
 
-    wrapDotnetProgram $out/lib/${pname}/Libation $out/bin/libation
-    wrapDotnetProgram $out/lib/${pname}/LibationCli $out/bin/libationcli
-    wrapDotnetProgram $out/lib/${pname}/Hangover $out/bin/hangover
+    wrapDotnetProgram $out/lib/libation/Libation $out/bin/libation
+    wrapDotnetProgram $out/lib/libation/LibationCli $out/bin/libationcli
+    wrapDotnetProgram $out/lib/libation/Hangover $out/bin/hangover
   '';
 
   meta = {

--- a/pkgs/by-name/li/libeduvpn-common/package.nix
+++ b/pkgs/by-name/li/libeduvpn-common/package.nix
@@ -16,13 +16,13 @@ buildGoModule rec {
 
   buildPhase = ''
     runHook preBuild
-    go build -o ${pname}-${version}.so -buildmode=c-shared -tags=release ./exports
+    go build -o libeduvpn-common-${version}.so -buildmode=c-shared -tags=release ./exports
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-    install -Dt $out/lib ${pname}-${version}.so
+    install -Dt $out/lib libeduvpn-common-${version}.so
     runHook postInstall
   '';
 

--- a/pkgs/by-name/li/libmamba/package.nix
+++ b/pkgs/by-name/li/libmamba/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mamba-org";
     repo = "mamba";
-    rev = "${pname}-${version}";
+    rev = "libmamba-${version}";
     hash = "sha256-sxZDlMFoMLq2EAzwBVO++xvU1C30JoIoZXEX/sqkXS0=";
   };
   nativeBuildInputs = [

--- a/pkgs/by-name/li/littlefs-fuse/package.nix
+++ b/pkgs/by-name/li/littlefs-fuse/package.nix
@@ -5,15 +5,15 @@ stdenv.mkDerivation rec {
   version = "2.7.8";
   src = fetchFromGitHub {
     owner = "littlefs-project";
-    repo = pname;
+    repo = "littlefs-fuse";
     rev = "v${version}";
     hash = "sha256-dJt2Tcw+qdcOoZ9ejao9NXys/OYQTvbP9+dD6DCzFAw=";
   };
   buildInputs = [ fuse ];
   installPhase = ''
     runHook preInstall
-    install -D lfs $out/bin/${pname}
-    ln -s $out/bin/${pname} $out/bin/mount.littlefs
+    install -D lfs $out/bin/littlefs-fuse
+    ln -s $out/bin/littlefs-fuse $out/bin/mount.littlefs
     ln -s $out/bin $out/sbin
     runHook postInstall
   '';

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -33,7 +33,7 @@ in {
   src = fetchurl {
     inherit hash;
     url = "https://github.com/logseq/logseq/releases/download/${version}/logseq-${suffix}";
-    name = lib.optionalString stdenv.isLinux "${pname}-${version}.AppImage";
+    name = lib.optionalString stdenv.isLinux "logseq-${version}.AppImage";
   };
 
   nativeBuildInputs = [ makeWrapper ]
@@ -52,35 +52,35 @@ in {
    appimageContents = appimageTools.extract { inherit pname src version; };
   in
   ''
-    mkdir -p $out/bin $out/share/${pname} $out/share/applications
-    cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
-    cp -a ${appimageContents}/Logseq.desktop $out/share/applications/${pname}.desktop
+    mkdir -p $out/bin $out/share/logseq $out/share/applications
+    cp -a ${appimageContents}/{locales,resources} $out/share/logseq
+    cp -a ${appimageContents}/Logseq.desktop $out/share/applications/logseq.desktop
 
     # remove the `git` in `dugite` because we want the `git` in `nixpkgs`
-    chmod +w -R $out/share/${pname}/resources/app/node_modules/dugite/git
-    chmod +w $out/share/${pname}/resources/app/node_modules/dugite
-    rm -rf $out/share/${pname}/resources/app/node_modules/dugite/git
-    chmod -w $out/share/${pname}/resources/app/node_modules/dugite
+    chmod +w -R $out/share/logseq/resources/app/node_modules/dugite/git
+    chmod +w $out/share/logseq/resources/app/node_modules/dugite
+    rm -rf $out/share/logseq/resources/app/node_modules/dugite/git
+    chmod -w $out/share/logseq/resources/app/node_modules/dugite
 
     mkdir -p $out/share/pixmaps
-    ln -s $out/share/${pname}/resources/app/icons/logseq.png $out/share/pixmaps/${pname}.png
+    ln -s $out/share/logseq/resources/app/icons/logseq.png $out/share/pixmaps/logseq.png
 
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace Exec=Logseq Exec=${pname} \
-      --replace Icon=Logseq Icon=${pname}
+    substituteInPlace $out/share/applications/logseq.desktop \
+      --replace Exec=Logseq Exec=logseq \
+      --replace Icon=Logseq Icon=logseq
   '') + lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/{Applications/Logseq.app,bin}
     cp -R . $out/Applications/Logseq.app
-    makeWrapper $out/Applications/Logseq.app/Contents/MacOS/Logseq $out/bin/${pname}
+    makeWrapper $out/Applications/Logseq.app/Contents/MacOS/Logseq $out/bin/logseq
   '' + ''
     runHook postInstall
   '';
 
   postFixup = lib.optionalString stdenv.isLinux ''
     # set the env "LOCAL_GIT_DIRECTORY" for dugite so that we can use the git in nixpkgs
-    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
+    makeWrapper ${electron}/bin/electron $out/bin/logseq \
       --set "LOCAL_GIT_DIRECTORY" ${git} \
-      --add-flags $out/share/${pname}/resources/app \
+      --add-flags $out/share/logseq/resources/app \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
   '';
 

--- a/pkgs/by-name/lx/lxgw-wenkai-tc/package.nix
+++ b/pkgs/by-name/lx/lxgw-wenkai-tc/package.nix
@@ -7,7 +7,7 @@ stdenvNoCC.mkDerivation rec {
   pname = "lxgw-wenkai-tc";
   version = "1.330";
   src = fetchurl {
-    url = "https://github.com/lxgw/LxgwWenKaiTC/releases/download/v${version}/${pname}-v${version}.tar.gz";
+    url = "https://github.com/lxgw/LxgwWenKaiTC/releases/download/v${version}/lxgw-wenkai-tc-v${version}.tar.gz";
     hash = "sha256-qpX5shH1HbGMa287u/R1rMFgQeAUC0wwKFVD+QSTyho=";
   };
 

--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = "2.0.1";
 
   src = fetchurl {
-    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/${pname}/${pname}_${version}_amd64.deb";
+    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_${version}_amd64.deb";
     hash = "sha256-O9zbImSWMrRsaOozj5PsCRvQ3UsaJzLfoTohmLZvLkM=";
   };
 

--- a/pkgs/by-name/mi/minetest-mapserver/package.nix
+++ b/pkgs/by-name/mi/minetest-mapserver/package.nix
@@ -8,7 +8,7 @@ buildGoModule rec {
   version = "4.9.1";
 
   src = fetchFromGitHub {
-    owner = pname;
+    owner = "minetest-mapserver";
     repo = "mapserver";
     rev = "v${version}";
     hash = "sha256-3bL23hwJgYMPV2nSSfq9plttcx7UYvhUa6OCbKfBACY=";
@@ -19,8 +19,8 @@ buildGoModule rec {
   meta = with lib; {
     description = "Realtime mapserver for minetest";
     mainProgram = "mapserver";
-    homepage = "https://github.com/${pname}/mapserver/blob/master/readme.md";
-    changelog = "https://github.com/${pname}/mapserver/releases/tag/v${version}";
+    homepage = "https://github.com/minetest-mapserver/mapserver/blob/master/readme.md";
+    changelog = "https://github.com/minetest-mapserver/mapserver/releases/tag/v${version}";
     license = with licenses; [ mit cc-by-sa-30 ];
     platforms = platforms.all;
     maintainers = with maintainers; [ gm6k ];

--- a/pkgs/by-name/ms/msalsdk-dbusclient/package.nix
+++ b/pkgs/by-name/ms/msalsdk-dbusclient/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "1.0.1";
 
   src = fetchurl {
-    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/${pname}/${pname}_${version}_amd64.deb";
+    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/msalsdk-dbusclient/msalsdk-dbusclient_${version}_amd64.deb";
     hash = "sha256-AVPrNxCjXGza2gGETP0YrlXeEgI6AjlrSVTtqKb2UBI=";
   };
 

--- a/pkgs/by-name/ne/neverest/package.nix
+++ b/pkgs/by-name/ne/neverest/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromSourcehut {
     owner = "~soywod";
-    repo = "${pname}-cli";
+    repo = "neverest-cli";
     rev = "v${version}";
     hash = "sha256-3PSJyhxrOCiuHUeVHO77+NecnI5fN5EZfPhYizuYvtE=";
   };

--- a/pkgs/by-name/nf/nf-test/package.nix
+++ b/pkgs/by-name/nf/nf-test/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "0.9.0";
 
   src = fetchurl {
-    url = "https://github.com/askimed/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
+    url = "https://github.com/askimed/nf-test/releases/download/v${version}/nf-test-${version}.tar.gz";
     hash = "sha256-PhI866NrbokMsSrU6YeSv03S1+VcNqVJsocI3xPfDcc=";
   };
   sourceRoot = ".";

--- a/pkgs/by-name/nu/numbat/package.nix
+++ b/pkgs/by-name/nu/numbat/package.nix
@@ -24,11 +24,11 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.Security
   ];
 
-  env.NUMBAT_SYSTEM_MODULE_PATH = "${placeholder "out"}/share/${pname}/modules";
+  env.NUMBAT_SYSTEM_MODULE_PATH = "${placeholder "out"}/share/numbat/modules";
 
   postInstall = ''
-    mkdir -p $out/share/${pname}
-    cp -r $src/${pname}/modules $out/share/${pname}/
+    mkdir -p $out/share/numbat
+    cp -r $src/numbat/modules $out/share/numbat/
   '';
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/by-name/pd/pdf2odt/package.nix
+++ b/pkgs/by-name/pd/pdf2odt/package.nix
@@ -28,7 +28,7 @@ resholve.mkDerivation rec {
     runHook preInstall
 
     install -Dm0555 pdf2odt           -t $out/bin
-    install -Dm0444 README.md LICENSE -t $out/share/doc/${pname}
+    install -Dm0444 README.md LICENSE -t $out/share/doc/pdf2odt
 
     ln -rs $out/bin/pdf2odt $out/bin/pdf2ods
 

--- a/pkgs/by-name/pl/plemoljp-hs/package.nix
+++ b/pkgs/by-name/pl/plemoljp-hs/package.nix
@@ -12,10 +12,10 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm444 PlemolJP_HS/*.ttf -t $out/share/fonts/truetype/${pname}
-    install -Dm444 PlemolJP35_HS/*.ttf -t $out/share/fonts/truetype/${pname}-35
-    install -Dm444 PlemolJPConsole_HS/*.ttf -t $out/share/fonts/truetype/${pname}-console
-    install -Dm444 PlemolJP35Console_HS/*.ttf -t $out/share/fonts/truetype/${pname}-35console
+    install -Dm444 PlemolJP_HS/*.ttf -t $out/share/fonts/truetype/plemoljp-hs
+    install -Dm444 PlemolJP35_HS/*.ttf -t $out/share/fonts/truetype/plemoljp-hs-35
+    install -Dm444 PlemolJPConsole_HS/*.ttf -t $out/share/fonts/truetype/plemoljp-hs-console
+    install -Dm444 PlemolJP35Console_HS/*.ttf -t $out/share/fonts/truetype/plemoljp-hs-35console
 
     runHook postInstall
   '';

--- a/pkgs/by-name/pl/plemoljp-nf/package.nix
+++ b/pkgs/by-name/pl/plemoljp-nf/package.nix
@@ -12,8 +12,8 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm444 PlemolJPConsole_NF/*.ttf -t $out/share/fonts/truetype/${pname}-console
-    install -Dm444 PlemolJP35Console_NF/*.ttf -t $out/share/fonts/truetype/${pname}-35console
+    install -Dm444 PlemolJPConsole_NF/*.ttf -t $out/share/fonts/truetype/plemoljp-nf-console
+    install -Dm444 PlemolJP35Console_NF/*.ttf -t $out/share/fonts/truetype/plemoljp-nf-35console
 
     runHook postInstall
   '';

--- a/pkgs/by-name/pl/plemoljp/package.nix
+++ b/pkgs/by-name/pl/plemoljp/package.nix
@@ -12,10 +12,10 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm444 PlemolJP/*.ttf -t $out/share/fonts/truetype/${pname}
-    install -Dm444 PlemolJP35/*.ttf -t $out/share/fonts/truetype/${pname}-35
-    install -Dm444 PlemolJPConsole/*.ttf -t $out/share/fonts/truetype/${pname}-console
-    install -Dm444 PlemolJP35Console/*.ttf -t $out/share/fonts/truetype/${pname}-35console
+    install -Dm444 PlemolJP/*.ttf -t $out/share/fonts/truetype/plemoljp
+    install -Dm444 PlemolJP35/*.ttf -t $out/share/fonts/truetype/plemoljp-35
+    install -Dm444 PlemolJPConsole/*.ttf -t $out/share/fonts/truetype/plemoljp-console
+    install -Dm444 PlemolJP35Console/*.ttf -t $out/share/fonts/truetype/plemoljp-35console
 
     runHook postInstall
   '';

--- a/pkgs/by-name/pr/proto/package.nix
+++ b/pkgs/by-name/pr/proto/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "moonrepo";
-    repo = pname;
+    repo = "proto";
     rev = "v${version}";
     hash = "sha256-o/du9XmiS7U5ypm6osQtVTjrJY60iLCkJ4DWCYOeIoY=";
   };
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     # proto looks up a proto-shim executable file in $PROTO_LOOKUP_DIR
-    wrapProgram $out/bin/${pname} \
+    wrapProgram $out/bin/proto \
       --set PROTO_LOOKUP_DIR $out/bin
   '';
 

--- a/pkgs/by-name/pu/pupdate/package.nix
+++ b/pkgs/by-name/pu/pupdate/package.nix
@@ -15,7 +15,7 @@ buildDotnetModule rec {
 
   src = fetchFromGitHub {
     owner = "mattpannella";
-    repo = "${pname}";
+    repo = "pupdate";
     rev = "${version}";
     hash = "sha256-odlKNp6kjOAYeRIHnLniqkCXTi1UXF3szn8tJtrxzQU=";
   };

--- a/pkgs/by-name/pw/pw3270/package.nix
+++ b/pkgs/by-name/pw/pw3270/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "PerryWerneck";
-    repo = pname;
+    repo = "pw3270";
     rev = version;
     hash = "sha256-Nk/OUqrWngKgb1D1Wi8q5ygKtvuRKUPhPQaLvWi1Z4g=";
   };
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     # Schemas get installed to wrong directory.
     mkdir -p $out/share/glib-2.0
-    mv $out/share/gsettings-schemas/${pname}-${version}/glib-2.0/schemas $out/share/glib-2.0/
+    mv $out/share/gsettings-schemas/pw3270-${version}/glib-2.0/schemas $out/share/glib-2.0/
     rm -rf $out/share/gsettings-schemas
   '';
 

--- a/pkgs/by-name/ra/ratchet/package.nix
+++ b/pkgs/by-name/ra/ratchet/package.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
     [
       "-s"
       "-w"
-      "-X ${package_url}/internal/version.name=${pname}"
+      "-X ${package_url}/internal/version.name=ratchet"
       "-X ${package_url}/internal/version.version=${version}"
       "-X ${package_url}/internal/version.commit=${src.rev}"
     ];

--- a/pkgs/by-name/re/read-it-later/package.nix
+++ b/pkgs/by-name/re/read-it-later/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
-    repo = pname;
+    repo = "read-it-later";
     rev = version;
     hash = "sha256-A8u1fecJAsVlordgZmUJt/KZWxx6EWMhfdayKWHTTFY=";
   };

--- a/pkgs/by-name/re/redmine/package.nix
+++ b/pkgs/by-name/re/redmine/package.nix
@@ -15,7 +15,7 @@ in
     inherit version;
 
     src = fetchurl {
-      url = "https://www.redmine.org/releases/${pname}-${version}.tar.gz";
+      url = "https://www.redmine.org/releases/redmine-${version}.tar.gz";
       hash = "sha256-iiIyD9nJQOZZjzrV+3o5MxlchgaO7plLpvzcIsXOy1k=";
     };
 

--- a/pkgs/by-name/re/regina/package.nix
+++ b/pkgs/by-name/re/regina/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "3.9.6";
 
   src = fetchurl {
-    url = "mirror://sourceforge/regina-rexx/regina-rexx/${version}/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/regina-rexx/regina-rexx/${version}/regina-rexx-${version}.tar.gz";
     hash = "sha256-7ZjHp/HVpBSLAv7xsWruSmpthljQGoDPXFAwFe8Br6U=";
   };
 

--- a/pkgs/by-name/re/regripper/package.nix
+++ b/pkgs/by-name/re/regripper/package.nix
@@ -34,12 +34,12 @@ stdenv.mkDerivation rec {
 
     cp -aR . "$out/share/regripper/"
 
-    cat > "$out/bin/${pname}" << EOF
+    cat > "$out/bin/regripper" << EOF
     #!${runtimeShell}
     exec ${perl}/bin/perl $out/share/regripper/rip.pl "\$@"
     EOF
 
-    chmod u+x  "$out/bin/${pname}"
+    chmod u+x  "$out/bin/regripper"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/re/revolt-desktop/package.nix
+++ b/pkgs/by-name/re/revolt-desktop/package.nix
@@ -47,19 +47,19 @@
 
           mkdir -p $out/bin $out/share/{applications,revolt-desktop}
 
-          cp -a ${final.appimageContents}/{locales,resources} $out/share/${pname}
-          cp -a ${final.appimageContents}/revolt-desktop.desktop $out/share/applications/${pname}.desktop
+          cp -a ${final.appimageContents}/{locales,resources} $out/share/revolt-desktop
+          cp -a ${final.appimageContents}/revolt-desktop.desktop $out/share/applications/revolt-desktop.desktop
           cp -a ${final.appimageContents}/usr/share/icons $out/share/icons
 
-          substituteInPlace $out/share/applications/${pname}.desktop \
-            --replace 'Exec=AppRun' 'Exec=${pname}'
+          substituteInPlace $out/share/applications/revolt-desktop.desktop \
+            --replace 'Exec=AppRun' 'Exec=revolt-desktop'
 
           runHook postInstall
         '';
 
         postFixup = ''
-          makeWrapper ${electron}/bin/electron $out/bin/${pname} \
-            --add-flags $out/share/${pname}/resources/app.asar \
+          makeWrapper ${electron}/bin/electron $out/bin/revolt-desktop \
+            --add-flags $out/share/revolt-desktop/resources/app.asar \
             --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations}}"
         '';
       }
@@ -77,7 +77,7 @@
 
           mkdir -p "$out/Applications/" "$out/bin/"
           mv Revolt.app "$out/Applications/"
-          makeWrapper "$out/Applications/Revolt.app/Contents/MacOS/Revolt" "$out/bin/${pname}"
+          makeWrapper "$out/Applications/Revolt.app/Contents/MacOS/Revolt" "$out/bin/revolt-desktop"
 
           runHook postInstall
         '';

--- a/pkgs/by-name/rs/rs/package.nix
+++ b/pkgs/by-name/rs/rs/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "20200313";
 
   src = fetchurl {
-    url = "https://www.mirbsd.org/MirOS/dist/mir/rs/${pname}-${version}.tar.gz";
+    url = "https://www.mirbsd.org/MirOS/dist/mir/rs/rs-${version}.tar.gz";
     sha256 = "0gxwlfk7bzivpp2260w2r6gkyl7vdi05cggn1fijfnp8kzf1b4li";
   };
 

--- a/pkgs/by-name/se/seahorse/package.nix
+++ b/pkgs/by-name/se/seahorse/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   version = "43.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/seahorse/${lib.versions.major version}/seahorse-${version}.tar.xz";
     hash = "sha256-Wx0b+6dPNlgifzyC4pbzMN0PzR70Y2tqIYIo/uXqgy0=";
   };
 
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "seahorse";
     };
   };
 

--- a/pkgs/by-name/si/signaturepdf/package.nix
+++ b/pkgs/by-name/si/signaturepdf/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "24eme";
-    repo = "${pname}";
+    repo = "signaturepdf";
     rev = "v${version}";
     hash = "sha256-WPcnG1iRT4l4S/CSZkj75lIiyzVLsrSyH3GUJa7Tedc=";
   };

--- a/pkgs/by-name/si/simple-scan/package.nix
+++ b/pkgs/by-name/si/simple-scan/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   version = "46.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/simple-scan/${lib.versions.major version}/simple-scan-${version}.tar.xz";
     hash = "sha256-wW5lkBQv5WO+UUMSKzu7U/awCn2p2VL2HEf6Jve08Kk=";
   };
 

--- a/pkgs/by-name/so/sonarlint-ls/package.nix
+++ b/pkgs/by-name/so/sonarlint-ls/package.nix
@@ -92,14 +92,14 @@ maven.buildMavenPackage rec {
           LATEST_TAG=$(curl https://api.github.com/repos/${src.owner}/${src.repo}/tags | \
             jq -r '[.[] | select(.name | test("^[0-9]"))] | sort_by(.name | split(".") |
             map(tonumber)) | reverse | .[0].name')
-          update-source-version ${pname} "$LATEST_TAG"
+          update-source-version sonarlint-ls "$LATEST_TAG"
           sed -i '0,/mvnHash *= *"[^"]*"/{s/mvnHash = "[^"]*"/mvnHash = ""/}' ${pkgFile}
 
           echo -e "\nFetching all mvn dependencies to calculate the mvnHash. This may take a while ..."
-          nix-build -A ${pname}.fetchedMavenDeps 2> ${pname}-stderr.log || true
+          nix-build -A sonarlint-ls.fetchedMavenDeps 2> sonarlint-ls-stderr.log || true
 
-          NEW_MVN_HASH=$(grep "got:" ${pname}-stderr.log | awk '{print ''$2}')
-          rm ${pname}-stderr.log
+          NEW_MVN_HASH=$(grep "got:" sonarlint-ls-stderr.log | awk '{print ''$2}')
+          rm sonarlint-ls-stderr.log
           # escaping double quotes looks ugly but is needed for variable substitution
           # use # instead of / as separator because the sha256 might contain the / character
           sed -i "0,/mvnHash *= *\"[^\"]*\"/{s#mvnHash = \"[^\"]*\"#mvnHash = \"$NEW_MVN_HASH\"#}" ${pkgFile}

--- a/pkgs/by-name/sr/srgn/package.nix
+++ b/pkgs/by-name/sr/srgn/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "alexpovel";
     repo = "srgn";
-    rev = "${pname}-v${version}";
+    rev = "srgn-v${version}";
     hash = "sha256-d53aSo1gzINC8WdMzjCHzU/8+9kvrrGglV4WsiCt+rM=";
   };
 

--- a/pkgs/by-name/st/stackit-cli/package.nix
+++ b/pkgs/by-name/st/stackit-cli/package.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   postInstall = ''
-    mv $out/bin/{${pname},stackit} # rename the binary
+    mv $out/bin/{stackit-cli,stackit} # rename the binary
 
     installShellCompletion --cmd stackit \
       --bash <($out/bin/stackit completion bash) \

--- a/pkgs/by-name/su/substudy/package.nix
+++ b/pkgs/by-name/su/substudy/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "emk";
     repo = "subtitles-rs";
-    rev = "${pname}_v${version}";
+    rev = "substudy_v${version}";
     hash = "sha256-ACYbSQKaOJ2hS8NbOAppfKo+Mk3CKg0OAwb56AH42Zs=";
   };
 

--- a/pkgs/by-name/su/sushi/package.nix
+++ b/pkgs/by-name/su/sushi/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   version = "46.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/sushi/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/sushi/${lib.versions.major version}/sushi-${version}.tar.xz";
     hash = "sha256-lghbqqQwqyFCxgaqtcR+L7sv0+two1ITfmXFmlig8sY=";
   };
 

--- a/pkgs/by-name/sw/swayosd/package.nix
+++ b/pkgs/by-name/sw/swayosd/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    name = "${pname}-${version}";
+    name = "swayosd-${version}";
     hash = "sha256-exbVanUvGp0ub4WE3VcsN8hkcK0Ipf0tNfd92UecICg=";
   };
 

--- a/pkgs/by-name/sy/synthesia/package.nix
+++ b/pkgs/by-name/sy/synthesia/package.nix
@@ -20,11 +20,11 @@ stdenvNoCC.mkDerivation rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = pname;
+      name = "synthesia";
       desktopName = "Synthesia";
       comment = meta.description;
-      exec = pname;
-      icon = pname;
+      exec = "synthesia";
+      icon = "synthesia";
       categories = [ "Game" "Audio" ];
       startupWMClass = "synthesia.exe";
     })
@@ -47,11 +47,11 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
-    cat <<'EOF' > $out/bin/${pname}
+    cat <<'EOF' > $out/bin/synthesia
     #!${runtimeShell}
     export PATH=${wineWowPackages.stable}/bin:$PATH
     export WINEARCH=win64
-    export WINEPREFIX="''${SYNTHESIA_HOME:-"''${XDG_DATA_HOME:-"''${HOME}/.local/share"}/${pname}"}/wine"
+    export WINEPREFIX="''${SYNTHESIA_HOME:-"''${XDG_DATA_HOME:-"''${HOME}/.local/share"}/synthesia"}/wine"
     export WINEDLLOVERRIDES="mscoree=" # disable mono
     if [ ! -d "$WINEPREFIX" ] ; then
       mkdir -p "$WINEPREFIX"
@@ -59,8 +59,8 @@ stdenvNoCC.mkDerivation rec {
     fi
     wine "$WINEPREFIX/drive_c/Program Files (x86)/Synthesia/Synthesia.exe"
     EOF
-    chmod +x $out/bin/${pname}
-    install -Dm644 ${icon} $out/share/icons/hicolor/48x48/apps/${pname}.png
+    chmod +x $out/bin/synthesia
+    install -Dm644 ${icon} $out/share/icons/hicolor/48x48/apps/synthesia.png
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ta/tarlz/package.nix
+++ b/pkgs/by-name/ta/tarlz/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ lzlib ];
 
   src = fetchurl {
-    url = "mirror://savannah/lzip/${pname}/${pname}-${version}.tar.lz";
+    url = "mirror://savannah/lzip/tarlz/tarlz-${version}.tar.lz";
     sha256 = "7d0bbe9c3a137bb93a10be56988fcf7362e4dbc65490639edc4255b704105fce";
   };
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # system clock issues
 
   meta = with lib; {
-    homepage = "https://www.nongnu.org/lzip/${pname}.html";
+    homepage = "https://www.nongnu.org/lzip/tarlz.html";
     description =
       "Massively parallel combined implementation of the tar archiver and the lzip compressor";
     license = licenses.gpl2Plus;

--- a/pkgs/by-name/te/termcap/package.nix
+++ b/pkgs/by-name/te/termcap/package.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation rec {
   postInstall = lib.optionalString (!enableStatic) ''
     rm $out/lib/libtermcap.a
   '' + lib.optionalString enableShared (let
-    libName = "lib${pname}${stdenv.hostPlatform.extensions.sharedLibrary}";
-    impLibName = "lib${pname}.dll.a";
+    libName = "libtermcap${stdenv.hostPlatform.extensions.sharedLibrary}";
+    impLibName = "libtermcap.dll.a";
     winImpLib = lib.optionalString stdenv.hostPlatform.isWindows
       "-Wl,--out-implib,${impLibName}";
   in ''

--- a/pkgs/by-name/ti/tinycompress/package.nix
+++ b/pkgs/by-name/ti/tinycompress/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "1.2.11";
 
   src = fetchurl {
-    url = "mirror://alsa/tinycompress/${pname}-${version}.tar.bz2";
+    url = "mirror://alsa/tinycompress/tinycompress-${version}.tar.bz2";
     hash = "sha256-6754jCgyjnzKJFqvkZSlrQ3JHp4NyIPCz5/rbULJ8/w=";
   };
 

--- a/pkgs/by-name/to/totem/package.nix
+++ b/pkgs/by-name/to/totem/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   version = "43.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/totem/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/totem/${lib.versions.major version}/totem-${version}.tar.xz";
     sha256 = "s202VZKLWJZGKk05+Dtq1m0328nJnc6wLqii43OUpB4=";
   };
 

--- a/pkgs/by-name/tr/tracexec/package.nix
+++ b/pkgs/by-name/tr/tracexec/package.nix
@@ -48,8 +48,8 @@ rustPlatform.buildRustPackage {
     # Remove test binaries (e.g. `empty-argv`, `corrupted-envp`) and only retain `tracexec`
     find "$out/bin" -type f \! -name tracexec -print0 | xargs -0 rm -v
 
-    install -Dm644 LICENSE -t "$out/share/licenses/${pname}/"
-    install -Dm644 THIRD_PARTY_LICENSES.HTML -t "$out/share/licenses/${pname}/"
+    install -Dm644 LICENSE -t "$out/share/licenses/tracexec/"
+    install -Dm644 THIRD_PARTY_LICENSES.HTML -t "$out/share/licenses/tracexec/"
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/tr/treefmt2/package.nix
+++ b/pkgs/by-name/tr/treefmt2/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X git.numtide.com/numtide/treefmt/build.Name=${pname}"
+    "-X git.numtide.com/numtide/treefmt/build.Name=treefmt"
     "-X git.numtide.com/numtide/treefmt/build.Version=v${version}"
   ];
 

--- a/pkgs/by-name/ud/udev-gothic-nf/package.nix
+++ b/pkgs/by-name/ud/udev-gothic-nf/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    install -Dm644 *.ttf -t $out/share/fonts/${pname}
+    install -Dm644 *.ttf -t $out/share/fonts/udev-gothic-nf
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ud/udev-gothic/package.nix
+++ b/pkgs/by-name/ud/udev-gothic/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    install -Dm644 *.ttf -t $out/share/fonts/${pname}
+    install -Dm644 *.ttf -t $out/share/fonts/udev-gothic
     runHook postInstall
   '';
 

--- a/pkgs/by-name/vv/vvvvvv/package.nix
+++ b/pkgs/by-name/vv/vvvvvv/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
       name = "VVVVVV";
       desktopName = "VVVVVV";
       comment = meta.description;
-      exec = pname;
+      exec = "vvvvvv";
       icon = "VVVVVV";
       terminal = false;
       categories = [ "Game" ];
@@ -69,12 +69,12 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 VVVVVV $out/bin/${pname}
+    install -Dm755 VVVVVV $out/bin/vvvvvv
     install -Dm644 "$src/desktop_version/icon.ico" "$out/share/pixmaps/VVVVVV.png"
     cp -r "$src/desktop_version/fonts/" "$out/share/"
     cp -r "$src/desktop_version/lang/" "$out/share/"
 
-    wrapProgram $out/bin/${pname} \
+    wrapProgram $out/bin/vvvvvv \
       --add-flags "-assets ${dataZip}" \
       --add-flags "-langdir $out/share/lang" \
       --add-flags "-fontsdir $out/share/fonts"

--- a/pkgs/by-name/ye/yelp-xsl/package.nix
+++ b/pkgs/by-name/ye/yelp-xsl/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "42.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/yelp-xsl/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/yelp-xsl/${lib.versions.major version}/yelp-xsl-${version}.tar.xz";
     sha256 = "sha256-I4vhULFlMIDOE5lxMw/TbTomWV4NagQKLAML89IAW80=";
   };
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "yelp-xsl";
     };
   };
 

--- a/pkgs/by-name/ye/yelp/package.nix
+++ b/pkgs/by-name/ye/yelp/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   version = "42.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/yelp/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/yelp/${lib.versions.major version}/yelp-${version}.tar.xz";
     sha256 = "sha256-osX9B4epCJxyLMZr0Phc33CI2HDntsyFeZ+OW/+erEs=";
   };
 

--- a/pkgs/by-name/yg/yggdrasil/package.nix
+++ b/pkgs/by-name/yg/yggdrasil/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   ldflags = [
     "-X github.com/yggdrasil-network/yggdrasil-go/src/version.buildVersion=${version}"
-    "-X github.com/yggdrasil-network/yggdrasil-go/src/version.buildName=${pname}"
+    "-X github.com/yggdrasil-network/yggdrasil-go/src/version.buildName=yggdrasil"
     "-X github.com/yggdrasil-network/yggdrasil-go/src/config.defaultAdminListen=unix:///var/run/yggdrasil/yggdrasil.sock"
     "-s"
     "-w"

--- a/pkgs/by-name/zs/zsync/package.nix
+++ b/pkgs/by-name/zs/zsync/package.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.6.2";
 
   src = fetchurl {
-    url = "http://zsync.moria.org.uk/download/${pname}-${version}.tar.bz2";
+    url = "http://zsync.moria.org.uk/download/zsync-${version}.tar.bz2";
     sha256 = "1wjslvfy76szf0mgg2i9y9q30858xyjn6v2acc24zal76d1m778b";
   };
 


### PR DESCRIPTION
## Description of changes

please squash merge this, i spam-commit for easier handling of merge conflicts.


done with

```shell
#!/usr/bin/env nix-shell
#!nix-shell --pure -i bash -p ripgrep sd jq git lix

export NIXPKGS_ALLOW_UNFREE=1
export NIXPKGS_ALLOW_INSECURE=1
export NIXPKGS_ALLOW_BROKEN=1

git restore .

test -s packages.json || ( set -x;
  time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --show-trace --no-allow-import-from-derivation > packages.json
)

jq <packages.json 'to_entries[] | select(.value.meta.position==null|not) | "\(.key)\t\(.value.meta.position)"' -r |
    sed -e "s#\t$(realpath .)/#\t#" |
    sed -e 's#:\([0-9]*\)$#\t\1#' |
    grep --fixed-strings "$( rg -F '${pname}' pkgs/ -tnix -l | sort | head -n 2500 )" |
    grep . |
    grep -iv haskell |
    grep -iv /top-level/ |
    grep -iv chicken |
    grep pkgs/by-name/ |
    grep -iv build |
    grep -E '/(package|default)\.nix' |
    while read attrpath fname col; do
        echo "$attrpath"
        data="$(nix eval --impure  --expr 'with import ./. {}; { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)"
        test -n "$data" || continue
        pname="$(jq <<<"$data" .pname -r)"
        test -n "$pname" || continue
        (set -x
            sd -F '${pname}' "$pname" "$fname"
            sd -F ' = pname;' " = \"$pname\";" "$fname"
        )
        data2="$(nix eval --impure  --expr 'with import ./. {}; { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)"
        if ! test "$data" = "$data2"; then
            (set -x; git restore "$fname")
        fi
    done
```

in `pkgs/by-name` this time around, and i selected the ones that made sense using `GIT_DIFF_OPTS=-u2000 git add --patch`.

I avoided various patterns like `name = "${pname}-${version}"` because that would hamper a different kind of treewide, and other patterns where `${pname}` is being used in passthru.tests or fod storepath names, and in assertions that makes sense to copy to dervations.

should be 0 rebuilds

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
