### PR TITLE
loudgain: add patches for FFmpeg 7 and GCC 14

### DIFF
--- a/pkgs/tools/audio/loudgain/default.nix
+++ b/pkgs/tools/audio/loudgain/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, ffmpeg_4, libebur128
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, ffmpeg_7, libebur128
 , libresample, taglib, zlib }:
 
 stdenv.mkDerivation rec {
@@ -12,8 +12,22 @@ stdenv.mkDerivation rec {
     hash = "sha256-XLj+n0GlY/GAkJlW2JVMd0jxMzgdv/YeSTuF6QUIGwU=";
   };
 
+  patches = [
+    # src/scan.c: Only call av_register_all() if using libavformat < 58.9.100
+    # https://github.com/Moonbase59/loudgain/pull/50
+    ./support-ffmpeg-5.patch
+
+    # src/scan.c: Declare "AVCodec" to be "const AVCodec"
+    # https://github.com/Moonbase59/loudgain/pull/65
+    ./fix-gcc-14.patch
+
+    # src/scan.c: Update for FFmpeg 7.0
+    # https://github.com/Moonbase59/loudgain/pull/66
+    ./support-ffmpeg-7.patch
+  ];
+
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ ffmpeg_4 libebur128 libresample taglib zlib ];
+  buildInputs = [ ffmpeg_7 libebur128 libresample taglib zlib ];
 
   postInstall = ''
     sed -e "1aPATH=$out/bin:\$PATH" -i "$out/bin/rgbpm"

--- a/pkgs/tools/audio/loudgain/fix-gcc-14.patch
+++ b/pkgs/tools/audio/loudgain/fix-gcc-14.patch
@@ -1,0 +1,23 @@
+From ad9c7f8ddf0907d408b3d2fbf4d00ecb55af8d13 Mon Sep 17 00:00:00 2001
+From: Hugh McMaster <hugh.mcmaster@outlook.com>
+Date: Mon, 29 Jul 2024 23:13:16 +1000
+Subject: [PATCH] src/scan.c: Declare "AVCodec" to be "const AVCodec"
+
+This fixes compilation with GCC-14.
+---
+ src/scan.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/scan.c b/src/scan.c
+index 85b36b3..e02ed86 100644
+--- a/src/scan.c
++++ b/src/scan.c
+@@ -115,7 +115,7 @@ int scan_file(const char *file, unsigned index) {
+ 
+ 	AVFormatContext *container = NULL;
+ 
+-	AVCodec *codec;
++	const AVCodec *codec;
+ 	AVCodecContext *ctx;
+ 
+ 	AVFrame *frame;

--- a/pkgs/tools/audio/loudgain/support-ffmpeg-5.patch
+++ b/pkgs/tools/audio/loudgain/support-ffmpeg-5.patch
@@ -1,0 +1,29 @@
+From 977332e9e45477b1b41a5af7a2484f92b340413b Mon Sep 17 00:00:00 2001
+From: Hugh McMaster <hugh.mcmaster@outlook.com>
+Date: Thu, 1 Sep 2022 14:44:17 +1000
+Subject: [PATCH] src/scan.c: Only call av_register_all() if using libavformat
+ < 58.9.100
+
+This function is deprecated.
+
+Thanks to Leigh Scott for suggesting this patch.
+---
+ src/scan.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/scan.c b/src/scan.c
+index 85b36b3..ee72cf8 100644
+--- a/src/scan.c
++++ b/src/scan.c
+@@ -69,9 +69,9 @@ int scan_init(unsigned nb_files) {
+ 	 * It is now useless
+ 	 * https://github.com/FFmpeg/FFmpeg/blob/70d25268c21cbee5f08304da95be1f647c630c15/doc/APIchanges#L86
+ 	 */
+-  if (avformat_version() < AV_VERSION_INT(58,9,100))
++#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58,9,100)
+     av_register_all();
+-
++#endif
+ 	av_log_set_callback(scan_av_log);
+ 
+ 	scan_nb_files = nb_files;

--- a/pkgs/tools/audio/loudgain/support-ffmpeg-7.patch
+++ b/pkgs/tools/audio/loudgain/support-ffmpeg-7.patch
@@ -1,0 +1,123 @@
+From 50741b98fb4b932759f05e8d208d80d93bcc8261 Mon Sep 17 00:00:00 2001
+From: Hugh McMaster <hugh.mcmaster@outlook.com>
+Date: Mon, 29 Jul 2024 23:15:35 +1000
+Subject: [PATCH] src/scan.c: Update for FFmpeg 7.0
+
+---
+ src/scan.c | 40 +++++++++++++++++++++-------------------
+ 1 file changed, 21 insertions(+), 19 deletions(-)
+
+diff --git a/src/scan.c b/src/scan.c
+index 85b36b3..91eb261 100644
+--- a/src/scan.c
++++ b/src/scan.c
+@@ -119,7 +119,7 @@ int scan_file(const char *file, unsigned index) {
+ 	AVCodecContext *ctx;
+ 
+ 	AVFrame *frame;
+-	AVPacket packet;
++	AVPacket *packet;
+ 
+ 	SwrContext *swr;
+ 
+@@ -177,8 +177,8 @@ int scan_file(const char *file, unsigned index) {
+ 	}
+ 
+   // try to get default channel layout (they aren’t specified in .wav files)
+-  if (!ctx->channel_layout)
+-    ctx->channel_layout = av_get_default_channel_layout(ctx->channels);
++  if (ctx->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC)
++    av_channel_layout_default(&ctx->ch_layout, ctx->ch_layout.nb_channels);
+ 
+   // show some information about the file
+   // only show bits/sample where it makes sense
+@@ -187,21 +187,21 @@ int scan_file(const char *file, unsigned index) {
+     snprintf(infotext, sizeof(infotext), "%d bit, ",
+       ctx->bits_per_raw_sample > 0 ? ctx->bits_per_raw_sample : ctx->bits_per_coded_sample);
+   }
+-  av_get_channel_layout_string(infobuf, sizeof(infobuf), -1, ctx->channel_layout);
++  av_channel_layout_describe(&ctx->ch_layout, infobuf, sizeof(infobuf));
+   ok_printf("Stream #%d: %s, %s%d Hz, %d ch, %s",
+-    stream_id, codec->long_name, infotext, ctx->sample_rate, ctx->channels, infobuf);
++    stream_id, codec->long_name, infotext, ctx->sample_rate, ctx->ch_layout.nb_channels, infobuf);
+ 
+ 	scan_codecs[index] = codec -> id;
+ 
+-	av_init_packet(&packet);
++	packet = av_packet_alloc();
+ 
+-	packet.data = buffer;
+-	packet.size = buffer_size;
++	packet->data = buffer;
++	packet->size = buffer_size;
+ 
+ 	swr = swr_alloc();
+ 
+ 	*ebur128 = ebur128_init(
+-		ctx -> channels, ctx -> sample_rate,
++		ctx->ch_layout.nb_channels, ctx->sample_rate,
+ 		EBUR128_MODE_S | EBUR128_MODE_I | EBUR128_MODE_LRA |
+ 		EBUR128_MODE_SAMPLE_PEAK | EBUR128_MODE_TRUE_PEAK
+ 	);
+@@ -222,10 +222,10 @@ int scan_file(const char *file, unsigned index) {
+ 
+ 	progress_bar(0, 0, 0, 0);
+ 
+-	while (av_read_frame(container, &packet) >= 0) {
+-		if (packet.stream_index == stream_id) {
++	while (av_read_frame(container, packet) >= 0) {
++		if (packet->stream_index == stream_id) {
+ 
+-      rc = avcodec_send_packet(ctx, &packet);
++      rc = avcodec_send_packet(ctx, packet);
+       if (rc < 0) {
+         err_printf("Error while sending a packet to the decoder");
+         break;
+@@ -252,7 +252,7 @@ int scan_file(const char *file, unsigned index) {
+       av_frame_unref(frame);
+     }
+ 
+-		av_packet_unref(&packet);
++		av_packet_unref(packet);
+ 	}
+ 
+   // complete progress bar for very short files (only cosmetic)
+@@ -263,9 +263,11 @@ int scan_file(const char *file, unsigned index) {
+ 
+ 	av_frame_free(&frame);
+ 
++        av_packet_free(&packet);
++
+ 	swr_free(&swr);
+ 
+-	avcodec_close(ctx);
++	avcodec_free_context(&ctx);
+ 
+ 	avformat_close_input(&container);
+ 
+@@ -413,12 +415,12 @@ static void scan_frame(ebur128_state *ebur128, AVFrame *frame,
+ 	int                 out_linesize;
+ 	enum AVSampleFormat out_fmt = AV_SAMPLE_FMT_S16;
+ 
+-	av_opt_set_channel_layout(swr, "in_channel_layout", frame -> channel_layout, 0);
+-	av_opt_set_channel_layout(swr, "out_channel_layout", frame -> channel_layout, 0);
++	av_opt_set_chlayout(swr, "in_chlayout", &frame->ch_layout, 0);
++	av_opt_set_chlayout(swr, "out_chlayout", &frame->ch_layout, 0);
+ 
+   // add channel count to properly handle .wav reading
+-  av_opt_set_int(swr, "in_channel_count",  frame -> channels, 0);
+-  av_opt_set_int(swr, "out_channel_count", frame -> channels, 0);
++  av_opt_set_int(swr, "in_channel_count",  frame->ch_layout.nb_channels, 0);
++  av_opt_set_int(swr, "out_channel_count", frame->ch_layout.nb_channels, 0);
+ 
+   av_opt_set_int(swr, "in_sample_rate", frame -> sample_rate, 0);
+   av_opt_set_int(swr, "out_sample_rate", frame -> sample_rate, 0);
+@@ -434,7 +436,7 @@ static void scan_frame(ebur128_state *ebur128, AVFrame *frame,
+ 	}
+ 
+ 	out_size = av_samples_get_buffer_size(
+-		&out_linesize, frame -> channels, frame -> nb_samples, out_fmt, 0
++		&out_linesize, frame->ch_layout.nb_channels, frame->nb_samples, out_fmt, 0
+ 	);
+ 
+ 	out_data = av_malloc(out_size);


### PR DESCRIPTION
## Description of changes

Another stop on the FFmpeg 4 removal train.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
