### PR TITLE
python312Packages.qtile-extras: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/qtile-extras/default.nix
+++ b/pkgs/development/python-modules/qtile-extras/default.nix
@@ -64,6 +64,8 @@ buildPythonPackage rec {
     # AttributeError: 'NoneType' object has no attribute 'theta'
     "test_image_size_horizontal"
     "test_image_size_vertical"
+    # flaky, timing sensitive
+    "test_visualiser"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
## Description of changes

fixes https://logs.ofborg.org/?key=nixos/nixpkgs.316208&attempt_id=cb479d56-8852-4366-a556-a0ac27006db5

reproduced locally:

```
qtile-extras> ____________________________ test_visualiser[1-x11] ____________________________
qtile-extras> 
qtile-extras> manager_nospawn = <test.helpers.TestManager object at 0x7ffff25ebc20>
qtile-extras> visualiser = <class 'test.widget.test_visualiser.visualiser.<locals>.GlobalMenuConfig'>
qtile-extras> 
qtile-extras>     def test_visualiser(manager_nospawn, visualiser):
qtile-extras>         manager_nospawn.start(visualiser)
qtile-extras> >       assert_length(manager_nospawn, 100)
qtile-extras> 
qtile-extras> test/widget/test_visualiser.py:59: 
qtile-extras> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
qtile-extras> 
qtile-extras> args = (<test.helpers.TestManager object at 0x7ffff25ebc20>, 100), kwargs = {}
qtile-extras> tmax = 1724187992.4794621, dt = 3.8443359375000004
qtile-extras> ignore_exceptions = (<class 'AssertionError'>,)
qtile-extras> 
qtile-extras>     @functools.wraps(fn)
qtile-extras>     def wrapper(*args, **kwargs):
qtile-extras>         tmax = time.time() + self.tmax
qtile-extras>         dt = self.dt
qtile-extras>         ignore_exceptions = self.ignore_exceptions
qtile-extras>     
qtile-extras>         while time.time() <= tmax:
qtile-extras>             try:
qtile-extras>                 return fn(*args, **kwargs)
qtile-extras>             except ignore_exceptions:
qtile-extras>                 pass
qtile-extras>             except AssertionError:
qtile-extras>                 break
qtile-extras>             time.sleep(dt)
qtile-extras>             dt *= 1.5
qtile-extras>         if self.return_on_fail:
qtile-extras>             return False
qtile-extras>         else:
qtile-extras> >           raise AssertionError(self.fail_msg)
qtile-extras> E           AssertionError: retry failed!
qtile-extras> 
qtile-extras> test/helpers.py:81: AssertionError
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
