### PR TITLE
mediastreamer: add Debian patch for FFmpeg ≥ 5

### DIFF
--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -2,7 +2,8 @@
 , bzrtp
 , cmake
 , fetchFromGitLab
-, ffmpeg_4
+, fetchpatch2
+, ffmpeg_7
 , glew
 , gsm
 , lib
@@ -43,6 +44,12 @@ stdenv.mkDerivation rec {
     # plugin directory with desired plugins and wrap executables so that the
     # environment variable points to that directory.
     ./plugins_dir.patch
+
+    # Port to ffmpeg 5.0 API
+    (fetchpatch2 {
+      url = "https://salsa.debian.org/pkg-voip-team/linphone-stack/mediastreamer2/-/raw/4e7784802d2eac57dffe210c8c23e696f40ac6ec/debian/patches/ffmpeg_5_0_fixes.patch";
+      hash = "sha256-5ay4iVbx8IOX952HEFaKLBGKLRYUWRntufciApUVhh0=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -58,7 +65,7 @@ stdenv.mkDerivation rec {
     bzrtp
     ortp
 
-    ffmpeg_4
+    ffmpeg_7
     glew
     libX11
     libXext


### PR DESCRIPTION
## Description of changes

Another FFmpeg 4 dependency down. Seems like upstream might be moving away from FFmpeg, maybe?

Result of `nixpkgs-review` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>liblinphone</li>
    <li>linphone</li>
    <li>mediastreamer</li>
    <li>mediastreamer-openh264</li>
    <li>msilbc</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
