### PR TITLE
treewide: avoid string-concatenating cmakeFlags

### DIFF
--- a/pkgs/applications/editors/molsketch/default.nix
+++ b/pkgs/applications/editors/molsketch/default.nix
@@ -33,9 +33,9 @@ stdenv.mkDerivation rec {
       --replace "CXX_STANDARD 14" "CXX_STANDARD 17"
   '';
 
-  preConfigure = ''
-    cmakeFlags="$cmakeFlags -DMSK_PREFIX=$out"
-  '';
+  cmakeFlags = [
+    "-DMSK_PREFIX=${placeholder "out"}"
+  ];
 
   postFixup = ''
     ln -s $out/lib/molsketch/* $out/lib/.

--- a/pkgs/applications/graphics/pymeshlab/default.nix
+++ b/pkgs/applications/graphics/pymeshlab/default.nix
@@ -88,12 +88,10 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/meshlab/src/external/ssynth.cmake \
       --replace-fail '$'{SSYNTH_LINK} ${structuresynth.src} \
       --replace-warn "MD5 ''${SSYNTH_MD5}" ""
-    export cmakeFlags="cmakeFlags
-      -DCMAKE_INSTALL_PREFIX=$out/${python3Packages.python.sitePackages}/pymeshlab
-    "
   '';
 
   cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/${python3Packages.python.sitePackages}/pymeshlab"
     "-DVCGDIR=${vcg.src}"
   ];
 

--- a/pkgs/applications/science/robotics/yarp/default.nix
+++ b/pkgs/applications/science/robotics/yarp/default.nix
@@ -18,10 +18,8 @@ stdenv.mkDerivation rec {
     "-DYARP_COMPILE_UNMAINTAINED:BOOL=ON"
     "-DCREATE_YARPC:BOOL=ON"
     "-DCREATE_YARPCXX:BOOL=ON"
+    "-DCMAKE_INSTALL_LIBDIR=${placeholder "out"}/lib"
   ];
-
-  # since we cant expand $out in cmakeFlags
-  preConfigure = ''cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_LIBDIR=$out/lib"'';
 
   postInstall = "mv ./$out/lib/*.so $out/lib/";
 

--- a/pkgs/development/libraries/aws-c-common/setup-hook.sh
+++ b/pkgs/development/libraries/aws-c-common/setup-hook.sh
@@ -1,5 +1,5 @@
 addAwsCCommonModuleDir() {
-    cmakeFlags="-DCMAKE_MODULE_PATH=@out@/lib/cmake ${cmakeFlags:-}"
+    prependToVar cmakeFlags "-DCMAKE_MODULE_PATH=@out@/lib/cmake"
 }
 
 postHooks+=(addAwsCCommonModuleDir)

--- a/pkgs/development/libraries/openwsman/default.nix
+++ b/pkgs/development/libraries/openwsman/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    cmakeFlags="$cmakeFlags -DPACKAGE_ARCHITECTURE=$(uname -m)";
+    appendToVar cmakeFlags "-DPACKAGE_ARCHITECTURE=$(uname -m)"
   '';
 
   configureFlags = [ "--disable-more-warnings" ];

--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -1,17 +1,18 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, boost
-, cmake
-, fftw
-, fftwSinglePrec
-, hdf5
-, ilmbase
-, libjpeg
-, libpng
-, libtiff
-, openexr
-, python3
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  boost,
+  cmake,
+  fftw,
+  fftwSinglePrec,
+  hdf5,
+  ilmbase,
+  libjpeg,
+  libpng,
+  libtiff,
+  openexr,
+  python3,
 }:
 
 let
@@ -46,9 +47,12 @@ stdenv.mkDerivation rec {
 
   preConfigure = "cmakeFlags+=\" -DVIGRANUMPY_INSTALL_DIR=$out/${python.sitePackages}\"";
 
-  cmakeFlags = [ "-DWITH_OPENEXR=1" ]
-    ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-linux")
-    [ "-DCMAKE_CXX_FLAGS=-fPIC" "-DCMAKE_C_FLAGS=-fPIC" ];
+  cmakeFlags =
+    [ "-DWITH_OPENEXR=1" ]
+    ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-linux") [
+      "-DCMAKE_CXX_FLAGS=-fPIC"
+      "-DCMAKE_C_FLAGS=-fPIC"
+    ];
 
   meta = with lib; {
     description = "Novel computer vision C++ library with customizable algorithms and data structures";

--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -45,10 +45,11 @@ stdenv.mkDerivation rec {
     python
   ];
 
-  preConfigure = "cmakeFlags+=\" -DVIGRANUMPY_INSTALL_DIR=$out/${python.sitePackages}\"";
-
   cmakeFlags =
-    [ "-DWITH_OPENEXR=1" ]
+    [
+      "-DWITH_OPENEXR=1"
+      "-DVIGRANUMPY_INSTALL_DIR=${placeholder "out"}/${python.sitePackages}"
+    ]
     ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-linux") [
       "-DCMAKE_CXX_FLAGS=-fPIC"
       "-DCMAKE_C_FLAGS=-fPIC"

--- a/pkgs/development/python-modules/hoomd-blue/default.nix
+++ b/pkgs/development/python-modules/hoomd-blue/default.nix
@@ -49,12 +49,8 @@ buildPythonPackage rec {
     "-DBUILD_HPMC=${onOffBool components.hpmc}"
     "-DBUILD_MD=${onOffBool components.md}"
     "-DBUILD_METAL=${onOffBool components.metal}"
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/${python.sitePackages}"
   ];
-
-  preConfigure = ''
-    # Since we can't expand $out in `cmakeFlags`
-    cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_PREFIX=$out/${python.sitePackages}"
-  '';
 
   # tests fail but have tested that package runs properly
   doCheck = false;

--- a/pkgs/development/python-modules/rdkit/default.nix
+++ b/pkgs/development/python-modules/rdkit/default.nix
@@ -100,10 +100,10 @@ buildPythonPackage rec {
 
   preConfigure = ''
     # Since we can't expand with bash in cmakeFlags
-    cmakeFlags="$cmakeFlags -DPYTHON_NUMPY_INCLUDE_PATH=$(${python}/bin/python -c 'import numpy; print(numpy.get_include())')"
-    cmakeFlags="$cmakeFlags -DFREESASA_DIR=$PWD/External/FreeSASA/freesasa"
-    cmakeFlags="$cmakeFlags -DFREESASA_SRC_DIR=$PWD/External/FreeSASA/freesasa"
-    cmakeFlags="$cmakeFlags -DAVALONTOOLS_DIR=$PWD/External/AvalonTools/avalon"
+    appendToVar cmakeFlags "-DPYTHON_NUMPY_INCLUDE_PATH=$(${python}/bin/python -c 'import numpy; print(numpy.get_include())')"
+    appendToVar cmakeFlags "-DFREESASA_DIR=$PWD/External/FreeSASA/freesasa"
+    appendToVar cmakeFlags "-DFREESASA_SRC_DIR=$PWD/External/FreeSASA/freesasa"
+    appendToVar cmakeFlags "-DAVALONTOOLS_DIR=$PWD/External/AvalonTools/avalon"
   '';
 
   cmakeFlags = [

--- a/pkgs/games/commandergenius/default.nix
+++ b/pkgs/games/commandergenius/default.nix
@@ -28,10 +28,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf libGL boost libvorbis zlib curl python3 ];
 
-  preConfigure = ''
-    export cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_PREFIX=$out -DSHAREDIR=$out/share"
-    export makeFlags="$makeFlags DESTDIR=$(out)"
-  '';
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DSHAREDIR=${placeholder "out"}/share"
+  ];
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 

--- a/pkgs/tools/filesystems/irods/common.nix
+++ b/pkgs/tools/filesystems/irods/common.nix
@@ -27,15 +27,13 @@
     "-DCPACK_GENERATOR=TGZ"
     "-DCMAKE_CXX_FLAGS=-I${lib.getDev libcxx}/include/c++/v1"
     "-DPAM_LIBRARY=${pam}/lib/libpam.so"
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DIRODS_HOME_DIRECTORY=${placeholder "out"}"
+    "-DCMAKE_INSTALL_SBINDIR=${placeholder "out"}/sbin"
   ];
 
   postPatch = ''
     patchShebangs ./packaging ./scripts
-    export cmakeFlags="$cmakeFlags
-      -DCMAKE_INSTALL_PREFIX=$out
-      -DIRODS_HOME_DIRECTORY=$out
-      -DCMAKE_INSTALL_SBINDIR=$out/sbin
-    "
   '';
 
   meta = with lib; {

--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -32,6 +32,12 @@ rec {
     # fix build with recent llvm versions
     env.NIX_CFLAGS_COMPILE = "-Wno-deprecated-register -Wno-deprecated-declarations";
 
+    cmakeFlags = common.cmakeFlags or [ ] ++ [
+      "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,${placeholder "out"}/lib"
+      "-DCMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath,${placeholder "out"}/lib"
+      "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-rpath,${placeholder "out"}/lib"
+    ];
+
     postPatch = common.postPatch + ''
       patchShebangs ./test
       substituteInPlace plugins/database/CMakeLists.txt --replace-fail "COMMAND cpp" "COMMAND ${gcc.cc}/bin/cpp"
@@ -39,11 +45,6 @@ rec {
       do
         substituteInPlace $file --replace-quiet "CATCH2}/include" "CATCH2}/include/catch2"
       done
-      export cmakeFlags="$cmakeFlags
-        -DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,$out/lib
-        -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath,$out/lib
-        -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-rpath,$out/lib
-        "
 
       substituteInPlace server/auth/CMakeLists.txt --replace-fail SETUID ""
     '';


### PR DESCRIPTION
## Description of changes

This PR replaces string-concatenated cmakeFlags operations with `cmakeFlags` attribute elements or `prependToVar` or `appendToVar`.

Cc:
@moni-dz `molsketch` maintainer
@nim65s `python3Packages.pymeshlab` maintainer
@nico202 `yarp` maintainer
@orivej @edolstra @r-burns `aws-c-common` maintainers
@deepfire `openwsman` maintainer
@viric `vigra` original package author and previous maintainer
@costrouc `python3Packages.hoomd-blue` original package author and previous maintainer
@rmcgibbo @natsukium `python3Packages.rdkit` maintainers
@hce `commandergenius` maintainer
@bzizou `irods` maintainer

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/READvME.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (The evaluation passes, and there are 491 changed reverse dependencies. I didn't test building because the build dependencies require at least 65GB of disk space.)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
