### PR TITLE
ppsspp: add upstream patch for FFmpeg 6

### DIFF
--- a/pkgs/by-name/pp/ppsspp/fix-ffmpeg-6.patch
+++ b/pkgs/by-name/pp/ppsspp/fix-ffmpeg-6.patch
@@ -1,0 +1,170 @@
+Backported from <https://github.com/hrydgard/ppsspp/commit/930b7f644d74c74d9e58bf8e5300bf9ea9fb78a9>.
+
+Original author: Andrew Udvare <audvare@gmail.com>
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bfd5e69035..f7c43800fa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -117,6 +117,7 @@
+ endif()
+ 
+ include(ccache)
++include(CheckCXXSourceCompiles)
+ include(GNUInstallDirs)
+ 
+ add_definitions(-DASSETS_DIR="${CMAKE_INSTALL_FULL_DATADIR}/ppsspp/assets/")
+@@ -949,6 +950,23 @@
+ 	endif()
+ 
+ 	find_package(FFmpeg REQUIRED avcodec avformat avutil swresample swscale)
++	# Check if we need to use avcodec_(alloc|free)_frame instead of av_frame_(alloc|free)
++	# Check if we need to use const AVCodec
++	set(CMAKE_REQUIRED_LIBRARIES avcodec;avformat)
++	set(CMAKE_REQUIRED_FLAGS "-pedantic -Wall -Werror -Wno-unused-variable")
++	check_cxx_source_compiles("extern \"C\" {
++		#include <libavcodec/avcodec.h>
++		#include <libavformat/avformat.h>
++		}
++		static AVCodecContext *s_codec_context = NULL;
++		int main() {
++			const AVCodec *codec = avcodec_find_encoder(s_codec_context->codec_id);
++			return 0;
++		}
++		" HAVE_LIBAVCODEC_CONST_AVCODEC FAIL_REGEX "invalid conversion")
++
++	# Check if we need to use avcodec_alloc_context3 instead of stream->codec
++	# Check if we need to use av_frame_get_buffer instead of avcodec_default_get_buffer
+ endif(USE_FFMPEG)
+ 
+ find_package(ZLIB)
+@@ -2020,6 +2038,7 @@
+ 	Core/ELF/PrxDecrypter.h
+ 	Core/ELF/ParamSFO.cpp
+ 	Core/ELF/ParamSFO.h
++	Core/FFMPEGCompat.h
+ 	Core/FileSystems/tlzrc.cpp
+ 	Core/FileSystems/BlobFileSystem.cpp
+ 	Core/FileSystems/BlobFileSystem.h
+@@ -2354,6 +2373,9 @@
+ 
+ if(FFmpeg_FOUND)
+ 	target_compile_definitions(${CoreLibName} PRIVATE USE_FFMPEG=1)
++	if (HAVE_LIBAVCODEC_CONST_AVCODEC)
++		target_compile_definitions(${CoreLibName} PRIVATE HAVE_LIBAVCODEC_CONST_AVCODEC=1)
++	endif()
+ 	set_target_properties(${CoreLibName} PROPERTIES NO_SYSTEM_FROM_IMPORTED true)
+ 	target_include_directories(${CoreLibName} BEFORE PUBLIC ${FFmpeg_INCLUDE_avcodec})
+ 	target_link_libraries(${CoreLibName}
+diff --git a/Core/AVIDump.cpp b/Core/AVIDump.cpp
+index 7c9576d292..aa81165031 100644
+--- a/Core/AVIDump.cpp
++++ b/Core/AVIDump.cpp
+@@ -45,9 +45,7 @@
+ #define av_frame_free avcodec_free_frame
+ #endif
+ 
+-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 16, 100)
+-#define AVCodec const AVCodec
+-#endif
++#include "FFMPEGCompat.h"
+ 
+ static AVFormatContext *s_format_context = nullptr;
+ static AVCodecContext *s_codec_context = nullptr;
+diff --git a/Core/FFMPEGCompat.h b/Core/FFMPEGCompat.h
+new file mode 100644
+index 0000000000..fed3b1c853
+--- /dev/null
++++ b/Core/FFMPEGCompat.h
+@@ -1,0 +1,8 @@
++#ifndef FFMPEG_COMPAT_H
++#define FFMPEG_COMPAT_H
++
++#ifdef HAVE_LIBAVCODEC_CONST_AVCODEC
++#define AVCodec const AVCodec
++#endif
++
++#endif // FFMPEG_COMPAT_H
+diff --git a/Core/HLE/sceAtrac.cpp b/Core/HLE/sceAtrac.cpp
+index fe0e8a54de..f83d9ffdf1 100644
+--- a/Core/HLE/sceAtrac.cpp
++++ b/Core/HLE/sceAtrac.cpp
+@@ -129,10 +129,7 @@
+ #include "libavcodec/avcodec.h"
+ #include "libavutil/version.h"
+ }
+-
+-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 16, 100)
+-#define AVCodec const AVCodec
+-#endif
++#include "Core/FFMPEGCompat.h"
+ 
+ #endif // USE_FFMPEG
+ 
+diff --git a/Core/HLE/sceMpeg.cpp b/Core/HLE/sceMpeg.cpp
+index d050d62f3d..8be78c73e0 100644
+--- a/Core/HLE/sceMpeg.cpp
++++ b/Core/HLE/sceMpeg.cpp
+@@ -113,9 +113,7 @@
+ #include "libswscale/swscale.h"
+ #include "libavcodec/avcodec.h"
+ }
+-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 16, 100)
+-#define AVCodec const AVCodec
+-#endif
++#include "Core/FFMPEGCompat.h"
+ static AVPixelFormat pmp_want_pix_fmt;
+ 
+ #endif
+diff --git a/Core/HW/MediaEngine.cpp b/Core/HW/MediaEngine.cpp
+index 0ed957edfd..7e8b37d4dc 100644
+--- a/Core/HW/MediaEngine.cpp
++++ b/Core/HW/MediaEngine.cpp
+@@ -56,9 +56,7 @@
+ 
+ #ifdef USE_FFMPEG
+ 
+-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 16, 100)
+-#define AVCodec const AVCodec
+-#endif
++#include "Core/FFMPEGCompat.h"
+ 
+ static AVPixelFormat getSwsFormat(int pspFormat)
+ {
+diff --git a/Core/HW/SimpleAudioDec.cpp b/Core/HW/SimpleAudioDec.cpp
+index 7994a7f402..80397bf6da 100644
+--- a/Core/HW/SimpleAudioDec.cpp
++++ b/Core/HW/SimpleAudioDec.cpp
+@@ -33,6 +33,7 @@
+ #include "libavutil/samplefmt.h"
+ #include "libavcodec/avcodec.h"
+ }
++#include "Core/FFMPEGCompat.h"
+ 
+ #endif  // USE_FFMPEG
+ 
+diff --git a/Core/HW/SimpleAudioDec.h b/Core/HW/SimpleAudioDec.h
+index 52a78bf3b4..9bf2427a4a 100644
+--- a/Core/HW/SimpleAudioDec.h
++++ b/Core/HW/SimpleAudioDec.h
+@@ -33,10 +33,6 @@
+ #include "libavutil/version.h"
+ };
+ 
+-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 16, 100)
+-#define AVCodec const AVCodec
+-#endif
+-
+ #endif
+ 
+ // Wraps FFMPEG for audio decoding in a nice interface.
+@@ -90,6 +86,9 @@
+ 	int wanted_resample_freq; // wanted resampling rate/frequency
+ 
+ 	AVFrame *frame_;
++#if HAVE_LIBAVCODEC_CONST_AVCODEC // USE_FFMPEG is implied
++	const
++#endif
+ 	AVCodec *codec_;
+ 	AVCodecContext  *codecCtx_;
+ 	SwrContext      *swrCtx_;

--- a/pkgs/by-name/pp/ppsspp/package.nix
+++ b/pkgs/by-name/pp/ppsspp/package.nix
@@ -4,7 +4,7 @@
   cmake,
   copyDesktopItems,
   fetchFromGitHub,
-  ffmpeg,
+  ffmpeg_6,
   glew,
   libffi,
   libsForQt5,
@@ -48,6 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-I84zJqEE1X/eo/ukeGA2iZe3lWKvilk+RNGUzl2wZXY=";
   };
 
+  patches = lib.optionals useSystemFfmpeg [
+    ./fix-ffmpeg-6.patch
+  ];
+
   postPatch = ''
     substituteInPlace git-version.cmake --replace unknown ${finalAttrs.src.rev}
     substituteInPlace UI/NativeApp.cpp --replace /usr/share $out/share
@@ -69,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ]
   ++ lib.optionals useSystemFfmpeg [
-    ffmpeg
+    ffmpeg_6
   ]
   ++ lib.optionals useSystemSnappy [
     snappy

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2673,7 +2673,6 @@ with pkgs;
 
   ppsspp-sdl = let
     argset = {
-      ffmpeg = ffmpeg_4;
       enableQt = false;
       enableVulkan = true;
       forceWayland = false;
@@ -2683,7 +2682,6 @@ with pkgs;
 
   ppsspp-sdl-wayland = let
     argset = {
-      ffmpeg = ffmpeg_4;
       enableQt = false;
       enableVulkan = false; # https://github.com/hrydgard/ppsspp/issues/13845
       forceWayland = true;
@@ -2693,7 +2691,6 @@ with pkgs;
 
   ppsspp-qt = let
     argset = {
-      ffmpeg = ffmpeg_4;
       enableQt = true;
       enableVulkan = false; # https://github.com/hrydgard/ppsspp/issues/11628
       forceWayland = false;


### PR DESCRIPTION
## Description of changes

The bundled FFmpeg is used by default anyway, but this fixes compilation with FFmpeg 6 when opting in.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
