### PR TITLE
[release-24.05] dotnet: add SRI hash support to dotnet packages

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-global-tool/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-global-tool/default.nix
@@ -5,6 +5,8 @@
   # Name of the nuget package to install, if different from pname
 , nugetName ? pname
   # Hash of the nuget package to install, will be given on first build
+  # nugetHash uses SRI hash and should be preferred
+, nugetHash ? ""
 , nugetSha256 ? ""
   # Additional nuget deps needed by the tool package
 , nugetDeps ? (_: [])
@@ -24,7 +26,7 @@ buildDotnetModule (args // {
   nugetDeps = mkNugetDeps {
     name = pname;
     nugetDeps = { fetchNuGet }: [
-      (fetchNuGet { pname = nugetName; inherit version; sha256 = nugetSha256; })
+      (fetchNuGet { pname = nugetName; inherit version; sha256 = nugetSha256; hash = nugetHash; })
     ] ++ (nugetDeps fetchNuGet);
   };
 

--- a/pkgs/build-support/dotnet/fetchnuget/default.nix
+++ b/pkgs/build-support/dotnet/fetchnuget/default.nix
@@ -5,15 +5,19 @@ attrs @
 , version
 , url ? "https://www.nuget.org/api/v2/package/${pname}/${version}"
 , sha256 ? ""
+, hash ? ""
 , md5 ? ""
 , ...
 }:
 if md5 != "" then
-  throw "fetchnuget does not support md5 anymore, please use sha256"
+  throw "fetchnuget does not support md5 anymore, please use 'hash' attribute with SRI hash"
+# This is also detected in fetchurl, but we just throw here to avoid confusion
+else if (sha256 != "" && hash != "") then
+  throw "multiple hashes passed to fetchNuGet"
 else
   buildDotnetPackage ({
     src = fetchurl {
-      inherit url sha256;
+      inherit url sha256 hash;
       name = "${pname}.${version}.zip";
     };
 

--- a/pkgs/build-support/dotnet/make-nuget-deps/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-deps/default.nix
@@ -1,11 +1,14 @@
 { linkFarmFromDrvs, fetchurl }:
 { name, nugetDeps ? import sourceFile, sourceFile ? null }:
 linkFarmFromDrvs "${name}-nuget-deps" (nugetDeps {
-  fetchNuGet = { pname, version, sha256
+  fetchNuGet = { pname, version, sha256 ? "", hash ? ""
     , url ? "https://www.nuget.org/api/v2/package/${pname}/${version}" }:
     fetchurl {
       name = "${pname}.${version}.nupkg";
-      inherit url sha256;
+      # There is no need to verify whether both sha256 and hash are
+      # valid here, because nuget-to-nix does not generate a deps.nix
+      # containing both.
+      inherit url sha256 hash;
     };
 }) // {
   inherit sourceFile;

--- a/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
+++ b/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
@@ -65,11 +65,11 @@ for package in *; do
     for source in "${remote_sources[@]}"; do
       url="${base_addresses[$source]}$package/$version/$package.$version.nupkg"
       if [[ "$source" == "$used_source" ]]; then
-        sha256="$(nix-hash --type sha256 --flat --base32 "$version/$package.$version".nupkg)"
+        hash="$(nix-hash --type sha256 --flat --sri "$version/$package.$version".nupkg)"
         found=true
         break
       else
-        if sha256=$(nix-prefetch-url "$url" 2>"$tmp"/error); then
+        if hash=$(nix-prefetch-url "$url" 2>"$tmp"/error); then
           # If multiple remote sources are enabled, nuget will try them all
           # concurrently and use the one that responds first. We always use the
           # first source that has the package.
@@ -91,9 +91,9 @@ for package in *; do
     fi
 
     if [[ "$source" != https://api.nuget.org/v3/index.json ]]; then
-      echo "  (fetchNuGet { pname = \"$id\"; version = \"$version\"; sha256 = \"$sha256\"; url = \"$url\"; })"
+      echo "  (fetchNuGet { pname = \"$id\"; version = \"$version\"; hash = \"$hash\"; url = \"$url\"; })"
     else
-      echo "  (fetchNuGet { pname = \"$id\"; version = \"$version\"; sha256 = \"$sha256\"; })"
+      echo "  (fetchNuGet { pname = \"$id\"; version = \"$version\"; hash = \"$hash\"; })"
     fi
   done
   cd ..


### PR DESCRIPTION
## Description of changes

A backport of #324526 to 24.05 so that future automatic backports don't break.

This avoids the last two commits in that PR to avoid unknown breakages from editing existing packages.

Examples of affected backports:
- #333767
- #334090

FYI @NixOS/dotnet @Aleksanaa @newAM @eclairevoyant @arianvp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
