### PR TITLE
haskellPackages.entropy: build with js backend

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
@@ -27,6 +27,8 @@ in
   jsaddle = addBuildDepend self.ghcjs-base super.jsaddle;
   jsaddle-dom = addBuildDepend self.ghcjs-base super.jsaddle-dom;
 
+  entropy = addBuildDepend self.ghcjs-dom super.entropy;
+
   reflex-dom = super.reflex-dom.override (drv: {
     jsaddle-webkit2gtk = null;
   });


### PR DESCRIPTION
## Description of changes
@doyougnu 

`nix-build -A pkgsCross.ghcjs.haskell.packages.ghc98.entropy`  actually builds but the logs show
```
/nix/store/k11rxbj9mvpgfk15rriqjn97by18r2xk-gnutar-1.35/bin/tar
No uhc found
Running phase: buildPhase

testRDRAND-302/testRDRAND.c:6:24: error:
     error: invalid output constraint '=qm' in asm
        6 |      : "=r" (therand), "=qm" (err));
          |                        ^
  |
6 |      : "=r" (therand), "=qm" (err));
  |                        ^
1 error generated.
`emcc' failed in phase `C Compiler'. (Exit code: 1)
Result of RDRAND Test: False
Result of libc getrandom() Test: True
Result of getentropy() Test: True
Preprocessing library for entropy-0.4.1.10..
Building library for entropy-0.4.1.10..
[1 of 2] Compiling System.EntropyGhcjs ( System/EntropyGhcjs.hs, dist/build/System/EntropyGhcjs.o )
```

It seems `#ifdef arch_x86_64` is wrongly being evaluated as true in https://github.com/haskell/entropy/blob/5d0c71ef2b95b2f6314fbb6a24be7bb39dba99bb/cbits/rdrand.c#L14C1-L15C1

I don't see this test error on a project where I use ghcjs 8.10, even though that file had no changes in 9 years so I suspect it's something specific to the js backend.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
