### PR TITLE
nexusmods-app: use `finalAttrs`

### DIFF
--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -10,18 +10,17 @@
   libICE,
   libSM,
   libX11,
-  nexusmods-app,
   runCommand,
   pname ? "nexusmods-app",
 }:
-buildDotnetModule rec {
+buildDotnetModule (finalAttrs: {
   inherit pname;
   version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "Nexus-Mods";
     repo = "NexusMods.App";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-FzQphMhiC1g+6qmk/R1v4rq2ldy35NcaWm0RR1UlwLA=";
   };
@@ -55,7 +54,8 @@ buildDotnetModule rec {
 
   makeWrapperArgs = [
     "--prefix PATH : ${lib.makeBinPath [ desktop-file-utils ]}"
-    "--set APPIMAGE ${placeholder "out"}/bin/${meta.mainProgram}" # Make associating with nxm links work on Linux
+    # Make associating with nxm links work on Linux
+    "--set APPIMAGE ${placeholder "out"}/bin/NexusMods.App"
   ];
 
   runtimeDeps = [
@@ -65,7 +65,7 @@ buildDotnetModule rec {
     libX11
   ];
 
-  executables = [ meta.mainProgram ];
+  executables = [ "NexusMods.App" ];
 
   doCheck = true;
 
@@ -93,15 +93,10 @@ buildDotnetModule rec {
       let
         runTest =
           name: script:
-          runCommand "${pname}-test-${name}"
-            {
-              # TODO: use finalAttrs when buildDotnetModule has support
-              nativeBuildInputs = [ nexusmods-app ];
-            }
-            ''
-              ${script}
-              touch $out
-            '';
+          runCommand "${pname}-test-${name}" { nativeBuildInputs = [ finalAttrs.finalPackage ]; } ''
+            ${script}
+            touch $out
+          '';
       in
       {
         serve = runTest "serve" ''
@@ -123,7 +118,7 @@ buildDotnetModule rec {
   meta = {
     mainProgram = "NexusMods.App";
     homepage = "https://github.com/Nexus-Mods/NexusMods.App";
-    changelog = "https://github.com/Nexus-Mods/NexusMods.App/releases/tag/${src.rev}";
+    changelog = "https://github.com/Nexus-Mods/NexusMods.App/releases/tag/${finalAttrs.src.rev}";
     license = [ lib.licenses.gpl3Plus ];
     maintainers = with lib.maintainers; [
       l0b0
@@ -158,4 +153,4 @@ buildDotnetModule rec {
       }
     '';
   };
-}
+})

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -53,10 +53,12 @@ buildDotnetModule (finalAttrs: {
   '';
 
   makeWrapperArgs = [
-    "--prefix PATH : ${lib.makeBinPath [ desktop-file-utils ]}"
+    "--prefix PATH : ${lib.makeBinPath finalAttrs.runtimeInputs}"
     # Make associating with nxm links work on Linux
     "--set APPIMAGE ${placeholder "out"}/bin/NexusMods.App"
   ];
+
+  runtimeInputs = [ desktop-file-utils ];
 
   runtimeDeps = [
     fontconfig


### PR DESCRIPTION
## Description of changes

- **nexusmods-app: use `finalAttrs` for recursive fixpoint**
- **nexusmods-app: use `buildInputs` for dependencies**

Follow up to #331355, make use of the `finalAttrs` support added to `buildDotnetModule` in #331398. Hopefully anything recursive in the package is now done correctly.

I was unsure how to handle the relationship between `executables` and `meta.mainProgram`, so I decided to define both explicitly for now. Perhaps `buildDotnetModule` should consider setting `mainProgram` automatically to `head executables`?

I also replaced the manual wrapper `PATH` creation with `buildInputs` for the `desktop-file-utils` dependency. AFAICT everything is still working.

Related issues:
- #315337
- #310373

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

cc @corngood @l0b0 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
