### PR TITLE
zutty: init at 0.16-unstable-2024-08-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17754,6 +17754,12 @@
     githubId = 17805516;
     name = "Rohan Rao";
   };
+  rolfschr = {
+    email = "rolf.schr@posteo.de";
+    github = "rolfschr";
+    githubId = 1188465;
+    name = "Rolf Schröder";
+  };
   rollf = {
     email = "rolf.schroeder@limbus-medtec.com";
     github = "rollf";

--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -117,6 +117,8 @@ let tests = {
       xfce4-terminal.pkg = p: p.xfce.xfce4-terminal;
 
       xterm.pkg = p: p.xterm;
+
+      zutty.pkg = p: p.zutty;
     };
 in mapAttrs (name: { pkg, executable ? name, cmd ? "SHELL=$command ${executable}", colourTest ? true, pinkValue ? "#FF0087", kill ? false }: makeTest
 {

--- a/pkgs/by-name/zu/zutty/package.nix
+++ b/pkgs/by-name/zu/zutty/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  pkg-config,
+  freetype,
+  wafHook,
+  python3,
+  libXmu,
+  glew,
+  ucs-fonts,
+  nixosTests,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zutty";
+  version = "0.16-unstable-2024-08-18";
+
+  src = fetchgit {
+    url = "https://git.hq.sig7.se/zutty.git";
+    rev = "04b2ca3b3aaa070c41583247f8112c31b6003886"; # 20240818
+    hash = "sha256-izUbn2B3RqIIOW9tuL7DFLqJdektCftxnpQssJMYxC8=";
+  };
+
+  postPatch =
+    let
+      fontpaths = [
+        "/run/current-system/sw/share/X11/fonts" # available if fonts.fontDir.enable = true
+        "${ucs-fonts}/share/fonts"
+      ];
+    in
+    ''
+      substituteInPlace src/options.h \
+        --replace-fail /usr/share/fonts ${builtins.concatStringsSep ":" fontpaths}
+    '';
+
+  nativeBuildInputs = [
+    pkg-config
+    wafHook
+    python3
+  ];
+
+  buildInputs = [
+    freetype
+    libXmu
+    glew
+  ];
+
+  passthru = {
+    tests = lib.optionalAttrs stdenv.isLinux { default = nixosTests.terminal-emulators.zutty; };
+  };
+
+  meta = {
+    homepage = "https://tomscii.sig7.se/zutty/";
+    description = "X terminal emulator rendering through OpenGL ES Compute Shaders";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.rolfschr ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

This PR adds [zutty](https://tomscii.sig7.se/zutty/), a terminal emulator.

It is based (and improves) on this previous [PR](https://github.com/NixOS/nixpkgs/pull/257156) which is now outdated. Compared to that, there are several improvements:
* A basic test is added
* `src` has been updated (on GitHub anymore)
* The "font path" issue [discussed there](https://github.com/NixOS/nixpkgs/pull/257156#discussion_r1380341764) has been addressed (see this [comment](https://github.com/NixOS/nixpkgs/pull/257156#issuecomment-2278807153), too)
* A newer version of zutty is used that contains a fix for certain fonts (see details [here](https://gist.github.com/rolfschr/4261ea856535c6007194b2b27f3dee04?permalink_comment_id=5161242#gistcomment-5161242))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
