### PR TITLE
splash: init at 3.10.3

### DIFF
--- a/pkgs/by-name/gi/giza/package.nix
+++ b/pkgs/by-name/gi/giza/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  gfortran,
+  cairo,
+  freetype,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "giza";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "danieljprice";
+    repo = "giza";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-spb46IoySf6DM454adcWmqqLlzNA2HK9z29TzOCECJ4=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    gfortran
+  ];
+
+  buildInputs = [
+    cairo
+    freetype
+  ];
+
+  meta = {
+    description = "Scientific plotting library for C/Fortran";
+    inherit (finalAttrs.src.meta) homepage;
+    changelog = "${finalAttrs.src.meta.homepage}/blob/${finalAttrs.src.rev}/ChangeLog";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/sp/splash/package.nix
+++ b/pkgs/by-name/sp/splash/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gfortran,
+  giza,
+  hdf5,
+  cairo,
+  freetype,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "splash";
+  version = "3.10.3";
+
+  src = fetchFromGitHub {
+    owner = "danieljprice";
+    repo = "splash";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-5ieJHUWZDGgsNj7U9tbdhtDIsN+wgbs03IxVd1xM+hw=";
+  };
+
+  nativeBuildInputs = [
+    gfortran
+  ];
+
+  buildInputs = [
+    giza
+    cairo
+    freetype
+    hdf5
+  ];
+  makeFlags = [
+    "SYSTEM=gfortran"
+    "GIZA_DIR=${giza}"
+    "PREFIX=${placeholder "out"}"
+  ];
+  # Upstream's simplistic makefile doesn't even `mkdir $(PREFIX)`, so we help
+  # it:
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "An interactive visualisation and plotting tool using kernel interpolation, mainly used for Smoothed Particle Hydrodynamics simulations";
+    inherit (finalAttrs.src.meta) homepage;
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
