### PR TITLE
taler-merchant: fix wrong templates and spa dirs

### DIFF
--- a/pkgs/by-name/ta/taler-exchange/0001-add-TALER_TEMPLATING_init_path.patch
+++ b/pkgs/by-name/ta/taler-exchange/0001-add-TALER_TEMPLATING_init_path.patch
@@ -1,0 +1,75 @@
+From 3ca51717bbb7643eb0629729d0680cca75ce34c8 Mon Sep 17 00:00:00 2001
+From: eljamm <fedi.jamoussi@protonmail.ch>
+Date: Wed, 14 Aug 2024 11:14:41 +0100
+Subject: [PATCH] add TALER_TEMPLATING_init_path
+
+The merchant uses `TALER_TEMPLATING_init` function from the exchange's
+headers, which makes it harder to patch in the correct directory.
+
+To circumvent this, a similar function that takes the templates path
+directly is added.
+---
+ src/include/taler_templating_lib.h |  9 +++++++++
+ src/templating/templating_api.c    | 25 +++++++++++++++++++++++++
+ 2 files changed, 34 insertions(+)
+
+diff --git a/src/include/taler_templating_lib.h b/src/include/taler_templating_lib.h
+index 6af6db715..343004ef1 100644
+--- a/src/include/taler_templating_lib.h
++++ b/src/include/taler_templating_lib.h
+@@ -120,6 +120,16 @@ TALER_TEMPLATING_reply_error (struct MHD_Connection *connection,
+ enum GNUNET_GenericReturnValue
+ TALER_TEMPLATING_init (const char *subsystem);
+
++/**
++ * Preload templates from path.
++ *
++ * @param subsystem name of the subsystem, "merchant" or "exchange"
++ * @param path name of the absolute template path
++ * @return #GNUNET_OK on success
++ */
++enum GNUNET_GenericReturnValue
++TALER_TEMPLATING_init_path (const char *subsystem, const char *path);
++
+
+ /**
+  * Nicely shut down templating subsystem.
+diff --git a/src/templating/templating_api.c b/src/templating/templating_api.c
+index 88a17c682..a9afa2b70 100644
+--- a/src/templating/templating_api.c
++++ b/src/templating/templating_api.c
+@@ -506,6 +506,31 @@ TALER_TEMPLATING_init (const char *subsystem)
+ }
+
+
++enum GNUNET_GenericReturnValue
++TALER_TEMPLATING_init_path (const char *subsystem, const char *path)
++{
++  char *dn;
++  int ret;
++
++  {
++    GNUNET_asprintf (&dn,
++                     "%s/%s/templates/",
++                     path,
++                     subsystem);
++  }
++  ret = GNUNET_DISK_directory_scan (dn,
++                                    &load_template,
++                                    NULL);
++  GNUNET_free (dn);
++  if (-1 == ret)
++  {
++    GNUNET_break (0);
++    return GNUNET_SYSERR;
++  }
++  return GNUNET_OK;
++}
++
++
+ void
+ TALER_TEMPLATING_done (void)
+ {
+--
+2.45.2
+

--- a/pkgs/by-name/ta/taler-exchange/package.nix
+++ b/pkgs/by-name/ta/taler-exchange/package.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation {
     hash = "sha256-yHRRMlqFA2OiFg0rBVzn7130wyVaxKn2dChFTPnVtbs=";
   };
 
+  patches = [ ./0001-add-TALER_TEMPLATING_init_path.patch ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config


### PR DESCRIPTION
## Description of changes

- The taler-exchange package is wrongfully used when initializing the `templates` and `spa` directories, which results in the merchant not working.

Replacing this relative path searching with an absolute path pointing to the correct merchant directories fixes this.

- Also removed `configureFlags` since `gnunet` and `taler-exchange` seem to be detected properly without being explicitly specified.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
