### PR TITLE
schemat: init at 0.2.9-unstable-2024-08-20

### DIFF
--- a/pkgs/by-name/sc/schemat/enable-error_in_core.patch
+++ b/pkgs/by-name/sc/schemat/enable-error_in_core.patch
@@ -1,0 +1,10 @@
+diff --git a/src/main.rs b/src/main.rs
+index eddf879..3465aa7 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,4 +1,4 @@
+-#![feature(allocator_api, iter_intersperse)]
++#![feature(allocator_api, iter_intersperse, error_in_core)]
+ 
+ mod ast;
+ mod context;

--- a/pkgs/by-name/sc/schemat/package.nix
+++ b/pkgs/by-name/sc/schemat/package.nix
@@ -1,0 +1,30 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  lib,
+}:
+rustPlatform.buildRustPackage {
+  name = "schemat";
+  version = "0.2.9-unstable-2024-08-20";
+
+  src = fetchFromGitHub {
+    owner = "raviqqe";
+    repo = "schemat";
+    rev = "9dc2265aec54273c0abc8f60aba4c94408129006";
+    hash = "sha256-2nIzM6qW4lJCF8vg3q4NaBSlO5HttRTYyLN5KQMoRVs=";
+  };
+
+  cargoHash = "sha256-/CH3KFd4r2hwLu1UeEfpKknmIZ/Ls4/EtkLAs+EdSfk=";
+
+  RUSTC_BOOTSTRAP = true;
+
+  patches = [ ./enable-error_in_core.patch ];
+
+  meta = {
+    description = "Code formatter for Scheme, Lisp, and any S-expressions";
+    homepage = "https://github.com/raviqqe/schemat";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ bddvlpr ];
+    mainProgram = "schemat";
+  };
+}


### PR DESCRIPTION
## Description of changes
A code formatter for Scheme, Lisp, and any S-expressions.

https://github.com/raviqqe/schemat

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
