### PR TITLE
microcodeAmd-platomav: init at 0-unstable-2025-04-13

### DIFF
--- a/pkgs/by-name/mi/microcode-amd-platomav/package.nix
+++ b/pkgs/by-name/mi/microcode-amd-platomav/package.nix
@@ -78,6 +78,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/platomav/CPUMicrocodes";
     license = lib.licenses.unfreeRedistributableFirmware;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ d-brasher ];
+    maintainers = with lib.maintainers; [
+      d-brasher
+      johnrtitor
+    ];
   };
 })

--- a/pkgs/by-name/mi/microcode-amd-platomav/package.nix
+++ b/pkgs/by-name/mi/microcode-amd-platomav/package.nix
@@ -21,7 +21,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "microcodeAmd-platomav";
+  pname = "microcode-amd-platomav";
   version = "0-unstable-2025-10-04";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/mi/microcode-amd-platomav/package.nix
+++ b/pkgs/by-name/mi/microcode-amd-platomav/package.nix
@@ -76,7 +76,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "Microcode update image for AMD CPUs from platomav's github";
     homepage = "https://github.com/platomav/CPUMicrocodes";
-    license = lib.licenses.unfreeRedistributableFirmware;
+    license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       d-brasher

--- a/pkgs/by-name/mi/microcodeAmd-platomav/package.nix
+++ b/pkgs/by-name/mi/microcodeAmd-platomav/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+
+  amd-ucodegen,
+  microcode-amd,
+  libarchive,
+
+  nix-update-script,
+
+  # CPU families to include in the final image
+  # The decimal number of the CPU family can be optained with
+  # `cat /proc/cpuinfo | grep family`
+  # See also https://en.wikipedia.org/wiki/List_of_AMD_CPU_microarchitectures#Nomenclature
+  withFamily15h ? true, # Decimal 21
+  withFamily16h ? true, # Decimal 22
+  withFamily17h ? true, # Decimal 23
+  withFamily19h ? true, # Decimal 25
+  withFamily1Ah ? true, # Decimal 26
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "microcodeAmd-platomav";
+  version = "0-unstable-2025-10-04";
+
+  src = fetchFromGitHub {
+    owner = "platomav";
+    repo = "CPUMicrocodes";
+    rev = "ae2c33ecd7a5855a743b360a05bc984911d16957";
+    hash = "sha256-HMq/XjTY/Dmjzufho8dw8bL/2iMlcIZEUcJI84o6/no=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    amd-ucodegen
+    libarchive
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+  ''
+  + lib.optionalString withFamily15h ''
+    amd-ucodegen AMD/cpu??6??F??_*
+  ''
+  + lib.optionalString withFamily16h ''
+    amd-ucodegen AMD/cpu??7??F??_*
+  ''
+  + lib.optionalString withFamily17h ''
+    amd-ucodegen AMD/cpu??8??F??_*
+  ''
+  + lib.optionalString withFamily19h ''
+    amd-ucodegen AMD/cpu??A??F??_*
+  ''
+  + lib.optionalString withFamily1Ah ''
+    amd-ucodegen AMD/cpu??B??F??_*
+  ''
+  + ''
+
+    # Similar to microcodeAmd package
+    mkdir -p kernel/x86/microcode
+    find ./ -name microcode_amd\*.bin -print0 | sort -z |\
+      xargs -0 -I{} sh -c 'cat {} >> kernel/x86/microcode/AuthenticAMD.bin'
+
+    runHook postBuild
+  '';
+
+  inherit (microcode-amd) installPhase;
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+  };
+
+  meta = {
+    description = "Microcode update image for AMD CPUs from platomav's github";
+    homepage = "https://github.com/platomav/CPUMicrocodes";
+    license = lib.licenses.unfreeRedistributableFirmware;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ d-brasher ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1743,6 +1743,7 @@ mapAliases {
   mhwaveedit = throw "'mkwaveedit' has been removed due to lack of maintenance upstream. Consider using 'audacity' or 'tenacity' instead"; # Added 2024-09-15
   microcodeAmd = microcode-amd; # Added 2024-09-08
   microcodeIntel = microcode-intel; # Added 2024-09-08
+  microcodeAmd-platomav = microcode-amd-platomav; # Added 2025-10-18
   micropad = throw "micropad has been removed, since it was unmaintained and blocked the Electron 27 removal."; # Added 2025-02-24
   microsoft_gsl = microsoft-gsl; # Added 2023-05-26
   midori = throw "'midori' original project has been abandonned upstream and the package was broken for a while in nixpkgs"; # Added 2025-05-19


### PR DESCRIPTION
## Description of changes

This package generates a microcode update image for AMD CPUs from the genuine microcode dumps hosted on [platomav's github](https://github.com/platomav/CPUMicrocodes). They are dumped from official vendors firmware updates and are signed by AMD.

This is useful, for example, if a vendor is slow rolling out firmware updates for fixing CPU vulnerabilities, or for older unsupported hardware.

This has been inspired by a [similar package on the AUR](https://aur.archlinux.org/packages/amd-zen-ucode-platomav).

The microcode update image can be applied with:
```
initrd.prepend = lib.mkOrder 1 [ "${pkgs.microcodeAmd-platomav}/amd-ucode.img" ];
```

~If this gets merged I can write a module that adds the possibility to override the image used by `cpu.amd.updateMicrocode`~ Done in https://github.com/NixOS/nixpkgs/pull/434472.

Additional discussion in https://github.com/NixOS/nixpkgs/pull/413202

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
