### PR TITLE
linuxPackages.nvidiaPackages.latest: 555.58.02 -> 560.35.03

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -42,12 +42,12 @@ rec {
   };
 
   latest = selectHighestVersion production (generic {
-    version = "555.58.02";
-    sha256_64bit = "sha256-xctt4TPRlOJ6r5S54h5W6PT6/3Zy2R4ASNFPu8TSHKM=";
-    sha256_aarch64 = "sha256-wb20isMrRg8PeQBU96lWJzBMkjfySAUaqt4EgZnhyF8=";
-    openSha256 = "sha256-8hyRiGB+m2hL3c9MDA/Pon+Xl6E788MZ50WrrAGUVuY=";
-    settingsSha256 = "sha256-ZpuVZybW6CFN/gz9rx+UJvQ715FZnAOYfHn5jt5Z2C8=";
-    persistencedSha256 = "sha256-a1D7ZZmcKFWfPjjH1REqPM5j/YLWKnbkP9qfRyIyxAw=";
+    version = "560.35.03";
+    sha256_64bit = "sha256-8pMskvrdQ8WyNBvkU/xPc/CtcYXCa7ekP73oGuKfH+M=";
+    sha256_aarch64 = "sha256-s8ZAVKvRNXpjxRYqM3E5oss5FdqW+tv1qQC2pDjfG+s=";
+    openSha256 = "sha256-/32Zf0dKrofTmPZ3Ratw4vDM7B+OgpC4p7s+RHUjCrg=";
+    settingsSha256 = "sha256-kQsvDgnxis9ANFmwIwB7HX5MkIAcpEEAHc8IBOLdXvk=";
+    persistencedSha256 = "sha256-E2J2wYYyRu7Kc3MMZz/8ZIemcZg68rkzvqEwFAL3fFs=";
   });
 
   beta = selectHighestVersion latest (generic {


### PR DESCRIPTION
## Description of changes

- Highlights since R560 2nd Beta Release, 560.31.02
  - Fixed a bug, introduced in 555.58, where some DVI outputs would not work with HDMI monitors.
  - Fixed a bug that could cause KDE Plasma Shell to freeze while hovering over or opening applets when running in Wayland compositor mode.
  - Fixed a bug that could cause the display to freeze when presenting windows using Wayland direct scanout on multiple monitors.
  - Fixed a bug that could cause kernel crashes upon attempting KMS operations through DRM when nvidia_drm was loaded with modeset=0.
- Highlights from R560 2nd Beta Release, 560.31.02
  - Fixed a bug that caused widespread crashing with Xwayland games.
  - Fixed a race condition involving modeset ownership which could lead to flip event timeout errors when enabling the 'fbdev' kernel module parameter in nvidia-drm.
  - Fixed a regression that caused nvidia-powerd to exit when nvidia-dbus.conf was not present in the /etc/dbus-1/system.d/ directory.
  - Fixed a bug that could cause memory corruption while handling ACPI events on some notebooks.
  - Fixed a bug that could cause external displays to become frozen until the next modeset when using PRIME Display Offloading with the NVIDIA dGPU acting as the display offload sink.
- Highlights from R560 Beta Release, 560.28.03
  - Updated nvidia-installer to select the NVIDIA open GPU kernel modules by default on systems with GPUs that support both the proprietary and open kernel modules.
  - Fixed a bug that caused GPU driver installation to fail when the system used alternate implementations of the 'tr' utility, such as from the busybox or toybox projects.
  - Fixed a bug that could cause the wrong image format to be used for render pass image clears in Vulkan applications when using a VkImage created with VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT. This could lead to rendering corruption, as described in issues such as: https://github.com/doitsujin/dxvk/issues/3961
  - Fixed multiple issues that could cause crashes or unexpected behaviors when re-creating an NvFBC capture session.
  - Added support for EGL_KHR_platform_x11 and EGL_EXT_platform_xcb on Xwayland.
  - Fixed a bug that could cause some displays to appear multiple times in the nvidia-settings display layout configuration page on systems with multiple GPUs.
  - Added a PipeWire backend to NvFBC that allows it to work on the Wayland compositors that support screencasting via XDG Desktop Portal. This new interface will be available through an upcoming Capture SDK release.
  - Added support for multiple concurrent clients to NvFBC direct capture.
  - Added reporting of Vulkan information to nvidia-settings control panel.
  - Compiling nvidia-settings from source now requires Vulkan header files to be available.
  - Support DRM-KMS explicit synchronization via the IN_FENCE_FD mode setting property.
  - Support VRR (Variable Refresh Rate) for Wayland on pre-Volta GPUs.
  - Added support for Variable Refresh Rate on notebooks with the open kernel modules.
  - Updated glXWaitVideoSyncSGI() to be more efficient. This reduces frame stutter in some KDE configurations with GSP offload.
  - Fixed a bug that caused OpenGL triple buffering to behave like double buffering.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
