### PR TITLE
taler-wallet-core: init at 0.12.12

### DIFF
--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  stdenv,
+  esbuild,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchgit,
+  srcOnly,
+  removeReferencesTo,
+  nodejs,
+  pnpm,
+  python3,
+  git,
+  jq,
+  zip,
+}:
+let
+  nodeSources = srcOnly nodejs;
+  esbuild' = esbuild.override {
+    buildGoModule =
+      args:
+      buildGoModule (
+        args
+        // rec {
+          version = "0.19.9";
+          src = fetchFromGitHub {
+            owner = "evanw";
+            repo = "esbuild";
+            rev = "v${version}";
+            hash = "sha256-GiQTB/P+7uVGZfUaeM7S/5lGvfHlTl/cFt7XbNfE0qw=";
+          };
+          vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+        }
+      );
+  };
+  customPython = python3.withPackages (p: [ p.setuptools ]);
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "taler-wallet-core";
+  version = "0.12.12";
+
+  src = fetchgit {
+    url = "https://git.taler.net/wallet-core.git";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-36P74gRFSdDzyas/OFyjdwnoIT3sjVmSs/N4ozld7sE=";
+  };
+
+  nativeBuildInputs = [
+    customPython
+    nodejs
+    pnpm.configHook
+    git
+    jq
+    zip
+  ];
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-7az1wJ6BK9nPKirtW/fmXo3013JCPf+TNk/aG/mGTfo=";
+  };
+
+  buildInputs = [ nodejs ];
+
+  # Make a fake git repo with a commit.
+  # Without this, the package does not build.
+  postUnpack = ''
+    git init -b master
+    git config user.email "root@localhost"
+    git config user.name "root"
+    git commit --allow-empty -m "Initial commit"
+  '';
+
+  postPatch = ''
+    patchShebangs packages/*/*.mjs
+    substituteInPlace pnpm-lock.yaml \
+      --replace-fail "esbuild: 0.12.29" "esbuild: ${esbuild'.version}"
+  '';
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  # After the pnpm configure, we need to build the binaries of all instances
+  # of better-sqlite3. It has a native part that it wants to build using a
+  # script which is disallowed.
+  # Adapted from mkYarnModules.
+  preBuild = ''
+    for f in $(find -path '*/node_modules/better-sqlite3' -type d); do
+      (cd "$f" && (
+      npm run build-release --offline --nodedir="${nodeSources}"
+      find build -type f -exec \
+        ${lib.getExe removeReferencesTo} \
+        -t "${nodeSources}" {} \;
+      ))
+    done
+  '';
+
+  env.ESBUILD_BINARY_PATH = lib.getExe esbuild';
+
+  meta = {
+    homepage = "https://git.taler.net/wallet-core.git/";
+    description = "CLI wallet for GNU Taler written in TypeScript and Anastasis Web UI";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [
+      # maintained by the team working on NGI-supported software, no group for this yet
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "taler-wallet-cli";
+  };
+})


### PR DESCRIPTION
## Description of changes

Adapted from [ngi-nix/ngipkgs](https://github.com/ngi-nix/ngipkgs/blob/4dfe0968fc1c00d728231826614f2297d5bf3a88/pkgs/by-name/taler-wallet-core/package.nix)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
