### PR TITLE
nushell: 0.96.1 -> 0.97.1

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -21,7 +21,7 @@
 }:
 
 let
-  version = "0.96.1";
+  version = "0.97.1";
 in
 
 rustPlatform.buildRustPackage {
@@ -32,10 +32,10 @@ rustPlatform.buildRustPackage {
     owner = "nushell";
     repo = "nushell";
     rev = version;
-    hash = "sha256-I9cCvm2qTCwnRonfE86ippBV4V1r8U5HFr9OA96wVqI=";
+    hash = "sha256-hrcPWJ5OXFozfNux6iR/nEw/1z64N5BV4DD/JWhlH2U=";
   };
 
-  cargoHash = "sha256-XlsK7zu3Pyc5p5SPVCsBqxIyKedaAPF58Ki7keOZRYM=";
+  cargoHash = "sha256-iGmAgrj1oy0t8SsSuCNiUoqWXDFA2CdsPnYYYOpXofs=";
 
   nativeBuildInputs = [ pkg-config ]
     ++ lib.optionals (withDefaultFeatures && stdenv.isLinux) [ python3 ]

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -1,21 +1,24 @@
-{ stdenv
-, lib
-, rustPlatform
-, nushell
-, pkg-config
-, IOKit
-, Foundation
-, nix-update-script
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  nushell,
+  pkg-config,
+  IOKit,
+  Foundation,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_formats";
   inherit (nushell) version src;
-  cargoHash = "sha256-R4a+lD0KkdKrh2l7Fuyf/g/SvluDLjgAkolAF2h3Bl4=";
+  cargoHash = "sha256-pWtQYraMJ8nXJiTQPXxu/kEg4ftQy8YAjhUj9WPEYS8=";
 
-  nativeBuildInputs = [ pkg-config ]
-    ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
-  buildInputs = lib.optionals stdenv.isDarwin [ IOKit Foundation ];
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+  buildInputs = lib.optionals stdenv.isDarwin [
+    IOKit
+    Foundation
+  ];
   cargoBuildFlags = [ "--package nu_plugin_formats" ];
 
   checkPhase = ''
@@ -32,7 +35,10 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "nu_plugin_formats";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_formats";
     license = licenses.mit;
-    maintainers = with maintainers; [ viraptor aidalgol ];
+    maintainers = with maintainers; [
+      viraptor
+      aidalgol
+    ];
     platforms = with platforms; all;
   };
 }

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -1,20 +1,20 @@
-{ stdenv
-, lib
-, rustPlatform
-, openssl
-, nushell
-, pkg-config
-, Security
-, nix-update-script
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  openssl,
+  nushell,
+  pkg-config,
+  Security,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_gstat";
   inherit (nushell) version src;
-  cargoHash = "sha256-lVuCLp18jqeMdpEpIesN5vUgceLTg+un8n7SkGf8xZU=";
+  cargoHash = "sha256-f7gH5Kxz8vsYQluvIl/VNklFh80kFKCZEyJvH5eD9Qk=";
 
-  nativeBuildInputs = [ pkg-config ]
-    ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
   cargoBuildFlags = [ "--package nu_plugin_gstat" ];
 
@@ -32,7 +32,10 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "nu_plugin_gstat";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_gstat";
     license = licenses.mit;
-    maintainers = with maintainers; [ mrkkrp aidalgol ];
+    maintainers = with maintainers; [
+      mrkkrp
+      aidalgol
+    ];
     platforms = with platforms; all;
   };
 }

--- a/pkgs/shells/nushell/plugins/polars.nix
+++ b/pkgs/shells/nushell/plugins/polars.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_polars";
   inherit (nushell) version src;
 
-  cargoHash = "sha256-Ym/ypm3bUPZkKXYVrym9LEDL0RenJCcruN3urpN2cEQ=";
+  cargoHash = "sha256-agUuDPv8LJixj3cBrvhW8UdPLQHNVYpSlPGvioxZoDU=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs =

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -1,24 +1,31 @@
-{ stdenv
-, lib
-, rustPlatform
-, nushell
-, IOKit
-, CoreFoundation
-, nix-update-script
-, pkg-config
-, openssl
-, curl
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  nushell,
+  IOKit,
+  CoreFoundation,
+  nix-update-script,
+  pkg-config,
+  openssl,
+  curl,
 }:
 
 rustPlatform.buildRustPackage {
   pname = "nushell_plugin_query";
   inherit (nushell) version src;
-  cargoHash = "sha256-m5DYMvvNWfd86e7P7JI7KLlp7AjqtKO+n9jjORaW9ss=";
+  cargoHash = "sha256-ygzHnrQ3zO1+lxzRUFO1+0XocGBemJKoDa4oiCjCe+0=";
 
-  nativeBuildInputs = [ pkg-config ]
-    ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
-  buildInputs = [ openssl curl ]
-    ++ lib.optionals stdenv.isDarwin [ IOKit CoreFoundation ];
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+  buildInputs =
+    [
+      openssl
+      curl
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      IOKit
+      CoreFoundation
+    ];
   cargoBuildFlags = [ "--package nu_plugin_query" ];
 
   checkPhase = ''
@@ -35,7 +42,10 @@ rustPlatform.buildRustPackage {
     mainProgram = "nu_plugin_query";
     homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_query";
     license = licenses.mit;
-    maintainers = with maintainers; [ happysalada aidalgol ];
+    maintainers = with maintainers; [
+      happysalada
+      aidalgol
+    ];
     platforms = with platforms; all;
   };
 }

--- a/pkgs/shells/nushell/update.sh
+++ b/pkgs/shells/nushell/update.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash
+#!nix-shell -p git nix-update nixpkgs-review nixfmt-rfc-style
+
+set -euxo pipefail
+
+basedir="$(git rev-parse --show-toplevel)"
+cd "$basedir"
+
+branch="update-nushell"
+nuPath="pkgs/shells/nushell"
+
+function staged() {
+    if git status --porcelain | grep -q -E "^[AM].? +$1"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function version() {
+    grep '\s*version = ' "$nuPath/default.nix" | cut -d'"' -f 2 | head --lines 1
+}
+
+git checkout -B "$branch"
+
+version_old=$(version)
+if ! staged "$nuPath/default.nix"; then
+    nix-update nushell
+    git add "$nuPath/default.nix"
+fi
+version_new=$(version)
+
+declare -a plugins=(formats query polars gstat)
+for plugin in "${plugins[@]}"; do
+    attr="nushellPlugins.$plugin"
+    pluginPath="$nuPath/plugins/$plugin.nix"
+
+    if staged "$pluginPath"; then
+        echo "Skipping '$plugin' because it's alredy staged"
+        continue
+    fi
+
+    echo "Attempting to build $attr"
+
+    set +e
+    newHash=$(nix build ".#$attr" 2> \
+        >(grep got |
+            awk -F' ' '{ print $2 }'))
+    set -e
+
+    # New hash ?
+    if [ -n "$newHash" ]; then
+        # Add the new hash
+        sed -i "s!cargoHash = ".*";!cargoHash = \"$newHash\";!" "$pluginPath"
+        nixfmt "$pluginPath"
+
+        echo "Building $plugin again with new hash $newHash"
+        nix build ".#$attr"
+        git add "$pluginPath"
+        echo "Plugin $plugin built sucessfully"
+    else
+        echo "No new hash for '$plugin'"
+    fi
+done
+
+git commit -m "nushell: $version_old -> $version_new"
+
+echo "Starting nixpkgs-review"
+nixpkgs-review rev "$branch"


### PR DESCRIPTION
## Description of changes

Created an update script to update nushell and its plugins (feedback appreciated)
Update nushell to 0.97.1 using the update script

[Release notes/Changelog](https://www.nushell.sh/blog/2024-08-20-nushell_0_97_1.html)

Version 0.97.0 was "skipped". See release notes
> Note: this was going to be version 0.97.0, but that version had to be yanked due to a last minute bug. This is still the next major version, not a patch release.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
