### PR TITLE
Unbreak Agda's standard library by bumping to 2.1.1-rc2

### DIFF
--- a/pkgs/development/libraries/agda/agda-prelude/default.nix
+++ b/pkgs/development/libraries/agda/agda-prelude/default.nix
@@ -24,5 +24,6 @@ mkDerivation rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with maintainers; [ mudri alexarice turion ];
+    broken = true;  # currently not compatible with Agda 2.7.0
   };
 }

--- a/pkgs/development/libraries/agda/standard-library/default.nix
+++ b/pkgs/development/libraries/agda/standard-library/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "standard-library";
-  version = "2.1";
+  version = "2.1.1-rc2";
 
   src = fetchFromGitHub {
     repo = "agda-stdlib";
     owner = "agda";
     rev = "v${version}";
-    hash = "sha256-tv/Fj8ZJgSvieNLlXBjyIR7MSmDp0e2QbN1d/0xBpFg=";
+    hash = "sha256-F/LwPRzorkIoGsObB9m/hNpRBIJFy/GuaEotq0CQMH4=";
   };
 
   nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];


### PR DESCRIPTION
## Description of changes

When #335932 is merged, our current version (2.1) of Agda's standard library will stop working as #335932 bumps Agda from the old 2.6.4.3 to the new 2.7.0, with which stdlib 2.1 is not compatible.

As a remedy, this pull request bumps Agda's standard library from 2.1 to 2.2.1-rc2.

According to an announcement on the Agda mailing list, the official 2.2.1 is likely to be released in about a week. But as we strive for the master branch to always contain a working Agda environment (including the standard library and a couple of others), I believe that we should bump to 2.2.1-rc2 now instead of shipping a broken version in the window between the marge of haskell-updates and the release of 2.2.1.

This pull request also marks agda-prelude, a different library, as broken, as it is currently not compatible with Agda 2.7.0.

Together with the companion pull request #336027, this pull request ensures that Agda + libraries will work after the merge of #335932, and supersedes the draft pull request #335824. You can test this pull request with:

```
$ nix-shell -I nixpkgs=https://github.com/iblech/nixpkgs/archive/patch-agda-stdlib-2.1.1rc2.zip -p "agda.withPackages (p: [ p.standard-library p.functional-linear-algebra p.agda-categories p.generics p.cubical ])
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
