### PR TITLE
teleport_16: 16.0.4 -> 16.1.4

### DIFF
--- a/pkgs/servers/teleport/16/default.nix
+++ b/pkgs/servers/teleport/16/default.nix
@@ -1,9 +1,9 @@
 { wasm-bindgen-cli, ... }@args:
 import ../generic.nix (args // {
-  version = "16.0.4";
-  hash = "sha256-svDqcYm6PbmPyHhN00VKn/sGRkfb7ah2N7BtEVdZ9hg=";
-  vendorHash = "sha256-H4Rwel/UAvxY8/4CfSbneJYjt9HHgsuNbYXUM6MtqXM=";
-  yarnHash = "sha256-OHNnN66MevDiH4Zr6Uq3Om65XBzf4O3AIrPvhlvhkbE=";
+  version = "16.1.4";
+  hash = "sha256-WgMQzS7nwIwPojcf9HTLajLd0WV+RYEbyp/aWr9XFWc=";
+  vendorHash = "sha256-8WN4hVueA2o2bHhhxLGPYxPX+1qky8QHGTRqhEGNh9s=";
+  pnpmHash = "sha256-phDrOSFQsgA+I4PDK9LJasUBXBO8EkVtQIMx9M4v8u0=";
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {

--- a/pkgs/servers/teleport/tsh_16.patch
+++ b/pkgs/servers/teleport/tsh_16.patch
@@ -1,0 +1,17 @@
+diff --git a/tool/tsh/common/tsh.go b/tool/tsh/common/tsh.go
+index 5de21c69d0..3995c19e3c 100644
+--- a/tool/tsh/common/tsh.go
++++ b/tool/tsh/common/tsh.go
+@@ -1084,10 +1084,11 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
+ 
+ 	var err error
+ 
+-	cf.executablePath, err = os.Executable()
++	tempBinaryPath, err := os.Executable()
+ 	if err != nil {
+ 		return trace.Wrap(err)
+ 	}
++	cf.executablePath = filepath.Dir(tempBinaryPath) + "/tsh"
+ 
+ 	// configs
+ 	setEnvFlags(&cf)


### PR DESCRIPTION
## Description of changes

New minor version of Teleport 16. Upstream switched from Yarn to PNPM in both master and [the v16 branch](https://github.com/gravitational/teleport/pull/44450), so the derivation needed some changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
