### PR TITLE
compressDrv: fix a confusing comment

### DIFF
--- a/pkgs/build-support/compress-drv/default.nix
+++ b/pkgs/build-support/compress-drv/default.nix
@@ -41,7 +41,7 @@
   compressDrv pkgs.spdx-license-list-data.json {
     formats = ["json"];
     compressors = {
-      "json" = "${zopfli}/bin/zopfli --keep {}";
+      gz = "${zopfli}/bin/zopfli --keep {}";
     };
   }
   =>


### PR DESCRIPTION
A confusing piece of documentation, leftover from fast iteration earlier.