### PR TITLE
prometheus-redfish-exporter: init at 0.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21369,6 +21369,12 @@
     githubId = 29992205;
     keys = [ { fingerprint = "6684 4E7D D213 C75D 8828  6215 C714 A58B 6C1E 0F52"; } ];
   };
+  underknowledge = {
+    name = "Underknowledge";
+    email = "blackhole@underknowledge.cc";
+    github = "underknowledge";
+    githubId = 20793849;
+  };
   unhammer = {
     email = "unhammer@fsfe.org";
     github = "unhammer";

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -73,6 +73,7 @@ let
     "process"
     "pve"
     "py-air-control"
+    "redfish"
     "redis"
     "restic"
     "rspamd"

--- a/nixos/modules/services/monitoring/prometheus/exporters/redfish.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/redfish.nix
@@ -1,0 +1,79 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.redfish;
+  inherit (lib)
+    mkOption
+    types
+    mkPackageOption
+    optionalString
+    concatStringsSep
+    optionalAttrs
+    ;
+  settingsFormat = pkgs.formats.yaml { };
+  configFile = settingsFormat.generate "redfish-config.yml" cfg.settings;
+in
+{
+  port = 9610;
+  extraOpts = {
+    settings = mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = ''
+        Configuration for redfish_exporter, see
+        <https://github.com/jenningsloy318/redfish_exporter>
+        for supported values.
+      '';
+    };
+
+    loglevel = mkOption {
+      type = types.enum [
+        "debug"
+        "info"
+        "warn"
+        "error"
+        "fatal"
+      ];
+      default = "info";
+      description = ''
+        Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal].
+      '';
+    };
+    logformat = mkOption {
+      type = types.str;
+      default = "logger:stderr";
+      description = ''
+        Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"
+      '';
+    };
+
+    webConfigFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      example = "/var/lib/redfish-exporter/webConfigFile.conf";
+      description = ''
+        [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
+      '';
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-redfish-exporter}/bin/redfish_exporter \
+          --config.file="${configFile}" \
+          --web.listen-address=${cfg.listenAddress}:${toString cfg.port} \
+          --log.level=${cfg.loglevel} \
+          --log.format="${cfg.logformat}" \
+          ${optionalString (cfg.webConfigFile != null) "--web.config.file=${cfg.webConfigFile}"} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-redfish-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-redfish-exporter/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "redfish-exporter";
+  version = "0.11.0";
+  src = fetchFromGitHub {
+    owner = "jenningsloy318";
+    repo = "redfish_exporter";
+    rev = "d388474c4024d09df0f3ab0290068e9072a7cf21";
+    hash = "sha256-TkbME8rdmDvxzpK3KKk4XKS35oVGWaDVBzqiAjx+6sA==";
+  };
+  vendorHash = "sha256-M/5n6LFX8T0BCbM/TdA1qJN/3lNXLi/ZVlWucenp0yk=";
+  ldflags = [
+    "-X 'main.Version=${version}'"
+    "-X 'main.BuildRevision=${src.rev}'"
+    "-X 'main.BuildBranch=master'"
+    "-X 'main.BuildUser=nix@nixpkgs'"
+    "-X 'main.BuildDate=unknown'"
+  ];
+
+  # Todo?
+  #   passthru.tests = { inherit (nixosTests.prometheus-exporters) redfish; };
+  # https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/prometheus-exporters.nix
+
+  meta = {
+    description = "Prometheus exporter for Redfish metrics";
+    mainProgram = "redfish_exporter";
+    homepage = "https://github.com/jenningsloy318/redfish_exporter";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ underknowledge ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

For the sys admins out there. 
Redfish exporter that can pull hardware info out of an server. 
see:
https://github.com/jenningsloy318/redfish_exporter
as for settings, follows closely the ping exporter. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-
  prometheus-redfish-exporter: init at 0.11.0
  module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
