### PR TITLE
gnome-secrets: 8.0 -> 9.6

### DIFF
--- a/pkgs/applications/misc/gnome-secrets/default.nix
+++ b/pkgs/applications/misc/gnome-secrets/default.nix
@@ -17,7 +17,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gnome-secrets";
-  version = "8.0";
+  version = "9.6";
   format = "other";
 
   src = fetchFromGitLab {
@@ -25,7 +25,7 @@ python3Packages.buildPythonApplication rec {
     owner = "World";
     repo = "secrets";
     rev = version;
-    hash = "sha256-SEPQjl6hd8IBs0c0LBEYaqn2n8CGQmYSEMJp5yoL/PA=";
+    hash = "sha256-iF2AQYAwwIr/sCZUz1pdqEa74DH4y4Nts6aJj3mS2f4=";
   };
 
   nativeBuildInputs = [
@@ -49,9 +49,11 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = with python3Packages; [
     pygobject3
     construct
+    pykcs11
     pykeepass
     pyotp
     validators
+    yubico
     zxcvbn
   ];
 

--- a/pkgs/development/python-modules/pykcs11/default.nix
+++ b/pkgs/development/python-modules/pykcs11/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  callPackage,
+  fetchPypi,
+  setuptools,
+  swig4,
+}:
+
+buildPythonPackage rec {
+  pname = "pykcs11";
+  version = "1.5.16";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Q9dGsGd/Q8xjS598Tastm6axqDuTHiWYJHBi+P9kHgc=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ swig4 ];
+
+  pypaBuildFlags = [ "--skip-dependency-check" ];
+
+  outputs = [
+    "out"
+    "testout"
+  ];
+
+  postInstall = ''
+    mkdir $testout
+    cp -R test $testout/test
+  '';
+
+  pythonImportsCheck = [ "PyKCS11" ];
+
+  doCheck = false;
+
+  # tests complain about circular import, do testing with passthru.tests instead
+  passthru.tests = {
+    pytest = callPackage ./tests.nix { };
+  };
+
+  meta = with lib; {
+    description = "PKCS#11 wrapper for Python";
+    homepage = "https://github.com/LudovicRousseau/PyKCS11";
+    changelog = "https://github.com/LudovicRousseau/PyKCS11/releases/tag/${version}";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ hulr ];
+  };
+}

--- a/pkgs/development/python-modules/pykcs11/tests.nix
+++ b/pkgs/development/python-modules/pykcs11/tests.nix
@@ -1,0 +1,33 @@
+{
+  buildPythonPackage,
+  asn1crypto,
+  pykcs11,
+  pytestCheckHook,
+  softhsm,
+}:
+
+buildPythonPackage {
+  pname = "pykcs11-tests";
+  inherit (pykcs11) version;
+  format = "other";
+
+  src = pykcs11.testout;
+
+  dontBuild = true;
+  dontInstall = true;
+
+  nativeCheckInputs = [
+    asn1crypto
+    pykcs11
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    export PYKCS11LIB=${softhsm}/lib/softhsm/libsofthsm2.so
+    export SOFTHSM2_CONF=$HOME/softhsm2.conf
+    echo "directories.tokendir = $HOME/tokens" > $HOME/softhsm2.conf
+    mkdir $HOME/tokens
+    ${softhsm}/bin/softhsm2-util --init-token --label "A token" --pin 1234 --so-pin 123456 --slot 0
+  '';
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10399,6 +10399,8 @@ self: super: with self; {
 
   pyixapi = callPackage ../development/python-modules/pyixapi { };
 
+  pykcs11 = callPackage ../development/python-modules/pykcs11 { };
+
   pykrakenapi = callPackage ../development/python-modules/pykrakenapi { };
 
   pylance = callPackage ../development/python-modules/pylance { };


### PR DESCRIPTION
## Description of changes

https://gitlab.gnome.org/World/secrets/-/compare/8.0...9.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
