### PR TITLE
lib.fixedPoints.toExtension: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -79,7 +79,8 @@ let
       fromHexString toHexString toBaseDigits inPureEvalMode isBool isInt pathExists
       genericClosure readFile;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
-      composeManyExtensions makeExtensible makeExtensibleWithCustomName;
+      composeManyExtensions makeExtensible makeExtensibleWithCustomName
+      toExtension;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrNames attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -463,8 +463,17 @@ rec {
     # Type
 
     ```
-    toExtension ::: (a | a -> a | a -> a -> a) -> a -> a -> a
-    a = AttrSet & !Function
+    toExtension ::
+      b' -> Any -> Any -> b'
+    or
+    toExtension ::
+      (a -> b') -> Any -> a -> b'
+    or
+    toExtension ::
+      (a -> a -> b) -> a -> a -> b
+    where b' = ! Callable
+
+    Set a = b = b' = AttrSet & ! Callable to make toExtension return an extending function.
     ```
 
     # Examples

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -444,21 +444,20 @@ rec {
 
     `toExtension` is the `toFunction` for extending functions (a.k.a. extensions or overlays).
     It converts a non-function or a single-argument function to an extending function,
-    while returning a double-argument function as-is.
+    while returning a two-argument function as-is.
 
-    That is, it takes one of `x`, `prev: x`, or `final: prev: x`,
-    and returns `final: prev: x`, where `x` is not a function.
+    That is, it takes a value of the shape `x`, `prev: x`, or `final: prev: x`,
+    and returns `final: prev: x`, assuming `x` is not a function.
 
-    This function is extracted from the implementation of
-    the fixed-point arguments support of `stdenv.mkDerivation`.
+    This function takes care of the input to `stdenv.mkDerivation`'s
+    `overrideAttrs` function.
     It bridges the gap between `<pkg>.overrideAttrs`
-    before and after the overlay-style support,
-    as well as `config.packageOverrides` and `config.overlays` in `pkgs`.
+    before and after the overlay-style support.
 
     # Inputs
 
     `f`
-    : The function or non-function to convert to an extending function.
+    : The function or value to convert to an extending function.
 
     # Type
 
@@ -509,6 +508,6 @@ rec {
         # f is (prev: { ... })
         fPrev
     else
-      # f is { ... }
+      # f is not a function; probably { ... }
       final: prev: f;
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -233,11 +233,6 @@ runTests {
     ];
   };
 
-  testFix = {
-    expr = fix (x: {a = if x ? a then "a" else "b";});
-    expected = {a = "a";};
-  };
-
   testComposeExtensions = {
     expr = let obj = makeExtensible (self: { foo = self.bar; });
                f = self: super: { bar = false; baz = true; };
@@ -1236,6 +1231,13 @@ runTests {
   testAttrsToListsCanDealWithFunctions = testingEval (
     attrsToList { someFunc= a: a + 1;}
   );
+
+# FIXED-POINTS
+
+  testFix = {
+    expr = fix (x: {a = if x ? a then "a" else "b";});
+    expected = {a = "a";};
+  };
 
 # GENERATORS
 # these tests assume attributes are converted to lists

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -45,6 +45,7 @@ let
     const
     escapeXML
     evalModules
+    extends
     filter
     fix
     fold
@@ -102,6 +103,7 @@ let
     take
     testAllTrue
     toBaseDigits
+    toExtension
     toHexString
     fromHexString
     toInt
@@ -1237,6 +1239,21 @@ runTests {
   testFix = {
     expr = fix (x: {a = if x ? a then "a" else "b";});
     expected = {a = "a";};
+  };
+
+  testToExtension = {
+    expr = [
+      (fix (final: { a = 0; c = final.a; }))
+      (fix (extends (toExtension { a = 1; b = 2; }) (final: { a = 0; c = final.a; })))
+      (fix (extends (toExtension (prev: { a = 1; b = prev.a; })) (final: { a = 0; c = final.a; })))
+      (fix (extends (toExtension (final: prev: { a = 1; b = prev.a; c = final.a + 1; })) (final: { a = 0; c = final.a; })))
+    ];
+    expected = [
+      { a = 0; c = 0; }
+      { a = 1; b = 2; c = 1; }
+      { a = 1; b = 0; c = 1; }
+      { a = 1; b = 0; c = 2; }
+    ];
   };
 
 # GENERATORS

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -63,20 +63,6 @@ let
   GO111MODULE = "on";
   GOTOOLCHAIN = "local";
 
-  toExtension =
-    overlay0:
-    if lib.isFunction overlay0 then
-      final: prev:
-      if lib.isFunction (overlay0 prev) then
-        # `overlay0` is `final: prev: { ... }`
-        overlay0 final prev
-      else
-        # `overlay0` is `prev: { ... }`
-        overlay0 prev
-    else
-      # `overlay0` is `{ ... }`
-      final: prev: overlay0;
-
 in
 (stdenv.mkDerivation (finalAttrs:
   args
@@ -333,7 +319,7 @@ in
       # Canonicallize `overrideModAttrs` as an attribute overlay.
       # `passthru.overrideModAttrs` will be overridden
       # when users want to override `goModules`.
-      overrideModAttrs = toExtension overrideModAttrs;
+      overrideModAttrs = lib.toExtension overrideModAttrs;
     } // passthru;
 
     meta = {

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -67,26 +67,8 @@ let
       #              ^^^^
 
       overrideAttrs = f0:
-        let
-          f = self: super:
-            # Convert f0 to an overlay. Legacy is:
-            #   overrideAttrs (super: {})
-            # We want to introduce self. We follow the convention of overlays:
-            #   overrideAttrs (self: super: {})
-            # Which means the first parameter can be either self or super.
-            # This is surprising, but far better than the confusion that would
-            # arise from flipping an overlay's parameters in some cases.
-            let x = f0 super;
-            in
-              if builtins.isFunction x
-              then
-                # Can't reuse `x`, because `self` comes first.
-                # Looks inefficient, but `f0 super` was a cheap thunk.
-                f0 self super
-              else x;
-        in
-          makeDerivationExtensible
-            (self: let super = rattrs self; in super // (if builtins.isFunction f0 || f0?__functor then f self super else f0));
+        makeDerivationExtensible
+          (lib.extends (lib.toExtension f0) rattrs);
 
       finalPackage =
         mkDerivationSimple overrideAttrs args;


### PR DESCRIPTION
## Description of changes

This function is taken from `stdenv.mkDerivation`'s implementation of `overrideAttrs`, and acts as a `toFunction` analogy for overlays.

Some packages/package sets have an argument in their `override` interface to take override functions, which might be anything from a plain attribute set to an overlay. To use the override interface while keeping the previous overriding, one would extend it with `lib.composeExtensions`, which only accepts overlays.

#225051 locally uses a function like this to convert the `overrideModAttrs` argument to `passthru.overrideModAttrs`. The former could be anything to pass to `.overrideAttrs`, but the latter must be an attribute overlay so that people could override with `lib.composeExtension`.

Other potential use cases include enabling custom overriders such as `overridePythonAttrs` support overlay-style overriding (`drv.overridePythonAttrs (finalAttrs: previousPythonAttrs: { ... })`), but that is out of the scope of this PR.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (no rebuild)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
