### PR TITLE
netdata: 1.46.1 -> 1.46.3

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -374,14 +374,6 @@ in {
         permissions = "u+rx,g+x,o-rwx";
       };
 
-      "logs-management.plugin" = {
-        source = "${cfg.package}/libexec/netdata/plugins.d/logs-management.plugin.org";
-        capabilities = "cap_dac_read_search,cap_syslog+ep";
-        owner = cfg.user;
-        group = cfg.group;
-        permissions = "u+rx,g+x,o-rwx";
-      };
-
       "slabinfo.plugin" = {
         source = "${cfg.package}/libexec/netdata/plugins.d/slabinfo.plugin.org";
         capabilities = "cap_dac_override+ep";
@@ -402,6 +394,14 @@ in {
       "network-viewer.plugin" = {
         source = "${cfg.package}/libexec/netdata/plugins.d/network-viewer.plugin.org";
         capabilities = "cap_sys_admin,cap_dac_read_search,cap_sys_ptrace+ep";
+        owner = cfg.user;
+        group = cfg.group;
+        permissions = "u+rx,g+x,o-rwx";
+      };
+    } // optionalAttrs (cfg.package.withLogsManagement) {
+      "logs-management.plugin" = {
+        source = "${cfg.package}/libexec/netdata/plugins.d/logs-management.plugin.org";
+        capabilities = "cap_dac_read_search,cap_syslog+ep";
         owner = cfg.user;
         group = cfg.group;
         permissions = "u+rx,g+x,o-rwx";

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -17,10 +17,11 @@
 , withDebug ? false
 , withEbpf ? false
 , withNetworkViewer ? (!stdenv.isDarwin)
+, withLogsManagement ? false
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.46.1";
+  version = "1.46.3";
   pname = "netdata";
 
   src = fetchFromGitHub {
@@ -28,9 +29,9 @@ stdenv.mkDerivation rec {
     repo = "netdata";
     rev = "v${version}";
     hash = if withCloudUi
-      then "sha256-tFjczhJ7bIEUDZx3MxYBu4tGkJhoQn5V79D4sLV2o8U="
+      then "sha256-VyFqwkB9/cLxuXkxS5fSP48fjSWofuqemJIiZDDsdMU="
       # we delete the v2 GUI after fetching
-      else "sha256-uW3jRiJjFIFSfmmavM3KVF985F8nMKa+lQAgNBZvKyE=";
+      else "sha256-/Sqdi/u2IgNP55RZ6KjbkcHwq2903ZuSOvC8w+8+zvE=";
     fetchSubmodules = true;
 
     # Remove v2 dashboard distributed under NCUL1. Make sure an empty
@@ -94,8 +95,6 @@ stdenv.mkDerivation rec {
        $out/libexec/netdata/plugins.d/slabinfo.plugin.org
     mv $out/libexec/netdata/plugins.d/debugfs.plugin \
        $out/libexec/netdata/plugins.d/debugfs.plugin.org
-    mv $out/libexec/netdata/plugins.d/logs-management.plugin \
-       $out/libexec/netdata/plugins.d/logs-management.plugin.org
     ${lib.optionalString withSystemdJournal ''
       mv $out/libexec/netdata/plugins.d/systemd-journal.plugin \
          $out/libexec/netdata/plugins.d/systemd-journal.plugin.org
@@ -107,6 +106,10 @@ stdenv.mkDerivation rec {
     ${lib.optionalString withNetworkViewer ''
       mv $out/libexec/netdata/plugins.d/network-viewer.plugin \
          $out/libexec/netdata/plugins.d/network-viewer.plugin.org
+    ''}
+    ${lib.optionalString withLogsManagement ''
+      mv $out/libexec/netdata/plugins.d/logs-management.plugin \
+         $out/libexec/netdata/plugins.d/logs-management.plugin.org
     ''}
     ${lib.optionalString (!withCloudUi) ''
       rm -rf $out/share/netdata/web/index.html
@@ -156,6 +159,7 @@ stdenv.mkDerivation rec {
     (lib.cmakeBool "ENABLE_PLUGIN_CUPS" withCups)
     (lib.cmakeBool "ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE" withConnPrometheus)
     (lib.cmakeBool "ENABLE_JEMALLOC" true)
+    (lib.cmakeBool "ENABLE_PLUGIN_LOGS_MANAGEMENT" withLogsManagement)
     # Suggested by upstream.
     "-G Ninja"
   ];
@@ -194,7 +198,7 @@ stdenv.mkDerivation rec {
         license = lib.licenses.gpl3Only;
       };
     }).goModules;
-    inherit withIpmi withNetworkViewer;
+    inherit withIpmi withNetworkViewer withLogsManagement;
     tests.netdata = nixosTests.netdata;
   };
 

--- a/pkgs/tools/system/netdata/ndsudo-fix-path.patch
+++ b/pkgs/tools/system/netdata/ndsudo-fix-path.patch
@@ -2,7 +2,7 @@
 #     https://github.com/netdata/netdata/security/advisories/GHSA-pmhq-4cxq-wj93
 
 diff --git a/src/collectors/plugins.d/ndsudo.c b/src/collectors/plugins.d/ndsudo.c
-index 8b4d76f46..68fa52d38 100644
+index d53ca9f28..b42a121bf 100644
 --- a/src/collectors/plugins.d/ndsudo.c
 +++ b/src/collectors/plugins.d/ndsudo.c
 @@ -357,9 +357,6 @@ int main(int argc, char *argv[]) {
@@ -12,5 +12,6 @@ index 8b4d76f46..68fa52d38 100644
 -    char new_path[] = "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin";
 -    putenv(new_path);
 -
-     bool found = false;
-     char filename[FILENAME_MAX];
+     setuid(0);
+     setgid(0);
+     setegid(0);


### PR DESCRIPTION
## Description of changes

I've disabled log management since it's the new default <https://github.com/netdata/netdata/commit/43c72b303c1c896f0fafaee7fdbacce363c5874a>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
