### PR TITLE
linearmouse: init at 0.10.0

### DIFF
--- a/pkgs/by-name/li/linearmouse/package.nix
+++ b/pkgs/by-name/li/linearmouse/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "linearmouse";
+  version = "0.10.0";
+
+  src = fetchurl {
+    url = "https://github.com/linearmouse/linearmouse/releases/download/v${version}/LinearMouse.dmg";
+    hash = "sha256-Ic0dEQEN1e78H/M2jOg2bEEU+ZtZ6nN6ykMJ+db7afE=";
+  };
+
+  sourceRoot = ".";
+
+  unpackCmd = ''
+    mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
+
+    function finish {
+      /usr/bin/hdiutil detach $mnt -force
+      rm -rf $mnt
+    }
+    trap finish EXIT
+
+    /usr/bin/hdiutil attach -nobrowse -mountpoint $mnt $src
+    cp -a $mnt/LinearMouse.app $PWD/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/Applications"
+    mv LinearMouse.app $out/Applications/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The mouse and trackpad utility for Mac";
+    homepage = "https://github.com/linearmouse/linearmouse";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ ilaumjd ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
## Description of changes

Added LinearMouse mac app: https://github.com/linearmouse/linearmouse

Question to address: is it okay to use system binary like `hdiutil`?
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
