### PR TITLE
zet: fix build

### DIFF
--- a/pkgs/tools/text/zet/default.nix
+++ b/pkgs/tools/text/zet/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, fetchpatch2
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -13,6 +14,15 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-IjM+jSb+kdML0zZGuz9+9wrFzQCujn/bg9/vaTzMtUs=";
   };
+
+  patches = [
+    # fix unused_qualifications lint with rust 1.78+
+    # https://github.com/yarrow/zet/commit/b6a0c67f6ac76fb7bf8234951678b77fbac12d76
+    (fetchpatch2 {
+      url = "https://github.com/yarrow/zet/commit/b6a0c67f6ac76fb7bf8234951678b77fbac12d76.patch?full_index=1";
+      hash = "sha256-HojhKM7UJh5xpD9a18Wh0hiiUDOE+jK0BKGYozYjMBc=";
+    })
+  ];
 
   cargoHash = "sha256-kHIOsSR7ZxBzp4dtm2hbi8ddtlQ86x5EASk5HFmnhFo=";
 


### PR DESCRIPTION
## Description of changes

- add patch from upstream commit, fixing deny unused_qualifications lint that appeared in rust 1.78+

Upstream commit:
https://github.com/yarrow/zet/commit/b6a0c67f6ac76fb7bf8234951678b77fbac12d76

Fixes build of `zet`:
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.zet.x86_64-linux
https://hydra.nixos.org/build/269641275

Error log:
```text
error: unnecessary qualification
   --> src/help.rs:112:71
    |
112 |             self.entries.iter().map(|e| e.item.indented_by()).fold(0, std::cmp::Ord::max);
    |                                                                       ^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:68:5
    |
68  |     unused_qualifications,
    |     ^^^^^^^^^^^^^^^^^^^^^
help: remove the unnecessary path segments
    |
112 -             self.entries.iter().map(|e| e.item.indented_by()).fold(0, std::cmp::Ord::max);
112 +             self.entries.iter().map(|e| e.item.indented_by()).fold(0, Ord::max);
    |

error: could not compile `zet` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
