### PR TITLE
python312Packages.pgvector: 0.2.4 -> 0.3.2; postgresql16Packages.pgvector: 0.6.2 -> 0.7.4

### DIFF
--- a/pkgs/development/python-modules/pgvector/default.nix
+++ b/pkgs/development/python-modules/pgvector/default.nix
@@ -13,13 +13,14 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
+  scipy,
   sqlalchemy,
   sqlmodel,
 }:
 
 buildPythonPackage rec {
   pname = "pgvector";
-  version = "0.2.4";
+  version = "0.3.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -28,7 +29,7 @@ buildPythonPackage rec {
     owner = "pgvector";
     repo = "pgvector-python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-XKoaEwLW59pV4Dwis7p2L65XoO2zUEa1kXxz6Lgs2d8=";
+    hash = "sha256-8F2tNUtRgeIK/1utkbL+xF/bTlJxvhn+RxerpGMUP/k=";
   };
 
   propagatedBuildInputs = [ numpy ];
@@ -43,6 +44,7 @@ buildPythonPackage rec {
     psycopg2
     pytest-asyncio
     pytestCheckHook
+    scipy
     sqlalchemy
     sqlmodel
   ];

--- a/pkgs/development/python-modules/pgvector/default.nix
+++ b/pkgs/development/python-modules/pgvector/default.nix
@@ -14,6 +14,7 @@
   pytestCheckHook,
   pythonOlder,
   scipy,
+  setuptools,
   sqlalchemy,
   sqlmodel,
 }:
@@ -21,7 +22,7 @@
 buildPythonPackage rec {
   pname = "pgvector";
   version = "0.3.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -32,7 +33,9 @@ buildPythonPackage rec {
     hash = "sha256-8F2tNUtRgeIK/1utkbL+xF/bTlJxvhn+RxerpGMUP/k=";
   };
 
-  propagatedBuildInputs = [ numpy ];
+  build-system = [ setuptools ];
+
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [
     asyncpg

--- a/pkgs/servers/sql/postgresql/ext/pgvector.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvector.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pgvector";
-  version = "0.6.2";
+  version = "0.7.4";
 
   src = fetchFromGitHub {
     owner = "pgvector";
     repo = "pgvector";
     rev = "v${version}";
-    hash = "sha256-r+TpFJg6WrMn0L2B7RpmSRvw3XxpHzMRtpFWDCzLvgs=";
+    hash = "sha256-qwPaguQUdDHV8q6GDneLq5MuhVroPizpbqt7f08gKJI=";
   };
 
   buildInputs = [ postgresql ];

--- a/pkgs/servers/sql/postgresql/ext/pgvector.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvector.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/pgvector/pgvector/raw/v${version}/CHANGELOG.md";
     license = licenses.postgresql;
     platforms = postgresql.meta.platforms;
-    maintainers = [ ];
+    maintainers = with maintainers; [ natsukium ];
   };
 }


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/pgvector/pgvector-python/compare/refs/tags/v0.2.4...v0.3.2
Changelog: https://github.com/pgvector/pgvector-python/blob/refs/tags/v0.3.2/CHANGELOG.md

Diff: https://github.com/pgvector/pgvector/compare/v0.6.2...v0.7.4
Changelog: https://github.com/pgvector/pgvector/raw/v0.7.4/CHANGELOG.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
