### PR TITLE
llvmPackages_19: fix building libclc, add aliases

### DIFF
--- a/pkgs/development/compilers/llvm/19/libclc/use-default-paths.patch
+++ b/pkgs/development/compilers/llvm/19/libclc/use-default-paths.patch
@@ -1,0 +1,31 @@
+From e8b910246d0c7c3d9fff994f71c6f8a48ec09a50 Mon Sep 17 00:00:00 2001
+From: Tristan Ross <tristan.ross@midstall.com>
+Date: Sat, 24 Aug 2024 19:56:24 -0700
+Subject: [PATCH] [libclc] use default paths with find_program when possible
+
+---
+ libclc/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 02bb859ae8590b..6bcd8ae52a5794 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -55,7 +55,7 @@ if( LIBCLC_STANDALONE_BUILD OR CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DI
+   # Import required tools
+   if( NOT EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
+     foreach( tool IN ITEMS clang llvm-as llvm-link opt )
+-      find_program( LLVM_TOOL_${tool} ${tool} PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )
++      find_program( LLVM_TOOL_${tool} ${tool} PATHS ${LLVM_TOOLS_BINARY_DIR} )
+       set( ${tool}_exe ${LLVM_TOOL_${tool}} )
+       set( ${tool}_target )
+     endforeach()
+@@ -104,7 +104,7 @@ foreach( tool IN ITEMS clang opt llvm-as llvm-link )
+ endforeach()
+ 
+ # llvm-spirv is an optional dependency, used to build spirv-* targets.
+-find_program( LLVM_SPIRV llvm-spirv PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )
++find_program( LLVM_SPIRV llvm-spirv PATHS ${LLVM_TOOLS_BINARY_DIR} )
+ 
+ if( LLVM_SPIRV )
+   add_executable( libclc::llvm-spirv IMPORTED GLOBAL )

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -279,6 +279,12 @@ let
                   path = ../14;
                 }
               ];
+              "libclc/use-default-paths.patch" = [
+                {
+                  after = "19";
+                  path = ../19;
+                }
+              ];
             };
 
             constraints = patches."${p}" or null;

--- a/pkgs/development/compilers/llvm/common/libclc.nix
+++ b/pkgs/development/compilers/llvm/common/libclc.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv, version, runCommand, monorepoSrc, llvm, buildPackages, buildLlvmTools, ninja, cmake, python3 }:
-
+{ lib, stdenv, version, runCommand, monorepoSrc, llvm, buildPackages, buildLlvmTools, ninja, cmake, python3, release_version, getVersionFile }:
+let
+  spirv-llvm-translator = buildPackages.spirv-llvm-translator.override { inherit (buildLlvmTools) llvm; };
+in
 stdenv.mkDerivation rec {
   pname = "libclc";
   inherit version;
@@ -16,10 +18,14 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./libclc/libclc-gnu-install-dirs.patch
-  ];
+  ] # LLVM 19 changes how host tools are looked up.
+    # Need to remove NO_DEFAULT_PATH and the PATHS arguments for find_program
+    # so CMake can actually find the tools in nativeBuildInputs.
+    # https://github.com/llvm/llvm-project/pull/105969
+    ++ lib.optional (lib.versionAtLeast release_version "19") (getVersionFile "libclc/use-default-paths.patch");
 
   # cmake expects all required binaries to be in the same place, so it will not be able to find clang without the patch
-  postPatch = ''
+  postPatch = lib.optionalString (lib.versionOlder release_version "19") ''
     substituteInPlace CMakeLists.txt \
       --replace 'find_program( LLVM_CLANG clang PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
                 'find_program( LLVM_CLANG clang PATHS "${buildLlvmTools.clang.cc}/bin" NO_DEFAULT_PATH )' \
@@ -30,13 +36,17 @@ stdenv.mkDerivation rec {
       --replace 'find_program( LLVM_OPT opt PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
                 'find_program( LLVM_OPT opt PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
       --replace 'find_program( LLVM_SPIRV llvm-spirv PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                'find_program( LLVM_SPIRV llvm-spirv PATHS "${buildPackages.spirv-llvm-translator.override { inherit (buildLlvmTools) llvm; }}/bin" NO_DEFAULT_PATH )'
+                'find_program( LLVM_SPIRV llvm-spirv PATHS "${spirv-llvm-translator}/bin" NO_DEFAULT_PATH )'
   '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     substituteInPlace CMakeLists.txt \
       --replace 'COMMAND prepare_builtins' 'COMMAND ${buildLlvmTools.libclc.dev}/bin/prepare_builtins'
   '';
 
-  nativeBuildInputs = [ cmake ninja python3 ];
+  nativeBuildInputs = [ cmake ninja python3 ] ++ lib.optional (lib.versionAtLeast release_version "19") [
+    buildLlvmTools.clang.cc
+    buildLlvmTools.llvm
+    spirv-llvm-translator
+  ];
   buildInputs = [ llvm ];
   strictDeps = true;
 

--- a/pkgs/development/compilers/llvm/common/libclc.nix
+++ b/pkgs/development/compilers/llvm/common/libclc.nix
@@ -1,12 +1,28 @@
-{ lib, stdenv, version, runCommand, monorepoSrc, llvm, buildPackages, buildLlvmTools, ninja, cmake, python3, release_version, getVersionFile }:
+{
+  lib,
+  stdenv,
+  version,
+  runCommand,
+  monorepoSrc,
+  llvm,
+  buildPackages,
+  buildLlvmTools,
+  ninja,
+  cmake,
+  python3,
+  release_version,
+  getVersionFile,
+}:
 let
-  spirv-llvm-translator = buildPackages.spirv-llvm-translator.override { inherit (buildLlvmTools) llvm; };
+  spirv-llvm-translator = buildPackages.spirv-llvm-translator.override {
+    inherit (buildLlvmTools) llvm;
+  };
 in
 stdenv.mkDerivation rec {
   pname = "libclc";
   inherit version;
 
-  src = runCommand "${pname}-src-${version}" {} ''
+  src = runCommand "${pname}-src-${version}" { } ''
     mkdir -p "$out"
     cp -r ${monorepoSrc}/cmake "$out"
     cp -r ${monorepoSrc}/${pname} "$out"
@@ -14,39 +30,52 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${src.name}/${pname}";
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
-  patches = [
-    ./libclc/libclc-gnu-install-dirs.patch
-  ] # LLVM 19 changes how host tools are looked up.
+  patches =
+    [ ./libclc/libclc-gnu-install-dirs.patch ]
+    # LLVM 19 changes how host tools are looked up.
     # Need to remove NO_DEFAULT_PATH and the PATHS arguments for find_program
     # so CMake can actually find the tools in nativeBuildInputs.
     # https://github.com/llvm/llvm-project/pull/105969
-    ++ lib.optional (lib.versionAtLeast release_version "19") (getVersionFile "libclc/use-default-paths.patch");
+    ++ lib.optional (lib.versionAtLeast release_version "19") (
+      getVersionFile "libclc/use-default-paths.patch"
+    );
 
   # cmake expects all required binaries to be in the same place, so it will not be able to find clang without the patch
-  postPatch = lib.optionalString (lib.versionOlder release_version "19") ''
-    substituteInPlace CMakeLists.txt \
-      --replace 'find_program( LLVM_CLANG clang PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                'find_program( LLVM_CLANG clang PATHS "${buildLlvmTools.clang.cc}/bin" NO_DEFAULT_PATH )' \
-      --replace 'find_program( LLVM_AS llvm-as PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                'find_program( LLVM_AS llvm-as PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
-      --replace 'find_program( LLVM_LINK llvm-link PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                'find_program( LLVM_LINK llvm-link PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
-      --replace 'find_program( LLVM_OPT opt PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                'find_program( LLVM_OPT opt PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
-      --replace 'find_program( LLVM_SPIRV llvm-spirv PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                'find_program( LLVM_SPIRV llvm-spirv PATHS "${spirv-llvm-translator}/bin" NO_DEFAULT_PATH )'
-  '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
-    substituteInPlace CMakeLists.txt \
-      --replace 'COMMAND prepare_builtins' 'COMMAND ${buildLlvmTools.libclc.dev}/bin/prepare_builtins'
-  '';
+  postPatch =
+    lib.optionalString (lib.versionOlder release_version "19") ''
+      substituteInPlace CMakeLists.txt \
+        --replace 'find_program( LLVM_CLANG clang PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
+                  'find_program( LLVM_CLANG clang PATHS "${buildLlvmTools.clang.cc}/bin" NO_DEFAULT_PATH )' \
+        --replace 'find_program( LLVM_AS llvm-as PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
+                  'find_program( LLVM_AS llvm-as PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
+        --replace 'find_program( LLVM_LINK llvm-link PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
+                  'find_program( LLVM_LINK llvm-link PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
+        --replace 'find_program( LLVM_OPT opt PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
+                  'find_program( LLVM_OPT opt PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
+        --replace 'find_program( LLVM_SPIRV llvm-spirv PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
+                  'find_program( LLVM_SPIRV llvm-spirv PATHS "${spirv-llvm-translator}/bin" NO_DEFAULT_PATH )'
+    ''
+    + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+      substituteInPlace CMakeLists.txt \
+        --replace 'COMMAND prepare_builtins' 'COMMAND ${buildLlvmTools.libclc.dev}/bin/prepare_builtins'
+    '';
 
-  nativeBuildInputs = [ cmake ninja python3 ] ++ lib.optional (lib.versionAtLeast release_version "19") [
-    buildLlvmTools.clang.cc
-    buildLlvmTools.llvm
-    spirv-llvm-translator
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      ninja
+      python3
+    ]
+    ++ lib.optional (lib.versionAtLeast release_version "19") [
+      buildLlvmTools.clang.cc
+      buildLlvmTools.llvm
+      spirv-llvm-translator
+    ];
   buildInputs = [ llvm ];
   strictDeps = true;
 

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -15,7 +15,11 @@ let
 
   # ROCm, if actively updated will always be at the latest version
   branch =
-    if llvmMajor == "18" then rec {
+    if llvmMajor == "19" then rec {
+      version = "19.1.0";
+      rev = "dad1f0eaab8047a4f73c50ed5f3d1694b78aae97";
+      hash = "sha256-mUvDF5y+cBnqUaHjyiiE8cJGH5MfQMqGFy6bYv9vCVY=";
+    } else if llvmMajor == "18" then rec {
       version = "18.1.0";
       rev = "v${version}";
       hash = "sha256-64guZiuO7VpaX01wNIjV7cnjEAe6ineMdY44S6sA33k=";
@@ -96,7 +100,8 @@ stdenv.mkDerivation {
     "-DLLVM_SPIRV_BUILD_EXTERNAL=YES"
     # RPATH of binary /nix/store/.../bin/llvm-spirv contains a forbidden reference to /build/
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
-  ] ++ lib.optional (llvmMajor != "11") "-DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${spirv-headers.src}";
+  ] ++ lib.optional (llvmMajor != "11") "-DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${spirv-headers.src}"
+    ++ lib.optional (llvmMajor == "19") "-DBASE_LLVM_VERSION=${lib.versions.majorMinor llvm.version}.0";
 
   # FIXME: CMake tries to run "/llvm-lit" which of course doesn't exist
   doCheck = false;

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv
-, fetchFromGitHub
-, fetchpatch
-, cmake
-, pkg-config
-, lit
-, llvm
-, spirv-headers
-, spirv-tools
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  lit,
+  llvm,
+  spirv-headers,
+  spirv-tools,
 }:
 
 let
@@ -15,35 +17,50 @@ let
 
   # ROCm, if actively updated will always be at the latest version
   branch =
-    if llvmMajor == "19" then rec {
-      version = "19.1.0";
-      rev = "dad1f0eaab8047a4f73c50ed5f3d1694b78aae97";
-      hash = "sha256-mUvDF5y+cBnqUaHjyiiE8cJGH5MfQMqGFy6bYv9vCVY=";
-    } else if llvmMajor == "18" then rec {
-      version = "18.1.0";
-      rev = "v${version}";
-      hash = "sha256-64guZiuO7VpaX01wNIjV7cnjEAe6ineMdY44S6sA33k=";
-    } else if llvmMajor == "17" || isROCm then rec {
-      version = "17.0.0";
-      rev = "v${version}";
-      hash = "sha256-Rzm5Py9IPFtS9G7kME+uSwZ/0gPGW6MlL35ZWk4LfHM=";
-    } else if llvmMajor == "16" then rec {
-      version = "16.0.0";
-      rev = "v${version}";
-      hash = "sha256-EUabcYqSjXshbPmcs1DRLvCSL1nd9rEdpqELBrItCW8=";
-    } else if llvmMajor == "15" then rec {
-      version = "15.0.0";
-      rev = "v${version}";
-      hash = "sha256-OsDohXRxovtEXaWiRGp8gJ0dXmoALyO+ZimeSO8aPVI=";
-    } else if llvmMajor == "14" then {
-      version = "14.0.0+unstable-2024-07-15";
-      rev = "2823e7052b7999c10fff63bc8089e5aa205716f4";
-      hash = "sha256-8/4B74hYge6WiH7PzRGEgE3W7f9IkQ4VMmfkWKYA/l4=";
-    } else if llvmMajor == "11" then {
-      version = "11.0.0+unstable-2022-05-04";
-      rev = "4ef524240833abfeee1c5b9fff6b1bd53f4806b3"; # 267 commits ahead of v11.0.0
-      hash = "sha256-NoIoa20+2sH41rEnr8lsMhtfesrtdPINiXtUnxYVm8s=";
-    } else throw "Incompatible LLVM version.";
+    if llvmMajor == "19" then
+      rec {
+        version = "19.1.0";
+        rev = "dad1f0eaab8047a4f73c50ed5f3d1694b78aae97";
+        hash = "sha256-mUvDF5y+cBnqUaHjyiiE8cJGH5MfQMqGFy6bYv9vCVY=";
+      }
+    else if llvmMajor == "18" then
+      rec {
+        version = "18.1.0";
+        rev = "v${version}";
+        hash = "sha256-64guZiuO7VpaX01wNIjV7cnjEAe6ineMdY44S6sA33k=";
+      }
+    else if llvmMajor == "17" || isROCm then
+      rec {
+        version = "17.0.0";
+        rev = "v${version}";
+        hash = "sha256-Rzm5Py9IPFtS9G7kME+uSwZ/0gPGW6MlL35ZWk4LfHM=";
+      }
+    else if llvmMajor == "16" then
+      rec {
+        version = "16.0.0";
+        rev = "v${version}";
+        hash = "sha256-EUabcYqSjXshbPmcs1DRLvCSL1nd9rEdpqELBrItCW8=";
+      }
+    else if llvmMajor == "15" then
+      rec {
+        version = "15.0.0";
+        rev = "v${version}";
+        hash = "sha256-OsDohXRxovtEXaWiRGp8gJ0dXmoALyO+ZimeSO8aPVI=";
+      }
+    else if llvmMajor == "14" then
+      {
+        version = "14.0.0+unstable-2024-07-15";
+        rev = "2823e7052b7999c10fff63bc8089e5aa205716f4";
+        hash = "sha256-8/4B74hYge6WiH7PzRGEgE3W7f9IkQ4VMmfkWKYA/l4=";
+      }
+    else if llvmMajor == "11" then
+      {
+        version = "11.0.0+unstable-2022-05-04";
+        rev = "4ef524240833abfeee1c5b9fff6b1bd53f4806b3"; # 267 commits ahead of v11.0.0
+        hash = "sha256-NoIoa20+2sH41rEnr8lsMhtfesrtdPINiXtUnxYVm8s=";
+      }
+    else
+      throw "Incompatible LLVM version.";
 in
 stdenv.mkDerivation {
   pname = "SPIRV-LLVM-Translator";
@@ -55,72 +72,87 @@ stdenv.mkDerivation {
     inherit (branch) rev hash;
   };
 
-  patches = lib.optionals (llvmMajor == "18") [
-    # Fixes build after SPV_INTEL_maximum_registers breaking change
-    # TODO: remove on next spirv-headers release
-    (fetchpatch {
-      url = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/d970c9126c033ebcbb7187bc705eae2e54726b74.patch";
-      revert = true;
-      hash = "sha256-71sJuGqVjTcB549eIiCO0LoqAgxkdEHCoxh8Pd/Qzz8=";
-    })
-  ] ++ lib.optionals (lib.versionAtLeast llvmMajor "15" && lib.versionOlder llvmMajor "18") [
-    # Fixes build after spirv-headers breaking change
-    (fetchpatch {
-      url = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/0166a0fb86dc6c0e8903436bbc3a89bc3273ebc0.patch";
-      excludes = ["spirv-headers-tag.conf"];
-      hash = "sha256-17JJG8eCFVphElY5fVT/79hj0bByWxo8mVp1ZNjQk/M=";
-    })
-  ] ++ lib.optionals (llvmMajor == "16") [
-    # Fixes builds that link against external LLVM dynamic library
-    (fetchpatch {
-      url = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/f3b9b604d7eda18d0d1029d94a6eebd33aa3a3fe.patch";
-      hash = "sha256-opDjyZcy7O4wcSfm/A51NCIiDyIvbcmbv9ns1njdJbc=";
-    })
-  ] ++ lib.optionals (llvmMajor == "14") [
-    (fetchpatch {
-      # tries to install llvm-spirv into llvm nix store path
-      url = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/cce9a2f130070d799000cac42fe24789d2b777ab.patch";
-      revert = true;
-      hash = "sha256-GbFacttZRDCgA0jkUoFA4/B3EDn3etweKvM09OwICJ8=";
-    })
-  ];
+  patches =
+    lib.optionals (llvmMajor == "18") [
+      # Fixes build after SPV_INTEL_maximum_registers breaking change
+      # TODO: remove on next spirv-headers release
+      (fetchpatch {
+        url = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/d970c9126c033ebcbb7187bc705eae2e54726b74.patch";
+        revert = true;
+        hash = "sha256-71sJuGqVjTcB549eIiCO0LoqAgxkdEHCoxh8Pd/Qzz8=";
+      })
+    ]
+    ++ lib.optionals (lib.versionAtLeast llvmMajor "15" && lib.versionOlder llvmMajor "18") [
+      # Fixes build after spirv-headers breaking change
+      (fetchpatch {
+        url = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/0166a0fb86dc6c0e8903436bbc3a89bc3273ebc0.patch";
+        excludes = [ "spirv-headers-tag.conf" ];
+        hash = "sha256-17JJG8eCFVphElY5fVT/79hj0bByWxo8mVp1ZNjQk/M=";
+      })
+    ]
+    ++ lib.optionals (llvmMajor == "16") [
+      # Fixes builds that link against external LLVM dynamic library
+      (fetchpatch {
+        url = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/f3b9b604d7eda18d0d1029d94a6eebd33aa3a3fe.patch";
+        hash = "sha256-opDjyZcy7O4wcSfm/A51NCIiDyIvbcmbv9ns1njdJbc=";
+      })
+    ]
+    ++ lib.optionals (llvmMajor == "14") [
+      (fetchpatch {
+        # tries to install llvm-spirv into llvm nix store path
+        url = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/cce9a2f130070d799000cac42fe24789d2b777ab.patch";
+        revert = true;
+        hash = "sha256-GbFacttZRDCgA0jkUoFA4/B3EDn3etweKvM09OwICJ8=";
+      })
+    ];
 
-  nativeBuildInputs = [ pkg-config cmake ]
-    ++ (if isROCm then [ llvm ] else [ llvm.dev ]);
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ] ++ (if isROCm then [ llvm ] else [ llvm.dev ]);
 
-  buildInputs = [ spirv-headers spirv-tools ]
-    ++ lib.optionals (!isROCm) [ llvm ];
+  buildInputs = [
+    spirv-headers
+    spirv-tools
+  ] ++ lib.optionals (!isROCm) [ llvm ];
 
   nativeCheckInputs = [ lit ];
 
-  cmakeFlags = [
-    "-DLLVM_INCLUDE_TESTS=ON"
-    "-DLLVM_DIR=${(if isROCm then llvm else llvm.dev)}"
-    "-DBUILD_SHARED_LIBS=YES"
-    "-DLLVM_SPIRV_BUILD_EXTERNAL=YES"
-    # RPATH of binary /nix/store/.../bin/llvm-spirv contains a forbidden reference to /build/
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
-  ] ++ lib.optional (llvmMajor != "11") "-DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${spirv-headers.src}"
+  cmakeFlags =
+    [
+      "-DLLVM_INCLUDE_TESTS=ON"
+      "-DLLVM_DIR=${(if isROCm then llvm else llvm.dev)}"
+      "-DBUILD_SHARED_LIBS=YES"
+      "-DLLVM_SPIRV_BUILD_EXTERNAL=YES"
+      # RPATH of binary /nix/store/.../bin/llvm-spirv contains a forbidden reference to /build/
+      "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    ]
+    ++ lib.optional (llvmMajor != "11") "-DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${spirv-headers.src}"
     ++ lib.optional (llvmMajor == "19") "-DBASE_LLVM_VERSION=${lib.versions.majorMinor llvm.version}.0";
 
   # FIXME: CMake tries to run "/llvm-lit" which of course doesn't exist
   doCheck = false;
 
-  makeFlags = [ "all" "llvm-spirv" ];
+  makeFlags = [
+    "all"
+    "llvm-spirv"
+  ];
 
-  postInstall = ''
-    install -D tools/llvm-spirv/llvm-spirv $out/bin/llvm-spirv
-  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    install_name_tool $out/bin/llvm-spirv \
-      -change @rpath/libLLVMSPIRVLib.dylib $out/lib/libLLVMSPIRVLib.dylib
-  '';
+  postInstall =
+    ''
+      install -D tools/llvm-spirv/llvm-spirv $out/bin/llvm-spirv
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install_name_tool $out/bin/llvm-spirv \
+        -change @rpath/libLLVMSPIRVLib.dylib $out/lib/libLLVMSPIRVLib.dylib
+    '';
 
   meta = with lib; {
-    homepage    = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator";
+    homepage = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator";
     description = "Tool and a library for bi-directional translation between SPIR-V and LLVM IR";
     mainProgram = "llvm-spirv";
-    license     = licenses.ncsa;
-    platforms   = platforms.unix;
+    license = licenses.ncsa;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ gloaming ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -297,6 +297,7 @@ mapAliases {
   clang16Stdenv = lowPrio llvmPackages_16.stdenv;
   clang17Stdenv = lowPrio llvmPackages_17.stdenv;
   clang18Stdenv = lowPrio llvmPackages_18.stdenv;
+  clang19Stdenv = lowPrio llvmPackages_19.stdenv;
 
   clang-tools_6 = throw "clang-tools_6 has been removed from nixpkgs"; # Added 2024-01-08
   clang-tools_7 = throw "clang-tools_7 has been removed from nixpkgs"; # Added 2023-11-19
@@ -318,6 +319,7 @@ mapAliases {
   clang-tools_16 = llvmPackages_16.clang-tools; # Added 2024-04-22
   clang-tools_17 = llvmPackages_17.clang-tools; # Added 2024-04-22
   clang-tools_18 = llvmPackages_18.clang-tools; # Added 2024-04-22
+  clang-tools_19 = llvmPackages_19.clang-tools; # Added 2024-08-21
 
   cq-editor = throw "cq-editor has been removed, as it use a dependency that was disabled since python 3.8 and was last updated in 2021"; # Added 2024-05-13
 


### PR DESCRIPTION
## Description of changes

Makes `libclc` eval & build, add some aliases for LLVM 19. `openmp` & `lldb-manpages` are fixed in the rc3 bump, this PR finalizes getting `llvmPackages_19` more stable ahead of the LLVM 19 full release.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
