### PR TITLE
stdenv/freebsd: build bootstrap files without recursive-nix feature

### DIFF
--- a/pkgs/stdenv/freebsd/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/freebsd/make-bootstrap-tools.nix
@@ -15,7 +15,7 @@
         rm -f $base/nix-support/propagated-build-inputs
         for f in $requisites; do
           cd $f
-          rsync --chmod="+w" -av . $base
+          rsync --safe-links --chmod="+w" -av . $base
         done
         cd $base
 

--- a/pkgs/stdenv/freebsd/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/freebsd/make-bootstrap-tools.nix
@@ -1,18 +1,15 @@
 { pkgs ? import ../../.. {} }:
   let
-    inherit (pkgs) runCommand lib;
+    inherit (pkgs) runCommand closureInfo;
     # splicing doesn't seem to work right here
-    inherit (pkgs.buildPackages) nix rsync;
+    inherit (pkgs.buildPackages) dumpnar rsync;
     pack-all =
       packCmd: name: pkgs: fixups:
       (runCommand name {
-        requiredSystemFeatures = [ "recursive-nix" ];
-        nativeBuildInputs = [ nix rsync ];
+        nativeBuildInputs = [ rsync dumpnar ];
       } ''
         base=$PWD
-        requisites="$(nix-store --query --requisites ${lib.concatStringsSep " " pkgs} | tac)"
-
-        rm -f $base/nix-support/propagated-build-inputs
+        requisites="$(cat ${closureInfo { rootPaths = pkgs; }}/store-paths)"
         for f in $requisites; do
           cd $f
           rsync --safe-links --chmod="+w" -av . $base
@@ -28,14 +25,14 @@
             cat $f >>"$base/nix-support/$f"
           done
         done
+        rm -f $base/nix-support/propagated-build-inputs
         cd $base
 
         ${fixups}
 
-        rm .nix-socket
         ${packCmd}
       '');
-    nar-all = pack-all "nix-store --dump . | xz -9 -e -T $NIX_BUILD_CORES >$out";
+    nar-all = pack-all "dumpnar . | xz -9 -e -T $NIX_BUILD_CORES >$out";
     tar-all = pack-all "XZ_OPT=\"-9 -e -T $NIX_BUILD_CORES\" tar cJf $out --hard-dereference --sort=name --numeric-owner --owner=0 --group=0 --mtime=@1 .";
     coreutils-big = pkgs.coreutils.override { singleBinary = false; };
     mkdir = runCommand "mkdir" { coreutils = coreutils-big; } ''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Followup to #328582. Should be able to build bootstrap tools cross on hydra now. 

Bonus commit fixes a regression I encountered while building the FreeBSD native stdenv with these new tools. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
