### PR TITLE
[Backport release-24.05] kanidm: 1.2.3 -> 1.3.3

### DIFF
--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -6,6 +6,13 @@ import ./make-test-python.nix ({ pkgs, ... }:
     testCredentials = {
       password = "Password1_cZPEwpCWvrReripJmAZdmVIZd8HHoHcl";
     };
+
+    # copy certs to store to work around mount namespacing
+    certsPath = pkgs.runCommandNoCC "snakeoil-certs" { } ''
+      mkdir $out
+      cp ${certs."${serverDomain}".cert} $out/snakeoil.crt
+      cp ${certs."${serverDomain}".key} $out/snakeoil.key
+    '';
   in
   {
     name = "kanidm";
@@ -19,8 +26,8 @@ import ./make-test-python.nix ({ pkgs, ... }:
           domain = serverDomain;
           bindaddress = "[::]:443";
           ldapbindaddress = "[::1]:636";
-          tls_chain = certs."${serverDomain}".cert;
-          tls_key = certs."${serverDomain}".key;
+          tls_chain = "${certsPath}/snakeoil.crt";
+          tls_key = "${certsPath}/snakeoil.key";
         };
       };
 

--- a/pkgs/by-name/ka/kanidm/package.nix
+++ b/pkgs/by-name/ka/kanidm/package.nix
@@ -20,16 +20,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "kanidm";
-  version = "1.3.2";
+  version = "1.3.3";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-YFmWZlDcsSk+7EGkoK0SkAhNsrIQa55IRIVqisX3zqE=";
+    hash = "sha256-W5G7osV4du6w/BfyY9YrDzorcLNizRsoz70RMfO2AbY=";
   };
 
-  cargoHash = "sha256-8ZENe576gqm+FkQPCgz6mScqdacHilARFWmfe+kDL2A=";
+  cargoHash = "sha256-gJrzOK6vPPBgsQFkKrbMql00XSfKGjgpZhYJLTURxoI=";
 
   KANIDM_BUILD_PROFILE = "release_nixos_${arch}";
 
@@ -89,7 +89,7 @@ rustPlatform.buildRustPackage rec {
       inherit (nixosTests) kanidm;
     };
 
-    updateScript = nix-update-script { 
+    updateScript = nix-update-script {
       # avoid spurious releases and tags such as "debs"
       extraArgs = [
         "-vr"

--- a/pkgs/by-name/ka/kanidm/package.nix
+++ b/pkgs/by-name/ka/kanidm/package.nix
@@ -20,16 +20,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "kanidm";
-  version = "1.2.3";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-J02IbAY5lyoMaq6wJiHizqeFBd5hB6id2YMPxlPsASM=";
+    hash = "sha256-vjYbj8wIrnVCrokmXv6h4V/n02nKtUQ/mh1xosXj4IE=";
   };
 
-  cargoHash = "sha256-JuTKHXpEhWga2vAZhCpyPFy4w6+9UaasD70oBcrr0Rw=";
+  cargoHash = "sha256-ASDfIpwvgYR3vukhtpXJWles5ErytUpW2VjYIpidyWk=";
 
   KANIDM_BUILD_PROFILE = "release_nixos_${arch}";
 
@@ -41,13 +41,15 @@ rustPlatform.buildRustPackage rec {
         cpu_flags = if stdenv.isx86_64 then "x86_64_legacy" else "none";
         default_config_path = "/etc/kanidm/server.toml";
         default_unix_shell_path = "${lib.getBin bashInteractive}/bin/bash";
+        htmx_ui_pkg_path = "@htmx_ui_pkg_path@";
         web_ui_pkg_path = "@web_ui_pkg_path@";
       };
     in
     ''
       cp ${format profile} libs/profiles/${KANIDM_BUILD_PROFILE}.toml
       substituteInPlace libs/profiles/${KANIDM_BUILD_PROFILE}.toml \
-        --replace '@web_ui_pkg_path@' "${placeholder "out"}/ui"
+        --replace '@htmx_ui_pkg_path@' "${placeholder "out"}/ui/hpkg" \
+        --replace '@web_ui_pkg_path@' "${placeholder "out"}/ui/pkg"
     '';
 
   nativeBuildInputs = [
@@ -67,8 +69,9 @@ rustPlatform.buildRustPackage rec {
   postBuild = ''
     # We don't compile the wasm-part form source, as there isn't a rustc for
     # wasm32-unknown-unknown in nixpkgs yet.
-    mkdir $out
-    cp -r server/web_ui/pkg $out/ui
+    mkdir -p $out/ui
+    cp -r server/web_ui/pkg $out/ui/pkg
+    cp -r server/core/static $out/ui/hpkg
   '';
 
   preFixup = ''

--- a/pkgs/by-name/ka/kanidm/package.nix
+++ b/pkgs/by-name/ka/kanidm/package.nix
@@ -89,7 +89,13 @@ rustPlatform.buildRustPackage rec {
       inherit (nixosTests) kanidm;
     };
 
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script { 
+      # avoid spurious releases and tags such as "debs"
+      extraArgs = [
+        "-vr"
+        "v(.*)"
+      ];
+    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/ka/kanidm/package.nix
+++ b/pkgs/by-name/ka/kanidm/package.nix
@@ -20,16 +20,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "kanidm";
-  version = "1.3.1";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-vjYbj8wIrnVCrokmXv6h4V/n02nKtUQ/mh1xosXj4IE=";
+    hash = "sha256-YFmWZlDcsSk+7EGkoK0SkAhNsrIQa55IRIVqisX3zqE=";
   };
 
-  cargoHash = "sha256-ASDfIpwvgYR3vukhtpXJWles5ErytUpW2VjYIpidyWk=";
+  cargoHash = "sha256-8ZENe576gqm+FkQPCgz6mScqdacHilARFWmfe+kDL2A=";
 
   KANIDM_BUILD_PROFILE = "release_nixos_${arch}";
 

--- a/pkgs/by-name/ka/kanidm/package.nix
+++ b/pkgs/by-name/ka/kanidm/package.nix
@@ -50,6 +50,8 @@ rustPlatform.buildRustPackage rec {
       substituteInPlace libs/profiles/${KANIDM_BUILD_PROFILE}.toml \
         --replace '@htmx_ui_pkg_path@' "${placeholder "out"}/ui/hpkg" \
         --replace '@web_ui_pkg_path@' "${placeholder "out"}/ui/pkg"
+
+        substituteInPlace Cargo.toml --replace-fail 'rust-version = "1.79"' 'rust-version = "1.77"'
     '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
We need to upgrade stable to 1.3, as skip upgrades are not permitted. Since upstream currently releases quarterly, we will need to backport releases moving forward.

x86 tests
/nix/store/2nhjvgdccb83y5l788pmnc9w954kfbyv-vm-test-run-kanidm

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
