### PR TITLE
nixos/nix: move nix.nixPath into nix.settings.nix-path

### DIFF
--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -9,7 +9,6 @@
 { config, lib, ... }:
 let
   inherit (lib)
-    mkDefault
     mkIf
     mkOption
     stringAfter
@@ -39,7 +38,7 @@ in
         };
       };
 
-      nixPath = mkOption {
+      settings.nix-path = mkOption {
         type = types.listOf types.str;
         default =
           if cfg.channel.enable
@@ -76,8 +75,11 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  imports = [
+    (lib.mkRenamedOptionModule ["nix" "nixPath"] ["nix" "settings" "nix-path"])
+  ];
 
+  config = mkIf cfg.enable {
     environment.extraInit =
       mkIf cfg.channel.enable ''
         if [ -e "$HOME/.nix-defexpr/channels" ]; then
@@ -92,7 +94,7 @@ in
     # NIX_PATH has a non-empty default according to Nix docs, so we don't unset
     # it when empty.
     environment.sessionVariables = {
-      NIX_PATH = cfg.nixPath;
+      NIX_PATH = cfg.settings.nix-path;
     };
 
     systemd.tmpfiles.rules = lib.mkIf cfg.channel.enable [

--- a/nixos/modules/misc/nixpkgs-flake.nix
+++ b/nixos/modules/misc/nixpkgs-flake.nix
@@ -102,7 +102,7 @@ in
         # because we would need some kind of evil shim taking the *calling* flake's self path,
         # perhaps, to ever make that work (in order to know where the Nix expr for the system came
         # from and how to call it).
-        nix.nixPath = lib.mkDefault (
+        nix.settings.nix-path = lib.mkDefault (
           [ "nixpkgs=flake:nixpkgs" ]
           ++ lib.optional config.nix.channel.enable "/nix/var/nix/profiles/per-user/root/channels"
         );


### PR DESCRIPTION
This removes some confusion when setting nix.settings.nix-path to a custom value, disabling channels and ending up with an empty NIX_PATH. This is important since nix 2.24 fixed NIX_PATH not overwriting the nix-path setting.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
