### PR TITLE
ci: Update pinned Nixpkgs

### DIFF
--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "521d48afa9ae596930a95325529df27fa7135ff5",
-  "sha256": "0a1pa5azw990narsfipdli1wng4nc3vhvrp00hb8v1qfchcq7dc9"
+  "rev": "4de4818c1ffa76d57787af936e8a23648bda6be4",
+  "sha256": "0l3b9jr5ydzqgvd10j12imc9jqb6jv5v2bdi1gyy5cwkwplfay67"
 }


### PR DESCRIPTION
## Description of changes

From the nixpkgs-unstable channel: https://hydra.nixos.org/eval/1808410#tabs-inputs

Makes the new nixfmt version be used by CI: https://github.com/NixOS/nixpkgs/pull/336322

Ping @NixOS/nix-formatting 

## Things done
- [x] Tested CI (the CI result for this PR indicates it working)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
