### PR TITLE
[24.05 backport] nodejs changes

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -68,10 +68,10 @@ let
       # Note: do not set TERM=dumb environment variable globally, it is used in
       # test-ci-js test suite to skip tests that otherwise run fine.
       NINJA = "TERM=dumb ninja";
-    } // lib.optionalAttrs (stdenv.isDarwin && stdenv.isx86_64) {
+    } // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) {
       # Make sure libc++ uses `posix_memalign` instead of `aligned_alloc` on x86_64-darwin.
       # Otherwise, nodejs would require the 11.0 SDK and macOS 10.15+.
-      NIX_CFLAGS_COMPILE = "-D__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__=101300";
+      NIX_CFLAGS_COMPILE = "-D__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__=101300 -Wno-macro-redefined";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc openssl libuv zlib icu ];
@@ -192,7 +192,7 @@ let
         "test-tls-cli-max-version-1.3"
         "test-tls-client-auth"
         "test-tls-sni-option"
-      ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
         # Disable tests that don’t work under macOS sandbox.
         "test-macos-app-sandbox"
         "test-os"
@@ -217,6 +217,11 @@ let
         "test-runner-run"
         "test-runner-watch-mode"
         "test-watch-mode-files_watcher"
+      ] ++ lib.optionals (stdenv.buildPlatform.isDarwin && stdenv.buildPlatform.isx86_64) [
+        # These tests fail on x86_64-darwin (even without sandbox).
+        # TODO: revisit at a later date.
+        "test-fs-readv"
+        "test-fs-readv-sync"
       ])}"
     ];
 

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -192,11 +192,6 @@ let
         "test-tls-cli-max-version-1.3"
         "test-tls-client-auth"
         "test-tls-sni-option"
-      ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
-        # Disable tests that don’t work under macOS sandbox.
-        "test-macos-app-sandbox"
-        "test-os"
-        "test-os-process-priority"
         # This is a bit weird, but for some reason fs watch tests fail with
         # sandbox.
         "test-fs-promises-watch"
@@ -217,6 +212,11 @@ let
         "test-runner-run"
         "test-runner-watch-mode"
         "test-watch-mode-files_watcher"
+      ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
+        # Disable tests that don’t work under macOS sandbox.
+        "test-macos-app-sandbox"
+        "test-os"
+        "test-os-process-priority"
       ] ++ lib.optionals (stdenv.buildPlatform.isDarwin && stdenv.buildPlatform.isx86_64) [
         # These tests fail on x86_64-darwin (even without sandbox).
         # TODO: revisit at a later date.

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -45,7 +45,13 @@ let
       (builtins.attrNames sharedLibDeps);
 
   extraConfigFlags = lib.optionals (!enableNpm) [ "--without-npm" ];
-  self = stdenv.mkDerivation {
+
+  package = stdenv.mkDerivation (finalAttrs:
+  let
+    /** the final package fixed point, after potential overrides */
+    self = finalAttrs.finalPackage;
+  in
+  {
     inherit pname version;
 
     src = fetchurl {
@@ -295,5 +301,5 @@ let
     };
 
     passthru.python = python; # to ensure nodeEnv uses the same version
-  };
-in self
+  });
+in package

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -61,7 +61,14 @@ let
 
     strictDeps = true;
 
-    env = lib.optionalAttrs (stdenv.isDarwin && stdenv.isx86_64) {
+    env = {
+      # Tell ninja to avoid ANSI sequences, otherwise we don’t see build
+      # progress in Nix logs.
+      #
+      # Note: do not set TERM=dumb environment variable globally, it is used in
+      # test-ci-js test suite to skip tests that otherwise run fine.
+      NINJA = "TERM=dumb ninja";
+    } // lib.optionalAttrs (stdenv.isDarwin && stdenv.isx86_64) {
       # Make sure libc++ uses `posix_memalign` instead of `aligned_alloc` on x86_64-darwin.
       # Otherwise, nodejs would require the 11.0 SDK and macOS 10.15+.
       NIX_CFLAGS_COMPILE = "-D__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__=101300";
@@ -143,6 +150,9 @@ let
     # TODO: what about tests when cross-compiling?
     # Note that currently stdenv does not run check phase if build ≠ host.
     doCheck = true;
+
+    # See https://github.com/nodejs/node/issues/22006
+    enableParallelChecking = false;
 
     # Some dependencies required for tools/doc/node_modules (and therefore
     # test-addons, jstest and others) target are not included in the tarball.

--- a/pkgs/development/web/nodejs/use-correct-env-in-tests.patch
+++ b/pkgs/development/web/nodejs/use-correct-env-in-tests.patch
@@ -1,12 +1,5 @@
 `/usr/bin/env` is not available.
 
---- old/test/common/assertSnapshot.js
-+++ new/test/common/assertSnapshot.js
-@@ -81,2 +81,2 @@ async function spawnAndAssert(filename, transform = (x) => x, { tty = false, ...
--  const executable = tty ? 'tools/pseudo-tty.py' : process.execPath;
--  const args = tty ? [process.execPath, ...flags, filename] : [...flags, filename];
-+  const executable = tty ? 'python3' : process.execPath;
-+  const args = tty ? ['tools/pseudo-tty.py', process.execPath, ...flags, filename] : [...flags, filename];
 --- old/test/parallel/test-child-process-default-options.js
 +++ new/test/parallel/test-child-process-default-options.js
 @@ -35 +35 @@ if (isWindows) {

--- a/pkgs/development/web/nodejs/v18-openssl-3.0.14.patch
+++ b/pkgs/development/web/nodejs/v18-openssl-3.0.14.patch
@@ -1,0 +1,24 @@
+diff --git a/test/parallel/test-tls-alpn-server-client.js b/test/parallel/test-tls-alpn-server-client.js
+index 522dd34ad2..3f0ee2a0f9 100644
+--- a/test/parallel/test-tls-alpn-server-client.js
++++ b/test/parallel/test-tls-alpn-server-client.js
+@@ -195,7 +195,8 @@ function TestALPNCallback() {
+ 
+     // Callback picks 2nd preference => undefined => ALPN rejected:
+     assert.strictEqual(results[1].server, undefined);
+-    assert.strictEqual(results[1].client.error.code, 'ECONNRESET');
++    const allowedErrors = ['ECONNRESET', 'ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL'];
++    assert.ok(allowedErrors.includes(results[1].client.error.code), `'${results[1].client.error.code}' was not one of ${allowedErrors}.`);
+ 
+     TestBadALPNCallback();
+   });
+@@ -218,7 +219,8 @@ function TestBadALPNCallback() {
+   runTest(clientsOptions, serverOptions, function(results) {
+     // Callback returns 'http/5' => doesn't match client ALPN => error & reset
+     assert.strictEqual(results[0].server, undefined);
+-    assert.strictEqual(results[0].client.error.code, 'ECONNRESET');
++    const allowedErrors = ['ECONNRESET', 'ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL'];
++    assert.ok(allowedErrors.includes(results[0].client.error.code), `'${results[0].client.error.code}' was not one of ${allowedErrors}.`);
+ 
+     TestALPNOptionsCallback();
+   });

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -37,5 +37,14 @@ buildNodejs {
       url = "https://github.com/nodejs/node/commit/534c122de166cb6464b489f3e6a9a544ceb1c913.patch";
       hash = "sha256-4q4LFsq4yU1xRwNsM1sJoNVphJCnxaVe2IyL6AeHJ/I=";
     })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/87598d4b63ef2c827a2bebdfa0f1540c35718519.patch";
+      hash = "sha256-JJi8z9aaWnu/y3nZGOSUfeNzNSCYzD9dzoHXaGkeaEA=";
+      includes = ["test/common/assertSnapshot.js"];
+    })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/d0a6b605fba6cd69a82e6f12ff0363eef8fe1ee9.patch";
+      hash = "sha256-TfYal/PikRZHL6zpAlC3SmkYXCe+/8Gs83dLX/X/P/k=";
+    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -1,4 +1,4 @@
-{ callPackage, lib, overrideCC, pkgs, buildPackages, openssl, python3, fetchpatch2, enableNpm ? true }:
+{ callPackage, lib, overrideCC, pkgs, buildPackages, openssl, python311, fetchpatch2, enableNpm ? true }:
 
 let
   # Clang 16+ cannot build Node v18 due to -Wenum-constexpr-conversion errors.
@@ -14,7 +14,7 @@ let
     inherit openssl;
     stdenv = ensureCompatibleCC pkgs;
     buildPackages = buildPackages // { stdenv = ensureCompatibleCC buildPackages; };
-    python = python3;
+    python = python311;
   };
 
   gypPatches = callPackage ./gyp-patches.nix { } ++ [
@@ -32,6 +32,7 @@ buildNodejs {
     ./node-npm-build-npm-package-logic.patch
     ./trap-handler-backport.patch
     ./use-correct-env-in-tests.patch
+    ./v18-openssl-3.0.14.patch
     (fetchpatch2 {
       url = "https://github.com/nodejs/node/commit/534c122de166cb6464b489f3e6a9a544ceb1c913.patch";
       hash = "sha256-4q4LFsq4yU1xRwNsM1sJoNVphJCnxaVe2IyL6AeHJ/I=";

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -23,5 +23,17 @@ buildNodejs {
       url = "https://github.com/nodejs/node/commit/534c122de166cb6464b489f3e6a9a544ceb1c913.patch";
       hash = "sha256-4q4LFsq4yU1xRwNsM1sJoNVphJCnxaVe2IyL6AeHJ/I=";
     })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/14863e80584e579fd48c55f6373878c821c7ff7e.patch";
+      hash = "sha256-I7Wjc7DE059a/ZyXAvAqEGvDudPjxQqtkBafckHCFzo=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/87598d4b63ef2c827a2bebdfa0f1540c35718519.patch";
+      hash = "sha256-efRJ2nN9QXaT91SQTB+ESkHvXtBq30Cb9BEDEZU9M/8=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/d0a6b605fba6cd69a82e6f12ff0363eef8fe1ee9.patch";
+      hash = "sha256-TfYal/PikRZHL6zpAlC3SmkYXCe+/8Gs83dLX/X/P/k=";
+    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -12,21 +12,13 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "20.15.1";
-  sha256 = "sha256-/dU6VynZNmkaKhFRBG+0iXchy4sPyir5V4I6m0D+DDQ=";
+  version = "20.16.0";
+  sha256 = "cd6c8fc3ff2606aadbc7155db6f7e77247d2d0065ac18e2f7f049095584b8b46";
   patches = [
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch
     ./use-correct-env-in-tests.patch
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/534c122de166cb6464b489f3e6a9a544ceb1c913.patch";
-      hash = "sha256-4q4LFsq4yU1xRwNsM1sJoNVphJCnxaVe2IyL6AeHJ/I=";
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/14863e80584e579fd48c55f6373878c821c7ff7e.patch";
-      hash = "sha256-I7Wjc7DE059a/ZyXAvAqEGvDudPjxQqtkBafckHCFzo=";
-    })
     (fetchpatch2 {
       url = "https://github.com/nodejs/node/commit/87598d4b63ef2c827a2bebdfa0f1540c35718519.patch";
       hash = "sha256-efRJ2nN9QXaT91SQTB+ESkHvXtBq30Cb9BEDEZU9M/8=";

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchpatch2, openssl, python3, enableNpm ? true }:
+{ callPackage, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -12,20 +12,12 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "20.16.0";
-  sha256 = "cd6c8fc3ff2606aadbc7155db6f7e77247d2d0065ac18e2f7f049095584b8b46";
+  version = "20.17.0";
+  sha256 = "9abf03ac23362c60387ebb633a516303637145cb3c177be3348b16880fd8b28c";
   patches = [
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch
     ./use-correct-env-in-tests.patch
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/87598d4b63ef2c827a2bebdfa0f1540c35718519.patch";
-      hash = "sha256-efRJ2nN9QXaT91SQTB+ESkHvXtBq30Cb9BEDEZU9M/8=";
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/d0a6b605fba6cd69a82e6f12ff0363eef8fe1ee9.patch";
-      hash = "sha256-TfYal/PikRZHL6zpAlC3SmkYXCe+/8Gs83dLX/X/P/k=";
-    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchpatch2, openssl, python3, enableNpm ? true }:
+{ callPackage, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -12,17 +12,13 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "22.5.1";
-  sha256 = "924f381a32cf26b6bedbe95feedde348450f4fd321283d3bf3f7965aa45ce831";
+  version = "22.6.0";
+  sha256 = "37259d618d5565ca55acc2585045c7e1c5b9965a3d4eb44c0a237fdae84b9d44";
   patches = [
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch
     ./use-correct-env-in-tests.patch
     ./bin-sh-node-run-v22.patch
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/d0a6b605fba6cd69a82e6f12ff0363eef8fe1ee9.patch";
-      hash = "sha256-TfYal/PikRZHL6zpAlC3SmkYXCe+/8Gs83dLX/X/P/k=";
-    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -12,8 +12,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "22.7.0";
-  sha256 = "1e0b6f2f2ca4fb0b4644a11363169daf4b7c42f00e5a53d2c65a9fdc463e7d88";
+  version = "22.8.0";
+  sha256 = "f130e82176d1ee0702d99afc1995d0061bf8ed357c38834a32a08c9ef74f1ac7";
   patches = [
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -12,8 +12,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "22.6.0";
-  sha256 = "37259d618d5565ca55acc2585045c7e1c5b9965a3d4eb44c0a237fdae84b9d44";
+  version = "22.7.0";
+  sha256 = "1e0b6f2f2ca4fb0b4644a11363169daf4b7c42f00e5a53d2c65a9fdc463e7d88";
   patches = [
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -20,5 +20,13 @@ buildNodejs {
     ./node-npm-build-npm-package-logic.patch
     ./use-correct-env-in-tests.patch
     ./bin-sh-node-run-v22.patch
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/87598d4b63ef2c827a2bebdfa0f1540c35718519.patch";
+      hash = "sha256-efRJ2nN9QXaT91SQTB+ESkHvXtBq30Cb9BEDEZU9M/8=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/d0a6b605fba6cd69a82e6f12ff0363eef8fe1ee9.patch";
+      hash = "sha256-TfYal/PikRZHL6zpAlC3SmkYXCe+/8Gs83dLX/X/P/k=";
+    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -12,18 +12,14 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "22.4.1";
-  sha256 = "sha256-ZfyFf1qoJWqvyQCzRMARXJrq4loCVB/Vzg29Tf0cX7k=";
+  version = "22.5.1";
+  sha256 = "924f381a32cf26b6bedbe95feedde348450f4fd321283d3bf3f7965aa45ce831";
   patches = [
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch
     ./use-correct-env-in-tests.patch
     ./bin-sh-node-run-v22.patch
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/87598d4b63ef2c827a2bebdfa0f1540c35718519.patch";
-      hash = "sha256-efRJ2nN9QXaT91SQTB+ESkHvXtBq30Cb9BEDEZU9M/8=";
-    })
     (fetchpatch2 {
       url = "https://github.com/nodejs/node/commit/d0a6b605fba6cd69a82e6f12ff0363eef8fe1ee9.patch";
       hash = "sha256-TfYal/PikRZHL6zpAlC3SmkYXCe+/8Gs83dLX/X/P/k=";


### PR DESCRIPTION
## Description of changes

Generated with 

```sh
for commit in $(git log HEAD...origin/staging --reverse --pretty=format:"%H" -- pkgs/development/web/nodejs/); do
             echo "About to cherry-pick $commit";
             git cherry-pick -x "$commit";
             read -p "Press any key to resume ...";
done
```

I only picked the commits that did not break the builds.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
