### PR TITLE
[Backport release-24.05] lomiri.lomiri-gallery-app: init at 3.0.2

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -26,6 +26,7 @@ in {
         lomiri-clock-app
         lomiri-download-manager
         lomiri-filemanager-app
+        lomiri-gallery-app
         lomiri-polkit-agent
         lomiri-schemas # exposes some required dbus interfaces
         lomiri-session # wrappers to properly launch the session

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -522,6 +522,7 @@ in {
   lomiri-camera-app = runTest ./lomiri-camera-app.nix;
   lomiri-clock-app = runTest ./lomiri-clock-app.nix;
   lomiri-filemanager-app = runTest ./lomiri-filemanager-app.nix;
+  lomiri-gallery-app = runTest ./lomiri-gallery-app.nix;
   lomiri-system-settings = handleTest ./lomiri-system-settings.nix {};
   lorri = handleTest ./lorri/default.nix {};
   maddy = discoverTests (import ./maddy { inherit handleTest; });

--- a/nixos/tests/lomiri-camera-app.nix
+++ b/nixos/tests/lomiri-camera-app.nix
@@ -35,7 +35,7 @@
       fonts = {
         packages = with pkgs; [
           # Intended font & helps with OCR
-          ubuntu-classic
+          ubuntu_font_family
         ];
       };
 

--- a/nixos/tests/lomiri-gallery-app.nix
+++ b/nixos/tests/lomiri-gallery-app.nix
@@ -1,0 +1,156 @@
+{ lib, ... }:
+{
+  name = "lomiri-gallery-app-standalone";
+  meta.maintainers = lib.teams.lomiri.members;
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [ ./common/x11.nix ];
+
+      services.xserver.enable = true;
+
+      environment = {
+        systemPackages =
+          with pkgs;
+          [
+            ffmpeg # make a video from the image
+            (imagemagick.override { ghostscriptSupport = true; }) # example image creation
+            mpv # URI dispatching for video support
+            xdotool # mouse movement
+          ]
+          ++ (with pkgs.lomiri; [
+            suru-icon-theme
+            lomiri-gallery-app
+            lomiri-thumbnailer # finds new images & generates thumbnails
+          ]);
+        variables = {
+          UITK_ICON_THEME = "suru";
+        };
+      };
+
+      i18n.supportedLocales = [ "all" ];
+
+      fonts = {
+        packages = with pkgs; [
+          # Intended font & helps with OCR
+          ubuntu_font_family
+        ];
+      };
+    };
+
+  enableOCR = true;
+
+  testScript =
+    let
+      imageLabel = "Image";
+    in
+    ''
+      machine.wait_for_x()
+
+      with subtest("lomiri gallery launches"):
+          machine.succeed("lomiri-gallery-app >&2 &")
+          machine.sleep(2)
+          machine.wait_for_text(r"(Albums|Events|Photos)")
+          machine.screenshot("lomiri-gallery_open")
+
+      machine.succeed("pkill -f lomiri-gallery-app")
+
+      machine.succeed("mkdir /root/Pictures /root/Videos")
+      # Setup example data, OCR-friendly:
+      # - White square, black text
+      # - uppercase extension
+      machine.succeed("magick -size 500x500 -background white -fill black canvas:white -pointsize 70 -annotate +100+300 '${imageLabel}' /root/Pictures/output.PNG")
+
+      # Different image formats
+      machine.succeed("magick /root/Pictures/output.PNG /root/Pictures/output.JPG")
+      machine.succeed("magick /root/Pictures/output.PNG /root/Pictures/output.BMP")
+      machine.succeed("magick /root/Pictures/output.PNG /root/Pictures/output.GIF")
+
+      # Video for dispatching
+      machine.succeed("ffmpeg -loop 1 -r 1 -i /root/Pictures/output.PNG -t 100 -pix_fmt yuv420p /root/Videos/output.MP4")
+
+      with subtest("lomiri gallery handles files"):
+          machine.succeed("lomiri-gallery-app >&2 &")
+          machine.sleep(2)
+          machine.wait_for_text(r"(Albums|Events|Photos|${imageLabel})")
+
+          machine.succeed("xdotool mousemove 30 40 click 1") # burger menu for categories
+          machine.sleep(2)
+          machine.succeed("xdotool mousemove 30 180 click 1") # photos
+          machine.sleep(2)
+          machine.wait_for_text("${imageLabel}") # should see thumbnail of at least one of them
+          machine.screenshot("lomiri-gallery_photos")
+
+          machine.succeed("xdotool mousemove 80 140 click 1") # select newest one
+          machine.sleep(2)
+          machine.succeed("xdotool mousemove 80 140 click 1") # enable top-bar
+          machine.sleep(2)
+
+          with subtest("lomiri gallery handles mp4"):
+              machine.succeed("xdotool mousemove 870 50 click 1") # open media information
+              machine.sleep(2)
+              machine.wait_for_text("MP4") # make sure we're looking at the right file
+              machine.screenshot("lomiri-gallery_mp4_info")
+              machine.send_key("esc")
+
+              machine.wait_for_text("${imageLabel}") # make sure thumbnail rendering worked
+
+              machine.succeed("xdotool mousemove 450 350 click 1") # dispatch to system's video handler
+              machine.wait_until_succeeds("pgrep -u root -f mpv") # wait for video to start
+              machine.sleep(10)
+              machine.succeed("pgrep -u root -f mpv") # should still be playing
+              machine.screenshot("lomiri-gallery_mp4_dispatch")
+
+              machine.send_key("q")
+              machine.wait_until_fails("pgrep mpv") # wait for video to stop
+
+              machine.send_key("right")
+
+          with subtest("lomiri gallery handles gif"):
+              machine.succeed("xdotool mousemove 870 50 click 1") # open media information
+              machine.sleep(2)
+              machine.wait_for_text("GIF") # make sure we're looking at the right file
+              machine.screenshot("lomiri-gallery_gif_info")
+              machine.send_key("esc")
+
+              machine.wait_for_text("${imageLabel}") # make sure media shows fine
+              machine.send_key("right")
+
+          with subtest("lomiri gallery handles bmp"):
+              machine.succeed("xdotool mousemove 840 50 click 1") # open media information (extra icon, different location)
+              machine.sleep(2)
+              machine.wait_for_text("BMP") # make sure we're looking at the right file
+              machine.screenshot("lomiri-gallery_bmp_info")
+              machine.send_key("esc")
+
+              machine.wait_for_text("${imageLabel}") # make sure media shows fine
+              machine.send_key("right")
+
+          with subtest("lomiri gallery handles jpg"):
+              machine.succeed("xdotool mousemove 840 50 click 1") # open media information (extra icon, different location)
+              machine.sleep(2)
+              machine.wait_for_text("JPG") # make sure we're looking at the right file
+              machine.screenshot("lomiri-gallery_jpg_info")
+              machine.send_key("esc")
+
+              machine.wait_for_text("${imageLabel}") # make sure media shows fine
+              machine.send_key("right")
+
+          with subtest("lomiri gallery handles png"):
+              machine.succeed("xdotool mousemove 840 50 click 1") # open media information (extra icon, different location)
+              machine.sleep(2)
+              machine.wait_for_text("PNG") # make sure we're looking at the right file
+              machine.screenshot("lomiri-gallery_png_info")
+              machine.send_key("esc")
+
+              machine.wait_for_text("${imageLabel}") # make sure media shows fine
+
+      machine.succeed("pkill -f lomiri-gallery-app")
+
+      with subtest("lomiri gallery localisation works"):
+          machine.succeed("env LANG=de_DE.UTF-8 lomiri-gallery-app >&2 &")
+          machine.wait_for_text(r"(Alben|Ereignisse|Fotos)")
+          machine.screenshot("lomiri-gallery_localised")
+    '';
+}

--- a/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
@@ -1,0 +1,187 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  cmake,
+  content-hub,
+  exiv2,
+  imagemagick,
+  libglvnd,
+  libmediainfo,
+  lomiri-thumbnailer,
+  lomiri-ui-extras,
+  lomiri-ui-toolkit,
+  pkg-config,
+  qqc2-suru-style,
+  qtbase,
+  qtdeclarative,
+  qtmultimedia,
+  qtsvg,
+  wrapQtAppsHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-gallery-app";
+  version = "3.0.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/apps/lomiri-gallery-app";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-nX9dTL4W0WxrwvszGd4AUIx4yUrghMM7ZMtGZLhZE/8=";
+  };
+
+  patches = [
+    # Remove when version > 3.0.2
+    (fetchpatch {
+      name = "0001-lomiri-gallery-app-Newer-Evix2-compat.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/afa019b5e9071fbafaa9afb3b4effdae6e0774c5.patch";
+      hash = "sha256-gBc++6EQ7t3VcBZTknkIpC0bJ/P15oI+G0YoQWtjnSY=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/merge_requests/147 merged & in release
+    (fetchpatch {
+      name = "0002-lomiri-gallery-app-Stop-using-qt5_use_modules.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/0149c8d422c3e0889d7d523789dc65776a52c4f9.patch";
+      hash = "sha256-jS81F7KNbAn5J8sDDXzhXARNYAu6dEKcbNHpHp/3MaI=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/merge_requests/148 merged & in release
+    (fetchpatch {
+      name = "0003-lomiri-gallery-app-Fix-GNUInstallDirs.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/805121b362a9b486094e570053884b9ffa92b152.patch";
+      hash = "sha256-fyAqKjZ0g7Sw7fWP1IW4SpZ+g0xi/pH6RJie1K3doP0=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/merge_requests/149 merged & in release
+    (fetchpatch {
+      name = "0004-lomiri-gallery-app-Fix-icons.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/906966536363e80fe9906dee935d991955e8f842.patch";
+      hash = "sha256-LJ+ILhokceXFUvP/G1BEBE/J1/XUAmNBxu551x0Q6nk=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/merge_requests/150 merged & in release
+    (fetchpatch {
+      name = "0005-lomiri-gallery-app-Add-ENABLE_WERROR.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/fe32a3453b88cc3563e53ab124f669ce307e9688.patch";
+      hash = "sha256-nFCtY3857D5e66rIME+lj6x4exEfx9D2XGEgyWhemgI=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/merge_requests/151 merged & in release
+    (fetchpatch {
+      name = "0006-lomiri-gallery-app-BUILD_TESTING.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/51f3d5e643db5576b051da63c58ba3492c851e44.patch";
+      hash = "sha256-5aGx2xfCDgq/khgkzGsvUOmTIYALjyfn6W7IR5dldr8=";
+    })
+    (fetchpatch {
+      name = "0007-lomiri-gallery-app-Top-level-Qt5Test.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/c308c689c2841d71554ff6397a110d1a12016b70.patch";
+      hash = "sha256-fXVOKjnj4EPeby9iEp3mZRqx9MLqdF8SUVEouCkyDRc=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/merge_requests/152 merged & in release
+    (fetchpatch {
+      name = "0008-lomiri-gallery-app-bindtextdomain.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/90a79972741ee0c5dc734dba6c42afeb3ee6a699.patch";
+      hash = "sha256-YAmH0he5/rZYKWFyPzUFAKJuHhUTxB3q8zbLL7Spz/c=";
+    })
+  ];
+
+  postPatch = ''
+    # 0003-lomiri-gallery-app-Fix-icons.patch cannot be fully applied via patches due to binary diffs
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/merge_requests/149 merged & in release
+    for size in 64x64 128x128 256x256; do
+      rm desktop/icons/hicolor/"$size"/apps/gallery-app.png
+      magick desktop/lomiri-gallery-app.svg -resize "$size" desktop/icons/hicolor/"$size"/apps/lomiri-gallery-app.png
+    done
+
+    # Make splash path in desktop file relative
+    substituteInPlace desktop/lomiri-gallery-app.desktop.in.in \
+      --replace-fail 'X-Lomiri-Splash-Image=@SPLASH@' 'X-Lomiri-Splash-Image=lomiri-app-launch/splash/lomiri-gallery-app.svg'
+
+    # Tried to open videos via 'gio open video://', don't know how this is supposed to be set up yet
+    # Just leave it as file:// schema, which resolves fine
+    substituteInPlace rc/qml/MediaViewer/SingleMediaViewer.qml \
+      --replace-fail '"file://", "video://"' '"file://", "file://"'
+
+    # This makes it harder to see what went wrong in the tests
+    substituteInPlace tests/unittests/mediaobjectfactory/CMakeLists.txt \
+      --replace-fail ' -xunitxml -o test_mediaobjectfactory.xml' ""
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    imagemagick
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    exiv2
+    libglvnd
+    libmediainfo
+    qtbase
+    qtdeclarative
+    qtsvg
+
+    # QML
+    content-hub
+    lomiri-thumbnailer
+    lomiri-ui-extras
+    lomiri-ui-toolkit
+    qqc2-suru-style
+    qtmultimedia
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CLICK_MODE" false)
+    (lib.cmakeBool "INSTALL_TESTS" false)
+    (lib.cmakeFeature "OpenGL_GL_PREFERENCE" "GLVND")
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck =
+    let
+      listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
+    in
+    ''
+      export QT_PLUGIN_PATH=${
+        listToQtVar qtbase.qtPluginPrefix [
+          qtbase
+          qtsvg
+        ]
+      }
+      export XDG_RUNTIME_DIR=$TMP
+    '';
+
+  postInstall = ''
+    # Link splash to splash dir
+    mkdir -p $out/share/lomiri-app-launch/splash
+    ln -s $out/share/{lomiri-gallery-app/lomiri-gallery-app-splash.svg,lomiri-app-launch/splash/lomiri-gallery-app.svg}
+
+    # Old name
+    mv $out/share/content-hub/peers/{,lomiri-}gallery-app
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "Photo gallery application for Ubuntu Touch devices";
+    homepage = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/blob/v${finalAttrs.version}/ChangeLog";
+    license = with lib.licenses; [
+      gpl3Only
+      cc-by-sa-30
+    ];
+    maintainers = lib.teams.lomiri.members;
+    mainProgram = "lomiri-gallery-app";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   fetchpatch,
   gitUpdater,
+  nixosTests,
   cmake,
   content-hub,
   exiv2,
@@ -169,6 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    tests.vm = nixosTests.lomiri-gallery-app;
     updateScript = gitUpdater { rev-prefix = "v"; };
   };
 

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -13,6 +13,7 @@ let
     lomiri-camera-app = callPackage ./applications/lomiri-camera-app { };
     lomiri-clock-app = callPackage ./applications/lomiri-clock-app { };
     lomiri-filemanager-app = callPackage ./applications/lomiri-filemanager-app { };
+    lomiri-gallery-app = callPackage ./applications/lomiri-gallery-app { };
     lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
     lomiri-system-settings-security-privacy = callPackage ./applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix { };
     lomiri-system-settings = callPackage ./applications/lomiri-system-settings/wrapper.nix { };


### PR DESCRIPTION
## Description of changes

Backport of #334629, + a fix to #331273

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
