### PR TITLE
nixos/engelsystem: prune template cache on version changes

### DIFF
--- a/nixos/modules/services/web-apps/engelsystem.nix
+++ b/nixos/modules/services/web-apps/engelsystem.nix
@@ -1,40 +1,49 @@
-{ config, lib, pkgs, utils, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
 
 let
-  inherit (lib) mkDefault mkEnableOption mkIf mkOption types mkPackageOption;
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    mkRenamedOptionModule
+    types
+  ;
+
   cfg = config.services.engelsystem;
 in {
-  options = {
-    services.engelsystem = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = ''
-          Whether to enable engelsystem, an online tool for coordinating volunteers
-          and shifts on large events.
-        '';
-        type = lib.types.bool;
-      };
+  imports = [
+    (mkRenamedOptionModule [ "services" "engelsystem" "config" ] [ "services" "engelsystem" "settings" ])
+  ];
 
-      domain = mkOption {
-        type = types.str;
-        example = "engelsystem.example.com";
-        description = "Domain to serve on.";
-      };
+  options.services.engelsystem = {
+    enable = mkEnableOption "engelsystem, an online tool for coordinating volunteers and shifts on large events";
 
-      package = mkPackageOption pkgs "engelsystem" { };
+    package = mkPackageOption pkgs "engelsystem" { };
 
-      createDatabase = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to create a local database automatically.
-          This will override every database setting in {option}`services.engelsystem.config`.
-        '';
-      };
+    domain = mkOption {
+      type = types.str;
+      example = "engelsystem.example.com";
+      description = "Domain to serve on.";
     };
 
-    services.engelsystem.config = mkOption {
+    createDatabase = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to create a local database automatically.
+        This will override every database setting in {option}`services.engelsystem.config`.
+      '';
+    };
+
+    settings = mkOption {
       type = types.attrs;
       default = {
         database = {
@@ -144,7 +153,7 @@ in {
       script =
         let
           genConfigScript = pkgs.writeScript "engelsystem-gen-config.sh"
-            (utils.genJqSecretsReplacementSnippet cfg.config "config.json");
+            (utils.genJqSecretsReplacementSnippet cfg.settings "config.json");
         in ''
           umask 077
           mkdir -p /var/lib/engelsystem/storage/app

--- a/nixos/modules/services/web-apps/engelsystem.nix
+++ b/nixos/modules/services/web-apps/engelsystem.nix
@@ -163,7 +163,17 @@ in {
         Group = "engelsystem";
       };
       script = ''
-        ${cfg.package}/bin/migrate
+        versionFile="/var/lib/engelsystem/.version"
+        version=$(cat "$versionFile" 2>/dev/null || echo 0)
+
+        if [[ $version != ${cfg.package.version} ]]; then
+          # prune template cache between releases
+          rm -rfv /var/lib/engelsystem/storage/cache/*
+
+          ${cfg.package}/bin/migrate
+
+          echo ${cfg.package.version} > "$versionFile"
+        fi
       '';
       after = [ "engelsystem-init.service" "mysql.service" ];
     };


### PR DESCRIPTION
After upgrading to 3.5.0 we noticed, that registering would redirect to the login page and not work at all. At the same time the admin user was unable to access its user settings.

This issue could be tracked back to the template cache, that must be invalidated between release upgrades.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
