### PR TITLE
[Backport release-24.05] lixVersions.lix_2_91: init

### DIFF
--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -12,8 +12,9 @@ let
     # If the attribute is not named 'test'
     # You will break all the universe on the release-*.nix side of things.
     # `discoverTests` relies on `test` existence to perform a `callTest`.
-    test = testMiscFeatures args;
-    passthru.override = args': testsForPackage (args // args');
+    test = testMiscFeatures args // {
+      passthru.override = args': testsForPackage (args // args');
+    };
   };
 
   testMiscFeatures = { nixPackage, ... }: pkgs.testers.nixosTest (

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -11,6 +11,7 @@
     inherit hash;
   },
   docCargoHash ? null,
+  docCargoLock ? null,
   patches ? [ ],
   maintainers ? lib.teams.lix.members,
 }@args:
@@ -65,6 +66,12 @@ assert (hash == null) -> (src != null);
   util-linuxMinimal,
   xz,
   nixosTests,
+  lix-doc ? callPackage ./doc {
+    inherit src;
+    version = "${version}${suffix}";
+    cargoHash = docCargoHash;
+    cargoLock = docCargoLock;
+  },
 
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   enableStatic ? stdenv.hostPlatform.isStatic,
@@ -78,212 +85,207 @@ assert (hash == null) -> (src != null);
   stateDir,
   storeDir,
 }:
-let
-  lix-doc = callPackage ./doc {
-    inherit src;
-    version = "${version}${suffix}";
-    cargoHash = docCargoHash;
-  };
-  self = stdenv.mkDerivation {
-    pname = "lix";
+assert lib.assertMsg (docCargoHash != null || docCargoLock != null)
+  "Either `lix-doc`'s cargoHash using `docCargoHash` or `lix-doc`'s `cargoLock.lockFile` using `docCargoLock` must be set!";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lix";
 
-    version = "${version}${suffix}";
-    VERSION_SUFFIX = suffix;
+  version = "${version}${suffix}";
+  VERSION_SUFFIX = suffix;
 
-    inherit src patches;
+  inherit src patches;
 
-    outputs =
-      [
-        "out"
-        "dev"
-      ]
-      ++ lib.optionals enableDocumentation [
-        "man"
-        "doc"
-      ];
-
-    strictDeps = true;
-
-    nativeBuildInputs =
-      [
-        pkg-config
-        bison
-        flex
-        jq
-        meson
-        ninja
-        cmake
-        python3
-        doxygen
-
-        # Tests
-        git
-        mercurial
-        jq
-        lsof
-      ]
-      ++ lib.optionals (enableDocumentation) [
-        (lib.getBin lowdown)
-        mdbook
-        mdbook-linkcheck
-      ]
-      ++ lib.optionals stdenv.isLinux [ util-linuxMinimal ];
-
-    buildInputs =
-      [
-        boost
-        brotli
-        bzip2
-        curl
-        editline
-        libsodium
-        openssl
-        sqlite
-        xz
-        gtest
-        libarchive
-        lowdown
-        rapidcheck
-        toml11
-        lix-doc
-      ]
-      ++ lib.optionals stdenv.isDarwin [ Security ]
-      ++ lib.optionals (stdenv.isx86_64) [ libcpuid ]
-      ++ lib.optionals withLibseccomp [ libseccomp ]
-      ++ lib.optionals withAWS [ aws-sdk-cpp ];
-
-    propagatedBuildInputs = [
-      boehmgc
-      nlohmann_json
+  outputs =
+    [
+      "out"
+      "dev"
+    ]
+    ++ lib.optionals enableDocumentation [
+      "man"
+      "doc"
     ];
 
-    postPatch = ''
-      patchShebangs --build tests
-    '';
+  strictDeps = true;
 
-    preConfigure =
-      # Copy libboost_context so we don't get all of Boost in our closure.
-      # https://github.com/NixOS/nixpkgs/issues/45462
-      lib.optionalString (!enableStatic) ''
-        mkdir -p $out/lib
-        cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
-        rm -f $out/lib/*.a
-        ${lib.optionalString stdenv.isLinux ''
-          chmod u+w $out/lib/*.so.*
-          patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
-        ''}
-        ${lib.optionalString stdenv.hostPlatform.isDarwin ''
-          for LIB in $out/lib/*.dylib; do
-            chmod u+w $LIB
-            install_name_tool -id $LIB $LIB
-            install_name_tool -delete_rpath ${boost}/lib/ $LIB || true
-          done
-          install_name_tool -change ${boost}/lib/libboost_system.dylib $out/lib/libboost_system.dylib $out/lib/libboost_thread.dylib
-        ''}
-      '';
+  nativeBuildInputs =
+    [
+      pkg-config
+      bison
+      flex
+      jq
+      meson
+      ninja
+      cmake
+      python3
+      doxygen
 
-    mesonBuildType = "release";
-    mesonFlags =
-      [
-        # LTO optimization
-        (lib.mesonBool "b_lto" (!stdenv.isDarwin))
-        (lib.mesonEnable "gc" true)
-        (lib.mesonBool "enable-tests" true)
-        (lib.mesonBool "enable-docs" enableDocumentation)
-        (lib.mesonBool "enable-embedded-sandbox-shell" (stdenv.isLinux && stdenv.hostPlatform.isStatic))
-        (lib.mesonEnable "seccomp-sandboxing" withLibseccomp)
+      # Tests
+      git
+      mercurial
+      jq
+      lsof
+    ]
+    ++ lib.optionals (enableDocumentation) [
+      (lib.getBin lowdown)
+      mdbook
+      mdbook-linkcheck
+    ]
+    ++ lib.optionals stdenv.isLinux [ util-linuxMinimal ];
 
-        (lib.mesonOption "store-dir" storeDir)
-        (lib.mesonOption "state-dir" stateDir)
-        (lib.mesonOption "sysconfdir" confDir)
-      ]
-      ++ lib.optionals stdenv.isLinux [
-        (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")
-      ];
-
-    # Needed for Meson to find Boost.
-    # https://github.com/NixOS/nixpkgs/issues/86131.
-    env = {
-      BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
-      BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-    };
-
-    postInstall =
-      ''
-        mkdir -p $doc/nix-support
-        echo "doc manual $doc/share/doc/nix/manual" >> $doc/nix-support/hydra-build-products
-      ''
-      + lib.optionalString stdenv.hostPlatform.isStatic ''
-        mkdir -p $out/nix-support
-        echo "file binary-dist $out/bin/nix" >> $out/nix-support/hydra-build-products
-      ''
-      + lib.optionalString stdenv.isDarwin ''
-        for lib in liblixutil.dylib liblixexpr.dylib; do
-          install_name_tool \
-            -change "${lib.getLib boost}/lib/libboost_context.dylib" \
-            "$out/lib/libboost_context.dylib" \
-            "$out/lib/$lib"
-        done
-      '';
-
-    doCheck = true;
-    mesonCheckFlags = [ "--suite=check" ];
-    checkInputs = [
+  buildInputs =
+    [
+      boost
+      brotli
+      bzip2
+      curl
+      editline
+      libsodium
+      openssl
+      sqlite
+      xz
       gtest
+      libarchive
+      lowdown
       rapidcheck
+      toml11
+      lix-doc
+    ]
+    ++ lib.optionals stdenv.isDarwin [ Security ]
+    ++ lib.optionals (stdenv.isx86_64) [ libcpuid ]
+    ++ lib.optionals withLibseccomp [ libseccomp ]
+    ++ lib.optionals withAWS [ aws-sdk-cpp ];
+
+  propagatedBuildInputs = [
+    boehmgc
+    nlohmann_json
+  ];
+
+  postPatch = ''
+    patchShebangs --build tests
+  '';
+
+  preConfigure =
+    # Copy libboost_context so we don't get all of Boost in our closure.
+    # https://github.com/NixOS/nixpkgs/issues/45462
+    lib.optionalString (!enableStatic) ''
+      mkdir -p $out/lib
+      cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
+      rm -f $out/lib/*.a
+      ${lib.optionalString stdenv.isLinux ''
+        chmod u+w $out/lib/*.so.*
+        patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
+      ''}
+      ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+        for LIB in $out/lib/*.dylib; do
+          chmod u+w $LIB
+          install_name_tool -id $LIB $LIB
+          install_name_tool -delete_rpath ${boost}/lib/ $LIB || true
+        done
+        install_name_tool -change ${boost}/lib/libboost_system.dylib $out/lib/libboost_system.dylib $out/lib/libboost_thread.dylib
+      ''}
+    '';
+
+  # Needed for Meson to find Boost.
+  # https://github.com/NixOS/nixpkgs/issues/86131.
+  env = {
+    BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
+    BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
+  };
+
+  mesonBuildType = "release";
+  mesonFlags =
+    [
+      # LTO optimization
+      (lib.mesonEnable "gc" true)
+      (lib.mesonBool "enable-tests" true)
+      (lib.mesonBool "enable-docs" enableDocumentation)
+      (lib.mesonBool "enable-embedded-sandbox-shell" (stdenv.isLinux && stdenv.hostPlatform.isStatic))
+      (lib.mesonEnable "seccomp-sandboxing" withLibseccomp)
+
+      (lib.mesonOption "store-dir" storeDir)
+      (lib.mesonOption "state-dir" stateDir)
+      (lib.mesonOption "sysconfdir" confDir)
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")
     ];
 
-    doInstallCheck = true;
-    mesonInstallCheckFlags = [ "--suite=installcheck" ];
-
-    preInstallCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # socket path becomes too long otherwise
-      export TMPDIR=$NIX_BUILD_TOP
-      # Prevent crashes in libcurl due to invoking Objective-C `+initialize` methods after `fork`.
-      # See http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html.
-      export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+  postInstall =
+    ''
+      mkdir -p $doc/nix-support
+      echo "doc manual $doc/share/doc/nix/manual" >> $doc/nix-support/hydra-build-products
+    ''
+    + lib.optionalString stdenv.hostPlatform.isStatic ''
+      mkdir -p $out/nix-support
+      echo "file binary-dist $out/bin/nix" >> $out/nix-support/hydra-build-products
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      for lib in liblixutil.dylib liblixexpr.dylib; do
+        install_name_tool \
+          -change "${lib.getLib boost}/lib/libboost_context.dylib" \
+          "$out/lib/libboost_context.dylib" \
+          "$out/lib/$lib"
+      done
     '';
 
-    installCheckPhase = ''
-      runHook preInstallCheck
-      flagsArray=($mesonInstallCheckFlags "''${mesonInstallCheckFlagsArray[@]}")
-      meson test --no-rebuild "''${flagsArray[@]}"
-      runHook postInstallCheck
-    '';
+  doCheck = true;
+  mesonCheckFlags = [ "--suite=check" ];
+  checkInputs = [
+    gtest
+    rapidcheck
+  ];
+
+  doInstallCheck = true;
+  mesonInstallCheckFlags = [ "--suite=installcheck" ];
+
+  preInstallCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # socket path becomes too long otherwise
+    export TMPDIR=$NIX_BUILD_TOP
+    # Prevent crashes in libcurl due to invoking Objective-C `+initialize` methods after `fork`.
+    # See http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html.
+    export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    flagsArray=($mesonInstallCheckFlags "''${mesonInstallCheckFlagsArray[@]}")
+    meson test --no-rebuild "''${flagsArray[@]}"
+    runHook postInstallCheck
+  '';
+  hardeningDisable = [
     # strictoverflow is disabled because we trap on signed overflow instead
-    hardeningDisable = [ "strictoverflow" ] ++ lib.optional stdenv.hostPlatform.isStatic "pie";
-    # hardeningEnable = lib.optionals (!stdenv.isDarwin) [ "pie" ];
-    # hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
-    separateDebugInfo = stdenv.isLinux && !enableStatic;
-    enableParallelBuilding = true;
+    "strictoverflow"
+  ] ++ lib.optional stdenv.hostPlatform.isStatic "pie";
+  # hardeningEnable = lib.optionals (!stdenv.isDarwin) [ "pie" ];
+  # hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
+  separateDebugInfo = stdenv.isLinux && !enableStatic;
+  enableParallelBuilding = true;
 
-    passthru = {
-      inherit aws-sdk-cpp boehmgc;
-      tests = {
-        misc = nixosTests.misc.lix.passthru.override { nixPackage = self; };
-      };
-    };
-
-    # point 'nix edit' and ofborg at the file that defines the attribute,
-    # not this common file.
-    pos = builtins.unsafeGetAttrPos "version" args;
-    meta = with lib; {
-      description = "Powerful package manager that makes package management reliable and reproducible";
-      longDescription = ''
-        Lix (a fork of Nix) is a powerful package manager for Linux and other Unix systems that
-        makes package management reliable and reproducible. It provides atomic
-        upgrades and rollbacks, side-by-side installation of multiple versions of
-        a package, multi-user package management and easy setup of build
-        environments.
-      '';
-      homepage = "https://lix.systems";
-      license = licenses.lgpl21Plus;
-      inherit maintainers;
-      platforms = platforms.unix;
-      outputsToInstall = [ "out" ] ++ optional enableDocumentation "man";
-      mainProgram = "nix";
-      broken = enableStatic;
+  passthru = {
+    inherit aws-sdk-cpp boehmgc;
+    tests = {
+      misc = nixosTests.misc.lix.passthru.override { nixPackage = finalAttrs.finalPackage; };
     };
   };
-in
-self
+
+  # point 'nix edit' and ofborg at the file that defines the attribute,
+  # not this common file.
+  pos = builtins.unsafeGetAttrPos "version" args;
+  meta = with lib; {
+    description = "Powerful package manager that makes package management reliable and reproducible";
+    longDescription = ''
+      Lix (a fork of Nix) is a powerful package manager for Linux and other Unix systems that
+      makes package management reliable and reproducible. It provides atomic
+      upgrades and rollbacks, side-by-side installation of multiple versions of
+      a package, multi-user package management and easy setup of build
+      environments.
+    '';
+    homepage = "https://lix.systems";
+    license = licenses.lgpl21Plus;
+    inherit maintainers;
+    platforms = platforms.unix;
+    outputsToInstall = [ "out" ] ++ optional enableDocumentation "man";
+    mainProgram = "nix";
+    broken = enableStatic;
+  };
+})

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -19,7 +19,6 @@ assert (hash == null) -> (src != null);
 {
   stdenv,
   meson,
-  bash,
   bison,
   boehmgc,
   boost,
@@ -27,29 +26,20 @@ assert (hash == null) -> (src != null);
   busybox-sandbox-shell,
   bzip2,
   callPackage,
-  coreutils,
   curl,
   cmake,
-  docbook_xsl_ns,
-  docbook5,
   doxygen,
   editline,
   flex,
   git,
-  gnutar,
   gtest,
-  gzip,
   jq,
   lib,
   libarchive,
   libcpuid,
-  libgit2,
   libsodium,
-  libxml2,
-  libxslt,
   lowdown,
   lsof,
-  man,
   mercurial,
   mdbook,
   mdbook-linkcheck,
@@ -57,8 +47,8 @@ assert (hash == null) -> (src != null);
   ninja,
   openssl,
   toml11,
+  pegtl,
   python3,
-  perl,
   pkg-config,
   rapidcheck,
   Security,
@@ -87,6 +77,9 @@ assert (hash == null) -> (src != null);
 }:
 assert lib.assertMsg (docCargoHash != null || docCargoLock != null)
   "Either `lix-doc`'s cargoHash using `docCargoHash` or `lix-doc`'s `cargoLock.lockFile` using `docCargoLock` must be set!";
+let
+  isLegacyParser = lib.versionOlder version "2.91";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lix";
 
@@ -103,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals enableDocumentation [
       "man"
       "doc"
+      "devdoc"
     ];
 
   strictDeps = true;
@@ -110,14 +104,12 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs =
     [
       pkg-config
-      bison
       flex
       jq
       meson
       ninja
       cmake
       python3
-      doxygen
 
       # Tests
       git
@@ -125,10 +117,12 @@ stdenv.mkDerivation (finalAttrs: {
       jq
       lsof
     ]
-    ++ lib.optionals (enableDocumentation) [
+    ++ lib.optionals isLegacyParser [ bison ]
+    ++ lib.optionals enableDocumentation [
       (lib.getBin lowdown)
       mdbook
       mdbook-linkcheck
+      doxygen
     ]
     ++ lib.optionals stdenv.isLinux [ util-linuxMinimal ];
 
@@ -150,6 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
       toml11
       lix-doc
     ]
+    ++ lib.optionals (!isLegacyParser) [ pegtl ]
     ++ lib.optionals stdenv.isDarwin [ Security ]
     ++ lib.optionals (stdenv.isx86_64) [ libcpuid ]
     ++ lib.optionals withLibseccomp [ libseccomp ]
@@ -161,7 +156,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    patchShebangs --build tests
+    patchShebangs --build tests doc/manual
   '';
 
   preConfigure =
@@ -192,13 +187,20 @@ stdenv.mkDerivation (finalAttrs: {
     BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
   };
 
-  mesonBuildType = "release";
+  # -O3 seems to anger a gcc bug and provide no performance benefit.
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114360
+  # We use -O2 upstream https://gerrit.lix.systems/c/lix/+/554
+  mesonBuildType = "debugoptimized";
+
   mesonFlags =
     [
-      # LTO optimization
+      # Enable LTO, since it improves eval performance a fair amount
+      # LTO is disabled on static due to strange linking errors
+      (lib.mesonBool "b_lto" (!stdenv.hostPlatform.isStatic))
       (lib.mesonEnable "gc" true)
       (lib.mesonBool "enable-tests" true)
       (lib.mesonBool "enable-docs" enableDocumentation)
+      (lib.mesonEnable "internal-api-docs" enableDocumentation)
       (lib.mesonBool "enable-embedded-sandbox-shell" (stdenv.isLinux && stdenv.hostPlatform.isStatic))
       (lib.mesonEnable "seccomp-sandboxing" withLibseccomp)
 
@@ -210,10 +212,15 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")
     ];
 
+  ninjaFlags = [ "-v" ];
+
   postInstall =
-    ''
+    lib.optionalString enableDocumentation ''
       mkdir -p $doc/nix-support
       echo "doc manual $doc/share/doc/nix/manual" >> $doc/nix-support/hydra-build-products
+
+      mkdir -p $devdoc/nix-support
+      echo "devdoc internal-api $devdoc/share/doc/nix/internal-api" >> $devdoc/nix-support/hydra-build-products
     ''
     + lib.optionalString stdenv.hostPlatform.isStatic ''
       mkdir -p $out/nix-support
@@ -228,15 +235,27 @@ stdenv.mkDerivation (finalAttrs: {
       done
     '';
 
+  # This needs to run after _multioutDocs moves the docs to $doc
+  postFixup = lib.optionalString enableDocumentation ''
+    mkdir -p $devdoc/share/doc/nix
+    mv $doc/share/doc/nix/internal-api $devdoc/share/doc/nix
+  '';
+
   doCheck = true;
-  mesonCheckFlags = [ "--suite=check" ];
+  mesonCheckFlags = [
+    "--suite=check"
+    "--print-errorlogs"
+  ];
   checkInputs = [
     gtest
     rapidcheck
   ];
 
   doInstallCheck = true;
-  mesonInstallCheckFlags = [ "--suite=installcheck" ];
+  mesonInstallCheckFlags = [
+    "--suite=installcheck"
+    "--print-errorlogs"
+  ];
 
   preInstallCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # socket path becomes too long otherwise
@@ -255,11 +274,16 @@ stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [
     # strictoverflow is disabled because we trap on signed overflow instead
     "strictoverflow"
-  ] ++ lib.optional stdenv.hostPlatform.isStatic "pie";
+  ]
+  # fortify breaks the build with lto and musl for some reason
+  ++ lib.optional stdenv.hostPlatform.isMusl "fortify";
+
   # hardeningEnable = lib.optionals (!stdenv.isDarwin) [ "pie" ];
-  # hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
   separateDebugInfo = stdenv.isLinux && !enableStatic;
   enableParallelBuilding = true;
+
+  # Used by (1) test which has dynamic port assignment.
+  __darwinAllowLocalNetworking = true;
 
   passthru = {
     inherit aws-sdk-cpp boehmgc;
@@ -271,7 +295,7 @@ stdenv.mkDerivation (finalAttrs: {
   # point 'nix edit' and ofborg at the file that defines the attribute,
   # not this common file.
   pos = builtins.unsafeGetAttrPos "version" args;
-  meta = with lib; {
+  meta = {
     description = "Powerful package manager that makes package management reliable and reproducible";
     longDescription = ''
       Lix (a fork of Nix) is a powerful package manager for Linux and other Unix systems that
@@ -281,11 +305,10 @@ stdenv.mkDerivation (finalAttrs: {
       environments.
     '';
     homepage = "https://lix.systems";
-    license = licenses.lgpl21Plus;
+    license = lib.licenses.lgpl21Plus;
     inherit maintainers;
-    platforms = platforms.unix;
-    outputsToInstall = [ "out" ] ++ optional enableDocumentation "man";
+    platforms = lib.platforms.unix;
+    outputsToInstall = [ "out" ] ++ lib.optional enableDocumentation "man";
     mainProgram = "nix";
-    broken = enableStatic;
   };
 })

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -4,6 +4,7 @@
   boehmgc,
   callPackage,
   fetchFromGitHub,
+  fetchpatch,
   Security,
 
   storeDir ? "/nix/store",
@@ -33,6 +34,9 @@ let
         requiredSystemFeatures = [ ];
       };
 
+  # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
+  needsBoehmgcPatches = version: lib.versionOlder version "2.91";
+
   common =
     args:
     callPackage (import ./common.nix ({ inherit lib fetchFromGitHub; } // args)) {
@@ -42,11 +46,11 @@ let
         stateDir
         confDir
         ;
-      boehmgc = boehmgc-nix;
+      boehmgc = if needsBoehmgcPatches args.version then boehmgc-nix else boehmgc-nix_2_3;
       aws-sdk-cpp = aws-sdk-cpp-nix;
     };
 in
-lib.makeExtensible (self: ({
+lib.makeExtensible (self: {
   buildLix = common;
 
   lix_2_90 = (
@@ -57,6 +61,31 @@ lib.makeExtensible (self: ({
     }
   );
 
-  latest = self.lix_2_90;
-  stable = self.lix_2_90;
-}))
+  lix_2_91 = (
+    common {
+      version = "2.91.0";
+      hash = "sha256-Rosl9iA9MybF5Bud4BTAQ9adbY81aGmPfV8dDBGl34s=";
+      docCargoHash = "sha256-KOn1fXF7k7c/0e5ZCNZwt3YZmjL1oi5A2mhwxQWKaUo=";
+
+      patches = [
+        # Fix meson to not use target_machine, fixing cross. This commit is in release-2.91: remove when updating to 2.91.1 (if any).
+        # https://gerrit.lix.systems/c/lix/+/1781
+        # https://git.lix.systems/lix-project/lix/commit/ca2b514e20de12b75088b06b8e0e316482516401
+        (fetchpatch {
+          url = "https://git.lix.systems/lix-project/lix/commit/ca2b514e20de12b75088b06b8e0e316482516401.patch";
+          hash = "sha256-TZauU4RIsn07xv9vZ33amrDvCLMbrtcHs1ozOTLgu98=";
+        })
+        # Fix musl builds. This commit is in release-2.91: remove when updating to 2.91.1 (if any).
+        # https://gerrit.lix.systems/c/lix/+/1823
+        # https://git.lix.systems/lix-project/lix/commit/ed51a172c69996fc6f3b7dfaa86015bff50c8ba8
+        (fetchpatch {
+          url = "https://git.lix.systems/lix-project/lix/commit/ed51a172c69996fc6f3b7dfaa86015bff50c8ba8.patch";
+          hash = "sha256-X59N+tOQ2GN17p9sXvo9OiuEexzB23ieuOvtq2sre5c=";
+        })
+      ];
+    }
+  );
+
+  latest = self.lix_2_91;
+  stable = self.lix_2_91;
+})

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -47,6 +47,8 @@ let
     };
 in
 lib.makeExtensible (self: ({
+  buildLix = common;
+
   lix_2_90 = (
     common {
       version = "2.90.0";

--- a/pkgs/tools/package-management/lix/doc/default.nix
+++ b/pkgs/tools/package-management/lix/doc/default.nix
@@ -2,11 +2,12 @@
   src,
   rustPlatform,
   version,
-  cargoHash,
+  cargoHash ? null,
+  cargoLock ? null
 }:
 
 rustPlatform.buildRustPackage {
   pname = "lix-doc";
-  sourceRoot = "${src.name}/lix-doc";
-  inherit version src cargoHash;
+  sourceRoot = "${src.name or src}/lix-doc";
+  inherit version src cargoHash cargoLock;
 }


### PR DESCRIPTION
## Description of changes

Original PR: https://github.com/NixOS/nixpkgs/pull/334269

This adds Lix 2.91.0 to nixpkgs and sets it as the default Lix release.
This is compliant with the 24.05 stability policy because Lix 2.91 does
not break any users (io_uring is already only partially available due to
old kernels, nobody on github uses build-hook, and nix 2.3 is the oldest
version of nix with security support).

Reviewer note: this is split into commits on purpose. I recommend an ignore-whitespace diff (?w=1 in url on github).

Blog post:
https://lix.systems/blog/2024-08-12-lix-2.91-release/

Release notes:
https://docs.lix.systems/manual/lix/stable/release-notes/rl-2.91.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
