### PR TITLE
ghidra-extensions.ghidra-delinker-extension: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
 }:
 let
-  version = "0.4.0";
+  version = "0.5.0";
   self = ghidra.buildGhidraExtension {
     pname = "ghidra-delinker-extension";
     inherit version;
@@ -13,8 +13,8 @@ let
     src = fetchFromGitHub {
       owner = "boricj";
       repo = "ghidra-delinker-extension";
-      rev = "04338fd028bf8b5449ff3f5373635111140bbeda";
-      hash = "sha256-tfO92dnpfY13ZbvL36WzV/pC3xH/fbQDICNAF8D4fCI=";
+      rev = "v${version}";
+      hash = "sha256-y0afqqIsWN33b/zGsxJYn8O+R5IP4eD300CgzMymEA0=";
     };
 
     postPatch = ''


### PR DESCRIPTION
## Description of changes

Unfortunately a few days before my original PR got merged an update occurred to this and I didn't have time to update my PR, so this is a follow-up.

ghidra-delinker-extension 0.5.0 comes with a barrage of fixes for the COFF exporter, a fix for the ELF exporter, a fix for the x86 relocation synthesizer, and a couple of new options for symbols.

Tested using:
```shell
nix run --impure --expr "with builtins.getFlake \"git+file://$PWD\"; with legacyPackages.\${builtins.currentSystem}; ghidra.withExtensions (_: [ ghidra-extensions.ghidra-delinker-extension ])"
```

Full release notes: https://github.com/boricj/ghidra-delinker-extension/releases/tag/v0.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
