### PR TITLE
haskell.ghc910: overrides for cabal-install and haskell-language-server.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -52,7 +52,7 @@ self: super: {
       cabalInstallOverlay = cself: csuper:
         {
           hackage-security = self.hackage-security_0_6_2_6;
-        } // lib.optionalAttrs (lib.versionOlder self.ghc.version "9.10") {
+        } // lib.optionalAttrs (lib.versionOlder self.ghc.version "9.10.2") {
           Cabal = cself.Cabal_3_12_1_0;
           Cabal-syntax = cself.Cabal-syntax_3_12_1_0;
         };

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -1,5 +1,7 @@
 { pkgs, haskellLib }:
 
+with haskellLib;
+
 let
   inherit (pkgs) lib;
 
@@ -14,7 +16,7 @@ self: super: {
   base = null;
   binary = null;
   bytestring = null;
-  Cabal = null;
+  Cabal = doDistribute self.Cabal_3_12_1_0; # GHC ships with Cabal 3.12.0.0, but there is no corresponding cabal-install
   Cabal-syntax = null;
   containers = null;
   deepseq = null;
@@ -46,7 +48,7 @@ self: super: {
   system-cxx-std-lib = null;
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
-  terminfo = if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then null else haskellLib.doDistribute self.terminfo_0_4_1_6;
+  terminfo = if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then null else doDistribute self.terminfo_0_4_1_6;
   text = null;
   time = null;
   transformers = null;
@@ -55,4 +57,67 @@ self: super: {
 
   # https://gitlab.haskell.org/ghc/ghc/-/issues/23392
   gi-gtk = disableParallelBuilding super.gi-gtk;
+
+  #
+  # Version upgrades
+  #
+
+  # Upgrade to accommodate new core library versions, where the authors have
+  # already made the relevant changes.
+  aeson = doDistribute self.aeson_2_2_3_0;
+  apply-refact = doDistribute self.apply-refact_0_14_0_0;
+  attoparsec-aeson = doDistribute self.attoparsec-aeson_2_2_2_0;
+  extensions = doDistribute self.extensions_0_1_0_2;
+  hashable = doDistribute self.hashable_1_4_7_0;
+  integer-conversion = doDistribute self.integer-conversion_0_1_1;
+  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_10_1_20240511;
+  lens = doDistribute self.lens_5_3_2;
+  lukko = doDistribute self.lukko_0_1_2;
+  primitive = doDistribute (dontCheck self.primitive_0_9_0_0); # tests introduce a recursive dependency via hspec
+  quickcheck-instances = doDistribute self.quickcheck-instances_0_3_31;
+  rebase = doDistribute self.rebase_1_21_1;
+  rerebase = doDistribute self.rerebase_1_21_1;
+  scientific = doDistribute self.scientific_0_3_8_0;
+  semirings = doDistribute self.semirings_0_7;
+  th-abstraction = doDistribute self.th-abstraction_0_7_0_0;
+  uuid-types = doDistribute self.uuid-types_1_0_6;
+
+  # A given major version of ghc-exactprint only supports one version of GHC.
+  ghc-exactprint = doDistribute self.ghc-exactprint_1_10_0_0;
+  ghc-exactprint_1_10_0_0 = addBuildDepends [
+    self.Diff
+    self.extra
+    self.ghc-paths
+    self.silently
+    self.syb
+    self.HUnit
+  ] super.ghc-exactprint_1_10_0_0;
+
+  #
+  # Jailbreaks
+  #
+  base64 = doJailbreak super.base64; # base <4.20
+  commutative-semigroups = doJailbreak super.commutative-semigroups; # base <4.20
+  floskell = doJailbreak super.floskell; # base <4.20
+  lucid = doJailbreak super.lucid; # base <4.20
+  tar = doJailbreak super.tar; # base <4.20
+  tree-diff = doJailbreak super.tree-diff; # base <4.20
+  time-compat = doJailbreak super.time-compat; # base <4.20
+
+  bitvec = doJailbreak super.bitvec; # primitive <0.9
+
+  apply-refact_0_14_0_0 = doJailbreak super.apply-refact_0_14_0_0; # ghc-exactprint <1.9
+  retrie = doJailbreak super.retrie; # base <4.20, ghc<9.9, ghc-exactprint<1.9
+
+  hashable_1_4_7_0 = doJailbreak super.hashable_1_4_7_0; # relax bounds for QuickCheck, tasty, and tasty-quickcheck
+  hashable_1_5_0_0 = doJailbreak super.hashable_1_5_0_0; # relax bounds for QuickCheck, tasty, and tasty-quickcheck
+
+  #
+  # Test suite issues
+  #
+  call-stack = dontCheck super.call-stack; # expects the package to be named "main", but we generate a name
+  lifted-base = dontCheck super.lifted-base; # doesn't compile with transformers ==0.6.*
+  lukko_0_1_2 = dontCheck super.lukko_0_1_2; # doesn't compile with tasty ==1.4.*
+  resolv = dontCheck super.resolv; # doesn't compile with filepath ==1.5.*
+  primitive-unlifted = dontCheck super.primitive-unlifted; # doesn't compile with primitive ==0.9.*
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -16,7 +16,7 @@ self: super: {
   base = null;
   binary = null;
   bytestring = null;
-  Cabal = doDistribute self.Cabal_3_12_1_0; # GHC ships with Cabal 3.12.0.0, but there is no corresponding cabal-install
+  Cabal = null;
   Cabal-syntax = null;
   containers = null;
   deepseq = null;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -76,6 +76,7 @@ extra-packages:
   - haddock-api == 2.23.*               # required on GHC < 8.10.x
   - haddock-library ==1.7.*             # required by stylish-cabal-0.5.0.0
   - happy == 1.19.12                    # for ghcjs
+  - hashable == 1.4.7.0                 # allows GHC 9.10
   - hinotify == 0.3.9                   # for xmonad-0.26: https://github.com/kolmodin/hinotify/issues/29
   - ansi-wl-pprint >= 0.6 && < 0.7      # 2024-03-23: required for ghcjs
   - hlint == 3.2.8                      # 2022-09-21: needed for hls on ghc 8.8


### PR DESCRIPTION
## Description of changes

This adds package overrides for GHC 9.10.1 to make `cabal-install` compile.

It also gets `haskell-language-server` much closer, but unfortunately there's still a way to go. Right now I am blocked on no GHC 9.10.x-compatible version of `apply-refact`.

Apologies if this steps on anyone's toes or is not welcome. It was mostly born of frustration and a "how long can this possibly take?" attitude.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
