### PR TITLE
flameshot: fix build on Darwin

### DIFF
--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -1,13 +1,14 @@
-{ libsForQt5
-, stdenv
-, lib
-, fetchFromGitHub
-, cmake
-, nix-update-script
-, fetchpatch
-, grim
-, makeBinaryWrapper
-, enableWlrSupport ? false
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  libsForQt5,
+  grim,
+  makeBinaryWrapper,
+  nix-update-script,
+  enableWlrSupport ? false,
 }:
 
 stdenv.mkDerivation {
@@ -31,12 +32,6 @@ stdenv.mkDerivation {
       hash = "sha256-SnjVbFMDKD070vR4vGYrwLw6scZAFaQA4b+MbI+0W9E=";
     })
   ];
-
-  passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [ "--version=branch" ];
-    };
-  };
 
   cmakeFlags = [
     (lib.cmakeBool "USE_WAYLAND_CLIPBOARD" true)
@@ -64,11 +59,18 @@ stdenv.mkDerivation {
       ''${qtWrapperArgs[@]}
   '';
 
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+  };
+
   meta = with lib; {
     description = "Powerful yet simple to use screenshot software";
     homepage = "https://github.com/flameshot-org/flameshot";
     mainProgram = "flameshot";
-    maintainers = with maintainers; [ scode oxalica ];
+    maintainers = with maintainers; [
+      scode
+      oxalica
+    ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -1,9 +1,13 @@
 {
   stdenv,
   lib,
+  overrideSDK,
+  darwin,
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  imagemagick,
+  libicns,
   libsForQt5,
   grim,
   makeBinaryWrapper,
@@ -12,7 +16,13 @@
   enableMonochromeIcon ? false,
 }:
 
-stdenv.mkDerivation {
+assert stdenv.isDarwin -> (!enableWlrSupport);
+
+let
+  stdenv' = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+in
+
+stdenv'.mkDerivation {
   pname = "flameshot";
   # wlr screenshotting is currently only available on unstable version (>12.1.0)
   version = "12.1.0-unstable-2024-08-02";
@@ -42,28 +52,67 @@ stdenv.mkDerivation {
     ++ lib.optionals stdenv.isLinux [
       (lib.cmakeBool "USE_WAYLAND_CLIPBOARD" true)
       (lib.cmakeBool "USE_WAYLAND_GRIM" enableWlrSupport)
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      (lib.cmakeFeature "Qt5_DIR" "${libsForQt5.qtbase.dev}/lib/cmake/Qt5")
     ];
 
-  nativeBuildInputs = [
-    cmake
-    libsForQt5.qttools
-    libsForQt5.qtsvg
-    libsForQt5.wrapQtAppsHook
-    makeBinaryWrapper
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      libsForQt5.qttools
+      libsForQt5.qtsvg
+      libsForQt5.wrapQtAppsHook
+      makeBinaryWrapper
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      imagemagick
+      libicns
+    ];
 
   buildInputs = [
     libsForQt5.qtbase
     libsForQt5.kguiaddons
   ];
 
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    # Fix icns generation running concurrently with png generation
+    sed -E -i '/"iconutil -o/i\
+        )\
+        execute_process(\
+    ' src/CMakeLists.txt
+
+    # Replace unavailable commands
+    sed -E -i \
+        -e 's/"sips -z ([0-9]+) ([0-9]+) +(.+) --out /"magick \3 -resize \1x\2\! /' \
+        -e 's/"iconutil -o (.+) -c icns (.+)"/"png2icns \1 \2\/*{16,32,128,256,512}.png"/' \
+        src/CMakeLists.txt
+  '';
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    mkdir $out/Applications
+    mv $out/bin/flameshot.app $out/Applications
+
+    ln -s $out/Applications/flameshot.app/Contents/MacOS/flameshot $out/bin/flameshot
+
+    rm -r $out/share/applications
+    rm -r $out/share/dbus*
+    rm -r $out/share/icons
+    rm -r $out/share/metainfo
+  '';
+
   dontWrapQtApps = true;
 
-  postFixup = ''
-    wrapProgram $out/bin/flameshot \
-      ${lib.optionalString enableWlrSupport "--prefix PATH : ${lib.makeBinPath [ grim ]}"} \
-      ''${qtWrapperArgs[@]}
-  '';
+  postFixup =
+    let
+      binary =
+        if stdenv.isDarwin then "Applications/flameshot.app/Contents/MacOS/flameshot" else "bin/flameshot";
+    in
+    ''
+      wrapProgram $out/${binary} \
+        ${lib.optionalString enableWlrSupport "--prefix PATH : ${lib.makeBinPath [ grim ]}"} \
+        ''${qtWrapperArgs[@]}
+    '';
 
   passthru = {
     updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };

--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -9,6 +9,7 @@
   makeBinaryWrapper,
   nix-update-script,
   enableWlrSupport ? false,
+  enableMonochromeIcon ? false,
 }:
 
 stdenv.mkDerivation {
@@ -33,10 +34,15 @@ stdenv.mkDerivation {
     })
   ];
 
-  cmakeFlags = [
-    (lib.cmakeBool "USE_WAYLAND_CLIPBOARD" true)
-    (lib.cmakeBool "USE_WAYLAND_GRIM" enableWlrSupport)
-  ];
+  cmakeFlags =
+    [
+      (lib.cmakeBool "DISABLE_UPDATE_CHECKER" true)
+      (lib.cmakeBool "USE_MONOCHROME_ICON" enableMonochromeIcon)
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      (lib.cmakeBool "USE_WAYLAND_CLIPBOARD" true)
+      (lib.cmakeBool "USE_WAYLAND_GRIM" enableWlrSupport)
+    ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Description of changes

Fix build on Darwin.

Closes #334739.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
