### PR TITLE
python3Packages.matrix-nio: relax dependency aiohttp-socks

### DIFF
--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -65,6 +65,10 @@ buildPythonPackage rec {
     unpaddedbase64
   ];
 
+  pythonRelaxDeps = [
+    "aiohttp-socks" # Pending matrix-nio/matrix-nio#516
+  ];
+
   passthru.optional-dependencies = {
     e2e = [
       atomicwrites


### PR DESCRIPTION
## Description of changes

matrix-nio [specifies](https://github.com/matrix-nio/matrix-nio/blob/0.24.0/pyproject.toml#L34) aiohttp-socks 0.8 but nixpkgs [provides](https://github.com/NixOS/nixpkgs/pull/335432) 0.9. The [changes](https://github.com/romis2012/aiohttp-socks/compare/v0.8.4...v0.9.0) introduced in 0.9 are internal and compatible with matrix-nio, so nixpkgs may simply relax the version specification. matrix-nio/matrix-nio#516 proposes to do the same upstream.

Resolves:

```console
Running phase: pythonRuntimeDepsCheckHook
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for matrix_nio-0.24.0-py3-none-any.whl
  - aiohttp-socks<0.9.0,>=0.8.4 not satisfied by version 0.9.0
error: build of '/nix/store/…-python3.12-matrix-nio-0.24.0.drv' failed: builder for '/nix/store/…-python3.12-matrix-nio-0.24.0.drv' failed with exit code 1
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
