### PR TITLE
dr-robotniks-ring-racers: init at 2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1096,6 +1096,13 @@
     name = "alyaeanyx";
     keys = [ { fingerprint = "1F73 8879 5E5A 3DFC E2B3 FA32 87D1 AADC D25B 8DEE"; } ];
   };
+  amadalusia = {
+    email = "balkenix@outlook.com";
+    github = "amadalusia";
+    githubId = "77496597";
+    name = "Artur Manuel";
+    keys = [ { fingerprint = "CE75 09F4 6A54 9161 9B5F EACE EEDC F0D7 7ECE F174"; } ];
+  };
   amadejkastelic = {
     email = "amadejkastelic7@gmail.com";
     github = "amadejkastelic";

--- a/pkgs/by-name/dr/dr-robotniks-ring-racers/package.nix
+++ b/pkgs/by-name/dr/dr-robotniks-ring-racers/package.nix
@@ -1,0 +1,67 @@
+{
+  clangStdenv,
+  fetchgit,
+  lib,
+  cmake,
+  zlib,
+  curl,
+  libpng,
+  libogg,
+  libvorbis,
+  libvpx,
+  libyuv,
+  SDL2,
+  makeWrapper,
+  fetchzip,
+}:
+let
+  pname = "dr-robotniks-ring-racers";
+  version = "2.3";
+  assets = fetchzip {
+    curlOptsList = [ "-L" ];
+    stripRoot = false;
+    url = "https://github.com/KartKrewDev/RingRacers/releases/download/v${version}/Dr.Robotnik.s-Ring-Racers-v${version}-Assets.zip";
+    hash = "sha256-sHeI1E6uNF0gBNd1e1AU/JT9wyZdkCQgYLiMPZqXAVc=";
+  };
+in
+clangStdenv.mkDerivation {
+  inherit pname version;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    zlib
+    curl
+    libpng
+    libogg
+    libvorbis
+    libvpx
+    libyuv
+    SDL2
+    makeWrapper
+  ];
+
+  src = fetchgit {
+    url = "https://git.do.srb2.org/KartKrew/RingRacers.git";
+    rev = "03241a13c5b22f567577c2cb06c4bbfb2f8e3cc9";
+    hash = "sha256-X2rSwZOEHtnSJBpu+Xf2vkxGUAZSNSXi6GCuGlM6jhY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"/bin "$out"/share/games
+    install -Dm755 bin/ringracers "$out"/bin
+    cp -R ${assets} "$out"/share/games/RingRacers
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://www.kartkrew.org/";
+    description = "Dr. Robotnik’s Ring Racers is a Technical Kart Racer, drawing inspiration from antigrav racers, fighting games, and traditional-style kart racing.";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.amadalusia ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes
I have added myself to the list of maintainers, and along with that I have added Dr. Robotnik's Ring Racers package in `pkgs/by-name/dr/dr-robotniks-ring-racers`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
“Dr. Robotnik’s Ring Racers” is a Technical Kart Racer, drawing inspiration from “antigrav” racers, fighting games, and traditional-style kart racing.

Designed to minimize randomness and emphasize player expression, Ring Racers isn’t just about precise handling—you’ll need to master tense combat, resource management, and taking risks under pressure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
