### PR TITLE
python3Packages.matrix-nio: permit insecure Olm during check phase

### DIFF
--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -40,6 +40,21 @@
   zulip,
 }:
 
+let
+  permitInsecureOlm = map (
+    pythonPackage:
+    pythonPackage.override (
+      lib.optionalAttrs (pythonPackage.pname == "python-olm") (
+        let
+          olm = lib.findFirst (p: p.pname == "olm") null pythonPackage.buildInputs;
+        in
+        {
+          olm = olm.overrideAttrs (lib.addMetaAttrs { knownVulnerabilities = [ ]; });
+        }
+      )
+    )
+  );
+in
 buildPythonPackage rec {
   pname = "matrix-nio";
   version = "0.24.0";
@@ -83,7 +98,7 @@ buildPythonPackage rec {
     pytest-aiohttp
     pytest-benchmark
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.e2e;
+  ] ++ permitInsecureOlm passthru.optional-dependencies.e2e;
 
   pytestFlagsArray = [ "--benchmark-disable" ];
 


### PR DESCRIPTION
## Description of changes

Olm has a [known vulnerability](https://github.com/NixOS/nixpkgs/pull/334638) but is only an [optional dependency](https://github.com/matrix-nio/matrix-nio/blob/0.24.0/pyproject.toml#L37) of nio, so in theory nio should by default be unaffected. nio’s tests, however, cover its full suite of extra features, so Olm is still evaluated as a dependency of the check phase. Since the check phase doesn’t process user data or access the network this vulnerability isn’t relevant and can be ignored, allowing nio to evaluate and ultimately be run without Olm.

I’m not confident in this implementation. Is there a tidier way to do it? Should the permission be narrowed to specifically this vulnerability? I haven’t found any precedent for this and wonder if something like a `checkPhasePermittedInsecurePackages` would be warranted.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `git cherry-pick NixOS/#336651 && nixpkgs-review rev HEAD`.
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
