### PR TITLE
densify: init at 0.3.2

### DIFF
--- a/pkgs/by-name/de/densify/package.nix
+++ b/pkgs/by-name/de/densify/package.nix
@@ -1,0 +1,78 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+  python3,
+  gtk3,
+  gobject-introspection,
+  wrapGAppsHook3,
+  xorg,
+  gnugrep,
+  ghostscript,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "densify";
+  version = "0.3.2";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "hkdb";
+    repo = "Densify";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-giFFy8HiSmnOqFKLyrPD1kTry8hMQxotEgD/u2FEMRY=";
+  };
+
+  postPatch = ''
+    # Fix fail loading program icon from runtime path
+    substituteInPlace densify \
+      --replace-fail "/icon.png" "/../share/densify/icon.png"
+  '';
+
+  dependencies = with python3Packages; [ pygobject3 ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [ gtk3 ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${
+        lib.makeBinPath [
+          ghostscript
+          gnugrep
+          xorg.xrandr
+        ]
+      }"
+    )
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin densify
+    install -Dm644 -t $out/share/applications densify.desktop
+    install -Dm644 -t $out/share/densify desktop-icon.png icon.png
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/share/applications/densify.desktop \
+      --replace-fail "/opt/Densify/densify" "densify" \
+      --replace-fail "Path=/opt/Densify/" "Path=$out/bin/" \
+      --replace-fail "/opt/Densify/desktop-icon.png" "$out/share/densify/desktop-icon.png"
+  '';
+
+  meta = {
+    description = "Compress PDF files with Ghostscript";
+    homepage = "https://github.com/hkdb/Densify";
+    changelog = "https://github.com/hkdb/Densify/blob/${src.rev}/README.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ onny ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Packaging [Densify](https://github.com/hkdb/Densify),  a GTK+ GUI application written in Python that simplifies compressing PDF files with Ghostscript 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
