### PR TITLE
scala-next: Init at 3.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5394,6 +5394,12 @@
     name = "Misha Gusarov";
     keys = [ { fingerprint = "A8DF 1326 9E5D 9A38 E57C  FAC2 9D20 F650 3E33 8888"; } ];
   };
+  dottybot = {
+    name = "Scala Organization (dottybot)";
+    email = "dottybot@groupes.epfl.ch";
+    github = "dottybot";
+    githubId = 12519979;
+  };
   dpaetzel = {
     email = "david.paetzel@posteo.de";
     github = "dpaetzel";
@@ -7981,6 +7987,12 @@
     github = "moredhel";
     githubId = 1742172;
     name = "Hamish Hutchings";
+  };
+  hamzaremmal = {
+    email = "hamza.remmal@epfl.ch";
+    github = "hamzaremmal";
+    githubId = 56235032;
+    name = "Hamza Remmal";
   };
   hanemile = {
     email = "mail@emile.space";
@@ -14381,6 +14393,13 @@
     github = "nathyong";
     githubId = 818502;
     name = "Nathan Yong";
+  };
+  natsukagami = {
+    email = "natsukagami@gmail.com";
+    github = "natsukagami";
+    githubId = 9061737;
+    name = "Natsu Kagami";
+    keys = [ { fingerprint = "5581 26DC 886F E14D 501D  B0F2 D6AD 7B57 A992 460C"; } ];
   };
   natsukium = {
     email = "nixpkgs@natsukium.com";

--- a/pkgs/by-name/sc/scala-next/package.nix
+++ b/pkgs/by-name/sc/scala-next/package.nix
@@ -1,0 +1,10 @@
+{ scala, fetchurl }:
+
+scala.bare.overrideAttrs (oldAttrs: {
+  version = "3.5.1";
+  pname = "scala-next";
+  src = fetchurl {
+    inherit (oldAttrs.src) url;
+    hash = "sha256-pRfoCXFVnnEh3zyB9HbUZK3qrQ94Gq3iXX2fWGS/l9o=";
+  };
+})

--- a/pkgs/development/compilers/scala/bare.nix
+++ b/pkgs/development/compilers/scala/bare.nix
@@ -1,15 +1,25 @@
-{ lib, stdenv, fetchurl, makeWrapper, jre, ncurses }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  jre,
+  ncurses,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "3.3.3";
   pname = "scala-bare";
 
   src = fetchurl {
-    url = "https://github.com/lampepfl/dotty/releases/download/${version}/scala3-${version}.tar.gz";
+    url = "https://github.com/scala/scala3/releases/download/${finalAttrs.version}/scala3-${finalAttrs.version}.tar.gz";
     hash = "sha256-61lAETEvqkEqr5pbDltFkh+Qvp+EnCDilXN9X67NFNE=";
   };
 
-  propagatedBuildInputs = [ jre ncurses.dev ] ;
+  propagatedBuildInputs = [
+    jre
+    ncurses.dev
+  ];
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
@@ -20,23 +30,24 @@ stdenv.mkDerivation rec {
   # Use preFixup instead of fixupPhase
   # because we want the default fixupPhase as well
   preFixup = ''
-        bin_files=$(find $out/bin -type f ! -name common)
-        for f in $bin_files ; do
-          wrapProgram $f --set JAVA_HOME ${jre} --prefix PATH : '${ncurses.dev}/bin'
-        done
+    bin_files=$(find $out/bin -type f ! -name "*common*" ! -name "scala-cli.jar")
+    for f in $bin_files ; do
+      wrapProgram $f --set JAVA_HOME ${jre} --prefix PATH : '${ncurses.dev}/bin'
+    done
   '';
 
   meta = with lib; {
-    description = "Research platform for new language concepts and compiler technologies for Scala";
-    longDescription = ''
-       Dotty is a platform to try out new language concepts and compiler technologies for Scala.
-       The focus is mainly on simplification. We remove extraneous syntax (e.g. no XML literals),
-       and try to boil down Scala’s types into a smaller set of more fundamental constructs.
-       The theory behind these constructs is researched in DOT, a calculus for dependent object types.
-    '';
-    homepage = "http://dotty.epfl.ch/";
-    license = licenses.bsd3;
+    description = "The Scala 3 compiler, also known as Dotty";
+    homepage = "https://scala-lang.org/";
+    license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ karolchmist virusdave kashw2 ];
+    maintainers = with maintainers; [
+      karolchmist
+      virusdave
+      kashw2
+      natsukagami
+      hamzaremmal
+      dottybot
+    ];
   };
-}
+})

--- a/pkgs/development/compilers/scala/default.nix
+++ b/pkgs/development/compilers/scala/default.nix
@@ -1,8 +1,19 @@
-{ stdenv, fetchurl, makeWrapper, jre, callPackage }:
+{
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  jre,
+  callPackage,
+}:
 
 let
   bare = callPackage ./bare.nix {
-    inherit stdenv fetchurl makeWrapper jre;
+    inherit
+      stdenv
+      fetchurl
+      makeWrapper
+      jre
+      ;
   };
 in
 
@@ -21,4 +32,7 @@ stdenv.mkDerivation {
   '';
 
   inherit (bare) meta;
-} // { inherit bare; }
+}
+// {
+  inherit bare;
+}


### PR DESCRIPTION
## Description of changes
This change allows to use the latest non-LTS scala version which is currently 3.5.1. Since 3.5.1 now ships with the `scala-cli` I needed to modify the `preFixup` attribute.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
