### PR TITLE
ocamlPackages.lockfree: 0.4.0 → 0.5.0

### DIFF
--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -42,7 +42,6 @@ buildDunePackage' rec {
     cmdliner
     containers-data
     digestif
-    domainslib
     eio_main
     lwd
     nottui

--- a/pkgs/development/ocaml-modules/backoff/default.nix
+++ b/pkgs/development/ocaml-modules/backoff/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, fetchurl, alcotest}:
+
+buildDunePackage rec {
+  pname = "backoff";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/backoff/releases/download/${version}/backoff-${version}.tbz";
+    hash = "sha256-EaSseCKekNE03gaNiqh5Y11r8TF9XulR9AZboPWMIwA=";
+  };
+
+  doCheck = true;
+
+  checkInputs = [ alcotest ];
+
+  meta = {
+    description = "Exponential backoff mechanism for OCaml";
+    homepage = "https://github.com/ocaml-multicore/backoff";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+  minimalOCamlVersion = "4.13";
+}

--- a/pkgs/development/ocaml-modules/domainslib/default.nix
+++ b/pkgs/development/ocaml-modules/domainslib/default.nix
@@ -29,5 +29,6 @@ buildDunePackage rec {
     description = "Nested-parallel programming";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
+    broken = true; # Not compatible with saturn > 0.4.0
   };
 }

--- a/pkgs/development/ocaml-modules/multicore-bench/default.nix
+++ b/pkgs/development/ocaml-modules/multicore-bench/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, fetchurl
+, domain-local-await, mtime, multicore-magic, yojson
+}:
+
+buildDunePackage rec {
+  pname = "multicore-bench";
+  version = "0.1.4";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/multicore-bench/releases/download/${version}/multicore-bench-${version}.tbz";
+    hash = "sha256-iCx5QvhYo/e53cW23Sza2as4aez4HeESVvLPF1DW85A=";
+  };
+
+  propagatedBuildInputs = [ domain-local-await mtime multicore-magic yojson ];
+
+  meta = {
+    description = "Framework for writing multicore benchmark executables to run on current-bench";
+    homepage = "https://github.com/ocaml-multicore/multicore-bench";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/multicore-magic/default.nix
+++ b/pkgs/development/ocaml-modules/multicore-magic/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, fetchurl
+, alcotest, domain_shims
+}:
+
+buildDunePackage rec {
+  pname = "multicore-magic";
+  version = "2.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/multicore-magic/releases/download/${version}/multicore-magic-${version}.tbz";
+    hash = "sha256-r50UqLOd2DoTz0CEXHpJMHX0fty+mGiAKTdtykgnzu4=";
+  };
+
+  doCheck = true;
+
+  checkInputs = [ alcotest domain_shims ];
+
+  meta = {
+    description = "Low-level multicore utilities for OCaml";
+    license = lib.licenses.isc;
+    homepage = "https://github.com/ocaml-multicore/multicore-magic";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/saturn/default.nix
+++ b/pkgs/development/ocaml-modules/saturn/default.nix
@@ -1,6 +1,8 @@
 { lib, buildDunePackage, ocaml
 , saturn_lockfree
+, domain_shims
 , dscheck
+, multicore-bench
 , qcheck, qcheck-alcotest, qcheck-stm
 }:
 
@@ -12,7 +14,14 @@ buildDunePackage rec {
   propagatedBuildInputs = [ saturn_lockfree ];
 
   doCheck = lib.versionAtLeast ocaml.version "5.0";
-  checkInputs = [ dscheck qcheck qcheck-alcotest qcheck-stm ];
+  checkInputs = [
+    domain_shims
+    dscheck
+    multicore-bench
+    qcheck
+    qcheck-alcotest
+    qcheck-stm
+  ];
 
   meta = saturn_lockfree.meta // {
     description = "Parallelism-safe data structures for multicore OCaml";

--- a/pkgs/development/ocaml-modules/saturn/lockfree.nix
+++ b/pkgs/development/ocaml-modules/saturn/lockfree.nix
@@ -1,19 +1,19 @@
 { lib, fetchurl, buildDunePackage
-, domain_shims
+, backoff, multicore-magic
 }:
 
 buildDunePackage rec {
   pname = "saturn_lockfree";
-  version = "0.4.0";
+  version = "0.5.0";
 
-  minimalOCamlVersion = "4.12";
+  minimalOCamlVersion = "4.13";
 
   src = fetchurl {
     url = "https://github.com/ocaml-multicore/saturn/releases/download/${version}/saturn-${version}.tbz";
-    hash = "sha256-fHvslaJwVbQaqDVA/MHGqHybetYbxRGlMrhgXqM3iPs=";
+    hash = "sha256-ZmmxwIe5PiPYTTdvOHbOjRbv2b/bb9y0IekByfREPjk=";
   };
 
-  propagatedBuildInputs = [ domain_shims ];
+  propagatedBuildInputs = [ backoff multicore-magic ];
 
   meta = {
     description = "Lock-free data structures for multicore OCaml";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1201,6 +1201,8 @@ let
 
     mtime =  callPackage ../development/ocaml-modules/mtime { };
 
+    multicore-bench =  callPackage ../development/ocaml-modules/multicore-bench { };
+
     multicore-magic =  callPackage ../development/ocaml-modules/multicore-magic { };
 
     multipart-form-data =  callPackage ../development/ocaml-modules/multipart-form-data { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1199,6 +1199,8 @@ let
 
     mtime =  callPackage ../development/ocaml-modules/mtime { };
 
+    multicore-magic =  callPackage ../development/ocaml-modules/multicore-magic { };
+
     multipart-form-data =  callPackage ../development/ocaml-modules/multipart-form-data { };
 
     mustache =  callPackage ../development/ocaml-modules/mustache { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -64,6 +64,8 @@ let
 
     b0 = callPackage ../development/ocaml-modules/b0 { };
 
+    backoff = callPackage ../development/ocaml-modules/backoff { };
+
     bap = janeStreet_0_15.bap;
 
     base64 = callPackage ../development/ocaml-modules/base64 { };


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/ocaml-multicore/saturn/0.5.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
