### PR TITLE
mongodb-ce: fix darwin build

### DIFF
--- a/pkgs/by-name/mo/mongodb-ce/package.nix
+++ b/pkgs/by-name/mo/mongodb-ce/package.nix
@@ -45,7 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
       or (throw "unsupported system: ${stdenv.hostPlatform.system}")
   );
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  dontStrip = true;
 
   buildInputs = [
     # This is to avoid the following error:


### PR DESCRIPTION
It's failing on `x86_64-darwin`:

```
install: skipping file '/dev/fd/63', as it was replaced while being copied
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
install: skipping file '/dev/fd/63', as it was replaced while being copied
unpacking source archive /nix/store/27msp8r5kmcqx78zmvx18jyhg331f9di-mongodb-macos-x86_64-7.0.12.tgz
source root is mongodb-macos-x86_64-7.0.12
setting SOURCE_DATE_EPOCH to timestamp 1719341791 of file mongodb-macos-x86_64-7.0.12/bin/mongos
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
install: skipping file '/dev/fd/63', as it was replaced while being copied
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
install: skipping file '/dev/fd/63', as it was replaced while being copied
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
install: skipping file '/dev/fd/63', as it was replaced while being copied
no Makefile or custom buildPhase, doing nothing
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
install: skipping file '/dev/fd/63', as it was replaced while being copied
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
install: skipping file '/dev/fd/63', as it was replaced while being copied
checking for references to /private/tmp/nix-build-mongodb-ce-7.0.12.drv-0/ in /nix/store/m0dvrwgr5zwpxw4s5mq8p8vsrpp0z5iz-mongodb-ce-7.0.12...
patching script interpreter paths in /nix/store/m0dvrwgr5zwpxw4s5mq8p8vsrpp0z5iz-mongodb-ce-7.0.12
stripping (with command strip and flags -S) in  /nix/store/m0dvrwgr5zwpxw4s5mq8p8vsrpp0z5iz-mongodb-ce-7.0.12/bin
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: /nix/store/xwa9wwj8yjk0mk5xnxbkrp2a37vn4i0w-cctools-binutils-darwin-1010.6/bin/strip --enable-deterministic-archives -S /nix/store/m0dvrwgr5zwpxw4s5mq8p8vsrpp0z5iz-mongodb-ce-7.0.12/bin/mongos
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  libLLVM.dylib            0x000000010f7d26cc llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 60
1  libLLVM.dylib            0x000000010f7d1518 llvm::sys::RunSignalHandlers() + 264
2  libLLVM.dylib            0x000000010f7d2dc9 SignalHandler(int) + 361
3  libsystem_platform.dylib 0x00007ff8054ccfdd _sigtramp + 29
4  libcorecrypto.dylib      0x00007ff80521563e cbc_wrapper_aesni + 38
5  libLLVM.dylib            0x000000011112a592 llvm::objcopy::macho::MachOWriter::writeTail() + 1506
6  libLLVM.dylib            0x000000011112a988 llvm::objcopy::macho::MachOWriter::write() + 248
7  libLLVM.dylib            0x000000011111ed4a llvm::objcopy::macho::executeObjcopyOnBinary(llvm::objcopy::CommonConfig const&, llvm::objcopy::MachOConfig const&, llvm::object::MachOObjectFile&, llvm::raw_ostream&) + 11642
8  libLLVM.dylib            0x00000001110d9689 llvm::objcopy::executeObjcopyOnBinary(llvm::objcopy::MultiFormatConfig const&, llvm::object::Binary&, llvm::raw_ostream&) + 249
9  llvm-objcopy             0x000000010769174f std::__1::__function::__func<executeObjcopy(llvm::objcopy::ConfigManager&)::$_2, std::__1::allocator<executeObjcopy(llvm::objcopy::ConfigManager&)::$_2>, llvm::Error (llvm::raw_ostream&)>::operator()(llvm::ra>
10 libLLVM.dylib            0x000000010f7b6f0d llvm::writeToOutput(llvm::StringRef, std::__1::function<llvm::Error (llvm::raw_ostream&)>) + 285
11 llvm-objcopy             0x00000001076902f7 llvm_objcopy_main(int, char**) + 2583
12 dyld                     0x00007ff805112345 start + 1909
xargs: strip: terminated by signal 11
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: /nix/store/xwa9wwj8yjk0mk5xnxbkrp2a37vn4i0w-cctools-binutils-darwin-1010.6/bin/strip --enable-deterministic-archives -S /nix/store/m0dvrwgr5zwpxw4s5mq8p8vsrpp0z5iz-mongodb-ce-7.0.12/bin/mongod
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  libLLVM.dylib            0x00000001097d26cc llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 60
1  libLLVM.dylib            0x00000001097d1518 llvm::sys::RunSignalHandlers() + 264
2  libLLVM.dylib            0x00000001097d2dc9 SignalHandler(int) + 361
3  libsystem_platform.dylib 0x00007ff8054ccfdd _sigtramp + 29
4  libcorecrypto.dylib      0x00007ff80521563e cbc_wrapper_aesni + 38
5  libLLVM.dylib            0x000000010b12a592 llvm::objcopy::macho::MachOWriter::writeTail() + 1506
6  libLLVM.dylib            0x000000010b12a988 llvm::objcopy::macho::MachOWriter::write() + 248
7  libLLVM.dylib            0x000000010b11ed4a llvm::objcopy::macho::executeObjcopyOnBinary(llvm::objcopy::CommonConfig const&, llvm::objcopy::MachOConfig const&, llvm::object::MachOObjectFile&, llvm::raw_ostream&) + 11642
8  libLLVM.dylib            0x000000010b0d9689 llvm::objcopy::executeObjcopyOnBinary(llvm::objcopy::MultiFormatConfig const&, llvm::object::Binary&, llvm::raw_ostream&) + 249
9  llvm-objcopy             0x000000010167774f std::__1::__function::__func<executeObjcopy(llvm::objcopy::ConfigManager&)::$_2, std::__1::allocator<executeObjcopy(llvm::objcopy::ConfigManager&)::$_2>, llvm::Error (llvm::raw_ostream&)>::operator()(llvm::ra>
10 libLLVM.dylib            0x00000001097b6f0d llvm::writeToOutput(llvm::StringRef, std::__1::function<llvm::Error (llvm::raw_ostream&)>) + 285
11 llvm-objcopy             0x00000001016762f7 llvm_objcopy_main(int, char**) + 2583
12 dyld                     0x00007ff805112345 start + 1909
xargs: strip: terminated by signal 11
```


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
