### PR TITLE
petsc: removed default unfree dependencies

### DIFF
--- a/pkgs/applications/science/math/getdp/default.nix
+++ b/pkgs/applications/science/math/getdp/default.nix
@@ -1,6 +1,8 @@
 { lib, stdenv, fetchurl, cmake, gfortran, blas, lapack, mpi, petsc, python3 }:
 
-stdenv.mkDerivation rec {
+let
+  mpiSupport = petsc.passthru.mpiSupport;
+in stdenv.mkDerivation rec {
   pname = "getdp";
   version = "3.6.0";
   src = fetchurl {
@@ -8,7 +10,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-nzefwCV+Z9BHDofuTfhR+vhqm3cCSiUT+7cbtn601N8=";
   };
 
-  inherit (petsc) mpiSupport;
   nativeBuildInputs = [ cmake python3 ];
   buildInputs = [ gfortran blas lapack petsc ]
     ++ lib.optional mpiSupport mpi

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -15,6 +15,7 @@
   hdf5,
   metis,
   parmetis,
+  withParmetis ? false,
   pkg-config,
   p4est,
   zlib, # propagated by p4est but required by petsc
@@ -36,7 +37,6 @@ stdenv.mkDerivation rec {
   };
 
   inherit mpiSupport;
-  withp4est = petsc-withp4est;
 
   strictDeps = true;
   nativeBuildInputs = [
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     blas
     lapack
-  ] ++ lib.optional hdf5-support hdf5 ++ lib.optional withp4est p4est;
+  ] ++ lib.optional hdf5-support hdf5 ++ lib.optional petsc-withp4est p4est ++ lib.optionals withParmetis [ metis parmetis ];
 
   prePatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace config/install.py \
@@ -60,49 +60,42 @@ stdenv.mkDerivation rec {
   # These messages contaminate test output, which makes the quicktest suite to fail. The patch adds filtering for these messages.
   patches = [ ./filter_mpi_warnings.patch ];
 
+  configureFlags = [
+    "--with-blas=1"
+    "--with-lapack=1"
+    "--with-scalar-type=${petsc-scalar-type}"
+    "--with-precision=${petsc-precision}"
+    "--with-mpi=${if mpiSupport then "1" else "0"}"
+  ] ++ lib.optionals mpiSupport [
+    "--CC=mpicc"
+    "--with-cxx=mpicxx"
+    "--with-fc=mpif90"
+  ] ++ lib.optionals (mpiSupport && withParmetis) [
+    "--with-metis=1"
+    "--with-metis-dir=${metis}"
+    "--with-parmetis=1"
+    "--with-parmetis-dir=${parmetis}"
+  ] ++ lib.optionals petsc-optimized [
+    "--with-debugging=0"
+    "COPTFLAGS=-O3"
+    "FOPTFLAGS=-O3"
+    "CXXOPTFLAGS=-O3"
+    "CXXFLAGS=-O3"
+  ];
   preConfigure = ''
     patchShebangs ./lib/petsc/bin
-    configureFlagsArray=(
-      $configureFlagsArray
-      ${
-        if !mpiSupport then
-          ''
-            "--with-mpi=0"
-          ''
-        else
-          ''
-            "--CC=mpicc"
-            "--with-cxx=mpicxx"
-            "--with-fc=mpif90"
-            "--with-mpi=1"
-            "--with-metis=1"
-            "--with-metis-dir=${metis}"
-            "--with-parmetis=1"
-            "--with-parmetis-dir=${parmetis}"
-          ''
-      }
-      ${lib.optionalString withp4est ''
-        "--with-p4est=1"
-        "--with-zlib-include=${zlib.dev}/include"
-        "--with-zlib-lib=-L${zlib}/lib -lz"
-      ''}
-      ${lib.optionalString hdf5-support ''
-        "--with-hdf5=1"
-        "--with-hdf5-fortran-bindings=1"
-        "--with-hdf5-lib=-L${hdf5}/lib -lhdf5"
-        "--with-hdf5-include=${hdf5.dev}/include"
-      ''}
-      "--with-blas=1"
-      "--with-lapack=1"
-      "--with-scalar-type=${petsc-scalar-type}"
-      "--with-precision=${petsc-precision}"
-      ${lib.optionalString petsc-optimized ''
-        "--with-debugging=0"
-        COPTFLAGS='-O3'
-        FOPTFLAGS='-O3'
-        CXXOPTFLAGS='-O3'
-        CXXFLAGS='-O3'
-      ''}
+  '' + lib.optionalString petsc-withp4est ''
+    configureFlagsArray+=(
+      "--with-p4est=1"
+      "--with-zlib-include=${zlib.dev}/include"
+      "--with-zlib-lib=-L${zlib}/lib -lz"
+    )
+  '' + lib.optionalString hdf5-support ''
+    configureFlagsArray+=(
+      "--with-hdf5=1"
+      "--with-hdf5-fortran-bindings=1"
+      "--with-hdf5-include=${hdf5.dev}/include"
+      "--with-hdf5-lib=-L${hdf5}/lib -lhdf5"
     )
   '';
 

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -36,8 +36,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-dxHa8JUJCN4zRIXMCx7gcvbzFH2SPtkJ377ssIevjgU=";
   };
 
-  inherit mpiSupport;
-
   strictDeps = true;
   nativeBuildInputs = [
     python3
@@ -114,6 +112,10 @@ stdenv.mkDerivation rec {
   # the library is installed and available.
   doInstallCheck = true;
   installCheckTarget = "check_install";
+
+  passthru = {
+    inherit mpiSupport;
+  };
 
   meta = with lib; {
     description = "Portable Extensible Toolkit for Scientific computation";


### PR DESCRIPTION
## Description of changes

PETSc itself is opensource, however ParMETIS is not, which breaks building by default with unfree disabled. Added an off-by-default flag to build with METIS/ParMETIS.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
