### PR TITLE
nixos/openafsServer: give users the possibility of specifying privileged administrators declaratively

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -513,6 +513,8 @@
 
 - `programs.fzf.keybindings` now supports the fish shell.
 
+- The OpenAFS server module now supports setting the list of privileged administrator users declaratively via the `services.openafsServer.privilegedAdministrators` option.
+
 - `gerbera` now has wavpack support.
 
 - `ddclient` was updated from 3.11.2 to 4.0.0 [Release notes](https://github.com/ddclient/ddclient/releases/tag/v4.0.0)

--- a/nixos/modules/services/network-filesystems/openafs/server.nix
+++ b/nixos/modules/services/network-filesystems/openafs/server.nix
@@ -282,6 +282,27 @@ in
         '';
       };
 
+      privilegedAdministrators = mkOption {
+        default = null;
+        type = types.nullOr (types.listOf types.str);
+        description = ''
+          List of AFS principals that are allowed to carry out privileged
+          administrative operations. If set to null, AFS servers will use the
+          contents of any pre-existing {file}`/etc/openafs/server/UserList`
+          file, instead (see {manpage}`UserList(5)`).
+
+          ::: {.warning}
+          Changing the value of this attribute to anything other than null
+          deletes any pre-existing content from
+          {file}`/etc/openafs/server/UserList` on server startup. Further
+          changes to the list of privileged administrators via the {command}`bos
+          adduser` and {command}`bos removeuser` commands will also be discarded
+          at the next startup.
+          :::
+        '';
+        example = [ "root.admin" ];
+      };
+
     };
 
   };
@@ -337,9 +358,18 @@ in
           mkdir -m 0755 -p /var/openafs
           ${optionalString (netInfo != null) "cp ${netInfo} /var/openafs/netInfo"}
           ${optionalString useBuCellServDB "cp ${buCellServDB}"}
+        '' + lib.optionalString (cfg.privilegedAdministrators != null) ''
+          rm -f /etc/openafs/server/UserList
         '';
         serviceConfig = {
           ExecStart = "${openafsBin}/bin/bosserver -nofork";
+          ExecStartPost = mkIf (cfg.privilegedAdministrators != null)
+            (pkgs.writeShellScript "openafs-admin-init" ''
+               for admin in ${lib.escapeShellArgs cfg.privilegedAdministrators}
+               do
+                 ${openafsBin}/bin/bos adduser localhost "$admin" -localauth
+               done
+             '');
           ExecStop = "${openafsBin}/bin/bos shutdown localhost -wait -localauth";
         };
       };


### PR DESCRIPTION
## Description of changes
OpenAFS has the concept of "privileged administrators", a set of users that are given the ability of executing administrative operations on the local AFS server (see [UserList(5)](https://docs.openafs.org/Reference/5/UserList.html)). In order to configure this list of users, the system administrator must construct it imperatively via successive `bos adduser`/`bos removeuser` commands.

This change introduces a new setting, named `privilegedAdministrators`, which allows a system administrator to configure the list of privileged users declaratively, overwriting any pre-existing list. The original behavior is retained by default, or by setting `privilegedAdministrators = null`.

This addition represents a step forward towards achieving complete automatic deployment, easing the configuration of machines with volatile root partitions, and implementing automated tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
