### PR TITLE
python3Packages.pyobjc-core: init at 10.3.1

### DIFF
--- a/pkgs/development/python-modules/pyobjc-core/default.nix
+++ b/pkgs/development/python-modules/pyobjc-core/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  setuptools,
+  fetchPypi,
+  darwin,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-core";
+  version = "10.3.1";
+  src = fetchPypi {
+    pname = "pyobjc_core";
+    inherit version;
+    hash = "sha256-sgSoDMwHD5qz+K9COjolpv14fiKFCNAMTDD4rFOLpyA=";
+  };
+  pyproject = true;
+  build-system = [ setuptools ];
+
+
+  buildInputs = [
+    darwin.libffi
+  ];
+
+  checkPhase = ''
+    # TODO: This library does not follow standard testing with pytest
+    # and implemented its own test runner bootstrapping unittest
+    python3 setup.py test
+  '';
+
+  hardeningDisable = [ "strictoverflow" ]; # -fno-strict-overflow is not supported in clang on darwin
+  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=deprecated-declarations" ];
+  postPatch = ''
+    # TODO: Make patch for setup.py
+    # ignore the manual include flag for ffi, appears that it needs a very specific ffi from sdk (needs confirmation)
+    substituteInPlace setup.py --replace-fail '"-I/usr/include/ffi"' '#"-I/usr/include/ffi"'
+    # make os.path.exists that can spoil objc4 return True
+    substituteInPlace setup.py --replace-fail 'os.path.join(self.sdk_root, "usr/include/objc/runtime.h")' '"/"'
+
+    # Turn off clang’s Link Time Optimization, or else we can’t recognize (and link) Objective C .o’s:
+    sed -r 's/"-flto=[^"]+",//g' -i setup.py
+    # Fix some test code:
+    grep -RF '"sw_vers"' | cut -d: -f1 | while IFS= read -r file ; do
+      sed -r "s+"sw_vers"+"/usr/bin/sw_vers"+g" -i "$file"
+    done
+
+    # Disables broken tests and fixes some of them
+    # TODO: make a patch for tests
+    substituteInPlace \
+      PyObjCTest/test_nsdecimal.py \
+      --replace-fail "Cannot compare NSDecimal and decimal.Decimal" "Cannot compare NSDecimal and (\\\\w+.)?Decimal"
+    substituteInPlace \
+      PyObjCTest/test_bundleFunctions.py \
+      --replace-fail "os.path.expanduser(\"~\")" "\"/var/empty\""
+    substituteInPlace \
+      PyObjCTest/test_methodaccess.py \
+      --replace-fail "testClassThroughInstance2" \
+      "disable_testClassThroughInstance2"
+
+
+    # Fixes impurities in the package and fixes darwin min version
+    # TODO: Propose a patch that fixes it in a better way
+    # Force it to target our ‘darwinMinVersion’, it’s not recognized correctly:
+    grep -RF -- '-DPyObjC_BUILD_RELEASE=%02d%02d' | cut -d: -f1 | while IFS= read -r file ; do
+      sed -r '/-DPyObjC_BUILD_RELEASE=%02d%02d/{s/%02d%02d/${
+        lib.concatMapStrings (lib.fixedWidthString 2 "0") (
+          lib.splitString "." stdenv.targetPlatform.darwinMinVersion
+        )
+      }/;n;d;}' -i "$file"
+    done
+    # impurities:
+    ( grep -RF '/usr/bin/xcrun' || true ; ) | cut -d: -f1 | while IFS= read -r file ; do
+      sed -r "s+/usr/bin/xcrun+$(which xcrun)+g" -i "$file"
+    done
+    ( grep -RF '/usr/bin/python' || true ; ) | cut -d: -f1 | while IFS= read -r file ; do
+      sed -r "s+/usr/bin/python+$(which python)+g" -i "$file"
+    done
+  '';
+  meta = {
+    description = "The Python <-> Objective-C Bridge with bindings for macOS frameworks";
+    homepage = "https://pypi.org/project/pyobjc-core/";
+    platforms = lib.platforms.darwin;
+    maintainers = [ lib.maintainers.ferrine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12016,6 +12016,8 @@ self: super: with self; {
 
   pyobihai = callPackage ../development/python-modules/pyobihai { };
 
+  pyobjc-core = callPackage ../development/python-modules/pyobjc-core { };
+
   pyocd = callPackage ../development/python-modules/pyocd { };
 
   pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
