### PR TITLE
python3Packages.pymanopt: 2.2.0 -> 2.2.0-unstable-2024-07-10

### DIFF
--- a/pkgs/development/python-modules/pymanopt/default.nix
+++ b/pkgs/development/python-modules/pymanopt/default.nix
@@ -8,21 +8,31 @@
   autograd,
   matplotlib,
   pytestCheckHook,
+  setuptools-scm,
 }:
 
 buildPythonPackage rec {
   pname = "pymanopt";
-  version = "2.2.0";
-  format = "setuptools";
+  version = "2.2.0-unstable-2024-07-10";
+  pyproject = true;
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = "2.2.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-pDFRYhswcuAHG9pcqvzXIy3Ivhxe5R5Ric7AFRh7MK4=";
+    rev = "1de3b6f47258820fdc072fceaeaa763b9fd263b0";
+    hash = "sha256-j/fVeMgoLLBgRYFtSj2ZyNJb8iuWlnn2/YpBqUoCAFk=";
   };
 
-  propagatedBuildInputs = [
+  preConfigure = ''
+    substituteInPlace pyproject.toml --replace-fail "\"pip==22.3.1\"," ""
+  '';
+
+  build-system = [
+    setuptools-scm
+  ];
+  dependencies = [
     numpy
     scipy
     torch
@@ -35,14 +45,15 @@ buildPythonPackage rec {
 
   preCheck = ''
     substituteInPlace "tests/conftest.py" \
-      --replace "import tensorflow as tf" ""
+      --replace-fail "import tensorflow as tf" ""
     substituteInPlace "tests/conftest.py" \
-      --replace "tf.random.set_seed(seed)" ""
+      --replace-fail "tf.random.set_seed(seed)" ""
   '';
 
   disabledTestPaths = [
     "tests/test_examples.py"
     "tests/backends/test_tensorflow.py"
+    "tests/backends/test_jax.py"
     "tests/test_problem.py"
   ];
 
@@ -53,6 +64,5 @@ buildPythonPackage rec {
     homepage = "https://www.pymanopt.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ yl3dy ];
-    broken = lib.versionAtLeast scipy.version "1.10.0";
   };
 }


### PR DESCRIPTION
## Description of changes

Updated to the latest master and unmarked as broken, as it now works with the current scipy. See also #233629

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc