### PR TITLE
sscep: init at 0.10.0

### DIFF
--- a/pkgs/by-name/ss/sscep/package.nix
+++ b/pkgs/by-name/ss/sscep/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  openssl,
+  autoreconfHook,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sscep";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "certnanny";
+    repo = "sscep";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-wlxQONOCLPuNdI6AyMJoLP09cs+ak7Jv9idhXTT5RWA=";
+  };
+
+  buildInputs = [ openssl ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Client-only implementation of the SCEP (Cisco System's Simple Certificate Enrollment Protocol)";
+    homepage = "https://github.com/certnanny/sscep";
+    maintainers = [ lib.maintainers.stv0g ];
+    license = [
+      lib.licenses.bsd2
+      lib.licenses.openssl
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

SSCEP is a client-only implementation of the SCEP (Cisco System's Simple Certificate Enrollment Protocol). SSCEP is designed for OpenBSD's isakmpd, but it will probably work with any Unix system with a recent compiler and OpenSSL toolkit libraries installed.

https://github.com/certnanny/sscep

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
