### PR TITLE
filesystems: fix values with spaces or tabs in their name

### DIFF
--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -186,7 +186,7 @@ let
       isBindMount = fs: builtins.elem "bind" fs.options;
       skipCheck = fs: fs.noCheck || fs.device == "none" || builtins.elem fs.fsType fsToSkipCheck || isBindMount fs;
       # https://wiki.archlinux.org/index.php/fstab#Filepath_spaces
-      escape = string: builtins.replaceStrings [ " " "\t" ] [ "\\040" "\\011" ] string;
+      escape = string: builtins.replaceStrings [ " " "\t" ] [ "\\x20" "\\x9" ] string;
     in fstabFileSystems: { }: concatMapStrings (fs:
       (if fs.device != null then escape fs.device
          else if fs.label != null then "/dev/disk/by-label/${escape fs.label}"


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Today I noticed that I can't have a `fileSystems.<name>.device` with the value containing spaces. The fstab would be generated correctly, but after the rebuild, the mount unit `<name>.mount` created automatically by systemd-fstab-generator would fail to restart, and would throw you into emergency mode (if `nofail` wasn't in the options list).

So after some digging I realised it has to do with the fact that systemd-fstab-generator was replacing the `\040` put in place by Nix in the fstab with a space and it would fail to find the block device this way. Looking into the actual folder where the block device is, I realised that there isn't any space in the name, and it is `\x20`.

Then I edited the `<name>.mount` unit manually to replace the space with `\x20` and i saw the unit was able to start, which made me realise that likely systemd mount units want their `Mount.What` to be an exact path to the block device.

So then I tried setting `fileSystems.<name>.device` to `"/dev/disk/by-partlabel/partlabel\\x20with\\x20spaces"`, instead of `"/dev/disk/by-partlabel/partlabel with spaces"`, which passes [the filters in the fileSystems module](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/tasks/filesystems.nix#L191) and actually lets the space be `\x20` in the fstab too, which would get picked up correctly by systemd-fstab-generator, with no more failures at restarting `<name>.mount`.

So I thought it'd be cool if Nix could just escape the space correctly for systemd-fstab-generator too, and this is what this change does.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
