### PR TITLE
nixos/tests/nixos-rebuild-install-bootloader: fix build on hydra

### DIFF
--- a/nixos/tests/nixos-rebuild-install-bootloader.nix
+++ b/nixos/tests/nixos-rebuild-install-bootloader.nix
@@ -14,7 +14,41 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         connect-timeout = 1;
       };
 
-      system.includeBuildDependencies = true;
+      # From nixos/tests/installer.nix
+      # The test cannot access the network, so any packages we
+      # need must be included in the VM.
+      system.extraDependencies = with pkgs; [
+        bintools
+        brotli
+        brotli.dev
+        brotli.lib
+        desktop-file-utils
+        docbook5
+        docbook_xsl_ns
+        kbd.dev
+        kmod.dev
+        libarchive.dev
+        libxml2.bin
+        libxslt.bin
+        nixos-artwork.wallpapers.simple-dark-gray-bottom
+        ntp
+        perlPackages.ListCompare
+        perlPackages.XMLLibXML
+        # make-options-doc/default.nix
+        (python3.withPackages (p: [ p.mistune ]))
+        shared-mime-info
+        sudo
+        texinfo
+        unionfs-fuse
+        xorg.lndir
+
+        # add curl so that rather than seeing the test attempt to download
+        # curl's tarball, we see what it's trying to download
+        curl
+
+        # for --install-bootloader
+        grub2
+      ];
 
       virtualisation = {
         cores = 2;
@@ -62,6 +96,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       with subtest("Switch system again and install bootloader"):
           result = machine.succeed("nixos-rebuild switch --install-bootloader 2>&1")
           # install-grub2.pl messages
+          machine.log(result)
           assert "updating GRUB 2 menu..." in result
           assert "installing the GRUB 2 boot loader on /dev/vda..." in result
           # GRUB message


### PR DESCRIPTION
## Description of changes

- replace 'includeBuildDependencies' with explicit list of dependencies from nixos/tests/installer.nix to reduce size of vm disk image
- add log for output from '--install-bootloader' command

Reduces `nixos-disk-image` (vm disk image) size to something hydra can build.
Dependencies list was copied from `nixos/tests/installer.nix`:
https://www.github.com/NixOS/nixpkgs/blob/6c31eb9b990446880000e3297f69f4fdee5b69d7/nixos/tests/installer.nix#L612-L642

Size for `nixosTests.nixos-rebuild-install-bootloader` before change:
```text
nix path-info --recursive --size -h ./result | sort -h -k 2 -r | head
/nix/store/7i3fqch8br2dnpnf9kxw6y9w3g8646wn-nixos-disk-image                             32.0G
/nix/store/4f928hz6bn9fjpzp54k7w3qsr3wmlqlv-ghc-binary-9.2.4                              2.2G
/nix/store/1axdm2calisg4kybpqzd8z2zvs770js0-ghc-9.6.6                                     1.7G
/nix/store/wha2hi4yhkjmccqhivxavbfspsg1wrsj-source                                        1.5G
/nix/store/yl54abbp74h208gwwx7anqhm97q1j8ih-source                                        1.1G
/nix/store/x5f648ycbdh41agc4dafiswr3651g48q-linux-firmware-20240811                       1.1G
/nix/store/fiyp1sr6f0p7n6606dkpbjrlymd9kja2-llvm-src-18.1.8                             847.0M
/nix/store/j5f2hkvdkmzym46qii357n4m8psqy5qa-clang-18.1.8-lib                            774.7M
/nix/store/ymhg169d9dl659mbwhj2115ga47ds3a6-source                                      735.6M
/nix/store/5d8gysj9z6xaqidxcxjdkckli6kk0vpp-rustc-1.80.1                                727.2M
```

After:
```text
nix path-info --recursive --size -h ./result | sort -h -k 2 -r | head
/nix/store/glspgmzzfh2lxy468h82hjbjbd4kvkp1-nixos-disk-image                              2.7G
/nix/store/mar9pxll3agxyqk7rxi1qfzlkj1654nf-linux-firmware-20240811-zstd                473.9M
/nix/store/kpb7svzd4zsmcdbkjmcvp8l9kv65y5gd-qemu-host-cpu-only-for-vm-tests-9.0.2       300.7M
/nix/store/wl7xs26116sswgw18pnc3yw9r5gxr6hx-gcc-13.3.0                                  220.8M
/nix/store/blb8mkns9xhfhb4ks8d065sf3ifh95id-nixos-24.11test                             173.9M
/nix/store/g2jkfv566lz06ikfrik3cjlqk66i04i6-linux-6.6.47                                130.4M
/nix/store/ckxg2q6mfhasfm93lad61q6cyfhgsvv3-python3-3.12.4                              108.3M
/nix/store/04gg5w1s662l329a8kh9xcwyp0k64v5a-python3-3.12.4                              108.3M
/nix/store/2rsxigsdpd88a427kbwpak8k5mnx5kcm-samba-4.20.1                                 81.0M
/nix/store/bm7ivkyh3cp485d2jp1zx51cq16ym4w2-perl-5.38.2                                  55.8M
```

Fixes build failure of `nixosTests.nixos-rebuild-install-bootloader` on hydra with "Output limit exceeded" (never built successfully of hydra):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.nixos-rebuild-install-bootloader.x86_64-linux
https://hydra.nixos.org/build/270105347

---
For future ref, there may be a way to do it without building `nixos-disk-image` at all.
But if you set `virtualisation.useBootLoader = false;` there is no partition table in `/dev/vdb` and grub while doing `--install-loader` warns about it which may not be desirable for test purposes (thought test still passes):
```text
/nix/store/ky872qyz6b2al4r9brmfa0ax6kd124f9-grub-2.12/sbin/grub-install: warning: File system `ext2' doesn't support embedding.
/nix/store/ky872qyz6b2al4r9brmfa0ax6kd124f9-grub-2.12/sbin/grub-install: warning: Embedding is not possible.  GRUB can only be installed in this setup by using blocklists.  However, blocklists are UNRELIABLE and their use is discouraged..
```

There may also be some way to not create disk image, but still use bootloader with some combination of `useBootLoader`,`mountHostNixStore`, `additionalPaths` and `useDefaultFilesystems` (or doing manual partitioning/bootloader install), but I have not figured it out.
This seems to be the part where disk image is created:
https://www.github.com/NixOS/nixpkgs/blob/6c31eb9b990446880000e3297f69f4fdee5b69d7/nixos/modules/virtualisation/qemu-vm.nix#L111-L121
https://www.github.com/NixOS/nixpkgs/blob/6c31eb9b990446880000e3297f69f4fdee5b69d7/nixos/modules/virtualisation/qemu-vm.nix#L269-L292

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
