### PR TITLE
treewide: remove CMAKE_BUILD_TYPE from cmakeFlags

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
@@ -68,9 +68,7 @@ clangStdenv.mkDerivation rec {
     zlib
   ];
 
-  cmakeFlags = lib.optionals debug [
-    "-DCMAKE_BUILD_TYPE=Debug"
-  ];
+  cmakeBuildType = if debug then "Debug" else "Release";
 
   postPatch = ''
     substituteInPlace src/xmagics/executable.cpp \

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -151,7 +151,6 @@ in mkDerivation rec {
   env.QT_QPA_PLATFORM_PLUGIN_PATH="${qtbase}/${qtbase.qtPluginPrefix}/platforms";
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DWITH_3D=True"
     "-DWITH_PDAL=True"
     "-DENABLE_TESTS=False"

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -152,7 +152,6 @@ in mkDerivation rec {
   env.QT_QPA_PLATFORM_PLUGIN_PATH="${qtbase}/${qtbase.qtPluginPrefix}/platforms";
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DWITH_3D=True"
     "-DWITH_PDAL=True"
     "-DENABLE_TESTS=False"

--- a/pkgs/by-name/_2/_2ship2harkinian/package.nix
+++ b/pkgs/by-name/_2/_2ship2harkinian/package.nix
@@ -138,7 +138,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "NON_PORTABLE" true)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/2s2h")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_IMGUI" "${imgui'.src}")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_LIBGFXD" "${libgfxd}")

--- a/pkgs/by-name/cl/clang-uml/package.nix
+++ b/pkgs/by-name/cl/clang-uml/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     yaml-cpp
   ];
 
-  cmakeFlags = if debug then [ "-DCMAKE_BUILD_TYPE=Debug" ] else [ ];
+  cmakeBuildType = if debug then "Debug" else "Release";
 
   clang = if enableLibcxx then llvmPackages.libcxxClang else llvmPackages.clang;
 

--- a/pkgs/by-name/cr/cro-mag-rally/package.nix
+++ b/pkgs/by-name/cr/cro-mag-rally/package.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation {
     SDL2
   ];
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
-
   installPhase = ''
     runHook preInstall
     mkdir -p "$out/share/CroMagRally"

--- a/pkgs/by-name/ht/httping/package.nix
+++ b/pkgs/by-name/ht/httping/package.nix
@@ -35,10 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
   ];
 
-  cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
-  ];
-
   installPhase = ''
     runHook preInstall
     install -D httping $out/bin/httping

--- a/pkgs/by-name/li/libvpl/package.nix
+++ b/pkgs/by-name/li/libvpl/package.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
       "-DENABLE_DRI3=ON"
       "-DENABLE_DRM=ON"
       "-DENABLE_VA=ON"

--- a/pkgs/by-name/lm/lms/package.nix
+++ b/pkgs/by-name/lm/lms/package.nix
@@ -55,8 +55,6 @@ stdenv.mkDerivation rec {
     substituteInPlace src/tools/cover/LmsCover.cpp --replace-fail "/etc/lms.conf" "$out/share/lms/lms.conf"
   '';
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
-
   postInstall = ''
     substituteInPlace $out/share/lms/lms.conf --replace-fail "/usr/bin/ffmpeg" "${ffmpeg}/bin/ffmpeg"
     substituteInPlace $out/share/lms/lms.conf --replace-fail "/usr/share/Wt/resources" "${wt}/share/Wt/resources"

--- a/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
+++ b/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
@@ -54,9 +54,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       ]
     );
 
+  cmakeBuildType = "None";
+
   cmakeFlags =
     [
-      (lib.cmakeFeature "CMAKE_BUILD_TYPE" "None")
       (lib.cmakeBool "BUILD_SHARED_LIBS" true)
     ]
     ++ lib.optionals cudaSupport [

--- a/pkgs/by-name/ma/maa-assistant-arknights/package.nix
+++ b/pkgs/by-name/ma/maa-assistant-arknights/package.nix
@@ -57,13 +57,14 @@ in
       ]
     );
 
+  cmakeBuildType = "None";
+
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
     (lib.cmakeBool "INSTALL_FLATTEN" false)
     (lib.cmakeBool "INSTALL_PYTHON" true)
     (lib.cmakeBool "INSTALL_RESOURCE" true)
     (lib.cmakeBool "USE_MAADEPS" false)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "None")
     (lib.cmakeFeature "MAA_VERSION" "v${finalAttr.version}")
   ];
 

--- a/pkgs/by-name/ma/manifold/package.nix
+++ b/pkgs/by-name/ma/manifold/package.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DBUILD_SHARED_LIBS=ON"
     "-DMANIFOLD_TEST=ON"
     "-DMANIFOLD_PAR=TBB"

--- a/pkgs/by-name/op/opengv/package.nix
+++ b/pkgs/by-name/op/opengv/package.nix
@@ -23,10 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
     eigen
   ];
 
-  cmakeFlakes = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
-  ];
-
   meta = {
     description = "Collection of computer vision methods for solving geometric vision problems";
     homepage = "https://github.com/laurentkneip/opengv";

--- a/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
+++ b/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
@@ -62,17 +62,14 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i "/add_subdirectory(bridge-gui-tester)/d" CMakeLists.txt
   '';
 
-  preConfigure = ''
-    cmakeFlagsArray+=(
-      "-DCMAKE_BUILD_TYPE=Release"
-      "-DBRIDGE_APP_FULL_NAME=Proton Mail Bridge"
-      "-DBRIDGE_VENDOR=Proton AG"
-      "-DBRIDGE_REVISION=${finalAttrs.src.rev}"
-      "-DBRIDGE_TAG=${finalAttrs.version}"
-      "-DBRIDGE_BUILD_ENV=Nix"
-      "-DBRIDGE_APP_VERSION=${finalAttrs.version}"
-    )
-  '';
+  cmakeFlags = [
+    "-DBRIDGE_APP_FULL_NAME=Proton Mail Bridge"
+    "-DBRIDGE_VENDOR=Proton AG"
+    "-DBRIDGE_REVISION=${finalAttrs.src.rev}"
+    "-DBRIDGE_TAG=${finalAttrs.version}"
+    "-DBRIDGE_BUILD_ENV=Nix"
+    "-DBRIDGE_APP_VERSION=${finalAttrs.version}"
+  ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/qd/qdiskinfo/package.nix
+++ b/pkgs/by-name/qd/qdiskinfo/package.nix
@@ -29,8 +29,9 @@ stdenv.mkDerivation (finalAttrs: {
     smartmontools
   ];
 
+  cmakeBuildType = "MinSizeRel";
+
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE:STRING=MinSizeRel"
     "-DQT_VERSION_MAJOR=6"
   ];
 

--- a/pkgs/by-name/ra/raze/package.nix
+++ b/pkgs/by-name/ra/raze/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "DYN_GTK" false)
     (lib.cmakeBool "DYN_OPENAL" false)
   ];

--- a/pkgs/by-name/ri/ricochet-refresh/package.nix
+++ b/pkgs/by-name/ri/ricochet-refresh/package.nix
@@ -44,9 +44,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  cmakeBuildType = "MinSizeRel";
+
   # https://github.com/blueprint-freespeech/ricochet-refresh/blob/main/BUILDING.md
   cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "MinSizeRel")
     (lib.cmakeBool "RICOCHET_REFRESH_INSTALL_DESKTOP" true)
     (lib.cmakeBool "USE_SUBMODULE_FMT" true)
   ];

--- a/pkgs/by-name/rs/rsgain/package.nix
+++ b/pkgs/by-name/rs/rsgain/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
       sha256 = "sha256-kTvIMsRI99U2ovkN5pC4OUS/bJWpRYSuRcvObvQRnbQ=";
     };
 
-    cmakeFlags = ["-DCMAKE_BUILD_TYPE='Release'"];
-
     nativeBuildInputs = [pkg-config cmake];
     buildInputs = [libebur128 taglib ffmpeg inih fmt zlib];
 

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ glib zlib libpng ];
 
-  cmakeFlags = [ "-DINSTALL_HELPER_SCRIPTS=OFF" "-DCMAKE_BUILD_TYPE=RELEASE" ];
+  cmakeFlags = [ "-DINSTALL_HELPER_SCRIPTS=OFF" ];
 
   meta = with lib; {
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/games/widelands/default.nix
+++ b/pkgs/games/widelands/default.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-Wno-dev" # dev warnings are only needed for upstream development
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DWL_INSTALL_BASEDIR=${placeholder "out"}/share/widelands" # for COPYING, Changelog, etc.
     "-DWL_INSTALL_DATADIR=${placeholder "out"}/share/widelands" # for game data
     "-DWL_INSTALL_BINDIR=${placeholder "out"}/bin"


### PR DESCRIPTION
## Description of changes
Use `cmakeBuildType` instead of adding `CMAKE_BUILD_TYPE` to the `cmakeFlags`, in case where `CMAKE_BUILD_TYPE` is set to `Release` drop it as that is the default value for `cmakeBuildType`, in the few cases where `CMAKE_BUILD_TYPE` was in the `preConfigure` phase move all the cmake flags out of `preConfigure`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>gimpPlugins.exposureBlend</li>
    <li>gimpPlugins.resynthesizer</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>ansel</li>
  </ul>
</details>
<details>
  <summary>86 packages built:</summary>
  <ul>
    <li>_2ship2harkinian</li>
    <li>art</li>
    <li>clang-uml</li>
    <li>cro-mag-rally</li>
    <li>darktable</li>
    <li>digikam</li>
    <li>gegl</li>
    <li>gegl.dev</li>
    <li>gegl.devdoc</li>
    <li>gimp</li>
    <li>gimp-with-plugins</li>
    <li>gimp.dev</li>
    <li>gimpPlugins.bimp</li>
    <li>gimpPlugins.farbfeld</li>
    <li>gimpPlugins.fourier</li>
    <li>gimpPlugins.gap</li>
    <li>gimpPlugins.gimplensfun</li>
    <li>gimpPlugins.gmic</li>
    <li>gimpPlugins.lightning</li>
    <li>gimpPlugins.lqrPlugin</li>
    <li>gimpPlugins.texturize</li>
    <li>gimpPlugins.waveletSharpen</li>
    <li>gnome-photos</li>
    <li>gnome-photos.installedTests</li>
    <li>httping</li>
    <li>hugin</li>
    <li>lensfun</li>
    <li>libvpl</li>
    <li>lms</li>
    <li>maa-assistant-arknights</li>
    <li>maa-cli</li>
    <li>manifold</li>
    <li>nufraw</li>
    <li>nufraw-thumbnailer</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.advanced-scene-switcher</li>
    <li>obs-studio-plugins.droidcam-obs</li>
    <li>obs-studio-plugins.input-overlay</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-3d-effect</li>
    <li>obs-studio-plugins.obs-backgroundremoval</li>
    <li>obs-studio-plugins.obs-command-source</li>
    <li>obs-studio-plugins.obs-composite-blur</li>
    <li>obs-studio-plugins.obs-freeze-filter</li>
    <li>obs-studio-plugins.obs-gradient-source</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-hyperion</li>
    <li>obs-studio-plugins.obs-livesplit-one</li>
    <li>obs-studio-plugins.obs-move-transition</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-mute-filter</li>
    <li>obs-studio-plugins.obs-ndi</li>
    <li>obs-studio-plugins.obs-nvfbc</li>
    <li>obs-studio-plugins.obs-pipewire-audio-capture</li>
    <li>obs-studio-plugins.obs-replay-source</li>
    <li>obs-studio-plugins.obs-rgb-levels-filter</li>
    <li>obs-studio-plugins.obs-scale-to-sound</li>
    <li>obs-studio-plugins.obs-shaderfilter</li>
    <li>obs-studio-plugins.obs-source-clone</li>
    <li>obs-studio-plugins.obs-source-record</li>
    <li>obs-studio-plugins.obs-source-switcher</li>
    <li>obs-studio-plugins.obs-teleport</li>
    <li>obs-studio-plugins.obs-text-pthread</li>
    <li>obs-studio-plugins.obs-transition-table</li>
    <li>obs-studio-plugins.obs-tuna</li>
    <li>obs-studio-plugins.obs-vaapi</li>
    <li>obs-studio-plugins.obs-vertical-canvas</li>
    <li>obs-studio-plugins.obs-vintage-filter</li>
    <li>obs-studio-plugins.obs-vkcapture</li>
    <li>obs-studio-plugins.obs-webkitgtk</li>
    <li>obs-studio-plugins.obs-websocket</li>
    <li>obs-studio-plugins.waveform</li>
    <li>obs-studio-plugins.wlrobs</li>
    <li>opengv</li>
    <li>photoprism</li>
    <li>protonmail-bridge-gui</li>
    <li>qdiskinfo</li>
    <li>qgis</li>
    <li>qgis-ltr</li>
    <li>rawtherapee</li>
    <li>raze</li>
    <li>ricochet-refresh</li>
    <li>rsgain</li>
    <li>toppler</li>
    <li>widelands</li>
    <li>xeus-cling</li>
  </ul>
</details>
