### PR TITLE
tmux-fingers: 2.1.1 -> 2.2.2

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -242,29 +242,8 @@ in rec {
     };
   };
 
-  fingers = mkTmuxPlugin rec {
-    pluginName = "tmux-fingers";
-    rtpFilePath = "load-config.tmux";
-    version = "2.1.1";
-    src = fetchFromGitHub {
-      owner = "Morantron";
-      repo = "tmux-fingers";
-      rev = "${version}";
-      sha256 = "sha256-1YMh6m8M6FKf8RPXsOfWCVC5CXSr/MynguwkG7O+oEY=";
-    };
-    nativeBuildInputs = [ pkgs.makeWrapper pkgs.crystal pkgs.shards ];
-    postInstall = ''
-      shards build --production
-      rm -rf $target/* $target/.*
-      cp -r bin $target/bin
-      echo "$target/bin/${pluginName} load-config" > $target/${rtpFilePath}
-      chmod +x $target/${rtpFilePath}
-
-      wrapProgram $target/${rtpFilePath} \
-        --prefix PATH : ${with pkgs; lib.makeBinPath (
-          [ gawk ] ++ lib.optionals stdenv.isDarwin [ reattach-to-user-namespace ]
-        )}
-    '';
+  fingers = pkgs.callPackage ./tmux-fingers {
+    inherit mkTmuxPlugin;
   };
 
   fpp = mkTmuxPlugin {

--- a/pkgs/misc/tmux-plugins/tmux-fingers/default.nix
+++ b/pkgs/misc/tmux-plugins/tmux-fingers/default.nix
@@ -1,0 +1,46 @@
+{
+  mkTmuxPlugin,
+  substituteAll,
+  fetchFromGitHub,
+  crystal,
+}:
+let
+  fingers = crystal.buildCrystalPackage rec {
+    format = "shards";
+    version = "2.2.2";
+    pname = "fingers";
+    src = fetchFromGitHub {
+      owner = "Morantron";
+      repo = "tmux-fingers";
+      rev = "${version}";
+      sha256 = "sha256-m9QON7diHVEDnnv/alXCJOG+BnfrAKygScrubZZ605I=";
+    };
+
+    shardsFile = ./shards.nix;
+    crystalBinaries.tmux-fingers.src = "src/fingers.cr";
+
+    postInstall = ''
+      shopt -s dotglob extglob
+      rm -rv !("tmux-fingers.tmux"|"bin")
+      shopt -u dotglob extglob
+    '';
+
+    # TODO: Needs starting a TMUX session to run tests
+    # Unhandled exception: Missing ENV key: "TMUX" (KeyError)
+    doCheck = false;
+    doInstallCheck = false;
+  };
+in
+mkTmuxPlugin {
+  inherit (fingers) version src meta;
+
+  pluginName = fingers.src.repo;
+  rtpFilePath = "tmux-fingers.tmux";
+
+  patches = [
+    (substituteAll {
+      src = ./fix.patch;
+      tmuxFingersDir = "${fingers}/bin";
+    })
+  ];
+}

--- a/pkgs/misc/tmux-plugins/tmux-fingers/fix.patch
+++ b/pkgs/misc/tmux-plugins/tmux-fingers/fix.patch
@@ -1,0 +1,41 @@
+diff --git a/tmux-fingers.tmux b/tmux-fingers.tmux
+index f15b509..a14e312 100755
+--- a/tmux-fingers.tmux
++++ b/tmux-fingers.tmux
+@@ -1,35 +1,4 @@
+ #!/usr/bin/env bash
+ 
+-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+-
+-if command -v "tmux-fingers" &>/dev/null; then
+-  FINGERS_BINARY="tmux-fingers"
+-elif [[ -f "$CURRENT_DIR/bin/tmux-fingers" ]]; then
+-  FINGERS_BINARY="$CURRENT_DIR/bin/tmux-fingers"
+-fi
+-
+-if [[ -z "$FINGERS_BINARY" ]]; then
+-  tmux run-shell -b "bash $CURRENT_DIR/install-wizard.sh"
+-  exit 0
+-fi
+-
+-CURRENT_FINGERS_VERSION="$($FINGERS_BINARY version)"
+-
+-pushd $CURRENT_DIR &> /dev/null
+-CURRENT_GIT_VERSION=$(cat shard.yml | grep "^version" | cut -f2 -d':' | sed "s/ //g")
+-popd &> /dev/null
+-
+-SKIP_WIZARD=$(tmux show-option -gqv @fingers-skip-wizard)
+-SKIP_WIZARD=${SKIP_WIZARD:-0}
+-
+-if [ "$SKIP_WIZARD" = "0" ] && [ "$CURRENT_FINGERS_VERSION" != "$CURRENT_GIT_VERSION" ]; then
+-  tmux run-shell -b "FINGERS_UPDATE=1 bash $CURRENT_DIR/install-wizard.sh"
+-
+-  if [[ "$?" != "0" ]]; then
+-    echo "Something went wrong while updating tmux-fingers. Please try again."
+-    exit 1
+-  fi
+-fi
+-
+-tmux run "$FINGERS_BINARY load-config"
++tmux run "@tmuxFingersDir@/tmux-fingers load-config"
+ exit $?

--- a/pkgs/misc/tmux-plugins/tmux-fingers/shards.nix
+++ b/pkgs/misc/tmux-plugins/tmux-fingers/shards.nix
@@ -1,0 +1,12 @@
+{
+  cling = {
+    url = "https://github.com/devnote-dev/cling.git";
+    rev = "v3.0.0";
+    sha256 = "0mj5xvpiif1vhg4qds938p9zb5a47qzl397ybz1l1jks0gg361wq";
+  };
+  xdg_base_directory = {
+    url = "https://github.com/tijn/xdg_base_directory.git";
+    rev = "60bf28dc060c221d5af52727927e92b840022eb0";
+    sha256 = "1sa8bw8mzsz0pbj3m8v0w1pnk1q86zjivr0jndfg77wa33ki34y0";
+  };
+}


### PR DESCRIPTION
## Description of changes

First time writing a Crystal derivation, let me know any changes or improvements I should do!

Friendly ping: @Mic92 @WilliamHsieh 

[tmux-fingers/CHANGELOG.md at master · Morantron/tmux-fingers](https://github.com/Morantron/tmux-fingers/blob/master/CHANGELOG.md)

From [use cling shard to handle arg parsing · Morantron/tmux-fingers@97d1ddd](https://github.com/Morantron/tmux-fingers/commit/97d1ddd46721fa37faa4114f57bac1b3b3da7c67), `tmux-fingers` need shards to build.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Used `crystal2nix` to generate `shards.nix`
2. Built `fingers` binary
3. Added patch to substitute upstream binary location to fingers' binary

I mostly copied the build pattern from [nixpkgs/pkgs/misc/tmux-plugins/tmux-thumbs/default.nix at master · NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/misc/tmux-plugins/tmux-thumbs/default.nix)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
