### PR TITLE
pixelorama: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/by-name/pi/pixelorama/package.nix
+++ b/pkgs/by-name/pi/pixelorama/package.nix
@@ -21,9 +21,9 @@
 let
   preset =
     if stdenv.isLinux then
-      if stdenv.is64bit then "Linux/X11 64-bit" else "Linux/X11 32-bit"
+      if stdenv.is64bit then "Linux 64-bit" else "Linux 32-bit"
     else if stdenv.isDarwin then
-      "Mac OSX"
+      "macOS"
     else
       throw "unsupported platform";
 
@@ -31,13 +31,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "pixelorama";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "Orama-Interactive";
     repo = "Pixelorama";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lfim5ZiykOhI1kgsu0ni2frUVHPRIPJdrGx6TuUQcSY=";
+    hash = "sha256-rFXUy6fvGKmB+aaNgiI+NNRG0xlj1migdetnU4iVDDQ=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/pi/pixelorama/package.nix
+++ b/pkgs/by-name/pi/pixelorama/package.nix
@@ -19,13 +19,14 @@
 }:
 
 let
+  presets = {
+    "i686-linux" = "Linux 32-bit";
+    "x86_64-linux" = "Linux 64-bit";
+    "aarch64-linux" = "Linux ARM64";
+  };
   preset =
-    if stdenv.isLinux then
-      if stdenv.is64bit then "Linux 64-bit" else "Linux 32-bit"
-    else if stdenv.isDarwin then
-      "macOS"
-    else
-      throw "unsupported platform";
+    presets.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   godot_version_folder = lib.replaceStrings [ "-" ] [ "." ] godot_4.version;
 in
@@ -95,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = [
       "i686-linux"
       "x86_64-linux"
+      "aarch64-linux"
     ];
     maintainers = with maintainers; [ felschr ];
     mainProgram = "pixelorama";


### PR DESCRIPTION
## Description of changes

Updates Pixelorama to [v1.0.2](https://github.com/Orama-Interactive/Pixelorama/releases/tag/v1.0.2) and adds support for `aarch64-linux`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
