### PR TITLE
gcalcli: enable tests

### DIFF
--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -1,5 +1,10 @@
-{ stdenv, lib, fetchFromGitHub, python3
-, libnotify ? null }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  python3,
+  libnotify ? null,
+}:
 
 with python3.pkgs;
 
@@ -8,9 +13,9 @@ buildPythonApplication rec {
   version = "4.3.0";
 
   src = fetchFromGitHub {
-    owner  = "insanum";
-    repo   = pname;
-    rev    = "v${version}";
+    owner = "insanum";
+    repo = pname;
+    rev = "v${version}";
     sha256 = "0s5fhcmz3n0dwh3vkqr4aigi59q43v03ch5jhh6v75149icwr0df";
   };
 
@@ -20,8 +25,15 @@ buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = [
-    python-dateutil gflags httplib2 parsedatetime six vobject
-    google-api-python-client oauth2client uritemplate
+    python-dateutil
+    gflags
+    httplib2
+    parsedatetime
+    six
+    vobject
+    google-api-python-client
+    oauth2client
+    uritemplate
     libnotify
   ];
 

--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -2,29 +2,30 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  python3,
-  libnotify ? null,
+  python3Packages,
+  libnotify,
 }:
 
-with python3.pkgs;
-
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "gcalcli";
   version = "4.3.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "insanum";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0s5fhcmz3n0dwh3vkqr4aigi59q43v03ch5jhh6v75149icwr0df";
+    repo = "gcalcli";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-roHMWUwklLMNhLJANsAeBKcSX1Qk47kH5A3Y8SuDrmg=";
   };
 
   postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace gcalcli/argparsers.py \
-      --replace "'notify-send" "'${libnotify}/bin/notify-send"
+      --replace-fail "'notify-send" "'${lib.getExe libnotify}"
   '';
 
-  propagatedBuildInputs = [
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
     python-dateutil
     gflags
     httplib2
@@ -37,7 +38,7 @@ buildPythonApplication rec {
     libnotify
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
   meta = with lib; {
     description = "CLI for Google Calendar";

--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -37,8 +37,7 @@ buildPythonApplication rec {
     libnotify
   ];
 
-  # There are no tests as of 4.0.0a4
-  doCheck = false;
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "CLI for Google Calendar";


### PR DESCRIPTION
## Description of changes

~~I noticed that #326353 doesn’t happen when `PYTHONPATH` is unset, though I don’t really understand what the problem was. Is this a reasonable solution, or is there a more conventional way to resolve this?~~

Just [keeping](https://github.com/NixOS/nixpkgs/pull/336883#issuecomment-2307973468) the maintenance commits from this.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
