### PR TITLE
postgis: Do not hardcode test suite path

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -96,6 +96,8 @@ stdenv.mkDerivation rec {
     substituteInPlace regress/Makefile --replace-fail 's,\$$libdir,$(REGRESS_INSTALLDIR)/lib,g' "s,\\$\$libdir,$PWD/regress/00-regress-install$out/lib,g" \
       --replace-fail '$(REGRESS_INSTALLDIR)/share/contrib/postgis/*.sql' "$PWD/regress/00-regress-install$out/share/postgresql/contrib/postgis/*.sql"
     substituteInPlace doc/postgis-out.xml --replace-fail "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" "${docbook_xml_dtd_45}/xml/dtd/docbook/docbookx.dtd"
+    # The test suite hardcodes it to use /tmp.
+    export PGIS_REG_TMPDIR="$TMPDIR/pgis_reg"
   '';
 
   # create aliases for all commands adding version information


### PR DESCRIPTION
## Description of changes

Upstream: https://git.osgeo.org/gitea/postgis/postgis/pulls/213

If PostGIS derivations are built twice on the same machine and get scheduled onto different `nixbld` users, the test suite fails. If the first build is scheduled onto `nixbld1`, then the test suite will create `/tmp/pgis_reg` with permissions 755 (not writable by other users in the group). Then, if the second build is scheduled onto `nixbld2`, then the test suite will attempt to write a file in `/tmp/pgis_reg`, but will be denied:

```
Creating database 'postgis_reg-3.4'.
sh: line 1: /tmp/pgis_reg/regress_log: Permission denied
2024-08-23 19:26:18.810 UTC [3295760] FATAL:  database "postgis_reg-3.4" does not exist
psql: error: FATAL:  database "postgis_reg-3.4" does not exist
Loading unpackaged components from /tmp/nix-build-postgis-3.4.2.drv-0/postgis-3.4.2/regress/00-regress-install/nix/store/kg8g82wxhar9iadxrd3pra3af174khpb-postgis-3.4.2/share/postgresql/contrib/postgis
Loading PostGIS into 'postgis_reg-3.4'
sh: line 1: /tmp/pgis_reg/regress_log: Permission denied
 failed (Error encountered loading /tmp/nix-build-postgis-3.4.2.drv-0/postgis-3.4.2/regress/00-regress-install/nix/store/kg8g82wxhar9iadxrd3pra3af174khpb-postgis-3.4.2/share/postgresql/contrib/postgis/postgis.sql: /tmp/pgis_reg/regress_log)
make: *** [regress/runtest.mk:24: check-regress] Error 1
```

This can happen if a build is canceled and restarted, if different versions of PostGIS are built (this logic has not been changed upstream since it was added 12 years ago), if any of PostGIS' dependencies are changed, or if the `--rebuild` flag is used.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
