### PR TITLE
python312Packages.scikit-build-core: 0.9.6 -> 0.10.5; python312Packages.nanobind: use tensorflow-bin

### DIFF
--- a/pkgs/development/python-modules/awkward-cpp/default.nix
+++ b/pkgs/development/python-modules/awkward-cpp/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     ninja
     pybind11
     scikit-build-core
-  ] ++ scikit-build-core.optional-dependencies.pyproject;
+  ];
 
   dependencies = [ numpy ];
 

--- a/pkgs/development/python-modules/iminuit/default.nix
+++ b/pkgs/development/python-modules/iminuit/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pathspec
     ninja
     pyproject-metadata
-  ] ++ scikit-build-core.optional-dependencies.pyproject;
+  ];
 
   propagatedBuildInputs = [ numpy ];
 

--- a/pkgs/development/python-modules/laszip/default.nix
+++ b/pkgs/development/python-modules/laszip/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     ninja
     pybind11
     scikit-build-core
-  ] ++ scikit-build-core.optional-dependencies.pyproject;
+  ];
 
   dontUseCmakeConfigure = true;
 

--- a/pkgs/development/python-modules/pyopencl/default.nix
+++ b/pkgs/development/python-modules/pyopencl/default.nix
@@ -7,7 +7,6 @@
   # build-system
   cmake,
   scikit-build-core,
-  pathspec,
   ninja,
   nanobind,
 
@@ -45,7 +44,6 @@ buildPythonPackage rec {
     nanobind
     ninja
     numpy
-    pathspec
     scikit-build-core
   ];
 

--- a/pkgs/development/python-modules/scikit-build-core/default.nix
+++ b/pkgs/development/python-modules/scikit-build-core/default.nix
@@ -1,18 +1,25 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  distlib,
+  fetchFromGitHub,
   pythonOlder,
-  exceptiongroup,
+
+  # build-system
   hatch-vcs,
   hatchling,
-  cattrs,
   cmake,
   ninja,
+
+  # dependencies
   packaging,
   pathspec,
-  pyproject-metadata,
+  exceptiongroup,
+
+  # tests
+  build,
+  cattrs,
+  numpy,
+  pybind11,
   pytest-subprocess,
   pytestCheckHook,
   setuptools,
@@ -23,62 +30,56 @@
 
 buildPythonPackage rec {
   pname = "scikit-build-core";
-  version = "0.9.6";
+  version = "0.10.5";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "scikit_build_core";
-    inherit version;
-    hash = "sha256-e+r5M89zSsvrttlsApNlQQIkcJvN5o87C08MsD4FSTk=";
+  src = fetchFromGitHub {
+    owner = "scikit-build";
+    repo = "scikit-build-core";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-hpwXEWPofgMT4ua2tZI1mtGbaBkT2XPBd6QL8xTi1A0=";
   };
 
   postPatch = lib.optionalString (pythonOlder "3.11") ''
     substituteInPlace pyproject.toml \
-      --replace '"error",' '"error", "ignore::UserWarning",'
+      --replace-fail '"error",' '"error", "ignore::UserWarning",'
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     hatch-vcs
     hatchling
   ];
 
-  propagatedBuildInputs =
-    [ packaging ]
+  dependencies =
+    [
+      packaging
+      pathspec
+    ]
     ++ lib.optionals (pythonOlder "3.11") [
       exceptiongroup
       tomli
     ];
 
-  passthru.optional-dependencies = {
-    pyproject = [
-      distlib
-      pathspec
-      pyproject-metadata
-    ];
-  };
-
-  dontUseCmakeConfigure = true;
-
   nativeCheckInputs = [
+    build
     cattrs
     cmake
     ninja
+    numpy
+    pybind11
     pytest-subprocess
     pytestCheckHook
     setuptools
     virtualenv
     wheel
-  ] ++ passthru.optional-dependencies.pyproject;
+  ];
+
+  # cmake is only used for tests
+  dontUseCmakeConfigure = true;
+
+  pytestFlagsArray = [ "-m 'not isolated and not network'" ];
 
   disabledTestPaths = [
-    # runs pip, requires network access
-    "tests/test_custom_modules.py"
-    "tests/test_hatchling.py"
-    "tests/test_pyproject_pep517.py"
-    "tests/test_pyproject_pep518.py"
-    "tests/test_pyproject_pep660.py"
-    "tests/test_setuptools_pep517.py"
-    "tests/test_setuptools_pep518.py"
     # store permissions issue in Nix:
     "tests/test_editable.py"
   ];


### PR DESCRIPTION
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.9.7
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.9.8
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.9.9
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.9.10
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.10.0
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.10.1
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.10.2
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.10.3
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.10.4
https://github.com/scikit-build/scikit-build-core/releases/tag/v0.10.5

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
