### PR TITLE
treewide: modernize python packages

### DIFF
--- a/pkgs/development/python-modules/py-libzfs/default.nix
+++ b/pkgs/development/python-modules/py-libzfs/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch2,
+  setuptools,
   cython_0,
   zfs,
 }:
@@ -27,16 +28,16 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [ cython_0 ];
+  build-system = [ cython_0 ];
   buildInputs = [ zfs ];
 
   # Passing CFLAGS in configureFlags does not work, see https://github.com/truenas/py-libzfs/issues/107
   postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace configure \
-      --replace \
+      --replace-fail \
         'CFLAGS="-DCYTHON_FALLTHROUGH"' \
         'CFLAGS="-DCYTHON_FALLTHROUGH -I${zfs.dev}/include/libzfs -I${zfs.dev}/include/libspl"' \
-      --replace 'zof=false' 'zof=true'
+      --replace-fail 'zof=false' 'zof=true'
   '';
 
   pythonImportsCheck = [ "libzfs" ];

--- a/pkgs/development/python-modules/pygmt/default.nix
+++ b/pkgs/development/python-modules/pygmt/default.nix
@@ -20,7 +20,7 @@
 buildPythonPackage rec {
   pname = "pygmt";
   version = "0.11.0";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.9";
 

--- a/pkgs/development/python-modules/pyisbn/default.nix
+++ b/pkgs/development/python-modules/pyisbn/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   hypothesis,
   pythonOlder,
   pytestCheckHook,
@@ -11,14 +12,16 @@
 buildPythonPackage rec {
   pname = "pyisbn";
   version = "1.3.1";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "06fm9rn31cb4b61hzy63cnwfjpppgyy517k8a04gzcv9g60n7xbh";
+    hash = "sha256-cPVjgXlps/8IUGieULx/917puGXD+A+DWWSxMGxO1Rk=";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     hypothesis

--- a/pkgs/development/python-modules/pymarshal/default.nix
+++ b/pkgs/development/python-modules/pymarshal/default.nix
@@ -12,7 +12,7 @@
 buildPythonPackage rec {
   pname = "pymarshal";
   version = "2.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stargateaudio";
@@ -23,12 +23,12 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'" ""
+      --replace-fail "'pytest-runner'" ""
   '';
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ bson ];
+  dependencies = [ bson ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/pymetar/default.nix
+++ b/pkgs/development/python-modules/pymetar/default.nix
@@ -4,26 +4,29 @@
   buildPythonPackage,
   isPy3k,
   fetchPypi,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pymetar";
   version = "1.4";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "48dbe6c4929961021cb61e49bb9e0605b54c4b61b9fb9ade51076705a08ecd54";
+    hash = "sha256-SNvmxJKZYQIcth5Ju54GBbVMS2G5+5reUQdnBaCOzVQ=";
   };
+
+  build-system = [ setuptools ];
 
   checkPhase = ''
     cd testing/smoketest
     tar xzf reports.tgz
     mkdir logs
     patchShebangs runtests.sh
-    substituteInPlace runtests.sh --replace "break" "exit 1"  # fail properly
+    substituteInPlace runtests.sh --replace-fail "break" "exit 1"  # fail properly
     export PYTHONPATH="$PYTHONPATH:$out/${python.sitePackages}"
     ./runtests.sh
   '';

--- a/pkgs/development/python-modules/pymoo/default.nix
+++ b/pkgs/development/python-modules/pymoo/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
+  setuptools,
   pytestCheckHook,
   writeText,
   autograd,
@@ -21,7 +22,7 @@
 buildPythonPackage rec {
   pname = "pymoo";
   version = "0.6.0.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anyoptimization";
@@ -45,19 +46,21 @@ buildPythonPackage rec {
     })
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "cma==3.2.2" "cma" \
-      --replace "'alive-progress'," ""
+  pythonRelaxDeps = [ "cma" ];
+  pythonRemoveDeps = [ "alive-progress" ];
 
+  postPatch = ''
     substituteInPlace pymoo/util/display/display.py \
-      --replace "from pymoo.util.display.progress import ProgressBar" "" \
-      --replace "ProgressBar() if progress else None" \
+      --replace-fail "from pymoo.util.display.progress import ProgressBar" "" \
+      --replace-fail "ProgressBar() if progress else None" \
                 "print('Missing alive_progress needed for progress=True!') if progress else None"
   '';
 
-  nativeBuildInputs = [ cython ];
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+    cython
+  ];
+  dependencies = [
     autograd
     cma
     deprecated
@@ -70,7 +73,7 @@ buildPythonPackage rec {
   doCheck = true;
   preCheck = ''
     substituteInPlace pymoo/config.py \
-      --replace "https://raw.githubusercontent.com/anyoptimization/pymoo-data/main/" \
+      --replace-fail "https://raw.githubusercontent.com/anyoptimization/pymoo-data/main/" \
                 "file://$pymoo_data/"
   '';
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyosf/default.nix
+++ b/pkgs/development/python-modules/pyosf/default.nix
@@ -3,13 +3,14 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
+  setuptools,
   requests,
 }:
 
 buildPythonPackage rec {
   pname = "pyosf";
   version = "1.0.5";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -22,12 +23,14 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner', " ""
+      --replace-fail "'pytest-runner', " ""
   '';
 
   preBuild = "export HOME=$TMP";
 
-  propagatedBuildInputs = [ requests ];
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
 
   # Tests require network access
   doCheck = false;

--- a/pkgs/development/python-modules/pyosohotwaterapi/default.nix
+++ b/pkgs/development/python-modules/pyosohotwaterapi/default.nix
@@ -25,18 +25,15 @@ buildPythonPackage rec {
     hash = "sha256-7FLGmmndrFqSl4oC8QFIYNlFJPr+xbiZG5ZRt4vx8+s=";
   };
 
-  postPatch = ''
-    # https://github.com/osohotwateriot/apyosohotwaterapi/pull/3
-    substituteInPlace requirements.txt \
-      --replace "pre-commit" ""
-  '';
+  # https://github.com/osohotwateriot/apyosohotwaterapi/pull/3
+  pythonRemoveDeps = [ "pre-commit" ];
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     unasync
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     aiohttp
     loguru
     numpy

--- a/pkgs/development/python-modules/pysrim/default.nix
+++ b/pkgs/development/python-modules/pysrim/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   numpy,
   pythonOlder,
   pyyaml,
@@ -10,7 +11,7 @@
 buildPythonPackage rec {
   pname = "pysrim";
   version = "0.5.10";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -21,10 +22,12 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner', " ""
+      --replace-fail "'pytest-runner', " ""
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     numpy
     pyyaml
   ];

--- a/pkgs/development/python-modules/pysychonaut/default.nix
+++ b/pkgs/development/python-modules/pysychonaut/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   requests,
   requests-cache,
   beautifulsoup4,
@@ -10,6 +11,7 @@
 buildPythonPackage rec {
   pname = "pysychonaut";
   version = "0.6.0";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "PySychonaut";
@@ -18,10 +20,12 @@ buildPythonPackage rec {
   };
 
   preConfigure = ''
-    substituteInPlace setup.py --replace "bs4" "beautifulsoup4"
+    substituteInPlace setup.py --replace-fail "bs4" "beautifulsoup4"
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     requests
     requests-cache
     beautifulsoup4

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -29,18 +29,18 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace tests/conftest.py inventory \
-      --replace '/usr/bin/env' '${coreutils}/bin/env'
+    substituteInPlace inventory \
+      --replace-fail '/usr/bin/env' '${lib.getExe' coreutils "env"}'
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     setuptools-scm
   ];
 
   buildInputs = [ pytest ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     ansible-core
     ansible-compat
     packaging

--- a/pkgs/development/python-modules/pytest-pylint/default.nix
+++ b/pkgs/development/python-modules/pytest-pylint/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   pylint,
   pytest,
   pytestCheckHook,
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "pytest-pylint";
   version = "0.21.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -23,12 +24,14 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pytest-runner" ""
+      --replace-fail "pytest-runner" ""
   '';
+
+  build-system = [ setuptools ];
 
   buildInputs = [ pytest ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pylint
     toml
   ];

--- a/pkgs/development/python-modules/pytest-raisesregexp/default.nix
+++ b/pkgs/development/python-modules/pytest-raisesregexp/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   py,
   pytest,
 }:
@@ -9,23 +10,19 @@
 buildPythonPackage rec {
   pname = "pytest-raisesregexp";
   version = "2.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b54372494fc1f11388b1b9348aeb36b69609699eb8f46e0e010afc733d78236a";
+    hash = "sha256-tUNySU/B8ROIsbk0ius2tpYJaZ649G4OAQr8cz14I2o=";
   };
+
+  build-system = [ setuptools ];
 
   buildInputs = [
     py
     pytest
   ];
-
-  # https://github.com/kissgyorgy/pytest-raisesregexp/pull/3
-  prePatch = ''
-    sed -i '3i\import io' setup.py
-    substituteInPlace setup.py --replace "long_description=open('README.rst').read()," "long_description=io.open('README.rst', encoding='utf-8').read(),"
-  '';
 
   meta = with lib; {
     description = "Simple pytest plugin to look for regex in Exceptions";

--- a/pkgs/development/python-modules/python-redis-lock/default.nix
+++ b/pkgs/development/python-modules/python-redis-lock/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   # Fix django tests
   postPatch = ''
     substituteInPlace tests/test_project/settings.py \
-      --replace "USE_L10N = True" ""
+      --replace-fail "USE_L10N = True" ""
   '';
 
   patches = [

--- a/pkgs/development/python-modules/python-tds/default.nix
+++ b/pkgs/development/python-modules/python-tds/default.nix
@@ -26,12 +26,12 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "version.get_git_version()" '"${version}"'
+      --replace-fail "version.get_git_version()" '"${version}"'
   '';
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ six ];
+  dependencies = [ six ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/python-twitter/default.nix
+++ b/pkgs/development/python-modules/python-twitter/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'" ""
+      --replace-fail "'pytest-runner'" ""
   '';
 
   disabledTests = [

--- a/pkgs/development/python-modules/pyverilog/default.nix
+++ b/pkgs/development/python-modules/pyverilog/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
+  setuptools,
   jinja2,
   ply,
   iverilog,
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "pyverilog";
   version = "1.3.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -24,10 +25,14 @@ buildPythonPackage rec {
   patchPhase = ''
     # The path to Icarus can still be overridden via an environment variable at runtime.
     substituteInPlace pyverilog/vparser/preprocessor.py \
-      --replace "iverilog = 'iverilog'" "iverilog = '${iverilog}/bin/iverilog'"
+      --replace-fail \
+        "iverilog = 'iverilog'" \
+        "iverilog = '${lib.getExe' iverilog "iverilog"}'"
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     jinja2
     ply
     iverilog
@@ -35,7 +40,7 @@ buildPythonPackage rec {
 
   preCheck = ''
     substituteInPlace pytest.ini \
-      --replace "python_paths" "pythonpath"
+      --replace-fail "python_paths" "pythonpath"
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/pyweatherflowrest/default.nix
+++ b/pkgs/development/python-modules/pyweatherflowrest/default.nix
@@ -10,7 +10,7 @@
 buildPythonPackage rec {
   pname = "pyweatherflowrest";
   version = "1.0.11";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -21,14 +21,9 @@ buildPythonPackage rec {
     hash = "sha256-l1V3HgzqnnoY6sWHwfgBtcIR782RwKhekY2qOLrUMNY=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ aiohttp ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "--cov=pyweatherflowrest --cov-append" ""
-  '';
+  dependencies = [ aiohttp ];
 
   # Module has no tests. test.py is a demo script
   doCheck = false;

--- a/pkgs/development/python-modules/qualysclient/default.nix
+++ b/pkgs/development/python-modules/qualysclient/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  setuptools,
   certifi,
   charset-normalizer,
   fetchFromGitHub,
@@ -17,7 +18,7 @@
 buildPythonPackage rec {
   pname = "qualysclient";
   version = "0.0.4.8.3";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
@@ -30,10 +31,12 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "version=__version__," 'version="${version}",'
+      --replace-fail "version=__version__," 'version="${version}",'
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     certifi
     charset-normalizer
     idna

--- a/pkgs/development/python-modules/quart-cors/default.nix
+++ b/pkgs/development/python-modules/quart-cors/default.nix
@@ -20,7 +20,7 @@
 buildPythonPackage rec {
   pname = "quart-cors";
   version = "0.7.0";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pgjones";
@@ -29,9 +29,9 @@ buildPythonPackage rec {
     hash = "sha256-qUzs0CTZHf3fGADBXPkd3CjZ6dnz1t3cTxflMErvz/k=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [ quart ] ++ lib.optionals (pythonOlder "3.10") [ typing-extensions ];
+  dependencies = [ quart ] ++ lib.optionals (pythonOlder "3.10") [ typing-extensions ];
 
   pythonImportsCheck = [ "quart_cors" ];
 

--- a/pkgs/development/python-modules/rouge-score/default.nix
+++ b/pkgs/development/python-modules/rouge-score/default.nix
@@ -3,6 +3,7 @@
   fetchPypi,
   fetchFromGitHub,
   buildPythonPackage,
+  setuptools,
   absl-py,
   nltk,
   numpy,
@@ -22,7 +23,7 @@ in
 buildPythonPackage rec {
   pname = "rouge-score";
   version = "0.1.2";
-  format = "setuptools";
+  pyproject = true;
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
@@ -35,10 +36,14 @@ buildPythonPackage rec {
   # the tar file from pypi doesn't come with the test data
   postPatch = ''
     substituteInPlace rouge_score/test_util.py \
-      --replace 'os.path.join(os.path.dirname(__file__), "testdata")' '"${testdata}/rouge/testdata/"'
+      --replace-fail \
+        'os.path.join(os.path.dirname(__file__), "testdata")' \
+        '"${testdata}/rouge/testdata/"'
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     absl-py
     nltk
     numpy

--- a/pkgs/development/python-modules/sanic-auth/default.nix
+++ b/pkgs/development/python-modules/sanic-auth/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   sanic,
   sanic-testing,
   pytestCheckHook,
@@ -10,15 +11,17 @@
 buildPythonPackage rec {
   pname = "sanic-auth";
   version = "0.3.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "Sanic-Auth";
     inherit version;
-    sha256 = "0dc24ynqjraqwgvyk0g9bj87zgpq4xnssl24hnsn7l5vlkmk8198";
+    hash = "sha256-KAU066S70GO1hURQrW0n+L5/kFzpgen341hlia0ngjU=";
   };
 
-  propagatedBuildInputs = [ sanic ];
+  build-system = [ setuptools ];
+
+  dependencies = [ sanic ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -33,7 +36,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Support for httpx>=0.20.0
     substituteInPlace tests/test_auth.py \
-      --replace "allow_redirects=False" "follow_redirects=False"
+      --replace-fail "allow_redirects=False" "follow_redirects=False"
   '';
 
   pythonImportsCheck = [ "sanic_auth" ];

--- a/pkgs/development/python-modules/schemdraw/default.nix
+++ b/pkgs/development/python-modules/schemdraw/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   # Strip out references to unfree fonts from the test suite
   postPatch = ''
-    substituteInPlace test/test_styles.ipynb --replace "font='Times', " ""
+    substituteInPlace test/test_backend.ipynb --replace-fail "(font='Times')" "()"
   '';
 
   preCheck = "rm test/test_pictorial.ipynb"; # Tries to download files

--- a/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
+++ b/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
@@ -1,9 +1,11 @@
 {
   lib,
   buildPythonPackage,
+  setuptools,
   fake-useragent,
   faker,
   fetchFromGitHub,
+  pytest-cov-stub,
   pytest-mock,
   pytestCheckHook,
   pythonOlder,
@@ -13,7 +15,7 @@
 buildPythonPackage rec {
   pname = "scrapy-fake-useragent";
   version = "1.4.4";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -27,15 +29,18 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace " --cov=scrapy_fake_useragent --cov-report=term --cov-report=html --fulltrace" ""
+      --replace-fail " --fulltrace" ""
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     fake-useragent
     faker
   ];
 
   nativeCheckInputs = [
+    pytest-cov-stub
     pytest-mock
     pytestCheckHook
     scrapy

--- a/pkgs/development/python-modules/semaphore-bot/default.nix
+++ b/pkgs/development/python-modules/semaphore-bot/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   python-dateutil,
   attrs,
   anyio,
@@ -10,18 +11,22 @@
 buildPythonPackage rec {
   pname = "semaphore-bot";
   version = "0.17.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit version pname;
     hash = "sha256-3zb6+HdOB6+YrVRcmIHsokFKUOlFmKCoVNllvM+aOXQ=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "anyio>=3.5.0,<=3.6.2" "anyio"
-  '';
+  pythonRelaxDeps = [
+    "anyio"
+    "attrs"
+    "python-dateutil"
+  ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     anyio
     attrs
     python-dateutil

--- a/pkgs/development/python-modules/skyfield/default.nix
+++ b/pkgs/development/python-modules/skyfield/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
+  setuptools,
   certifi,
   numpy,
   sgp4,
@@ -16,7 +17,7 @@
 buildPythonPackage rec {
   pname = "skyfield";
   version = "1.45";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "skyfielders";
@@ -29,10 +30,12 @@ buildPythonPackage rec {
   # https://github.com/skyfielders/python-skyfield/issues/582#issuecomment-822033858
   postPatch = ''
     substituteInPlace skyfield/tests/test_planetarylib.py \
-      --replace "if IS_32_BIT" "if True"
+      --replace-fail "if IS_32_BIT" "if True"
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     certifi
     numpy
     sgp4

--- a/pkgs/development/python-modules/snakebite/default.nix
+++ b/pkgs/development/python-modules/snakebite/default.nix
@@ -2,24 +2,27 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   protobuf,
 }:
 
 buildPythonPackage rec {
   pname = "snakebite";
   version = "2.11.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "085238b4944cb9c658ee62d5794de936ac3d0c337c504b2cc86424a205ae978a";
+    hash = "sha256-CFI4tJRMucZY7mLVeU3pNqw9DDN8UEssyGQkogWul4o=";
   };
 
-  propagatedBuildInputs = [ protobuf ];
+  build-system = [ setuptools ];
+
+  dependencies = [ protobuf ];
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'argparse'" ""
+      --replace-fail "'argparse'" ""
   '';
 
   # Tests require hadoop hdfs

--- a/pkgs/development/python-modules/snakemake-storage-plugin-s3/default.nix
+++ b/pkgs/development/python-modules/snakemake-storage-plugin-s3/default.nix
@@ -14,7 +14,7 @@
 buildPythonPackage rec {
   pname = "snakemake-storage-plugin-s3";
   version = "0.2.12";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snakemake";
@@ -23,14 +23,9 @@ buildPythonPackage rec {
     hash = "sha256-TKv/7b3+uhY18v7p1ZSya5KJEMUv4M1NkObP9vPzMxU=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace ">=2.0,<2.2" "*"
-  '';
+  build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ poetry-core ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     boto3
     botocore
     snakemake-interface-storage-plugins

--- a/pkgs/development/python-modules/snakemake-storage-plugin-xrootd/default.nix
+++ b/pkgs/development/python-modules/snakemake-storage-plugin-xrootd/default.nix
@@ -12,7 +12,7 @@
 buildPythonPackage rec {
   pname = "snakemake-storage-plugin-xrootd";
   version = "unstable-2023-12-16";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snakemake";
@@ -22,14 +22,11 @@ buildPythonPackage rec {
   };
 
   # xrootd<6.0.0,>=5.6.4 not satisfied by version 5.7rc20240303
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'xrootd = "^5.6.4"' ""
-  '';
+  pythonRelaxDeps = [ "xrootd" ];
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     snakemake-interface-storage-plugins
     snakemake-interface-common
     xrootd

--- a/pkgs/development/python-modules/spyse-python/default.nix
+++ b/pkgs/development/python-modules/spyse-python/default.nix
@@ -34,18 +34,19 @@ buildPythonPackage rec {
     })
   ];
 
+  pythonRemoveDeps = [ "dataclasses" ];
+
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'dataclasses~=0.6'," "" \
-      --replace "dataclasses-json~=0.5.4" "dataclasses-json>=0.5.4" \
-      --replace "responses~=0.13.3" "responses>=0.13.3" \
-      --replace "limiter~=0.1.2" "limiter>=0.1.2" \
-      --replace "requests~=2.26.0" "requests>=2.26.0"
+      --replace-fail "dataclasses-json~=0.5.4" "dataclasses-json>=0.5.4" \
+      --replace-fail "responses~=0.13.3" "responses>=0.13.3" \
+      --replace-fail "limiter~=0.1.2" "limiter>=0.1.2" \
+      --replace-fail "requests~=2.26.0" "requests>=2.26.0"
   '';
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     requests
     dataclasses-json
     responses

--- a/pkgs/development/python-modules/testing-common-database/default.nix
+++ b/pkgs/development/python-modules/testing-common-database/default.nix
@@ -2,11 +2,13 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "testing.common.database";
   version = "2.0.3";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -15,8 +17,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace src/testing/common/database.py \
-      --replace "collections.Callable" "collections.abc.Callable"
+      --replace-fail "collections.Callable" "collections.abc.Callable"
   '';
+
+  build-system = [ setuptools ];
 
   # There are no unit tests
   doCheck = false;

--- a/pkgs/development/python-modules/testing-postgresql/default.nix
+++ b/pkgs/development/python-modules/testing-postgresql/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   pg8000,
   postgresql,
   psycopg2,
@@ -15,7 +16,7 @@ buildPythonPackage rec {
   pname = "testing-postgresql";
   # Version 1.3.0 isn't working so let's use the latest commit from GitHub
   version = "unstable-2017-10-31";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -26,7 +27,9 @@ buildPythonPackage rec {
     hash = "sha256-A4tahAaa98X66ZYa3QxIQDZkwAwVB6ZDRObEhkbUWKs=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     testing-common-database
     pg8000
   ];
@@ -40,12 +43,14 @@ buildPythonPackage rec {
   # Add PostgreSQL to search path
   prePatch = ''
     substituteInPlace src/testing/postgresql.py \
-      --replace "/usr/local/pgsql" "${postgresql}"
+      --replace-fail "/usr/local/pgsql" "${postgresql}"
   '';
+
+  pythonRelaxDeps = [ "pg8000" ];
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pg8000 >= 1.10" "pg8000"
+      --replace-fail "pg8000 >= 1.10" "pg8000"
     substituteInPlace tests/test_postgresql.py \
       --replace-fail "self.assertRegexpMatches" "self.assertRegex"
   '';

--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     substituteInPlace requirements.txt \
       --replace-fail "==" ">="
     substituteInPlace pytest.ini \
-      --replace ' -m "not premium"' ""
+      --replace-fail ' -m "not premium"' ""
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/twitch-python/default.nix
+++ b/pkgs/development/python-modules/twitch-python/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   requests,
   rx,
   pytestCheckHook,
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "twitch-python";
   version = "0.0.20";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -22,10 +23,12 @@ buildPythonPackage rec {
   disabled = !isPy3k;
 
   postPatch = ''
-    substituteInPlace setup.py --replace "'pipenv'," ""
+    substituteInPlace setup.py --replace-fail "'pipenv'," ""
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     requests
     rx
   ];

--- a/pkgs/development/python-modules/versiontag/default.nix
+++ b/pkgs/development/python-modules/versiontag/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   git,
 }:
 
 buildPythonPackage rec {
   pname = "versiontag";
   version = "1.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "thelabnyc";
@@ -19,8 +20,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "get_version(pypi=True)" '"${version}"'
+      --replace-fail "get_version(pypi=True)" '"${version}"'
   '';
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ git ];
 

--- a/pkgs/development/python-modules/videocr/default.nix
+++ b/pkgs/development/python-modules/videocr/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   levenshtein,
   pytesseract,
   opencv4,
@@ -11,14 +12,16 @@
 buildPythonPackage rec {
   pname = "videocr";
   version = "0.1.6";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1clifwczvhvbaw2spgxkkyqsbqh21vyfw3rh094pxfmq89ylyj63";
+    hash = "sha256-w0hPfUK4un5JAjAP7vwOAuKlsZ+zv6sFV2vD/Rl3kbI=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     levenshtein
     pytesseract
     opencv4
@@ -27,12 +30,12 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "python-Levenshtein" "Levenshtein" \
-      --replace "opencv-python" "opencv"
+      --replace-fail "python-Levenshtein" "Levenshtein" \
+      --replace-fail "opencv-python" "opencv"
     substituteInPlace videocr/constants.py \
-      --replace "master" "main"
+      --replace-fail "master" "main"
     substituteInPlace videocr/video.py \
-      --replace '--tessdata-dir "{}"' '--tessdata-dir="{}"'
+      --replace-fail '--tessdata-dir "{}"' '--tessdata-dir="{}"'
   '';
 
   # Project has no tests

--- a/pkgs/development/python-modules/webdav4/default.nix
+++ b/pkgs/development/python-modules/webdav4/default.nix
@@ -10,6 +10,7 @@
   httpx,
   pytest-xdist,
   pytestCheckHook,
+  pytest-cov-stub,
   python-dateutil,
   pythonOlder,
   wsgidav,
@@ -29,17 +30,12 @@ buildPythonPackage rec {
     hash = "sha256-LgWYgERRuUODFzUnC08kDJTVRx9vanJ+OU8sREEMVwM=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace " --cov" ""
-  '';
-
-  nativeBuildInputs = [
+  build-system = [
     hatch-vcs
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     httpx
     python-dateutil
   ];
@@ -49,6 +45,7 @@ buildPythonPackage rec {
     colorama
     pytest-xdist
     pytestCheckHook
+    pytest-cov-stub
     wsgidav
   ] ++ passthru.optional-dependencies.fsspec;
 

--- a/pkgs/development/python-modules/yowsup/default.nix
+++ b/pkgs/development/python-modules/yowsup/default.nix
@@ -4,6 +4,7 @@
   pythonOlder,
   isPy3k,
   fetchFromGitHub,
+  setuptools,
   appdirs,
   consonance,
   protobuf,
@@ -16,7 +17,7 @@
 buildPythonPackage rec {
   pname = "yowsup";
   version = "3.3.0";
-  format = "setuptools";
+  pyproject = true;
 
   # The Python 2.x support of this package is incompatible with `six==1.11`:
   # https://github.com/tgalal/yowsup/issues/2416#issuecomment-365113486
@@ -29,15 +30,14 @@ buildPythonPackage rec {
     sha256 = "1pz0r1gif15lhzdsam8gg3jm6zsskiv2yiwlhaif5rl7lv3p0v7q";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "argparse" "" \
-      --replace "==" ">=" \
-  '';
+  pythonRelaxDeps = true;
+  pythonRemoveDeps = [ "argparse" ];
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     appdirs
     consonance
     protobuf

--- a/pkgs/development/python-modules/zeversolarlocal/default.nix
+++ b/pkgs/development/python-modules/zeversolarlocal/default.nix
@@ -7,6 +7,7 @@
   dos2unix,
   httpx,
   pytest-asyncio,
+  pytest-cov-stub,
   pytest-mock,
   pytestCheckHook,
   pythonOlder,
@@ -15,24 +16,25 @@
 buildPythonPackage rec {
   pname = "zeversolarlocal";
   version = "1.1.0";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ExZy5k5RE7k+D0lGmuIkGWrWQ+m24K2oqbUEg4BAVuY=";
+    hash = "sha256-ExZy5k5RE7k+D0lGmuIkGWrWQ+m24K2oqbUEg4BAVuY=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     flit-core
     dos2unix
   ];
 
-  propagatedBuildInputs = [ httpx ];
+  dependencies = [ httpx ];
 
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-cov-stub
     pytest-mock
     pytestCheckHook
   ];
@@ -50,11 +52,6 @@ buildPythonPackage rec {
       hash = "sha256-tzFCwPzhAfwVfN5mLY/DMwRv7zGzx3ScBe+kKzkYcvo=";
     })
   ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "--cov zeversolarlocal --cov-report xml:cov.xml --cov-report term-missing -vv" ""
-  '';
 
   disabledTests = [
     # Test requires network access


### PR DESCRIPTION
## Description of changes

Continuation of https://github.com/NixOS/nixpkgs/pull/334019, I grepped for --replace and:

* use `pyproject = true;`
* use `build-system` and `dependencies`
* use `--replace-fail`, and fix failures by or either changing, deleting or using other means like `pytest-cov-stub` and `pythonRelaxDeps`
* remove `repo = pname;`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
