### PR TITLE
python312Packages.salmon-mail: 3.2.0 -> 3.3.0

### DIFF
--- a/pkgs/development/python-modules/salmon-mail/default.nix
+++ b/pkgs/development/python-modules/salmon-mail/default.nix
@@ -1,39 +1,45 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  setuptools,
   dnspython,
   chardet,
-  lmtpd,
   python-daemon,
-  six,
   jinja2,
-  mock,
   click,
+  unittestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "salmon-mail";
-  version = "3.2.0";
-  format = "setuptools";
+  version = "3.3.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0q2m6xri1b7qv46rqpv2qfdgk2jvswj8lpaacnxwjna3m685fhfx";
+  src = fetchFromGitHub {
+    owner = "moggers87";
+    repo = "salmon";
+    rev = "refs/tags/${version}";
+    hash = "sha256-ysBO/ridfy7YPoTsVwAxar9UvfM/qxrx2dp0EtDNLvE=";
   };
 
   nativeCheckInputs = [
     jinja2
-    mock
+    unittestCheckHook
   ];
-  propagatedBuildInputs = [
+
+  build-system = [ setuptools ];
+
+  dependencies = [
     chardet
-    dnspython
-    lmtpd
-    python-daemon
-    six
     click
+    dnspython
+    python-daemon
+  ];
+
+  pythonImportsCheck = [
+    "salmon"
+    "salmon.handlers"
   ];
 
   # Darwin tests fail without this. See:
@@ -42,15 +48,13 @@ buildPythonPackage rec {
 
   # The tests use salmon executable installed by salmon itself so we need to add
   # that to PATH
-  checkPhase = ''
-    # tests fail and pytest is not supported
-    rm tests/server_tests.py
-    PATH=$out/bin:$PATH python setup.py test
+  preCheck = ''
+    export PATH=$out/bin:$PATH
   '';
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     homepage = "https://salmon-mail.readthedocs.org/";
+    changelog = "https://github.com/moggers87/salmon/blob/${src.rev}/CHANGELOG.rst";
     description = "Pythonic mail application server";
     mainProgram = "salmon";
     license = licenses.gpl3Only;


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/moggers87/salmon/compare/refs/tags/3.2.0...3.3.0

Changelog: https://github.com/moggers87/salmon/blob/refs/tags/3.3.0/CHANGELOG.rst



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
