### PR TITLE
footage: init at 1.3.2

### DIFF
--- a/pkgs/by-name/fo/footage/package.nix
+++ b/pkgs/by-name/fo/footage/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  rustPlatform,
+  cargo,
+  rustc,
+  appstream-glib,
+  blueprint-compiler,
+  desktop-file-utils,
+  gettext,
+  glib,
+  gst_all_1,
+  gtk4,
+  libadwaita,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook4,
+  a52dec,
+  fdk_aac,
+  ffmpeg,
+  x264,
+  x265,
+  vo-aacenc,
+  svt-av1,
+  libmpeg2,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "footage";
+  version = "1.3.2";
+
+  src = fetchFromGitLab {
+    owner = "adhami3310";
+    repo = "Footage";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-VEL96JrJ5eJEoX2miiB4dqGUXizNlYWCUZkkYkh09B8=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-RWMNeMrctIlcA4MiRx9t7OfzKeHtw3phrYsYFZH7z4c=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    rustc
+    appstream-glib
+    blueprint-compiler
+    desktop-file-utils
+    gettext
+    gtk4 # for gtk-update-icon-cache
+    glib # for glib-compile-schemas
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs =
+    [
+      glib
+      gtk4
+      libadwaita
+      a52dec
+      fdk_aac
+      ffmpeg
+      x264
+      x265
+      vo-aacenc
+      svt-av1
+      libmpeg2
+    ]
+    ++ (with gst_all_1; [
+      gst-plugins-base
+      gst-plugins-good
+      gst-plugins-rs
+      gst-plugins-good
+      gst-plugins-bad
+      gst-plugins-ugly
+      gstreamer
+      gst-editing-services
+    ]);
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ gst_all_1.gstreamer ]}"
+    )
+  '';
+
+  meta = {
+    description = "Video editing tool that allows you to trim, flip, rotate, and crop clips";
+    homepage = "https://gitlab.com/adhami3310/Footage";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ onny ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding [Footage](https://gitlab.com/adhami3310/Footage), video editing tool that allows you to trim, flip, rotate, and crop clips

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
