### PR TITLE
protoc-gen-tonic: 0.4.0 -> 0.4.1, protoc-gen-prost: 0.3.1 -> 0.4.0, protoc-gen-prost-serde: 0.3.0 -> 0.3.1, protoc-gen-prost-crate: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/by-name/pr/protoc-gen-prost-crate/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-prost-crate/package.nix
@@ -7,14 +7,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "protoc-gen-prost-crate";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-+TSZ2QstAF8DXsHunV/nQyqF++0bFud1ZWJQEI3JEwc=";
+    hash = "sha256-9rIFDZbI6XGDsNzFMnMYY4loJxojdz6vnQKAz9eDAyQ=";
   };
 
-  cargoHash = "sha256-KbErgnXG11ngzLVSktuyUAupYs1ZD64z3plKVtzLx1A=";
+  cargoHash = "sha256-uAygKDdm+0SEDFBQcaoYTRMRgnodiO/kL1sGbRmdJKE=";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/pr/protoc-gen-prost-serde/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-prost-serde/package.nix
@@ -7,14 +7,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "protoc-gen-prost-serde";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-O2Mpft31ZQncqETWzwD73I1nX1Wt5XVHcTJUk5qhRLY=";
+    hash = "sha256-RQlNVGa6BRIqIGodqNN3eGl//hkUWrq7GpTGpRBCDgE=";
   };
 
-  cargoHash = "sha256-aUWmNS3jF1I0NLApBn3GMMv6ID9mM/j7r7sPFCsFIuw=";
+  cargoHash = "sha256-ZQOlDqDUd1nZi+2iFKCUq4Gnc9HGcLblIGY2cdQyGM0=";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/pr/protoc-gen-prost/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-prost/package.nix
@@ -7,14 +7,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "protoc-gen-prost";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-ma9sdt3/uq06BMELwsNadMkiEfstQhA4DAQEPdizZJM=";
+    hash = "sha256-Bz5/LyKludw0Tz3r+xr4DMRdMSz/nRzjs7Q66z1PrTU=";
   };
 
-  cargoHash = "sha256-pJDrwX5uDIrycxtmbds8l4wadZE0RdgmNpMwVkUGJDs=";
+  cargoHash = "sha256-X6yEJBgW9XzCNSxEQYj6LdPjbCPyh4SnKwdA/+sNNeg=";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/pr/protoc-gen-tonic/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-tonic/package.nix
@@ -7,14 +7,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "protoc-gen-tonic";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-3qz1ea9lEsZjhWNA0lcwqsPkNmjj2ZBljqNRr5/2lKM=";
+    hash = "sha256-H7YQ8y6YA8kjR9bhHfBOYu0OEFc8ezqXkqC6jGScs3s=";
   };
 
-  cargoHash = "sha256-nUsRoDaP+omZdOTnaxvHbJT1uNGtyfgXyEFZbp/CeYA=";
+  cargoHash = "sha256-eYX3w/rSi/kuH6gyWCWT4on7pKedPKnl9pht1jXNwpg=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
## Description of changes

Updates to `protoc-gen-{tonic,prost{,-crate,-serde}}`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
