### PR TITLE
ayatana-indicator-bluetooth: init at 24.5.0

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -50,6 +50,10 @@ in {
       };
     };
 
+    hardware = {
+      bluetooth.enable = lib.mkDefault true;
+    };
+
     networking.networkmanager.enable = lib.mkDefault true;
 
     systemd.packages = with pkgs.lomiri; [
@@ -87,6 +91,8 @@ in {
         ayatana-indicator-messages
         ayatana-indicator-power
         ayatana-indicator-session
+      ] ++ lib.optionals config.hardware.bluetooth.enable [
+        ayatana-indicator-bluetooth
       ] ++ lib.optionals (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) [
         ayatana-indicator-sound
       ]) ++ (with pkgs.lomiri; [

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -33,6 +33,7 @@ in
         packages =
           with pkgs;
           [
+            ayatana-indicator-bluetooth
             ayatana-indicator-datetime
             ayatana-indicator-display
             ayatana-indicator-messages

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -654,12 +654,18 @@ in
               machine.send_key("left")
               machine.send_key("left")
               machine.send_key("left")
+              machine.send_key("left")
               # Notifications are usually empty, nothing to check there
 
               with subtest("ayatana indicator display works"):
                   # We start on this, don't go right
                   wait_for_text("Lock")
                   machine.screenshot("indicators_display")
+
+              with subtest("ayatana indicator bluetooth works"):
+                  machine.send_key("right")
+                  wait_for_text("Bluetooth settings")
+                  machine.screenshot("indicators_bluetooth")
 
               with subtest("lomiri indicator network works"):
                   machine.send_key("right")

--- a/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   gitUpdater,
+  nixosTests,
   cmake,
   gettext,
   glib,
@@ -65,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     };
     updateScript = gitUpdater { };
+    tests.vm = nixosTests.ayatana-indicators;
   };
 
   meta = {

--- a/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
@@ -1,0 +1,82 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  cmake,
+  gettext,
+  glib,
+  gobject-introspection,
+  intltool,
+  libayatana-common,
+  lomiri,
+  pkg-config,
+  systemd,
+  vala,
+  wrapGAppsHook3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ayatana-indicator-bluetooth";
+  version = "24.5.0";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "ayatana-indicator-bluetooth";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-EreOhrlWbSZtwazsvwWsPji2iLfQxr2LbjCI13Hrb28=";
+  };
+
+  postPatch = ''
+    substituteInPlace data/CMakeLists.txt \
+      --replace-fail 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})' \
+      --replace-fail '/etc' "\''${CMAKE_INSTALL_SYSCONFDIR}"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    gobject-introspection
+    intltool
+    pkg-config
+    vala
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    lomiri.cmake-extras
+    glib
+    libayatana-common
+    systemd
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
+    (lib.cmakeBool "GSETTINGS_COMPILE" true)
+  ];
+
+  passthru = {
+    ayatana-indicators = {
+      ayatana-indicator-bluetooth = [
+        "ayatana"
+        "lomiri"
+      ];
+    };
+    updateScript = gitUpdater { };
+  };
+
+  meta = {
+    description = "Ayatana System Indicator for Bluetooth Management";
+    longDescription = ''
+      This Ayatana Indicator exposes bluetooth functionality via the system
+      indicator API and provides fast user controls for Bluetooth devices.
+    '';
+    homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-bluetooth";
+    changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-bluetooth/blob/${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards https://github.com/NixOS/nixpkgs/issues/99090.

[Ayatana Indicator Bluetooth](https://github.com/AyatanaIndicators/ayatana-indicator-bluetooth), for showing & changing bluetooth settings.

![image](https://github.com/user-attachments/assets/58255165-0251-4771-8acd-89d2b16dcd46)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
