### PR TITLE
stdenv/linux: disable and drop `isl` from gcc's bootstrap tools

### DIFF
--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -44,7 +44,10 @@ rec {
     '';
   };
 
-  bootGCC = pkgs.gcc.cc.override { enableLTO = false; };
+  bootGCC = pkgs.gcc.cc.override {
+    enableLTO = false;
+    isl = null;
+  };
 
   bootBinutils = pkgs.binutils.bintools.override {
     withAllTargets = false;

--- a/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
@@ -17,7 +17,6 @@
   gnumake,
   gnused,
   gzip,
-  isl,
   libc,
   libmpc,
   mpfr,
@@ -156,7 +155,6 @@ stdenv.mkDerivation (finalAttrs: {
       rm -rf $out/include/c++/*/ext/parallel
 
       cp -d ${gmpxx.out}/lib/libgmp*.so* $out/lib
-      cp -d ${isl.out}/lib/libisl*.so* $out/lib
       cp -d ${mpfr.out}/lib/libmpfr*.so* $out/lib
       cp -d ${libmpc.out}/lib/libmpc*.so* $out/lib
       cp -d ${zlib.out}/lib/libz.so* $out/lib


### PR DESCRIPTION
`isl` is only needed to support `gcc` transformations enabled by `-fgraphite*` options. Packages do not usually use those flags. None of the bootstrap packages use it.

`nixpkgs` does not use up-to-date `isl` for `gcc` either. Let's drop `isl` dependency from the bootstrap binary seed.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
