### PR TITLE
nixos/dhcpcd: harden and run as unprivileged user 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -189,6 +189,11 @@
 
 - The nvidia driver no longer defaults to the proprietary driver starting with version 560. You will need to manually set `hardware.nvidia.open` to select the proprietary or open driver.
 
+- The dhcpcd service (`networking.useDHCP`) has been hardened and now runs exclusively as the "dhcpcd" user.
+  Users that were relying on the root privileges in `networking.dhcpcd.runHook` will have to write specific [sudo](security.sudo.extraRules) or [polkit](security.polkit.extraConfig) rules to allow dhcpcd to perform privileged actions.
+
+  As part of these changes, the DHCP lease files directory has also been moved from `/var/db/dhcpcd` to `/var/lib/dhcpcd`. This migration is performed automatically, but users may have to update their backup configuration.
+
 - `singularity-tools` have the `storeDir` argument removed from its override interface and use `builtins.storeDir` instead.
 
 - Two build helpers in `singularity-tools`, i.e., `mkLayer` and `shellScript`, are deprecated, as they are no longer involved in image-building. Maintainers will remove them in future releases.

--- a/nixos/modules/config/resolvconf.nix
+++ b/nixos/modules/config/resolvconf.nix
@@ -132,6 +132,8 @@ in
     }
 
     (lib.mkIf cfg.enable {
+      users.groups.resolvconf = {};
+
       networking.resolvconf.package = pkgs.openresolv;
 
       environment.systemPackages = [ cfg.package ];
@@ -143,12 +145,13 @@ in
         wants = [ "network-pre.target" ];
         wantedBy = [ "multi-user.target" ];
         restartTriggers = [ config.environment.etc."resolvconf.conf".source ];
+        serviceConfig.RemainAfterExit = true;
 
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = "${cfg.package}/bin/resolvconf -u";
-          RemainAfterExit = true;
-        };
+        script = ''
+          ${lib.getExe cfg.package} -u
+          chgrp -R resolvconf /etc/resolv.conf /run/resolvconf
+          chmod -R g=u /etc/resolv.conf /run/resolvconf
+        '';
       };
 
     })

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -232,6 +232,18 @@ in
             Group = "dhcpcd";
             StateDirectory = "dhcpcd";
             RuntimeDirectory = "dhcpcd";
+
+            ExecStartPre = "+${pkgs.writeShellScript "migrate-dhcpcd" ''
+              # migrate from old database directory
+              if test -f /var/db/dhcpcd/duid; then
+                echo 'migrating DHCP leases from /var/db/dhcpcd to /var/lib/dhcpcd ...'
+                mv /var/db/dhcpcd/* -t /var/lib/dhcpcd
+                chown dhcpcd:dhcpcd /var/lib/dhcpcd/*
+                rmdir /var/db/dhcpcd || true
+                echo done
+              fi
+            ''}";
+
             ExecStart = "@${dhcpcd}/sbin/dhcpcd dhcpcd --quiet ${lib.optionalString cfg.persistent "--persistent"} --config ${dhcpcdConf}";
             ExecReload = "${dhcpcd}/sbin/dhcpcd --rebind";
             Restart = "always";

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -10,8 +10,6 @@ let
   enableDHCP = config.networking.dhcpcd.enable &&
         (config.networking.useDHCP || lib.any (i: i.useDHCP == true) interfaces);
 
-  enableNTPService = (config.services.ntp.enable || config.services.ntpd-rs.enable || config.services.openntpd.enable || config.services.chrony.enable);
-
   # Don't start dhcpcd on explicitly configured interfaces or on
   # interfaces that are part of a bridge, bond or sit device.
   ignoredInterfaces =
@@ -87,23 +85,6 @@ let
 
       ${cfg.extraConfig}
     '';
-
-  exitHook = pkgs.writeText "dhcpcd.exit-hook" ''
-    ${lib.optionalString enableNTPService ''
-      if [ "$reason" = BOUND -o "$reason" = REBOOT ]; then
-        # Restart ntpd. We need to restart it to make sure that it will actually do something:
-        # if ntpd cannot resolve the server hostnames in its config file, then it will never do
-        # anything ever again ("couldn't resolve ..., giving up on it"), so we silently lose
-        # time synchronisation. This also applies to openntpd.
-        ${lib.optionalString config.services.ntp.enable "/run/current-system/systemd/bin/systemctl try-reload-or-restart ntpd.service || true"}
-        ${lib.optionalString config.services.ntpd-rs.enable "/run/current-system/systemd/bin/systemctl try-reload-or-restart ntpd-rs.service || true"}
-        ${lib.optionalString config.services.openntpd.enable "/run/current-system/systemd/bin/systemctl try-reload-or-restart openntpd.service || true"}
-        ${lib.optionalString config.services.chrony.enable "/run/current-system/systemd/bin/systemctl try-reload-or-restart chronyd.service || true"}
-      fi
-    ''}
-
-    ${cfg.runHook}
-  '';
 
 in
 
@@ -217,7 +198,7 @@ in
         wants = [ "network.target" ];
         before = [ "network-online.target" ];
 
-        restartTriggers = lib.optional (enableNTPService || cfg.runHook != "") [ exitHook ];
+        restartTriggers = [ cfg.runHook ];
 
         # Stopping dhcpcd during a reconfiguration is undesirable
         # because it brings down the network interfaces configured by
@@ -246,9 +227,7 @@ in
 
     environment.systemPackages = [ dhcpcd ];
 
-    environment.etc."dhcpcd.exit-hook" = lib.mkIf (enableNTPService || cfg.runHook != "") {
-      source = exitHook;
-    };
+    environment.etc."dhcpcd.exit-hook".text = cfg.runHook;
 
     powerManagement.resumeCommands = lib.mkIf config.systemd.services.dhcpcd.enable
       ''

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -206,22 +206,6 @@ in
 
   config = lib.mkIf enableDHCP {
 
-    assertions = [ {
-      # dhcpcd doesn't start properly with malloc ∉ [ libc scudo ]
-      # see https://github.com/NixOS/nixpkgs/issues/151696
-      assertion =
-        dhcpcd.enablePrivSep
-          -> lib.elem config.environment.memoryAllocator.provider [ "libc" "scudo" ];
-      message = ''
-        dhcpcd with privilege separation is incompatible with chosen system malloc.
-          Currently only the `libc` and `scudo` allocators are known to work.
-          To disable dhcpcd's privilege separation, overlay Nixpkgs and override dhcpcd
-          to set `enablePrivSep = false`.
-      '';
-    } ];
-
-    environment.etc."dhcpcd.conf".source = dhcpcdConf;
-
     systemd.services.dhcpcd = let
       cfgN = config.networking;
       hasDefaultGatewaySet = (cfgN.defaultGateway != null && cfgN.defaultGateway.address != "")

--- a/nixos/tests/chrony.nix
+++ b/nixos/tests/chrony.nix
@@ -13,8 +13,6 @@ import ./make-test-python.nix ({ lib, ... }:
       specialisation.hardened.configuration = {
         services.chrony.enableMemoryLocking = true;
         environment.memoryAllocator.provider = "graphene-hardened";
-        # dhcpcd privsep is incompatible with graphene-hardened
-        networking.useNetworkd = true;
       };
     };
   };

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -11,11 +11,6 @@ import ./make-test-python.nix ({ pkgs, ... } : {
       imports = [ ../modules/profiles/hardened.nix ];
       environment.memoryAllocator.provider = "graphene-hardened";
       nix.settings.sandbox = false;
-      nixpkgs.overlays = [
-        (final: super: {
-          dhcpcd = super.dhcpcd.override { enablePrivSep = false; };
-        })
-      ];
       virtualisation.emptyDiskImages = [ 4096 ];
       boot.initrd.postDeviceCommands = ''
         ${pkgs.dosfstools}/bin/mkfs.vfat -n EFISYS /dev/vdb

--- a/nixos/tests/networking/networkd-and-scripted.nix
+++ b/nixos/tests/networking/networkd-and-scripted.nix
@@ -132,6 +132,10 @@ let
               client.wait_until_succeeds("ip addr show dev enp2s0 | grep -q '192.168.2'")
               client.wait_until_succeeds("ip addr show dev enp2s0 | grep -q 'fd00:1234:5678:2:'")
 
+          with subtest("Wait until we have received the nameservers"):
+              client.wait_until_succeeds("grep -q 2001:db8::1 /etc/resolv.conf")
+              client.wait_until_succeeds("grep -q 192.168.2.1 /etc/resolv.conf")
+
           with subtest("Test vlan 1"):
               client.wait_until_succeeds("ping -c 1 192.168.1.1")
               client.wait_until_succeeds("ping -c 1 fd00:1234:5678:1::1")

--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -121,6 +121,7 @@ let
         static.wait_for_unit("NetworkManager.service")
 
         dynamic.wait_until_succeeds("cat /etc/resolv.conf | grep -q '192.168.1.1'")
+        dynamic.wait_until_succeeds("cat /etc/resolv.conf | grep -q '2001:db8::1'")
         static.wait_until_succeeds("cat /etc/resolv.conf | grep -q '10.10.10.10'")
         static.wait_until_fails("cat /etc/resolv.conf | grep -q '192.168.1.1'")
       '';

--- a/nixos/tests/networking/router.nix
+++ b/nixos/tests/networking/router.nix
@@ -72,6 +72,7 @@
           AdvSendAdvert on;
           AdvManagedFlag on;
           AdvOtherConfigFlag on;
+          RDNSS 2001:db8::1 {};
 
           prefix fd00:1234:5678:${toString n}::/64 {
             AdvAutonomous off;

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -7,7 +7,6 @@
 , runtimeShellPackage
 , runtimeShell
 , nixosTests
-, enablePrivSep ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -38,17 +37,8 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-  ]
-  ++ (
-    if ! enablePrivSep
-    then [ "--disable-privsep" ]
-    else [
-      "--enable-privsep"
-      # dhcpcd disables privsep if it can't find the default user,
-      # so we explicitly specify a user.
-      "--privsepuser=dhcpcd"
-    ]
-  );
+    "--disable-privsep"
+  ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
@@ -59,9 +49,8 @@ stdenv.mkDerivation rec {
   # Check that the udev plugin got built.
   postInstall = lib.optionalString (udev != null && stdenv.isLinux) "[ -e ${placeholder "out"}/lib/dhcpcd/dev/udev.so ]";
 
-  passthru = {
-    inherit enablePrivSep;
-    tests = { inherit (nixosTests.networking.scripted) macvlan dhcpSimple dhcpOneIf; };
+  passthru.tests = {
+    inherit (nixosTests.networking.scripted) macvlan dhcpSimple dhcpOneIf;
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -38,11 +38,12 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--disable-privsep"
+    "--dbdir=/var/lib/dhcpcd"
   ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
-  # Hack to make installation succeed.  dhcpcd will still use /var/db
+  # Hack to make installation succeed.  dhcpcd will still use /var/lib
   # at runtime.
   installFlags = [ "DBDIR=$(TMPDIR)/db" "SYSCONFDIR=${placeholder "out"}/etc" ];
 


### PR DESCRIPTION
## Description of changes

These changes replace the dhcpcd privsep mode with a combination of POSIX capabilities and systemd security features that allow to fully run dhcpcd as an unprivileged user. See the commit messages for why I think this is an improvement.

There are a couple of backward incompatibilities, but most users shouldn't notice any difference.

## Things done

- [x] Tested via `dhcpcd.tests`
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I re-created the PR because I messed up the staging rebase, as usual.