### PR TITLE
esp-idf: init at v5.3

### DIFF
--- a/pkgs/by-name/es/esp-idf/esp-clang.nix
+++ b/pkgs/by-name/es/esp-idf/esp-clang.nix
@@ -1,0 +1,24 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  lib,
+  libxml2,
+  libz,
+  sourceInfo ?
+    (builtins.fromJSON (builtins.readFile ./source-info.json)).tools.${stdenv.system}.esp-clang,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  dontBuild = true;
+  installPhase = "cp -R . $out";
+
+  nativeBuildInputs = lib.optional stdenv.isLinux autoPatchelfHook;
+  buildInputs = [
+    libxml2
+    libz
+    stdenv.cc.cc.lib
+  ];
+}

--- a/pkgs/by-name/es/esp-idf/esp-rom-elfs.nix
+++ b/pkgs/by-name/es/esp-idf/esp-rom-elfs.nix
@@ -1,0 +1,15 @@
+{
+  fetchurl,
+  sourceInfo ? (builtins.fromJSON (builtins.readFile ./source-info.json)).tools.any.esp-rom-elfs,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  # work around "unpacker appears to have produced no directories"
+  sourceRoot = ".";
+
+  dontBuild = true;
+  installPhase = "cp -R . $out";
+}

--- a/pkgs/by-name/es/esp-idf/esp32ulp-elf.nix
+++ b/pkgs/by-name/es/esp-idf/esp32ulp-elf.nix
@@ -1,0 +1,17 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  lib,
+  sourceInfo ?
+    (builtins.fromJSON (builtins.readFile ./source-info.json)).tools.${stdenvNoCC.system}.esp32ulp-elf,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  dontBuild = true;
+  installPhase = "cp -R . $out";
+
+  nativeBuildInputs = lib.optional stdenvNoCC.isLinux autoPatchelfHook;
+}

--- a/pkgs/by-name/es/esp-idf/openocd-esp32.nix
+++ b/pkgs/by-name/es/esp-idf/openocd-esp32.nix
@@ -1,0 +1,24 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  lib,
+  libusb1,
+  libz,
+  sourceInfo ?
+    (builtins.fromJSON (builtins.readFile ./source-info.json)).tools.${stdenvNoCC.system}.openocd-esp32,
+  stdenvNoCC,
+  systemd,
+}:
+stdenvNoCC.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  dontBuild = true;
+  installPhase = "cp -R . $out";
+
+  nativeBuildInputs = lib.optional stdenvNoCC.isLinux autoPatchelfHook;
+  buildInputs = lib.optional stdenvNoCC.isLinux systemd ++ [
+    libusb1
+    libz
+  ];
+}

--- a/pkgs/by-name/es/esp-idf/package.nix
+++ b/pkgs/by-name/es/esp-idf/package.nix
@@ -1,0 +1,140 @@
+{
+  ccache,
+  cmake,
+  esp-clang,
+  esp-rom-elfs,
+  esp32ulp-elf,
+  fetchFromGitHub,
+  fetchpatch,
+  jq,
+  lib,
+  ninja,
+  openocd-esp32,
+  python3Packages,
+  qemu-riscv32,
+  qemu-xtensa,
+  riscv32-esp-elf,
+  riscv32-esp-elf-gdb,
+  sourceInfo ? builtins.fromJSON (builtins.readFile ./source-info.json),
+  stdenv,
+  xtensa-esp-elf,
+  xtensa-esp-elf-gdb,
+}:
+stdenv.mkDerivation {
+  inherit (sourceInfo) version;
+  pname = "esp-idf";
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "esp-idf";
+    rev = "v${sourceInfo.version}";
+    hash = "sha256-w+xyva4t21STVtfYZOXY2xw6sDc2XvJXBZSx+wd1N6Y=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # ref. https://github.com/espressif/esp-idf/pull/14402
+    # but this does not apply directly on v5.3
+    (fetchpatch {
+      name = "remove-distutils.patch";
+      url = "https://github.com/nim65s/esp-idf/commit/e61eea3916f1e04eda52929e6a6ef81508dcc1d4.patch";
+      hash = "sha256-BcI/pjItdBzYy3RvQUp2LW2o1tHLEYFJhP0WGUv7FvM=";
+    })
+    (fetchpatch {
+      name = "fix-venv-detection.patch";
+      url = "https://github.com/espressif/esp-idf/pull/14435/commits/c25b563061af37df8b403c9e973ac53685ec7011.patch";
+      hash = "sha256-99EVuYFYkdND0KywfIP1V30dfVltRz9RbS11UBmHrGM=";
+    })
+  ];
+
+  postPatch = ''
+    # Don't run pip install: we already have everything.
+    # And network is not available anyways.
+    substituteInPlace tools/idf_tools.py --replace-fail \
+      "subprocess.check_call(run_args, stdout=sys.stdout, stderr=sys.stderr, env=env_copy)" \
+      ""
+
+    # When a version is found in path, we can consider it is installed.
+    substituteInPlace tools/idf_tools.py --replace-fail \
+      "self.versions_installed = []" \
+      "self.versions_installed = [self.version_in_path]"
+
+    # Nixpkgs CMake & Ninja version are fine.
+    # And explain which esp-row-elfs version is currently installed.
+    ${lib.getExe jq} \
+        '(.tools[] | select(.name == "cmake") | .versions)
+            += [{"name": "${cmake.version}", "status": "supported"}]
+         | (.tools[] | select(.name == "ninja") | .versions)
+            += [{"name": "${ninja.version}", "status": "supported"}]
+         | (.tools[] | select(.name == "esp-rom-elfs")) += {
+           "version_cmd": ["echo", "${esp-rom-elfs.version}"],
+           "version_regex": "([0-9.]+)",
+           "version_regex_replace": "\\1"}' \
+        tools/tools.json > tools.json
+    mv tools.json tools/
+  '';
+
+  env = {
+    ESP_ROM_ELF_DIR = "${esp-rom-elfs}";
+    IDF_PYTHON_ENV_PATH = "${placeholder "out"}/venv";
+    IDF_PYTHON_CHECK_CONSTRAINTS = "no";
+  };
+
+  dontUseCmakeConfigure = true;
+
+  buildPhase = "bash ./install.sh";
+
+  doCheck = true;
+  checkPhase = ''
+    python tools/idf_tools.py check
+    python tools/idf_tools.py check-python-dependencies
+  '';
+
+  installPhase = "cp -R . $out";
+
+  propagatedBuildInputs = [
+    # ref. tools/tools.json
+    ccache
+    cmake
+    esp-clang
+    esp-rom-elfs
+    esp32ulp-elf
+    ninja
+    openocd-esp32
+    qemu-riscv32
+    qemu-xtensa
+    riscv32-esp-elf
+    riscv32-esp-elf-gdb
+    xtensa-esp-elf
+    xtensa-esp-elf-gdb
+
+    # ref. tools/requirements/requirements.core.txt
+    python3Packages.setuptools
+    python3Packages.packaging
+    python3Packages.click
+    python3Packages.pyserial
+    python3Packages.cryptography
+    python3Packages.pyparsing
+    python3Packages.pyelftools
+    python3Packages.idf-component-manager
+    python3Packages.esp-coredump
+    python3Packages.esptool
+    python3Packages.esp-idf-kconfig
+    python3Packages.esp-idf-monitor
+    python3Packages.esp-idf-nvs-partition-gen
+    python3Packages.esp-idf-size
+    python3Packages.esp-idf-panic-decoder
+    python3Packages.pyclang
+    python3Packages.construct
+    python3Packages.freertos-gdb
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Espressif IoT Development Framework. Official development framework for Espressif SoCs";
+    homepage = "https://github.com/espressif/esp-idf";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/by-name/es/esp-idf/qemu-riscv32.nix
+++ b/pkgs/by-name/es/esp-idf/qemu-riscv32.nix
@@ -1,0 +1,43 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  glib,
+  lib,
+  libgcrypt,
+  libslirp,
+  libz,
+  SDL2,
+  sourceInfo ?
+    (builtins.fromJSON (builtins.readFile ./source-info.json)).tools.${stdenv.system}.qemu-riscv32,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  dontBuild = true;
+  installPhase = "cp -R . $out";
+
+  preFixup = lib.optionalString stdenv.isDarwin ''
+    install_name_tool \
+      -change \
+        /opt/homebrew/opt/libgcrypt/lib/libgcrypt.20.dylib \
+        ${lib.getLib libgcrypt}/lib/libgcrypt.20.dylib \
+      -change \
+        /opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib \
+        ${lib.getLib SDL2}/lib/libSDL2-2.0.0.dylib \
+      -change \
+        /opt/homebrew/opt/libslirp/lib/libslirp.0.dylib \
+        ${lib.getLib libslirp}/lib/libslirp.0.dylib \
+      $out/bin/qemu-system-riscv32
+  '';
+
+  nativeBuildInputs = lib.optional stdenv.isLinux autoPatchelfHook;
+  buildInputs = [
+    glib
+    libgcrypt
+    libslirp
+    libz
+    SDL2
+  ];
+}

--- a/pkgs/by-name/es/esp-idf/qemu-xtensa.nix
+++ b/pkgs/by-name/es/esp-idf/qemu-xtensa.nix
@@ -1,0 +1,43 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  glib,
+  lib,
+  libgcrypt,
+  libslirp,
+  libz,
+  SDL2,
+  sourceInfo ?
+    (builtins.fromJSON (builtins.readFile ./source-info.json)).tools.${stdenv.system}.qemu-xtensa,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  dontBuild = true;
+  installPhase = "cp -R . $out";
+
+  preFixup = lib.optionalString stdenv.isDarwin ''
+    install_name_tool \
+      -change \
+        /opt/homebrew/opt/libgcrypt/lib/libgcrypt.20.dylib \
+        ${lib.getLib libgcrypt}/lib/libgcrypt.20.dylib \
+      -change \
+        /opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib \
+        ${lib.getLib SDL2}/lib/libSDL2-2.0.0.dylib \
+      -change \
+        /opt/homebrew/opt/libslirp/lib/libslirp.0.dylib \
+        ${lib.getLib libslirp}/lib/libslirp.0.dylib \
+      $out/bin/qemu-system-xtensa
+  '';
+
+  nativeBuildInputs = lib.optional stdenv.isLinux autoPatchelfHook;
+  buildInputs = [
+    glib
+    libgcrypt
+    libslirp
+    libz
+    SDL2
+  ];
+}

--- a/pkgs/by-name/es/esp-idf/riscv32-esp-elf-gdb.nix
+++ b/pkgs/by-name/es/esp-idf/riscv32-esp-elf-gdb.nix
@@ -1,0 +1,31 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  lib,
+  python3,
+  sourceInfo ?
+    (builtins.fromJSON (builtins.readFile ./source-info.json))
+    .tools.${stdenvNoCC.system}.riscv32-esp-elf-gdb,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R include package.json share $out
+    # avoid riscv32-esp-elf-gdb-3.X for other python versions
+    cp \
+      bin/riscv32-esp-elf-gdb \
+      bin/riscv32-esp-elf-gdb-3.${python3.sourceVersion.minor} \
+      bin/riscv32-esp-elf-gdb-add-index \
+      bin/riscv32-esp-elf-gdb-no-python \
+      bin/riscv32-esp-elf-gprof \
+      $out/bin
+  '';
+
+  nativeBuildInputs = lib.optional stdenvNoCC.isLinux autoPatchelfHook;
+  buildInputs = [ python3 ];
+}

--- a/pkgs/by-name/es/esp-idf/riscv32-esp-elf.nix
+++ b/pkgs/by-name/es/esp-idf/riscv32-esp-elf.nix
@@ -1,0 +1,27 @@
+{
+  autoPatchelfHook,
+  darwin,
+  fetchurl,
+  lib,
+  sourceInfo ?
+    (builtins.fromJSON (builtins.readFile ./source-info.json)).tools.${stdenv.system}.riscv32-esp-elf,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  dontBuild = true;
+  installPhase = "cp -R . $out";
+
+  preFixup = lib.optionalString stdenv.isDarwin ''
+    for lib in $out/libexec/gcc/riscv32-esp-elf/${builtins.head (lib.splitString "_" sourceInfo.version)}/*.so
+    do install_name_tool -id $lib $lib
+    done
+  '';
+
+  nativeBuildInputs =
+    lib.optional stdenv.isLinux autoPatchelfHook
+    ++ lib.optional stdenv.isDarwin darwin.autoSignDarwinBinariesHook;
+  buildInputs = [ stdenv.cc.cc.lib ];
+}

--- a/pkgs/by-name/es/esp-idf/source-info.json
+++ b/pkgs/by-name/es/esp-idf/source-info.json
@@ -1,0 +1,325 @@
+{
+  "version": "5.3",
+  "url": "https://github.com/espressif/esp-idf/releases/download/v5.3/esp-idf-v5.3.zip",
+  "hash": "sha256-MM+OQLiMXBSZARPVjN/BXacjFded7oeF1e2B0nONBZk=",
+  "tools": {
+    "any": {
+      "esp-rom-elfs": {
+        "pname": "esp-rom-elfs",
+        "name": "esp-rom-elfs-20240305.tar.gz",
+        "version": "20240305",
+        "url": "https://github.com/espressif/esp-rom-elfs/releases/download/20240305/esp-rom-elfs-20240305.tar.gz",
+        "sha256": "a26609b415710f0163d785850c769752717004059c129c472e9a0cbd54e0422c"
+      }
+    },
+    "aarch64-darwin": {
+      "xtensa-esp-elf-gdb": {
+        "pname": "xtensa-esp-elf-gdb",
+        "name": "xtensa-esp-elf-gdb-14.2_20240403-aarch64-apple-darwin21.1.tar.gz",
+        "version": "14.2_20240403",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-aarch64-apple-darwin21.1.tar.gz",
+        "sha256": "ea757c6bf8c25238f6d2fdcc6bbab25a1b00608a0f9e19b7ddd2f37ddbdc3fb1"
+      },
+      "riscv32-esp-elf-gdb": {
+        "pname": "riscv32-esp-elf-gdb",
+        "name": "riscv32-esp-elf-gdb-14.2_20240403-aarch64-apple-darwin21.1.tar.gz",
+        "version": "14.2_20240403",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-aarch64-apple-darwin21.1.tar.gz",
+        "sha256": "d88b6116e86456c8480ce9bc95aed375a35c0d091f1da0a53b86be0e6ef3d320"
+      },
+      "xtensa-esp-elf": {
+        "pname": "xtensa-esp-elf",
+        "name": "xtensa-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.xz",
+        "version": "13.2.0_20240530",
+        "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.xz",
+        "sha256": "d967e49a64f823e18fbae273efb1b094ac55e2207aa21fd3947c9d59f999f47e"
+      },
+      "esp-clang": {
+        "pname": "esp-clang",
+        "name": "llvm-esp-16.0.0-20230516-macos-arm64.tar.xz",
+        "version": "16.0.0-20230516",
+        "url": "https://github.com/espressif/llvm-project/releases/download/esp-16.0.0-20230516/llvm-esp-16.0.0-20230516-macos-arm64.tar.xz",
+        "sha256": "ed5621396dc3e48413e14e8b6caed8e2993e7f2ab5fca1410081f40c940a1060"
+      },
+      "riscv32-esp-elf": {
+        "pname": "riscv32-esp-elf",
+        "name": "riscv32-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.xz",
+        "version": "13.2.0_20240530",
+        "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.xz",
+        "sha256": "230628fcf464ca8856c82c55514e40a8919e97fbc5e66b7165ca42c9653d2302"
+      },
+      "esp32ulp-elf": {
+        "pname": "esp32ulp-elf",
+        "name": "esp32ulp-elf-2.38_20240113-macos-arm64.tar.gz",
+        "version": "2.38_20240113",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp32ulp-elf-2.38_20240113/esp32ulp-elf-2.38_20240113-macos-arm64.tar.gz",
+        "sha256": "e3a4dfea043e2bce8cd00b3a0b260a59249fa61ca5931bf02f18a3d43c18deb4"
+      },
+      "cmake": {
+        "pname": "cmake",
+        "name": "cmake-3.24.0-macos-universal.tar.gz",
+        "version": "3.24.0",
+        "url": "https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-macos-universal.tar.gz",
+        "sha256": "3e0cca74a56d9027dabb845a5a26e42ef8e8b33beb1655d6a724187a345145e4"
+      },
+      "openocd-esp32": {
+        "pname": "openocd-esp32",
+        "name": "openocd-esp32-macos-arm64-0.12.0-esp32-20240318.tar.gz",
+        "version": "0.12.0-esp32-20240318",
+        "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-macos-arm64-0.12.0-esp32-20240318.tar.gz",
+        "sha256": "534ec925ae6e35e869e4e4e6e4d2c4a1eb081f97ebcc2dd5efdc52d12f4c2f86"
+      },
+      "ninja": {
+        "pname": "ninja",
+        "name": "ninja-mac.zip",
+        "version": "1.11.1",
+        "url": "https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip",
+        "sha256": "482ecb23c59ae3d4f158029112de172dd96bb0e97549c4b1ca32d8fad11f873e"
+      },
+      "qemu-xtensa": {
+        "pname": "qemu-xtensa",
+        "name": "qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-aarch64-apple-darwin.tar.xz",
+        "version": "8.2.0-20240122",
+        "url": "https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-aarch64-apple-darwin.tar.xz",
+        "sha256": "9134f6dc653c6dd556a6c9c2d80b9eca0c437a8f625e994f9285aadf7b2e7d6f"
+      },
+      "qemu-riscv32": {
+        "pname": "qemu-riscv32",
+        "name": "qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-aarch64-apple-darwin.tar.xz",
+        "version": "8.2.0-20240122",
+        "url": "https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-aarch64-apple-darwin.tar.xz",
+        "sha256": "b3f23e294cf325f92e5e8948583cc985d55d5d2ba3d79c04c9d09f080b62954d"
+      }
+    },
+    "aarch64-linux": {
+      "xtensa-esp-elf-gdb": {
+        "pname": "xtensa-esp-elf-gdb",
+        "name": "xtensa-esp-elf-gdb-14.2_20240403-aarch64-linux-gnu.tar.gz",
+        "version": "14.2_20240403",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-aarch64-linux-gnu.tar.gz",
+        "sha256": "bdabc3217994815fc311c4e16e588b78f6596b5ad4ffa46c80b40e982cfb1e66"
+      },
+      "riscv32-esp-elf-gdb": {
+        "pname": "riscv32-esp-elf-gdb",
+        "name": "riscv32-esp-elf-gdb-14.2_20240403-aarch64-linux-gnu.tar.gz",
+        "version": "14.2_20240403",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-aarch64-linux-gnu.tar.gz",
+        "sha256": "ba10f2866c61410b88c65957274280b1a62e3bed05131654ed9b6758efe18e55"
+      },
+      "xtensa-esp-elf": {
+        "pname": "xtensa-esp-elf",
+        "name": "xtensa-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.xz",
+        "version": "13.2.0_20240530",
+        "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.xz",
+        "sha256": "cfe55b92b4baeaa4309a948ba65e2adfc2d17a542c64856e36650869b419574a"
+      },
+      "esp-clang": {
+        "pname": "esp-clang",
+        "name": "llvm-esp-16.0.0-20230516-linux-arm64.tar.xz",
+        "version": "16.0.0-20230516",
+        "url": "https://github.com/espressif/llvm-project/releases/download/esp-16.0.0-20230516/llvm-esp-16.0.0-20230516-linux-arm64.tar.xz",
+        "sha256": "4b115af6ddd04a9bffc1908fc05837998ee71d450891d741c446186f2aa9b961"
+      },
+      "riscv32-esp-elf": {
+        "pname": "riscv32-esp-elf",
+        "name": "riscv32-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.xz",
+        "version": "13.2.0_20240530",
+        "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.xz",
+        "sha256": "276351b883a53e81b695d858be74114a8b627bbe4fc9c69ef46a7127ab143680"
+      },
+      "esp32ulp-elf": {
+        "pname": "esp32ulp-elf",
+        "name": "esp32ulp-elf-2.38_20240113-linux-arm64.tar.gz",
+        "version": "2.38_20240113",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp32ulp-elf-2.38_20240113/esp32ulp-elf-2.38_20240113-linux-arm64.tar.gz",
+        "sha256": "ecce0788ce1000e5c669c5adaf2fd5bf7f9bf96dcdbd3555d1d9ce4dcb311038"
+      },
+      "cmake": {
+        "pname": "cmake",
+        "name": "cmake-3.24.0-linux-aarch64.tar.gz",
+        "version": "3.24.0",
+        "url": "https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-aarch64.tar.gz",
+        "sha256": "50c3b8e9d3a3cde850dd1ea143df9d1ae546cbc5e74dc6d223eefc1979189651"
+      },
+      "openocd-esp32": {
+        "pname": "openocd-esp32",
+        "name": "openocd-esp32-linux-arm64-0.12.0-esp32-20240318.tar.gz",
+        "version": "0.12.0-esp32-20240318",
+        "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-arm64-0.12.0-esp32-20240318.tar.gz",
+        "sha256": "9b97a37aa2cab94424a778c25c0b4aa0f90d6ef9cda764a1d9289d061305f4b7"
+      },
+      "qemu-xtensa": {
+        "pname": "qemu-xtensa",
+        "name": "qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-aarch64-linux-gnu.tar.xz",
+        "version": "8.2.0-20240122",
+        "url": "https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-aarch64-linux-gnu.tar.xz",
+        "sha256": "77c83f2772f7d9b0c770722c2cebf3625d21d8eddbccfea6816f3d8f4982ea86"
+      },
+      "qemu-riscv32": {
+        "pname": "qemu-riscv32",
+        "name": "qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-aarch64-linux-gnu.tar.xz",
+        "version": "8.2.0-20240122",
+        "url": "https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-aarch64-linux-gnu.tar.xz",
+        "sha256": "4089f7958f753779e5b4c93fe2469d62850a1f209b0bda8b75d55fe4a61ca39b"
+      }
+    },
+    "x86_64-darwin": {
+      "xtensa-esp-elf-gdb": {
+        "pname": "xtensa-esp-elf-gdb",
+        "name": "xtensa-esp-elf-gdb-14.2_20240403-x86_64-apple-darwin14.tar.gz",
+        "version": "14.2_20240403",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-x86_64-apple-darwin14.tar.gz",
+        "sha256": "023e74b3fda793da4bc0509b02de776ee0dad6efaaac17bef5916fb7dc9c26b9"
+      },
+      "riscv32-esp-elf-gdb": {
+        "pname": "riscv32-esp-elf-gdb",
+        "name": "riscv32-esp-elf-gdb-14.2_20240403-x86_64-apple-darwin14.tar.gz",
+        "version": "14.2_20240403",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-x86_64-apple-darwin14.tar.gz",
+        "sha256": "8f6bda832d70dad5860a639d55aba4237bd10cbac9f4822db1eece97357b34a9"
+      },
+      "xtensa-esp-elf": {
+        "pname": "xtensa-esp-elf",
+        "name": "xtensa-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.xz",
+        "version": "13.2.0_20240530",
+        "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.xz",
+        "sha256": "39ee7df749f4ceb93624d73627688d5b86269a7429022f986f2940499936aacd"
+      },
+      "esp-clang": {
+        "pname": "esp-clang",
+        "name": "llvm-esp-16.0.0-20230516-macos.tar.xz",
+        "version": "16.0.0-20230516",
+        "url": "https://github.com/espressif/llvm-project/releases/download/esp-16.0.0-20230516/llvm-esp-16.0.0-20230516-macos.tar.xz",
+        "sha256": "d9824acafd3e7b1d17ace084243b82a95bbdcb149a26b085bba487ab3d3716d7"
+      },
+      "riscv32-esp-elf": {
+        "pname": "riscv32-esp-elf",
+        "name": "riscv32-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.xz",
+        "version": "13.2.0_20240530",
+        "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.xz",
+        "sha256": "cfbf5deaba05bf217701c8ceab7396bb0c2ca95ab58e134d4b2e175b86c2fd6c"
+      },
+      "esp32ulp-elf": {
+        "pname": "esp32ulp-elf",
+        "name": "esp32ulp-elf-2.38_20240113-macos.tar.gz",
+        "version": "2.38_20240113",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp32ulp-elf-2.38_20240113/esp32ulp-elf-2.38_20240113-macos.tar.gz",
+        "sha256": "b2aeba8eaafdf156e9e30be928dde1f133b00eaf33802d96827ec544ac7c864c"
+      },
+      "cmake": {
+        "pname": "cmake",
+        "name": "cmake-3.24.0-macos-universal.tar.gz",
+        "version": "3.24.0",
+        "url": "https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-macos-universal.tar.gz",
+        "sha256": "3e0cca74a56d9027dabb845a5a26e42ef8e8b33beb1655d6a724187a345145e4"
+      },
+      "openocd-esp32": {
+        "pname": "openocd-esp32",
+        "name": "openocd-esp32-macos-0.12.0-esp32-20240318.tar.gz",
+        "version": "0.12.0-esp32-20240318",
+        "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-macos-0.12.0-esp32-20240318.tar.gz",
+        "sha256": "b16c3082c94df1079367c44d99f7a8605534cd48aabc18898e46e94a2c8c57e7"
+      },
+      "ninja": {
+        "pname": "ninja",
+        "name": "ninja-mac.zip",
+        "version": "1.11.1",
+        "url": "https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip",
+        "sha256": "482ecb23c59ae3d4f158029112de172dd96bb0e97549c4b1ca32d8fad11f873e"
+      },
+      "qemu-xtensa": {
+        "pname": "qemu-xtensa",
+        "name": "qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-x86_64-apple-darwin.tar.xz",
+        "version": "8.2.0-20240122",
+        "url": "https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-x86_64-apple-darwin.tar.xz",
+        "sha256": "897126a12aeac1cc7d8e9a50626cdf0bc4812fd4bceb77b07ff4a81b86deaaa4"
+      },
+      "qemu-riscv32": {
+        "pname": "qemu-riscv32",
+        "name": "qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-x86_64-apple-darwin.tar.xz",
+        "version": "8.2.0-20240122",
+        "url": "https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-x86_64-apple-darwin.tar.xz",
+        "sha256": "e9cc3c1344f6bf1ffa3748a4c59d88f9005c2689cc0583458cea35409a73c923"
+      }
+    },
+    "x86_64-linux": {
+      "xtensa-esp-elf-gdb": {
+        "pname": "xtensa-esp-elf-gdb",
+        "name": "xtensa-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz",
+        "version": "14.2_20240403",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz",
+        "sha256": "9d68472d4cba5cf8c2b79d94f86f92c828e76a632bd1e6be5e7706e5b304d36e"
+      },
+      "riscv32-esp-elf-gdb": {
+        "pname": "riscv32-esp-elf-gdb",
+        "name": "riscv32-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz",
+        "version": "14.2_20240403",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz",
+        "sha256": "ce004bc0bbd71b246800d2d13b239218b272a38bd528e316f21f1af2db8a4b13"
+      },
+      "xtensa-esp-elf": {
+        "pname": "xtensa-esp-elf",
+        "name": "xtensa-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.xz",
+        "version": "13.2.0_20240530",
+        "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.xz",
+        "sha256": "fcef03d87eac44c0dbee2bbee98443ed2fcf82720dcd8ebfe00640807b0f07c2"
+      },
+      "esp-clang": {
+        "pname": "esp-clang",
+        "name": "llvm-esp-16.0.0-20230516-linux-amd64.tar.xz",
+        "version": "16.0.0-20230516",
+        "url": "https://github.com/espressif/llvm-project/releases/download/esp-16.0.0-20230516/llvm-esp-16.0.0-20230516-linux-amd64.tar.xz",
+        "sha256": "3dbd8dd290913a93e8941da8a451ecd49f9798cc2d74bb9b63ef5cf5c4fee37f"
+      },
+      "riscv32-esp-elf": {
+        "pname": "riscv32-esp-elf",
+        "name": "riscv32-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.xz",
+        "version": "13.2.0_20240530",
+        "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.xz",
+        "sha256": "f69a491d2f42f63e119f9077da995f7743ea8e1bf6944166a42a312cf60728a8"
+      },
+      "esp32ulp-elf": {
+        "pname": "esp32ulp-elf",
+        "name": "esp32ulp-elf-2.38_20240113-linux-amd64.tar.gz",
+        "version": "2.38_20240113",
+        "url": "https://github.com/espressif/binutils-gdb/releases/download/esp32ulp-elf-2.38_20240113/esp32ulp-elf-2.38_20240113-linux-amd64.tar.gz",
+        "sha256": "d13a808365b78465fa6591636dfbbb9604d9d15a397c3d9cd22626d54828ac2c"
+      },
+      "cmake": {
+        "pname": "cmake",
+        "name": "cmake-3.24.0-linux-x86_64.tar.gz",
+        "version": "3.24.0",
+        "url": "https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-x86_64.tar.gz",
+        "sha256": "726f88e6598523911e4bce9b059dc20b851aa77f97e4cc5573f4e42775a5c16f"
+      },
+      "openocd-esp32": {
+        "pname": "openocd-esp32",
+        "name": "openocd-esp32-linux-amd64-0.12.0-esp32-20240318.tar.gz",
+        "version": "0.12.0-esp32-20240318",
+        "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-amd64-0.12.0-esp32-20240318.tar.gz",
+        "sha256": "cf26c5cef4f6b04aa23cd2778675604e5a74a4ce4d8d17b854d05fbcb782d52c"
+      },
+      "ninja": {
+        "pname": "ninja",
+        "name": "ninja-linux.zip",
+        "version": "1.11.1",
+        "url": "https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip",
+        "sha256": "b901ba96e486dce377f9a070ed4ef3f79deb45f4ffe2938f8e7ddc69cfb3df77"
+      },
+      "qemu-xtensa": {
+        "pname": "qemu-xtensa",
+        "name": "qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-x86_64-linux-gnu.tar.xz",
+        "version": "8.2.0-20240122",
+        "url": "https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-x86_64-linux-gnu.tar.xz",
+        "sha256": "e7c72ef5705ad1444d391711088c8717fc89f42e9bf6d1487f9c2a326b8cfa83"
+      },
+      "qemu-riscv32": {
+        "pname": "qemu-riscv32",
+        "name": "qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-x86_64-linux-gnu.tar.xz",
+        "version": "8.2.0-20240122",
+        "url": "https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-x86_64-linux-gnu.tar.xz",
+        "sha256": "95ac86d7b53bf98b5ff19c33aa926189b849f5a0daf8f41e160bc86c5e31abd4"
+      }
+    }
+  }
+}

--- a/pkgs/by-name/es/esp-idf/tools.jq
+++ b/pkgs/by-name/es/esp-idf/tools.jq
@@ -1,0 +1,28 @@
+def parse(args):
+    map(args.data.versions[0][args.key] as $info
+        | select($info.url != null)
+        | {(.name): {
+            pname: .name,
+            name: $info.url
+                | split("/")[8],
+            version: $info.url
+                | split("/")[7]
+                | sub("^esp-"; "")
+                | sub("^gdb-"; "")
+                | sub("^develop-"; "")
+                | sub("^v"; "")
+                | sub("^esp32ulp-elf-"; ""),
+            url: $info.url,
+            sha256: $info.sha256,
+        }}
+        )
+    | add;
+
+.tools
+    | {
+        "any": parse({"data": ., "key": "any"}),
+        "aarch64-darwin": parse({"data": ., "key": "macos-arm64"}),
+        "aarch64-linux": parse({"data": ., "key": "linux-arm64"}),
+        "x86_64-darwin": parse({"data": ., "key": "macos"}),
+        "x86_64-linux": parse({"data": ., "key": "linux-amd64"}),
+    }

--- a/pkgs/by-name/es/esp-idf/update.sh
+++ b/pkgs/by-name/es/esp-idf/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash --pure -p cacert curl jq nurl
+# shellcheck shell=bash
+
+set -euo pipefail
+
+# https://stackoverflow.com/a/246128/1368502
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+info_json=$(curl -sSLf https://api.github.com/repos/espressif/esp-idf/releases)
+version=$(jq -r 'map(.tag_name) | sort | map(select(contains("-") | not))[-1]' <<< "$info_json")
+url=$(jq -r "map(select(.tag_name == \"$version\"))[0].assets[0].browser_download_url" <<< "$info_json")
+hash=$(nurl -H "$url")
+tools_json=$(curl -sSLf "https://raw.githubusercontent.com/espressif/esp-idf/$version/tools/tools.json")
+tools=$(jq -f "$SCRIPT_DIR/tools.jq" <<< "$tools_json")
+
+jq -n \
+    --arg version "${version/v}" \
+    --arg url "$url" \
+    --arg hash "$hash" \
+    --argjson tools "$tools" \
+    '$ARGS.named' \
+    | tee "$SCRIPT_DIR/source-info.json" 1>&2

--- a/pkgs/by-name/es/esp-idf/xtensa-esp-elf-gdb.nix
+++ b/pkgs/by-name/es/esp-idf/xtensa-esp-elf-gdb.nix
@@ -1,0 +1,33 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  lib,
+  python3,
+  sourceInfo ?
+    (builtins.fromJSON (builtins.readFile ./source-info.json))
+    .tools.${stdenvNoCC.system}.xtensa-esp-elf-gdb,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R include lib package.json share $out
+    # avoid xtensa-esp-elf-gdb-3.X for other python versions
+    cp \
+      bin/xtensa-esp-elf-gdb-3.${python3.sourceVersion.minor} \
+      bin/xtensa-esp-elf-gdb-add-index \
+      bin/xtensa-esp-elf-gdb-no-python \
+      bin/xtensa-esp-elf-gprof \
+      bin/xtensa-esp32-elf-gdb \
+      bin/xtensa-esp32s2-elf-gdb \
+      bin/xtensa-esp32s3-elf-gdb \
+      $out/bin
+  '';
+
+  nativeBuildInputs = lib.optional stdenvNoCC.isLinux autoPatchelfHook;
+  buildInputs = [ python3 ];
+}

--- a/pkgs/by-name/es/esp-idf/xtensa-esp-elf.nix
+++ b/pkgs/by-name/es/esp-idf/xtensa-esp-elf.nix
@@ -1,0 +1,27 @@
+{
+  autoPatchelfHook,
+  darwin,
+  fetchurl,
+  lib,
+  sourceInfo ?
+    (builtins.fromJSON (builtins.readFile ./source-info.json)).tools.${stdenv.system}.xtensa-esp-elf,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  inherit (sourceInfo) pname version;
+  src = fetchurl { inherit (sourceInfo) name url sha256; };
+
+  dontBuild = true;
+  installPhase = "cp -R . $out";
+
+  preFixup = lib.optionalString stdenv.isDarwin ''
+    for lib in $out/lib/*.so
+    do install_name_tool -id $lib $lib
+    done
+  '';
+
+  nativeBuildInputs =
+    lib.optional stdenv.isLinux autoPatchelfHook
+    ++ lib.optional stdenv.isDarwin darwin.autoSignDarwinBinariesHook;
+  buildInputs = [ stdenv.cc.cc.lib ];
+}

--- a/pkgs/development/python-modules/esp-coredump/default.nix
+++ b/pkgs/development/python-modules/esp-coredump/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  setuptools,
+  construct,
+  esptool,
+  pygdbmi,
+}:
+
+buildPythonPackage rec {
+  pname = "esp-coredump";
+  version = "1.11.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "esp-coredump";
+    rev = "v${version}";
+    hash = "sha256-yrt/45+vF0YY3D0fK71R/g4Bg2/Qi8SaxbC3Ztkxobo=";
+  };
+
+  patches = [
+    # This was merged upstream and can be removed on next release
+    (fetchpatch {
+      name = "replace-distutils-with-shutil.patch";
+      url = "https://github.com/espressif/esp-coredump/pull/10/commits/d45c2e7fa98e771d9b22e6fc74e6e5d32dab20a7.patch";
+      hash = "sha256-/ufaBFX0Dr+7liz/QxO1NKQNUpZZagVVwx45OkV1W0Q=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [
+    construct
+    esptool
+    pygdbmi
+  ];
+
+  pythonImportsCheck = [ "esp_coredump" ];
+
+  meta = {
+    description = "help users to retrieve and analyse core dumps";
+    homepage = "https://github.com/espressif/esp-coredump";
+    changelog = "https://github.com/espressif/esp-coredump/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "esp-coredump";
+  };
+}

--- a/pkgs/development/python-modules/esp-idf-kconfig/default.nix
+++ b/pkgs/development/python-modules/esp-idf-kconfig/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "esp-idf-kconfig";
+  version = "2.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "esp-idf-kconfig";
+    rev = "v${version}";
+    hash = "sha256-aZUSl4Q++GTxnS7/V+p1rcpdGbTAMLXBvUJ3Cmb5DJg=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  pythonImportsCheck = [ "esp_idf_kconfig" ];
+
+  meta = {
+    description = "enable espressif project configuration using the kconfig language";
+    homepage = "https://github.com/espressif/esp-idf-kconfig";
+    changelog = "https://github.com/espressif/esp-idf-kconfig/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/esp-idf-monitor/default.nix
+++ b/pkgs/development/python-modules/esp-idf-monitor/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  esp-coredump,
+  esp-idf-panic-decoder,
+  pyserial,
+}:
+
+buildPythonPackage rec {
+  pname = "esp-idf-monitor";
+  version = "1.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "esp-idf-monitor";
+    rev = "v${version}";
+    hash = "sha256-TMs0X9//UCIgb+tZ0pPIcWFFjse40DL1Dghbu4Am4aM=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [
+    esp-coredump
+    esp-idf-panic-decoder
+    pyserial
+  ];
+
+  pythonImportsCheck = [ "esp_idf_monitor" ];
+
+  meta = {
+    description = "serial communication input and output in ESP-IDF projects";
+    homepage = "https://github.com/espressif/esp-idf-monitor";
+    changelog = "https://github.com/espressif/esp-idf-monitor/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/esp-idf-nvs-partition-gen/default.nix
+++ b/pkgs/development/python-modules/esp-idf-nvs-partition-gen/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cryptography,
+}:
+
+buildPythonPackage rec {
+  pname = "esp-idf-nvs-partition-gen";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "esp-idf-nvs-partition-gen";
+    # has no tags, so use commit "ci: Fix release PyPI GitHub action and bump version"
+    rev = "251d2166ae5dcc95c369ade77b5f6459b657e620";
+    hash = "sha256-fFNqv3AJPthKfnvHC2Rt0lpVTYqY06z6RjHu0bREKY8=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [ cryptography ];
+
+  pythonImportsCheck = [ "esp_idf_nvs_partition_gen" ];
+
+  meta = {
+    description = "NVS Partition Generator tool";
+    homepage = "https://github.com/espressif/esp-idf-nvs-partition-gen";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/esp-idf-panic-decoder/default.nix
+++ b/pkgs/development/python-modules/esp-idf-panic-decoder/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pyelftools,
+}:
+
+buildPythonPackage rec {
+  pname = "esp-idf-panic-decoder";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "esp-idf-panic-decoder";
+    rev = "v${version}";
+    hash = "sha256-5KeYX5kNWopkLorh6rLZ4YeZYPjROJ+dQzI8tPsVUa4=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [ pyelftools ];
+
+  pythonImportsCheck = [ "esp_idf_panic_decoder" ];
+
+  meta = {
+    description = "parses ESP-IDF panic handler output (registers & stack dump)";
+    homepage = "https://github.com/espressif/esp-idf-panic-decoder";
+    changelog = "https://github.com/espressif/esp-idf-panic-decoder/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/esp-idf-size/default.nix
+++ b/pkgs/development/python-modules/esp-idf-size/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pyyaml,
+  rich,
+}:
+
+buildPythonPackage rec {
+  pname = "esp-idf-size";
+  version = "1.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "esp-idf-size";
+    rev = "v${version}";
+    hash = "sha256-a01OYlHY/0ujcSW+X2GJPRQvmDWhSW9RPQS/KK4bisY=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [
+    pyyaml
+    rich
+  ];
+
+  pythonImportsCheck = [ "esp_idf_size" ];
+
+  meta = {
+    description = "explore statically allocated RAM used by the final binary firmware image";
+    homepage = "https://github.com/espressif/esp-idf-size";
+    changelog = "https://github.com/espressif/esp-idf-size/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/idf-component-manager/default.nix
+++ b/pkgs/development/python-modules/idf-component-manager/default.nix
@@ -1,0 +1,112 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+  setuptools,
+  click,
+  colorama,
+  git,
+  jinja2,
+  jsonref,
+  jsonschema,
+  pexpect,
+  pydantic,
+  pydantic-core,
+  pydantic-settings,
+  pyparsing,
+  pytest,
+  pytestCheckHook,
+  pytest-cov,
+  pytest-mock,
+  pyyaml,
+  requests,
+  requests-file,
+  requests-mock,
+  requests-toolbelt,
+  sphinx,
+  sphinxHook,
+  sphinx-click,
+  sphinx-collapse,
+  sphinx-copybutton,
+  sphinx-rtd-theme,
+  sphinx-tabs,
+  stdenv,
+  tqdm,
+  typing-extensions,
+  vcrpy,
+}:
+
+buildPythonPackage rec {
+  pname = "idf-component-manager";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "idf-component-manager";
+    rev = "v${version}";
+    hash = "sha256-kfUIy+xjbHoZjMNFWfgwe+84TEvY8905tJSDUJn50Gs=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [
+    click
+    colorama
+    jsonref
+    pydantic
+    pydantic-core
+    pydantic-settings
+    pyparsing
+    pyyaml
+    requests
+    requests-file
+    requests-toolbelt
+    tqdm
+    typing-extensions
+  ];
+
+  sphinxRoot = "docs/en";
+  nativeBuildInputs = [
+    sphinx
+    sphinxHook
+    sphinx-click
+    sphinx-collapse
+    sphinx-copybutton
+    sphinx-rtd-theme
+    sphinx-tabs
+  ];
+
+  checkInputs = [
+    jinja2
+    jsonschema
+    pexpect
+    pytest
+    pytest-cov
+    pytest-mock
+    requests-mock
+    vcrpy
+  ];
+
+  nativeCheckInputs = lib.optionals stdenv.isLinux [
+    git
+    pytestCheckHook
+  ];
+
+  preCheck = "export XDG_CACHE_HOME=$(mktemp -d)";
+  # Tries to get https://components.espressif.com/api/tokens/current
+  disabledTests = [ "test_no_registry_token_error" ];
+  # bin/compote is not yet in PATH
+  disabledTestPaths = [ "tests/cli/test_compote.py" ];
+
+  pythonImportsCheck = [ "idf_component_manager" ];
+
+  meta = {
+    description = "Tool for installing ESP-IDF components";
+    homepage = "https://github.com/espressif/idf-component-manager";
+    changelog = "https://github.com/espressif/idf-component-manager/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "compote";
+  };
+}

--- a/pkgs/development/python-modules/pyclang/default.nix
+++ b/pkgs/development/python-modules/pyclang/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage rec {
+  pname = "pyclang";
+  version = "0.4.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "clang-tidy-runner";
+    rev = "v${version}";
+    hash = "sha256-UiSKt8p6VuviKzP1xq9oqtxVlyz9Dhj/HcqLYmklmjo=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "pyclang" ];
+
+  meta = {
+    description = "Clang Tidy Runner";
+    homepage = "https://github.com/espressif/clang-tidy-runner";
+    changelog = "https://github.com/espressif/clang-tidy-runner/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-click/default.nix
+++ b/pkgs/development/python-modules/sphinx-click/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  click,
+  docutils,
+  pbr,
+  setuptools,
+  sphinx,
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-click";
+  version = "5.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "click-contrib";
+    repo = "sphinx-click";
+    rev = version;
+    hash = "sha256-RL/e6eN9/8Baqq6Q0rU/b1ZJWt0LAeLzmfyOgDPbvnw=";
+  };
+
+  env.PBR_VERSION = version;
+
+  build-system = [
+    setuptools
+    pbr
+  ];
+
+  propagatedBuildInputs = [
+    click
+    docutils
+    sphinx
+  ];
+
+  pythonImportsCheck = [ "sphinx_click" ];
+
+  meta = {
+    description = "A Sphinx plugin to automatically document click-based applications";
+    homepage = "https://github.com/click-contrib/sphinx-click";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-collapse/default.nix
+++ b/pkgs/development/python-modules/sphinx-collapse/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  sphinx,
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-collapse";
+  version = "0.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dgarcia360";
+    repo = "sphinx-collapse";
+    rev = version;
+    hash = "sha256-ehKtXqq7FPrEKg5o8+61xLFMnD+5d7fHYXYeT+PkHWk=";
+  };
+
+  build-system = [ flit-core ];
+
+  checkInputs = [ sphinx ];
+
+  pythonImportsCheck = [ "sphinx_collapse" ];
+
+  meta = {
+    description = "Sphinx extension to hide large amounts of content";
+    homepage = "https://github.com/dgarcia360/sphinx-collapse";
+    changelog = "https://github.com/dgarcia360/sphinx-collapse/blob/${src.rev}/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27063,6 +27063,8 @@ with pkgs;
 
   riscv-pk = callPackage ../misc/riscv-pk { };
 
+  riscv32-esp-elf-gdb = callPackage ../by-name/es/esp-idf/riscv32-esp-elf-gdb.nix { };
+
   ristate = callPackage ../tools/misc/ristate { };
 
   roccat-tools = callPackage ../os-specific/linux/roccat-tools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32971,6 +32971,8 @@ with pkgs;
 
   qemu-riscv32 = callPackage ../by-name/es/esp-idf/qemu-riscv32.nix { };
 
+  qemu-xtensa = callPackage ../by-name/es/esp-idf/qemu-xtensa.nix { };
+
   canokey-qemu = callPackage ../applications/virtualization/qemu/canokey-qemu.nix { };
 
   wrapQemuBinfmtP = callPackage ../applications/virtualization/qemu/binfmt-p-wrapper.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29731,6 +29731,8 @@ with pkgs;
 
   errbot = callPackage ../applications/networking/errbot { };
 
+  esp-clang = callPackage ../by-name/es/esp-idf/esp-clang.nix { };
+
   espeak-classic = callPackage ../applications/audio/espeak { };
 
   espeak-ng = callPackage ../applications/audio/espeak-ng {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32969,6 +32969,8 @@ with pkgs;
     userOnly = true;
   };
 
+  qemu-riscv32 = callPackage ../by-name/es/esp-idf/qemu-riscv32.nix { };
+
   canokey-qemu = callPackage ../applications/virtualization/qemu/canokey-qemu.nix { };
 
   wrapQemuBinfmtP = callPackage ../applications/virtualization/qemu/binfmt-p-wrapper.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24295,6 +24295,8 @@ with pkgs;
 
   xlslib = callPackage ../development/libraries/xlslib { };
 
+  xtensa-esp-elf-gdb = callPackage ../by-name/es/esp-idf/xtensa-esp-elf-gdb.nix { };
+
   xtensor = callPackage ../development/libraries/xtensor { };
 
   xtl = callPackage ../development/libraries/xtl { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29735,6 +29735,8 @@ with pkgs;
 
   esp-rom-elfs = callPackage ../by-name/es/esp-idf/esp-rom-elfs.nix { };
 
+  esp32ulp-elf = callPackage ../by-name/es/esp-idf/esp32ulp-elf.nix { };
+
   espeak-classic = callPackage ../applications/audio/espeak { };
 
   espeak-ng = callPackage ../applications/audio/espeak-ng {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18595,6 +18595,8 @@ with pkgs;
 
   openocd = callPackage ../development/embedded/openocd { };
 
+  openocd-esp32 = callPackage ../by-name/es/esp-idf/openocd-esp32.nix { };
+
   openocd-rp2040 = openocd.overrideAttrs (old: {
     pname = "openocd-rp2040";
     src = fetchFromGitHub {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27063,6 +27063,8 @@ with pkgs;
 
   riscv-pk = callPackage ../misc/riscv-pk { };
 
+  riscv32-esp-elf = callPackage ../by-name/es/esp-idf/riscv32-esp-elf.nix { };
+
   riscv32-esp-elf-gdb = callPackage ../by-name/es/esp-idf/riscv32-esp-elf-gdb.nix { };
 
   ristate = callPackage ../tools/misc/ristate { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24295,6 +24295,8 @@ with pkgs;
 
   xlslib = callPackage ../development/libraries/xlslib { };
 
+  xtensa-esp-elf = callPackage ../by-name/es/esp-idf/xtensa-esp-elf.nix { };
+
   xtensa-esp-elf-gdb = callPackage ../by-name/es/esp-idf/xtensa-esp-elf-gdb.nix { };
 
   xtensor = callPackage ../development/libraries/xtensor { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29733,6 +29733,8 @@ with pkgs;
 
   esp-clang = callPackage ../by-name/es/esp-idf/esp-clang.nix { };
 
+  esp-rom-elfs = callPackage ../by-name/es/esp-idf/esp-rom-elfs.nix { };
+
   espeak-classic = callPackage ../applications/audio/espeak { };
 
   espeak-ng = callPackage ../applications/audio/espeak-ng {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5902,6 +5902,8 @@ self: super: with self; {
 
   identify = callPackage ../development/python-modules/identify { };
 
+  idf-component-manager = callPackage ../development/python-modules/idf-component-manager { };
+
   idna = callPackage ../development/python-modules/idna { };
 
   idna-ssl = callPackage ../development/python-modules/idna-ssl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4024,6 +4024,8 @@ self: super: with self; {
 
   esp-idf-panic-decoder = callPackage ../development/python-modules/esp-idf-panic-decoder { };
 
+  esp-idf-size = callPackage ../development/python-modules/esp-idf-size { };
+
   espeak-phonemizer = callPackage ../development/python-modules/espeak-phonemizer { };
 
   esper = callPackage ../development/python-modules/esper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11252,6 +11252,8 @@ self: super: with self; {
 
   pychromecast = callPackage ../development/python-modules/pychromecast { };
 
+  pyclang = callPackage ../development/python-modules/pyclang { };
+
   pyclimacell = callPackage ../development/python-modules/pyclimacell { };
 
   pyclip = callPackage ../development/python-modules/pyclip { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4020,6 +4020,8 @@ self: super: with self; {
 
   esp-idf-monitor = callPackage ../development/python-modules/esp-idf-monitor { };
 
+  esp-idf-panic-decoder = callPackage ../development/python-modules/esp-idf-panic-decoder { };
+
   espeak-phonemizer = callPackage ../development/python-modules/espeak-phonemizer { };
 
   esper = callPackage ../development/python-modules/esper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4015,6 +4015,8 @@ self: super: with self; {
   esig = callPackage ../development/python-modules/esig { };
 
   esp-coredump = callPackage ../development/python-modules/esp-coredump { };
+  
+  esp-idf-kconfig = callPackage ../development/python-modules/esp-idf-kconfig { };
 
   espeak-phonemizer = callPackage ../development/python-modules/espeak-phonemizer { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4014,6 +4014,8 @@ self: super: with self; {
 
   esig = callPackage ../development/python-modules/esig { };
 
+  esp-coredump = callPackage ../development/python-modules/esp-coredump { };
+
   espeak-phonemizer = callPackage ../development/python-modules/espeak-phonemizer { };
 
   esper = callPackage ../development/python-modules/esper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4024,6 +4024,8 @@ self: super: with self; {
 
   esprima = callPackage ../development/python-modules/esprima { };
 
+  esptool = toPythonModule pkgs.esptool;
+
   escapism = callPackage ../development/python-modules/escapism { };
 
   essentials = callPackage ../development/python-modules/essentials { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4020,6 +4020,8 @@ self: super: with self; {
 
   esp-idf-monitor = callPackage ../development/python-modules/esp-idf-monitor { };
 
+  esp-idf-nvs-partition-gen = callPackage ../development/python-modules/esp-idf-nvs-partition-gen { };
+
   esp-idf-panic-decoder = callPackage ../development/python-modules/esp-idf-panic-decoder { };
 
   espeak-phonemizer = callPackage ../development/python-modules/espeak-phonemizer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14850,6 +14850,8 @@ self: super: with self; {
 
   sphinx-codeautolink = callPackage ../development/python-modules/sphinx-codeautolink { };
 
+  sphinx-collapse = callPackage ../development/python-modules/sphinx-collapse { };
+
   sphinx-comments = callPackage ../development/python-modules/sphinx-comments { };
 
   sphinx-design = callPackage ../development/python-modules/sphinx-design { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14846,6 +14846,8 @@ self: super: with self; {
 
   sphinx-book-theme = callPackage ../development/python-modules/sphinx-book-theme { };
 
+  sphinx-click = callPackage ../development/python-modules/sphinx-click { };
+
   sphinx-codeautolink = callPackage ../development/python-modules/sphinx-codeautolink { };
 
   sphinx-comments = callPackage ../development/python-modules/sphinx-comments { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4015,8 +4015,10 @@ self: super: with self; {
   esig = callPackage ../development/python-modules/esig { };
 
   esp-coredump = callPackage ../development/python-modules/esp-coredump { };
-  
+
   esp-idf-kconfig = callPackage ../development/python-modules/esp-idf-kconfig { };
+
+  esp-idf-monitor = callPackage ../development/python-modules/esp-idf-monitor { };
 
   espeak-phonemizer = callPackage ../development/python-modules/espeak-phonemizer { };
 


### PR DESCRIPTION
## Description of changes

This add the https://github.com/espressif/esp-idf framework.

For now, this get binaries for the required "tools" (mostly forks of stdenv stuff for xtensa/riscv32). Their sources seem available, but build instructions are not clear enough for me. This can be improved once something like #144452 is merged.

## Things done

Tested with
```nix
pkgs.mkShell {
  IDF_PATH = "${pkgs.esp-idf}";
  IDF_PYTHON_ENV_PATH = "${pkgs.esp-idf}/venv";
  IDF_PYTHON_CHECK_CONSTRAINTS = "no";
  packages = [ pkgs.esp-idf ];
  shellHook = "source ${pkgs.esp-idf}/export.sh";
};
```
 
on eg:
```bash
cp -r $IDF_PATH/examples/get-started/hello_world/* .
chmod -R u+w .
idf.py build  # compile for esp32 xtensa target
idf.py qemu monitor  # run that in qemu
idf.py set-target esp32-c3
idf.py build  # compile for esp32-c3 riscv32 target
idf.py qemu monitor  # run that in qemu
idf.py flash  # flash it on a real esp32-c3 dev kit
idf.py monitor  # check the output of that chip
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
