### PR TITLE
treewide: fix pg_config / postgresql headers moved to dev output

### DIFF
--- a/doc/languages-frameworks/ruby.section.md
+++ b/doc/languages-frameworks/ruby.section.md
@@ -154,7 +154,7 @@ let
     defaultGemConfig = pkgs.defaultGemConfig // {
       pg = attrs: {
         buildFlags =
-        [ "--with-pg-config=${pkgs."postgresql_${pg_version}"}/bin/pg_config" ];
+        [ "--with-pg-config=${lib.getDev pkgs."postgresql_${pg_version}"}/bin/pg_config" ];
       };
     };
   };
@@ -172,7 +172,7 @@ let
     gemConfig = pkgs.defaultGemConfig // {
       pg = attrs: {
         buildFlags =
-        [ "--with-pg-config=${pkgs."postgresql_${pg_version}"}/bin/pg_config" ];
+        [ "--with-pg-config=${lib.getDev pkgs."postgresql_${pg_version}"}/bin/pg_config" ];
       };
     };
   };
@@ -190,9 +190,7 @@ let
         defaultGemConfig = super.defaultGemConfig // {
           pg = attrs: {
             buildFlags = [
-              "--with-pg-config=${
-                pkgs."postgresql_${pg_version}"
-              }/bin/pg_config"
+              "--with-pg-config=${lib.getDev pkgs."postgresql_${pg_version}"}/bin/pg_config"
             ];
           };
         };

--- a/pkgs/applications/misc/pgmodeler/default.nix
+++ b/pkgs/applications/misc/pgmodeler/default.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config qmake wrapQtAppsHook ];
   qmakeFlags = [ "pgmodeler.pro" "CONFIG+=release" ] ++ lib.optionals stdenv.isDarwin [
-    "PGSQL_INC=${postgresql}/include"
-    "PGSQL_LIB=${postgresql.lib}/lib/libpq.dylib"
+    "PGSQL_INC=${lib.getDev postgresql}/include"
+    "PGSQL_LIB=${lib.getLib postgresql}/lib/libpq.dylib"
     "XML_INC=${libxml2.dev}/include/libxml2"
     "XML_LIB=${libxml2.out}/lib/libxml2.dylib"
     "PREFIX=${placeholder "out"}/Applications/pgModeler.app/Contents"

--- a/pkgs/applications/networking/misc/zammad/default.nix
+++ b/pkgs/applications/networking/misc/zammad/default.nix
@@ -74,7 +74,7 @@ let
     ];
     gemConfig = defaultGemConfig // {
       pg = attrs: {
-        buildFlags = [ "--with-pg-config=${postgresql}/bin/pg_config" ];
+        buildFlags = [ "--with-pg-config=${lib.getDev postgresql}/bin/pg_config" ];
       };
       rszr = attrs: {
         buildInputs = [ imlib2 imlib2.dev ];

--- a/pkgs/development/compilers/urweb/default.nix
+++ b/pkgs/development/compilers/urweb/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-openssl=${openssl.dev}" ];
 
   preConfigure = ''
-    export PGHEADER="${postgresql}/include/libpq-fe.h";
     export MSHEADER="${libmysqlclient}/include/mysql/mysql.h";
     export SQHEADER="${sqlite.dev}/include/sqlite3.h";
     export ICU_INCLUDES="-I${icu.dev}/include";

--- a/pkgs/development/libraries/libdbi-drivers/default.nix
+++ b/pkgs/development/libraries/libdbi-drivers/default.nix
@@ -42,8 +42,6 @@ stdenv.mkDerivation rec {
     "--with-sqlite3-libdir=${sqlite.out}/lib/sqlite"
   ] ++ lib.optionals (postgresql != null) [
     "--with-pgsql"
-    "--with-pgsql_incdir=${postgresql}/include"
-    "--with-pgsql_libdir=${postgresql.lib}/lib"
   ];
 
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.cc.isClang [

--- a/pkgs/development/libraries/opendbx/default.nix
+++ b/pkgs/development/libraries/opendbx/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     export CPPFLAGS="-I${getDev libmysqlclient}/include/mysql"
-    export LDFLAGS="-L${libmysqlclient}/lib/mysql -L${postgresql}/lib"
+    export LDFLAGS="-L${libmysqlclient}/lib/mysql"
     configureFlagsArray=(--with-backends="mysql pgsql sqlite3")
   '';
 

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -74,9 +74,14 @@ let
 
     nativeBuildInputs = [
       cython
+      # needed to find pg_config with strictDeps
       postgresql
       setuptools
       tomli
+    ];
+
+    buildInputs = [
+      postgresql
     ];
 
     # tested in psycopg

--- a/pkgs/development/python-modules/psycopg2/default.nix
+++ b/pkgs/development/python-modules/psycopg2/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     # some linker flags are added but the linker ignores them because they're incompatible
     # https://github.com/psycopg/psycopg2/blob/89005ac5b849c6428c05660b23c5a266c96e677d/setup.py
     substituteInPlace setup.py \
-      --replace "self.pg_config_exe = self.build_ext.pg_config" 'self.pg_config_exe = "${lib.getExe' buildPackages.postgresql "pg_config"}"'
+      --replace-fail "self.pg_config_exe = self.build_ext.pg_config" 'self.pg_config_exe = "${lib.getDev buildPackages.postgresql}/bin/pg_config"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -671,7 +671,7 @@ in
     # Force pkg-config lookup for libpq.
     # See https://github.com/ged/ruby-pg/blob/6629dec6656f7ca27619e4675b45225d9e422112/ext/extconf.rb#L34-L55
     #
-    # Note that setting --with-pg-config=${postgresql}/bin/pg_config would add
+    # Note that setting --with-pg-config=${lib.getDev postgresql}/bin/pg_config would add
     # an unnecessary reference to the entire postgresql package.
     buildFlags = [ "--with-pg-config=ignore" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
@@ -86,7 +86,7 @@ let
   preBuildAndTest = ''
     export PGRX_HOME=$(mktemp -d)
     export PGDATA="$PGRX_HOME/data-${pgrxPostgresMajor}/"
-    cargo-pgrx pgrx init "--pg${pgrxPostgresMajor}" ${postgresql}/bin/pg_config
+    cargo-pgrx pgrx init "--pg${pgrxPostgresMajor}" ${lib.getDev postgresql}/bin/pg_config
     echo "unix_socket_directories = '$(mktemp -d)'" > "$PGDATA/postgresql.conf"
 
     # This is primarily for Mac or other Nix systems that don't use the nixbld user.
@@ -120,7 +120,7 @@ let
       PGRX_BUILD_FLAGS="--frozen -j $NIX_BUILD_CORES ${builtins.concatStringsSep " " cargoBuildFlags}" \
       ${lib.optionalString stdenv.isDarwin ''RUSTFLAGS="''${RUSTFLAGS:+''${RUSTFLAGS} }-Clink-args=-Wl,-undefined,dynamic_lookup"''} \
       cargo pgrx package \
-        --pg-config ${postgresql}/bin/pg_config \
+        --pg-config ${lib.getDev postgresql}/bin/pg_config \
         ${maybeDebugFlag} \
         --features "${builtins.concatStringsSep " " buildFeatures}" \
         --out-dir "$out"

--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -82,7 +82,6 @@ in stdenv.mkDerivation rec {
         s:^# \(LOOKUP_PGSQL=yes\)$:\1:
         s:^\(LOOKUP_LIBS\)=\(.*\):\1=\2 -lpq -L${postgresql.lib}/lib:
         s:^# \(LOOKUP_LIBS\)=.*:\1=-lpq -L${postgresql.lib}/lib:
-        s:^# \(LOOKUP_INCLUDE\)=.*:\1=-I${postgresql}/include:
       ''}
       ${lib.optionalString enableSqlite ''
         s:^# \(LOOKUP_SQLITE=yes\)$:\1:

--- a/pkgs/servers/sql/postgresql/ext/age.nix
+++ b/pkgs/servers/sql/postgresql/ext/age.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
       echo -e "include Makefile\nfiles:\n\t@echo \$(REGRESS)" > Makefile.regress
       REGRESS_TESTS=$(make -f Makefile.regress files)
 
-      ${postgresql}/lib/pgxs/src/test/regress/pg_regress \
+      ${lib.getDev postgresql}/lib/pgxs/src/test/regress/pg_regress \
         --inputdir=./ \
         --bindir='${postgresqlAge}/bin' \
         --encoding=UTF-8 \

--- a/pkgs/servers/sql/postgresql/ext/plv8/default.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8/default.nix
@@ -112,7 +112,7 @@ in stdenv.mkDerivation (finalAttrs: {
             echo -e "include Makefile\nprint_regress_files:\n\t@echo \$(REGRESS)" > Makefile.regress
             REGRESS_TESTS=$(make -f Makefile.regress print_regress_files)
 
-            ${postgresql}/lib/pgxs/src/test/regress/pg_regress \
+            ${lib.getDev postgresql}/lib/pgxs/src/test/regress/pg_regress \
               --bindir='${postgresqlWithSelf}/bin' \
               --temp-instance=regress-instance \
               --dbname=contrib_regression \

--- a/pkgs/servers/sql/postgresql/ext/tsja.nix
+++ b/pkgs/servers/sql/postgresql/ext/tsja.nix
@@ -18,10 +18,10 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace /usr/local/pgsql ${postgresql} \
-      --replace -L/usr/local/lib "" \
-      --replace -I/usr/local/include ""
-    substituteInPlace tsja.c --replace /usr/local/lib/mecab ${mecab}/lib/mecab
+      --replace-fail /usr/local/pgsql ${lib.getDev postgresql} \
+      --replace-fail -L/usr/local/lib "" \
+      --replace-fail -I/usr/local/include ""
+    substituteInPlace tsja.c --replace-fail /usr/local/lib/mecab ${mecab}/lib/mecab
   '';
 
   buildInputs = [ mecab postgresql ];

--- a/pkgs/tools/backup/bacula/default.nix
+++ b/pkgs/tools/backup/bacula/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-sqlite3=${sqlite.dev}"
-    "--with-postgresql=${postgresql}"
+    "--with-postgresql=${lib.getDev postgresql}"
     "--with-logdir=/var/log/bacula"
     "--with-working-dir=/var/lib/bacula"
     "--mandir=\${out}/share/man"

--- a/pkgs/tools/networking/kea/default.nix
+++ b/pkgs/tools/networking/kea/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--with-openssl=${lib.getDev openssl}"
   ]
-  ++ lib.optional withPostgres "--with-pgsql=${postgresql}/bin/pg_config"
+  ++ lib.optional withPostgres "--with-pgsql=${lib.getDev postgresql}/bin/pg_config"
   ++ lib.optional withMysql "--with-mysql=${lib.getDev libmysqlclient}/bin/mysql_config";
 
   postConfigure = ''

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -586,7 +586,7 @@ in {
         {
           name = "pdo_pgsql";
           internalDeps = [ php.extensions.pdo ];
-          configureFlags = [ "--with-pdo-pgsql=${postgresql}" ];
+          configureFlags = [ "--with-pdo-pgsql=${lib.getDev postgresql}" ];
           doCheck = false;
         }
         {
@@ -599,7 +599,7 @@ in {
         {
           name = "pgsql";
           buildInputs = [ pcre2 ];
-          configureFlags = [ "--with-pgsql=${postgresql}" ];
+          configureFlags = [ "--with-pgsql=${lib.getDev postgresql}" ];
           doCheck = false;
         }
         { name = "posix"; doCheck = false; }


### PR DESCRIPTION
This was supposed to happen in #294504, but the commit was accidentally left out when splitting off some libpq-related changes. Originated in #179962, by Sandro.

@Ma27 

ToDo:
- [x] Fix some more direct references to `${postgresql}`
- [x] Build all changed packages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
