### PR TITLE
gitea: drop PAM support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -191,6 +191,8 @@
 
 - `forgejo` and `forgejo-lts` no longer support the opt-in feature [PAM (Pluggable Authentication Module)](https://forgejo.org/docs/latest/user/authentication/#pam-pluggable-authentication-module).
 
+- `gitea` no longer supports the opt-in feature [PAM (Pluggable Authentication Module)][https://docs.gitea.com/usage/authentication#pam-pluggable-authentication-module].
+
 - `services.ddclient.use` has been deprecated: `ddclient` now supports separate IPv4 and IPv6 configuration. Use `services.ddclient.usev4` and `services.ddclient.usev6` instead.
 
 - `services.pgbouncer` systemd service is configured with `Type=notify-reload` and allows reloading configuration without process restart. PgBouncer configuration options were moved to the free-form type option named [`services.pgbouncer.settings`](#opt-services.pgbouncer.settings) according to the NixOS RFC 0042.

--- a/pkgs/by-name/gi/gitea/package.nix
+++ b/pkgs/by-name/gi/gitea/package.nix
@@ -10,9 +10,7 @@
 , gitea
 , gzip
 , openssh
-, pam
 , sqliteSupport ? true
-, pamSupport ? stdenv.hostPlatform.isLinux
 , nixosTests
 , buildNpmPackage
 }:
@@ -64,10 +62,7 @@ in buildGoModule rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = lib.optional pamSupport pam;
-
-  tags = lib.optional pamSupport "pam"
-    ++ lib.optionals sqliteSupport [ "sqlite" "sqlite_unlock_notify" ];
+  tags = lib.optionals sqliteSupport [ "sqlite" "sqlite_unlock_notify" ];
 
   ldflags = [
     "-s"


### PR DESCRIPTION

## Description of changes
Strongly inspired by the forgejo counterpart[1], for the following reasons:

* The feature is broken with the current module and crashes on authentication with the following stacktrace (with a PAM service `gitea` added):

      server # Stack trace of thread 1008:
      server # #0  0x00007f3116917dfb __nptl_setxid (libc.so.6 + 0x8ddfb)
      server # #1  0x00007f3116980ae6 setuid (libc.so.6 + 0xf6ae6)
      server # #2  0x00007f30cc80f420 _unix_run_helper_binary (pam_unix.so + 0x5420)
      server # #3  0x00007f30cc8108c9 _unix_verify_password (pam_unix.so + 0x68c9)
      server # #4  0x00007f30cc80e1b5 pam_sm_authenticate (pam_unix.so + 0x41b5)
      server # #5  0x00007f3116a84e5b _pam_dispatch (libpam.so.0 + 0x3e5b)
      server # #6  0x00007f3116a846a3 pam_authenticate (libpam.so.0 + 0x36a3)
      server # #7  0x00000000029b1e7a n/a (.gitea-wrapped + 0x25b1e7a)
      server # #8  0x000000000047c7e4 n/a (.gitea-wrapped + 0x7c7e4)
      server # ELF object binary architecture: AMD x86-64
      server #
      server # [   42.420827] gitea[897]: pam_unix(gitea:auth): unix_chkpwd abnormal exit: 159
      server # [   42.423142] gitea[897]: pam_unix(gitea:auth): authentication failure; logname= uid=998 euid=998 tty= ruser= rhost=  user=snenskek

  It only worked after turning off multiple sandbox settings and adding `shadow` as supplementary group to `gitea.service`.

  I'm not willing to maintain additional multiple sandbox settings for different features, especially given that it was probably not used for quite a long time:

  * There was no PR or bugreport about sandboxing issues related to PAM.

  * Ever since the module exists, it used the user `gitea`, i.e. it had never read-access to `/etc/shadow`.

* Upstream has it disabled by default[2].

If somebody really needs it, it can still be brought back by an overlay updating `tags` accordingly and modifying the systemd service config.

[1] 07641a91c96ddb9030ac13d62e3a3e0bb1495842
[2] https://docs.gitea.com/usage/authentication#pam-pluggable-authentication-module

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
