### PR TITLE
cryptoverif: 2.09 -> 2.10

### DIFF
--- a/pkgs/applications/science/logic/cryptoverif/default.nix
+++ b/pkgs/applications/science/logic/cryptoverif/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cryptoverif";
-  version = "2.09";
+  version = "2.10";
 
   src = fetchurl {
     url    = "http://prosecco.gforge.inria.fr/personal/bblanche/cryptoverif/cryptoverif${finalAttrs.version}.tar.gz";
-    hash = "sha256-FJlPZgTUZ+6HzhG/B0dOiVIjDvoCnF6yg2E9UriSojw=";
+    hash = "sha256-Gg7PYMB5cYWk9+xuxxcFY9L9vynHX2xYyMDo/0DauPM=";
   };
 
   /* Fix up the frontend to load the 'default' cryptoverif library

--- a/pkgs/applications/science/logic/cryptoverif/default.nix
+++ b/pkgs/applications/science/logic/cryptoverif/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ocaml }:
+{ lib, stdenv, fetchurl, ocaml, writeScript }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cryptoverif";
@@ -40,10 +40,22 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  passthru.updateScript = writeScript "update-cryptoverif" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts curl pcre2
+
+    set -eu -o pipefail
+
+    version="$(curl -s https://bblanche.gitlabpages.inria.fr/CryptoVerif/ |
+      pcre2grep -o1 '\bCryptoVerif version ([.[:alnum:]]+),')"
+
+    update-source-version "$UPDATE_NIX_ATTR_PATH" "$version"
+  '';
+
   meta = {
     description = "Cryptographic protocol verifier in the computational model";
     mainProgram = "cryptoverif";
-    homepage    = "https://prosecco.gforge.inria.fr/personal/bblanche/cryptoverif/";
+    homepage    = "https://bblanche.gitlabpages.inria.fr/CryptoVerif/";
     license     = lib.licenses.cecill-b;
     platforms   = lib.platforms.unix;
     maintainers = [ lib.maintainers.thoughtpolice ];


### PR DESCRIPTION
## Description of changes

https://gitlab.inria.fr/bblanche/CryptoVerif/-/raw/274bc28abf4b574ae0e98d08d8b4616b3849748b/CHANGES

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package built:</summary>
  <ul>
    <li>cryptoverif</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc