### PR TITLE
ffmpeg: add avs2/3 options

### DIFF
--- a/pkgs/by-name/da/davs2/package.nix
+++ b/pkgs/by-name/da/davs2/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  stdenv,
+  testers,
+  nasm,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "davs2";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "pkuvcl";
+    repo = "davs2";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-SUY3arrVsFecMcbpmQP0+4rtcSRfQc6pzxZDcEuMWPU=";
+  };
+
+  postPatch = ''
+    substituteInPlace ./version.sh \
+      --replace-fail "date" 'date -ud "@$SOURCE_DATE_EPOCH"'
+  '';
+
+  preConfigure =
+    ''
+      # Generate version.h
+      ./version.sh
+      cd build/linux
+    ''
+    + lib.optionalString stdenv.hostPlatform.isx86 ''
+      # `AS' is set to the binutils assembler, but we need nasm
+      unset AS
+    '';
+
+  configureFlags =
+    [ "--cross-prefix=${stdenv.cc.targetPrefix}" ]
+    ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
+      (lib.enableFeature true "shared")
+      "--system-libdavs2"
+    ];
+
+  nativeBuildInputs = [
+    nasm
+  ];
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  passthru = {
+    updateScript = gitUpdater { };
+    tests.pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    homepage = "https://github.com/pkuvcl/davs2";
+    description = "Open-source decoder of AVS2-P2/IEEE1857.4 video coding standard";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "davs2";
+    pkgConfigModules = [ "davs2" ];
+    maintainers = with lib.maintainers; [ jopejoe1 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/na/nasm/package.nix
+++ b/pkgs/by-name/na/nasm/package.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [
       pSub
     ];
+    mainProgram = "nasm";
     license = licenses.bsd2;
   };
 }

--- a/pkgs/by-name/ua/uavs3d/package.nix
+++ b/pkgs/by-name/ua/uavs3d/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  cmake,
+  stdenv,
+  testers,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "uavs3d";
+  version = "1.1-unstable-2023-02-23";
+
+  src = fetchFromGitHub {
+    owner = "uavs3";
+    repo = "uavs3d";
+    rev = "1fd04917cff50fac72ae23e45f82ca6fd9130bd8";
+    hash = "sha256-ZSuFgTngOd4NbZnOnw4XVocv4nAR9HPkb6rP2SASLrM=";
+  };
+
+  cmakeFlags = [
+    (lib.cmakeBool "COMPILE_10BIT" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+    tests.pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    homepage = "https://github.com/uavs3/uavs3d";
+    description = "AVS3 decoder which supports AVS3-P2 baseline profile";
+    license = lib.licenses.bsd3;
+    pkgConfigModules = [ "uavs3d" ];
+    maintainers = with lib.maintainers; [ jopejoe1 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/xa/xavs2/package.nix
+++ b/pkgs/by-name/xa/xavs2/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  stdenv,
+  testers,
+  nasm,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xavs2";
+  version = "1.4";
+
+  src = fetchFromGitHub {
+    owner = "pkuvcl";
+    repo = "xavs2";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-4w/WTXvRQbohKL+YALQCCYglHQKVvehlUYfitX/lLPw=";
+  };
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    [
+      "-Wno-incompatible-pointer-types"
+    ]
+    ++ lib.optionals (stdenv.cc.isClang || stdenv.cc.isZig) [
+      "-Wno-incompatible-function-pointer-types"
+    ]
+  );
+
+  postPatch = ''
+    substituteInPlace ./version.sh \
+      --replace-fail "date" 'date -ud "@$SOURCE_DATE_EPOCH"'
+  '';
+
+  preConfigure =
+    ''
+      # Generate version.h
+      ./version.sh
+      cd build/linux
+    ''
+    + lib.optionalString stdenv.hostPlatform.isx86 ''
+      # `AS' is set to the binutils assembler, but we need nasm
+      unset AS
+    '';
+
+  configureFlags =
+    [ "--cross-prefix=${stdenv.cc.targetPrefix}" ]
+    ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
+      (lib.enableFeature true "shared")
+      "--system-libxavs2"
+    ];
+
+  postInstall = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
+    rm $lib/lib/*.a
+  '';
+
+  nativeBuildInputs = [
+    nasm
+  ];
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  passthru = {
+    updateScript = gitUpdater { };
+    tests.pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    homepage = "https://github.com/pkuvcl/xavs2";
+    description = "Open-source encoder of AVS2-P2/IEEE1857.4 video coding standard";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "xavs2";
+    pkgConfigModules = [ "xavs2" ];
+    maintainers = with lib.maintainers; [ jopejoe1 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -64,6 +64,7 @@
   withCudaNVCC ? withFullDeps && withUnfree && config.cudaSupport,
   withCuvid ? withHeadlessDeps && withNvcodec,
   withDav1d ? withHeadlessDeps, # AV1 decoder (focused on speed and correctness)
+  withDavs2 ? withFullDeps && withGPL, # AVS2 decoder
   withDc1394 ? withFullDeps && !stdenv.hostPlatform.isDarwin, # IIDC-1394 grabbing (ieee 1394)
   withDrm ? withHeadlessDeps && (with stdenv; isLinux || isFreeBSD), # libdrm support
   withDvdnav ? withFullDeps && withGPL && lib.versionAtLeast version "7", # needed for DVD demuxing
@@ -137,6 +138,7 @@
   withTensorflow ? false, # Tensorflow dnn backend support (Increases closure size by ~390 MiB)
   withTheora ? withHeadlessDeps, # Theora encoder
   withTwolame ? withFullDeps, # MP2 encoding
+  withUavs3d ? withFullDeps, # AVS3 decoder
   withV4l2 ? withHeadlessDeps && stdenv.hostPlatform.isLinux, # Video 4 Linux support
   withV4l2M2m ? withV4l2,
   withVaapi ? withHeadlessDeps && (with stdenv; isLinux || isFreeBSD), # Vaapi hardware acceleration
@@ -153,6 +155,7 @@
   withX264 ? withHeadlessDeps && withGPL, # H.264/AVC encoder
   withX265 ? withHeadlessDeps && withGPL, # H.265/HEVC encoder
   withXavs ? withFullDeps && withGPL, # AVS encoder
+  withXavs2 ? withFullDeps && withGPL, # AVS2 encoder
   withXcb ? withXcbShm || withXcbxfixes || withXcbShape, # X11 grabbing using XCB
   withXcbShape ? withFullDeps, # X11 grabbing shape rendering
   withXcbShm ? withFullDeps, # X11 grabbing shm communication
@@ -243,6 +246,7 @@
   codec2,
   clang,
   dav1d,
+  davs2,
   fdk_aac,
   flite,
   fontconfig,
@@ -328,6 +332,7 @@
   speex,
   srt,
   svt-av1,
+  uavs3d,
   vid-stab,
   vo-amrwbenc,
   vulkan-headers,
@@ -336,6 +341,7 @@
   x264,
   x265,
   xavs,
+  xavs2,
   xevd,
   xeve,
   xvidcore,
@@ -613,6 +619,7 @@ stdenv.mkDerivation (
         (enableFeature withCudaNVCC "cuda-nvcc")
         (enableFeature withCuvid "cuvid")
         (enableFeature withDav1d "libdav1d")
+        (enableFeature withDavs2 "libdavs2")
         (enableFeature withDc1394 "libdc1394")
         (enableFeature withDrm "libdrm")
       ]
@@ -712,6 +719,7 @@ stdenv.mkDerivation (
         (enableFeature withTensorflow "libtensorflow")
         (enableFeature withTheora "libtheora")
         (enableFeature withTwolame "libtwolame")
+        (enableFeature withUavs3d "libuavs3d")
         (enableFeature withV4l2 "libv4l2")
         (enableFeature withV4l2M2m "v4l2-m2m")
         (enableFeature withVaapi "vaapi")
@@ -736,6 +744,7 @@ stdenv.mkDerivation (
         (enableFeature withX264 "libx264")
         (enableFeature withX265 "libx265")
         (enableFeature withXavs "libxavs")
+        (enableFeature withXavs2 "libxavs2")
         (enableFeature withXcb "libxcb")
         (enableFeature withXcbShape "libxcb-shape")
         (enableFeature withXcbShm "libxcb-shm")
@@ -827,6 +836,7 @@ stdenv.mkDerivation (
         cuda_nvcc
       ]
       ++ optionals withDav1d [ dav1d ]
+      ++ optionals withDavs2 [ davs2 ]
       ++ optionals withDc1394 ([ libdc1394 ] ++ (lib.optional stdenv.hostPlatform.isLinux libraw1394))
       ++ optionals withDrm [ libdrm ]
       ++ optionals withDvdnav [ libdvdnav ]
@@ -902,6 +912,7 @@ stdenv.mkDerivation (
       ++ optionals withTensorflow [ libtensorflow ]
       ++ optionals withTheora [ libtheora ]
       ++ optionals withTwolame [ twolame ]
+      ++ optionals withUavs3d [ uavs3d ]
       ++ optionals withV4l2 [ libv4l ]
       ++ optionals withVaapi [ (if withSmallDeps then libva else libva-minimal) ]
       ++ optionals withVdpau [ libvdpau ]
@@ -920,6 +931,7 @@ stdenv.mkDerivation (
       ++ optionals withX264 [ x264 ]
       ++ optionals withX265 [ x265 ]
       ++ optionals withXavs [ xavs ]
+      ++ optionals withXavs2 [ xavs2 ]
       ++ optionals withXcb [ libxcb ]
       ++ optionals withXevd [ xevd ]
       ++ optionals withXeve [ xeve ]


### PR DESCRIPTION
## Description of changes
Adds support for de-/encoding of avs2 and decoding of avs3.

Can be tested with the following commands.

```bash
ffmpeg -f lavfi -i testsrc -t 10 -c:v avs2 /tmp/avs2.mkv
ffmpeg -i /tmp/avs2.mkv -c:v hevc /tmp/decoded-avs2.mkv
ffmpeg -i /tmp/avs3-sample.mkv -c:v hevc /tmp/decoded-avs3.mkv
```
Samples can be found at https://github.com/xatabhk/avs2-avs3-video-samples
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
