### PR TITLE
imapsync: 2.229 -> 2.290

### DIFF
--- a/pkgs/tools/networking/imapsync/default.nix
+++ b/pkgs/tools/networking/imapsync/default.nix
@@ -1,20 +1,19 @@
-{ lib
-, fetchFromGitHub
-, makeWrapper
-, perl
-, perlPackages
-, stdenv
+{
+  lib,
+  fetchurl,
+  makeWrapper,
+  perl,
+  perlPackages,
+  stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "imapsync";
-  version = "2.229";
+  version = "2.290";
 
-  src = fetchFromGitHub {
-    owner = "imapsync";
-    repo = "imapsync";
-    rev = "imapsync-${version}";
-    sha256 = "sha256-nlNePOV3Y0atEPSRByRo3dHj/WjIaefEDeWdMKTo4gc=";
+  src = fetchurl {
+    url = "https://imapsync.lamiral.info/dist/old_releases/${finalAttrs.version}/imapsync-${finalAttrs.version}.tgz";
+    hash = "sha256-uFhTxnaUDP793isfpF/7T8d4AnXDL4uN6zU8igY+EFE=";
   };
 
   postPatch = ''
@@ -44,6 +43,7 @@ stdenv.mkDerivation rec {
     MailIMAPClient
     ModuleImplementation
     ModuleScanDeps
+    NetServer
     NTLM
     PackageStash
     PackageStashXS
@@ -67,7 +67,10 @@ stdenv.mkDerivation rec {
     mainProgram = "imapsync";
     homepage = "https://imapsync.lamiral.info/";
     license = licenses.nlpl;
-    maintainers = with maintainers; [ pSub ];
+    maintainers = with maintainers; [
+      pSub
+      motiejus
+    ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Upstream no longer uses git, publishing to
https://imapsync.lamiral.info/dist instead.

`old_releases` is not exactly what it sounds like, it is just a stable version for release artifacts:
https://github.com/imapsync/imapsync/issues/468#issuecomment-2294102132

I feel like this is a useful enough utility and I can bump it from time to time; adding myself to maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
