### PR TITLE
caprine: init at 2.60.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/caprine/default.nix
+++ b/pkgs/applications/networking/instant-messengers/caprine/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, electron
+, buildNpmPackage
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+buildNpmPackage rec {
+	pname = "Caprine";
+	version = "2.60.1";
+	src = fetchFromGitHub {
+		owner = "sindresorhus";
+		repo = "caprine";
+		rev = "v${version}";
+		sha256 = "sha256-y4W295i7FhgJC3SlwSr801fLOGJY1WF136bbkkBUvyw=";
+	};
+	
+	npmDepsHash = "sha256-JHaUc2p+wHsqWtls8xquHK9qnypuCrR0AQMGxcrTsC0=";	
+
+	ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+	nativeBuildInputs = [ copyDesktopItems ];
+
+	postBuild = ''
+		npm exec electron-builder -- \
+		--dir \
+		--linux \
+		-c.electronDist=${electron}/libexec/electron \
+		-c.electronVersion=${electron.version}
+	'';
+
+	installPhase = ''
+		runHook preInstall
+
+		mkdir -p $out/share/lib/caprine $out/bin		
+		cp -r dist/linux*-unpacked/{locales,resources{,.pak}} $out/share/lib/caprine
+		makeWrapper '${electron}/bin/electron' "$out/bin/caprine" \
+			--add-flags $out/share/lib/caprine/resources/app.asar \
+			--add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+			--inherit-argv0
+		
+		for s in 16 32 48 64 128 256 512; do
+			size=${"$"}{s}x$s
+			install -Dm644 $src/build/icons/$size.png $out/share/icons/hicolor/$size/apps/caprine.png
+		done
+
+		runHook postInstall
+	'';
+
+	desktopItems = [
+		(makeDesktopItem {
+		name = "caprine";
+		exec = "caprine %U";
+		icon = "caprine";
+		desktopName = "Caprine";
+		comment = meta.description;
+		categories = [ "Network" "Chat" ];
+		startupWMClass = "Caprine";
+		})
+	];
+
+
+	meta = with lib; {
+		description = "An elegant Facebook Messenger desktop app";
+		homepage = "https://sindresorhus.com/caprine";
+		license = licenses.mit;
+		maintainers = with maintainers; [ dxwil ];
+		inherit (electron.meta) platforms;
+		mainProgram = "caprine";
+	};
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29199,6 +29199,8 @@ with pkgs;
 
   canto-daemon = callPackage ../applications/networking/feedreaders/canto-daemon { };
 
+  caprine = callPackage ../applications/networking/instant-messengers/caprine { };
+
   caprine-bin = callPackage ../applications/networking/instant-messengers/caprine-bin { };
 
   carddav-util = callPackage ../tools/networking/carddav-util { };


### PR DESCRIPTION
## Description of changes

[caprine-bin](https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=caprine) but built from source, this adds support for aarch64 linux

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
