### PR TITLE
surreal-engine: init at 2024-11-08

### DIFF
--- a/pkgs/by-name/su/surreal-engine/package.nix
+++ b/pkgs/by-name/su/surreal-engine/package.nix
@@ -1,0 +1,75 @@
+{
+  alsa-lib,
+  cmake,
+  dbus,
+  fetchFromGitHub,
+  lib,
+  libffi,
+  makeWrapper,
+  openal,
+  pkg-config,
+  SDL2,
+  stdenv,
+  vulkan-loader,
+  wayland,
+  waylandpp,
+  libxkbcommon,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "surreal-engine";
+  version = "0-unstable-2024-11-08";
+
+  src = fetchFromGitHub {
+    owner = "dpjudas";
+    repo = "SurrealEngine";
+    rev = "087fa2af7fd0ce51702dd4024b4ae15a88222678";
+    hash = "sha256-AEIBhTkkRq4+L4ycx82GE29dM7zNgE0oHOkwEH9ezUg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    dbus
+    libffi
+    openal
+    SDL2
+    vulkan-loader
+    wayland
+    waylandpp
+    libxkbcommon
+  ];
+
+  postPatch = ''
+    substituteInPlace SurrealEngine/UI/WidgetResourceData.cpp --replace-fail /usr/share $out/share
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt $out/bin Surreal{Debugger,Editor,Engine}
+    install -Dt $out/share/surrealengine SurrealEngine.pk3
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    for bin in $out/bin/Surreal{Debugger,Editor,Engine}; do
+      wrapProgram $bin --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+    done
+  '';
+
+  meta = with lib; {
+    description = "Reimplementation of the original Unreal Engine";
+    mainProgram = "SurrealEngine";
+    homepage = "https://github.com/dpjudas/SurrealEngine";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ hughobrien ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Introduce [SurrealEngine](https://github.com/dpjudas/SurrealEngine) 

```
The goal of this project is to reimplement enough of the original Unreal Engine
to make the Unreal Tournament (UT99) maps playable.
```

Testing this package requires [Unreal Tournament (1999)](https://archive.org/details/Nova_UnrealTournamentUSA) to be available. I used wine to run the installer.
```
nix-shell -p p7zip --command '7z x -out99-img "Unreal Tournament (USA) (Disc 1) (Game).7z"'
nix-shell -p bchunk --command 'bchunk ut99-img/*.bin ut99-img/*.cue ut99-img/ut99'
nix-shell -p p7zip --command '7z x -out99-fs ut99-img/ut9901.iso'
WINEPREFIX=${PWD}/ut99-wine nix-shell -p wineWowPackages.full --command "wine ut99-fs/Setup.exe"
```

One should also [patch](https://unrealarchive.org/unreal-tournament/patches-updates/patches/patch-436/index.html) the installation to the version best supported by SurrealEngine
```
WINEPREFIX=${PWD}/ut99-wine nix-shell -p wineWowPackages.full --command "wine UTPatch436nodelta.exe"
```

Then run with
```
nix-shell -I nixpkgs=/data/nixpkgs -p surreal-engine --command "SurrealEngine ut99-wine/drive_c/UnrealTournament"
```

![2024-08-24T14:59:21-04:00](https://github.com/user-attachments/assets/ee6ed60d-f66f-4498-b1cb-584e71457c8e)

If the dialog box is blank, move your cursor around the bottom area where the buttons should be.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
