### PR TITLE
python3Packages.parsedmarc: correct location of dependency management

### DIFF
--- a/pkgs/by-name/pa/parsedmarc/package.nix
+++ b/pkgs/by-name/pa/parsedmarc/package.nix
@@ -1,44 +1,4 @@
-{
-  python3,
-  fetchFromGitHub,
-}:
+{ python3Packages }:
 
-let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: {
-      # https://github.com/domainaware/parsedmarc/issues/464
-      msgraph-core = super.msgraph-core.overridePythonAttrs (old: rec {
-        version = "0.2.2";
-
-        src = fetchFromGitHub {
-          owner = "microsoftgraph";
-          repo = "msgraph-sdk-python-core";
-          rev = "v${version}";
-          hash = "sha256-eRRlG3GJX3WeKTNJVWgNTTHY56qiUGOlxtvEZ2xObLA=";
-        };
-
-        nativeBuildInputs = with self; [
-          flit-core
-        ];
-
-        propagatedBuildInputs = with self; [
-          requests
-        ];
-
-        nativeCheckInputs = with self; [
-          pytestCheckHook
-          responses
-        ];
-
-        disabledTestPaths = [
-          "tests/integration"
-        ];
-
-        pythonImportsCheck = [ "msgraph.core" ];
-      });
-    };
-  };
-in
-with python.pkgs;
+with python3Packages;
 toPythonApplication parsedmarc

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -17,6 +17,7 @@
   elasticsearch-dsl,
   elasticsearch,
   expiringdict,
+  flit-core,
   geoip2,
   google-api-core,
   google-api-python-client,
@@ -45,6 +46,26 @@ let
     url = "https://raw.githubusercontent.com/domainaware/parsedmarc/77331b55c54cb3269205295bd57d0ab680638964/grafana/Grafana-DMARC_Reports.json";
     sha256 = "0wbihyqbb4ndjg79qs8088zgrcg88km8khjhv2474y7nzjzkf43i";
   };
+
+  # https://github.com/domainaware/parsedmarc/issues/464
+  msgraph-core-0 = msgraph-core.overridePythonAttrs (old: rec {
+    version = "0.2.2";
+
+    src = old.src.override {
+      tag = "v${version}";
+      hash = "sha256-eRRlG3GJX3WeKTNJVWgNTTHY56qiUGOlxtvEZ2xObLA=";
+    };
+
+    nativeBuildInputs = [
+      flit-core
+    ];
+
+    disabledTestPaths = [
+      "tests/integration"
+    ];
+
+    pythonImportsCheck = [ "msgraph.core" ];
+  });
 in
 buildPythonPackage rec {
   pname = "parsedmarc";
@@ -87,7 +108,7 @@ buildPythonPackage rec {
     kafka-python-ng
     lxml
     mailsuite
-    msgraph-core
+    msgraph-core-0
     opensearch-py
     publicsuffixlist
     pygelf
@@ -114,7 +135,5 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ talyz ];
     mainProgram = "parsedmarc";
-    # https://github.com/domainaware/parsedmarc/issues/464
-    broken = lib.versionAtLeast msgraph-core.version "1.0.0";
   };
 }


### PR DESCRIPTION
## Description of changes

### Background

[`parsedmarc`](https://github.com/domainaware/parsedmarc) has both a Python library and CLI. Our packaging of the library is currently broken by an unmet dependency. A [fix](https://github.com/NixOS/nixpkgs/pull/280940/commits/471a8ed428b1734b2ca95358285e8803438d2d76) was applied to the CLI, but the library remains broken.

### Proposed change

Move the fix to the library, so that both the library and CLI are usable:

| Package                      | Before                                      | After                             |
|------------------------------|---------------------------------------------|-----------------------------------|
| `python3Packages.parsedmarc` | Broken by unmet dependency                  | Fixed                             |
| `parsedmarc`                 | Fixes and uses `python3Packages.parsedmarc` | Uses `python3Packages.parsedmarc` |

### Example

<details><summary>Test functions</summary>

```bash
test_application() {
  nix-shell \
    --packages 'parsedmarc' \
    --run 'env --unset PYTHONPATH parsedmarc --version'
}

test_module() {
  nix-shell \
    --packages 'python3Packages.parsedmarc' \
    --run "python -c 'import parsedmarc; print(parsedmarc.email.policy.default)'"
}
```

</details>

Before:

```console
$ test_module
error: Package ‘python3.12-parsedmarc-8.12.0’ in …/pkgs/development/python-modules/parsedmarc/default.nix:103 is marked as broken, refusing to evaluate.
$ test_application
8.12.0
```

After:

```console
$ test_module
EmailPolicy()
$ test_application
8.12.0
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
