### PR TITLE
nixos/hardware.pulseaudio: remove `with lib;`

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -1,8 +1,4 @@
 { config, lib, pkgs, ... }:
-
-with pkgs;
-with lib;
-
 let
 
   cfg = config.hardware.pulseaudio;
@@ -10,28 +6,28 @@ let
   hasZeroconf = let z = cfg.zeroconf; in z.publish.enable || z.discovery.enable;
 
   overriddenPackage = cfg.package.override
-    (optionalAttrs hasZeroconf { zeroconfSupport = true; });
-  binary = "${getBin overriddenPackage}/bin/pulseaudio";
+    (lib.optionalAttrs hasZeroconf { zeroconfSupport = true; });
+  binary = "${lib.getBin overriddenPackage}/bin/pulseaudio";
   binaryNoDaemon = "${binary} --daemonize=no";
 
   # Forces 32bit pulseaudio and alsa-plugins to be built/supported for apps
   # using 32bit alsa on 64bit linux.
-  enable32BitAlsaPlugins = cfg.support32Bit && stdenv.isx86_64 && (pkgs.pkgsi686Linux.alsa-lib != null && pkgs.pkgsi686Linux.libpulseaudio != null);
+  enable32BitAlsaPlugins = cfg.support32Bit && pkgs.stdenv.isx86_64 && (pkgs.pkgsi686Linux.alsa-lib != null && pkgs.pkgsi686Linux.libpulseaudio != null);
 
 
   myConfigFile =
     let
-      addModuleIf = cond: mod: optionalString cond "load-module ${mod}";
-      allAnon = optional cfg.tcp.anonymousClients.allowAll "auth-anonymous=1";
+      addModuleIf = cond: mod: lib.optionalString cond "load-module ${mod}";
+      allAnon = lib.optional cfg.tcp.anonymousClients.allowAll "auth-anonymous=1";
       ipAnon =  let a = cfg.tcp.anonymousClients.allowedIpRanges;
-                in optional (a != []) ''auth-ip-acl=${concatStringsSep ";" a}'';
-    in writeTextFile {
+                in lib.optional (a != []) ''auth-ip-acl=${lib.concatStringsSep ";" a}'';
+    in pkgs.writeTextFile {
       name = "default.pa";
         text = ''
         .include ${cfg.configFile}
         ${addModuleIf cfg.zeroconf.publish.enable "module-zeroconf-publish"}
         ${addModuleIf cfg.zeroconf.discovery.enable "module-zeroconf-discover"}
-        ${addModuleIf cfg.tcp.enable (concatStringsSep " "
+        ${addModuleIf cfg.tcp.enable (lib.concatStringsSep " "
            ([ "module-native-protocol-tcp" ] ++ allAnon ++ ipAnon))}
         ${addModuleIf config.services.jack.jackd.enable "module-jack-sink"}
         ${addModuleIf config.services.jack.jackd.enable "module-jack-source"}
@@ -49,7 +45,7 @@ let
   # Create pulse/client.conf even if PulseAudio is disabled so
   # that we can disable the autospawn feature in programs that
   # are built with PulseAudio support (like KDE).
-  clientConf = writeText "client.conf" ''
+  clientConf = pkgs.writeText "client.conf" ''
     autospawn=no
     ${cfg.extraClientConf}
   '';
@@ -82,16 +78,16 @@ in {
   options = {
 
     hardware.pulseaudio = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable the PulseAudio sound server.
         '';
       };
 
-      systemWide = mkOption {
-        type = types.bool;
+      systemWide = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           If false, a PulseAudio server is launched automatically for
@@ -105,8 +101,8 @@ in {
         '';
       };
 
-      support32Bit = mkOption {
-        type = types.bool;
+      support32Bit = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to include the 32-bit pulseaudio libraries in the system or not.
@@ -114,8 +110,8 @@ in {
         '';
       };
 
-      configFile = mkOption {
-        type = types.nullOr types.path;
+      configFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         description = ''
           The path to the default configuration options the PulseAudio server
           should use. By default, the "default.pa" configuration
@@ -123,8 +119,8 @@ in {
         '';
       };
 
-      extraConfig = mkOption {
-        type = types.lines;
+      extraConfig = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = ''
           Literal string to append to `configFile`
@@ -132,21 +128,21 @@ in {
         '';
       };
 
-      extraClientConf = mkOption {
-        type = types.lines;
+      extraClientConf = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = ''
           Extra configuration appended to pulse/client.conf file.
         '';
       };
 
-      package = mkOption {
-        type = types.package;
+      package = lib.mkOption {
+        type = lib.types.package;
         default = if config.services.jack.jackd.enable
                   then pkgs.pulseaudioFull
                   else pkgs.pulseaudio;
-        defaultText = literalExpression "pkgs.pulseaudio";
-        example = literalExpression "pkgs.pulseaudioFull";
+        defaultText = lib.literalExpression "pkgs.pulseaudio";
+        example = lib.literalExpression "pkgs.pulseaudioFull";
         description = ''
           The PulseAudio derivation to use.  This can be used to enable
           features (such as JACK support, Bluetooth) via the
@@ -154,10 +150,10 @@ in {
         '';
       };
 
-      extraModules = mkOption {
-        type = types.listOf types.package;
+      extraModules = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
         default = [];
-        example = literalExpression "[ pkgs.pulseaudio-modules-bt ]";
+        example = lib.literalExpression "[ pkgs.pulseaudio-modules-bt ]";
         description = ''
           Extra pulseaudio modules to use. This is intended for out-of-tree
           pulseaudio modules like extra bluetooth codecs.
@@ -167,8 +163,8 @@ in {
       };
 
       daemon = {
-        logLevel = mkOption {
-          type = types.str;
+        logLevel = lib.mkOption {
+          type = lib.types.str;
           default = "notice";
           description = ''
             The log level that the system-wide pulseaudio daemon should use,
@@ -176,31 +172,31 @@ in {
           '';
         };
 
-        config = mkOption {
-          type = types.attrsOf types.unspecified;
+        config = lib.mkOption {
+          type = lib.types.attrsOf lib.types.unspecified;
           default = {};
           description = "Config of the pulse daemon. See `man pulse-daemon.conf`.";
-          example = literalExpression ''{ realtime-scheduling = "yes"; }'';
+          example = lib.literalExpression ''{ realtime-scheduling = "yes"; }'';
         };
       };
 
       zeroconf = {
         discovery.enable =
-          mkEnableOption "discovery of pulseaudio sinks in the local network";
+          lib.mkEnableOption "discovery of pulseaudio sinks in the local network";
         publish.enable =
-          mkEnableOption "publishing the pulseaudio sink in the local network";
+          lib.mkEnableOption "publishing the pulseaudio sink in the local network";
       };
 
       # TODO: enable by default?
       tcp = {
-        enable = mkEnableOption "tcp streaming support";
+        enable = lib.mkEnableOption "tcp streaming support";
 
         anonymousClients = {
-          allowAll = mkEnableOption "all anonymous clients to stream to the server";
-          allowedIpRanges = mkOption {
-            type = types.listOf types.str;
+          allowAll = lib.mkEnableOption "all anonymous clients to stream to the server";
+          allowedIpRanges = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
             default = [];
-            example = literalExpression ''[ "127.0.0.1" "192.168.1.0/24" ]'';
+            example = lib.literalExpression ''[ "127.0.0.1" "192.168.1.0/24" ]'';
             description = ''
               A list of IP subnets that are allowed to stream to the server.
             '';
@@ -213,7 +209,7 @@ in {
   };
 
 
-  config = lib.mkIf cfg.enable (mkMerge [
+  config = lib.mkIf cfg.enable (lib.mkMerge [
     {
       environment.etc."pulse/client.conf".source = clientConf;
 
@@ -222,21 +218,21 @@ in {
       environment.etc = {
         "alsa/conf.d/99-pulseaudio.conf".text = alsaConf;
 
-        "pulse/daemon.conf".source = writeText "daemon.conf"
+        "pulse/daemon.conf".source = pkgs.writeText "daemon.conf"
           (lib.generators.toKeyValue {} cfg.daemon.config);
 
-        "openal/alsoft.conf".source = writeText "alsoft.conf" "drivers=pulse";
+        "openal/alsoft.conf".source = pkgs.writeText "alsoft.conf" "drivers=pulse";
 
-        "libao.conf".source = writeText "libao.conf" "default_driver=pulse";
+        "libao.conf".source = pkgs.writeText "libao.conf" "default_driver=pulse";
       };
 
-      hardware.pulseaudio.configFile = mkDefault "${getBin overriddenPackage}/etc/pulse/default.pa";
+      hardware.pulseaudio.configFile = lib.mkDefault "${lib.getBin overriddenPackage}/etc/pulse/default.pa";
 
       # Disable flat volumes to enable relative ones
-      hardware.pulseaudio.daemon.config.flat-volumes = mkDefault "no";
+      hardware.pulseaudio.daemon.config.flat-volumes = lib.mkDefault "no";
 
       # Upstream defaults to speex-float-1 which results in audible artifacts
-      hardware.pulseaudio.daemon.config.resample-method = mkDefault "speex-float-5";
+      hardware.pulseaudio.daemon.config.resample-method = lib.mkDefault "speex-float-5";
 
       # Allow PulseAudio to get realtime priority using rtkit.
       security.rtkit.enable = true;
@@ -247,7 +243,7 @@ in {
       services.udev.packages = [ overriddenPackage ];
     }
 
-    (mkIf (cfg.extraModules != []) {
+    (lib.mkIf (cfg.extraModules != []) {
       hardware.pulseaudio.daemon.config.dl-search-path = let
         overriddenModules = builtins.map
           (drv: drv.override { pulseaudio = overriddenPackage; })
@@ -259,15 +255,15 @@ in {
       in lib.concatStringsSep ":" modulePaths;
     })
 
-    (mkIf hasZeroconf {
+    (lib.mkIf hasZeroconf {
       services.avahi.enable = true;
     })
-    (mkIf cfg.zeroconf.publish.enable {
+    (lib.mkIf cfg.zeroconf.publish.enable {
       services.avahi.publish.enable = true;
       services.avahi.publish.userServices = true;
     })
 
-    (mkIf (!cfg.systemWide) {
+    (lib.mkIf (!cfg.systemWide) {
       environment.etc = {
         "pulse/default.pa".source = myConfigFile;
       };
@@ -278,7 +274,7 @@ in {
             RestartSec = "500ms";
             PassEnvironment = "DISPLAY";
           };
-        } // optionalAttrs config.services.jack.jackd.enable {
+        } // lib.optionalAttrs config.services.jack.jackd.enable {
           environment.JACK_PROMISCUOUS_SERVER = "jackaudio";
         };
         sockets.pulseaudio = {
@@ -287,7 +283,7 @@ in {
       };
     })
 
-    (mkIf cfg.systemWide {
+    (lib.mkIf cfg.systemWide {
       users.users.pulse = {
         # For some reason, PulseAudio wants UID == GID.
         uid = assert uid == gid; uid;


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
