### PR TITLE
[Backport release-24.05] librewolf-unwrapped: add librewolf pref pane

### DIFF
--- a/pkgs/applications/networking/browsers/librewolf/librewolf.nix
+++ b/pkgs/applications/networking/browsers/librewolf/librewolf.nix
@@ -6,7 +6,7 @@ rec {
 
   inherit (src) packageVersion firefox source;
 
-  extraPatches = [ ];
+  extraPatches = [ "${source}/patches/pref-pane/pref-pane-small.patch" ];
 
   extraConfigureFlags = [
     "--with-app-name=librewolf"
@@ -26,6 +26,12 @@ rec {
     cp ${source}/assets/search-config.json services/settings/dumps/main/search-config.json
     sed -i '/MOZ_SERVICES_HEALTHREPORT/ s/True/False/' browser/moz.configure
     sed -i '/MOZ_NORMANDY/ s/True/False/' browser/moz.configure
+
+    cp ${source}/patches/pref-pane/category-librewolf.svg browser/themes/shared/preferences
+    cp ${source}/patches/pref-pane/librewolf.css browser/themes/shared/preferences
+    cp ${source}/patches/pref-pane/librewolf.inc.xhtml browser/components/preferences
+    cp ${source}/patches/pref-pane/librewolf.js browser/components/preferences
+    cat ${source}/patches/pref-pane/preferences.ftl >> browser/locales/en-US/browser/preferences/preferences.ftl
   '';
 
   extraPrefsFiles = [ "${src.settings}/librewolf.cfg" ];


### PR DESCRIPTION
## Description of changes

- Adds the Librewolf preferences pane
- Adds an extra patching step from the upstream build script

https://codeberg.org/librewolf/source/src/commit/1b75cbb46/scripts/librewolf-patches.py#L132

Fixes #300107

This qualifies as a backport because it's a bug fix.

(cherry picked from commit ddc59b790063200b95b4bb4abb66660263b895d1)

(Backport of #337061)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
