### PR TITLE
lomiri.lomiri-docviewer-app: init at 3.0.4

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -24,6 +24,7 @@ in {
         lomiri-calculator-app
         lomiri-camera-app
         lomiri-clock-app
+        lomiri-docviewer-app
         lomiri-download-manager
         lomiri-filemanager-app
         lomiri-gallery-app

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -545,6 +545,7 @@ in {
   lomiri-calculator-app = runTest ./lomiri-calculator-app.nix;
   lomiri-camera-app = runTest ./lomiri-camera-app.nix;
   lomiri-clock-app = runTest ./lomiri-clock-app.nix;
+  lomiri-docviewer-app = runTest ./lomiri-docviewer-app.nix;
   lomiri-filemanager-app = runTest ./lomiri-filemanager-app.nix;
   lomiri-gallery-app = runTest ./lomiri-gallery-app.nix;
   lomiri-system-settings = handleTest ./lomiri-system-settings.nix {};

--- a/nixos/tests/lomiri-docviewer-app.nix
+++ b/nixos/tests/lomiri-docviewer-app.nix
@@ -1,0 +1,84 @@
+{ lib, ... }:
+let
+  exampleText = "Lorem ipsum dolor sit amet";
+in
+{
+  name = "lomiri-docviewer-app-standalone";
+  meta.maintainers = lib.teams.lomiri.members;
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [ ./common/x11.nix ];
+
+      services.xserver.enable = true;
+
+      environment = {
+        etc."docviewer-sampletext.txt".text = exampleText;
+        systemPackages =
+          with pkgs;
+          [
+            libreoffice # txt -> odf to test LibreOfficeKit integration
+          ]
+          ++ (with pkgs.lomiri; [
+            suru-icon-theme
+            lomiri-docviewer-app
+          ]);
+        variables = {
+          UITK_ICON_THEME = "suru";
+        };
+      };
+
+      i18n.supportedLocales = [ "all" ];
+
+      fonts = {
+        packages = with pkgs; [
+          # Intended font & helps with OCR
+          ubuntu-classic
+        ];
+      };
+    };
+
+  enableOCR = true;
+
+  testScript = ''
+    machine.wait_for_x()
+
+    with subtest("lomiri docviewer launches"):
+        machine.succeed("lomiri-docviewer-app >&2 &")
+        machine.wait_for_text("No documents")
+        machine.screenshot("lomiri-docviewer_open")
+
+    machine.succeed("pkill -f lomiri-docviewer-app")
+
+    # Setup different document types
+    machine.succeed("soffice --convert-to odt --outdir /root/ /etc/docviewer-sampletext.txt")
+    machine.succeed("soffice --convert-to pdf --outdir /root/ /etc/docviewer-sampletext.txt")
+
+    with subtest("lomiri docviewer txt works"):
+        machine.succeed("lomiri-docviewer-app /etc/docviewer-sampletext.txt >&2 &")
+        machine.wait_for_text("${exampleText}")
+        machine.screenshot("lomiri-docviewer_txt")
+
+    machine.succeed("pkill -f lomiri-docviewer-app")
+
+    with subtest("lomiri docviewer odt works"):
+        machine.succeed("lomiri-docviewer-app /root/docviewer-sampletext.odt >&2 &")
+        machine.wait_for_text("${exampleText}")
+        machine.screenshot("lomiri-docviewer_odt")
+
+    machine.succeed("pkill -f lomiri-docviewer-app")
+
+    with subtest("lomiri docviewer pdf works"):
+        machine.succeed("lomiri-docviewer-app /root/docviewer-sampletext.pdf >&2 &")
+        machine.wait_for_text("${exampleText}")
+        machine.screenshot("lomiri-docviewer_pdf")
+
+    machine.succeed("pkill -f lomiri-docviewer-app")
+
+    with subtest("lomiri docviewer localisation works"):
+        machine.succeed("env LANG=de_DE.UTF-8 lomiri-docviewer-app >&2 &")
+        machine.wait_for_text("Keine Dokumente")
+        machine.screenshot("lomiri-docviewer_localised")
+  '';
+}

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -545,8 +545,9 @@ in stdenv.mkDerivation (finalAttrs: {
   ];
 
   postInstall = optionalString (variant != "collabora") ''
-    mkdir -p $out/share/icons
+    mkdir -p $out/{include,share/icons}
 
+    cp -r include/LibreOfficeKit $out/include/
     cp -r sysui/desktop/icons/hicolor $out/share/icons
 
     # Rename icons for consistency

--- a/pkgs/desktops/lomiri/applications/lomiri-docviewer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-docviewer-app/default.nix
@@ -1,0 +1,155 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  fetchpatch2,
+  gitUpdater,
+  cmake,
+  content-hub,
+  gettext,
+  libreoffice,
+  libreoffice-unwrapped,
+  lomiri-ui-toolkit,
+  pkg-config,
+  poppler,
+  qtbase,
+  qtdeclarative,
+  qtsystems,
+  wrapQtAppsHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-docviewer-app";
+  version = "3.0.4";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/apps/lomiri-docviewer-app";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-xUBE+eSAfG2yMlE/DI+6JHQx+3HiNwtSTv/P4YOAE7Y=";
+  };
+
+  patches = [
+    # Remove when version > 3.0.4
+    (fetchpatch {
+      name = "0001-lomiri-docviewer-app-Set-gettext-domain.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/8dc2c911817c45451ff341e4ae4b841bcc134945.patch";
+      hash = "sha256-vP6MYl7qhJzkgtnVelMMIbc0ZkHxC1s3abUXJ2zVi4w=";
+    })
+    (fetchpatch {
+      name = "0002-lomiri-docviewer-app-Install-splash-file.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/ef20bbdd5e80040bf11273a5fc2964400086fdc9.patch";
+      hash = "sha256-ylPFn53PJRyyzhN1SxtmNFMFeDsV9UxyQhAqULA5PJM=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/merge_requests/72 merged & in release
+    (fetchpatch {
+      name = "1001-lomiri-docviewer-app-Stop-using-qt5_use_modules.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/120c81dd71356f2e06ef5c44d114b665236a7382.patch";
+      hash = "sha256-4VCw90qYnQ/o67ndp9o8h+wUl2IUpmVGb9xyY55AMIQ=";
+    })
+    (fetchpatch {
+      name = "1002-lomiri-docviewer-app-Move-Qt-find_package-to-top-level.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/43ee96a3a33b7a8f04e95f434982bcc60ba4b257.patch";
+      hash = "sha256-3LggdNo4Yak4SVAD/4/mMCl8PjZy1dIx9i5hKHM5fJU=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/merge_requests/73 merged & in release
+    (fetchpatch {
+      name = "1011-lomiri-docviewer-app-Call-i18n-bindtextdomain.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/67599a841917304f76ffa1167a217718542a8b46.patch";
+      hash = "sha256-nbi3qX14kWtFcXrxAD41IeybDIRTNfUdRgSP1vDI/Hs=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/merge_requests/74 merged & in release
+    (fetchpatch {
+      name = "1021-lomiri-docviewer-app-Use-GNUInstallDirs-more-better.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/40a860a118077c05692002db694be77ea62dc5b3.patch";
+      hash = "sha256-/zhpIdqZ7WsU4tx4/AZs5w8kEopjH2boiHdHaJk5RXk=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/merge_requests/75 merged & in release
+    (fetchpatch {
+      name = "1031-lomiri-docviewer-app-Use-BUILD_TESTING.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/6f1eb739a3e0bf0ba847f94f8ea8411e0a385c2d.patch";
+      hash = "sha256-yVuYG+1JGo/I4TVRZ3UQeO/TJ8GiFO5BJ9Bs7glK7hg=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/merge_requests/76 merged & in release
+    # fetchpatch2 because there's a file rename
+    (fetchpatch2 {
+      name = "1041-lomiri-docviewer-app-Configurable-LibreOffice-path.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/6e1aee99b31b88a90b07f3c5fcf6340c54ce9aaa.patch";
+      hash = "sha256-KdHyKXM0hMMIFkuDn5JZJOEuitWAXT2QQOuR+1AolP0=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/merge_requests/77 merged & in release
+    (fetchpatch {
+      name = "1051-lomiri-docviewer-app-Install-content-hub-lomiri-url-dispatcher-files.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/98f5ab9d51ba05e8c3ed1991c0b67d3922b5ba90.patch";
+      hash = "sha256-JA26ga1CNOdbis87lSzqbUbs94Oc1vlxraXZxx3dsu8=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace cmake/modules/Click.cmake \
+      --replace-fail 'qmake -query QT_INSTALL_QML' "echo $out/${qtbase.qtQmlPrefix}"
+
+    # We don't want absolute paths in desktop files
+    substituteInPlace data/CMakeLists.txt \
+      --replace-fail 'ICON "''${DATA_DIR}/''${ICON_FILE}"' 'ICON lomiri-docviewer-app' \
+      --replace-fail 'SPLASH "''${DATA_DIR}/''${SPLASH_FILE}"' 'SPLASH "lomiri-app-launch/splash/lomiri-docviewer-app.svg"'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libreoffice-unwrapped # LibreOfficeKit
+    poppler
+    qtbase
+    qtdeclarative
+
+    # QML
+    content-hub
+    lomiri-ui-toolkit
+    qtsystems
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "INSTALL_TESTS" false)
+    (lib.cmakeBool "CLICK_MODE" false)
+    (lib.cmakeFeature "LIBREOFFICE_PREFIX" "${libreoffice-unwrapped}")
+  ];
+
+  # Only autopilot tests we can't run
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/{icons/hicolor/scalable/apps,lomiri-app-launch/splash}
+
+    ln -s $out/share/{lomiri-docviewer-app/docviewer-app.svg,icons/hicolor/scalable/apps/lomiri-docviewer-app.svg}
+    ln -s $out/share/{lomiri-docviewer-app/docviewer-app-splash.svg,lomiri-app-launch/splash/lomiri-docviewer-app.svg}
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "Document Viewer application for Ubuntu Touch devices";
+    homepage = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/blob/v${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    mainProgram = "lomiri-docviewer-app";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-docviewer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-docviewer-app/default.nix
@@ -5,6 +5,7 @@
   fetchpatch,
   fetchpatch2,
   gitUpdater,
+  nixosTests,
   cmake,
   content-hub,
   gettext,
@@ -140,6 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    tests.vm = nixosTests.lomiri-docviewer-app;
     updateScript = gitUpdater { rev-prefix = "v"; };
   };
 

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -17,6 +17,7 @@ let
       lomiri-calculator-app = callPackage ./applications/lomiri-calculator-app { };
       lomiri-camera-app = callPackage ./applications/lomiri-camera-app { };
       lomiri-clock-app = callPackage ./applications/lomiri-clock-app { };
+      lomiri-docviewer-app = callPackage ./applications/lomiri-docviewer-app { };
       lomiri-filemanager-app = callPackage ./applications/lomiri-filemanager-app { };
       lomiri-gallery-app = callPackage ./applications/lomiri-gallery-app { };
       lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };


### PR DESCRIPTION
## Description of changes

Working towards https://github.com/NixOS/nixpkgs/issues/99090.

[Lomiri Document Viewer App](https://gitlab.com/ubports/development/apps/lomiri-docviewer-app) is the… *document viewing app* for *Lomiri*. (duh)

![Bildschirmfoto_2024-08-24_23-25-06](https://github.com/user-attachments/assets/4f7a14e8-8677-4f0d-aced-6f6ef2fd94ca)

Interestingly, it supports displaying LibreOffice documents by using [LibreOfficeKit](https://docs.libreoffice.org/libreofficekit.html) headers to (afaict) dispatch the rendering to LibreOffice. We didn't install those headers so far, so this PR also takes care of that. The docviewer VM test takes care of testing this functionality.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
