### PR TITLE
rathole: 0.5.0 -> 0.5.0-unstable-2024-06-06

### DIFF
--- a/pkgs/by-name/ra/rathole/package.nix
+++ b/pkgs/by-name/ra/rathole/package.nix
@@ -1,11 +1,12 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, rustPlatform
-, pkg-config
-, openssl
-, nixosTests
-, darwin
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  nixosTests,
+  darwin,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -21,21 +22,19 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-UyQXAUPnp32THZJAs/p3bIXZjcXTvjy207QBVLCfkr8=";
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
     openssl
-  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-    CoreServices
-  ]);
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ CoreServices ]);
 
   __darwinAllowLocalNetworking = true;
 
   doCheck = false; # https://github.com/rapiz1/rathole/issues/222
 
-  passthru.tests = { inherit (nixosTests) rathole; };
+  passthru.tests = {
+    inherit (nixosTests) rathole;
+  };
 
   meta = with lib; {
     description = "Reverse proxy for NAT traversal";

--- a/pkgs/by-name/ra/rathole/package.nix
+++ b/pkgs/by-name/ra/rathole/package.nix
@@ -9,18 +9,18 @@
   darwin,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "rathole";
-  version = "0.5.0";
+  version = "0.5.0-unstable-2024-06-06";
 
   src = fetchFromGitHub {
     owner = "rapiz1";
-    repo = pname;
-    rev = "refs/tags/v${version}";
-    hash = "sha256-YfLzR1lHk+0N3YU1XTNxz+KE1S3xaiKJk0zASm6cr1s=";
+    repo = "rathole";
+    rev = "be14d124a22e298d12d92e56ef4fec0e51517998";
+    hash = "sha256-C0/G4JOZ4pTAvcKZhRHsGvlLlwAyWBQ0rMScLvaLSuA=";
   };
 
-  cargoHash = "sha256-UyQXAUPnp32THZJAs/p3bIXZjcXTvjy207QBVLCfkr8=";
+  cargoHash = "sha256-zlwIgzqpoEgYqZe4Gv8owJQ3m7UFgPA5joRMiyq+T/M=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -30,18 +30,18 @@ rustPlatform.buildRustPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  doCheck = false; # https://github.com/rapiz1/rathole/issues/222
-
   passthru.tests = {
     inherit (nixosTests) rathole;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Reverse proxy for NAT traversal";
     homepage = "https://github.com/rapiz1/rathole";
-    changelog = "https://github.com/rapiz1/rathole/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ dit7ya ];
+    license = lib.licenses.asl20;
     mainProgram = "rathole";
+    maintainers = with lib.maintainers; [
+      dit7ya
+      xokdvium
+    ];
   };
 }

--- a/pkgs/by-name/ra/rathole/package.nix
+++ b/pkgs/by-name/ra/rathole/package.nix
@@ -5,7 +5,7 @@
 , pkg-config
 , openssl
 , nixosTests
-, CoreServices
+, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -27,9 +27,9 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     openssl
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     CoreServices
-  ];
+  ]);
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18732,10 +18732,6 @@ with pkgs;
 
   ran = callPackage ../servers/http/ran { };
 
-  rathole = callPackage ../tools/networking/rathole {
-    inherit (darwin.apple_sdk.frameworks) CoreServices;
-  };
-
   retry = callPackage ../tools/system/retry { };
 
   rizin = pkgs.callPackage ../development/tools/analysis/rizin { };


### PR DESCRIPTION
## Description of changes

Fixes build failure introduced with Rust 1.80. See tracking issue: https://github.com/NixOS/nixpkgs/issues/332957.
The necessary time crate bump is already in main: https://github.com/rapiz1/rathole/issues/380

- Move to pkgs/by-name
- Update to [be14d12](https://github.com/rapiz1/rathole/commit/be14d12), which has Rust 1.80 fixes
- Re-enable doCheck
- Add myself as maintainer
- Sort meta attributes
- Remove with lib; usage
- Drop changelog for unstable version, since upstream does not track unreleased changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
