### PR TITLE
avrdude: 7.3 -> 8.0

### DIFF
--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, stdenv, fetchFromGitHub, cmake, bison, flex, libusb1, elfutils
+{ lib, callPackage, stdenv, fetchFromGitHub, cmake, bison, flex, pkg-config, libusb1, elfutils
 , libftdi1, readline, hidapi, libserialport, libusb-compat-0_1
 # Documentation building doesn't work on Darwin. It fails with:
 #   Undefined subroutine &Locale::Messages::dgettext called in ... texi2html
@@ -12,16 +12,16 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "avrdude";
-  version = "7.3";
+  version = "8.0";
 
   src = fetchFromGitHub {
     owner = "avrdudes";
-    repo = "avdude";
+    repo = "avrdude";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-JqW3AOMmAfcy+PQRcqviWlxA6GoMSEfzIFt1pRYY7Dw=";
+    sha256 = "w58HVCvKuWpGJwllupbj7ndeq4iE9LPs/IjFSUN0DOU=";
   };
 
-  nativeBuildInputs = [ cmake bison flex ] ++ lib.optionals docSupport [
+  nativeBuildInputs = [ cmake bison flex pkg-config ] ++ lib.optionals docSupport [
     unixtools.more
     texliveMedium
     texinfo
@@ -47,11 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
   #   -DHAVE_LINUXGPIO=ON    because it's incompatible with libgpiod 2.x
   cmakeFlags = lib.optionals docSupport [ "-DBUILD_DOC=ON" ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ "-DHAVE_LINUXSPI=ON" "-DHAVE_PARPORT=ON" ];
-
-  # dvips output references texlive in comments, resulting in a huge closure
-  postInstall = lib.optionalString docSupport ''
-    rm $out/share/doc/avrdude/*.ps
-  '';
 
   passthru = {
     # Vendored and mutated copy of libelf for avrdudes use.


### PR DESCRIPTION
## Description of changes

Release notes: https://github.com/avrdudes/avrdude/blob/4fa07e563fbe7ce0fa3c467eff20fc9e04de5298/NEWS

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
