### PR TITLE
nixos/openafsServer: automatic extraction of authentication keys from Kerberos 5 service keytab

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -513,6 +513,8 @@
 
 - `programs.fzf.keybindings` now supports the fish shell.
 
+- The OpenAFS server module now supports the automatic extraction of service authentication keys from a Kerberos 5 keytab. Just specify the runtime path of the keytab and (optionally) the principal representing the AFS cell as the values of `services.openafsServer.authentication.keytab` and `services.openafsServer.authentication.principal`, respectively. The old behavior of using a pre-existing `/etc/openafs/server/KeyFileExt` managed by the `asetkey` command is retained by default.
+
 - `gerbera` now has wavpack support.
 
 - `ddclient` was updated from 3.11.2 to 4.0.0 [Release notes](https://github.com/ddclient/ddclient/releases/tag/v4.0.0)


### PR DESCRIPTION
## Description of changes
Contemporary OpenAFS cells authenticate both users and servers by relying on an existing Kerberos infrastructure. For legacy and compatibility reasons, OpenAFS servers do not use Kerberos 5 service keytabs directly, but instead rely on an OpenAFS-specific keyring located at `/etc/openafs/server/KeyFileExt`. This keyring must be filled and managed imperatively by way of the `asetkey` command.

To make matters more complicated, `asetkey` expects the administrator to be aware of the internal numerical encoding used by Kerberos 5 to represent encryption key types, and requires this information to be entered for each key that is added to the keyring via `asetkey add` (see [asetkey(8)](https://docs.openafs.org/Reference/8/asetkey.html)).

This PR introduces an automatic mechanism that, given an ordinary Kerberos 5 keytab, parses it for the AFS service keys (identified by a user-configured principal) and automatically constructs a `KeyFileExt` from these, declaratively and without any further user interaction. The AFS administrator only has to assign the *runtime path* of the keytab to the `services.openafsServer.authentication.keytab` option and, if needed, indicate the Kerberos 5 principal of the AFS service by setting the value of `services.openafsServer.authentication.principal`.

The legacy behavior is retained by default or by explicitly setting `services.openafsServer.authentication.keytab = null`.

This improvement constitutes a further step towards achieving complete AFS automatic deployment, easing the configuration of machines with volatile root partitions, and implementing automated tests.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
