### PR TITLE
nixos/qbittorrent-nox: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -91,6 +91,8 @@
 
 - [Proton Mail bridge](https://proton.me/mail/bridge), a desktop application that runs in the background, encrypting and decrypting messages as they enter and leave your computer. It lets you add your Proton Mail account to your favorite email client via IMAP/SMTP by creating a local email server on your computer.
 
+- [qBittorrent-nox](https://github.com/qbittorrent/qBittorrent/wiki/Running-qBittorrent-without-X-server-(WebUI-only,-systemd-service-set-up,-Ubuntu-15.04-or-newer)), a headless web ui for qBittorrent. That allows a torrent client to run as a daemon on your computer. Available as [services.qbittorrent-nox](#opt-services.qbittorrent-nox.enable).
+
 - [chromadb](https://www.trychroma.com/), an open-source AI application
   database. Batteries included. Available as [services.chromadb](options.html#opt-services.chromadb.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1353,6 +1353,7 @@
   ./services/torrent/magnetico.nix
   ./services/torrent/opentracker.nix
   ./services/torrent/peerflix.nix
+  ./services/torrent/qbittorrent-nox.nix
   ./services/torrent/rtorrent.nix
   ./services/torrent/transmission.nix
   ./services/torrent/torrentstream.nix

--- a/nixos/modules/services/torrent/qbittorrent-nox.md
+++ b/nixos/modules/services/torrent/qbittorrent-nox.md
@@ -1,0 +1,14 @@
+# qBittorrent-nox {#module-services-torrent-qbittorrent-nox}
+
+qBittorrent-nox is available as a standalone package as `qbittorrent-nox`, it can be installed to test the program before setting up the service.
+
+Options can be decleared like the following. On first start up check the logs with `journelctl -u qbittorrent-nox`, You'll need the temporary password to login to the webui as the admin account, Then you can go to the gear icon -> `Web UI` -> `Authentication` and change the password. [You can connect to the webui at port 8080 as shown in the example below.](http://localhost:8080/)
+```nix
+services.qbittorrent-nox = {
+  enable = true;
+
+  port = 8080;
+  openFirewall = true;
+};
+```
+[More options are listed here.](https://search.nixos.org/options?query=services.qbittorrent) Lastly, watch out for permissions problems with other programs that either read/write from the downloads folder.

--- a/nixos/modules/services/torrent/qbittorrent-nox.nix
+++ b/nixos/modules/services/torrent/qbittorrent-nox.nix
@@ -1,0 +1,137 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.qbittorrent-nox;
+in
+{
+  meta = {
+    doc = ./qbittorrent-nox.md;
+    maintainers = with lib.maintainers; [ redhawk ];
+  };
+
+  options.services.qbittorrent-nox = {
+    enable = lib.mkEnableOption "qBittorrent-nox headless";
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/qbittorrent-nox";
+      description = "The directory where qBittorrent-nox stores its data files.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open services.qbittorrent-nox.port to the outside network.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "qbittorrent-nox";
+      description = "User account under which qBittorrent-nox runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "qbittorrent-nox";
+      description = "Group under which qBittorrent-nox runs.";
+    };
+
+    webui-port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "qBittorrent-nox web UI port.";
+    };
+
+    package = lib.mkPackageOption pkgs "qbittorrent-nox" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.webui-port ]; };
+
+    systemd = {
+      services.qbittorrent-nox = {
+        description = "qBittorrent-nox service";
+        documentation = [ "man:qbittorrent-nox(1)" ];
+        after = [
+          "network-online.target"
+          "nss-lookup.target"
+        ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          User = cfg.user;
+          Group = cfg.group;
+
+          ExecStart = "${lib.getExe cfg.package} --webui-port=${toString cfg.webui-port}";
+
+          IOSchedulingClass = "idle";
+          IOSchedulingPriority = "7";
+
+          Restart = "always";
+          UMask = "0022";
+
+          PrivateTmp = false;
+          PrivateNetwork = false;
+          RemoveIPC = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProtectHome = "yes";
+          ProtectProc = "invisible";
+          ProcSubset = "pid";
+          ProtectSystem = "full";
+          ProtectClock = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_NETLINK"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          SystemCallArchitectures = "native";
+          CapabilityBoundingSet = "";
+          SystemCallFilter = [ "@system-service" ];
+
+        };
+        environment.QBT_PROFILE = cfg.dataDir; # required
+      };
+
+      tmpfiles.settings."qbittorrent-nox" = {
+        "${cfg.dataDir}" = {
+          d = {
+            user = cfg.user;
+            group = cfg.group;
+            mode = "0755";
+          };
+        };
+      };
+    };
+
+    users = {
+      users = lib.mkIf (cfg.user == "qbittorrent-nox") {
+        qbittorrent-nox = {
+          group = cfg.group;
+          isSystemUser = true;
+        };
+      };
+
+      groups = lib.mkIf (cfg.group == "qbittorrent-nox") {
+        qbittorrent-nox = { };
+
+      };
+    };
+  };
+}


### PR DESCRIPTION
use tmpfiles instead of prescript

## Description of changes
This adds a service for the qbittorrent nox web ui with some basic options for the systemd job.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
