### PR TITLE
outfly: init at v0.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -262,6 +262,11 @@
     githubId = 12578560;
     name = "Quinn Bohner";
   };
+  _71rd = {
+    name = "71rd";
+    github = "71rd";
+    githubId = 69214273;
+  };
   _71zenith = {
     email = "71zenith@proton.me";
     github = "71zenith";

--- a/pkgs/by-name/ou/outfly/package.nix
+++ b/pkgs/by-name/ou/outfly/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  fetchFromGitea,
+  rustPlatform,
+  makeDesktopItem,
+  pkg-config,
+  libxkbcommon,
+  alsa-lib,
+  libGL,
+  vulkan-loader,
+  wayland,
+  libXrandr,
+  libXcursor,
+  libX11,
+  libXi,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "outfly";
+  version = "0.14.0";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "outfly";
+    repo = "outfly";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-FRvu3FgbT3i5888ll573nhb7naYx04Oi8nrcfgEHxUo=";
+  };
+
+  runtimeInputs = [
+    libxkbcommon
+    libGL
+    libXrandr
+    libX11
+    vulkan-loader
+  ];
+
+  buildInputs = [
+    alsa-lib.dev
+    libXcursor
+    libXi
+    wayland
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+  doCheck = false; # no meaningful tests
+
+  postFixup = ''
+    patchelf $out/bin/outfly \
+    --add-rpath ${lib.makeLibraryPath runtimeInputs}
+  '';
+
+  cargoHash = "sha256-Hs7IxDildYzDYMUjv7fN1cUArKNehX2al++g/DoZ7rk=";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "outfly";
+      exec = "outfly";
+      desktopName = "OutFly";
+      categories = [ "Game" ];
+    })
+  ];
+  meta = {
+    description = "Breathtaking 3D space game in the rings of Jupiter";
+    homepage = "https://yunicode.itch.io/outfly";
+    downloadPage = "https://codeberg.org/outfly/outfly/releases";
+    changelog = "https://codeberg.org/outfly/outfly/releases/tag/v${version}";
+    license = with lib.licenses; [
+      cc-by-30
+      cc-by-40
+      cc-by-sa-20
+      cc-by-sa-30
+      cc0
+      gpl3
+      ofl
+      publicDomain
+    ];
+    maintainers = with lib.maintainers; [ _71rd ];
+    mainProgram = "outfly";
+  };
+}


### PR DESCRIPTION
## Description of changes

Outfly is an open source 3d  game allowing the player to fly around the rings of jupiter.
Available at:
https://codeberg.org/outfly/outfly
https://yunicode.itch.io/outfly

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
