### PR TITLE
workflows/check-by-name: Mention who to ping for trouble

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -120,5 +120,6 @@ jobs:
           else
             exitCode=$?
             echo "To run locally: ./maintainers/scripts/check-by-name.sh $GITHUB_BASE_REF https://github.com/$GITHUB_REPOSITORY.git"
+            echo "If you're having trouble, ping @NixOS/nixpkgs-check-by-name"
             exit "$exitCode"
           fi


### PR DESCRIPTION
## Description of changes

The check-by-name team can't be looking through all PRs to see if anybody is struggling.

Similar to https://github.com/NixOS/nixpkgs/pull/337118

Ping @NixOS/nixpkgs-check-by-name 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
