### PR TITLE
signal-desktop: replace unlicensed Apple emoji

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/copy-noto-emoji.py
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/copy-noto-emoji.py
@@ -1,0 +1,118 @@
+"""Copy Noto Color Emoji PNGs into an extracted Signal ASAR archive.
+
+Signal loads small Apple emoji PNGs directly from
+`node_modules/emoji-datasource-apple/img/apple/64`, and downloads and
+caches large Apple emoji WebP files in `.proto` bundles on the fly. The
+latter are not a copyright concern for the Nixpkgs cache, but would
+result in inconsistent presentation between small and large emoji.
+
+We skip the complexity and buy some additional privacy by replacing the
+`emoji://jumbo?emoji=` URL prefix with a `file://` path to the copied
+PNGs inside the ASAR archive, and linking the `node_modules` PNG paths
+directly to them.
+"""
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+def signal_name_to_emoji(signal_emoji_name: str) -> str:
+    r"""Return the emoji corresponding to a Signal emoji name.
+
+    Signal emoji names are concatenations of UTF‐16 code units,
+    represented in lowercase big‐endian hex padded to four digits.
+
+    >>> signal_name_to_emoji("d83dde36200dd83cdf2bfe0f")
+    '😶‍🌫️'
+    >>> b"\xd8\x3d\xde\x36\x20\x0d\xd8\x3c\xdf\x2b\xfe\x0f".decode("utf-16-be")
+    '😶‍🌫️'
+    """
+    hex_bytes = zip(signal_emoji_name[::2], signal_emoji_name[1::2])
+    emoji_utf_16_be = bytes(
+        int("".join(hex_pair), 16) for hex_pair in hex_bytes
+    )
+    return emoji_utf_16_be.decode("utf-16-be")
+
+
+def emoji_to_noto_name(emoji: str) -> str:
+    r"""Return the Noto emoji name of an emoji.
+
+    Noto emoji names are underscore‐separated Unicode scalar values,
+    represented in lowercase big‐endian hex padded to at least four
+    digits. Any U+FE0F variant selectors are omitted.
+
+    >>> emoji_to_noto_name("😶‍🌫️")
+    '1f636_200d_1f32b'
+    >>> emoji_to_noto_name("\U0001f636\u200d\U0001f32b\ufe0f")
+    '1f636_200d_1f32b'
+    """
+    return "_".join(
+        f"{ord(scalar_value):04x}"
+        for scalar_value in emoji
+        if scalar_value != "\ufe0f"
+    )
+
+
+def emoji_to_emoji_data_name(emoji: str) -> str:
+    r"""Return the npm emoji-data emoji name of an emoji.
+
+    emoji-data emoji names are hyphen‐minus‐separated Unicode scalar
+    values, represented in lowercase big‐endian hex padded to at least
+    four digits.
+
+    >>> emoji_to_emoji_data_name("😶‍🌫️")
+    '1f636-200d-1f32b-fe0f'
+    >>> emoji_to_emoji_data_name("\U0001f636\u200d\U0001f32b\ufe0f")
+    '1f636-200d-1f32b-fe0f'
+    """
+    return "-".join(f"{ord(scalar_value):04x}" for scalar_value in emoji)
+
+
+def _main() -> None:
+    noto_png_path, asar_root = (Path(arg) for arg in sys.argv[1:])
+    asar_root = asar_root.absolute()
+
+    out_path = asar_root / "images" / "nixpkgs-emoji"
+    out_path.mkdir(parents=True)
+
+    emoji_data_out_path = (
+        asar_root
+        / "node_modules"
+        / "emoji-datasource-apple"
+        / "img"
+        / "apple"
+        / "64"
+    )
+    emoji_data_out_path.mkdir(parents=True)
+
+    jumbomoji_json_path = asar_root / "build" / "jumbomoji.json"
+    with jumbomoji_json_path.open() as jumbomoji_json_file:
+        jumbomoji_packs = json.load(jumbomoji_json_file)
+
+    for signal_emoji_names in jumbomoji_packs.values():
+        for signal_emoji_name in signal_emoji_names:
+            emoji = signal_name_to_emoji(signal_emoji_name)
+
+            try:
+                shutil.copy(
+                    noto_png_path / f"emoji_u{emoji_to_noto_name(emoji)}.png",
+                    out_path / emoji,
+                )
+            except FileNotFoundError:
+                print(
+                    f"Missing Noto emoji: {emoji} {signal_emoji_name}",
+                    file=sys.stderr,
+                )
+                continue
+
+            (
+                emoji_data_out_path / f"{emoji_to_emoji_data_name(emoji)}.png"
+            ).symlink_to(out_path / emoji)
+
+    print(out_path.relative_to(asar_root))
+
+
+if __name__ == "__main__":
+    _main()

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/generic.nix
@@ -1,8 +1,13 @@
 { stdenv
 , lib
+, callPackage
 , fetchurl
 , autoPatchelfHook
+, noto-fonts-color-emoji
 , dpkg
+, asar
+, rsync
+, python3
 , wrapGAppsHook3
 , makeWrapper
 , nixosTests
@@ -57,6 +62,27 @@
 let
   inherit (stdenv) targetPlatform;
   ARCH = if targetPlatform.isAarch64 then "arm64" else "x64";
+
+  # Noto Color Emoji PNG files for emoji replacement; see below.
+  noto-fonts-color-emoji-png = noto-fonts-color-emoji.overrideAttrs (prevAttrs: {
+    pname = "noto-fonts-color-emoji-png";
+
+    # The build produces 136×128 PNGs by default for arcane font
+    # reasons, but we want square PNGs.
+    buildFlags = prevAttrs.buildFlags or [ ] ++ [ "BODY_DIMENSIONS=128x128" ];
+
+    makeTargets = [ "compressed" ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share
+      mv build/compressed_pngs $out/share/noto-fonts-color-emoji-png
+      python3 add_aliases.py --srcdir=$out/share/noto-fonts-color-emoji-png
+
+      runHook postInstall
+    '';
+  });
 in
 stdenv.mkDerivation rec {
   inherit pname version;
@@ -71,11 +97,36 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     inherit url hash;
+    recursiveHash = true;
+    downloadToTemp = true;
+    nativeBuildInputs = [ dpkg asar ];
+    # Signal ships the Apple emoji set without a licence via an npm
+    # package and upstream does not seem terribly interested in fixing
+    # this; see:
+    #
+    # * <https://github.com/signalapp/Signal-Android/issues/5862>
+    # * <https://whispersystems.discoursehosting.net/t/signal-is-likely-violating-apple-license-terms-by-using-apple-emoji-in-the-sticker-creator-and-android-and-desktop-apps/52883>
+    #
+    # We work around this by replacing it with the Noto Color Emoji
+    # set, which is available under a FOSS licence and more likely to
+    # be used on a NixOS machine anyway. The Apple emoji are removed
+    # during `fetchurl` to ensure that the build doesn’t cache the
+    # unlicensed emoji files, but the rest of the work is done in the
+    # main derivation.
+    postFetch = ''
+      dpkg-deb -x $downloadedFile $out
+      asar extract "$out/opt/${dir}/resources/app.asar" $out/asar-contents
+      rm -r \
+        "$out/opt/${dir}/resources/app.asar"{,.unpacked} \
+        $out/asar-contents/node_modules/emoji-datasource-apple
+    '';
   };
 
   nativeBuildInputs = [
+    rsync
+    asar
+    python3
     autoPatchelfHook
-    dpkg
     (wrapGAppsHook3.override { inherit makeWrapper; })
   ];
 
@@ -127,10 +178,12 @@ stdenv.mkDerivation rec {
     wayland
   ];
 
-  unpackPhase = "dpkg-deb -x $src .";
-
   dontBuild = true;
   dontConfigure = true;
+
+  unpackPhase = ''
+    rsync -a --chmod=+w $src/ .
+  '';
 
   installPhase = ''
     runHook preInstall
@@ -146,6 +199,30 @@ stdenv.mkDerivation rec {
 
     # Create required symlinks:
     ln -s libGLESv2.so "$out/lib/${dir}/libGLESv2.so.2"
+
+    # Copy the Noto Color Emoji PNGs into the ASAR contents. See `src`
+    # for the motivation, and the script for the technical details.
+    emojiPrefix=$(
+      python3 ${./copy-noto-emoji.py} \
+      ${noto-fonts-color-emoji-png}/share/noto-fonts-color-emoji-png \
+      asar-contents
+    )
+
+    # Replace the URL used for fetching large versions of emoji with
+    # the local path to our copied PNGs.
+    substituteInPlace asar-contents/preload.bundle.js \
+      --replace-fail \
+        'emoji://jumbo?emoji=' \
+        "file://$out/lib/${lib.escapeURL dir}/resources/app.asar/$emojiPrefix/"
+
+    # `asar(1)` copies files from the corresponding `.unpacked`
+    # directory when extracting, and will put them back in the modified
+    # archive if you don’t specify them again when repacking. Signal
+    # leaves their native `.node` libraries unpacked, so we match that.
+    asar pack \
+      --unpack '*.node' \
+      asar-contents \
+      "$out/lib/${dir}/resources/app.asar"
 
     runHook postInstall
   '';
@@ -180,7 +257,12 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://signal.org/";
     changelog = "https://github.com/signalapp/Signal-Desktop/releases/tag/v${version}";
-    license = lib.licenses.agpl3Only;
+    license = [
+      lib.licenses.agpl3Only
+
+      # Various npm packages
+      lib.licenses.free
+    ];
     maintainers = with lib.maintainers; [
       eclairevoyant
       mic92

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/generic.nix
@@ -181,7 +181,15 @@ stdenv.mkDerivation rec {
     homepage = "https://signal.org/";
     changelog = "https://github.com/signalapp/Signal-Desktop/releases/tag/v${version}";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ eclairevoyant mic92 equirosa urandom bkchr teutat3s ];
+    maintainers = with lib.maintainers; [
+      eclairevoyant
+      mic92
+      equirosa
+      urandom
+      bkchr
+      teutat3s
+      emily
+    ];
     mainProgram = pname;
     platforms = [ "x86_64-linux" "aarch64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/pyproject.toml
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.mypy]
+files = ["*.py"]
+strict = true
+
+[tool.ruff]
+line-length = 80
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = ["COM812", "D203", "D213", "ISC001", "T201"]
+allowed-confusables = ["‐"]
+
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = "dynamic"

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop-aarch64.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop-aarch64.nix
@@ -4,5 +4,5 @@ callPackage ./generic.nix { } rec {
   dir = "Signal";
   version = "7.19.0";
   url = "https://github.com/0mniteck/Signal-Desktop-Mobian/raw/${version}/builds/release/signal-desktop_${version}_arm64.deb";
-  hash = "sha256-L5Wj1ofMR+QJezd4V6pAhkINLF6y9EB5VNFAIOZE5PU=";
+  hash = "sha256-wyXVZUuY1TDGAVq7Gx9r/cuBuoMmSk9KQttTJlIN+k8=";
 }

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop-beta.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop-beta.nix
@@ -4,5 +4,5 @@ callPackage ./generic.nix { } rec {
   dir = "Signal Beta";
   version = "7.19.0-beta.1";
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop-beta/signal-desktop-beta_${version}_amd64.deb";
-  hash = "sha256-kD08xke+HYhwAZG7jmU1ILo013556vNcvAFc/+9BTjg=";
+  hash = "sha256-dIZvzJ45c5kL+2HEaKrtbck5Zz572pQAj3YTenzz6Zs=";
 }

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop.nix
@@ -4,5 +4,5 @@ callPackage ./generic.nix { } rec {
   dir = "Signal";
   version = "7.21.0";
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-  hash = "sha256-mjf27BISkvN9Xsi36EXtiSkvaPEc4j/Cwjlh4gkfdsA=";
+  hash = "sha256-c4INjHMqTH2B71aUJtzgLSFZSe/KFo1OW/wv7rApSxA=";
 }


### PR DESCRIPTION
## Description of changes

Signal ships the Apple emoji set without a licence via an npm package and upstream does not seem terribly interested in fixing this; see:

* <https://github.com/signalapp/Signal-Android/issues/5862>
* <https://whispersystems.discoursehosting.net/t/signal-is-likely-violating-apple-license-terms-by-using-apple-emoji-in-the-sticker-creator-and-android-and-desktop-apps/52883>

I don’t want to mark Signal as `lib.licenses.unfree`, so this change instead replaces the bundled Apple emoji PNGs with ones generated from our freely‐licensed Noto Color Emoji font.

I chose Noto Color Emoji because it is the best‐maintained FOSS emoji font, and because Signal Android will also use the Noto emoji if the “Chats → Keyboard → Use system emoji” setting is turned on. Therefore, Noto Color Emoji is both within the bounds of the Signal user experience on other platforms, and more likely to match the emoji font installed on a NixOS system to boot. I have verified that Noto Color Emoji covers all the standalone emoji that the bundled Apple set does, and could not find any emoji sequence that reliably displayed correctly in Signal before these changes but did not afterwards. (Though I sure did find a good number of emoji that displayed weirdly in Signal both before and after.)

Signal will also download and cache large versions of the Apple emoji from their own update server at runtime. This does not pose a copyright concern for the Nixpkgs cache, but would result in inconsistent presentation between small and large emoji. Therefore, we also point these to our Noto Color Emoji PNGs, and gain a little privacy in the process.

**No invasive patches are made to the Signal code;** the only changes are to replace the unlicensed Apple emoji files with our own, and replace the URL that large versions are fetched from to point to them. There is no functional change to the application other than showing different images on the client and not requesting the jumbomoji pack files from the Signal update server. Ideally we’d build this package from source and simply omit the problematic files in the first place, but apparently that’s a little tricky and we should solve the compliance problem now.

The best solution, of course, would be for Signal to replace their unlicensed copy of Apple’s emoji with a freely‐licensed set compatible with their AGPLv3 licence. I may try and raise this situation again with Signal, although given the past response I am not optimistic, but I wanted to first address the potential copyright violation in Nixpkgs as swiftly as possible.

Although the Python script used to copy and rename the Noto PNGs is very simple, I have extensively documented it to help increase confidence in it and ease further maintenance. To reflect my willingness to keep this change maintained and take responsibility for it, I have added myself to the package maintainer list.

These changes actually result in the uncompressed size of the resulting package decreasing from 450 MiB to 435 MiB; as Signal would ordinarily download and cache up to 27 MiB of jumbomoji sheets from their servers during use, the effective disk space savings are likely to be higher.

Thanks to @mjm for helping test this.

I considered offering a `withUnfree` flag to allow the use of the bundled and downloaded Apple emoji, but it meaningfully complicates the derivation. If people feel very strongly about keeping the unlicensed Apple emoji, I can rework this change to add a flag at the cost of additional code complexity. (Although it’s arguably more `lib.licenses.illegal` than `lib.licenses.unfree`…)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
