### PR TITLE
bitwarden-desktop: 2024.6.4 -> 2024.8.0

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -3,7 +3,7 @@
 , cargo
 , copyDesktopItems
 , dbus
-, electron_29
+, electron_31
 , fetchFromGitHub
 , glib
 , gnome-keyring
@@ -12,7 +12,6 @@
 , libsecret
 , makeDesktopItem
 , makeWrapper
-, moreutils
 , napi-rs-cli
 , nodejs_20
 , patchutils_0_4_2
@@ -26,41 +25,28 @@
 let
   description = "Secure and free password manager for all of your devices";
   icon = "bitwarden";
-  electron = electron_29;
+  electron = electron_31;
 in buildNpmPackage rec {
   pname = "bitwarden-desktop";
-  version = "2024.6.4";
+  version = "2024.8.0";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    hash = "sha256-oQ2VZoxePdYUC+xMKlRMpvPubSPULvt31XSh/OBw3Ec=";
+    hash = "sha256-szIa7fASDmeWKZPc6HtHKeXKerCAXrYZQWTVFMugAxk=";
   };
 
   patches = [
     ./electron-builder-package-lock.patch
   ];
 
-  # The nested package-lock.json from upstream is out-of-date, so copy the
-  # lock metadata from the root package-lock.json.
-  postPatch = ''
-    cat {,apps/desktop/src/}package-lock.json \
-      | ${lib.getExe jq} -s '
-        .[1].packages."".dependencies.argon2 = .[0].packages."".dependencies.argon2
-          | .[0].packages."" = .[1].packages.""
-          | .[1].packages = .[0].packages
-          | .[1]
-        ' \
-      | ${moreutils}/bin/sponge apps/desktop/src/package-lock.json
-  '';
-
   nodejs = nodejs_20;
 
   makeCacheWritable = true;
   npmFlags = [ "--engine-strict" "--legacy-peer-deps" ];
   npmWorkspace = "apps/desktop";
-  npmDepsHash = "sha256-9d9pWrFYelAx/PPDHY3m92Frp8RSQuBqpiOjmWtm/1g=";
+  npmDepsHash = "sha256-5neEpU7ZhVO5OR181owsvAnFfl7lr0MymvqbRFCPs3M=";
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     name = "${pname}-${version}";
@@ -76,7 +62,7 @@ in buildNpmPackage rec {
       patches;
     patchFlags = [ "-p4" ];
     sourceRoot = "${src.name}/${cargoRoot}";
-    hash = "sha256-ZmblY1APVa8moAR1waVBZPhrf5Wt1Gi6dvAxkhizckQ=";
+    hash = "sha256-ya/5z5XpsyuWayziLxuETu/dY8LzZspaAMqL2p8jYN8=";
   };
   cargoRoot = "apps/desktop/desktop_native";
 
@@ -87,10 +73,9 @@ in buildNpmPackage rec {
     copyDesktopItems
     jq
     makeWrapper
-    moreutils
     napi-rs-cli
     pkg-config
-    python3
+    (python3.withPackages (ps: with ps; [ setuptools ]))
     rustc
     rustPlatform.cargoCheckHook
     rustPlatform.cargoSetupHook
@@ -102,18 +87,36 @@ in buildNpmPackage rec {
     libsecret
   ];
 
+  # node-argon2 builds with LTO, but that causes missing symbols. So disable it
+  # and rebuild. Then we need to copy it into the build output for
+  # electron-builder, as `apps/desktop/src/package.json` specifies `argon2` as
+  # a dependency and electron-builder will otherwise install a fresh (and
+  # broken) argon2. See https://github.com/ranisalt/node-argon2/pull/415
+  preConfigure = ''
+    pushd node_modules/argon2
+    substituteInPlace binding.gyp --replace-fail '"-flto", ' ""
+    "$npm_config_node_gyp" rebuild
+    popd
+    mkdir -p apps/desktop/build/node_modules
+    cp -r ./{,apps/desktop/build/}node_modules/argon2
+  '';
+
   preBuild = ''
     if [[ $(jq --raw-output '.devDependencies.electron' < package.json | grep -E --only-matching '^[0-9]+') != ${lib.escapeShellArg (lib.versions.major electron.version)} ]]; then
       echo 'ERROR: electron version mismatch'
       exit 1
     fi
+
+    pushd apps/desktop/desktop_native/napi
+    npm run build
+    popd
   '';
 
   postBuild = ''
     pushd apps/desktop
 
     # desktop_native/index.js loads a file of that name regarldess of the libc being used
-    mv desktop_native/desktop_native.* desktop_native/desktop_native.linux-x64-musl.node
+    mv desktop_native/napi/desktop_napi.* desktop_native/napi/desktop_napi.linux-x64-musl.node
 
     npm exec electron-builder -- \
       --dir \


### PR DESCRIPTION
Diff: https://github.com/bitwarden/clients/compare/desktop-v2024.6.4...desktop-v2024.8.0

Changelog: https://github.com/bitwarden/clients/releases/tag/desktop-v2024.7.1
           https://github.com/bitwarden/clients/releases/tag/desktop-v2024.8.0

- The postPatch to fixup broken package{,-lock}.json in upstream seems to be no longer needed, so (happily) remove
- Python 3.12 removed distutils, so get it from setuptools
- Workaround broken node-argon2 dependency due to being updated (see inline comment)
- desktop_native/napi was split out of desktop_native, so adjust accordingly

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
closes https://github.com/NixOS/nixpkgs/pull/330137

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
