### PR TITLE
xdg-desktop-portal-gnome: add missing wayland-scanner dependency

### DIFF
--- a/pkgs/development/libraries/xdg-desktop-portal-gnome/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-gnome/default.nix
@@ -1,22 +1,23 @@
 { stdenv
 , lib
 , fetchurl
-, meson
-, ninja
-, pkg-config
-, wrapGAppsHook4
 , fontconfig
 , glib
+, gnome
+, gnome-desktop
 , gsettings-desktop-schemas
 , gtk4
 , libadwaita
-, gnome-desktop
-, xdg-desktop-portal
-, wayland
-, gnome
 , libjxl
 , librsvg
+, meson
+, ninja
+, pkg-config
+, wayland
+, wayland-scanner
 , webp-pixbuf-loader
+, wrapGAppsHook4
+, xdg-desktop-portal
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
+    wayland-scanner
     wrapGAppsHook4
   ];
 


### PR DESCRIPTION
## Description of changes

Targetting https://github.com/NixOS/nixpkgs/pull/336718

Build currently fails with: 

```
building '/nix/store/49qkgxrl1ks78srdiz81kavxdx02acq9-xdg-desktop-portal-gnome-46.2.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/99dc5rzj5k33n67qsi7nl1mac069r1vz-xdg-desktop-portal-gnome-46.2.tar.xz
source root is xdg-desktop-portal-gnome-46.2
setting SOURCE_DATE_EPOCH to timestamp 1716662769 of file xdg-desktop-portal-gnome-46.2/xdg-desktop-portal-gnome.doap
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
mesonConfigurePhase flags: --prefix=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2 --libdir=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2/lib --libexecdir=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2/libexec --bindir=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2/bin --sbindir=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2/sbin --includedir=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2/include --mandir=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2/share/man --infodir=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2/share/info --localedir=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2/share/locale -Dauto_features=enabled -Dwrap_mode=nodownload --buildtype=plain -Dsystemduserunitdir=/nix/store/kh5ybn53rk4b7yp65fkgbb3s7pqwbk8n-xdg-desktop-portal-gnome-46.2/lib/systemd/user
The Meson build system
Version: 1.5.1
Source dir: /build/xdg-desktop-portal-gnome-46.2
Build dir: /build/xdg-desktop-portal-gnome-46.2/build
Build type: native build
Project name: xdg-desktop-portal-gnome
Project version: 46.2
C compiler for the host machine: gcc (gcc 13.3.0 "gcc (GCC) 13.3.0")
C linker for the host machine: gcc ld.bfd 2.42
Host machine cpu family: x86_64
Host machine cpu: x86_64
Configuring gnome.portal using configuration
Configuring org.freedesktop.impl.portal.desktop.gnome.service using configuration
Configuring xdg-desktop-portal-gnome.service using configuration
Configuring xdg-desktop-portal-gnome.desktop.in using configuration
Program msgfmt found: YES (/nix/store/4h0chd6cwrs7iyzmn8hk735al1mmvxsk-gettext-0.21.1/bin/msgfmt)
Program msginit found: YES (/nix/store/4h0chd6cwrs7iyzmn8hk735al1mmvxsk-gettext-0.21.1/bin/msginit)
Program msgmerge found: YES (/nix/store/4h0chd6cwrs7iyzmn8hk735al1mmvxsk-gettext-0.21.1/bin/msgmerge)
Program xgettext found: YES (/nix/store/4h0chd6cwrs7iyzmn8hk735al1mmvxsk-gettext-0.21.1/bin/xgettext)
Found pkg-config: YES (/nix/store/fcmc82gp5qc0s8qvcw4c0w46c67zd295-pkg-config-wrapper-0.29.2/bin/pkg-config) 0.29.2
Run-time dependency xdg-desktop-portal found: YES 1.18.4
Build-time dependency gio-2.0 found: YES 2.80.4
Program /nix/store/4v6g5ssa7pzwfjn6nvfbrhw32h8ll8l1-glib-2.80.4-dev/bin/gdbus-codegen found: YES (/nix/store/4v6g5ssa7pzwfjn6nvfbrhw32h8ll8l1-glib-2.80.4-dev/bin/gdbus-codegen)
Dependency gio-2.0 found: YES 2.80.4 (cached)
Program /nix/store/4v6g5ssa7pzwfjn6nvfbrhw32h8ll8l1-glib-2.80.4-dev/bin/gdbus-codegen found: YES (/nix/store/4v6g5ssa7pzwfjn6nvfbrhw32h8ll8l1-glib-2.80.4-dev/bin/gdbus-codegen)
Dependency gio-2.0 found: YES 2.80.4 (cached)
Program /nix/store/4v6g5ssa7pzwfjn6nvfbrhw32h8ll8l1-glib-2.80.4-dev/bin/glib-compile-resources found: YES (/nix/store/4v6g5ssa7pzwfjn6nvfbrhw32h8ll8l1-glib-2.80.4-dev/bin/glib-compile-resources)
Configuring config.h using configuration
Run-time dependency libadwaita-1 found: YES 1.5.3
Library m found: YES
Run-time dependency fontconfig found: YES 2.15.0
Run-time dependency glib-2.0 found: YES 2.80.4
Run-time dependency gio-unix-2.0 found: YES 2.80.4
Run-time dependency gtk4 found: YES 4.14.5
Run-time dependency gtk4-unix-print found: YES 4.14.5
Run-time dependency gsettings-desktop-schemas found: YES 46.0
Run-time dependency gnome-desktop-4 found: YES 44.0
Run-time dependency gnome-bg-4 found: YES 44.0
Run-time dependency gtk4-x11 found: YES 4.14.5
Run-time dependency x11 found: YES 1.8.10
Run-time dependency gtk4-wayland found: YES 4.14.5
Program wayland-scanner found: NO

src/meson.build:140:20: ERROR: Program 'wayland-scanner' not found or not executable

A full log can be found at /build/xdg-desktop-portal-gnome-46.2/build/meson-logs/meson-log.txt
error: builder for '/nix/store/49qkgxrl1ks78srdiz81kavxdx02acq9-xdg-desktop-portal-gnome-46.2.drv' failed with exit code 1
error: 1 dependencies of derivation '/nix/store/cj5xd5d0dq56nx10gma2b6b2z2xj2gmn-man-paths.drv' failed to build
error: 1 dependencies of derivation '/nix/store/v5n1h87bmfyki4gy00x36ypzpnyz47x3-system-generators.drv' failed to build
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
