### PR TITLE
networkmanager-l2tp: sync patch to 1.20.16

### DIFF
--- a/pkgs/tools/networking/networkmanager/l2tp/fix-paths.patch
+++ b/pkgs/tools/networking/networkmanager/l2tp/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/shared/utils.c b/shared/utils.c
-index 453e277..28716a5 100644
+index ce5b5e1..898d209 100644
 --- a/shared/utils.c
 +++ b/shared/utils.c
-@@ -39,7 +39,7 @@ check_ipsec_daemon(const char *path)
+@@ -59,7 +59,7 @@ require_libreswan_ipsec_auto(const char *path)
  const char *
  nm_find_ipsec(void)
  {
@@ -11,7 +11,7 @@ index 453e277..28716a5 100644
                                                 "/sbin/ipsec",
                                                 "/usr/sbin/ipsec",
                                                 "/usr/local/sbin/ipsec",
-@@ -70,7 +70,7 @@ nm_find_l2tpd(NML2tpL2tpDaemon *l2tp_daemon)
+@@ -90,7 +90,7 @@ nm_find_l2tpd(NML2tpL2tpDaemon *l2tp_daemon)
                                                 "/usr/local/sbin/kl2tpd",
                                                 NULL};
  


### PR DESCRIPTION
## Description of changes
Correct patch line number to networkmanager-l2tp 1.20.16. This file is 2 years old unchanged to reflect new networkmanager-l2tp version. This patch only affect GTK as stated in https://github.com/NixOS/nixpkgs/issues/336660#issuecomment-2308122223. But since I use KDE plasma I don't run test this change.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
