### PR TITLE
swiftshader: fix build on hydra

### DIFF
--- a/pkgs/development/libraries/swiftshader/default.nix
+++ b/pkgs/development/libraries/swiftshader/default.nix
@@ -7,7 +7,14 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "https://swiftshader.googlesource.com/SwiftShader";
     rev = "4e40d502c440cc59b25fa3a5fee0eadbab7442aa";
-    sha256 = "085bdqn80s7zw5h2pz6xff3j34hmkxb9wxzgjmzdr9c24zwp2k1c";
+    hash = "sha256-YtbTaOkFhVMKdu3jiRHQsPmoEu3KDzIQXLZ5HFBSmWI=";
+    # Remove 1GB of test files to get under Hydra output limit
+    postFetch = ''
+      rm -r $out/third_party/llvm-project/llvm/test
+      rm -r $out/third_party/json/test
+      rm -r $out/third_party/cppdap/third_party/json/test
+      rm -r $out/third_party/llvm-project/clang/test
+    '';
   };
 
   nativeBuildInputs = [ cmake python3 jq ];


### PR DESCRIPTION
## Description of changes

- add `postFetch` removing 1GB of third party test files to reduce `src` size under Hydra output limit

Size before (3542497272 ~ 3.3GB) exceeds output limit on Hydra (3421225472):
```text
nix path-info /nix/store/kmnqzl8ssrs7w7mskcf2d9xfxwpkdcp0-SwiftShader-4e40d50 --size
/nix/store/kmnqzl8ssrs7w7mskcf2d9xfxwpkdcp0-SwiftShader-4e40d50  3542497272
---
/nix/store/kmnqzl8ssrs7w7mskcf2d9xfxwpkdcp0-SwiftShader-4e40d50    3.3G
---
434M    /nix/store/kmnqzl8ssrs7w7mskcf2d9xfxwpkdcp0-SwiftShader-4e40d50/third_party/llvm-project/llvm/test
189M    /nix/store/kmnqzl8ssrs7w7mskcf2d9xfxwpkdcp0-SwiftShader-4e40d50/third_party/json/test
189M    /nix/store/kmnqzl8ssrs7w7mskcf2d9xfxwpkdcp0-SwiftShader-4e40d50/third_party/cppdap/third_party/json/test
182M    /nix/store/kmnqzl8ssrs7w7mskcf2d9xfxwpkdcp0-SwiftShader-4e40d50/third_party/llvm-project/clang/test
```

Size after (2489220408 ~ 2.3GB):
```
nix path-info /nix/store/6dxjabip7nypc92jhn4g5qv6kdn68ipm-SwiftShader-4e40d50 --size
/nix/store/6dxjabip7nypc92jhn4g5qv6kdn68ipm-SwiftShader-4e40d50  2489220408
---
/nix/store/6dxjabip7nypc92jhn4g5qv6kdn68ipm-SwiftShader-4e40d50    2.3G
```

Fixes build of `swiftshader` on Hydra (failing with "Output limit exceeded" since `2023-09-15`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.swiftshader.x86_64-linux
https://hydra.nixos.org/build/269521559

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
