### PR TITLE
xmoto: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/games/xmoto/default.nix
+++ b/pkgs/games/xmoto/default.nix
@@ -1,25 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, gettext, makeWrapper, bzip2
-, curl, libjpeg, libxml2, xz, lua, ode, libGL, libpng, SDL, SDL_mixer, SDL_net
-, SDL_ttf, sqlite, libxdg_basedir, zlib }:
+{ lib, stdenv, fetchFromGitHub, cmake, gettext, makeWrapper, bzip2
+, curl, libjpeg, libxml2, xz, lua, ode, libGL, libGLU, libpng
+, pkg-config, SDL2, SDL2_mixer, SDL2_net , SDL2_ttf
+, sqlite, libxdg_basedir, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "xmoto";
-  version = "0.6.1";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = version;
-    sha256 = "00f5ha79lfa2iiaz66wl0hl5dapa1l15qdr7m7knzi0ll7j6z66n";
+    rev = "v${version}";
+    hash = "sha256-n58GB5HA50ybSq0ssvJMq+p3I3JThHUGLZ5sHy/245M=";
   };
-
-  patches = [
-    # Fix build with Nix
-    (fetchpatch {
-      url = "https://github.com/xmoto/xmoto/commit/536dcc7ec77a4c4c454b86220e85b1cb3cd1c7f7.patch";
-      sha256 = "0h9lld668jrbmrqva89zqwp63jiagjj86prkxzx6372p3kk9y7g7";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -36,15 +29,21 @@ stdenv.mkDerivation rec {
     lua
     ode
     libGL
+    libGLU
     libpng
-    SDL
-    SDL_mixer
-    SDL_net
-    SDL_ttf
+    SDL2
+    SDL2_mixer
+    SDL2_net
+    SDL2_ttf
     sqlite
     libxdg_basedir
     zlib
   ];
+
+  # Should normally come from SDL2_ttf pkg-config, but xmoto does not
+  # use it and uses include directories directly. Let's re-inject the
+  # path here.
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2}/include/SDL2";
 
   preFixup = ''
     wrapProgram "$out/bin/xmoto" \


### PR DESCRIPTION
The primary change is the switch to SDL2.

Changes: https://github.com/xmoto/xmoto/releases/tag/v0.6.2

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
