### PR TITLE
qidi-slicer-bin: init at 1.2.0

### DIFF
--- a/pkgs/by-name/qi/qidi-slicer-bin/package.nix
+++ b/pkgs/by-name/qi/qidi-slicer-bin/package.nix
@@ -1,0 +1,48 @@
+{
+  appimageTools,
+  fetchurl,
+  webkitgtk_4_1,
+  libsoup_3,
+  lib,
+  hicolor-icon-theme,
+}:
+let
+  pname = "qidi-slicer";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/QIDITECH/QIDISlicer/releases/download/V${version}/QIDISlicer_${version}_Linux_x64_newer.AppImage";
+    hash = "sha256-WMurkt9VJTlFnx66ByQq+WVtx37q5P4mA4cxF/UzC50=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit version pname src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  extraPkgs = pkgs: [
+    webkitgtk_4_1
+    libsoup_3
+  ];
+
+  extraInstallCommands = ''
+    ln -s "$out/bin/qidi-slicer" "$out/bin/qidi-gcodeviewer"
+    install -m 444 -D ${appimageContents}/QIDISlicer.desktop $out/share/applications/QIDISlicer.desktop
+    install -m 444 -D ${appimageContents}/usr/bin/resources/icons/QIDISlicer.svg $out/share/icons/hicolor/scalable/apps/QIDISlicer.svg
+  '';
+
+  meta = {
+    description = "Slicer for QIDI 3D Printers, based on PrusaSlicer";
+    longDescription = ''
+      QIDISlicer is a 3D printer slicing software that works with all QIDI Technology printers and filaments.
+      It is easy to use and has all the functions you need to learn 3D printing.
+    '';
+    homepage = "https://github.com/QIDITECH/QIDISlicer";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ j0hax ];
+    mainProgram = "qidi-slicer";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package QIDISlicer, a fork of PrusaSlicer for QIDI 3D Printers.

Currently uses an AppImage from upstream release, hence the -bin suffix. Relevant to #336869 until I can get a more powerful build host to build from source.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
