### PR TITLE
librewolf-unwrapped: use settings from submodule

### DIFF
--- a/pkgs/applications/networking/browsers/librewolf/librewolf.nix
+++ b/pkgs/applications/networking/browsers/librewolf/librewolf.nix
@@ -33,9 +33,9 @@ rec {
     cat ${source}/patches/pref-pane/preferences.ftl >> browser/locales/en-US/browser/preferences/preferences.ftl
   '';
 
-  extraPrefsFiles = [ "${src.settings}/librewolf.cfg" ];
+  extraPrefsFiles = [ "${source}/settings/librewolf.cfg" ];
 
-  extraPoliciesFiles = [ "${src.settings}/distribution/policies.json" ];
+  extraPoliciesFiles = [ "${source}/settings/distribution/policies.json" ];
 
   extraPassthru = {
     librewolf = {

--- a/pkgs/applications/networking/browsers/librewolf/src.json
+++ b/pkgs/applications/networking/browsers/librewolf/src.json
@@ -4,10 +4,6 @@
     "rev": "129.0.1-1",
     "sha256": "0pvv3v23q31hdjvqi1f3cqfyjrb8dbrrbfwxj2wacak1g0mzbxf4"
   },
-  "settings": {
-    "rev": "cbcf862e283669b49ecdf985d2d747eca9f4a794",
-    "sha256": "0aisg6l8xhk32wp8d9n532zgkk1nr4y4nsvqa9v8943g6vm4abb7"
-  },
   "firefox": {
     "version": "129.0.1",
     "sha512": "27c463e8277994c62bab85cf0e2f0cea16a9b272694b61fa56a6b3bd7c70d6481774288386094836a54df54c1b1144d61be67f4f5eac418c05479d452221c027"

--- a/pkgs/applications/networking/browsers/librewolf/src.nix
+++ b/pkgs/applications/networking/browsers/librewolf/src.nix
@@ -10,12 +10,6 @@ in
     fetchSubmodules = true;
     inherit (src.source) rev sha256;
   };
-  settings = fetchFromGitea {
-    domain = "codeberg.org";
-    owner = "librewolf";
-    repo = "settings";
-    inherit (src.settings) rev sha256;
-  };
   firefox = fetchurl {
     url =
       "mirror://mozilla/firefox/releases/${src.firefox.version}/source/firefox-${src.firefox.version}.source.tar.xz";

--- a/pkgs/applications/networking/browsers/librewolf/update.nix
+++ b/pkgs/applications/networking/browsers/librewolf/update.nix
@@ -57,18 +57,9 @@ writeScript "update-librewolf" ''
   ffHash=$(grep '\.source\.tar\.xz$' "$HOME"/shasums | grep '^[^ ]*' -o)
   echo "ffHash=$ffHash"
 
-  # upstream does not specify settings rev, so just get the latest. see https://github.com/NixOS/nixpkgs/issues/252276
-  settingsRev=$(curl 'https://codeberg.org/api/v1/repos/librewolf/settings/commits?sha=master&limit=1' | jq -r .[0].sha)
-  echo "settingsRev=$settingsRev"
-  repoUrl=https://codeberg.org/librewolf/settings
-  nix-prefetch-git $repoUrl --quiet --rev $settingsRev > $prefetchOut
-  settingsSha256=$(jq -r .sha256 < $prefetchOut)
-
   jq ".source.rev = \"$latestTag\"" $srcJson | sponge $srcJson
   jq ".source.sha256 = \"$srcHash\"" $srcJson | sponge $srcJson
   jq ".firefox.version = \"$ffVersion\"" $srcJson | sponge $srcJson
   jq ".firefox.sha512 = \"$ffHash\"" $srcJson | sponge $srcJson
   jq ".packageVersion = \"$lwVersion\"" $srcJson | sponge $srcJson
-  jq ".settings.rev = \"$settingsRev\"" $srcJson | sponge $srcJson
-  jq ".settings.sha256 = \"$settingsSha256\"" $srcJson | sponge $srcJson
 ''


### PR DESCRIPTION


## Description of changes
Upstream has pinned the settings repo using submodules since https://codeberg.org/librewolf/source/commit/3379ed0351

Use submodules to fetch the correct rev of the settings repo rather than guessing by choosing the latest rev.

Manual browsing tests pass on NixOS x86_64-linux.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
