### PR TITLE
widevine-cdm: add aarch64 support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5630,6 +5630,12 @@
     githubId = 6689924;
     name = "David Terry";
   };
+  dxwil = {
+    email = "dovydas@kersys.lt";
+    github = "dxwil";
+    githubId = 90563298;
+    name = "Dovydas Kersys";
+  };
   dylan-gonzalez = {
     email = "dylcg10@gmail.com";
     github = "dylan-gonzalez";

--- a/pkgs/applications/networking/browsers/misc/widevine-cdm.nix
+++ b/pkgs/applications/networking/browsers/misc/widevine-cdm.nix
@@ -1,34 +1,74 @@
 { lib
 , stdenv
 , fetchzip
+, fetchurl
+, fetchFromGitHub
+, squashfsTools
+, curl
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "widevine-cdm";
   version = "4.10.2710.0";
+  lacrosVersion = "120.0.6098.0";
 
-  src = fetchzip {
+  widevine-installer = if stdenv.isAarch64 then stdenv.mkDerivation rec {
+    name = "widevine-installer";
+    src = fetchFromGitHub {
+      owner = "AsahiLinux";
+      repo = "${name}";
+      rev = "7a3928fe1342fb07d96f61c2b094e3287588958b";
+      sha256 = "sha256-XI1y4pVNpXS+jqFs0KyVMrxcULOJ5rADsgvwfLF6e0Y=";
+    };
+
+    installPhase = ''
+      mkdir -p "$out/bin/"
+      cp widevine_fixup.py "$out/bin/"
+    '';
+  } else null;
+
+  src = if stdenv.isAarch64 then fetchurl {
+    url = "https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/chromeos-lacros-arm64-squash-zstd-${lacrosVersion}";
+    hash = "sha256-OKV8w5da9oZ1oSGbADVPCIkP9Y0MVLaQ3PXS3ZBLFXY=";
+  } else fetchzip {
     url = "https://dl.google.com/widevine-cdm/${version}-linux-x64.zip";
     hash = "sha256-lGTrSzUk5FluH1o4E/9atLIabEpco3C3gZw+y6H6LJo=";
     stripRoot = false;
   };
+
+  buildInputs = [ squashfsTools curl python3];
+
+  unpackPhase = if stdenv.isAarch64 then ''
+    curl -# -o lacros.squashfs "file://$src"
+    unsquashfs -q lacros.squashfs 'WidevineCdm/*'
+    python3 ${widevine-installer}/bin/widevine_fixup.py squashfs-root/WidevineCdm/_platform_specific/cros_arm64/libwidevinecdm.so libwidevinecdm.so
+    cp squashfs-root/WidevineCdm/manifest.json .
+    cp squashfs-root/WidevineCdm/LICENSE LICENSE.txt
+  '' else null;
 
   installPhase = ''
     runHook preInstall
 
     install -vD manifest.json $out/share/google/chrome/WidevineCdm/manifest.json
     install -vD LICENSE.txt $out/share/google/chrome/WidevineCdm/LICENSE.txt
-    install -vD libwidevinecdm.so $out/share/google/chrome/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so
+    install -vD libwidevinecdm.so $out/share/google/chrome/WidevineCdm/_platform_specific/linux_${ if stdenv.isAarch64 then "arm64" else "x64" }/libwidevinecdm.so
 
     runHook postInstall
   '';
+
+# Accoring to widevine-installer: "Hack because Chromium hardcodes a check for this right now..."
+  postInstall = if stdenv.isAarch64 then ''
+    mkdir -p "$out/share/google/chrome/WidevineCdm/_platform_specific/linux_x64"
+    touch "$out/share/google/chrome/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so"
+  '' else null;
 
   meta = with lib; {
     description = "Widevine CDM";
     homepage = "https://www.widevine.com";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ jlamur ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jlamur dxwil ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
## Description of changes

Adds support for arm64 widevine using code from [widevine-installer](https://github.com/AsahiLinux/widevine-installer). The package builds and outputs the relevant files in the same locations as the x64 version, although I cannot test it because I don't know how to make chromium.enableWideVine select a local version, it tries to install the x64 one (please help me on this one :).

There are also some things I would like input on from someone else:
1. Versioning between the two builds. Currently arm is using an older version, it's probably a good idea to make them the same, but without being able to test, I can't do that, because I don't know if newer versions exist and can be successfully patched for arm. List of chromeos images containing arm64 widevine [here](https://gsdview.appspot.com/chromeos-localmirror/distfiles/?marker=distfiles%2Fchromeos-lacros-amd64-squash-zstd-106.0.5249.42).
2. Firefox support. Shouldn't be hard to implement if we come up with a system. Chromium has the enableWideVine flag that as I'm aware does not exist for Firefox. All that Firefox needs are some options as well as one env variable, refer to [this](https://gist.github.com/psanford/1f70a0838c308d28478cf27a9b55c43d?permalink_comment_id=5165332#gistcomment-5165332). I could build this into the package but that would mean installing the package would configure Firefox automatically, which is different from the behavior that exists with Chromium (where enableWideVine needs to be set).

Edit: after some googling I see that Firefox drm works out of the box for x64, but for arm the changes linked above are still necessary.

Edit 2: What I don't understand is why Firefox doesn't need a seperate flag for widevine like chromium, is it because Firefox only installs widevine if drm is explicitly enabled and chromium auto installs it on launch? Could it also have something to do with licenses, why isn't Firefox unfree when it has widevine and chromium is?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
