### PR TITLE
qqwing: fix cross compilation and pkgconfig generation

### DIFF
--- a/pkgs/games/qqwing/default.nix
+++ b/pkgs/games/qqwing/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, perl, autoconf, automake, libtool }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  perl,
+  autoconf,
+  automake,
+  libtool,
+}:
 
 stdenv.mkDerivation rec {
   pname = "qqwing";
@@ -7,31 +15,42 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "stephenostermiller";
     repo = "qqwing";
-    rev = "v${version}";
-    sha256 = "1qq0vi4ch4y3a5fb1ncr0yzkj3mbvdiwa3d51qpabq94sh0cz09i";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-MYHPANQk4aUuDqUNxWPbqw45vweZ2bBcUcMTyEjcAOM=";
   };
 
-  postPatch = ''
-    for file in "src-first-comment.pl" "src_neaten.pl"; do
-      substituteInPlace "build/$file" \
-        --replace "#!/usr/bin/perl" "#!${perl}/bin/perl"
-    done
+  strictDeps = true;
 
-    substituteInPlace "build/cpp_install.sh" \
-      --replace "sudo " ""
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    perl
+  ];
+
+  configureFlags = [
+    "--prefix=${placeholder "out"}"
+  ];
+
+  buildFlags = [
+    "cppcompile"
+  ];
+
+  postPatch = ''
+    patchShebangs --build build/src-first-comment.pl build/src_neaten.pl
+
+    substituteInPlace build/cpp_configure.sh \
+      --replace-fail "./configure" "./configure $configureFlags"
+    substituteInPlace build/cpp_install.sh \
+      --replace-fail "sudo " ""
   '';
 
-  nativeBuildInputs = [ autoconf automake ];
-  buildInputs = [ perl libtool ];
-
-  makeFlags = [ "prefix=$(out)" "tgz" ];
-
-  meta = with lib; {
+  meta = {
     homepage = "https://qqwing.com";
     description = "Sudoku generating and solving software";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ nickcao ];
     mainProgram = "qqwing";
-    license = licenses.gpl2Plus;
-    platforms = platforms.unix;
-    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Description of changes
Transitively fixes the cross compilation of gnome-sudoku
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
