### PR TITLE
Add gitwatch module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18978,6 +18978,12 @@
     githubId = 67710369;
     keys = [ { fingerprint = "EA88 EA07 26E9 6CBF 6365  3966 163B 16EE 76ED 24CE"; } ];
   };
+  shved = {
+    name = "Yury Shvedov";
+    email = "mestofel13@gmail.com";
+    github = "ein-shved";
+    githubId = 3513222;
+  };
   shyim = {
     email = "s.sayakci@gmail.com";
     github = "shyim";

--- a/nixos/modules/services/monitoring/gitwatch.nix
+++ b/nixos/modules/services/monitoring/gitwatch.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  mkSystemdService =
+    name: cfg:
+    lib.nameValuePair "gitwatch-${name}" (
+      let
+        getvar = flag: var: lib.optionalString (cfg."${var}" != null) "${flag} ${cfg."${var}"}";
+        branch = getvar "-b" "branch";
+        remote = getvar "-r" "remote";
+      in
+      rec {
+        inherit (cfg) enable;
+        after = [ "network-online.target" ];
+        wants = after;
+        wantedBy = [ "multi-user.target" ];
+        description = "gitwatch for ${name}";
+        path = with pkgs; [
+          gitwatch
+          git
+          openssh
+        ];
+        script = ''
+          if [ -n "${cfg.remote}" ] && ! [ -d "${cfg.path}" ]; then
+            git clone ${branch} "${cfg.remote}" "${cfg.path}"
+          fi
+          gitwatch ${remote} ${branch} ${cfg.path}
+        '';
+        serviceConfig.User = cfg.user;
+      }
+    );
+in
+{
+  options.services.gitwatch = lib.mkOption {
+    description = ''
+      A set of git repositories to watch for. See
+      [gitwatch](https://github.com/gitwatch/gitwatch) for more.
+    '';
+    default = { };
+    example = {
+      my-repo = {
+        enable = true;
+        user = "user";
+        path = "/home/user/watched-project";
+        remote = "git@github.com:me/my-project.git";
+      };
+      disabled-repo = {
+        enable = false;
+        user = "user";
+        path = "/home/user/disabled-project";
+        remote = "git@github.com:me/my-old-project.git";
+        branch = "autobranch";
+      };
+    };
+    type =
+      with lib.types;
+      attrsOf (submodule {
+        options = {
+          enable = lib.mkEnableOption "watching for repo";
+          path = lib.mkOption {
+            description = "The path to repo in local machine";
+            type = str;
+          };
+          user = lib.mkOption {
+            description = "The name of services's user";
+            type = str;
+            default = "root";
+          };
+          remote = lib.mkOption {
+            description = "Optional url of remote repository";
+            type = nullOr str;
+            default = null;
+          };
+          branch = lib.mkOption {
+            description = "Optional branch in remote repository";
+            type = nullOr str;
+            default = null;
+          };
+        };
+      });
+  };
+  config.systemd.services = lib.mapAttrs' mkSystemdService config.services.gitwatch;
+}

--- a/pkgs/by-name/gi/gitwatch/package.nix
+++ b/pkgs/by-name/gi/gitwatch/package.nix
@@ -1,0 +1,49 @@
+{
+  runCommand,
+  lib,
+  makeWrapper,
+  fetchFromGitHub,
+
+  git,
+  openssh,
+  inotify-tools,
+}:
+runCommand "gitwatch"
+  rec {
+    version = "0.2";
+    src = fetchFromGitHub {
+      owner = "gitwatch";
+      repo = "gitwatch";
+      rev = "v${version}";
+      hash = "sha256-KuWD2FAMi2vZ/7e4fIg97DGuAPEV9b9iOuF8NIGFVpE=";
+    };
+    nativeBuildInputs = [ makeWrapper ];
+
+    meta = {
+      description = "Watch a filesystem and automatically stage changes to a git.";
+      mainProgram = "gitwatch";
+      longDescription = ''
+        A bash script to watch a file or folder and commit changes to a git repo.
+      '';
+      homepage = "https://github.com/gitwatch/gitwatch";
+      changelog = "https://github.com/gitwatch/gitwatch/releases/tag/v${version}";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [ shved ];
+    };
+  }
+  ''
+    mkdir -p $out/bin
+    dest="$out/bin/gitwatch"
+    cp "$src/gitwatch.sh" $dest
+    chmod +x $dest
+    patchShebangs $dest
+
+    wrapProgram $dest \
+      --prefix PATH ';' ${
+        lib.makeBinPath [
+          git
+          inotify-tools
+          openssh
+        ]
+      }
+  ''


### PR DESCRIPTION
## Create gitwatch script and module

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Gitwatch](https://github.com/gitwatch/gitwatch) is useful script to automatically commit and push changes in watched folders.

What to use it for?

* My case: **cad programs** which does not have their own version
  control or cloud. e.g. Kompas3D.

Next, copy-paste from README of project:

* **config files**: some programs auto-write their config files, without
  waiting for you to click an 'Apply' button; or even if there is such
  a button, most programs offer you no way of going  back to an earlier
  version of your settings. If you commit your config file(s) to a git repo,
  you can track changes and go back to older versions. This script makes it
  convenient, to have all changes recorded automatically.

* **document files**: if you use an editor that does not have built-in git
  support (or maybe if you don't like the git support it has), you can use
  gitwatch to automatically commit your files when you save them, or combine
  it with the editor's auto-save feature to fully automatically and regularly
  track your changes

Additionally, create module for gitwatch script. This module runs systemd services.
You are able to have several services for different paths at once.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
