### PR TITLE
naja: 0-unstable-2024-07-21 -> 0-unstable-2024-08-27, fix darwin

### DIFF
--- a/pkgs/by-name/na/naja/package.nix
+++ b/pkgs/by-name/na/naja/package.nix
@@ -15,20 +15,20 @@
 }:
 stdenv.mkDerivation {
   pname = "naja";
-  version = "0-unstable-2024-07-21";
+  version = "0-unstable-2024-08-27";
 
   src = fetchFromGitHub {
     owner = "najaeda";
     repo = "naja";
-    rev = "8c068f3bd1bbd57b851547f191a58a375fd35cda";
-    hash = "sha256-aUYPJGr4D5n92fp0namPT6I/gMRZoF7YHnB7GoRzwYI=";
+    rev = "ca7a544d16abb31d6992e702ccbd97be3a644c08";
+    hash = "sha256-lmgXv2nmmjKph0Tf9ZvV3kQBtbiGXYA7jrE77cgM+KU=";
     fetchSubmodules = true;
   };
 
   outputs = [
-    "dev"
-    "lib"
     "out"
+    "lib"
+    "dev"
   ];
 
   strictDeps = true;
@@ -51,10 +51,14 @@ stdenv.mkDerivation {
     tbb_2021_11
   ];
 
-  cmakeFlags = [
-    (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_LIBDWARF" true)
-    (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_ZSTD" true)
-  ];
+  cmakeFlags =
+    [
+      (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_LIBDWARF" true)
+      (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_ZSTD" true)
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      (lib.cmakeFeature "CMAKE_OSX_DEPLOYMENT_TARGET" "10.14") # For aligned allocation
+    ];
 
   doCheck = true;
 
@@ -67,7 +71,5 @@ stdenv.mkDerivation {
     ];
     mainProgram = "naja_edit";
     platforms = lib.platforms.all;
-    # "aligned deallocation function of type [...] is only available on macOS 10.13 or newer" even with 11.0 SDK
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

MacOS versions prior to `10.12` don't support aligned allocation, which is needed to build Naja.

The default sdk version for non-aarch64 darwin is `10.12`, which is then used for the `MACOSX_DEPLOYMENT_TARGET` flag:

https://github.com/NixOS/nixpkgs/blob/48e00dda260902c86a948e7003fd655f22bf59f3/lib/systems/default.nix#L252-L259

Unless explicitly specified, [CMAKE_OSX_DEPLOYMENT_TARGET](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html) defaults to this variable:

> If not set explicitly the value is initialized by the MACOSX_DEPLOYMENT_TARGET environment variable, if set, and otherwise computed based on the host platform.

As such, all we have to do to fix this is explicitly set the target platform to something higher than `10.12`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
