### PR TITLE
nixos/nvidia: various fixes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -137,6 +137,8 @@
   Processes also now run as a dynamically allocated user by default instead of
   root.
 
+- The nvidia driver no longer defaults to the proprietary driver starting with version 560. You will need to manually set `hardware.nvidia.open` to select the proprietary or open driver.
+
 - `singularity-tools` have the `storeDir` argument removed from its override interface and use `builtins.storeDir` instead.
 
 - Two build helpers in `singularity-tools`, i.e., `mkLayer` and `shellScript`, are deprecated, as they are no longer involved in image-building. Maintainers will remove them in future releases.

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -262,6 +262,14 @@ in
           lib.mkIf (lib.versionOlder config.hardware.nvidia.package.version "560") false
         '';
       };
+
+      gsp.enable = lib.mkEnableOption ''
+        the GPU System Processor (GSP) on the video card
+      '' // {
+        defaultText = lib.literalExpression ''
+          config.hardware.nvidia.open || lib.versionAtLeast config.hardware.nvidia.package.version "555"
+        '';
+      };
     };
   };
 
@@ -312,6 +320,7 @@ in
           environment.systemPackages = [ nvidia_x11.bin ];
 
           hardware.nvidia.open = lib.mkIf (lib.versionOlder nvidia_x11.version "560") (lib.mkDefault false);
+          hardware.nvidia.gsp.enable = lib.mkDefault (cfg.open || lib.versionAtLeast nvidia_x11.version "555");
         })
 
         # X11
@@ -370,8 +379,18 @@ in
             }
 
             {
-              assertion = cfg.open -> (cfg.package ? open && cfg.package ? firmware);
-              message = "This version of NVIDIA driver does not provide a corresponding opensource kernel driver";
+              assertion = cfg.gsp.enable -> (cfg.package ? firmware);
+              message = "This version of NVIDIA driver does not provide a GSP firmware.";
+            }
+
+            {
+              assertion = cfg.open -> (cfg.package ? open);
+              message = "This version of NVIDIA driver does not provide a corresponding opensource kernel driver.";
+            }
+
+            {
+              assertion = cfg.open -> cfg.gsp.enable;
+              message = "The GSP cannot be disabled when using the opensource kernel driver.";
             }
 
             {
@@ -558,7 +577,7 @@ in
 
           services.dbus.packages = lib.optional cfg.dynamicBoost.enable nvidia_x11.bin;
 
-          hardware.firmware = lib.optional (cfg.open || lib.versionAtLeast nvidia_x11.version "555") nvidia_x11.firmware;
+          hardware.firmware = lib.optional cfg.gsp.enable nvidia_x11.firmware;
 
           systemd.tmpfiles.rules =
             [

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -254,10 +254,13 @@ in
         '';
       };
 
-      open = lib.mkEnableOption ''
-        the open source NVIDIA kernel module
-      '' // {
-        defaultText = lib.literalExpression ''lib.versionAtLeast config.hardware.nvidia.package.version "560"'';
+      open = lib.mkOption {
+        example = true;
+        description = "Whether to enable the open source NVIDIA kernel module.";
+        type = lib.types.bool;
+        defaultText = lib.literalExpression ''
+          lib.mkIf (lib.versionOlder config.hardware.nvidia.package.version "560") false
+        '';
       };
     };
   };
@@ -308,7 +311,7 @@ in
           };
           environment.systemPackages = [ nvidia_x11.bin ];
 
-          hardware.nvidia.open = lib.mkDefault (lib.versionAtLeast nvidia_x11.version "560");
+          hardware.nvidia.open = lib.mkIf (lib.versionOlder nvidia_x11.version "560") (lib.mkDefault false);
         })
 
         # X11

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -81,6 +81,9 @@ installPhase() {
         mkdir $i/lib/vdpau
         mv $i/lib/libvdpau* $i/lib/vdpau
 
+        # Compatibility with openssl 1.1, unused
+        rm -f $i/lib/libnvidia-pkcs11.so*
+
         # Install ICDs, make absolute paths.
         # Be careful not to modify any original files because this runs twice.
 


### PR DESCRIPTION
## Description of changes

Cleaning up my backlog
- Remove unused `libnvidia-pkcs11.so` - https://github.com/NixOS/nixpkgs/issues/273064
- Make the driver version a mandatory choice for new releases - https://github.com/NixOS/nixpkgs/pull/329450#issuecomment-2271681614
  - Also add a release note about this change
- Allow the GSP to be toggled for the proprietary driver - https://github.com/NixOS/nixpkgs/issues/323886

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
