### PR TITLE
nixos/kerberos_server: add the "get-keys" ACL permission

### DIFF
--- a/nixos/modules/security/krb5/krb5-conf-format.nix
+++ b/nixos/modules/security/krb5/krb5-conf-format.nix
@@ -61,16 +61,18 @@ rec {
             description = "Which principal the rule applies to";
           };
           access = mkOption {
-            type = either (listOf (enum [
-              "all"
-              "add"
-              "cpw"
-              "delete"
-              "get-keys"
-              "get"
-              "list"
-              "modify"
-            ])) (enum [ "all" ]);
+            type = coercedTo str singleton (
+              listOf (enum [
+                "all"
+                "add"
+                "cpw"
+                "delete"
+                "get-keys"
+                "get"
+                "list"
+                "modify"
+              ])
+            );
             default = "all";
             description = ''
               The changes the principal is allowed to make.
@@ -78,6 +80,12 @@ rec {
               :::{.important}
               The "all" permission does not imply the "get-keys" permission. This
               is consistent with the behavior of both MIT Kerberos and Heimdal.
+              :::
+
+              :::{.warning}
+              Value "all" is allowed as a list member only if it appears alone
+              or accompanied by "get-keys". Any other combination involving
+              "all" will raise an exception.
               :::
             '';
           };

--- a/nixos/modules/security/krb5/krb5-conf-format.nix
+++ b/nixos/modules/security/krb5/krb5-conf-format.nix
@@ -62,15 +62,24 @@ rec {
           };
           access = mkOption {
             type = either (listOf (enum [
+              "all"
               "add"
               "cpw"
               "delete"
+              "get-keys"
               "get"
               "list"
               "modify"
             ])) (enum [ "all" ]);
             default = "all";
-            description = "The changes the principal is allowed to make.";
+            description = ''
+              The changes the principal is allowed to make.
+
+              :::{.important}
+              The "all" permission does not imply the "get-keys" permission. This
+              is consistent with the behavior of both MIT Kerberos and Heimdal.
+              :::
+            '';
           };
           target = mkOption {
             type = str;

--- a/nixos/modules/services/system/kerberos/default.nix
+++ b/nixos/modules/services/system/kerberos/default.nix
@@ -55,6 +55,17 @@ in
         assertion = lib.length (lib.attrNames cfg.settings.realms) <= 1;
         message = "Only one realm per server is currently supported.";
       }
+      {
+        assertion =
+          let
+            inherit (builtins) attrValues elem length;
+            realms = attrValues cfg.settings.realms;
+            accesses = lib.concatMap (r: map (a: a.access) r.acl) realms;
+            property = a: !elem "all" a || (length a <= 1) || (length a <= 2 && elem "get-keys" a);
+          in
+          builtins.all property accesses;
+        message = "Cannot specify \"all\" in a list with additional permissions other than \"get-keys\"";
+      }
     ];
 
     systemd.slices.system-kerberos-server = { };

--- a/nixos/modules/services/system/kerberos/mit.nix
+++ b/nixos/modules/services/system/kerberos/mit.nix
@@ -19,10 +19,11 @@ let
     add = "a";
     cpw = "c";
     delete = "d";
+    get-keys = "e";
     get = "i";
     list = "l";
     modify = "m";
-    all = "*";
+    all = "x";
   };
 
   aclConfigs = lib.pipe cfg.settings.realms [


### PR DESCRIPTION
## Description of changes
This permission was missing from the list of allowed ACL privileges allowed by the `kerberos_server` module. Both Heimdal and MIT Kerberos support it.

This addition also entails that the `all` permission must be allowed in the list of granted permissions, as it is necessary for both `all` and `get-keys` to be granted in order to give a certain principal the maximum privilege possible.

This commit also changes the translation of permission `all` from `*` to `x` for MIT Kerberos, as this latter form allows for the combination `xe` (permission `e` is not included in the wildcard permission for security reasons).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
