### PR TITLE
invidious: 2.20240427 -> 2.20240825.2

### DIFF
--- a/nixos/tests/invidious.nix
+++ b/nixos/tests/invidious.nix
@@ -20,7 +20,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       };
       networking.firewall.allowedTCPPorts = [ config.services.postgresql.settings.port ];
     };
-    machine = { config, lib, pkgs, ... }: {
+    machine = { lib, pkgs, ... }: {
       services.invidious = {
         enable = true;
       };
@@ -81,11 +81,11 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
 
     def activate_specialisation(name: str):
-        machine.succeed(f"${nodes.machine.config.system.build.toplevel}/specialisation/{name}/bin/switch-to-configuration test >&2")
+        machine.succeed(f"${nodes.machine.system.build.toplevel}/specialisation/{name}/bin/switch-to-configuration test >&2")
 
 
-    url = "http://localhost:${toString nodes.machine.config.services.invidious.port}"
-    port = ${toString nodes.machine.config.services.invidious.port}
+    url = "http://localhost:${toString nodes.machine.services.invidious.port}"
+    port = ${toString nodes.machine.services.invidious.port}
 
     # start postgres vm now
     postgres_tcp.start()

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -1,7 +1,7 @@
 { lib
 , callPackage
 , crystal
-, fetchFromGitea
+, fetchFromGitHub
 , librsvg
 , pkg-config
 , libxml2
@@ -29,8 +29,7 @@ crystal.buildCrystalPackage rec {
   pname = "invidious";
   inherit (versions.invidious) version;
 
-  src = fetchFromGitea {
-    domain = "gitea.invidious.io";
+  src = fetchFromGitHub {
     owner = "iv-org";
     repo = "invidious";
     fetchSubmodules = true;

--- a/pkgs/servers/invidious/shards.nix
+++ b/pkgs/servers/invidious/shards.nix
@@ -1,8 +1,8 @@
 {
   ameba = {
     url = "https://github.com/crystal-ameba/ameba.git";
-    rev = "v1.5.0";
-    sha256 = "1idivsbpmi40aqvs82fsv37nrgikirprxrj3ls9chsb876fq9p2d";
+    rev = "v1.6.1";
+    sha256 = "1qlgqpgycfxvvrfzih7b9ayb6fvkffz5aw0msbj70z2q7wvsq29p";
   };
   athena-negotiation = {
     url = "https://github.com/athena-framework/negotiation.git";

--- a/pkgs/servers/invidious/update.sh
+++ b/pkgs/servers/invidious/update.sh
@@ -36,7 +36,7 @@ if [ ! -d "$git_dir" ]; then
 fi
 git -C "$git_dir" fetch origin --tags "$git_branch"
 
-new_tag="$(git -C "$git_dir" ls-remote --tags --sort=committerdate origin | head -n1 | grep -Po '(?<=refs/tags/).*')"
+new_tag="$(git -C "$git_dir" ls-remote --tags --sort=-committerdate origin | tail -n1 | grep -Po '(?<=refs/tags/).*')"
 new_version="${new_tag#v}"
 
 if [ "$new_version" = "$old_version" ]; then
@@ -44,8 +44,9 @@ if [ "$new_version" = "$old_version" ]; then
     exit
 fi
 
+info "updating to $new_tag"
 commit="$(git -C "$git_dir" rev-list "$new_tag" --max-count=1 --abbrev-commit)"
-date="$(git -C "$git_dir" log -1 --format=%cd --date=format:%Y.%m.%d)"
+date="$(git -C "$git_dir" log -1 --format=%cd --date=format:%Y.%m.%d "$commit")"
 json_set '.invidious.date' "$date"
 json_set '.invidious.commit' "$commit"
 json_set '.invidious.version' "$new_version"

--- a/pkgs/servers/invidious/versions.json
+++ b/pkgs/servers/invidious/versions.json
@@ -1,9 +1,9 @@
 {
   "invidious": {
-    "hash": "sha256-YZ+uhn1ESuRTZxAMoxKCpxEaUfeCUqOrSr3LkdbrTkU=",
-    "version": "2.20240427",
-    "date": "2024.04.27",
-    "commit": "eda7444c"
+    "hash": "sha256-oNkEFATRVgPC8Bhp0v04an3LvqgsSEjLZdeblb7n8TI=",
+    "version": "2.20240825.2",
+    "date": "2024.08.26",
+    "commit": "4782a670"
   },
   "videojs": {
     "hash": "sha256-jED3zsDkPN8i6GhBBJwnsHujbuwlHdsVpVqa1/pzSH4="


### PR DESCRIPTION
## Description of changes

- **invidious: switch to github repo**
  Actually, gitea is only a mirror. The main repo is the GitHub one.
- **invidious: 2.20240427 -> 2.20240825.2**

Changelog: https://github.com/iv-org/invidious/releases/tag/v2.20240825.2

The update script was not working for me and I had to tweak it manually for the correct version to be correctly picked up.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
