### PR TITLE
[24.05] pnpm{,_8,_9,.fetchDeps}: init

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -348,6 +348,8 @@ In case you are patching `package.json` or `pnpm-lock.yaml`, make sure to pass `
 
 #### Dealing with `sourceRoot` {#javascript-pnpm-sourceRoot}
 
+NOTE: Nixpkgs pnpm tooling doesn't support building projects with a `pnpm-workspace.yaml`, or building monorepos. It maybe possible to use `pnpm.fetchDeps` for these projects, but it may be hard or impossible to produce a binary from such projects ([an example attempt](https://github.com/NixOS/nixpkgs/pull/290715#issuecomment-2144543728)).
+
 If the pnpm project is in a subdirectory, you can just define `sourceRoot` or `setSourceRoot` for `fetchDeps`. Note, that projects using `pnpm-workspace.yaml` are currently not supported, and will probably not work using this approach.
 If `sourceRoot` is different between the parent derivation and `fetchDeps`, you will have to set `pnpmRoot` to effectively be the same location as it is in `fetchDeps`.
 

--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -346,11 +346,11 @@ NOTE: It is highly recommended to use a pinned version of pnpm (i.e. `pnpm_8` or
 
 In case you are patching `package.json` or `pnpm-lock.yaml`, make sure to pass `finalAttrs.patches` to the function as well (i.e. `inherit (finalAttrs) patches`.
 
+`pnpm.configHook` supports adding additional `pnpm install` flags via `pnpmInstallFlags` which can be set to a Nix string array.
+
 #### Dealing with `sourceRoot` {#javascript-pnpm-sourceRoot}
 
-NOTE: Nixpkgs pnpm tooling doesn't support building projects with a `pnpm-workspace.yaml`, or building monorepos. It maybe possible to use `pnpm.fetchDeps` for these projects, but it may be hard or impossible to produce a binary from such projects ([an example attempt](https://github.com/NixOS/nixpkgs/pull/290715#issuecomment-2144543728)).
-
-If the pnpm project is in a subdirectory, you can just define `sourceRoot` or `setSourceRoot` for `fetchDeps`. Note, that projects using `pnpm-workspace.yaml` are currently not supported, and will probably not work using this approach.
+If the pnpm project is in a subdirectory, you can just define `sourceRoot` or `setSourceRoot` for `fetchDeps`.
 If `sourceRoot` is different between the parent derivation and `fetchDeps`, you will have to set `pnpmRoot` to effectively be the same location as it is in `fetchDeps`.
 
 Assuming the following directory structure, we can define `sourceRoot` and `pnpmRoot` as follows:
@@ -374,6 +374,55 @@ Assuming the following directory structure, we can define `sourceRoot` and `pnpm
   # by default the working directory is the extracted source
   pnpmRoot = "frontend";
 ```
+
+#### PNPM Workspaces {#javascript-pnpm-workspaces}
+
+If you need to use a PNPM workspace for your project, then set `pnpmWorkspace = "<workspace project name>"` in your `pnpm.fetchDeps` call,
+which will make PNPM only install dependencies for that workspace package.
+
+For example:
+
+```nix
+...
+pnpmWorkspace = "@astrojs/language-server";
+pnpmDeps = pnpm.fetchDeps {
+  inherit (finalAttrs) pnpmWorkspace;
+  ...
+}
+```
+
+The above would make `pnpm.fetchDeps` call only install dependencies for the `@astrojs/language-server` workspace package.
+Note that you do not need to set `sourceRoot` to make this work.
+
+Usually in such cases, you'd want to use `pnpm --filter=$pnpmWorkspace build` to build your project, as `npmHooks.npmBuildHook` probably won't work. A `buildPhase` based on the following example will probably fit most workspace projects:
+
+```nix
+buildPhase = ''
+  runHook preBuild
+
+  pnpm --filter=@astrojs/language-server build
+
+  runHook postBuild
+'';
+```
+
+#### Additional PNPM Commands and settings {#javascript-pnpm-extraCommands}
+
+If you require setting an additional PNPM configuration setting (such as `dedupe-peer-dependents` or similar),
+set `prePnpmInstall` to the right commands to run. For example:
+
+```nix
+prePnpmInstall = ''
+  pnpm config set dedupe-peer-dependants false
+'';
+pnpmDeps = pnpm.fetchDeps {
+  inherit (finalAttrs) prePnpmInstall;
+  ...
+};
+```
+
+In this example, `prePnpmInstall` will be run by both `pnpm.configHook` and by the `pnpm.fetchDeps` builder.
+
 
 ### yarn2nix {#javascript-yarn2nix}
 

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -8,8 +8,8 @@ let
       hash = "sha256-aR/hdu6pqKgN8g5JdvPftEoEhBzriFY4/iomF0+B5l4=";
     };
     "9" = {
-      version = "9.1.1";
-      hash = "sha256-lVHoA9y3oYOf31QWFTqEQGDHvOATIYzoI0EFMlBKwQs=";
+      version = "9.3.0";
+      hash = "sha256-4fno0aFmB6Rt08FYtfen3HlFUB0cYiLUVNY9Az0dkY8=";
     };
   };
 

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -1,0 +1,20 @@
+{ lib, callPackage }:
+let
+  inherit (lib) mapAttrs' nameValuePair;
+
+  variants = {
+    "8" = {
+      version = "8.15.8";
+      hash = "sha256-aR/hdu6pqKgN8g5JdvPftEoEhBzriFY4/iomF0+B5l4=";
+    };
+    "9" = {
+      version = "9.1.1";
+      hash = "sha256-lVHoA9y3oYOf31QWFTqEQGDHvOATIYzoI0EFMlBKwQs=";
+    };
+  };
+
+  callPnpm = variant: callPackage ./generic.nix {inherit (variant) version hash;};
+
+  mkPnpm = versionSuffix: variant: nameValuePair "pnpm_${versionSuffix}" (callPnpm variant);
+in
+mapAttrs' mkPnpm variants

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -8,8 +8,8 @@ let
       hash = "sha256-2qJ6C1QbxjUyP/lsLe2ZVGf/n+bWn/ZwIVWKqa2dzDY=";
     };
     "9" = {
-      version = "9.6.0";
-      hash = "sha256-2uD36CLFayCXm7WWXjtzuL2rtri47xIdpthXUIWZyjU=";
+      version = "9.7.0";
+      hash = "sha256-s1AY+/qPWDZosmSeQHkipyE1XNgfYb7rSsHUJY5YVVk=";
     };
   };
 

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -8,8 +8,8 @@ let
       hash = "sha256-aR/hdu6pqKgN8g5JdvPftEoEhBzriFY4/iomF0+B5l4=";
     };
     "9" = {
-      version = "9.3.0";
-      hash = "sha256-4fno0aFmB6Rt08FYtfen3HlFUB0cYiLUVNY9Az0dkY8=";
+      version = "9.4.0";
+      hash = "sha256-tv0L/aVV5+WErX5WswxosB1aBPnuk5ifS5PKhHPEnHQ=";
     };
   };
 

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -8,8 +8,8 @@ let
       hash = "sha256-aR/hdu6pqKgN8g5JdvPftEoEhBzriFY4/iomF0+B5l4=";
     };
     "9" = {
-      version = "9.4.0";
-      hash = "sha256-tv0L/aVV5+WErX5WswxosB1aBPnuk5ifS5PKhHPEnHQ=";
+      version = "9.6.0";
+      hash = "sha256-2uD36CLFayCXm7WWXjtzuL2rtri47xIdpthXUIWZyjU=";
     };
   };
 

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -4,8 +4,8 @@ let
 
   variants = {
     "8" = {
-      version = "8.15.8";
-      hash = "sha256-aR/hdu6pqKgN8g5JdvPftEoEhBzriFY4/iomF0+B5l4=";
+      version = "8.15.9";
+      hash = "sha256-2qJ6C1QbxjUyP/lsLe2ZVGf/n+bWn/ZwIVWKqa2dzDY=";
     };
     "9" = {
       version = "9.6.0";

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -1,0 +1,83 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  jq,
+  moreutils,
+  cacert,
+  makeSetupHook,
+  pnpm,
+}:
+{
+  fetchDeps =
+    {
+      src,
+      hash ? "",
+      pname,
+      ...
+    }@args:
+    let
+      args' = builtins.removeAttrs args [
+        "hash"
+        "pname"
+      ];
+      hash' =
+        if hash != "" then
+          { outputHash = hash; }
+        else
+          {
+            outputHash = "";
+            outputHashAlgo = "sha256";
+          };
+    in
+    stdenvNoCC.mkDerivation (
+      args'
+      // {
+        name = "${pname}-pnpm-deps";
+
+        nativeBuildInputs = [
+          jq
+          moreutils
+          pnpm
+          cacert
+        ];
+
+        installPhase = ''
+          runHook preInstall
+
+          export HOME=$(mktemp -d)
+          pnpm config set store-dir $out
+          # Some packages produce platform dependent outputs. We do not want to cache those in the global store
+          pnpm config set side-effects-cache false
+          # As we pin pnpm versions, we don't really care about updates
+          pnpm config set update-notifier false
+          # pnpm is going to warn us about using --force
+          # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
+          pnpm install --frozen-lockfile --ignore-script --force
+
+          runHook postInstall
+        '';
+
+        fixupPhase = ''
+          runHook preFixup
+
+          # Remove timestamp and sort the json files
+          rm -rf $out/v3/tmp
+          for f in $(find $out -name "*.json"); do
+            jq --sort-keys "del(.. | .checkedAt?)" $f | sponge $f
+          done
+
+          runHook postFixup
+        '';
+
+        dontConfigure = true;
+        dontBuild = true;
+        outputHashMode = "recursive";
+      }
+      // hash'
+    );
+
+  configHook = makeSetupHook {
+    name = "pnpm-config-hook";
+    propagatedBuildInputs = [ pnpm ];
+  } ./pnpm-config-hook.sh;
+}

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -1,6 +1,7 @@
 {
   stdenvNoCC,
   fetchurl,
+  callPackage,
   jq,
   moreutils,
   cacert,
@@ -29,7 +30,7 @@
             outputHashAlgo = "sha256";
           };
     in
-    stdenvNoCC.mkDerivation (
+    stdenvNoCC.mkDerivation (finalAttrs: (
       args'
       // {
         name = "${pname}-pnpm-deps";
@@ -69,12 +70,19 @@
           runHook postFixup
         '';
 
+        passthru = {
+          serve = callPackage ./serve.nix {
+            inherit pnpm;
+            pnpmDeps = finalAttrs.finalPackage;
+          };
+        };
+
         dontConfigure = true;
         dontBuild = true;
         outputHashMode = "recursive";
       }
       // hash'
-    );
+    ));
 
   configHook = makeSetupHook {
     name = "pnpm-config-hook";

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -1,6 +1,5 @@
 {
   stdenvNoCC,
-  fetchurl,
   callPackage,
   jq,
   moreutils,
@@ -11,7 +10,6 @@
 {
   fetchDeps =
     {
-      src,
       hash ? "",
       pname,
       ...
@@ -36,10 +34,10 @@
         name = "${pname}-pnpm-deps";
 
         nativeBuildInputs = [
+          cacert
           jq
           moreutils
           pnpm
-          cacert
         ];
 
         installPhase = ''

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -14,6 +14,8 @@
     {
       hash ? "",
       pname,
+      pnpmWorkspace ? "",
+      prePnpmInstall ? "",
       ...
     }@args:
     let
@@ -29,6 +31,7 @@
             outputHash = "";
             outputHashAlgo = "sha256";
           };
+      installFlags = lib.optionalString (pnpmWorkspace != "")  "--filter=${pnpmWorkspace}";
     in
     stdenvNoCC.mkDerivation (finalAttrs: (
       args'
@@ -58,11 +61,14 @@
           pnpm config set side-effects-cache false
           # As we pin pnpm versions, we don't really care about updates
           pnpm config set update-notifier false
+          # Run any additional pnpm configuration commands that users provide.
+          ${prePnpmInstall}
           # pnpm is going to warn us about using --force
           # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
           pnpm install \
               --force \
               --ignore-scripts \
+              ${installFlags} \
               --frozen-lockfile
 
           runHook postInstall

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -62,7 +62,7 @@
           # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
           pnpm install \
               --force \
-              --ignore-script \
+              --ignore-scripts \
               --frozen-lockfile
 
           runHook postInstall

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -60,7 +60,10 @@
           pnpm config set update-notifier false
           # pnpm is going to warn us about using --force
           # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
-          pnpm install --frozen-lockfile --ignore-script --force
+          pnpm install \
+              --force \
+              --ignore-script \
+              --frozen-lockfile
 
           runHook postInstall
         '';

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenvNoCC,
   callPackage,
   jq,
@@ -6,6 +7,7 @@
   cacert,
   makeSetupHook,
   pnpm,
+  yq,
 }:
 {
   fetchDeps =
@@ -38,10 +40,17 @@
           jq
           moreutils
           pnpm
+          yq
         ];
 
         installPhase = ''
           runHook preInstall
+
+          lockfileVersion="$(yq -r .lockfileVersion pnpm-lock.yaml)"
+          if [[ ''${lockfileVersion:0:1} -gt ${lib.versions.major pnpm.version} ]]; then
+            echo "ERROR: lockfileVersion $lockfileVersion in pnpm-lock.yaml is too new for the provided pnpm version ${lib.versions.major pnpm.version}!"
+            exit 1
+          fi
 
           export HOME=$(mktemp -d)
           pnpm config set store-dir $out

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=bash
+
+pnpmConfigHook() {
+    echo "Executing pnpmConfigHook"
+
+    if [ -n "${pnpmRoot-}" ]; then
+      pushd "$pnpmRoot"
+    fi
+
+    if [ -z "${pnpmDeps-}" ]; then
+      echo "Error: 'pnpmDeps' must be set when using pnpmConfigHook."
+      exit 1
+    fi
+
+    echo "Configuring pnpm store"
+
+    export HOME=$(mktemp -d)
+    export STORE_PATH=$(mktemp -d)
+
+    cp -Tr "$pnpmDeps" "$STORE_PATH"
+    chmod -R +w "$STORE_PATH"
+
+    pnpm config set store-dir "$STORE_PATH"
+
+    echo "Installing dependencies"
+
+    pnpm install --offline --frozen-lockfile --ignore-script
+
+    echo "Patching scripts"
+
+    patchShebangs node_modules/{*,.*}
+
+    if [ -n "${pnpmRoot-}" ]; then
+      popd
+    fi
+
+    echo "Finished pnpmConfigHook"
+}
+
+postConfigureHooks+=(pnpmConfigHook)

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -24,7 +24,11 @@ pnpmConfigHook() {
 
     echo "Installing dependencies"
 
-    pnpm install --offline --frozen-lockfile --ignore-script
+    pnpm install \
+        --offline \
+        --ignore-script \
+        --frozen-lockfile
+
 
     echo "Patching scripts"
 

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -26,7 +26,7 @@ pnpmConfigHook() {
 
     pnpm install \
         --offline \
-        --ignore-script \
+        --ignore-scripts \
         --frozen-lockfile
 
 

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -24,9 +24,15 @@ pnpmConfigHook() {
 
     echo "Installing dependencies"
 
+    if [[ -n "$pnpmWorkspace" ]]; then
+        pnpmInstallFlags+=("--filter=$pnpmWorkspace")
+    fi
+    runHook prePnpmInstall
+
     pnpm install \
         --offline \
         --ignore-scripts \
+        "${pnpmInstallFlags[@]}" \
         --frozen-lockfile
 
 

--- a/pkgs/development/tools/pnpm/fetch-deps/serve.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/serve.nix
@@ -1,0 +1,30 @@
+{ writeShellApplication, pnpm, pnpmDeps }:
+writeShellApplication {
+  name = "serve-pnpm-store";
+
+  runtimeInputs = [
+    pnpm
+  ];
+
+  text = ''
+    storePath=$(mktemp -d)
+
+    clean() {
+      echo "Cleaning up temporary store at '$storePath'..."
+
+      rm -rf "$storePath"
+    }
+
+    echo "Copying pnpm store '${pnpmDeps}' to temporary store..."
+
+    cp -Tr "${pnpmDeps}" "$storePath"
+    chmod -R +w "$storePath"
+
+    echo "Run 'pnpm install --store-dir \"$storePath\"' to install packages from this store."
+
+    trap clean EXIT
+
+    pnpm server start \
+      --store-dir "$storePath"
+  '';
+}

--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenvNoCC,
+  callPackages,
   fetchurl,
   nodejs,
   testers,
@@ -8,9 +9,7 @@
 
   version,
   hash,
-}:
-
-stdenvNoCC.mkDerivation (finalAttrs: {
+}: stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pnpm";
   inherit version;
 
@@ -32,7 +31,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru = {
+  passthru = let
+    fetchDepsAttrs = callPackages ./fetch-deps { pnpm = finalAttrs.finalPackage; };
+  in {
+    inherit (fetchDepsAttrs) fetchDeps configHook;
+
     tests.version = lib.optionalAttrs withNode (
       testers.testVersion { package = finalAttrs.finalPackage; }
     );

--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nodejs,
+  testers,
+  withNode ? true,
+
+  version,
+  hash,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "pnpm";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/pnpm/-/pnpm-${finalAttrs.version}.tgz";
+    inherit hash;
+  };
+
+  buildInputs = lib.optionals withNode [ nodejs ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/{bin,libexec}
+    cp -R . $out/libexec/pnpm
+    ln -s $out/libexec/pnpm/bin/pnpm.cjs $out/bin/pnpm
+    ln -s $out/libexec/pnpm/bin/pnpx.cjs $out/bin/pnpx
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.version = lib.optionalAttrs withNode (
+      testers.testVersion { package = finalAttrs.finalPackage; }
+    );
+  };
+
+  meta = with lib; {
+    description = "Fast, disk space efficient package manager for JavaScript";
+    homepage = "https://pnpm.io/";
+    changelog = "https://github.com/pnpm/pnpm/releases/tag/v${finalAttrs.version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Scrumplex ];
+    platforms = platforms.all;
+    mainProgram = "pnpm";
+  };
+})

--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -17,6 +17,11 @@
     url = "https://registry.npmjs.org/pnpm/-/pnpm-${finalAttrs.version}.tgz";
     inherit hash;
   };
+  # Remove binary files from src, we don't need them, and this way we make sure
+  # our distribution is free of binaryNativeCode
+  preConfigure = ''
+    rm -r dist/reflink.*node dist/vendor
+  '';
 
   buildInputs = lib.optionals withNode [ nodejs ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11891,6 +11891,10 @@ with pkgs;
 
   pngquant = callPackage ../tools/graphics/pngquant { };
 
+  inherit (callPackages ../development/tools/pnpm { })
+    pnpm_8 pnpm_9;
+  pnpm = pnpm_9;
+
   po4a = perlPackages.Po4a;
 
   poac = callPackage ../development/tools/poac {


### PR DESCRIPTION
## Description of changes

Manual backport of #290715, #319042, #320124, #317739, #322753, #325837, #323493, and #332966, omitting the changes that touched existing packages. Brings `pnpm.fetchDeps` support to 24.05 to be used for backports. I’ve verified that the port of `kiwitalk` from the original PR compiles on 24.05 after these commits, so the functionality works.

Since this doesn’t change any existing packages and just adds new functionality it should be fine to backport, but it is pretty heavy. The motivating example is https://github.com/NixOS/nixpkgs/pull/337312, where a package was ported to a non‐EOL Electron but switched to `pnpm.fetchDeps` in the process.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
