### PR TITLE
freebsd: set `BOOTSTRAPPING` when building for Linux

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/pkgs/libelf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libelf.nix
@@ -23,6 +23,4 @@ mkDerivation {
     install
     m4
   ];
-
-  BOOTSTRAPPING = !stdenv.hostPlatform.isFreeBSD;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/localedef.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/localedef.nix
@@ -35,5 +35,4 @@ mkDerivation (
 
     MK_TESTS = "no";
   }
-  // lib.optionalAttrs (!stdenv.hostPlatform.isFreeBSD) { BOOTSTRAPPING = 1; }
 )

--- a/pkgs/os-specific/bsd/freebsd/pkgs/localedef.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/localedef.nix
@@ -9,30 +9,28 @@
   makeMinimal,
   install,
 }:
-mkDerivation (
-  {
-    path = "usr.bin/localedef";
+mkDerivation ({
+  path = "usr.bin/localedef";
 
-    extraPaths = [
-      "lib/libc/locale"
-      "lib/libc/stdtime"
-    ] ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD) [ "." ];
+  extraPaths = [
+    "lib/libc/locale"
+    "lib/libc/stdtime"
+  ] ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD) [ "." ];
 
-    nativeBuildInputs = [
-      bsdSetupHook
-      byacc
-      freebsdSetupHook
-      makeMinimal
-      install
-    ];
+  nativeBuildInputs = [
+    bsdSetupHook
+    byacc
+    freebsdSetupHook
+    makeMinimal
+    install
+  ];
 
-    buildInputs = [ ];
+  buildInputs = [ ];
 
-    preBuild = lib.optionalString (!stdenv.hostPlatform.isFreeBSD) ''
-      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${compat}/include -D__unused= -D__pure= -Wno-strict-aliasing"
-      export NIX_LDFLAGS="$NIX_LDFLAGS -L${compat}/lib"
-    '';
+  preBuild = lib.optionalString (!stdenv.hostPlatform.isFreeBSD) ''
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${compat}/include -D__unused= -D__pure= -Wno-strict-aliasing"
+    export NIX_LDFLAGS="$NIX_LDFLAGS -L${compat}/lib"
+  '';
 
-    MK_TESTS = "no";
-  }
-)
+  MK_TESTS = "no";
+})

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -92,6 +92,7 @@ lib.makeOverridable (
       # Since STRIP in `makeFlags` has to be a flag, not the binary itself
       STRIPBIN = "${stdenv'.cc.bintools.targetPrefix}strip";
     }
+    // lib.optionalAttrs (!stdenv.hostPlatform.isFreeBSD) { BOOTSTRAPPING = true; }
     // lib.optionalAttrs stdenv'.hostPlatform.isDarwin { MKRELRO = "no"; }
     // lib.optionalAttrs (stdenv'.cc.isClang or false) {
       HAVE_LLVM = lib.versions.major (lib.getVersion stdenv'.cc.cc);

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -56,8 +56,6 @@ lib.makeOverridable (
       ] ++ attrs.extraNativeBuildInputs or [ ];
       buildInputs = compatIfNeeded;
 
-      HOST_SH = stdenv'.shell;
-
       makeFlags =
         [
           "STRIP=-s" # flag to install, not command
@@ -65,14 +63,36 @@ lib.makeOverridable (
         ++ lib.optional (!stdenv'.hostPlatform.isFreeBSD) "MK_WERROR=no"
         ++ lib.optional stdenv.hostPlatform.isStatic "SHLIB_NAME=";
 
-      # amd64 not x86_64 for this on unlike NetBSD
-      MACHINE_ARCH = freebsd-lib.mkBsdArch stdenv';
+      env =
+        {
+          HOST_SH = stdenv'.shell;
 
-      MACHINE = freebsd-lib.mkBsdMachine stdenv';
+          # amd64 not x86_64 for this on unlike NetBSD
+          MACHINE_ARCH = freebsd-lib.mkBsdArch stdenv';
 
-      MACHINE_CPUARCH = freebsd-lib.mkBsdCpuArch stdenv';
+          MACHINE = freebsd-lib.mkBsdMachine stdenv';
 
-      COMPONENT_PATH = attrs.path or null;
+          MACHINE_CPUARCH = freebsd-lib.mkBsdCpuArch stdenv';
+
+          COMPONENT_PATH = attrs.path or null;
+        }
+        // lib.optionalAttrs stdenv'.hasCC {
+          # TODO should CC wrapper set this?
+          CPP = "${stdenv'.cc.targetPrefix}cpp";
+
+          # Since STRIP in `makeFlags` has to be a flag, not the binary itself
+          STRIPBIN = "${stdenv'.cc.bintools.targetPrefix}strip";
+        }
+        // lib.optionalAttrs (!stdenv.hostPlatform.isFreeBSD) { BOOTSTRAPPING = true; }
+        // lib.optionalAttrs stdenv'.hostPlatform.isDarwin { MKRELRO = "no"; }
+        // lib.optionalAttrs (stdenv'.cc.isClang or false) {
+          HAVE_LLVM = lib.versions.major (lib.getVersion stdenv'.cc.cc);
+        }
+        // lib.optionalAttrs (stdenv'.cc.isGNU or false) {
+          HAVE_GCC = lib.versions.major (lib.getVersion stdenv'.cc.cc);
+        }
+        // lib.optionalAttrs (stdenv'.hostPlatform.isx86_32) { USE_SSP = "no"; }
+        // (attrs.env or { });
 
       strictDeps = true;
 
@@ -85,27 +105,11 @@ lib.makeOverridable (
         license = lib.licenses.bsd2;
       } // attrs.meta or { };
     }
-    // lib.optionalAttrs stdenv'.hasCC {
-      # TODO should CC wrapper set this?
-      CPP = "${stdenv'.cc.targetPrefix}cpp";
-
-      # Since STRIP in `makeFlags` has to be a flag, not the binary itself
-      STRIPBIN = "${stdenv'.cc.bintools.targetPrefix}strip";
-    }
-    // lib.optionalAttrs (!stdenv.hostPlatform.isFreeBSD) { BOOTSTRAPPING = true; }
-    // lib.optionalAttrs stdenv'.hostPlatform.isDarwin { MKRELRO = "no"; }
-    // lib.optionalAttrs (stdenv'.cc.isClang or false) {
-      HAVE_LLVM = lib.versions.major (lib.getVersion stdenv'.cc.cc);
-    }
-    // lib.optionalAttrs (stdenv'.cc.isGNU or false) {
-      HAVE_GCC = lib.versions.major (lib.getVersion stdenv'.cc.cc);
-    }
-    // lib.optionalAttrs (stdenv'.hostPlatform.isx86_32) { USE_SSP = "no"; }
     // lib.optionalAttrs (attrs.headersOnly or false) {
       installPhase = "includesPhase";
       dontBuild = true;
     }
-    // attrs
+    // (builtins.removeAttrs attrs [ "env" ])
     // lib.optionalAttrs (stdenv'.hasCC && stdenv'.cc.isClang or false && attrs.clangFixup or true) {
       preBuild =
         ''

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkcsmapper.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkcsmapper.nix
@@ -13,8 +13,6 @@ mkDerivation {
     "lib/libiconv_modules/mapper_std"
   ];
 
-  BOOTSTRAPPING = !stdenv.hostPlatform.isFreeBSD;
-
   extraNativeBuildInputs = [
     byacc
     flex

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkesdb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkesdb.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   mkDerivation,
   byacc,
   flex,
@@ -9,8 +8,6 @@ mkDerivation {
   path = "usr.bin/mkesdb";
 
   extraPaths = [ "lib/libc/iconv" ];
-
-  BOOTSTRAPPING = !stdenv.hostPlatform.isFreeBSD;
 
   extraNativeBuildInputs = [
     byacc


### PR DESCRIPTION
FreeBSD loves to access system headers for platform-specific builtins. This is fine on FreeBSD but often breaks when building utilities for Linux. `BOOTSTRAPPING` disables using most of these headers.

Fixes #335730

## Description of changes

Set `BOOTSTRAPPING` on all FreeBSD packages when the `hostPlatform` is not FreeBSD.

Also remove no-longer-needed `BOOTSTRAPPING` definitions. Due to strange FreeBSD bmake behavior, these always made the build happen in bootstrap mode,  even when they were set to false.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
