### PR TITLE
nixos/kerberos_server: split between server roles and make them activatable separately

### DIFF
--- a/nixos/modules/services/system/kerberos/default.nix
+++ b/nixos/modules/services/system/kerberos/default.nix
@@ -30,6 +30,29 @@ in
     services.kerberos_server = {
       enable = lib.mkEnableOption "the kerberos authentication server";
 
+      roles = {
+        kdc = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Enable the Key Distribution Center daemon.";
+        };
+        administrationServer = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Enable the administration server daemon (kadmind).";
+        };
+        passwordChangeServer = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Enable the password changing server daemon (kpasswdd).
+
+            This option is meaningful only for Heimdal-based servers, as
+            kpasswdd is built into the MIT Kerberos kadmind daemon.
+          '';
+        };
+      };
+
       settings = mkOption {
         type = format.type;
         description = ''

--- a/nixos/modules/services/system/kerberos/heimdal.nix
+++ b/nixos/modules/services/system/kerberos/heimdal.nix
@@ -67,6 +67,7 @@ in
       });
 
     systemd.services.kadmind = {
+      enable = cfg.roles.administrationServer;
       description = "Kerberos Administration Daemon";
       partOf = [ "kerberos-server.target" ];
       wantedBy = [ "kerberos-server.target" ];
@@ -79,6 +80,7 @@ in
     };
 
     systemd.services.kdc = {
+      enable = cfg.roles.kdc;
       description = "Key Distribution Center daemon";
       partOf = [ "kerberos-server.target" ];
       wantedBy = [ "kerberos-server.target" ];
@@ -91,6 +93,7 @@ in
     };
 
     systemd.services.kpasswdd = {
+      enable = cfg.roles.passwordChangeServer;
       description = "Kerberos Password Changing daemon";
       partOf = [ "kerberos-server.target" ];
       wantedBy = [ "kerberos-server.target" ];

--- a/nixos/modules/services/system/kerberos/mit.nix
+++ b/nixos/modules/services/system/kerberos/mit.nix
@@ -71,6 +71,7 @@ in
     };
 
     systemd.services.kadmind = {
+      enable = cfg.roles.administrationServer;
       description = "Kerberos Administration Daemon";
       partOf = [ "kerberos-server.target" ];
       wantedBy = [ "kerberos-server.target" ];
@@ -84,6 +85,7 @@ in
     };
 
     systemd.services.kdc = {
+      enable = cfg.roles.kdc;
       description = "Key Distribution Center daemon";
       partOf = [ "kerberos-server.target" ];
       wantedBy = [ "kerberos-server.target" ];


### PR DESCRIPTION
## Description of changes
Allow for the separate (de)activation of the different server daemons that constitute a Kerberos server (`krb5kdc`, `kadmind` and `kpasswdd`).

This is useful both for replicated deployments, where there should be only one instance of the administration server running within the realm, and for LDAP-backed deployments, where server functionalities can be flexibly split and replicated among many different computers.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
