### PR TITLE
zathura: 0.5.6 -> 0.5.8, all plugins updated

### DIFF
--- a/pkgs/applications/misc/zathura/cb/default.nix
+++ b/pkgs/applications/misc/zathura/cb/default.nix
@@ -11,12 +11,12 @@
   libarchive,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-cb";
   version = "0.1.10";
 
   src = fetchurl {
-    url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
+    url = "https://pwmt.org/projects/zathura-cb/download/zathura-cb-${finalAttrs.version}.tar.xz";
     hash = "sha256-ibDKF6gMuh6p/Rs7cvOnFz8KrToGqMNk2GXEmZwYu8g=";
   };
 
@@ -26,22 +26,23 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
   ];
+
   buildInputs = [
     libarchive
     zathura_core
     girara
   ];
 
-  PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+  env.PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 
-  meta = with lib; {
+  meta = {
     homepage = "https://pwmt.org/projects/zathura-cb/";
     description = "Zathura CB plugin";
     longDescription = ''
       The zathura-cb plugin adds comic book support to zathura.
     '';
-    license = licenses.zlib;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ jlesquembre ];
+    license = lib.licenses.zlib;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ jlesquembre ];
   };
-}
+})

--- a/pkgs/applications/misc/zathura/cb/default.nix
+++ b/pkgs/applications/misc/zathura/cb/default.nix
@@ -9,15 +9,17 @@
   girara,
   gettext,
   libarchive,
+  desktop-file-utils,
+  appstream-glib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-cb";
-  version = "0.1.10";
+  version = "0.1.11";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura-cb/download/zathura-cb-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ibDKF6gMuh6p/Rs7cvOnFz8KrToGqMNk2GXEmZwYu8g=";
+    hash = "sha256-TiAepUzcIKkyWMQ1VvY4lEGvmXQN59ymyh/1JBcvvUc=";
   };
 
   nativeBuildInputs = [
@@ -25,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     gettext
+    desktop-file-utils
+    appstream-glib
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   meson,
   ninja,
   wrapGAppsHook3,
@@ -28,14 +29,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura";
-  version = "0.5.6";
+  version = "0.5.8";
 
   src = fetchFromGitHub {
     owner = "pwmt";
     repo = "zathura";
     rev = finalAttrs.version;
-    hash = "sha256-lTEBIZ3lkzjJ+L1qecrcL8iseo8AvSIo3Wh65/ikwac=";
+    hash = "sha256-k6DEJpUA3s0mGxE38aYnX7uea98LrzevJhWW1abHo/c=";
   };
+
+  patches = [
+    # https://github.com/pwmt/zathura/issues/664
+    (fetchpatch {
+      name = "fix-build-on-macos.patch";
+      url = "https://github.com/pwmt/zathura/commit/53f151f775091abec55ccc4b63893a8f9a668588.patch";
+      hash = "sha256-d8lRdlBN1Kfw/aTjz8x0gvTKy+SqSYWHLQCjV7hF5MI=";
+    })
+  ];
 
   outputs = [
     "bin"
@@ -54,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Make sure tests are enabled for doCheck
     # (lib.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
     (lib.mesonEnable "seccomp" stdenv.hostPlatform.isLinux)
+    (lib.mesonEnable "landlock" stdenv.hostPlatform.isLinux)
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -85,11 +85,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = gitUpdater { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://pwmt.org/projects/zathura";
     description = "Core component for zathura PDF viewer";
-    license = licenses.zlib;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ globin ];
+    license = lib.licenses.zlib;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ globin ];
   };
 })

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -12,12 +12,12 @@
   gettext,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-djvu";
   version = "0.2.9";
 
   src = fetchurl {
-    url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
+    url = "https://pwmt.org/projects/zathura-djvu/download/zathura-djvu-${finalAttrs.version}.tar.xz";
     hash = "sha256-lub4pu5TIxBzsvcAMmSHL4RQHmPD2nvwWY0EYoawwgA=";
   };
 
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
   ];
+
   buildInputs = [
     djvulibre
     gettext
@@ -34,17 +35,17 @@ stdenv.mkDerivation rec {
     girara
   ];
 
-  PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+  env.PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 
-  meta = with lib; {
+  meta = {
     homepage = "https://pwmt.org/projects/zathura-djvu/";
     description = "Zathura DJVU plugin";
     longDescription = ''
       The zathura-djvu plugin adds DjVu support to zathura by using the
       djvulibre library.
     '';
-    license = licenses.zlib;
-    platforms = platforms.unix;
+    license = lib.licenses.zlib;
+    platforms = lib.platforms.unix;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -10,21 +10,25 @@
   girara,
   djvulibre,
   gettext,
+  desktop-file-utils,
+  appstream-glib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-djvu";
-  version = "0.2.9";
+  version = "0.2.10";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura-djvu/download/zathura-djvu-${finalAttrs.version}.tar.xz";
-    hash = "sha256-lub4pu5TIxBzsvcAMmSHL4RQHmPD2nvwWY0EYoawwgA=";
+    hash = "sha256-MunYmSmnbNfT/Lr3n0QYaL2r7fFzF9HRhD+qHxkzjZU=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
+    desktop-file-utils
+    appstream-glib
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -17,22 +17,26 @@
   tesseract,
   leptonica,
   mujs,
+  desktop-file-utils,
+  appstream-glib,
   gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "0.4.2";
+  version = "0.4.4";
   pname = "zathura-pdf-mupdf";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura-pdf-mupdf/download/zathura-pdf-mupdf-${finalAttrs.version}.tar.xz";
-    hash = "sha256-fFC+z9mJX9ccExsV336Ut+zJJa8UdfUz/qVp9YgcnhM=";
+    hash = "sha256-ASViSQHKvjov5jMVpG59lmoyPAKP9TiQ3694Vq2x9Pw=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
+    desktop-file-utils
+    appstream-glib
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -20,12 +20,12 @@
   gitUpdater,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "0.4.2";
   pname = "zathura-pdf-mupdf";
 
   src = fetchurl {
-    url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
+    url = "https://pwmt.org/projects/zathura-pdf-mupdf/download/zathura-pdf-mupdf-${finalAttrs.version}.tar.xz";
     hash = "sha256-fFC+z9mJX9ccExsV336Ut+zJJa8UdfUz/qVp9YgcnhM=";
   };
 
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     mujs
   ] ++ lib.optional stdenv.isDarwin gtk-mac-integration;
 
-  PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+  env.PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 
   postPatch = ''
     sed -i -e '/^mupdfthird =/d' -e 's/, mupdfthird//g' meson.build
@@ -57,15 +57,15 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gitUpdater { url = "https://git.pwmt.org/pwmt/zathura-pdf-mupdf.git"; };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://pwmt.org/projects/zathura-pdf-mupdf/";
     description = "Zathura PDF plugin (mupdf)";
     longDescription = ''
       The zathura-pdf-mupdf plugin adds PDF support to zathura by
       using the mupdf rendering library.
     '';
-    license = licenses.zlib;
-    platforms = platforms.unix;
+    license = lib.licenses.zlib;
+    platforms = lib.platforms.unix;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -8,21 +8,25 @@
   zathura_core,
   girara,
   poppler,
+  desktop-file-utils,
+  appstream-glib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-pdf-poppler";
-  version = "0.3.2";
+  version = "0.3.3";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura-pdf-poppler/download/zathura-pdf-poppler-${finalAttrs.version}.tar.xz";
-    hash = "sha256-cavu1RzR0YjO89vUwWR1jjw3FgR1aWeyOtF2rlNFMBE=";
+    hash = "sha256-yBLy9ERv1d4Wc04TwC6pqiW6Tjup9ytzLA/5D5ujSTU=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
+    desktop-file-utils
+    appstream-glib
     zathura_core
   ];
 

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -10,12 +10,12 @@
   poppler,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-pdf-poppler";
   version = "0.3.2";
 
   src = fetchurl {
-    url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
+    url = "https://pwmt.org/projects/zathura-pdf-poppler/download/zathura-pdf-poppler-${finalAttrs.version}.tar.xz";
     hash = "sha256-cavu1RzR0YjO89vUwWR1jjw3FgR1aWeyOtF2rlNFMBE=";
   };
 
@@ -25,22 +25,23 @@ stdenv.mkDerivation rec {
     pkg-config
     zathura_core
   ];
+
   buildInputs = [
     poppler
     girara
   ];
 
-  PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+  env.PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 
-  meta = with lib; {
+  meta = {
     homepage = "https://pwmt.org/projects/zathura-pdf-poppler/";
     description = "Zathura PDF plugin (poppler)";
     longDescription = ''
       The zathura-pdf-poppler plugin adds PDF support to zathura by
       using the poppler rendering library.
     '';
-    license = licenses.zlib;
-    platforms = platforms.unix;
+    license = lib.licenses.zlib;
+    platforms = lib.platforms.unix;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -11,12 +11,12 @@
   gettext,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-ps";
   version = "0.2.7";
 
   src = fetchurl {
-    url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
+    url = "https://pwmt.org/projects/zathura-ps/download/zathura-ps-${finalAttrs.version}.tar.xz";
     hash = "sha256-WJf5IEz1+Xi5QTvnzn/r3oQxV69I41GTjt8H2/kwjkY=";
   };
 
@@ -26,23 +26,24 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
   ];
+
   buildInputs = [
     libspectre
     zathura_core
     girara
   ];
 
-  PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+  env.PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 
-  meta = with lib; {
+  meta = {
     homepage = "https://pwmt.org/projects/zathura-ps/";
     description = "Zathura PS plugin";
     longDescription = ''
       The zathura-ps plugin adds PS support to zathura by using the
       libspectre library.
     '';
-    license = licenses.zlib;
-    platforms = platforms.unix;
+    license = lib.licenses.zlib;
+    platforms = lib.platforms.unix;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -9,15 +9,17 @@
   girara,
   libspectre,
   gettext,
+  desktop-file-utils,
+  appstream-glib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-ps";
-  version = "0.2.7";
+  version = "0.2.8";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura-ps/download/zathura-ps-${finalAttrs.version}.tar.xz";
-    hash = "sha256-WJf5IEz1+Xi5QTvnzn/r3oQxV69I41GTjt8H2/kwjkY=";
+    hash = "sha256-B8pZT3J3+YdtADgEhBg0PqKWQCjpPJD5Vp7/NqiTLko=";
   };
 
   nativeBuildInputs = [
@@ -25,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     gettext
+    desktop-file-utils
+    appstream-glib
   ];
 
   buildInputs = [


### PR DESCRIPTION
## Description of changes

Update zathura and plugins.

- zathura-cb: 0.1.10 -> 0.1.11
- zathura-djvu: 0.2.9 -> 0.2.10
- zathura-pdf-mupdf: 0.4.2 -> 0.4.4 (waiting for mupdf 1.24 to land on `master` #332385)
- zathura-pdf-poppler: 0.3.2 -> 0.3.3
- zathura-ps: 0.2.7 -> 0.2.8

For the plugins, their `data/meson.build` now requires `desktop-file-utils` (for `desktop-file-validate`) and `appstream-glib` (for `appstream-util`). Or the alternative is to patch the `required: get_option('tests')` argument for `find_program`.

Supersedes #325136.

Closes #334368 (last release is 0.4.4)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
