### PR TITLE
[Backport release-24.05] i2p: 2.5.1 -> 2.6.1

### DIFF
--- a/pkgs/by-name/i2/i2p/package.nix
+++ b/pkgs/by-name/i2/i2p/package.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "i2p";
-  version = "2.5.1";
+  version = "2.6.1";
 
   src = fetchzip {
     urls = [
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
       "https://files.i2p-projekt.de/"
       "https://download.i2p2.no/releases/"
     ]);
-    hash = "sha256-38kG0UyU1ngVdUb/H5tIuG3p+bsvJznjervDh3TWoGo=";
+    hash = "sha256-ntjTXdpgcTReEVxzDEoq9r3NAqS7q4m+rlJXp7is1k0=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/337305