### PR TITLE
flatpak: fix cross compilation

### DIFF
--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -7,6 +7,7 @@
   autoreconfHook,
   bison,
   bubblewrap,
+  buildPackages,
   bzip2,
   coreutils,
   curl,
@@ -40,6 +41,7 @@
   p11-kit,
   pkg-config,
   polkit,
+  pkgsCross,
   python3,
   shared-mime-info,
   socat,
@@ -205,8 +207,12 @@ stdenv.mkDerivation (finalAttrs: {
       PATH=${lib.makeBinPath [ vsc-py ]}:$PATH patchShebangs --build subprojects/variant-schema-compiler/variant-schema-compiler
 
       substituteInPlace configure.ac \
-        --replace-fail '$BWRAP --version' 'echo ${bubblewrap.version}' \
-        --replace-fail '$DBUS_PROXY --version' 'echo ${xdg-dbus-proxy.version}'
+        --replace-fail '$BWRAP --' ${
+          lib.escapeShellArg (stdenv.hostPlatform.emulator buildPackages + " $BWRAP --")
+        } \
+        --replace-fail '$DBUS_PROXY --' ${
+          lib.escapeShellArg (stdenv.hostPlatform.emulator buildPackages + " $DBUS_PROXY --")
+        }
     '';
 
   passthru = {
@@ -218,6 +224,8 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = nix-update-script { };
 
     tests = {
+      cross = pkgsCross.aarch64-multiplatform.flatpak;
+
       installedTests = nixosTests.installed-tests.flatpak;
 
       validate-icon = runCommand "test-icon-validation" { } ''


### PR DESCRIPTION
the 1.14.8 -> 1.14.10 update broke cross compilation, because the upstream build script now invokes runtime dependencies for feature detection. <https://github.com/flatpak/flatpak/blob/5a2503f1e8ef94364e3060ec440546cc47af7fa5/configure.ac#L178>

it seems the package will be more robust against changes if we simply emulate these checks rather than attempt to patch them out individually.

CC: @SuperSandro2000 and @getchoo for their familiarity with flatpak and with the original cross fix.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
