### PR TITLE
yandex-music: init at 5.13.2

### DIFF
--- a/pkgs/by-name/ya/yandex-music/info.json
+++ b/pkgs/by-name/ya/yandex-music/info.json
@@ -1,0 +1,7 @@
+{
+  "branch": "master",
+  "commit_hash": "4ac238a00ca0b36e9755e55e54a22d3107ba443c",
+  "commit_message": "Update packages",
+  "date": "2024-08-27",
+  "tag": "v5.13.2"
+}

--- a/pkgs/by-name/ya/yandex-music/package.nix
+++ b/pkgs/by-name/ya/yandex-music/package.nix
@@ -1,0 +1,88 @@
+{
+  fetchurl,
+  stdenvNoCC,
+  lib,
+  makeWrapper,
+  p7zip,
+  asar,
+  jq,
+  python3,
+  electron,
+  fetchFromGitHub,
+  electronArguments ? "",
+  trayEnabled ? true,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "yandex-music";
+  version = "5.13.2";
+
+  src = fetchFromGitHub {
+    owner = "cucumber-sp";
+    repo = "yandex-music-linux";
+    rev = "v${version}";
+    hash = "sha256-yQX2GEulAQ02BndpwAAwGdTYtUlNXCgsCUdmXxPwtKU=";
+  };
+
+  nativeBuildInputs = [
+    p7zip
+    asar
+    jq
+    python3
+    makeWrapper
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  ymExe =
+    let
+      ym_info = builtins.fromJSON (builtins.readFile ./ym_info.json);
+    in
+    fetchurl {
+      url = ym_info.ym.exe_link;
+      sha256 = ym_info.ym.exe_sha256;
+    };
+
+  buildPhase = ''
+    runHook preBuild
+    bash "./repack.sh" -o "./app" "$ymExe"
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/nodejs"
+    mv app/yandex-music.asar "$out/share/nodejs"
+
+    CONFIG_FILE="$out/share/yandex-music.conf"
+    echo "TRAY_ENABLED=${if trayEnabled then "1" else "0"}" >> "$CONFIG_FILE"
+    echo "ELECTRON_ARGS=\"${electronArguments}\"" >> "$CONFIG_FILE"
+
+
+    install -Dm755 "$src/templates/yandex-music.sh" "$out/bin/yandex-music"
+    substituteInPlace "$out/bin/yandex-music"                                  \
+      --replace-fail "%electron_path%" "${electron}/bin/electron"              \
+      --replace-fail "%asar_path%" "$out/share/nodejs/yandex-music.asar"
+
+    wrapProgram "$out/bin/yandex-music"                                        \
+      --set-default YANDEX_MUSIC_CONFIG "$CONFIG_FILE"
+
+    install -Dm644 "./app/favicon.png" "$out/share/pixmaps/yandex-music.png"
+    install -Dm644 "./app/favicon.png" "$out/share/icons/hicolor/48x48/apps/yandex-music.png"
+    install -Dm644 "./app/favicon.svg" "$out/share/icons/hicolor/scalable/apps/yandex-music.svg"
+
+    install -Dm644 "$src/templates/desktop" "$out/share/applications/yandex-music.desktop"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Yandex Music - Personal recommendations, selections for any occasion and new music";
+    homepage = "https://music.yandex.ru/";
+    downloadPage = "https://music.yandex.ru/download/";
+    changelog = "https://github.com/cucumber-sp/yandex-music-linux/releases/tag/v5.13.2";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ shved ];
+  };
+}

--- a/pkgs/by-name/ya/yandex-music/update.sh
+++ b/pkgs/by-name/ya/yandex-music/update.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p common-updater-scripts fd jq
+
+set -eou pipefail
+
+OWNER="cucumber-sp"
+REPO="yandex-music-linux"
+URL="https://api.github.com/repos/$OWNER/$REPO"
+RAW="https://raw.githubusercontent.com/$OWNER/$REPO"
+
+latest_release="$(curl --silent "$URL/releases/latest")"
+latest_tag="$(curl --silent "$URL/tags?per_page=1")"
+commit_hash="$(jq -r '.[0].commit.sha' <<<"$latest_tag")"
+latest_commit="$(curl --silent "$URL/commits/$commit_hash"'')"
+commit_message="$(jq -r '.commit.message' <<<"$latest_commit")"
+
+tag=$(jq -r '.tag_name' <<<"$latest_release")
+# drop 'v' prefix
+version="${tag#v}"
+
+branch=$(jq -r '.target_commitish' <<<"$latest_release")
+
+date=$(jq -r '.created_at' <<<"$latest_release")
+# truncate time
+date=${date%T*}
+
+# update version; otherwise fail
+update-source-version yandex-music "$version" --ignore-same-hash
+
+# set yandex-music dir
+dir="pkgs/by-name/ya/yandex-music"
+
+echo -e '{
+  "branch": "'"$branch"'",
+  "commit_hash": "'"$commit_hash"'",
+  "commit_message": "'"$commit_message"'",
+  "date": "'"$date"'",
+  "tag": "'"$tag"'"
+}' >"$dir/info.json" || echo "Please run the script in the root of the Nixpkgs repo"
+
+curl --silent "$RAW/$commit_hash/utility/version_info.json" |\
+        jq . > "$dir/ym_info.json" ||\
+        echo "Please run the script in the root of the Nixpkgs repo"

--- a/pkgs/by-name/ya/yandex-music/ym_info.json
+++ b/pkgs/by-name/ya/yandex-music/ym_info.json
@@ -1,0 +1,14 @@
+{
+  "ym": {
+    "version": "5.13.2",
+    "exe_name": "Yandex_Music_x64_5.13.2.exe",
+    "exe_link": "https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.13.2.exe",
+    "exe_sha256": "ac7a489a59e074358559f544a26143ca81a6bdfa41481242f3419b76eaffdb0b"
+  },
+  "electron": {
+    "version": "29.4.6",
+    "x64": "https://github.com/electron/electron/releases/download/v29.4.6/electron-v29.4.6-linux-x64.zip",
+    "armv7l": "https://github.com/electron/electron/releases/download/v29.4.6/electron-v29.4.6-linux-armv7l.zip",
+    "arm64": "https://github.com/electron/electron/releases/download/v29.4.6/electron-v29.4.6-linux-arm64.zip"
+  }
+}


### PR DESCRIPTION
## Description of changes

Introduce YandexMusic package. This package is based on the [beta](https://music.yandex.ru/download/) version of desktop application. There is another [project](https://github.com/cucumber-sp/yandex-music-linux) on github which repacks this desktop application for linux. So, this package uses that project as source and then uses hashes and urls from it to download the official archive and then the `repack.sh` to repack it for nixpkgs derivation. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
