### PR TITLE
instant-scala: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9452,6 +9452,12 @@
     githubId = 6789916;
     name = "Jason Odoom";
   };
+  jatcwang = {
+    email = "jatcwang@gmail.com";
+    github = "jatcwang";
+    githubId = 4957161;
+    name = "Jacob Wang";
+  };
   javaes = {
     email = "jan+dev@vanesdonk.de";
     github = "javaes";

--- a/pkgs/by-name/in/instant-scala/package.nix
+++ b/pkgs/by-name/in/instant-scala/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  scala-cli,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "instant-scala";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jatcwang";
+    repo = "instant-scala";
+    rev = "refs/tags/v${finalAttrs.version}";
+    sha256 = "jqSvKTL8NzqjwqDj/+55YWecx2bnzuArP8RdfH5q/1U=";
+  };
+
+  buildInputs = [
+    scala-cli
+  ];
+
+  installPhase = ''
+    install -Dm755 instant-scala $out/bin/instant-scala
+  '';
+
+  meta = {
+    description = "Write Scala scripts that starts instantly using scala-cli and GraalVM";
+    homepage = "https://github.com/jatcwang/instant-scala";
+    changelog = "https://github.com/jatcwang/instant-scala/releases/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jatcwang ];
+    mainProgram = "instant-scala";
+  };
+})


### PR DESCRIPTION
## Description of changes

Add instant-scala (https://github.com/jatcwang/instant-scala), a wrapper script around scala-cli/GraalVM which allow writing scala scripts that starts instantly.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
