### PR TITLE
gitlab-timelogs: init at 0.3.0

### DIFF
--- a/pkgs/by-name/gi/gitlab-timelogs/package.nix
+++ b/pkgs/by-name/gi/gitlab-timelogs/package.nix
@@ -1,0 +1,48 @@
+{
+  darwin,
+  fetchCrate,
+  iconv,
+  lib,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gitlab-timelogs";
+  version = "0.3.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-n+Jvm4RqHkXIeQcY55iOEBgwvbr77vLMhqxXgdau5MQ=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.SystemConfiguration
+      iconv
+    ];
+
+  cargoHash = "sha256-REE7DWY0l4TTDTwWFWVr3Zk/oLQlOjrbFEWSFUlBEig=";
+
+  meta = {
+    description = " CLI utility to support you with your time logs in GitLab";
+    mainProgram = "gitlab-timelogs";
+    longDescription = ''
+      CLI utility to support you with your time logs in GitLab.
+
+      gitlab-timelogs is not associated with the official GitLab project!
+    '';
+    homepage = "https://github.com/phip1611/gitlab-timelogs";
+    changelog = "https://github.com/phip1611/gitlab-timelogs/blob/v${version}/CHANGELOG.md";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [
+      blitz
+      phip1611
+    ];
+  };
+}


### PR DESCRIPTION
Inits the `gitlab-timelogs` CLI utility written in Rust.

## Description of changes

This inits <https://github.com/phip1611/gitlab-timelogs>. It is a CLI utility to support you with your time logs in GitLab.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
