### PR TITLE
gnupatch: fix segfault on cleanup

### DIFF
--- a/pkgs/tools/text/gnupatch/Abort_when_cleaning_up_fails.patch
+++ b/pkgs/tools/text/gnupatch/Abort_when_cleaning_up_fails.patch
@@ -1,0 +1,51 @@
+From b7b028a77bd855f6f56b17c8837fc1cca77b469d Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruen@gnu.org>
+Date: Fri, 28 Jun 2019 00:30:25 +0200
+Subject: Abort when cleaning up fails
+
+When a fatal error triggers during cleanup, another attempt will be made to
+clean up, which will likely lead to the same fatal error.  So instead, bail out
+when that happens.
+src/patch.c (cleanup): Bail out when called recursively.
+(main): There is no need to call output_files() before cleanup() as cleanup()
+already does that.
+---
+ src/patch.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/patch.c b/src/patch.c
+index 4616a48..02fd982 100644
+--- a/src/patch.c
++++ b/src/patch.c
+@@ -685,7 +685,6 @@ main (int argc, char **argv)
+     }
+     if (outstate.ofp && (ferror (outstate.ofp) || fclose (outstate.ofp) != 0))
+       write_fatal ();
+-    output_files (NULL);
+     cleanup ();
+     delete_files ();
+     if (somefailed)
+@@ -1991,7 +1990,6 @@ void
+ fatal_exit (int sig)
+ {
+   cleanup ();
+-
+   if (sig)
+     exit_with_signal (sig);
+ 
+@@ -2011,6 +2009,12 @@ remove_if_needed (char const *name, bool *needs_removal)
+ static void
+ cleanup (void)
+ {
++  static bool already_cleaning_up;
++
++  if (already_cleaning_up)
++    return;
++  already_cleaning_up = true;
++
+   remove_if_needed (TMPINNAME, &TMPINNAME_needs_removal);
+   remove_if_needed (TMPOUTNAME, &TMPOUTNAME_needs_removal);
+   remove_if_needed (TMPPATNAME, &TMPPATNAME_needs_removal);
+-- 
+cgit v1.1
+

--- a/pkgs/tools/text/gnupatch/default.nix
+++ b/pkgs/tools/text/gnupatch/default.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation rec {
     # https://git.savannah.gnu.org/cgit/patch.git/patch/?id=b5a91a01e5d0897facdd0f49d64b76b0f02b43e1
     ./Allow_input_files_to_be_missing_for_ed-style_patches.patch
 
+    # https://git.savannah.gnu.org/cgit/patch.git/patch/?id=b7b028a77bd855f6f56b17c8837fc1cca77b469d
+    ./Abort_when_cleaning_up_fails.patch
+
     # https://git.savannah.gnu.org/cgit/patch.git/patch/?id=123eaff0d5d1aebe128295959435b9ca5909c26d
     ./CVE-2018-1000156.patch
 


### PR DESCRIPTION
## Description of changes

Split from https://github.com/NixOS/nixpkgs/pull/335579#discussion_r1722013481

See https://savannah.gnu.org/bugs/?57717

Reproducer:

```console
$ patch -p1 <<'EOF'
diff --git a/file2.txt b/file2.txt
index e69de29..d20e9cd 100644
--- a/file2.txt
+++ b/file2.txt
@@ -1 +1 @@
-old content
+new content
EOF
```

```
(repeated lines omitted)
patch: **** Can't create file file2.txt.orig : Too many open files
patch: **** Can't create file file2.txt.orig : Too many open files
patch: **** Can't create file file2.txt.origSegmentation fault (core dumped)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
