### PR TITLE
vimcats: init at 1.0.2

### DIFF
--- a/pkgs/by-name/vi/vimcats/package.nix
+++ b/pkgs/by-name/vi/vimcats/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  testers,
+  vimcats,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "vimcats";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "mrcjkb";
+    repo = "vimcats";
+    rev = "v${version}";
+    sha256 = "sha256-YZPLZgC0v5zw/+X3r0G1MZ+46c0K8J3ClFQYH5BqbUE=";
+  };
+
+  buildFeatures = [ "cli" ];
+
+  cargoHash = "sha256-gxCsB8lx9gTEsWV3uCX2TKTzxCUZ9JHo+1+voU7gKhY=";
+
+  passthru.tests.version = testers.testVersion { package = vimcats; };
+
+  meta = with lib; {
+    description = "A CLI to generate vim/nvim help doc from LuaCATS. Forked from lemmy-help";
+    longDescription = ''
+      `vimcats` is a LuaCATS parser as well as a CLI which takes that parsed tree and converts it into vim help docs.
+      It is a fork of lemmy-help that aims to support more recent LuaCATS features.
+    '';
+    homepage = "https://github.com/mrcjkb/vimcats";
+    changelog = "https://github.com/mrcjkb/vimcats/CHANGELOG.md";
+    license = with licenses; [ gpl2Plus ];
+    maintainers = with maintainers; [ mrcjkb ];
+    mainProgram = "vimcats";
+  };
+}


### PR DESCRIPTION
## Description of changes

[vimcats](https://github.com/mrcjkb/vimcats) is a detached fork of [lemmy-help](https://github.com/numToStr/lemmy-help), 
which has not been touched in about two years.
It aims to support modern LuaCATs annotations (which are under constant development).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
