### PR TITLE
{prisma,prisma-engines}: 5.16.1 -> 5.18.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -233,6 +233,8 @@
   and `nodePackages.vscode-json-languageserver-bin` were dropped due to an unmaintained upstream.
   The `vscode-langservers-extracted` package is a maintained drop-in replacement.
 
+- `nodePackages.prisma` has been replaced by `prisma`.
+
 - `fetchNextcloudApp` has been rewritten to use `fetchurl` rather than
   `fetchzip`. This invalidates all existing hashes but you can restore the old
   behavior by passing it `unpack = true`.

--- a/pkgs/applications/office/documenso/default.nix
+++ b/pkgs/applications/office/documenso/default.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildNpmPackage
-, nodePackages
+, prisma
 , nix-update-script
 }:
 let
@@ -18,12 +18,14 @@ buildNpmPackage {
     hash = "sha256-uKOJVZ0GRHo/CYvd/Ix/tq1WDhutRji1tSGdcITsNlo=";
   };
 
+  nativeBuildInputs = [ prisma ];
+
   preBuild = ''
     # somehow for linux, npm is not finding the prisma package with the
     # packages installed with the lockfile.
     # This generates a prisma version incompatibility warning and is a kludge
     # until the upstream package-lock is modified.
-    ${nodePackages.prisma}/bin/prisma generate
+    prisma generate
   '';
 
   npmDepsHash = "sha256-+JbvFMi8xoyxkuL9k96K1Vq0neciCGkkyZUPd15ES2E=";

--- a/pkgs/by-name/pr/prisma/package.nix
+++ b/pkgs/by-name/pr/prisma/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  nodejs,
+  pnpm_8,
+  prisma-engines,
+  jq,
+  makeWrapper,
+  moreutils,
+  callPackage,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prisma";
+  version = "5.18.0";
+
+  src = fetchFromGitHub {
+    owner = "prisma";
+    repo = "prisma";
+    rev = finalAttrs.version;
+    hash = "sha256-BLD2nKryigXr03BCgGwb3PnCcBLMyDfSFb9Snj0VPKI=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_8.configHook
+    jq
+    makeWrapper
+    moreutils
+  ];
+
+  pnpmDeps = pnpm_8.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-lgdJk7HCfX3cAvdEI8xG/IVBiLWezdUN0q+e/0LtVUQ=";
+  };
+
+  patchPhase = ''
+    runHook prePatch
+
+    for package in packages/*; do
+      jq --arg version $version '.version = $version' $package/package.json | sponge $package/package.json
+    done
+
+    runHook postPatch
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  # FIXME: Use pnpm deploy: https://github.com/pnpm/pnpm/issues/5315
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/prisma
+
+    # Fetch CLI workspace dependencies
+    deps_json=$(pnpm list --filter ./packages/cli --prod --depth Infinity --json)
+    deps=$(jq -r '[.. | strings | select(startswith("link:../")) | sub("^link:../"; "")] | unique[]' <<< "$deps_json")
+
+    # Remove unnecessary external dependencies
+    rm -rf node_modules
+    pnpm install --offline --ignore-scripts --frozen-lockfile --prod --filter ./packages/cli
+    cp -r node_modules $out/lib/prisma
+
+    # Only install cli and its workspace dependencies
+    for package in cli $deps; do
+      filename=$(npm pack --json ./packages/$package | jq -r '.[].filename')
+      mkdir -p $out/lib/prisma/packages/$package
+      cp -r packages/$package/node_modules $out/lib/prisma/packages/$package
+      tar xf $filename --strip-components=1 -C $out/lib/prisma/packages/$package
+    done
+
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/prisma" \
+      --add-flags "$out/lib/prisma/packages/cli/build/index.js" \
+      --set PRISMA_SCHEMA_ENGINE_BINARY ${prisma-engines}/bin/schema-engine \
+      --set PRISMA_QUERY_ENGINE_BINARY ${prisma-engines}/bin/query-engine \
+      --set PRISMA_QUERY_ENGINE_LIBRARY ${lib.getLib prisma-engines}/lib/libquery_engine.node
+
+    runHook postInstall
+  '';
+
+  dontStrip = true;
+
+  passthru.tests = {
+    cli = callPackage ./test-cli.nix { };
+  };
+
+  meta = with lib; {
+    description = "Next-generation ORM for Node.js and TypeScript";
+    homepage = "https://www.prisma.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ aqrln ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/by-name/pr/prisma/test-cli.nix
+++ b/pkgs/by-name/pr/prisma/test-cli.nix
@@ -1,21 +1,29 @@
-{ lib, pkgs, runCommand, prisma }:
+{
+  lib,
+  runCommand,
+  prisma,
+  prisma-engines,
+  sqlite-interactive,
+}:
 
 let
-  inherit (prisma) packageName;
   prismaMajorVersion = lib.versions.majorMinor prisma.version;
-  enginesMajorVersion = lib.versions.majorMinor pkgs.prisma-engines.version;
+  enginesMajorVersion = lib.versions.majorMinor prisma-engines.version;
 in
-
-runCommand "${packageName}-tests" {
-  nativeBuildInputs = with pkgs; [ prisma sqlite-interactive ];
-  meta.timeout = 60;
-}
+runCommand "prisma-cli-tests"
+  {
+    nativeBuildInputs = [
+      prisma
+      sqlite-interactive
+    ];
+    meta.timeout = 60;
+  }
   ''
     mkdir $out
     cd $out
 
     if [ "${prismaMajorVersion}" != "${enginesMajorVersion}" ]; then
-      echo "nodePackages.prisma in version ${prismaMajorVersion} and prisma-engines in ${enginesMajorVersion}. Major versions must match."
+      echo "prisma in version ${prismaMajorVersion} and prisma-engines in ${enginesMajorVersion}. Major versions must match."
       exit 1
     fi
 

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -168,7 +168,6 @@
 , "prebuild-install"
 , "prettier"
 , "prettier-plugin-toml"
-, "prisma"
 , "@prisma/language-server"
 , "pscid"
 , "pulp"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -8707,51 +8707,6 @@ let
         sha512 = "j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==";
       };
     };
-    "@prisma/debug-5.17.0" = {
-      name = "_at_prisma_slash_debug";
-      packageName = "@prisma/debug";
-      version = "5.17.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@prisma/debug/-/debug-5.17.0.tgz";
-        sha512 = "l7+AteR3P8FXiYyo496zkuoiJ5r9jLQEdUuxIxNCN1ud8rdbH3GTxm+f+dCyaSv9l9WY+29L9czaVRXz9mULfg==";
-      };
-    };
-    "@prisma/engines-5.17.0" = {
-      name = "_at_prisma_slash_engines";
-      packageName = "@prisma/engines";
-      version = "5.17.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@prisma/engines/-/engines-5.17.0.tgz";
-        sha512 = "+r+Nf+JP210Jur+/X8SIPLtz+uW9YA4QO5IXA+KcSOBe/shT47bCcRMTYCbOESw3FFYFTwe7vU6KTWHKPiwvtg==";
-      };
-    };
-    "@prisma/engines-version-5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053" = {
-      name = "_at_prisma_slash_engines-version";
-      packageName = "@prisma/engines-version";
-      version = "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053.tgz";
-        sha512 = "tUuxZZysZDcrk5oaNOdrBnnkoTtmNQPkzINFDjz7eG6vcs9AVDmA/F6K5Plsb2aQc/l5M2EnFqn3htng9FA4hg==";
-      };
-    };
-    "@prisma/fetch-engine-5.17.0" = {
-      name = "_at_prisma_slash_fetch-engine";
-      packageName = "@prisma/fetch-engine";
-      version = "5.17.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.17.0.tgz";
-        sha512 = "ESxiOaHuC488ilLPnrv/tM2KrPhQB5TRris/IeIV4ZvUuKeaicCl4Xj/JCQeG9IlxqOgf1cCg5h5vAzlewN91Q==";
-      };
-    };
-    "@prisma/get-platform-5.17.0" = {
-      name = "_at_prisma_slash_get-platform";
-      packageName = "@prisma/get-platform";
-      version = "5.17.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.17.0.tgz";
-        sha512 = "UlDgbRozCP1rfJ5Tlkf3Cnftb6srGrEQ4Nm3og+1Se2gWmCZ0hmPIi+tQikGDUVLlvOWx3Gyi9LzgRP+HTXV9w==";
-      };
-    };
     "@prisma/prisma-schema-wasm-5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053" = {
       name = "_at_prisma_slash_prisma-schema-wasm";
       packageName = "@prisma/prisma-schema-wasm";
@@ -81402,31 +81357,6 @@ in
       description = "An opinionated `toml` formatter plugin for Prettier";
       homepage = "https://github.com/un-ts/prettier/tree/master/packages/prettier";
       license = "MIT";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
-  prisma = nodeEnv.buildNodePackage {
-    name = "prisma";
-    packageName = "prisma";
-    version = "5.17.0";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/prisma/-/prisma-5.17.0.tgz";
-      sha512 = "m4UWkN5lBE6yevqeOxEvmepnL5cNPEjzMw2IqDB59AcEV6w7D8vGljDLd1gPFH+W6gUxw9x7/RmN5dCS/WTPxA==";
-    };
-    dependencies = [
-      sources."@prisma/debug-5.17.0"
-      sources."@prisma/engines-5.17.0"
-      sources."@prisma/engines-version-5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053"
-      sources."@prisma/fetch-engine-5.17.0"
-      sources."@prisma/get-platform-5.17.0"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "Prisma is an open-source database toolkit. It includes a JavaScript/TypeScript ORM for Node.js, migrations and a modern GUI to view and edit the data in your database. You can use Prisma in new projects or add it to an existing one.";
-      homepage = "https://www.prisma.io";
-      license = "Apache-2.0";
     };
     production = true;
     bypassCache = true;

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -268,33 +268,6 @@ final: prev: {
     };
   });
 
-  # To update prisma, please first update prisma-engines to the latest
-  # version. Then change the correct hash to this package. The PR should hold
-  # two commits: one for the engines and the other one for the node package.
-  prisma = prev.prisma.override rec {
-    nativeBuildInputs = [ pkgs.buildPackages.makeWrapper ];
-
-    inherit (pkgs.prisma-engines) version;
-
-    src = fetchurl {
-      url = "https://registry.npmjs.org/prisma/-/prisma-${version}.tgz";
-      hash = "sha256-TlwKCuDQRFM6+Hhx9eFCfXbtLZq6RwBTIFCWzE4D8N8=";
-    };
-    postInstall = with pkgs; ''
-      wrapProgram "$out/bin/prisma" \
-        --set PRISMA_SCHEMA_ENGINE_BINARY ${prisma-engines}/bin/schema-engine \
-        --set PRISMA_QUERY_ENGINE_BINARY ${prisma-engines}/bin/query-engine \
-        --set PRISMA_QUERY_ENGINE_LIBRARY ${lib.getLib prisma-engines}/lib/libquery_engine.node \
-        --set PRISMA_FMT_BINARY ${prisma-engines}/bin/prisma-fmt
-    '';
-
-    passthru.tests = {
-      simple-execution = pkgs.callPackage ./package-tests/prisma.nix {
-        inherit (final) prisma;
-      };
-    };
-  };
-
   pulp = prev.pulp.override {
     # tries to install purescript
     npmFlags = builtins.toString [ "--ignore-scripts" ];

--- a/pkgs/development/tools/database/prisma-engines/Cargo.lock
+++ b/pkgs/development/tools/database/prisma-engines/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "time 0.3.25",
+ "time",
  "uuid",
 ]
 
@@ -520,30 +520,23 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.43",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -675,6 +668,16 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "concat-idents"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
+dependencies = [
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1028,9 +1031,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.7"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derivative"
@@ -1935,6 +1941,9 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "pest",
+ "pest_derive",
+ "serde",
  "similar",
  "yaml-rust",
 ]
@@ -2234,9 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.91.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2368312c59425dd133cb9a327afee65be0a633a8ce471d248e2202a48f8f68ae"
+checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
 dependencies = [
  "bitflags 1.3.2",
  "serde",
@@ -2645,7 +2654,7 @@ dependencies = [
  "smallvec",
  "subprocess",
  "thiserror",
- "time 0.3.25",
+ "time",
  "uuid",
 ]
 
@@ -2816,6 +2825,12 @@ checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -3332,6 +3347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,11 +3614,13 @@ dependencies = [
  "bit-vec",
  "byteorder",
  "bytes",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "chrono",
+ "concat-idents",
  "connection-string",
  "crosstarget-utils",
  "either",
+ "expect-test",
  "futures",
  "getrandom 0.2.11",
  "hex",
@@ -4258,7 +4281,7 @@ name = "request-handlers"
 version = "0.1.0"
 dependencies = [
  "bigdecimal",
- "cfg_aliases 0.2.0",
+ "cfg_aliases",
  "codspeed-criterion-compat",
  "connection-string",
  "dmmf",
@@ -4724,9 +4747,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -4753,9 +4776,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5082,6 +5105,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "cuid",
+ "expect-test",
  "futures",
  "itertools 0.12.0",
  "once_cell",
@@ -5424,9 +5448,9 @@ dependencies = [
 
 [[package]]
 name = "tiberius"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66303a42b7c5daffb95c10cd8f3007a9c29b3e90128cf42b3738f58102aa2516"
+checksum = "091052ba8f20c1e14f85913a5242a663a09d17ff4c0137b9b1f0735cb3c5dabc"
 dependencies = [
  "async-native-tls",
  "async-trait",
@@ -5456,22 +5480,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -5479,16 +5495,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.11"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -5842,7 +5859,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.25",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -6080,12 +6097,13 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.11",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/pkgs/development/tools/database/prisma-engines/default.nix
+++ b/pkgs/development/tools/database/prisma-engines/default.nix
@@ -9,8 +9,8 @@
 , stdenv
 }:
 
-# Updating this package will force an update for nodePackages.prisma. The
-# version of prisma-engines and nodePackages.prisma must be the same for them to
+# Updating this package will force an update for prisma. The
+# version of prisma-engines and prisma must be the same for them to
 # function correctly.
 rustPlatform.buildRustPackage rec {
   pname = "prisma-engines";
@@ -89,7 +89,7 @@ rustPlatform.buildRustPackage rec {
 # Here's an example application using Prisma with Nix: https://github.com/pimeys/nix-prisma-example
 # At example's `flake.nix` shellHook, notice the requirement of defining environment variables for prisma, it's values will show on `prisma --version`.
 # Read the example's README: https://github.com/pimeys/nix-prisma-example/blob/main/README.md
-# Prisma requires 2 packages, `prisma-engines` and `nodePackages.prisma`, to be at *exact* same versions.
+# Prisma requires 2 packages, `prisma-engines` and `prisma`, to be at *exact* same versions.
 # Certify at `package.json` that dependencies "@prisma/client" and "prisma" are equal, meaning no caret (`^`) in version.
 # Configure NPM to use exact version: `npm config set save-exact=true`
 # Delete `package-lock.json`, delete `node_modules` directory and run `npm install`.

--- a/pkgs/development/tools/database/prisma-engines/default.nix
+++ b/pkgs/development/tools/database/prisma-engines/default.nix
@@ -14,13 +14,13 @@
 # function correctly.
 rustPlatform.buildRustPackage rec {
   pname = "prisma-engines";
-  version = "5.16.1";
+  version = "5.18.0";
 
   src = fetchFromGitHub {
     owner = "prisma";
     repo = "prisma-engines";
     rev = version;
-    hash = "sha256-uJJX5lI0YFXygWLeaOuYxjgyswJcjSujPcqHn1aKn8M=";
+    hash = "sha256-ucAOz00dBgX2Bb63ueaBbyu1XtVQD+96EncUyo7STwA=";
   };
 
   # Use system openssl.
@@ -43,6 +43,12 @@ rustPlatform.buildRustPackage rec {
     openssl
     protobuf
   ] ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  # FIXME: Workaround Rust 1.80 support by updating time to 0.3.36
+  # https://github.com/prisma/prisma-engines/issues/4989
+  postPatch = ''
+    ln -sfn ${./Cargo.lock} Cargo.lock
+  '';
 
   preBuild = ''
     export OPENSSL_DIR=${lib.getDev openssl}

--- a/pkgs/servers/pingvin-share/backend.nix
+++ b/pkgs/servers/pingvin-share/backend.nix
@@ -3,7 +3,7 @@
   buildNpmPackage,
   vips,
   pkg-config,
-  nodePackages,
+  prisma,
   src,
   version,
   nixosTests,
@@ -28,7 +28,7 @@ buildNpmPackage {
   buildInputs = [ vips ];
   nativeBuildInputs = [
     pkg-config
-    nodePackages.prisma
+    prisma
   ];
 
   npmDepsHash = "sha256-btjvX+2krSc0/bJqeLcVTqHBVWqiTFipp3MidO9wApY=";


### PR DESCRIPTION
## Description of changes

Updates `prisma-engines` to v5.18.0

Diff: https://github.com/prisma/prisma-engines/compare/5.16.1...5.18.0

Includes a patched `Cargo.lock` with the `time` crate updated to `0.3.36` which fixes builds under Rust v1.80. Updated with the command `cargo update -p time`.



See https://github.com/prisma/prisma-engines/issues/4989

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
