### PR TITLE
nixos/kanidm: fix systemd service type

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -168,3 +168,6 @@ fc7a83f8b62e90de5679e993d4d49ca014ea013d
 
 # nrr: format with nixfmt-rfc-style (#334578)
 cffc27daf06c77c0d76bc35d24b929cb9d68c3c9
+
+# nixos/kanidm: inherit lib, nixfmt
+8f18393d380079904d072007fb19dc64baef0a3a

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -371,6 +371,8 @@
 
 - Kanidm can now be provisioned using the new [`services.kanidm.provision`] option, but requires using a patched version available via `pkgs.kanidm.withSecretProvisioning`.
 
+- Kanidm previously had an incorrect systemd service type, causing dependent units with an `after` and `requires` directive to start before `kanidm*` finished startup. The module has now been updated in line with upstream recommendations.
+
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.

--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -67,8 +67,13 @@ let
   ) [ ];
 
   defaultServiceConfig = {
+    # Setting the type to notify enables additional healthchecks, ensuring units
+    # after and requiring kanidm-* wait for it to complete startup
+    Type = "notify";
     BindReadOnlyPaths = [
       "/nix/store"
+      # For healthcheck notifications
+      "/run/systemd/notify"
       "-/etc/resolv.conf"
       "-/etc/nsswitch.conf"
       "-/etc/hosts"

--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -6,10 +6,42 @@
   ...
 }:
 let
+  inherit (lib)
+    any
+    attrNames
+    attrValues
+    concatLines
+    concatLists
+    converge
+    filter
+    filterAttrs
+    filterAttrsRecursive
+    flip
+    foldl'
+    getExe
+    hasInfix
+    hasPrefix
+    isStorePath
+    last
+    mapAttrsToList
+    mkEnableOption
+    mkForce
+    mkIf
+    mkMerge
+    mkOption
+    mkPackageOption
+    optional
+    optionalString
+    splitString
+    subtractLists
+    types
+    unique
+    ;
+
   cfg = config.services.kanidm;
   settingsFormat = pkgs.formats.toml { };
   # Remove null values, so we can document optional values that don't end up in the generated TOML file.
-  filterConfig = lib.converge (lib.filterAttrsRecursive (_: v: v != null));
+  filterConfig = converge (filterAttrsRecursive (_: v: v != null));
   serverConfigFile = settingsFormat.generate "server.toml" (filterConfig cfg.serverSettings);
   clientConfigFile = settingsFormat.generate "kanidm-config.toml" (filterConfig cfg.clientSettings);
   unixConfigFile = settingsFormat.generate "kanidm-unixd.toml" (filterConfig cfg.unixSettings);
@@ -22,17 +54,14 @@ let
   # This makes sure that if e.g. the tls_chain is in the nix store and /nix/store is already in the mount
   # paths, no new bind mount is added. Adding subpaths caused problems on ofborg.
   hasPrefixInList =
-    list: newPath:
-    lib.any (path: lib.hasPrefix (builtins.toString path) (builtins.toString newPath)) list;
-  mergePaths = lib.foldl' (
+    list: newPath: any (path: hasPrefix (builtins.toString path) (builtins.toString newPath)) list;
+  mergePaths = foldl' (
     merged: newPath:
     let
       # If the new path is a prefix to some existing path, we need to filter it out
-      filteredPaths = lib.filter (
-        p: !lib.hasPrefix (builtins.toString newPath) (builtins.toString p)
-      ) merged;
+      filteredPaths = filter (p: !hasPrefix (builtins.toString newPath) (builtins.toString p)) merged;
       # If a prefix of the new path is already in the list, do not add it
-      filteredNew = lib.optional (!hasPrefixInList filteredPaths newPath) newPath;
+      filteredNew = optional (!hasPrefixInList filteredPaths newPath) newPath;
     in
     filteredPaths ++ filteredNew
   ) [ ];
@@ -84,13 +113,13 @@ let
 
   mkPresentOption =
     what:
-    lib.mkOption {
+    mkOption {
       description = "Whether to ensure that this ${what} is present or absent.";
-      type = lib.types.bool;
+      type = types.bool;
       default = true;
     };
 
-  filterPresent = lib.filterAttrs (_: v: v.present);
+  filterPresent = filterAttrs (_: v: v.present);
 
   provisionStateJson = pkgs.writeText "provision-state.json" (
     builtins.toJSON { inherit (cfg.provision) groups persons systems; }
@@ -98,7 +127,7 @@ let
 
   # Only recover the admin account if a password should explicitly be provisioned
   # for the account. Otherwise it is not needed for provisioning.
-  maybeRecoverAdmin = lib.optionalString (cfg.provision.adminPasswordFile != null) ''
+  maybeRecoverAdmin = optionalString (cfg.provision.adminPasswordFile != null) ''
     KANIDM_ADMIN_PASSWORD=$(< ${cfg.provision.adminPasswordFile})
     # We always reset the admin account password if a desired password was specified.
     if ! KANIDM_RECOVER_ACCOUNT_PASSWORD=$KANIDM_ADMIN_PASSWORD ${cfg.package}/bin/kanidmd recover-account -c ${serverConfigFile} admin --from-environment >/dev/null; then
@@ -128,7 +157,7 @@ let
           echo "kanidm provision: Failed to recover admin account" >&2
           exit 1
         fi
-        if ! KANIDM_IDM_ADMIN_PASSWORD=$(grep '{"password' <<< "$recover_out" | ${lib.getExe pkgs.jq} -r .password); then
+        if ! KANIDM_IDM_ADMIN_PASSWORD=$(grep '{"password' <<< "$recover_out" | ${getExe pkgs.jq} -r .password); then
           echo "$recover_out" >&2
           echo "kanidm provision: Failed to parse password for idm_admin account" >&2
           exit 1
@@ -140,8 +169,8 @@ let
 
     # Wait for the kanidm server to come online
     count=0
-    while ! ${lib.getExe pkgs.curl} -L --silent --max-time 1 --connect-timeout 1 --fail \
-       ${lib.optionalString cfg.provision.acceptInvalidCerts "--insecure"} \
+    while ! ${getExe pkgs.curl} -L --silent --max-time 1 --connect-timeout 1 --fail \
+       ${optionalString cfg.provision.acceptInvalidCerts "--insecure"} \
        ${cfg.provision.instanceUrl} >/dev/null
     do
       sleep 1
@@ -156,58 +185,58 @@ let
     ${maybeRecoverAdmin}
 
     KANIDM_PROVISION_IDM_ADMIN_TOKEN=$KANIDM_IDM_ADMIN_PASSWORD \
-      ${lib.getExe pkgs.kanidm-provision} \
-        ${lib.optionalString (!cfg.provision.autoRemove) "--no-auto-remove"} \
-        ${lib.optionalString cfg.provision.acceptInvalidCerts "--accept-invalid-certs"} \
+      ${getExe pkgs.kanidm-provision} \
+        ${optionalString (!cfg.provision.autoRemove) "--no-auto-remove"} \
+        ${optionalString cfg.provision.acceptInvalidCerts "--accept-invalid-certs"} \
         --url "${cfg.provision.instanceUrl}" \
         --state ${provisionStateJson}
   '';
 
   serverPort =
     # ipv6:
-    if lib.hasInfix "]:" cfg.serverSettings.bindaddress then
-      lib.last (lib.splitString "]:" cfg.serverSettings.bindaddress)
+    if hasInfix "]:" cfg.serverSettings.bindaddress then
+      last (splitString "]:" cfg.serverSettings.bindaddress)
     else
     # ipv4:
-    if lib.hasInfix "." cfg.serverSettings.bindaddress then
-      lib.last (lib.splitString ":" cfg.serverSettings.bindaddress)
+    if hasInfix "." cfg.serverSettings.bindaddress then
+      last (splitString ":" cfg.serverSettings.bindaddress)
     # default is 8443
     else
       "8443";
 in
 {
   options.services.kanidm = {
-    enableClient = lib.mkEnableOption "the Kanidm client";
-    enableServer = lib.mkEnableOption "the Kanidm server";
-    enablePam = lib.mkEnableOption "the Kanidm PAM and NSS integration";
+    enableClient = mkEnableOption "the Kanidm client";
+    enableServer = mkEnableOption "the Kanidm server";
+    enablePam = mkEnableOption "the Kanidm PAM and NSS integration";
 
-    package = lib.mkPackageOption pkgs "kanidm" { };
+    package = mkPackageOption pkgs "kanidm" { };
 
-    serverSettings = lib.mkOption {
-      type = lib.types.submodule {
+    serverSettings = mkOption {
+      type = types.submodule {
         freeformType = settingsFormat.type;
 
         options = {
-          bindaddress = lib.mkOption {
+          bindaddress = mkOption {
             description = "Address/port combination the webserver binds to.";
             example = "[::1]:8443";
-            type = lib.types.str;
+            type = types.str;
           };
           # Should be optional but toml does not accept null
-          ldapbindaddress = lib.mkOption {
+          ldapbindaddress = mkOption {
             description = ''
               Address and port the LDAP server is bound to. Setting this to `null` disables the LDAP interface.
             '';
             example = "[::1]:636";
             default = null;
-            type = lib.types.nullOr lib.types.str;
+            type = types.nullOr types.str;
           };
-          origin = lib.mkOption {
+          origin = mkOption {
             description = "The origin of your Kanidm instance. Must have https as protocol.";
             example = "https://idm.example.org";
-            type = lib.types.strMatching "^https://.*";
+            type = types.strMatching "^https://.*";
           };
-          domain = lib.mkOption {
+          domain = mkOption {
             description = ''
               The `domain` that Kanidm manages. Must be below or equal to the domain
               specified in `serverSettings.origin`.
@@ -218,58 +247,58 @@ in
             '';
             example = "example.org";
             default = null;
-            type = lib.types.nullOr lib.types.str;
+            type = types.nullOr types.str;
           };
-          db_path = lib.mkOption {
+          db_path = mkOption {
             description = "Path to Kanidm database.";
             default = "/var/lib/kanidm/kanidm.db";
             readOnly = true;
-            type = lib.types.path;
+            type = types.path;
           };
-          tls_chain = lib.mkOption {
+          tls_chain = mkOption {
             description = "TLS chain in pem format.";
-            type = lib.types.path;
+            type = types.path;
           };
-          tls_key = lib.mkOption {
+          tls_key = mkOption {
             description = "TLS key in pem format.";
-            type = lib.types.path;
+            type = types.path;
           };
-          log_level = lib.mkOption {
+          log_level = mkOption {
             description = "Log level of the server.";
             default = "info";
-            type = lib.types.enum [
+            type = types.enum [
               "info"
               "debug"
               "trace"
             ];
           };
-          role = lib.mkOption {
+          role = mkOption {
             description = "The role of this server. This affects the replication relationship and thereby available features.";
             default = "WriteReplica";
-            type = lib.types.enum [
+            type = types.enum [
               "WriteReplica"
               "WriteReplicaNoUI"
               "ReadOnlyReplica"
             ];
           };
           online_backup = {
-            path = lib.mkOption {
+            path = mkOption {
               description = "Path to the output directory for backups.";
-              type = lib.types.path;
+              type = types.path;
               default = "/var/lib/kanidm/backups";
             };
-            schedule = lib.mkOption {
+            schedule = mkOption {
               description = "The schedule for backups in cron format.";
-              type = lib.types.str;
+              type = types.str;
               default = "00 22 * * *";
             };
-            versions = lib.mkOption {
+            versions = mkOption {
               description = ''
                 Number of backups to keep.
 
                 The default is set to `0`, in order to disable backups by default.
               '';
-              type = lib.types.ints.unsigned;
+              type = types.ints.unsigned;
               default = 0;
               example = 7;
             };
@@ -285,14 +314,14 @@ in
       '';
     };
 
-    clientSettings = lib.mkOption {
-      type = lib.types.submodule {
+    clientSettings = mkOption {
+      type = types.submodule {
         freeformType = settingsFormat.type;
 
-        options.uri = lib.mkOption {
+        options.uri = mkOption {
           description = "Address of the Kanidm server.";
           example = "http://127.0.0.1:8080";
-          type = lib.types.str;
+          type = types.str;
         };
       };
       description = ''
@@ -303,20 +332,20 @@ in
       '';
     };
 
-    unixSettings = lib.mkOption {
-      type = lib.types.submodule {
+    unixSettings = mkOption {
+      type = types.submodule {
         freeformType = settingsFormat.type;
 
         options = {
-          pam_allowed_login_groups = lib.mkOption {
+          pam_allowed_login_groups = mkOption {
             description = "Kanidm groups that are allowed to login using PAM.";
             example = "my_pam_group";
-            type = lib.types.listOf lib.types.str;
+            type = types.listOf types.str;
           };
-          hsm_pin_path = lib.mkOption {
+          hsm_pin_path = mkOption {
             description = "Path to a HSM pin.";
             default = "/var/cache/kanidm-unixd/hsm-pin";
-            type = lib.types.path;
+            type = types.path;
           };
         };
       };
@@ -329,73 +358,73 @@ in
     };
 
     provision = {
-      enable = lib.mkEnableOption "provisioning of groups, users and oauth2 resource servers";
+      enable = mkEnableOption "provisioning of groups, users and oauth2 resource servers";
 
-      instanceUrl = lib.mkOption {
+      instanceUrl = mkOption {
         description = "The instance url to which the provisioning tool should connect.";
         default = "https://localhost:${serverPort}";
         defaultText = ''"https://localhost:<port from serverSettings.bindaddress>"'';
-        type = lib.types.str;
+        type = types.str;
       };
 
-      acceptInvalidCerts = lib.mkOption {
+      acceptInvalidCerts = mkOption {
         description = ''
           Whether to allow invalid certificates when provisioning the target instance.
           By default this is only allowed when the instanceUrl is localhost. This is
           dangerous when used with an external URL.
         '';
-        type = lib.types.bool;
-        default = lib.hasPrefix "https://localhost:" cfg.provision.instanceUrl;
-        defaultText = ''lib.hasPrefix "https://localhost:" cfg.provision.instanceUrl'';
+        type = types.bool;
+        default = hasPrefix "https://localhost:" cfg.provision.instanceUrl;
+        defaultText = ''hasPrefix "https://localhost:" cfg.provision.instanceUrl'';
       };
 
-      adminPasswordFile = lib.mkOption {
+      adminPasswordFile = mkOption {
         description = "Path to a file containing the admin password for kanidm. Do NOT use a file from the nix store here!";
         example = "/run/secrets/kanidm-admin-password";
         default = null;
-        type = lib.types.nullOr lib.types.path;
+        type = types.nullOr types.path;
       };
 
-      idmAdminPasswordFile = lib.mkOption {
+      idmAdminPasswordFile = mkOption {
         description = ''
           Path to a file containing the idm admin password for kanidm. Do NOT use a file from the nix store here!
           If this is not given but provisioning is enabled, the idm_admin password will be reset on each restart.
         '';
         example = "/run/secrets/kanidm-idm-admin-password";
         default = null;
-        type = lib.types.nullOr lib.types.path;
+        type = types.nullOr types.path;
       };
 
-      autoRemove = lib.mkOption {
+      autoRemove = mkOption {
         description = ''
           Determines whether deleting an entity in this provisioning config should automatically
           cause them to be removed from kanidm, too. This works because the provisioning tool tracks
           all entities it has ever created. If this is set to false, you need to explicitly specify
           `present = false` to delete an entity.
         '';
-        type = lib.types.bool;
+        type = types.bool;
         default = true;
       };
 
-      groups = lib.mkOption {
+      groups = mkOption {
         description = "Provisioning of kanidm groups";
         default = { };
-        type = lib.types.attrsOf (
-          lib.types.submodule (groupSubmod: {
+        type = types.attrsOf (
+          types.submodule (groupSubmod: {
             options = {
               present = mkPresentOption "group";
 
-              members = lib.mkOption {
+              members = mkOption {
                 description = "List of kanidm entities (persons, groups, ...) which are part of this group.";
-                type = lib.types.listOf lib.types.str;
-                apply = lib.unique;
+                type = types.listOf types.str;
+                apply = unique;
                 default = [ ];
               };
             };
-            config.members = lib.concatLists (
-              lib.flip lib.mapAttrsToList cfg.provision.persons (
+            config.members = concatLists (
+              flip mapAttrsToList cfg.provision.persons (
                 person: personCfg:
-                lib.optional (
+                optional (
                   personCfg.present && builtins.elem groupSubmod.config._module.args.name personCfg.groups
                 ) person
               )
@@ -404,38 +433,38 @@ in
         );
       };
 
-      persons = lib.mkOption {
+      persons = mkOption {
         description = "Provisioning of kanidm persons";
         default = { };
-        type = lib.types.attrsOf (
-          lib.types.submodule {
+        type = types.attrsOf (
+          types.submodule {
             options = {
               present = mkPresentOption "person";
 
-              displayName = lib.mkOption {
+              displayName = mkOption {
                 description = "Display name";
-                type = lib.types.str;
+                type = types.str;
                 example = "My User";
               };
 
-              legalName = lib.mkOption {
+              legalName = mkOption {
                 description = "Full legal name";
-                type = lib.types.nullOr lib.types.str;
+                type = types.nullOr types.str;
                 example = "Jane Doe";
                 default = null;
               };
 
-              mailAddresses = lib.mkOption {
+              mailAddresses = mkOption {
                 description = "Mail addresses. First given address is considered the primary address.";
-                type = lib.types.listOf lib.types.str;
+                type = types.listOf types.str;
                 example = [ "jane.doe@example.com" ];
                 default = [ ];
               };
 
-              groups = lib.mkOption {
+              groups = mkOption {
                 description = "List of groups this person should belong to.";
-                type = lib.types.listOf lib.types.str;
-                apply = lib.unique;
+                type = types.listOf types.str;
+                apply = unique;
                 default = [ ];
               };
             };
@@ -443,119 +472,119 @@ in
         );
       };
 
-      systems.oauth2 = lib.mkOption {
+      systems.oauth2 = mkOption {
         description = "Provisioning of oauth2 resource servers";
         default = { };
-        type = lib.types.attrsOf (
-          lib.types.submodule {
+        type = types.attrsOf (
+          types.submodule {
             options = {
               present = mkPresentOption "oauth2 resource server";
 
-              public = lib.mkOption {
+              public = mkOption {
                 description = "Whether this is a public client (enforces PKCE, doesn't use a basic secret)";
-                type = lib.types.bool;
+                type = types.bool;
                 default = false;
               };
 
-              displayName = lib.mkOption {
+              displayName = mkOption {
                 description = "Display name";
-                type = lib.types.str;
+                type = types.str;
                 example = "Some Service";
               };
 
-              originUrl = lib.mkOption {
+              originUrl = mkOption {
                 description = "The origin URL of the service. OAuth2 redirects will only be allowed to sites under this origin. Must end with a slash.";
                 type =
                   let
-                    originStrType = lib.types.strMatching ".*://.*/$";
+                    originStrType = types.strMatching ".*://.*/$";
                   in
-                  lib.types.either originStrType (lib.types.nonEmptyListOf originStrType);
+                  types.either originStrType (types.nonEmptyListOf originStrType);
                 example = "https://someservice.example.com/";
               };
 
-              originLanding = lib.mkOption {
+              originLanding = mkOption {
                 description = "When redirecting from the Kanidm Apps Listing page, some linked applications may need to land on a specific page to trigger oauth2/oidc interactions.";
-                type = lib.types.str;
+                type = types.str;
                 example = "https://someservice.example.com/home";
               };
 
-              basicSecretFile = lib.mkOption {
+              basicSecretFile = mkOption {
                 description = ''
                   The basic secret to use for this service. If null, the random secret generated
                   by kanidm will not be touched. Do NOT use a path from the nix store here!
                 '';
-                type = lib.types.nullOr lib.types.path;
+                type = types.nullOr types.path;
                 example = "/run/secrets/some-oauth2-basic-secret";
                 default = null;
               };
 
-              enableLocalhostRedirects = lib.mkOption {
+              enableLocalhostRedirects = mkOption {
                 description = "Allow localhost redirects. Only for public clients.";
-                type = lib.types.bool;
+                type = types.bool;
                 default = false;
               };
 
-              enableLegacyCrypto = lib.mkOption {
+              enableLegacyCrypto = mkOption {
                 description = "Enable legacy crypto on this client. Allows JWT signing algorthms like RS256.";
-                type = lib.types.bool;
+                type = types.bool;
                 default = false;
               };
 
-              allowInsecureClientDisablePkce = lib.mkOption {
+              allowInsecureClientDisablePkce = mkOption {
                 description = ''
                   Disable PKCE on this oauth2 resource server to work around insecure clients
                   that may not support it. You should request the client to enable PKCE!
                   Only for non-public clients.
                 '';
-                type = lib.types.bool;
+                type = types.bool;
                 default = false;
               };
 
-              preferShortUsername = lib.mkOption {
+              preferShortUsername = mkOption {
                 description = "Use 'name' instead of 'spn' in the preferred_username claim";
-                type = lib.types.bool;
+                type = types.bool;
                 default = false;
               };
 
-              scopeMaps = lib.mkOption {
+              scopeMaps = mkOption {
                 description = ''
                   Maps kanidm groups to returned oauth scopes.
                   See [Scope Relations](https://kanidm.github.io/kanidm/stable/integrations/oauth2.html#scope-relationships) for more information.
                 '';
-                type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+                type = types.attrsOf (types.listOf types.str);
                 default = { };
               };
 
-              supplementaryScopeMaps = lib.mkOption {
+              supplementaryScopeMaps = mkOption {
                 description = ''
                   Maps kanidm groups to additionally returned oauth scopes.
                   See [Scope Relations](https://kanidm.github.io/kanidm/stable/integrations/oauth2.html#scope-relationships) for more information.
                 '';
-                type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+                type = types.attrsOf (types.listOf types.str);
                 default = { };
               };
 
-              removeOrphanedClaimMaps = lib.mkOption {
+              removeOrphanedClaimMaps = mkOption {
                 description = "Whether claim maps not specified here but present in kanidm should be removed from kanidm.";
-                type = lib.types.bool;
+                type = types.bool;
                 default = true;
               };
 
-              claimMaps = lib.mkOption {
+              claimMaps = mkOption {
                 description = ''
                   Adds additional claims (and values) based on which kanidm groups an authenticating party belongs to.
                   See [Claim Maps](https://kanidm.github.io/kanidm/master/integrations/oauth2.html#custom-claim-maps) for more information.
                 '';
                 default = { };
-                type = lib.types.attrsOf (
-                  lib.types.submodule {
+                type = types.attrsOf (
+                  types.submodule {
                     options = {
-                      joinType = lib.mkOption {
+                      joinType = mkOption {
                         description = ''
                           Determines how multiple values are joined to create the claim value.
                           See [Claim Maps](https://kanidm.github.io/kanidm/master/integrations/oauth2.html#custom-claim-maps) for more information.
                         '';
-                        type = lib.types.enum [
+                        type = types.enum [
                           "array"
                           "csv"
                           "ssv"
@@ -563,10 +592,10 @@ in
                         default = "array";
                       };
 
-                      valuesByGroup = lib.mkOption {
+                      valuesByGroup = mkOption {
                         description = "Maps kanidm groups to values for the claim.";
                         default = { };
-                        type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+                        type = types.attrsOf (types.listOf types.str);
                       };
                     };
                   }
@@ -579,26 +608,26 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.enableClient || cfg.enableServer || cfg.enablePam) {
+  config = mkIf (cfg.enableClient || cfg.enableServer || cfg.enablePam) {
     assertions =
       let
         entityList =
-          type: attrs: lib.flip lib.mapAttrsToList (filterPresent attrs) (name: _: { inherit type name; });
+          type: attrs: flip mapAttrsToList (filterPresent attrs) (name: _: { inherit type name; });
         entities =
           entityList "group" cfg.provision.groups
           ++ entityList "person" cfg.provision.persons
           ++ entityList "oauth2" cfg.provision.systems.oauth2;
 
         # Accumulate entities by name. Track corresponding entity types for later duplicate check.
-        entitiesByName = lib.foldl' (
+        entitiesByName = foldl' (
           acc: { type, name }: acc // { ${name} = (acc.${name} or [ ]) ++ [ type ]; }
         ) { } entities;
 
         assertGroupsKnown =
           opt: groups:
           let
-            knownGroups = lib.attrNames (filterPresent cfg.provision.groups);
-            unknownGroups = lib.subtractLists knownGroups groups;
+            knownGroups = attrNames (filterPresent cfg.provision.groups);
+            unknownGroups = subtractLists knownGroups groups;
           in
           {
             assertion = (cfg.enableServer && cfg.provision.enable) -> unknownGroups == [ ];
@@ -608,7 +637,7 @@ in
         assertEntitiesKnown =
           opt: entities:
           let
-            unknownEntities = lib.subtractLists (lib.attrNames entitiesByName) entities;
+            unknownEntities = subtractLists (attrNames entitiesByName) entities;
           in
           {
             assertion = (cfg.enableServer && cfg.provision.enable) -> unknownEntities == [ ];
@@ -620,7 +649,7 @@ in
           assertion =
             !cfg.enableServer
             || ((cfg.serverSettings.tls_chain or null) == null)
-            || (!lib.isStorePath cfg.serverSettings.tls_chain);
+            || (!isStorePath cfg.serverSettings.tls_chain);
           message = ''
             <option>services.kanidm.serverSettings.tls_chain</option> points to
             a file in the Nix store. You should use a quoted absolute path to
@@ -631,7 +660,7 @@ in
           assertion =
             !cfg.enableServer
             || ((cfg.serverSettings.tls_key or null) == null)
-            || (!lib.isStorePath cfg.serverSettings.tls_key);
+            || (!isStorePath cfg.serverSettings.tls_key);
           message = ''
             <option>services.kanidm.serverSettings.tls_key</option> points to
             a file in the Nix store. You should use a quoted absolute path to
@@ -677,9 +706,7 @@ in
               && (
                 cfg.provision.adminPasswordFile != null
                 || cfg.provision.idmAdminPasswordFile != null
-                || lib.any (x: x.basicSecretFile != null) (
-                  lib.attrValues (filterPresent cfg.provision.systems.oauth2)
-                )
+                || any (x: x.basicSecretFile != null) (attrValues (filterPresent cfg.provision.systems.oauth2))
               )
             )
             -> cfg.package.enableSecretProvisioning;
@@ -692,48 +719,48 @@ in
         (
           let
             # Filter all names that occurred in more than one entity type.
-            duplicateNames = lib.filterAttrs (_: v: builtins.length v > 1) entitiesByName;
+            duplicateNames = filterAttrs (_: v: builtins.length v > 1) entitiesByName;
           in
           {
             assertion = cfg.provision.enable -> duplicateNames == { };
             message = ''
               services.kanidm.provision requires all entity names (group, person, oauth2, ...) to be unique!
-              ${lib.concatLines (
-                lib.mapAttrsToList (name: xs: "  - '${name}' used as: ${toString xs}") duplicateNames
+              ${concatLines (
+                mapAttrsToList (name: xs: "  - '${name}' used as: ${toString xs}") duplicateNames
               )}'';
           }
         )
       ]
-      ++ lib.flip lib.mapAttrsToList (filterPresent cfg.provision.persons) (
+      ++ flip mapAttrsToList (filterPresent cfg.provision.persons) (
         person: personCfg:
         assertGroupsKnown "services.kanidm.provision.persons.${person}.groups" personCfg.groups
       )
-      ++ lib.flip lib.mapAttrsToList (filterPresent cfg.provision.groups) (
+      ++ flip mapAttrsToList (filterPresent cfg.provision.groups) (
         group: groupCfg:
         assertEntitiesKnown "services.kanidm.provision.groups.${group}.members" groupCfg.members
       )
-      ++ lib.concatLists (
-        lib.flip lib.mapAttrsToList (filterPresent cfg.provision.systems.oauth2) (
+      ++ concatLists (
+        flip mapAttrsToList (filterPresent cfg.provision.systems.oauth2) (
           oauth2: oauth2Cfg:
           [
             (assertGroupsKnown "services.kanidm.provision.systems.oauth2.${oauth2}.scopeMaps" (
-              lib.attrNames oauth2Cfg.scopeMaps
+              attrNames oauth2Cfg.scopeMaps
             ))
             (assertGroupsKnown "services.kanidm.provision.systems.oauth2.${oauth2}.supplementaryScopeMaps" (
-              lib.attrNames oauth2Cfg.supplementaryScopeMaps
+              attrNames oauth2Cfg.supplementaryScopeMaps
             ))
           ]
-          ++ lib.concatLists (
-            lib.flip lib.mapAttrsToList oauth2Cfg.claimMaps (
+          ++ concatLists (
+            flip mapAttrsToList oauth2Cfg.claimMaps (
               claim: claimCfg: [
                 (assertGroupsKnown "services.kanidm.provision.systems.oauth2.${oauth2}.claimMaps.${claim}.valuesByGroup" (
-                  lib.attrNames claimCfg.valuesByGroup
+                  attrNames claimCfg.valuesByGroup
                 ))
                 # At least one group must map to a value in each claim map
                 {
                   assertion =
                     (cfg.provision.enable && cfg.enableServer)
-                    -> lib.any (xs: xs != [ ]) (lib.attrValues claimCfg.valuesByGroup);
+                    -> any (xs: xs != [ ]) (attrValues claimCfg.valuesByGroup);
                   message = "services.kanidm.provision.systems.oauth2.${oauth2}.claimMaps.${claim} does not specify any values for any group";
                 }
                 # Public clients cannot define a basic secret
@@ -762,7 +789,7 @@ in
         )
       );
 
-    environment.systemPackages = lib.mkIf cfg.enableClient [ cfg.package ];
+    environment.systemPackages = mkIf cfg.enableClient [ cfg.package ];
 
     systemd.tmpfiles.settings."10-kanidm" = {
       ${cfg.serverSettings.online_backup.path}.d = {
@@ -772,11 +799,11 @@ in
       };
     };
 
-    systemd.services.kanidm = lib.mkIf cfg.enableServer {
+    systemd.services.kanidm = mkIf cfg.enableServer {
       description = "kanidm identity management daemon";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      serviceConfig = lib.mkMerge [
+      serviceConfig = mkMerge [
         # Merge paths and ignore existing prefixes needs to sidestep mkMerge
         (
           defaultServiceConfig
@@ -789,7 +816,7 @@ in
           StateDirectoryMode = "0700";
           RuntimeDirectory = "kanidmd";
           ExecStart = "${cfg.package}/bin/kanidmd server -c ${serverConfigFile}";
-          ExecStartPost = lib.mkIf cfg.provision.enable postStartScript;
+          ExecStartPost = mkIf cfg.provision.enable postStartScript;
           User = "kanidm";
           Group = "kanidm";
 
@@ -803,9 +830,9 @@ in
           AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
           CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
           # This would otherwise override the CAP_NET_BIND_SERVICE capability.
-          PrivateUsers = lib.mkForce false;
+          PrivateUsers = mkForce false;
           # Port needs to be exposed to the host network
-          PrivateNetwork = lib.mkForce false;
+          PrivateNetwork = mkForce false;
           RestrictAddressFamilies = [
             "AF_INET"
             "AF_INET6"
@@ -817,7 +844,7 @@ in
       environment.RUST_LOG = "info";
     };
 
-    systemd.services.kanidm-unixd = lib.mkIf cfg.enablePam {
+    systemd.services.kanidm-unixd = mkIf cfg.enablePam {
       description = "Kanidm PAM daemon";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
@@ -825,7 +852,7 @@ in
         unixConfigFile
         clientConfigFile
       ];
-      serviceConfig = lib.mkMerge [
+      serviceConfig = mkMerge [
         defaultServiceConfig
         {
           CacheDirectory = "kanidm-unixd";
@@ -848,7 +875,7 @@ in
             "/run/kanidm-unixd:/var/run/kanidm-unixd"
           ];
           # Needs to connect to kanidmd
-          PrivateNetwork = lib.mkForce false;
+          PrivateNetwork = mkForce false;
           RestrictAddressFamilies = [
             "AF_INET"
             "AF_INET6"
@@ -860,7 +887,7 @@ in
       environment.RUST_LOG = "info";
     };
 
-    systemd.services.kanidm-unixd-tasks = lib.mkIf cfg.enablePam {
+    systemd.services.kanidm-unixd-tasks = mkIf cfg.enablePam {
       description = "Kanidm PAM home management daemon";
       wantedBy = [ "multi-user.target" ];
       after = [
@@ -910,25 +937,25 @@ in
     };
 
     # These paths are hardcoded
-    environment.etc = lib.mkMerge [
-      (lib.mkIf cfg.enableServer { "kanidm/server.toml".source = serverConfigFile; })
-      (lib.mkIf options.services.kanidm.clientSettings.isDefined {
+    environment.etc = mkMerge [
+      (mkIf cfg.enableServer { "kanidm/server.toml".source = serverConfigFile; })
+      (mkIf options.services.kanidm.clientSettings.isDefined {
         "kanidm/config".source = clientConfigFile;
       })
-      (lib.mkIf cfg.enablePam { "kanidm/unixd".source = unixConfigFile; })
+      (mkIf cfg.enablePam { "kanidm/unixd".source = unixConfigFile; })
     ];
 
-    system.nssModules = lib.mkIf cfg.enablePam [ cfg.package ];
+    system.nssModules = mkIf cfg.enablePam [ cfg.package ];
 
-    system.nssDatabases.group = lib.optional cfg.enablePam "kanidm";
-    system.nssDatabases.passwd = lib.optional cfg.enablePam "kanidm";
+    system.nssDatabases.group = optional cfg.enablePam "kanidm";
+    system.nssDatabases.passwd = optional cfg.enablePam "kanidm";
 
-    users.groups = lib.mkMerge [
-      (lib.mkIf cfg.enableServer { kanidm = { }; })
-      (lib.mkIf cfg.enablePam { kanidm-unixd = { }; })
+    users.groups = mkMerge [
+      (mkIf cfg.enableServer { kanidm = { }; })
+      (mkIf cfg.enablePam { kanidm-unixd = { }; })
     ];
-    users.users = lib.mkMerge [
-      (lib.mkIf cfg.enableServer {
+    users.users = mkMerge [
+      (mkIf cfg.enableServer {
         kanidm = {
           description = "Kanidm server";
           isSystemUser = true;
@@ -936,7 +963,7 @@ in
           packages = [ cfg.package ];
         };
       })
-      (lib.mkIf cfg.enablePam {
+      (mkIf cfg.enablePam {
         kanidm-unixd = {
           description = "Kanidm PAM daemon";
           isSystemUser = true;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Added `inherit lib` to simplify the Kanidm module (changes taken from an earlier revision of #251598)
- The Kanidm module previously used an incorrect service type which caused a race condition for dependent units. Adding `systemd.services.<name> = { after = "kanidm-unixd.service"; requires = "kanidm-unixd.service";};` now functions as intended, waiting for `kanidm*` to report full initialization before starting.
  - _For more detailed information, see https://github.com/kanidm/kanidm/discussions/2892_

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
