### PR TITLE
cloudflare-dynamic-dns: init at 4.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23027,6 +23027,12 @@
     github = "zbioe";
     githubId = 7332055;
   };
+  zebradil = {
+    email = "german.lashevich+nixpkgs@gmail.com";
+    github = "zebradil";
+    githubId = 1475583;
+    name = "German Lashevich";
+  };
   zebreus = {
     matrix = "@lennart:cicen.net";
     email = "lennarteichhorn+nixpkgs@gmail.com";

--- a/pkgs/by-name/cl/cloudflare-dynamic-dns/package.nix
+++ b/pkgs/by-name/cl/cloudflare-dynamic-dns/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  cloudflare-dynamic-dns,
+  fetchFromGitHub,
+  testers,
+}:
+buildGoModule rec {
+  pname = "cloudflare-dynamic-dns";
+  version = "4.3.0";
+
+  src = fetchFromGitHub {
+    owner = "zebradil";
+    repo = "cloudflare-dynamic-dns";
+    rev = "refs/tags/${version}";
+    hash = "sha256-3sE4iaSkCAAMJ6FtZgXXkjb0aO73ehluY3WMQlOgxwc=";
+  };
+
+  vendorHash = "sha256-/UaTOCbE8ieCtME6AudbXE5ntCptPFoESYrdn7qK0MU=";
+
+  subPackages = ".";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${version}"
+    "-X=main.commit=nixpkg-${version}"
+    "-X=main.date=1970-01-01"
+  ];
+
+  CGO_ENABLED = 0;
+
+  passthru.tests.version = testers.testVersion { package = cloudflare-dynamic-dns; };
+
+  meta = with lib; {
+    changelog = "https://github.com/Zebradil/cloudflare-dynamic-dns/blob/${version}/CHANGELOG.md";
+    description = "Dynamic DNS client for Cloudflare";
+    homepage = "https://github.com/Zebradil/cloudflare-dynamic-dns";
+    license = licenses.mit;
+    mainProgram = "cloudflare-dynamic-dns";
+    maintainers = [ maintainers.zebradil ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds a new package: cloudflare-dynamic-dns.

## Things done

<details>
<summary>outdated note</summary>

> [!NOTE]  
> I can't build it on my machine (aarch64-darwin) with `nix build` currently due to issues with curl and certificates. I was able to build a [similar flake](https://github.com/Zebradil/cloudflare-dynamic-dns/blob/main/flake.nix), so I assume it should work. I mark this PR as draft until I can test it. But if the automation is able to build it, my tests are not necessary.

</details>

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
