### PR TITLE
assetripper: init at 1.1.3

### DIFF
--- a/pkgs/by-name/as/assetripper/deps.nix
+++ b/pkgs/by-name/as/assetripper/deps.nix
@@ -1,0 +1,373 @@
+{ fetchNuGet }:
+[
+  (fetchNuGet {
+    pname = "AsmResolver";
+    version = "6.0.0-beta.1";
+    hash = "sha256-ZW61z6Qmztdy2NaiqxvNcP5RWBIiIO6CWNnqYq0MwoA=";
+  })
+  (fetchNuGet {
+    pname = "AsmResolver.DotNet";
+    version = "6.0.0-beta.1";
+    hash = "sha256-VoTiIr2/r2my6sg2AOEeiqz9vZhWtq5mGaW2Hx90Uo4=";
+  })
+  (fetchNuGet {
+    pname = "AsmResolver.PE";
+    version = "6.0.0-beta.1";
+    hash = "sha256-tTU/flTxRJaC4gkmI/gctqIriGIMntkgTs51TqzcQlg=";
+  })
+  (fetchNuGet {
+    pname = "AsmResolver.PE.File";
+    version = "6.0.0-beta.1";
+    hash = "sha256-hPuFrpcm2VMiYEirsL4kYmAhOzjwjNXUklIfYJEonLo=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Checksum";
+    version = "1.0.0";
+    hash = "sha256-/RUgkXYya3tpl7NAEbfMoTpw8UJQodSEs0j3l4iO5t4=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.CIL";
+    version = "1.1.0";
+    hash = "sha256-cmB+Z9/HddmJPWwUsQFwSdfQiN+PDopa4R/N3aaAAeE=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.CIL";
+    version = "1.1.1";
+    hash = "sha256-N9XESLSwPWkgoPJ4RbxX+0bOsSbOstVZur3EeD92kE4=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Gee.External.Capstone";
+    version = "2.3.2";
+    hash = "sha256-IrcwjWUR0hAO2dmDVIFCd82pJYnpnrRrUMd8Z0dcVjk=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.HashAlgorithms";
+    version = "1.0.0";
+    hash = "sha256-z2ryExCXJymw2UsdZxKseYPWQWg5aJe9surz5QABof4=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.IO.Endian";
+    version = "1.1.0";
+    hash = "sha256-z5HWpVKW6qqnnzfkw427m3C9BsGFqQfE7/tv0igE+4U=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Mining.PredefinedAssets";
+    version = "1.3.2";
+    hash = "sha256-VosgW8cGxiBxe6dR6vaeGDH5hmvytU2oPgTPtnuo2Uk=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Primitives";
+    version = "2.0.1";
+    hash = "sha256-RCe+06jfz3Kf5K9AtEaT9F80hIpm/WeROs5+h8X7AxU=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Primitives";
+    version = "3.1.2";
+    hash = "sha256-8+ColCmLU5JM3S14ylyGRZE/syuds0+XLO0QHHfNfEM=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Primitives";
+    version = "3.1.3";
+    hash = "sha256-17RT4wzgcZwzWjS92fX9lsZk91BKxEM8/kHc5aG/WU0=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.SourceGenerated";
+    version = "1.1.3";
+    hash = "sha256-LG24/Y47iyu3VS/FG+JJUtS3lthfMzfnXD6dw+Tggkc=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Text.Html";
+    version = "1.0.0";
+    hash = "sha256-7dYAUOX/w0QIQPUXSCTHHKhNZADok2LE/zKxM83yqBs=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Text.SourceGeneration";
+    version = "1.1.0";
+    hash = "sha256-MfdxUjmIkGz9KiSFfwogM/tgl5MyOKrsaEeBf0jEAr8=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.TextureDecoder";
+    version = "2.2.1";
+    hash = "sha256-phuI2QVxqRHigl8PugFMfcZlnqtQGEXKmTtw97HVB/4=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Tpk";
+    version = "1.0.0";
+    hash = "sha256-/a5MDXNNLeXNeCJuxhNpFaeOv//xbmYRuUM6xlReE+8=";
+  })
+  (fetchNuGet {
+    pname = "CppSharp.Runtime";
+    version = "1.1.5.3168";
+    hash = "sha256-pVViQ1RqwH2B/H3yxULpjnVj1FW3XMTVAgRJ6RXqbRg=";
+  })
+  (fetchNuGet {
+    pname = "Disarm";
+    version = "2022.1.0-master.34";
+    hash = "sha256-Kz5wI8cmsF2YkCULu0VaQ9ukn7VkI+pOElfiYAspft8=";
+  })
+  (fetchNuGet {
+    pname = "DXDecompiler-ly";
+    version = "0.0.1";
+    hash = "sha256-R8Nyy60qOPru3SH5mPGNL1/tUKwqbxNq2QqbveoYznc=";
+  })
+  (fetchNuGet {
+    pname = "Echo";
+    version = "0.9.0.1";
+    hash = "sha256-7sr8afPgsAqVWfz0mZFfwGZJArPeLicL4P+3pjb1CoE=";
+    url = "https://nuget.washi.dev/v3/package/echo/0.9.0.1/echo.0.9.0.1.nupkg";
+  })
+  (fetchNuGet {
+    pname = "Echo.Ast";
+    version = "0.9.0.1";
+    hash = "sha256-sHuXHoJLF7lNW0O5khCbWvqkMxKp4/cYA1GOFDRlFzE=";
+    url = "https://nuget.washi.dev/v3/package/echo.ast/0.9.0.1/echo.ast.0.9.0.1.nupkg";
+  })
+  (fetchNuGet {
+    pname = "Echo.ControlFlow";
+    version = "0.9.0.1";
+    hash = "sha256-vqlikJBUnxE+o/FU07Cfpigbnk4SfcFXxsEYJZaw5f4=";
+    url = "https://nuget.washi.dev/v3/package/echo.controlflow/0.9.0.1/echo.controlflow.0.9.0.1.nupkg";
+  })
+  (fetchNuGet {
+    pname = "Echo.DataFlow";
+    version = "0.9.0.1";
+    hash = "sha256-xiYJSXHhnvmJsBxyGIlz9KrkQTtMhKf0Ak7KdLUTPHE=";
+    url = "https://nuget.washi.dev/v3/package/echo.dataflow/0.9.0.1/echo.dataflow.0.9.0.1.nupkg";
+  })
+  (fetchNuGet {
+    pname = "Echo.Platforms.AsmResolver";
+    version = "0.9.0.1";
+    hash = "sha256-1SNv9DzdxZF/4VmaRw9r6tbl1egXo1V/fq1IIYTrQQo=";
+    url = "https://nuget.washi.dev/v3/package/echo.platforms.asmresolver/0.9.0.1/echo.platforms.asmresolver.0.9.0.1.nupkg";
+  })
+  (fetchNuGet {
+    pname = "Fmod5Sharp";
+    version = "3.0.1";
+    hash = "sha256-Od9D7s20ONwuD1V6ZUCKkCyLR57pX8GRDuDs5oZzc+I=";
+  })
+  (fetchNuGet {
+    pname = "Iced";
+    version = "1.21.0";
+    hash = "sha256-0xYTYX4935Ejm7yUqMWHhJtCNuj4oqK6Weojl6FIfHo=";
+  })
+  (fetchNuGet {
+    pname = "ICSharpCode.Decompiler";
+    version = "8.2.0.7535";
+    hash = "sha256-4BWs04Va9pc/SLeMA/vKoBydhw+Bu6s9MDtoo/Ucft8=";
+  })
+  (fetchNuGet {
+    pname = "IndexRange";
+    version = "1.0.2";
+    hash = "sha256-bsoOY0HLG+nsjdeA3XiTOq0NSvXIz/xasFdSMe6svWQ=";
+  })
+  (fetchNuGet {
+    pname = "K4os.Compression.LZ4";
+    version = "1.3.6";
+    hash = "sha256-Vo2ofh0MNkxcvJZUkNPqft/IoA1QcU/awItB2i17rfs=";
+  })
+  (fetchNuGet {
+    pname = "K4os.Compression.LZ4";
+    version = "1.3.8";
+    hash = "sha256-OmT3JwO4qpkZDL7XqiFqZCyxySj64s9t+mXcN1T+IyA=";
+  })
+  (fetchNuGet {
+    pname = "Kyaru.Texture2DDecoder";
+    version = "0.17.0";
+    hash = "sha256-8eHFAZ8Y00C9g4ZmUTxYrgqIr4gxMwTM7vtxER8w29g=";
+  })
+  (fetchNuGet {
+    pname = "Kyaru.Texture2DDecoder.Linux";
+    version = "0.1.0";
+    hash = "sha256-Wrk4NnAGx3E/3zRn03822Zzfcuyx7U4+54NbAe7Mc58=";
+  })
+  (fetchNuGet {
+    pname = "Kyaru.Texture2DDecoder.macOS";
+    version = "0.1.0";
+    hash = "sha256-BjioRXZSKONx5A1v7HAQtYzhVpMHCzfsi6XvyxLdO0s=";
+  })
+  (fetchNuGet {
+    pname = "Kyaru.Texture2DDecoder.Windows";
+    version = "0.1.0";
+    hash = "sha256-I4Huq7yZFFVX+9lAebuKf88LVj+oKQB5AetnwalEhlA=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Win32.SystemEvents";
+    version = "8.0.0";
+    hash = "sha256-UcxurEamYD+Bua0PbPNMYAZaRulMrov8CfbJGIgTaRQ=";
+  })
+  (fetchNuGet {
+    pname = "NativeFileDialogs.AutoGen";
+    version = "1.2.1";
+    hash = "sha256-ezWtfTAwwbosn/+U4NyRJY1wv6ZQ8kjE2KiFL91VWJ4=";
+  })
+  (fetchNuGet {
+    pname = "NativeFileDialogs.Net";
+    version = "1.2.1";
+    hash = "sha256-UtQoc2fl0VANS2gzbFvh+anb+6pQ51++IeD69rOa/8M=";
+  })
+  (fetchNuGet {
+    pname = "NativeFileDialogs.Net.Runtime";
+    version = "1.2.1";
+    hash = "sha256-rHygKqoEVQyLysc7FiUm/FBOG9FjUeEbSNuVOlACKYM=";
+  })
+  (fetchNuGet {
+    pname = "NAudio.Core";
+    version = "2.2.1";
+    hash = "sha256-eUZF2/0w5IgGY9UtnZIk1VwwH6VCKP9iPJXVcseIc0c=";
+  })
+  (fetchNuGet {
+    pname = "NAudio.Vorbis";
+    version = "1.5.0";
+    hash = "sha256-FX5EHVRLcWfjY+/NhkUf33fMFrTcPG3Ztm5ptmu1caw=";
+  })
+  (fetchNuGet {
+    pname = "NVorbis";
+    version = "0.10.4";
+    hash = "sha256-6ZouAJWaNge6DFnLHDr35uf4vs6Kf12RPp4ahuEejlA=";
+  })
+  (fetchNuGet {
+    pname = "OggVorbisEncoder";
+    version = "1.2.0";
+    hash = "sha256-5UhHf3JJUTG968Bst/cLR30qMTe1AntntDIv8w1IkFY=";
+  })
+  (fetchNuGet {
+    pname = "Samboy063.Cpp2IL.Core";
+    version = "2022.1.0-pre-release.15";
+    hash = "sha256-o3sp4WgDhkUdxgaDf6/5Xl1WyPfj/tLNHIWjz/BWYwA=";
+  })
+  (fetchNuGet {
+    pname = "Samboy063.LibCpp2IL";
+    version = "2022.1.0-pre-release.15";
+    hash = "sha256-n5vkGXvnxnkzDggiZJzJcKIgAYAEnDQEonDgkKWvO6M=";
+  })
+  (fetchNuGet {
+    pname = "Samboy063.WasmDisassembler";
+    version = "2022.1.0-pre-release.15";
+    hash = "sha256-vf2ZOVEmu16Amye1OKpx0a1BwRAj6MHwO0JY/uUHJv8=";
+  })
+  (fetchNuGet {
+    pname = "SharpCompress";
+    version = "0.34.1";
+    hash = "sha256-MU7npOq2gSqcI1IPRCjlQIXH8EaAIG0ebk51d9L0AlQ=";
+  })
+  (fetchNuGet {
+    pname = "SharpCompress";
+    version = "0.37.2";
+    hash = "sha256-IP7/ssqWKT85YwLKrLGACHo0sgp7sMe603X+o485sYo=";
+  })
+  (fetchNuGet {
+    pname = "SharpGLTF.Core";
+    version = "1.0.1";
+    hash = "sha256-3aVy/jswB+mMEO8YoUEmgJ/V1fb7LPRCmB0iUodP9YU=";
+  })
+  (fetchNuGet {
+    pname = "SharpGLTF.Runtime";
+    version = "1.0.1";
+    hash = "sha256-yY7wqBxa5jG652jnsEVv+V4+8k6860Q06b9/JPqJY4Q=";
+  })
+  (fetchNuGet {
+    pname = "SharpGLTF.Toolkit";
+    version = "1.0.1";
+    hash = "sha256-n1/G9OeOhAjV+MBelACwnq89Wh/UN73tNjoSzGSNuHI=";
+  })
+  (fetchNuGet {
+    pname = "SharpZipLib";
+    version = "1.4.2";
+    hash = "sha256-/giVqikworG2XKqfN9uLyjUSXr35zBuZ2FX2r8X/WUY=";
+  })
+  (fetchNuGet {
+    pname = "StableNameDotNet";
+    version = "0.1.0-pre-release.15";
+    hash = "sha256-lUExcbgefrY8iN8DOD9Jta61qdpNkyOskwV7cKJIJoI=";
+  })
+  (fetchNuGet {
+    pname = "StbImageWriteSharp";
+    version = "1.16.7";
+    hash = "sha256-E9AQO6tcXneDo4rwcSaW/cNhqFDv881o74wqB2fTG0Y=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections.Immutable";
+    version = "1.7.1";
+    hash = "sha256-WMMAUqoxT3J1gW9DI8v31VAuhwqTc4Posose5jq1BNo=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections.Immutable";
+    version = "6.0.0";
+    hash = "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs=";
+  })
+  (fetchNuGet {
+    pname = "System.CommandLine";
+    version = "2.0.0-beta4.22272.1";
+    hash = "sha256-zSO+CYnMH8deBHDI9DHhCPj79Ce3GOzHCyH1/TiHxcc=";
+  })
+  (fetchNuGet {
+    pname = "System.Drawing.Common";
+    version = "8.0.8";
+    hash = "sha256-u/u0US7c0dfB8TmIdN+AI2GKrWUguuEmEKMGx7NLIKE=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.Hashing";
+    version = "8.0.0";
+    hash = "sha256-szOGt0TNBo6dEdC3gf6H+e9YW3Nw0woa6UnCGGGK5cE=";
+  })
+  (fetchNuGet {
+    pname = "System.Memory";
+    version = "4.5.3";
+    hash = "sha256-Cvl7RbRbRu9qKzeRBWjavUkseT2jhZBUWV1SPipUWFk=";
+  })
+  (fetchNuGet {
+    pname = "System.Memory";
+    version = "4.5.4";
+    hash = "sha256-3sCEfzO4gj5CYGctl9ZXQRRhwAraMQfse7yzKoRe65E=";
+  })
+  (fetchNuGet {
+    pname = "System.Memory";
+    version = "4.5.5";
+    hash = "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Metadata";
+    version = "6.0.0";
+    hash = "sha256-VJHXPjP05w6RE/Swu8wa2hilEWuji3g9bl/6lBMSC/Q=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.CompilerServices.Unsafe";
+    version = "6.0.0";
+    hash = "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.Encodings.Web";
+    version = "6.0.0";
+    hash = "sha256-UemDHGFoQIG7ObQwRluhVf6AgtQikfHEoPLC6gbFyRo=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.Encodings.Web";
+    version = "8.0.0";
+    hash = "sha256-IUQkQkV9po1LC0QsqrilqwNzPvnc+4eVvq+hCvq8fvE=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.Json";
+    version = "6.0.5";
+    hash = "sha256-NKWNrCcKy8S5ldsJzm6+udU53fWzmPGZZG/gpk0Kz4k=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.Json";
+    version = "8.0.3";
+    hash = "sha256-ljBBGkResXv3MbrA14hR6QXo8SFLLV52GkpA+wxKdEo=";
+  })
+  (fetchNuGet {
+    pname = "System.ValueTuple";
+    version = "4.5.0";
+    hash = "sha256-niH6l2fU52vAzuBlwdQMw0OEoRS/7E1w5smBFoqSaAI=";
+  })
+  (fetchNuGet {
+    pname = "ZstdSharp.Port";
+    version = "0.7.2";
+    hash = "sha256-IfqAP4cBMegPcH8y8nqwBdwlCp/Q5Tp+tm34ruR99lk=";
+  })
+  (fetchNuGet {
+    pname = "ZstdSharp.Port";
+    version = "0.8.1";
+    hash = "sha256-PeQvyz3lUrK+t+n1dFtNXCLztQtAfkqUuM6mOqBZHLg=";
+  })
+]

--- a/pkgs/by-name/as/assetripper/package.nix
+++ b/pkgs/by-name/as/assetripper/package.nix
@@ -1,0 +1,80 @@
+{
+  autoPatchelfHook,
+  buildDotnetModule,
+  dbus,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+}:
+
+buildDotnetModule (finalAttrs: {
+  pname = "assetripper";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "AssetRipper";
+    repo = "AssetRipper";
+    tag = finalAttrs.version;
+    hash = "sha256-KSCM4HY+IjbWnhfOiTxp3WEJPjeOgPo4r9p1CjvBshs=";
+  };
+
+  # Until https://github.com/AssetRipper/AssetRipper/issues/1414 is resolved.
+  patches = [ ./replace-ro-exe-dir-with-cwd.patch ];
+
+  buildInputs = [
+    dbus.lib
+    stdenv.cc.cc.lib
+  ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  # Prevent automatic patching of all files. This is necessary as applying
+  # autoPatchelf indiscriminately causes dangling references to openssl and
+  # icu4c in AssetRipper.GUI.Free
+  dontAutoPatchelf = true;
+
+  # Make the main executable available under a more intuitive name using a
+  # relative symlink.
+  postInstall = ''
+    mkdir -p $out/bin
+    ln -rs $out/bin/AssetRipper.GUI.Free $out/bin/AssetRipper
+  '';
+
+  # Patch some prebuilt libraries fetched via NuGet.
+  fixupPhase = ''
+    runHook preFixup
+
+    autoPatchelf $out/lib/${finalAttrs.pname}/libnfd.so
+    autoPatchelf $out/lib/${finalAttrs.pname}/libTexture2DDecoderNative.so
+
+    runHook postFixup
+  '';
+
+  projectFile = "Source/AssetRipper.GUI.Free/AssetRipper.GUI.Free.csproj";
+
+  # Error: "PublishTrimmed is implied by native compilation and cannot be disabled."
+  # We need to override the project settings and disable native AoT compilation
+  # as this is incompatible with PublishTrimmed.
+  dotnetInstallFlags = [ "-p:PublishAot=false" ];
+
+  nugetDeps = ./deps.nix;
+
+  executables = [ "AssetRipper.GUI.Free" ];
+
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
+
+  meta = {
+    description = "Tool for extracting assets from Unity serialized files and asset bundles";
+    homepage = "https://github.com/AssetRipper/AssetRipper";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "AssetRipper";
+    maintainers = with lib.maintainers; [ diadatp ];
+    platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode # libraries fetched by NuGet
+    ];
+  };
+})

--- a/pkgs/by-name/as/assetripper/replace-ro-exe-dir-with-cwd.patch
+++ b/pkgs/by-name/as/assetripper/replace-ro-exe-dir-with-cwd.patch
@@ -1,0 +1,117 @@
+diff --git a/Source/AssetRipper.IO.Files/Utils/TemporaryFileStorage.cs b/Source/AssetRipper.IO.Files/Utils/TemporaryFileStorage.cs
+index e5b8a41..ef8cdc5 100644
+--- a/Source/AssetRipper.IO.Files/Utils/TemporaryFileStorage.cs
++++ b/Source/AssetRipper.IO.Files/Utils/TemporaryFileStorage.cs
+@@ -2,7 +2,7 @@
+ 
+ public static class TemporaryFileStorage
+ {
+-	private static string ExecutingDirectory => AppContext.BaseDirectory;
++	private static string ExecutingDirectory => System.Environment.CurrentDirectory;
+ 
+ 	public static string LocalTemporaryDirectory { get; } = Path.Combine(ExecutingDirectory, "temp", GetRandomString()[0..4]);
+ 
+diff --git a/Source/AssetRipper.Import/Utils/ExecutingDirectory.cs b/Source/AssetRipper.Import/Utils/ExecutingDirectory.cs
+index 9a510a0..ecd281f 100644
+--- a/Source/AssetRipper.Import/Utils/ExecutingDirectory.cs
++++ b/Source/AssetRipper.Import/Utils/ExecutingDirectory.cs
+@@ -4,7 +4,7 @@
+ 	{
+ 		static ExecutingDirectory()
+ 		{
+-			Info = new DirectoryInfo(AppContext.BaseDirectory);
++			Info = new DirectoryInfo(System.Environment.CurrentDirectory);
+ 		}
+ 
+ 		public static DirectoryInfo Info { get; }
+diff --git a/Source/AssetRipper.Tools.CabMapGenerator/Program.cs b/Source/AssetRipper.Tools.CabMapGenerator/Program.cs
+index 244eb02..a5f9e7a 100644
+--- a/Source/AssetRipper.Tools.CabMapGenerator/Program.cs
++++ b/Source/AssetRipper.Tools.CabMapGenerator/Program.cs
+@@ -30,7 +30,7 @@ namespace AssetRipper.Tools.CabMapGenerator
+ 
+ 				if (string.IsNullOrEmpty(outputFile))
+ 				{
+-					outputFile = Path.Combine(AppContext.BaseDirectory, "cabmap.json");
++					outputFile = Path.Combine(System.Environment.CurrentDirectory, "cabmap.json");
+ 				}
+ 				using FileStream stream = File.Create(outputFile);
+ 				Dictionary<string, string> map = new();
+diff --git a/Source/AssetRipper.Tools.DependenceGrapher/Program.cs b/Source/AssetRipper.Tools.DependenceGrapher/Program.cs
+index 5b0ba5f..6d66d63 100644
+--- a/Source/AssetRipper.Tools.DependenceGrapher/Program.cs
++++ b/Source/AssetRipper.Tools.DependenceGrapher/Program.cs
+@@ -96,7 +96,7 @@ namespace AssetRipper.Tools.DependenceGrapher
+ 				List<IAssetFilter> filters = CreateFilterList(name, className, classID, pathID);
+ 				if (string.IsNullOrEmpty(outputFile))
+ 				{
+-					outputFile = Path.Combine(AppContext.BaseDirectory, "output.txt");
++					outputFile = Path.Combine(System.Environment.CurrentDirectory, "output.txt");
+ 				}
+ 				using FileStream stream = File.Create(outputFile);
+ 				using TextWriter writer = new StreamWriter(stream);
+diff --git a/Source/AssetRipper.Tools.FileExtractor/Program.cs b/Source/AssetRipper.Tools.FileExtractor/Program.cs
+index 3e9869a..5685909 100644
+--- a/Source/AssetRipper.Tools.FileExtractor/Program.cs
++++ b/Source/AssetRipper.Tools.FileExtractor/Program.cs
+@@ -7,7 +7,7 @@ namespace AssetRipper.Tools.FileExtractor
+ {
+ 	internal class Program
+ 	{
+-		private static readonly string outputDirectory = Path.Combine(AppContext.BaseDirectory, "Output");
++		private static readonly string outputDirectory = Path.Combine(System.Environment.CurrentDirectory, "Output");
+ 
+ 		static void Main(string[] args)
+ 		{
+diff --git a/Source/AssetRipper.Tools.JsonSerializer/Program.cs b/Source/AssetRipper.Tools.JsonSerializer/Program.cs
+index d75b815..410bdd3 100644
+--- a/Source/AssetRipper.Tools.JsonSerializer/Program.cs
++++ b/Source/AssetRipper.Tools.JsonSerializer/Program.cs
+@@ -10,7 +10,7 @@ namespace AssetRipper.Tools.JsonSerializer;
+ 
+ internal static class Program
+ {
+-	private static readonly string outputDirectory = Path.Combine(AppContext.BaseDirectory, "Output");
++	private static readonly string outputDirectory = Path.Combine(System.Environment.CurrentDirectory, "Output");
+ 
+ 	static void Main(string[] args)
+ 	{
+diff --git a/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs b/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs
+index 2357237..cfee7a1 100644
+--- a/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs
++++ b/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs
+@@ -19,7 +19,7 @@ namespace AssetRipper.Tools.RawTextureExtractor
+ {
+ 	internal static class Program
+ 	{
+-		private static readonly string outputDirectory = Path.Combine(AppContext.BaseDirectory, "Output");
++		private static readonly string outputDirectory = Path.Combine(System.Environment.CurrentDirectory, "Output");
+ 
+ 		static void Main(string[] args)
+ 		{
+diff --git a/Source/AssetRipper.Tools.SystemTester/Program.cs b/Source/AssetRipper.Tools.SystemTester/Program.cs
+index 0f5b46a..0e2866c 100644
+--- a/Source/AssetRipper.Tools.SystemTester/Program.cs
++++ b/Source/AssetRipper.Tools.SystemTester/Program.cs
+@@ -23,7 +23,7 @@ namespace AssetRipper.Tools.SystemTester
+ 			}
+ 			else
+ 			{
+-				Rip(args, Path.Combine(AppContext.BaseDirectory, "Ripped"));
++				Rip(args, Path.Combine(System.Environment.CurrentDirectory, "Ripped"));
+ 			}
+ 		}
+ 
+diff --git a/Source/AssetRipper.Tools.TypeTreeExtractor/Program.cs b/Source/AssetRipper.Tools.TypeTreeExtractor/Program.cs
+index 66f27e9..083c09f 100644
+--- a/Source/AssetRipper.Tools.TypeTreeExtractor/Program.cs
++++ b/Source/AssetRipper.Tools.TypeTreeExtractor/Program.cs
+@@ -7,7 +7,7 @@ namespace AssetRipper.Tools.TypeTreeExtractor
+ {
+ 	internal static class Program
+ 	{
+-		private static readonly string outputDirectory = System.IO.Path.Combine(AppContext.BaseDirectory, "Output");
++		private static readonly string outputDirectory = System.IO.Path.Combine(System.Environment.CurrentDirectory, "Output");
+ 
+ 		static void Main(string[] args)
+ 		{


### PR DESCRIPTION
## Description of changes

AssetRipper is a tool for extracting assets from Unity serialized files (CAB-\*, \*.assets, \*.sharedAssets, etc.) and asset bundles (\*.unity3d, \*.bundle, etc.) and converting them into the native Unity engine format.

https://github.com/AssetRipper/AssetRipper

The patch is is a temporary measure until https://github.com/AssetRipper/AssetRipper/issues/1414 is resolved.

Closes #297634

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
