### PR TITLE
kando: init at 1.4.0

### DIFF
--- a/pkgs/by-name/ka/kando/package.nix
+++ b/pkgs/by-name/ka/kando/package.nix
@@ -1,0 +1,152 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  overrideSDK,
+
+  electron,
+  nodejs,
+
+  cmake,
+  zip,
+  makeWrapper,
+  wayland-scanner,
+  copyDesktopItems,
+  makeDesktopItem,
+
+  libxkbcommon,
+  libX11,
+  libXtst,
+  libXi,
+  wayland,
+  darwin,
+}:
+
+let
+  buildNpmPackage' = buildNpmPackage.override {
+    stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+  };
+in
+buildNpmPackage' rec {
+  pname = "kando";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "kando-menu";
+    repo = "kando";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-JcPTplqrMgDsT0HDTh7liChUWvLqe9gwS51ANM3Wsds=";
+  };
+
+  npmDepsHash = "sha256-13NuhGq5Pv5GSLeXASWxbXZYaUb9KzMgR7y5I7mv+MA=";
+
+  npmFlags = [ "--ignore-scripts" ];
+
+  makeCacheWritable = true;
+
+  nativeBuildInputs =
+    [
+      cmake
+      zip
+      makeWrapper
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      wayland-scanner
+      copyDesktopItems
+    ];
+
+  buildInputs =
+    lib.optionals stdenv.isLinux [
+      libxkbcommon
+      libX11
+      libXtst
+      libXi
+      wayland
+    ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk_11_0.frameworks.AppKit ];
+
+  dontUseCmakeConfigure = true;
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    # use our own node headers since we skip downloading them
+    NIX_CFLAGS_COMPILE = "-I${nodejs}/include/node";
+    # disable code signing on Darwin
+    CSC_IDENTITY_AUTO_DISCOVERY = lib.optionalString stdenv.isDarwin "false";
+  };
+
+  postConfigure = ''
+    # electron files need to be writable on Darwin
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    pushd electron-dist
+    zip -0Xqr ../electron.zip .
+    popd
+
+    rm -r electron-dist
+
+    # force @electron/packager to use our electron instead of downloading it, even if it is a different version
+    substituteInPlace node_modules/@electron/packager/dist/packager.js \
+        --replace-fail 'await this.getElectronZipPath(downloadOpts)' '"electron.zip"'
+
+    # don't fetch node headers
+    substituteInPlace node_modules/cmake-js/lib/dist.js \
+        --replace-fail '!this.downloaded' 'false'
+  '';
+
+  # we used --ignore-scripts to have time to patch the dependencies
+  # now we'll have to call npm rebuild manually
+  preBuild = ''
+    npm rebuild --verbose
+  '';
+
+  npmBuildScript = "package";
+
+  installPhase = ''
+    runHook preInstall
+
+    ${lib.optionalString stdenv.isLinux ''
+      mkdir -p $out/share/kando
+      cp -r out/*/{locales,resources{,.pak}} $out/share/kando
+
+      install -Dm644 assets/icons/icon.svg $out/share/icons/hicolor/scalable/apps/kando.svg
+
+      makeWrapper ${lib.getExe electron} $out/bin/kando \
+          --add-flags $out/share/kando/resources/app \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+          --inherit-argv0
+    ''}
+
+    ${lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/Applications
+      cp -r out/*/Kando.app $out/Applications
+      makeWrapper $out/Applications/Kando.app/Contents/MacOS/Kando $out/bin/kando
+    ''}
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "kando";
+      exec = "kando %U";
+      icon = "kando";
+      desktopName = "Kando";
+      genericName = "Pie Menu";
+      comment = "The Cross-Platform Pie Menu";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  meta = {
+    changelog = "https://github.com/kando-menu/kando/releases/tag/v${version}";
+    description = "Cross-Platform Pie Menu";
+    homepage = "https://github.com/kando-menu/kando";
+    license = lib.licenses.mit;
+    mainProgram = "kando";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = electron.meta.platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes


Closes https://github.com/NixOS/nixpkgs/issues/297267

This PR adds 1 package: `kando`

The build process uses `cmake-js` which wants to fetch the node headers. I patched that out, and instead I specified the headers manually using `NIX_CFLAGS_COMPILE`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
