### PR TITLE
indilib,indi-full: 2.0.8 -> 2.0.9

### DIFF
--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "indilib";
-  version = "2.0.8";
+  version = "2.0.9";
 
   src = fetchFromGitHub {
     owner = "indilib";
     repo = "indi";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-qdPQMC8HCMdcbHyO8B0OFiefO+jM1ytA2dYNymE0Xuc=";
+    hash = "sha256-CV8nSz53wFeS/h7hGj9adN8qmyhsqOkTYj/0nuvhlSM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -24,6 +24,7 @@
   libexif,
   libftdi1,
   libgphoto2,
+  libgpiod_1,
   libpng,
   libraw,
   ninja,
@@ -44,7 +45,7 @@ let
     owner = "indilib";
     repo = "indi-3rdparty";
     rev = "v${indilib.version}";
-    hash = "sha256-0M+k3A2Lw9EU9V5bX9dGztmdcJzc71XQZv8srmY5NmY=";
+    hash = "sha256-RhtdhMvseQUUFcKDuR1N5qc/86IxmQ/7owpjT+qweqc=";
   };
 
   buildIndi3rdParty =
@@ -217,7 +218,7 @@ let
     pname = "libfishcamp";
 
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace "/lib/firmware" "lib/firmware"
+      substituteInPlace CMakeLists.txt --replace-fail "/lib/firmware" "lib/firmware"
     '';
 
     buildInputs = [
@@ -327,7 +328,7 @@ let
 
     postPatch = ''
       substituteInPlace CMakeLists.txt \
-        --replace "set (PK_DATADIR /usr/share/pktriggercord)" "set (PK_DATADIR $out/share/pkgtriggercord)"
+        --replace-fail "set (PK_DATADIR /usr/share/pktriggercord)" "set (PK_DATADIR $out/share/pkgtriggercord)"
     '';
 
     buildInputs = [ indilib ];
@@ -342,7 +343,7 @@ let
     pname = "libplayerone";
     postPatch = ''
       substituteInPlace 99-player_one_astronomy.rules \
-        --replace "/bin/echo" "${coreutils}/bin/echo" \
+        --replace-fail "/bin/echo" "${coreutils}/bin/echo" \
         --replace "/bin/sh" "${bash}/bin/sh"
     '';
 
@@ -362,14 +363,13 @@ let
     pname = "libqhy";
 
     postPatch = ''
-      sed -ie 's/LIBQHY_SOVERSION "24"/LIBQHY_SOVERSION "20"/' CMakeLists.txt
-      substituteInPlace CMakeLists.txt \
+      substituteInPlace --replace-fail CMakeLists.txt \
         --replace "/lib/firmware" "lib/firmware"
 
       substituteInPlace 85-qhyccd.rules \
-        --replace "/sbin/fxload" "${fxload}/sbin/fxload" \
-        --replace "/lib/firmware" "$out/lib/firmware" \
-        --replace "/bin/sleep" "${coreutils}/bin/sleep"
+        --replace-fail "/sbin/fxload" "${fxload}/sbin/fxload" \
+        --replace-fail "/lib/firmware" "$out/lib/firmware" \
+        --replace-fail "/bin/sleep" "${coreutils}/bin/sleep"
 
       sed -e 's|-D $env{DEVNAME}|-p $env{BUSNUM},$env{DEVNUM}|' -i 85-qhyccd.rules
     '';
@@ -418,10 +418,10 @@ let
     pname = "libsbig";
 
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace "/lib/firmware" "lib/firmware"
+      substituteInPlace CMakeLists.txt --replace-fail "/lib/firmware" "lib/firmware"
       substituteInPlace 51-sbig-debian.rules \
-        --replace "/sbin/fxload" "${fxload}/sbin/fxload" \
-        --replace "/lib/firmware" "$out/lib/firmware"
+        --replace-fail "/sbin/fxload" "${fxload}/sbin/fxload" \
+        --replace-fail "/lib/firmware" "$out/lib/firmware"
 
       sed -e 's|-D $env{DEVNAME}|-p $env{BUSNUM},$env{DEVNUM}|' -i 51-sbig-debian.rules
     '';
@@ -516,7 +516,7 @@ in
       libnova
     ];
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace "/lib/udev/rules.d" "lib/udev/rules.d"
+      substituteInPlace CMakeLists.txt --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d"
     '';
   };
 
@@ -637,11 +637,11 @@ in
 
     postPatch = ''
       substituteInPlace CMakeLists.txt \
-        --replace "/lib/udev/rules.d" "lib/udev/rules.d" \
-        --replace "/lib/firmware" "lib/firmware"
+        --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d" \
+        --replace-fail "/lib/firmware" "lib/firmware"
       substituteInPlace 99-meadedsi.rules \
-        --replace "/sbin/fxload" "${fxload}/sbin/fxload" \
-        --replace "/lib/firmware" "$out/lib/firmware"
+        --replace-fail "/sbin/fxload" "${fxload}/sbin/fxload" \
+        --replace-fail "/lib/firmware" "$out/lib/firmware"
 
       sed -e 's|-D $env{DEVNAME}|-p $env{BUSNUM},$env{DEVNUM}|' -i 99-meadedsi.rules
     '';
@@ -723,6 +723,16 @@ in
       zlib
     ];
     propagatedBuildInputs = [ libgphoto2 ];
+  };
+
+  indi-gpio = buildIndi3rdParty {
+    pname = "indi-gpio";
+    buildInputs = [
+      indilib
+      libgpiod_1
+      libnova
+      zlib
+    ];
   };
 
   indi-gpsd = buildIndi3rdParty {
@@ -862,7 +872,7 @@ in
     ];
 
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace "/lib/udev/rules.d" "lib/udev/rules.d"
+      substituteInPlace CMakeLists.txt --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d"
     '';
   };
 
@@ -918,7 +928,7 @@ in
     ];
 
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace "/lib/udev/rules.d" "lib/udev/rules.d"
+      substituteInPlace CMakeLists.txt --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d"
     '';
 
     meta.platforms = libqsi.meta.platforms;
@@ -1015,7 +1025,7 @@ in
       libusb1
     ];
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace "/lib/udev/rules.d" "lib/udev/rules.d"
+      substituteInPlace CMakeLists.txt --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d"
     '';
   };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates the indilib and indi-3rdparty packages to their new versions.
Changes:
https://github.com/indilib/indi/releases/tag/v2.0.9
https://github.com/indilib/indi-3rdparty/releases/tag/v2.0.9

Also added new indi-gpio driver, changed `substitueInPlace --replace` with `substitueInPlace --replace-fail`, removed workaround in libqhy for wrong so version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
