### PR TITLE
scotch: 7.0.4 -> 7.0.5

### DIFF
--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ [
       "LSCOTCHDIR=${scotch}/lib"
-      "ISCOTCH=-I${scotch}/include"
+      "ISCOTCH=-I${scotch.dev}/include"
       "LMETISDIR=${metis}/lib"
       "IMETIS=-I${metis}/include"
       "allshared"

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
   ];
 
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+
   nativeBuildInputs = [
     cmake
     gfortran

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -24,6 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-XXkVwTr8cbYfzXWWkPERTmjfE86JHUUuU6yxjp9k6II=";
   };
 
+  outputs = [
+    "bin"
+    "dev"
+    "out"
+  ];
+
   nativeBuildInputs = [
     cmake
     gfortran

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -14,14 +14,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scotch";
-  version = "7.0.4";
+  version = "7.0.5";
 
   src = fetchFromGitLab {
     domain = "gitlab.inria.fr";
     owner = "scotch";
     repo = "scotch";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-uaox4Q9pTF1r2BZjvnU2LE6XkZw3x9mGSKLdRVUobGU=";
+    hash = "sha256-XXkVwTr8cbYfzXWWkPERTmjfE86JHUUuU6yxjp9k6II=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Changes notes:

> 
> This revision is essentially a bugfix release, but it also provides new features:
> 
>     The installation of Scotch on Windows-like environments has been improved.
>     Native Windows threads are now supported.
>     The CMake compilation chain is now fully mature.
>     New routines have been added, to run the upcoming "ScotchPy" Python interface for Scotch and PT-Scotch.
> 

While here, separate outputs, as this package has 31 executables which look like tests. It might also help @matthewcroughan who has issues with `include/metis.h` overriding the one from metis → putting it in in another output  might help. I'll report this upstream though.

And also, shared libs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
