### PR TITLE
python312Packages.audiofs: init at 0.3

### DIFF
--- a/pkgs/by-name/au/audiofs/package.nix
+++ b/pkgs/by-name/au/audiofs/package.nix
@@ -1,0 +1,4 @@
+{ python3 }:
+
+with python3.pkgs;
+toPythonApplication audiofs

--- a/pkgs/development/python-modules/audiofs/default.nix
+++ b/pkgs/development/python-modules/audiofs/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  setuptools,
+  fuse,
+}:
+
+buildPythonPackage {
+  pname = "audiofs";
+  version = "0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "steelcandy2";
+    repo = "audiofs";
+    rev = "4fc4a5e432c9eae6b051918d62145236d8fbbd13";
+    hash = "sha256-DcLR3soQd/5iXEmqVtRMWFsQWl+MubRCx9IcucWNp7c=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "drop-python2-support.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/steelcandy2/audiofs/pull/1.patch";
+      hash = "sha256-2dVf5yXLk0e5pUKqUr5Zoc3TpPQxItjFZzida8l96wo=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [ fuse ];
+
+  pythonImportsCheck = [ "audiofs" ];
+
+  # no tests
+  doCheck = false;
+
+  meta = {
+    description = "Audio-related FUSE filesystems";
+    longDescription = "Audio-related FUSE filesystems, along with optional music directory management and MPD music server integration";
+    homepage = "https://github.com/steelcandy2/audiofs";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ vizid ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -985,6 +985,8 @@ self: super: with self; {
     inherit (pkgs.darwin.apple_sdk.frameworks) AudioToolbox AudioUnit CoreServices;
   };
 
+  audiofs = callPackage ../development/python-modules/audiofs { };
+
   auditok = callPackage ../development/python-modules/auditok { };
 
   auditwheel = callPackage ../development/python-modules/auditwheel {


### PR DESCRIPTION
## Description of changes
https://github.com/steelcandy2/audiofs
Audio-related FUSE filesystems, along with optional music directory management and MPD music server integration

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
