### PR TITLE
yarg: init at 0.12.6

### DIFF
--- a/pkgs/by-name/ya/yarg/package.nix
+++ b/pkgs/by-name/ya/yarg/package.nix
@@ -1,0 +1,126 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  autoPatchelfHook,
+  alsa-lib,
+  gtk3,
+  zlib,
+  dbus,
+  hidapi,
+  libGL,
+  libXcursor,
+  libXext,
+  libXi,
+  libXinerama,
+  libxkbcommon,
+  libXrandr,
+  libXScrnSaver,
+  libXxf86vm,
+  udev,
+  vulkan-loader,
+  wayland, # (not used by default, enable with SDL_VIDEODRIVER=wayland - doesn't support HiDPI)
+  makeDesktopItem,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yarg";
+  version = "0.12.6";
+
+  src = fetchzip {
+    url = "https://github.com/YARC-Official/YARG/releases/download/v${finalAttrs.version}/YARG_v${finalAttrs.version}-Linux-x86_64.zip";
+    stripRoot = false;
+    hash = "sha256-Za+CnuSTfJZVdW0pWvGDnKcbhZsgtNPRWYj1qOA8+Zs=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    # Load-time libraries (loaded from DT_NEEDED section in ELF binary)
+    alsa-lib
+    gtk3
+    stdenv.cc.cc.lib
+    zlib
+
+    # Run-time libraries (loaded with dlopen)
+    dbus
+    hidapi
+    libGL
+    libXcursor
+    libXext
+    libXi
+    libXinerama
+    libxkbcommon
+    libXrandr
+    libXScrnSaver
+    libXxf86vm
+    udev
+    vulkan-loader
+    wayland
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = "yarg";
+    desktopName = "YARG";
+    comment = finalAttrs.meta.description;
+    icon = "yarg";
+    exec = "yarg";
+    categories = [ "Game" ];
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 YARG "$out/bin/yarg"
+    install -Dm644 UnityPlayer.so "$out/libexec/yarg/UnityPlayer.so"
+
+    mkdir -p "$out/share/pixmaps"
+    cp -r YARG_Data "$out/share/yarg"
+    ln -s "$out/share/yarg" "$out/bin/yarg_Data"
+    ln -s "$out/share/yarg/Resources/UnityPlayer.png" "$out/share/pixmaps/yarg.png"
+    install -Dm644 "$desktopItem/share/applications/yarg.desktop" "$out/share/applications/yarg.desktop"
+
+    runHook postInstall
+  '';
+
+  # Patch required run-time libraries as load-time libraries
+  #
+  # Libraries found with:
+  # > strings UnityPlayer.so | grep '\.so'
+  # and:
+  # > LD_DEBUG=libs yarg
+  postFixup = ''
+    patchelf \
+      --add-needed libasound.so.2 \
+      --add-needed libdbus-1.so.3 \
+      --add-needed libGL.so.1 \
+      --add-needed libhidapi-hidraw.so.0 \
+      --add-needed libpthread.so.0 \
+      --add-needed libudev.so.1 \
+      --add-needed libvulkan.so.1 \
+      --add-needed libwayland-client.so.0 \
+      --add-needed libwayland-cursor.so.0 \
+      --add-needed libwayland-egl.so.1 \
+      --add-needed libX11.so.6 \
+      --add-needed libXcursor.so.1 \
+      --add-needed libXext.so.6 \
+      --add-needed libXi.so.6 \
+      --add-needed libXinerama.so.1 \
+      --add-needed libxkbcommon.so.0 \
+      --add-needed libXrandr.so.2 \
+      --add-needed libXss.so.1 \
+      --add-needed libXxf86vm.so.1 \
+      "$out/libexec/yarg/UnityPlayer.so"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Free, open-source, plastic guitar game";
+    homepage = "https://yarg.in";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ kira-bruneau ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes #334960

It's possible to build YARG from source, but this package just wraps the binary like we do with [clonehero](https://github.com/NixOS/nixpkgs/blob/9daa847339d0f6ebff5ad3615d6d499735df3151/pkgs/games/clonehero/default.nix).

It's built on Unity and I don't think it's worth the effort to try to create a build wrapper for Unity just to build this from source. Unity is also unfree, so we couldn't include it in the binary cache.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
