### PR TITLE
workflows/check-nix-format: Improve error message

### DIFF
--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -83,7 +83,7 @@ jobs:
 
           if (( "${#unformattedFiles[@]}" > 0 )); then
             echo "Some new/changed Nix files are not properly formatted"
-            echo "Please go to the Nixpkgs root directory, run \`nix-shell\`, then:"
+            echo "Please format them using the Nixpkgs-specific \`nixfmt\` by going to the Nixpkgs root directory, running \`nix-shell\`, then:"
             echo "nixfmt ${unformattedFiles[*]@Q}"
             echo "If you're having trouble, please ping @NixOS/nix-formatting"
             exit 1


### PR DESCRIPTION
## Description of changes

Looks like the error message could be a bit clearer still: https://github.com/NixOS/nixpkgs/pull/337109#issuecomment-2311175326 :smile:

Ping @NixOS/nix-formatting 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
