### PR TITLE
mise: 2024.5.9 -> 2024.8.13

### DIFF
--- a/pkgs/tools/misc/mise/default.nix
+++ b/pkgs/tools/misc/mise/default.nix
@@ -17,13 +17,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mise";
-  version = "2024.5.9";
+  version = "2024.8.13";
 
   src = fetchFromGitHub {
     owner = "jdx";
     repo = "mise";
     rev = "v${version}";
-    hash = "sha256-vmY+uI/NqMCLJwJaQU+aDppmn5OSLPUIbeqCSlN8Xb0=";
+    hash = "sha256-XarSfCjEwL1ps2Kwla0lLybpfjNUcIuvTD0kb5YiKgU=";
 
     # registry is not needed for compilation nor for tests.
     # contains files with the same name but different case, which cause problems with hash on darwin
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     '';
   };
 
-  cargoHash = "sha256-7kcs1vOM68uKjMrRn8jGI6mgXd90TeMUeYWnAGl8sgE=";
+  cargoHash = "sha256-F+CGCk1U+I0htfWw1ZTl02lBhzSxk19hM7VjTWM8T10=";
 
   nativeBuildInputs = [ installShellFiles pkg-config ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
@@ -41,20 +41,27 @@ rustPlatform.buildRustPackage rec {
     patchShebangs --build \
       ./test/data/plugins/**/bin/* \
       ./src/fake_asdf.rs \
+      ./src/cli/generate/git_pre_commit.rs \
+      ./src/cli/generate/snapshots/*.snap \
       ./src/cli/reshim.rs \
       ./test/cwd/.mise/tasks/filetask
 
+    substituteInPlace ./src/test.rs \
+      --replace-fail '/usr/bin/env bash' '${bash}/bin/bash'
+
     substituteInPlace ./src/env_diff.rs \
-      --replace '"bash"' '"${bash}/bin/bash"'
+      --replace-fail '"bash"' '"${bash}/bin/bash"'
 
     substituteInPlace ./src/cli/direnv/exec.rs \
-      --replace '"env"' '"${coreutils}/bin/env"' \
-      --replace 'cmd!("direnv"' 'cmd!("${direnv}/bin/direnv"'
+      --replace-fail '"env"' '"${coreutils}/bin/env"' \
+      --replace-fail 'cmd!("direnv"' 'cmd!("${direnv}/bin/direnv"'
   '';
 
   checkFlags = [
     # Requires .git directory to be present
     "--skip=cli::plugins::ls::tests::test_plugin_list_urls"
+    "--skip=cli::generate::git_pre_commit::tests::test_git_pre_commit"
+    "--skip=cli::generate::github_action::tests::test_github_action"
   ];
   cargoTestFlags = [ "--all-features" ];
   # some tests access the same folders, don't test in parallel to avoid race conditions


### PR DESCRIPTION
## Description of changes

Followed upstream's [`default.nix`](https://github.com/jdx/mise/blob/main/default.nix) and made some changes to avoid build/test failures.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
