### PR TITLE
mkPythonMetaPackage: init meta package function (and psycopg2-binary)

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -369,8 +369,11 @@ In nixpkgs this is used to package Python packages with split binary/source dist
 ```nix
 mkPythonMetaPackage {
   pname = "pscycopg2-binary";
-  inherit (psycopg2) optional-dependencies version meta;
+  inherit (psycopg2) optional-dependencies version;
   dependencies = [ psycopg2 ];
+  meta = {
+    inherit (psycopg2.meta) description homepage;
+  };
 }
 ```
 

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -361,6 +361,19 @@ modifications.
 
 Do pay attention to passing in the right Python version!
 
+#### `mkPythonMetaPackage` function {#mkpythonmetapackage-function}
+
+This will create a meta package containing [metadata files](https://packaging.python.org/en/latest/specifications/recording-installed-packages/) to satisfy a dependency on a package, without it actually having been installed into the environment.
+In nixpkgs this is used to package Python packages with split binary/source distributions such as [psycopg2](https://pypi.org/project/psycopg2/)/[psycopg2-binary](https://pypi.org/project/psycopg2-binary/).
+
+```nix
+mkPythonMetaPackage {
+  pname = "pscycopg2-binary";
+  inherit (psycopg2) optional-dependencies version meta;
+  dependencies = [ psycopg2 ];
+}
+```
+
 #### `python.buildEnv` function {#python.buildenv-function}
 
 Python environments can be created using the low-level `pkgs.buildEnv` function.

--- a/pkgs/development/interpreters/python/meta-package.nix
+++ b/pkgs/development/interpreters/python/meta-package.nix
@@ -1,0 +1,58 @@
+{
+  buildPythonPackage,
+  lib,
+  hatchling,
+}:
+{
+  pname,
+  version,
+  dependencies ? [ ],
+  optional-dependencies ? { },
+  passthru ? { },
+  meta ? { },
+}:
+
+# Create a "fake" meta package to satisfy a dependency on a package, but don't actually build it.
+# This is useful for packages that have a split binary/source dichotomy like psycopg2/psycopg2-binary,
+# where we want to use the former, but some projects declare a dependency on the latter.
+
+buildPythonPackage {
+  inherit
+    pname
+    version
+    dependencies
+    optional-dependencies
+    meta
+    passthru
+    ;
+
+  pyproject = true;
+
+  # Make a minimal pyproject.toml that can be built
+  unpackPhase = ''
+    cat > pyproject.toml << EOF
+    [project]
+    name = "${pname}"
+    version = "${version}"
+    dependencies = ${builtins.toJSON (map lib.getName dependencies)}
+
+    [project.optional-dependencies]
+    ${lib.optionalString (optional-dependencies != { }) (
+      (lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (
+          group: deps: group + " = " + builtins.toJSON (map lib.getName deps)
+        ) optional-dependencies
+      ))
+    )}
+
+    [tool.hatch.build.targets.wheel]
+    bypass-selection = true
+
+    [build-system]
+    requires = ["hatchling"]
+    build-backend = "hatchling.build"
+    EOF
+  '';
+
+  build-system = [ hatchling ];
+}

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -61,6 +61,8 @@ let
 
   removePythonPrefix = lib.removePrefix namePrefix;
 
+  mkPythonMetaPackage = callPackage ./meta-package.nix { };
+
   # Convert derivation to a Python module.
   toPythonModule = drv:
     drv.overrideAttrs( oldAttrs: {
@@ -97,6 +99,7 @@ in {
   inherit buildPythonPackage buildPythonApplication;
   inherit hasPythonModule requiredPythonModules makePythonPath disabled disabledIf;
   inherit toPythonModule toPythonApplication;
+  inherit mkPythonMetaPackage;
 
   python = toPythonModule python;
 

--- a/pkgs/development/python-modules/psycopg2-binary/default.nix
+++ b/pkgs/development/python-modules/psycopg2-binary/default.nix
@@ -1,0 +1,13 @@
+{
+  mkPythonMetaPackage,
+  psycopg2,
+}:
+mkPythonMetaPackage {
+  pname = "pscycopg2-binary";
+  inherit (psycopg2) version;
+  dependencies = [ psycopg2 ];
+  optional-dependencies = psycopg2.optional-dependencies or { };
+  meta = {
+    inherit (psycopg2.meta) description homepage;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10952,6 +10952,8 @@ self: super: with self; {
 
   psycopg2cffi = callPackage ../development/python-modules/psycopg2cffi { };
 
+  psycopg2-binary = callPackage ../development/python-modules/psycopg2-binary { };
+
   psygnal = callPackage ../development/python-modules/psygnal { };
 
   ptable = callPackage ../development/python-modules/ptable { };


### PR DESCRIPTION
## Description of changes

Adds a function `mkPythonMetaPackage` that exists to satisfy a dependency on a package, but don't actually build it.
This is useful for packages that have a split binary/source dichotomy like psycopg2/psycopg2-binary, where we want to use the former, but some projects declare a dependency on the latter.

This PR:
- Create a `mkPythonMetaPackage` function
- Adds a new package `psycopg2-binary` that uses it

Override hacks could be dropped from:
- irrd
- pretix
- vwsfriend
- aiopg
- dbt-postgres
- llama-index-vector-stores-postgres
- patator
- fit-trackee

cc @misuzu https://github.com/nix-community/pyproject.nix/issues/143

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
