### PR TITLE
{fytik, python311Packages.soapysdr}: unpin swig3

### DIFF
--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -10,7 +10,7 @@
   ncurses,
   usePython ? false,
   python ? null,
-  swig3,
+  swig,
   extraPackages ? [ ],
   buildPackages,
   testers,
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals usePython [
       python
-      swig3
+      swig
     ];
 
   propagatedBuildInputs = lib.optionals usePython [ python.pkgs.numpy ];

--- a/pkgs/applications/science/misc/fityk/default.nix
+++ b/pkgs/applications/science/misc/fityk/default.nix
@@ -10,7 +10,7 @@
 , xylib
 , readline
 , gnuplot
-, swig3
+, swig
 }:
 
 stdenv.mkDerivation rec {
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     xylib
     readline
     gnuplot
-    swig3
+    swig
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [


### PR DESCRIPTION
## Description of changes

Currently there are only four explicit uses of swig3 in tree: `gforth`, `lldb`, `fytik`, and `soapysdr` (although there will likely be more once `swig` itself becomes `swig4` rather than `swig3` via #337624 or similar). This PR unpins swig3 in the latter two of these four packages; although currently a no-op, I confirmed that they build with swig4.  `lldb` explicitly conditions on the `llvm` version to determine which swig version to use, and `gforth` uses a custom swig source download whose upstream has a closed PR to add swig4 support, so I didn't attempt to unpin these (given we will likely not be able to remove swig3 from tree immediately anyway).

Note that python312Packages.soapysdr is already broken in trunk for unrelated reasons.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
