### PR TITLE
spyder: 5.5.5 -> 5.5.6

### DIFF
--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -1,39 +1,50 @@
 {
   lib,
-  autopep8,
   buildPythonPackage,
-  docstring-to-markdown,
   fetchFromGitHub,
-  flake8,
-  flaky,
-  importlib-metadata,
+  pythonOlder,
+
+  # build-system
+  setuptools-scm,
+
+  # dependencies
+  docstring-to-markdown,
   jedi,
-  matplotlib,
-  mccabe,
-  numpy,
-  pandas,
   pluggy,
+  python-lsp-jsonrpc,
+  setuptools,
+  ujson,
+  importlib-metadata,
+
+  # optional-dependencies
+  autopep8,
+  flake8,
+  mccabe,
   pycodestyle,
   pydocstyle,
   pyflakes,
   pylint,
-  pytestCheckHook,
-  python-lsp-jsonrpc,
-  pythonOlder,
   rope,
-  setuptools,
-  setuptools-scm,
   toml,
-  ujson,
-  websockets,
   whatthepatch,
   yapf,
+
+  # checks
+  flaky,
+  matplotlib,
+  numpy,
+  pandas,
+  pytestCheckHook,
+  websockets,
+
+  testers,
+  python-lsp-server,
 }:
 
 buildPythonPackage rec {
   pname = "python-lsp-server";
-  version = "1.11.0";
-  format = "pyproject";
+  version = "1.12.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -41,7 +52,7 @@ buildPythonPackage rec {
     owner = "python-lsp";
     repo = "python-lsp-server";
     rev = "refs/tags/v${version}";
-    hash = "sha256-0DFcnGlyDOK0Lxpr++xV6klhFF9b1fihH5FY/tblr+E=";
+    hash = "sha256-oFqa7DtFpJmDZrw+GJqrFH3QqnMAu9159q3IWT9vRko=";
   };
 
   postPatch = ''
@@ -59,8 +70,6 @@ buildPythonPackage rec {
     "pyflakes"
   ];
 
-  nativeBuildInputs = [ setuptools-scm ];
-
   build-system = [ setuptools-scm ];
 
   dependencies = [
@@ -72,7 +81,7 @@ buildPythonPackage rec {
     ujson
   ] ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       autopep8
       flake8
@@ -101,27 +110,24 @@ buildPythonPackage rec {
     websockets = [ websockets ];
   };
 
-  nativeCheckInputs =
-    [
-      flaky
-      matplotlib
-      numpy
-      pandas
-      pytestCheckHook
-    ]
-    ++ passthru.optional-dependencies.all;
+  nativeCheckInputs = [
+    flaky
+    matplotlib
+    numpy
+    pandas
+    pytestCheckHook
+  ] ++ optional-dependencies.all;
 
-  disabledTests =
-    [
-      # Don't run lint tests
-      "test_pydocstyle"
-      # https://github.com/python-lsp/python-lsp-server/issues/243
-      "test_numpy_completions"
-      "test_workspace_loads_pycodestyle_config"
-      "test_autoimport_code_actions_and_completions_for_notebook_document"
-      # avoid dependencies on many Qt things just to run one singular test
-      "test_pyqt_completion"
-    ];
+  disabledTests = [
+    # Don't run lint tests
+    "test_pydocstyle"
+    # https://github.com/python-lsp/python-lsp-server/issues/243
+    # "test_numpy_completions"
+    "test_workspace_loads_pycodestyle_config"
+    "test_autoimport_code_actions_and_completions_for_notebook_document"
+    # avoid dependencies on many Qt things just to run one singular test
+    "test_pyqt_completion"
+  ];
 
   preCheck = ''
     export HOME=$(mktemp -d);
@@ -132,12 +138,19 @@ buildPythonPackage rec {
     "pylsp.python_lsp"
   ];
 
-  meta = with lib; {
+  passthru = {
+    tests.version = testers.testVersion {
+      package = python-lsp-server;
+      version = "v${version}";
+    };
+  };
+
+  meta = {
     description = "Python implementation of the Language Server Protocol";
     homepage = "https://github.com/python-lsp/python-lsp-server";
     changelog = "https://github.com/python-lsp/python-lsp-server/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "pylsp";
   };
 }

--- a/pkgs/development/python-modules/qstylizer/default.nix
+++ b/pkgs/development/python-modules/qstylizer/default.nix
@@ -2,33 +2,43 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  inflection,
-  pbr,
-  pytest-mock,
-  pytestCheckHook,
   pythonOlder,
+
+  # build-system
+  pbr,
+  setuptools,
+
+  # dependencies
+  inflection,
   tinycss2,
+
+  # checks
+  pytestCheckHook,
+  pytest-mock,
 }:
 
 buildPythonPackage rec {
   pname = "qstylizer";
-  version = "0.2.2";
-  format = "setuptools";
+  version = "0.2.3";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "blambright";
-    repo = pname;
-    rev = version;
-    hash = "sha256-QJ4xhaAoVO4/VncXKzI8Q5f/rPfctJ8CvfedkQVgZgQ=";
+    repo = "qstylizer";
+    rev = "refs/tags/${version}";
+    hash = "sha256-eZVBUGQxa2cr0O48iKWNTqM9E5ZAsiT1WfXjdYdxIdg=";
   };
 
   PBR_VERSION = version;
 
-  nativeBuildInputs = [ pbr ];
+  build-system = [
+    pbr
+    setuptools
+  ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     inflection
     tinycss2
   ];
@@ -40,10 +50,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "qstylizer" ];
 
-  meta = with lib; {
+  meta = {
     description = "Qt stylesheet generation utility for PyQt/PySide";
     homepage = "https://github.com/blambright/qstylizer";
-    license = licenses.mit;
-    maintainers = with maintainers; [ drewrisinger ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drewrisinger ];
   };
 }

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -3,6 +3,8 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
+
+  # dependencies
   atomicwrites,
   chardet,
   cloudpickle,
@@ -44,14 +46,14 @@
 
 buildPythonPackage rec {
   pname = "spyder";
-  version = "5.5.5";
+  version = "5.5.6";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Y+JZO/LfWi1QzoSSV1uDI4zxLcte0HwVMNmBK0aXgd4=";
+    hash = "sha256-lYtmn0oBXFw5EFDrbv+o2EZWqL/Eel9GrbopeEnYK90=";
   };
 
   patches = [ ./dont-clear-pythonpath.patch ];


### PR DESCRIPTION
## Description of changes

- **python312Packages.qstylizer: 0.2.2 -> 0.2.3**
  cc @drewrisinger 
- **python312Packages.python-lsp-server: 1.11.0 -> 1.12.0** (https://github.com/python-lsp/python-lsp-server/blob/v1.12.0/CHANGELOG.md)
  cc @fabaff 
- **spyder: 5.5.5 -> 5.5.6** (https://github.com/spyder-ide/spyder/blob/master/CHANGELOG.md)
  cc @gebner

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
