### PR TITLE
wasm-bindgen-cli: 0.2.92 -> 0.2.93

### DIFF
--- a/pkgs/development/tools/wasm-bindgen-cli/default.nix
+++ b/pkgs/development/tools/wasm-bindgen-cli/default.nix
@@ -1,18 +1,18 @@
-{ lib
-, rustPlatform
-, fetchCrate
-, nix-update-script
-, nodejs
-, pkg-config
-, openssl
-, stdenv
-, curl
-, Security
-, version ? "0.2.92"
-, hash ? "sha256-1VwY8vQy7soKEgbki4LD+v259751kKxSxmo/gqE6yV0="
-, cargoHash ? "sha256-aACJ+lYNEU8FFBs158G1/JG8sc6Rq080PeKCMnwdpH0="
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  nix-update-script,
+  nodejs,
+  pkg-config,
+  openssl,
+  stdenv,
+  curl,
+  Security,
+  version ? "0.2.93",
+  hash ? "sha256-DDdu5mM3gneraM85pAepBXWn3TMofarVR4NbjMdz3r0=",
+  cargoHash ? "sha256-birrg+XABBHHKJxfTKAMSlmTVYLmnmqMDfRnmG6g/YQ=",
 }:
-
 rustPlatform.buildRustPackage rec {
   pname = "wasm-bindgen-cli";
   inherit version hash cargoHash;
@@ -21,22 +21,28 @@ rustPlatform.buildRustPackage rec {
     inherit pname version hash;
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [pkg-config];
 
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ curl Security ];
+  buildInputs = [openssl] ++ lib.optionals stdenv.isDarwin [curl Security];
 
-  nativeCheckInputs = [ nodejs ];
+  nativeCheckInputs = [nodejs];
 
   # tests require it to be ran in the wasm-bindgen monorepo
   doCheck = false;
 
   meta = with lib; {
     homepage = "https://rustwasm.github.io/docs/wasm-bindgen/";
-    license = with licenses; [ asl20 /* or */ mit ];
+    license = with licenses; [
+      asl20
+      /*
+      or
+      */
+      mit
+    ];
     description = "Facilitating high-level interactions between wasm modules and JavaScript";
-    maintainers = with maintainers; [ rizary ];
+    maintainers = with maintainers; [rizary];
     mainProgram = "wasm-bindgen";
   };
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {};
 }


### PR DESCRIPTION
## Description of changes

Update to the latest minor version: 0.2.93

This likely bandaids (for now) https://github.com/NixOS/nixpkgs/issues/156890 because `wasm-pack` won't try to download it's own version of `wasm-bindgen` if the user includes it in `buildInputs = []` because the versions now match what it expects. Using the `--no-install` flag, as the issue mentions, would also help.

Crates.io
https://crates.io/crates/wasm-bindgen-cli


## Things done

- Built on platform(s)
  - [ ] x86_64-linux (can check tomorrow if need be)
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking (N/A)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

![Patron Saint of Pull Requests](https://raw.githubusercontent.com/xvrqt/cli-flake/dev/patron.png)
