### PR TITLE
eaglemode: 0.96.1 -> 0.96.2

### DIFF
--- a/pkgs/applications/misc/eaglemode/default.nix
+++ b/pkgs/applications/misc/eaglemode/default.nix
@@ -24,6 +24,12 @@
   copyDesktopItems,
   directoryListingUpdater,
   htmldoc,
+  binutils,
+  gzip,
+  p7zip,
+  xz,
+  zip,
+  extraRuntimeDeps ? [ ],
 }:
 
 stdenv.mkDerivation rec {
@@ -81,10 +87,21 @@ stdenv.mkDerivation rec {
 
   installPhase =
     let
-      runtimeDeps = lib.makeBinPath [
-        ghostscript # renders the manual
-        htmldoc # renders HTML files in file browser
-      ];
+      runtimeDeps = lib.makeBinPath (
+        [
+          ghostscript # renders the manual
+          htmldoc # renders HTML files in file browser
+          perl # various display scripts use Perl
+
+          # archive formats in the file browser:
+          binutils
+          gzip
+          p7zip
+          xz
+          zip
+        ]
+        ++ extraRuntimeDeps
+      );
     in
     ''
       runHook preInstall

--- a/pkgs/applications/misc/eaglemode/default.nix
+++ b/pkgs/applications/misc/eaglemode/default.nix
@@ -1,7 +1,30 @@
-{ lib, stdenv, fetchurl, perl, libX11, libXinerama, libjpeg, libpng, libtiff
-, libwebp, pkg-config, librsvg, glib, gtk2, libXext, libXxf86vm, poppler, vlc
-, ghostscript, makeWrapper, tzdata, makeDesktopItem, copyDesktopItems
-, directoryListingUpdater }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  perl,
+  libX11,
+  libXinerama,
+  libjpeg,
+  libpng,
+  libtiff,
+  libwebp,
+  pkg-config,
+  librsvg,
+  glib,
+  gtk2,
+  libXext,
+  libXxf86vm,
+  poppler,
+  vlc,
+  ghostscript,
+  makeWrapper,
+  tzdata,
+  makeDesktopItem,
+  copyDesktopItems,
+  directoryListingUpdater,
+  htmldoc,
+}:
 
 stdenv.mkDerivation rec {
   pname = "eaglemode";
@@ -17,9 +40,28 @@ stdenv.mkDerivation rec {
     substituteInPlace src/emClock/emTimeZonesModel.cpp --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
   '';
 
-  nativeBuildInputs = [ pkg-config makeWrapper copyDesktopItems ];
-  buildInputs = [ perl libX11 libXinerama libjpeg libpng libtiff libwebp
-    librsvg glib gtk2 libXxf86vm libXext poppler vlc ghostscript ];
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+    copyDesktopItems
+  ];
+  buildInputs = [
+    perl
+    libX11
+    libXinerama
+    libjpeg
+    libpng
+    libtiff
+    libwebp
+    librsvg
+    glib
+    gtk2
+    libXxf86vm
+    libXext
+    poppler
+    vlc
+    ghostscript
+  ];
 
   # The program tries to dlopen Xxf86vm, Xext and Xinerama, so we use the
   # trick on NIX_LDFLAGS and dontPatchELF to make it find them.
@@ -32,7 +74,10 @@ stdenv.mkDerivation rec {
 
   dontPatchELF = true;
   # eaglemode expects doc to be in the root directory
-  forceShare = [ "man" "info" ];
+  forceShare = [
+    "man"
+    "info"
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -52,7 +97,12 @@ stdenv.mkDerivation rec {
       icon = pname;
       desktopName = "Eagle Mode";
       genericName = meta.description;
-      categories = [ "Game" "Graphics" "System" "Utility" ];
+      categories = [
+        "Game"
+        "Graphics"
+        "System"
+        "Utility"
+      ];
     })
   ];
 
@@ -66,7 +116,10 @@ stdenv.mkDerivation rec {
     description = "Zoomable User Interface";
     changelog = "https://eaglemode.sourceforge.net/ChangeLog.html";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ chuangzhu ehmry ];
+    maintainers = with maintainers; [
+      chuangzhu
+      ehmry
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/eaglemode/default.nix
+++ b/pkgs/applications/misc/eaglemode/default.nix
@@ -28,11 +28,11 @@
 
 stdenv.mkDerivation rec {
   pname = "eaglemode";
-  version = "0.96.1";
+  version = "0.96.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/eaglemode/${pname}-${version}.tar.bz2";
-    hash = "sha256-FIhCcMghzLg7Odcsou9hBw7kIaqLVUFEAKUk9uwRNNw=";
+    hash = "sha256:1al5n2mcjp0hmsvi4hsdmzd7i0id5i3255xplk0il1nmzydh312a";
   };
 
   # Fixes "Error: No time zones found." on the clock

--- a/pkgs/applications/misc/eaglemode/default.nix
+++ b/pkgs/applications/misc/eaglemode/default.nix
@@ -79,16 +79,23 @@ stdenv.mkDerivation rec {
     "info"
   ];
 
-  installPhase = ''
-    runHook preInstall
-    perl make.pl install dir=$out
-    wrapProgram $out/bin/eaglemode --set EM_DIR "$out" --prefix LD_LIBRARY_PATH : "$out/lib" --prefix PATH : "${ghostscript}/bin"
-    for i in 32 48 96; do
-      mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
-      ln -s $out/res/icons/${pname}$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/${pname}.png
-    done
-    runHook postInstall
-  '';
+  installPhase =
+    let
+      runtimeDeps = lib.makeBinPath [
+        ghostscript # renders the manual
+        htmldoc # renders HTML files in file browser
+      ];
+    in
+    ''
+      runHook preInstall
+      perl make.pl install dir=$out
+      wrapProgram $out/bin/eaglemode --set EM_DIR "$out" --prefix LD_LIBRARY_PATH : "$out/lib" --prefix PATH : "${runtimeDeps}"
+      for i in 32 48 96; do
+        mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
+        ln -s $out/res/icons/${pname}$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/${pname}.png
+      done
+      runHook postInstall
+    '';
 
   desktopItems = [
     (makeDesktopItem {


### PR DESCRIPTION
## Description of changes

Updates [Eagle Mode](https://eaglemode.sourceforge.net/) to the latest released version, which includes various minor bug fixes (for example, on my machine, ghostscript rendering for the manual finally started working).

While here I've done some other related maintenance changes, see the commits for details.

Tested locally on my machine (recent NixOS unstable, x86_64).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Drank enough coffee and zoomed into the eagle's eye
