### PR TITLE
nixos/nixosTests.kerberos: add test suite for LDAP backend

### DIFF
--- a/nixos/tests/kerberos/default.nix
+++ b/nixos/tests/kerberos/default.nix
@@ -4,4 +4,5 @@
 {
   mit = import ./mit.nix { inherit system pkgs; };
   heimdal = import ./heimdal.nix { inherit system pkgs; };
+  ldap = import ./ldap { inherit system pkgs; };
 }

--- a/nixos/tests/kerberos/ldap/default.nix
+++ b/nixos/tests/kerberos/ldap/default.nix
@@ -1,0 +1,7 @@
+{
+  system ? builtins.currentSystem,
+  pkgs ? import ../../../.. { inherit system; },
+}:
+{
+  mit = import ./mit.nix { inherit system pkgs; };
+}

--- a/nixos/tests/kerberos/ldap/mit.nix
+++ b/nixos/tests/kerberos/ldap/mit.nix
@@ -1,0 +1,192 @@
+import ../../make-test-python.nix (
+  { pkgs, ... }:
+  let
+    DITRoot = "dc=example,dc=com";
+    realm = "EXAMPLE.COM";
+
+    krb5Package = pkgs.krb5.override { withLdap = true; };
+
+    # Password used by Kerberos services to bind to their identities
+    krbSrvPwd = "kerberos_service_password";
+    # Stash file read by Kerberos daemons containing the service password
+    # DO NOT DO THIS IN PRODUCTION! The stash file is a fundamental secret!
+    krbPwdStash = pkgs.runCommand "krb-pwd-stash" { } ''
+      for srv in cn=kadmin,${DITRoot} cn=kdc,${DITRoot}
+      do
+        echo -e "${krbSrvPwd}\n${krbSrvPwd}" | \
+             ${krb5Package}/bin/kdb5_ldap_util -r ${realm} stashsrvpw -f $out $srv 2>&1 > /dev/null
+      done
+    '';
+
+    # The LDAP schema for Kerberos 5 objects is part of the source distribution of Kerberos 5
+    krbLdapSchema = pkgs.runCommand "krb-ldap-schema" { } ''
+      tar -Oxf ${krb5Package.src} \
+        ${krb5Package.sourceRoot}/plugins/kdb/ldap/libkdb_ldap/kerberos.openldap.ldif > $out
+    '';
+
+    # Initial LDAP tree containing only the Kerberos services
+    ldapDIT = ''
+      dn: ${DITRoot}
+      objectClass: organization
+      objectClass: dcObject
+      dc: example
+      o: Example Company
+
+      dn: cn=kdc,${DITRoot}
+      objectClass: krbKdcService
+      objectClass: simpleSecurityObject
+      cn: kdc
+      userPassword: ${krbSrvPwd}
+
+      dn: cn=kadmin,${DITRoot}
+      objectClass: krbAdmService
+      objectClass: simpleSecurityObject
+      cn: kadmin
+      userPassword: ${krbSrvPwd}
+    '';
+
+    rootDnPwd = "ldap_root_password";
+  in
+  {
+    name = "kerberos_server-mit-ldap";
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+
+        services.openldap = {
+          enable = true;
+          urlList = [
+            "ldapi:///"
+            "ldap://"
+          ];
+          declarativeContents."${DITRoot}" = ldapDIT;
+          settings = {
+            children = {
+              "cn=schema".includes = [
+                "${pkgs.openldap}/etc/schema/core.ldif"
+                "${pkgs.openldap}/etc/schema/cosine.ldif"
+                "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
+                "${pkgs.openldap}/etc/schema/nis.ldif"
+                "${krbLdapSchema}"
+              ];
+              "olcDatabase={0}config" = {
+                attrs = {
+                  objectClass = [ "olcDatabaseConfig" ];
+                  olcDatabase = "{0}config";
+                };
+              };
+              "olcDatabase={1}mdb" = {
+                attrs = {
+                  objectClass = [
+                    "olcDatabaseConfig"
+                    "olcMdbConfig"
+                  ];
+                  olcDatabase = "{1}mdb";
+                  olcDbDirectory = "/var/lib/openldap/db";
+                  olcSuffix = DITRoot;
+                  olcRootDN = "cn=root,${DITRoot}";
+                  olcRootPW = rootDnPwd;
+                  # A tiny but realistic ACL
+                  olcAccess = [
+                    ''
+                      to attrs=userPassword
+                                          by anonymous auth
+                                          by * none''
+                    ''
+                      to dn.subtree="cn=${realm},cn=realms,${DITRoot}"
+                                          by dn.exact="cn=kdc,${DITRoot}" write
+                                          by dn.exact="cn=kadmin,${DITRoot}" write
+                                          by * none''
+                    ''
+                      to *
+                                          by * read''
+                  ];
+                };
+              };
+            };
+          };
+        };
+
+        services.kerberos_server = {
+          enable = true;
+          settings = {
+            libdefaults.default_realm = realm;
+            realms = {
+              "${realm}" = {
+                acl = [
+                  {
+                    principal = "admin";
+                    access = "all";
+                  }
+                ];
+              };
+            };
+            dbmodules = {
+              "${realm}" = {
+                db_library = "kldap";
+                ldap_kerberos_container_dn = "cn=realms,${DITRoot}";
+                ldap_kdc_dn = "cn=kdc,${DITRoot}";
+                ldap_kadmind_dn = "cn=kadmin,${DITRoot}";
+                ldap_service_password_file = toString krbPwdStash;
+                ldap_servers = "ldapi:///";
+              };
+            };
+          };
+        };
+
+        security.krb5 = {
+          enable = true;
+          package = krb5Package;
+          settings = {
+            libdefaults = {
+              default_realm = realm;
+            };
+            realms = {
+              "${realm}" = {
+                admin_server = "machine";
+                kdc = "machine";
+              };
+            };
+          };
+        };
+
+        users.extraUsers.alice = {
+          isNormalUser = true;
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("openldap.service")
+
+      with subtest("realm container initialization"):
+          machine.succeed(
+              # Passing a master key directly avoids the need for a separate master key stash file
+              "kdb5_ldap_util -D cn=root,${DITRoot} create -w ${rootDnPwd} -s -P master_key",
+          )
+
+      # These units are bound to fail, as they are started before the directory service is ready
+      machine.execute("systemctl restart kadmind.service kdc.service")
+
+      with subtest("service bind"):
+           for unit in ["kadmind", "kdc"]:
+               machine.wait_for_unit(f"{unit}.service")
+
+      with subtest("administration principal initialization"):
+           machine.succeed("kadmin.local add_principal -pw admin_pw admin")
+
+      with subtest("user principal creation and kinit"):
+           machine.succeed(
+               "kadmin -p admin -w admin_pw addprinc -pw alice_pw alice",
+               "echo alice_pw | sudo -u alice kinit",
+           )
+           # Make extra sure that the user principal actually exists in the directory
+           machine.succeed(
+             "ldapsearch -x -D cn=root,${DITRoot} -w ${rootDnPwd} \
+               -b ${DITRoot} 'krbPrincipalName=alice@${realm}' | grep 'numEntries: 1'"
+           )
+    '';
+
+    meta.maintainers = [ pkgs.lib.maintainers.nessdoor ];
+  }
+)

--- a/pkgs/by-name/op/openldap/package.nix
+++ b/pkgs/by-name/op/openldap/package.nix
@@ -129,6 +129,7 @@ stdenv.mkDerivation rec {
 
   passthru.tests = {
     inherit (nixosTests) openldap;
+    kerberosWithLdap = nixosTests.kerberos.ldap;
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes
This change adds a minimal test suite for the LDAP backend of MIT Kerberos, something I promised a long time ago in https://github.com/NixOS/nixpkgs/pull/286043#issuecomment-1928444665.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
