### PR TITLE
pcsx2-bin: 2.1.17 -> 2.1.116, simplified updateScript

### DIFF
--- a/pkgs/by-name/pc/pcsx2-bin/package.nix
+++ b/pkgs/by-name/pc/pcsx2-bin/package.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pcsx2-bin";
-  version = "2.1.17";
+  version = "2.1.116";
 
   src = fetchurl {
     url = "https://github.com/PCSX2/pcsx2/releases/download/v${finalAttrs.version}/pcsx2-v${finalAttrs.version}-macos-Qt.tar.xz";
-    hash = "sha256-WuxvMcGuCyTAc99JkUjG0qcV7SXWy9fmaZR0+8iGepQ=";
+    hash = "sha256-QKblXvqziToYOhSf7k9c/5J5NviRqo4NBLFCN1Q+0VA=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/pc/pcsx2-bin/update.sh
+++ b/pkgs/by-name/pc/pcsx2-bin/update.sh
@@ -3,41 +3,18 @@
 
 set -euo pipefail
 
-ROOT="$(dirname "$(readlink -f "$0")")"
-if [[ ! "$(basename "$ROOT")" == "pcsx2-bin" || ! -f "$ROOT/package.nix" ]]; then
-    echo "error: Not in the pcsx2-bin folder" >&2
-    exit 1
-fi
+cd "$(dirname "$0")" || exit 1
 
-PACKAGE_NIX="$ROOT/package.nix"
+# Grab latest version, ignoring "latest" and "preview" tags
+LATEST_VER="$(curl --fail -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/PCSX2/pcsx2/releases" | jq -r '.[0].tag_name' | sed 's/^v//')"
+CURRENT_VER="$(grep -oP 'version = "\K[^"]+' package.nix)"
 
-# Grab latest (pre)release version
-PCSX2_LATEST_VER="$(curl --fail -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/PCSX2/pcsx2/releases" | jq -r '.[0].tag_name' | sed 's/^v//')"
-PCSX2_CURRENT_VER="$(grep -oP 'version = "\K[^"]+' "$PACKAGE_NIX")"
-
-if [[ "$PCSX2_LATEST_VER" == "$PCSX2_CURRENT_VER" ]]; then
+if [[ "$LATEST_VER" == "$CURRENT_VER" ]]; then
     echo "pcsx2-bin is up-to-date"
     exit 0
 fi
 
-get_hash() {
-    # $1: URL
-    nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "$1")"
-}
+HASH="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "https://github.com/PCSX2/pcsx2/releases/download/v${LATEST_VER}/pcsx2-v${LATEST_VER}-macos-Qt.tar.xz")")"
 
-replace_hash_in_file() {
-    # $1: file
-    # $2: new hash
-    sed -i "s#hash = \".*\"#hash = \"$2\"#g" "$1"
-}
-
-replace_version_in_file() {
-    # $1: file
-    # $2: new version
-    sed -i "s#version = \".*\";#version = \"$2\";#g" "$1"
-}
-
-PCSX2_DARWIN_HASH="$(get_hash "https://github.com/PCSX2/pcsx2/releases/download/v${PCSX2_LATEST_VER}/pcsx2-v${PCSX2_LATEST_VER}-macos-Qt.tar.xz")"
-
-replace_hash_in_file "$PACKAGE_NIX" "$PCSX2_DARWIN_HASH"
-replace_version_in_file "$PACKAGE_NIX" "$PCSX2_LATEST_VER"
+sed -i "s#hash = \".*\"#hash = \"$HASH\"#g" package.nix
+sed -i "s#version = \".*\";#version = \"$LATEST_VER\";#g" package.nix


### PR DESCRIPTION
## Description of changes

- Update to the latest pre-release version.
- Simplified updateScript (similar to #334081 )

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
