### PR TITLE
openapi-python-client: init at 0.21.5

### DIFF
--- a/pkgs/by-name/op/openapi-python-client/package.nix
+++ b/pkgs/by-name/op/openapi-python-client/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  darwin,
+  python3Packages,
+  fetchFromGitHub,
+  installShellFiles,
+  ruff,
+  testers,
+  openapi-python-client,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "openapi-python-client";
+  version = "0.21.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    inherit version;
+    owner = "openapi-generators";
+    repo = "openapi-python-client";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/m/XXNqsr0FjYSEGMSw4zIUpWJDOqu9BzNuJKyb7fKY=";
+  };
+
+  nativeBuildInputs =
+    [
+      installShellFiles
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.ps
+    ];
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  dependencies =
+    (with python3Packages; [
+      attrs
+      httpx
+      jinja2
+      pydantic
+      python-dateutil
+      ruamel-yaml
+      shellingham
+      typer
+      typing-extensions
+    ])
+    ++ [ ruff ];
+
+  # ruff is not packaged as a python module in nixpkgs
+  pythonRemoveDeps = [ "ruff" ];
+
+  postInstall = ''
+    # see: https://github.com/fastapi/typer/blob/5889cf82f4ed925f92e6b0750bf1b1ed9ee672f3/typer/completion.py#L54
+    # otherwise shellingham throws exception on darwin
+    export _TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1
+    installShellCompletion --cmd openapi-python-client \
+      --bash <($out/bin/openapi-python-client --show-completion bash) \
+      --fish <($out/bin/openapi-python-client --show-completion fish) \
+      --zsh <($out/bin/openapi-python-client --show-completion zsh)
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = openapi-python-client;
+    };
+  };
+
+  meta = {
+    description = "Generate modern Python clients from OpenAPI";
+    homepage = "https://github.com/openapi-generators/openapi-python-client";
+    changelog = "https://github.com/openapi-generators/openapi-python-client/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "openapi-python-client";
+    maintainers = with lib.maintainers; [ konradmalik ];
+  };
+}


### PR DESCRIPTION
## Description of changes

A python application to generate modern Python clients from OpenAPI 3.0 and 3.1 documents.

Homepage: https://github.com/openapi-generators/openapi-python-client

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
