### PR TITLE
musescore: 4.3.2 -> 4.4.0

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , wrapQtAppsHook
 , pkg-config
@@ -18,18 +19,16 @@
 , portmidi
 , qtbase
 , qtdeclarative
-, qtgraphicaleffects
 , flac
 , libopusenc
 , libopus
 , tinyxml-2
-, qtquickcontrols
-, qtquickcontrols2
-, qtscript
+, qt5compat
+, qtwayland
 , qtsvg
-, qtxmlpatterns
+, qtscxml
 , qtnetworkauth
-, qtx11extras
+, qttools
 , nixosTests
 , darwin
 }:
@@ -50,31 +49,48 @@ let
   } else portaudio;
 in stdenv'.mkDerivation (finalAttrs: {
   pname = "musescore";
-  version = "4.3.2";
+  version = "4.4.0";
 
   src = fetchFromGitHub {
     owner = "musescore";
     repo = "MuseScore";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-QjvY8R2nq/DeFDikHn9qr4aCEwzAcogQXM5vdZqhoMM=";
+    sha256 = "sha256-oDbOaLFmSpZ7D8E7LBxUwFwiaPcucIUj3eEp6sXR5o8=";
   };
+  patches = [
+    # https://github.com/musescore/MuseScore/pull/24247
+    (fetchpatch {
+      name = "skip-downloading-harfbuzz.patch";
+      url = "https://github.com/musescore/MuseScore/commit/686ea243d58b43eb3dff7ebdabb2e09de4d212e4.patch";
+      hash = "sha256-fsb1hKFKXwBdMPh+Ek0UT3XtI8qg3ieWUQW1/XDvhmg=";
+    })
+    # https://github.com/musescore/MuseScore/pull/24261
+    (fetchpatch {
+      name = "allow-using-system-harfbuzz.patch";
+      url = "https://github.com/musescore/MuseScore/commit/696279e362afe72db5e92f8a47aa64b3a0e86a86.patch";
+      hash = "sha256-z1W2SmzUUlVL7mRR2frzUZjMEnwqkVfRVz4TufR1tDU=";
+    })
+    # https://github.com/musescore/MuseScore/pull/24326
+    (fetchpatch {
+      name = "fix-menubar-with-qt6.5+.patch";
+      url = "https://github.com/musescore/MuseScore/pull/24326/commits/b274f13311ad0b2bce339634a006ba22fbd3379e.patch";
+      hash = "sha256-ZGmjRa01CBEIxJdJYQMhdg4A9yjWdlgn0pCPmENBTq0=";
+    })
+  ];
 
   cmakeFlags = [
-    "-DMUSESCORE_BUILD_MODE=release"
+    "-DMUSE_APP_BUILD_MODE=release"
     # Disable the build and usage of the `/bin/crashpad_handler` utility - it's
     # not useful on NixOS, see:
     # https://github.com/musescore/MuseScore/issues/15571
-    "-DMUE_BUILD_CRASHPAD_CLIENT=OFF"
+    "-DMUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT=OFF"
     # Use our versions of system libraries
     "-DMUE_COMPILE_USE_SYSTEM_FREETYPE=ON"
+    "-DMUE_COMPILE_USE_SYSTEM_HARFBUZZ=ON"
     "-DMUE_COMPILE_USE_SYSTEM_TINYXML=ON"
     # Implies also -DMUE_COMPILE_USE_SYSTEM_OPUS=ON
     "-DMUE_COMPILE_USE_SYSTEM_OPUSENC=ON"
     "-DMUE_COMPILE_USE_SYSTEM_FLAC=ON"
-    # From some reason, in $src/build/cmake/SetupBuildEnvironment.cmake,
-    # upstream defaults to compiling to x86_64 only, unless this cmake flag is
-    # set
-    "-DMUE_COMPILE_BUILD_MACOS_APPLE_SILICON=ON"
     # Don't bundle qt qml files, relevant really only for darwin, but we set
     # this for all platforms anyway.
     "-DMUE_COMPILE_INSTALL_QTQML_FILES=OFF"
@@ -94,6 +110,7 @@ in stdenv'.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     wrapQtAppsHook
     cmake
+    qttools
     pkg-config
     ninja
   ];
@@ -114,14 +131,11 @@ in stdenv'.mkDerivation (finalAttrs: {
     tinyxml-2
     qtbase
     qtdeclarative
-    qtgraphicaleffects
-    qtquickcontrols
-    qtquickcontrols2
-    qtscript
+    qt5compat
+    qtwayland
     qtsvg
-    qtxmlpatterns
+    qtscxml
     qtnetworkauth
-    qtx11extras
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32071,7 +32071,7 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
-  musescore = libsForQt5.callPackage ../applications/audio/musescore { };
+  musescore = qt6.callPackage ../applications/audio/musescore { };
 
   music-player = callPackage ../applications/audio/music-player { };
 


### PR DESCRIPTION
## Description of changes

Not ready yet, see https://github.com/musescore/MuseScore/issues/24235 .

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
