### PR TITLE
python312Packages.itk: init at 5.4.0

### DIFF
--- a/pkgs/development/libraries/itk/generic.nix
+++ b/pkgs/development/libraries/itk/generic.nix
@@ -10,6 +10,8 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  castxml,
+  swig,
   expat,
   fftw,
   gdcm,
@@ -20,13 +22,21 @@
   libpng,
   libX11,
   libuuid,
+  patchelf,
+  python ? null,
+  numpy ? null,
   xz,
   vtk,
+  which,
   zlib,
   Cocoa,
+  enablePython ? false,
 }:
 
 let
+  # Python wrapper contains its own VTK support incompatible with MODULE_ITKVtkGlue
+  withVtk = !enablePython;
+
   itkGenericLabelInterpolatorSrc = fetchFromGitHub {
     owner = "InsightSoftwareConsortium";
     repo = "ITKGenericLabelInterpolator";
@@ -47,6 +57,19 @@ let
     rev = "bb896868fc6480835495d0da4356d5db009592a6";
     hash = "sha256-MfaIA0xxA/pzUBSwnAevr17iR23Bo5iQO2cSyknS3o4=";
   };
+
+  # remove after next swig update:
+  swigUnstable = swig.overrideAttrs ({
+    version = "4.2.1-unstable-2024-08-19";
+
+    src = fetchFromGitHub {
+      owner = "swig";
+      repo = "swig";
+      rev = "5ac5d90f970759fbe705fae551d0743a7c63c67e";
+      hash = "sha256-32EFLHpP4l04nqrc8dt4Qsr8deTBqLt8lUlhnNnaIGU=";
+    };
+
+  });
 in
 
 stdenv.mkDerivation {
@@ -77,39 +100,56 @@ stdenv.mkDerivation {
     ln -sr ${itkSimpleITKFiltersSrc} Modules/External/ITKSimpleITKFilters
   '';
 
-  cmakeFlags = [
-    "-DBUILD_EXAMPLES=OFF"
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DITK_FORBID_DOWNLOADS=ON"
-    "-DITK_USE_SYSTEM_LIBRARIES=ON" # finds common libraries e.g. hdf5, libpng, libtiff, zlib, but not GDCM, NIFTI, MINC, etc.
-    # note ITK_USE_SYSTEM_EIGEN, part of ITK_USE_SYSTEM_LIBRARIES,
-    # causes "...-itk-5.2.1/include/ITK-5.2/itkSymmetricEigenAnalysis.h:23:31: fatal error: Eigen/Eigenvalues: No such file or directory"
-    # when compiling c3d, but maybe an ITK 5.2/eigen version issue:
-    "-DITK_USE_SYSTEM_EIGEN=OFF"
-    "-DITK_USE_SYSTEM_GOOGLETEST=OFF" # ANTs build failure due to https://github.com/ANTsX/ANTs/issues/1489
-    "-DITK_USE_SYSTEM_GDCM=ON"
-    "-DITK_USE_SYSTEM_MINC=ON"
-    "-DLIBMINC_DIR=${libminc}/lib/cmake"
-    "-DModule_ITKMINC=ON"
-    "-DModule_ITKIOMINC=ON"
-    "-DModule_ITKIOTransformMINC=ON"
-    "-DModule_SimpleITKFilters=ON"
-    "-DModule_ITKVtkGlue=ON"
-    "-DModule_ITKReview=ON"
-    "-DModule_MGHIO=ON"
-    "-DModule_AdaptiveDenoising=ON"
-    "-DModule_GenericLabelInterpolator=ON"
-  ];
+  cmakeFlags =
+    [
+      "-DBUILD_EXAMPLES=OFF"
+      "-DBUILD_SHARED_LIBS=ON"
+      "-DITK_FORBID_DOWNLOADS=ON"
+      "-DITK_USE_SYSTEM_LIBRARIES=ON" # finds common libraries e.g. hdf5, libpng, libtiff, zlib, but not GDCM, NIFTI, MINC, etc.
+      # note ITK_USE_SYSTEM_EIGEN, part of ITK_USE_SYSTEM_LIBRARIES,
+      # causes "...-itk-5.2.1/include/ITK-5.2/itkSymmetricEigenAnalysis.h:23:31: fatal error: Eigen/Eigenvalues: No such file or directory"
+      # when compiling c3d, but maybe an ITK 5.2/eigen version issue:
+      "-DITK_USE_SYSTEM_EIGEN=OFF"
+      "-DITK_USE_SYSTEM_GOOGLETEST=OFF" # ANTs build failure due to https://github.com/ANTsX/ANTs/issues/1489
+      "-DITK_USE_SYSTEM_GDCM=ON"
+      "-DITK_USE_SYSTEM_MINC=ON"
+      "-DLIBMINC_DIR=${libminc}/lib/cmake"
+      "-DModule_ITKMINC=ON"
+      "-DModule_ITKIOMINC=ON"
+      "-DModule_ITKIOTransformMINC=ON"
+      "-DModule_SimpleITKFilters=ON"
+      "-DModule_ITKReview=ON"
+      "-DModule_MGHIO=ON"
+      "-DModule_AdaptiveDenoising=ON"
+      "-DModule_GenericLabelInterpolator=ON"
+    ]
+    ++ lib.optionals enablePython [
+      "-DITK_WRAP_PYTHON=ON"
+      "-DITK_USE_SYSTEM_CASTXML=ON"
+      "-DITK_USE_SYSTEM_SWIG=ON"
+      "-DPY_SITE_PACKAGES_PATH=${placeholder "out"}/${python.sitePackages}"
+    ]
+    ++ lib.optionals withVtk [ "-DModule_ITKVtkGlue=ON" ];
 
-  nativeBuildInputs = [
-    cmake
-    xz
-  ];
-  buildInputs = [
-    libX11
-    libuuid
-    vtk
-  ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
+  nativeBuildInputs =
+    [
+      cmake
+      xz
+    ]
+    ++ lib.optionals enablePython [
+      castxml
+      swigUnstable
+      which
+    ];
+
+  buildInputs =
+    [
+      libX11
+      libuuid
+    ]
+    ++ lib.optionals stdenv.isDarwin [ Cocoa ]
+    ++ lib.optionals enablePython [ python ]
+    ++ lib.optionals withVtk [ vtk ];
   # Due to ITKVtkGlue=ON and the additional dependencies needed to configure VTK 9
   # (specifically libGL and libX11 on Linux),
   # it's now seemingly necessary for packages that configure ITK to
@@ -130,12 +170,30 @@ stdenv.mkDerivation {
     libpng
     libtiff
     zlib
-  ] ++ vtk.propagatedBuildInputs;
+  ] ++ lib.optionals withVtk vtk.propagatedBuildInputs ++ lib.optionals enablePython [ numpy ];
+
+  postInstall = lib.optionalString enablePython ''
+    substitute \
+      ${./itk.egg-info} \
+      $out/${python.sitePackages}/itk-${version}.egg-info \
+      --subst-var-by ITK_VER "${version}"
+  '';
+
+  # remove forbidden reference to /build which occur when building the Python wrapping
+  # (also remove a copy of itkTestDriver with incorrect permissions/RPATH):
+  preFixup = lib.optionals enablePython ''
+    rm $out/${python.sitePackages}/itk/itkTestDriver
+    find $out/${python.sitePackages}/itk -type f -name '*.so*' -exec \
+      patchelf {} --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" \;
+  '';
 
   meta = {
     description = "Insight Segmentation and Registration Toolkit";
     homepage = "https://www.itk.org";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bcdarwin ];
+    # aarch64-linux Python wrapping fails with "error: unknown type name '_Float128'" and similar;
+    # compilation runs slowly and times out on Darwin
+    platforms = with lib.platforms; if enablePython then [ "x86_64-linux" ] else unix;
   };
 }

--- a/pkgs/development/libraries/itk/itk.egg-info
+++ b/pkgs/development/libraries/itk/itk.egg-info
@@ -1,0 +1,5 @@
+Metadata-Version: 2.1
+Name: itk
+Version: @ITK_VER@
+Summary: Insight Segmentation and Registration Toolkit
+Platform: UNKNOWN

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6206,6 +6206,12 @@ self: super: with self; {
 
   itanium-demangler = callPackage ../development/python-modules/itanium-demangler { };
 
+  itk = toPythonModule (pkgs.itk.override {
+    inherit python numpy;
+    enablePython = true;
+  });
+
+
   item-synchronizer = callPackage ../development/python-modules/item-synchronizer { };
 
   itemadapter = callPackage ../development/python-modules/itemadapter { };
@@ -14477,7 +14483,7 @@ self: super: with self; {
   simplehound = callPackage ../development/python-modules/simplehound { };
 
   simpleitk = callPackage ../development/python-modules/simpleitk {
-    inherit (pkgs) simpleitk;
+    inherit (pkgs) itk simpleitk;
   };
 
   simplejson = callPackage ../development/python-modules/simplejson { };


### PR DESCRIPTION
## Description of changes

Init the Python wrapping for [ITK](https://github.com/InsightSoftwareConsortium/ITK), a major biomedical imaging software package. The wrapping is useful in its own right and is also a dependency of various other packages such as ITKElastix, MONAI-Label, MONAI-Vista, ITKWidgets, ITKWASM, ngff-zarr, etc.

Unfortunately, the SWIG/castXML wrapping is a bit of a beast to build relative to the `C++`-only build, though not horrible by the standards of C++ projects.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
