### PR TITLE
[24.05] webtorrent_desktop: update and use latest electron

### DIFF
--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -2,20 +2,14 @@
 
 buildNpmPackage {
   pname = "webtorrent-desktop";
-  version = "0.25-pre-1eb612";
+  version = "0.25-pre-ac7f16";
   src = fetchFromGitHub {
     owner = "webtorrent";
     repo = "webtorrent-desktop";
-    rev = "1eb61201d6360698a2cc4ea72bf0fa7ee78b457c";
-    sha256 = "sha256-DBEFOamncyidMXypvKNnUmDIPUq1LzYjDgox7fa4+Gg=";
+    rev = "ac7f16e71c96c5ad670bfcb8728df5af78ae21a1";
+    sha256 = "sha256-UEN5NhLVSQEO8rsiTW1hJPjNFL9KobW/Bho98FzKaf4=";
   };
   patches = [
-    # electron 27 fix
-    (fetchpatch {
-      name = "2388.patch"; # https://github.com/webtorrent/webtorrent-desktop/pull/2388
-      url = "https://github.com/webtorrent/webtorrent-desktop/compare/ebaf9cf8487dbd9e14a9a0c5adc3eab23b199e58...0c3e55d1f091bf66a342e2732550ebeccc2e4169.patch";
-      hash = "sha256-gam5oAZtsaiCNFwecA5ff0nhraySLx3SOHlb/js+cPM=";
-    })
     # startup fix
     (fetchpatch {
       name = "2389.patch"; # https://github.com/webtorrent/webtorrent-desktop/pull/2389
@@ -23,7 +17,7 @@ buildNpmPackage {
       hash = "sha256-hBJGLNNjcGRhYOFlLm/RL0po+70tEeJtR6Y/CfacPAI=";
     })
   ];
-  npmDepsHash = "sha256-tqhp3jDb1xtyV/n9kJtzkiznLQfqeYWeZiTnTVV0ibE=";
+  npmDepsHash = "sha256-otAes6GkqoAVvfeWhWgyY4IVZIZxw3WtkrVdEWIk1Lk=";
   makeCacheWritable = true;
   npmRebuildFlags = [ "--ignore-scripts" ];
   installPhase = ''

--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -12,12 +12,14 @@ buildNpmPackage {
   patches = [
     # electron 27 fix
     (fetchpatch {
-      url = "https://github.com/webtorrent/webtorrent-desktop/pull/2388.patch";
+      name = "2388.patch"; # https://github.com/webtorrent/webtorrent-desktop/pull/2388
+      url = "https://github.com/webtorrent/webtorrent-desktop/compare/ebaf9cf8487dbd9e14a9a0c5adc3eab23b199e58...0c3e55d1f091bf66a342e2732550ebeccc2e4169.patch";
       hash = "sha256-gam5oAZtsaiCNFwecA5ff0nhraySLx3SOHlb/js+cPM=";
     })
     # startup fix
     (fetchpatch {
-      url = "https://github.com/webtorrent/webtorrent-desktop/pull/2389.patch";
+      name = "2389.patch"; # https://github.com/webtorrent/webtorrent-desktop/pull/2389
+      url = "https://github.com/webtorrent/webtorrent-desktop/commit/407046d150ed7ff876a5e1978f68630e9c8f0074.patch";
       hash = "sha256-hBJGLNNjcGRhYOFlLm/RL0po+70tEeJtR6Y/CfacPAI=";
     })
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35388,9 +35388,7 @@ with pkgs;
 
   webssh = with python3Packages; toPythonApplication webssh;
 
-  webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop {
-    electron = electron_27;
-  };
+  webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop { };
 
   wrapWeechat = callPackage ../applications/networking/irc/weechat/wrapper.nix { };
 


### PR DESCRIPTION
## Description of changes

Backport #320293 to release 24.05 to unblock #337776

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
