### PR TITLE
jetbrains.plugins: add Minecraft Development, GdScript and Vineflower

### DIFF
--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -657,6 +657,37 @@
       },
       "name": "netbeans-6-5-keymap"
     },
+    "20123": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-community",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "241.18034.1093": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "241.18968.39": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "242.20224.385": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "242.20224.413": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "242.20224.424": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "242.20224.425": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "242.20224.427": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "242.20224.431": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "242.21829.142": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "242.21829.149": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip",
+        "242.21829.153": "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip"
+      },
+      "name": "gdscript"
+    },
     "20146": {
       "compatible": [
         "clion",
@@ -722,6 +753,7 @@
     "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip": "sha256-uMIrYoZE16X/K96HuDJx8QMh6wUbi4+qSw+HJAq7ukI=",
     "https://plugins.jetbrains.com/files/17718/590469/github-copilot-intellij-1.5.20.6554.zip": "sha256-QNVo6sLKwj+jJ2PMcJ3P5cAr1LwhFpH2+uglWO9ncQE=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
+    "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip": "sha256-pHmcD0gITA5E9vwHajnHfk+x7V6ijpXoTc4f/4xGRT4=",
     "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip": "sha256-DUiIQYIzYoXmgtBakSLtMB+xxJMaR70Jgg9erySa3wQ=",
     "https://plugins.jetbrains.com/files/2162/542984/StringManipulation-9.14.1.zip": "sha256-OqeQCqFe8iW/8NPg+9i+UKh+twIPQ9uLZrItMukCi7k=",
     "https://plugins.jetbrains.com/files/22407/591052/intellij-rust-241.38968.39.zip": "sha256-Pgtj1czuScTmog7oh/2aME9jv4KlhT/ep6hwjSB73Ak=",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -309,6 +309,16 @@
       },
       "name": "-deprecated-rust-beta"
     },
+    "8327": {
+      "compatible": [
+        "idea-community",
+        "idea-ultimate"
+      ],
+      "builds": {
+        "242.21829.142": "https://plugins.jetbrains.com/files/8327/585232/MinecraftDev-2024.2-1.8.1.zip"
+      },
+      "name": "minecraft-development"
+    },
     "8554": {
       "compatible": [
         "goland",
@@ -728,6 +738,7 @@
     "https://plugins.jetbrains.com/files/7322/595111/python-ce-242.21829.142.zip": "sha256-DwQNhbNO1zk75lcf35spNnzo0u103UAhXignhO+grek=",
     "https://plugins.jetbrains.com/files/7391/561441/asciidoctor-intellij-plugin-0.42.2.zip": "sha256-oKczkLHAk2bJRNRgToVe0ySEJGF8+P4oWqQ33olwzWw=",
     "https://plugins.jetbrains.com/files/7391/591338/asciidoctor-intellij-plugin-0.43.1.zip": "sha256-AGP8YY6NG/hy7xIDoiJy3GZHRB9stVNYYoHtqOmYCx0=",
+    "https://plugins.jetbrains.com/files/8327/585232/MinecraftDev-2024.2-1.8.1.zip": "sha256-DoL+BctbcXT55bjcvmtx5wqfPK+VoAunyfvupoV459c=",
     "https://plugins.jetbrains.com/files/8554/579645/featuresTrainer-242.20224.175.zip": "sha256-5gYFQjYWFro/nDxCn8q51GkLLv3JkJDS7jr70xhM0Q0=",
     "https://plugins.jetbrains.com/files/8554/588322/featuresTrainer-242.21829.14.zip": "sha256-pL+j0K6U0DZibnmcIE6kY9Kj/+5g8akuHeuppuZiEII=",
     "https://plugins.jetbrains.com/files/8607/587258/NixIDEA-0.4.0.15.zip": "sha256-j5/LgTrFJ4OEIlocX4jcjgYzHlBId1nh1NfE2qLc1HQ=",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -626,6 +626,16 @@
       },
       "name": "github-copilot"
     },
+    "18032": {
+      "compatible": [
+        "idea-community",
+        "idea-ultimate"
+      ],
+      "builds": {
+        "242.21829.142": "https://plugins.jetbrains.com/files/18032/594467/vineflower-intellij-plugin-1.2.0.zip"
+      },
+      "name": "vineflower"
+    },
     "18444": {
       "compatible": [
         "clion",
@@ -752,6 +762,7 @@
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip": "sha256-uMIrYoZE16X/K96HuDJx8QMh6wUbi4+qSw+HJAq7ukI=",
     "https://plugins.jetbrains.com/files/17718/590469/github-copilot-intellij-1.5.20.6554.zip": "sha256-QNVo6sLKwj+jJ2PMcJ3P5cAr1LwhFpH2+uglWO9ncQE=",
+    "https://plugins.jetbrains.com/files/18032/594467/vineflower-intellij-plugin-1.2.0.zip": "sha256-w92j6LAHFAikFAIrOUg8a5C7odVD624nIcQT050hLDo=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/20123/563619/GdScript-2.5.6.zip": "sha256-pHmcD0gITA5E9vwHajnHfk+x7V6ijpXoTc4f/4xGRT4=",
     "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip": "sha256-DUiIQYIzYoXmgtBakSLtMB+xxJMaR70Jgg9erySa3wQ=",


### PR DESCRIPTION
## Description of changes
These are some missing plugins I personally use.

- [Minecraft Development](https://plugins.jetbrains.com/plugin/8327-minecraft-development): for Minecraft mod development
- [GdScript](https://plugins.jetbrains.com/plugin/20123-gdscript): Support for file formats of the Godot game engine
	- NOTE: another plugin with a very similar name exists (different casing, "GDScript"), could be a problem if both were to be added?
- [Vineflower](https://plugins.jetbrains.com/plugin/18032-vineflower): Java decompiler

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
