### PR TITLE
warp-terminal: Add Aarch64 support

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -23,12 +23,17 @@ pname = "warp-terminal";
 versions = lib.importJSON ./versions.json;
 passthru.updateScript = ./update.sh;
 
+linux_arch =
+  if stdenv.hostPlatform.system == "x86_64-linux"
+    then "x86_64"
+    else "aarch64";
+
 linux = stdenv.mkDerivation (finalAttrs:  {
   inherit pname meta passthru;
-  inherit (versions.linux) version;
+  inherit (versions."linux_${linux_arch}") version;
   src = fetchurl {
-    inherit (versions.linux) hash;
-    url = "https://releases.warp.dev/stable/v${finalAttrs.version}/warp-terminal-v${finalAttrs.version}-1-x86_64.pkg.tar.zst";
+    inherit (versions."linux_${linux_arch}") hash;
+    url = "https://releases.warp.dev/stable/v${finalAttrs.version}/warp-terminal-v${finalAttrs.version}-1-${linux_arch}.pkg.tar.zst";
   };
 
   sourceRoot = ".";
@@ -100,7 +105,7 @@ meta = with lib; {
   license = licenses.unfree;
   sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   maintainers = with maintainers; [ emilytrau imadnyc donteatoreo johnrtitor ];
-  platforms = platforms.darwin ++ [ "x86_64-linux" ];
+  platforms = platforms.darwin ++ [ "x86_64-linux" "aarch64-linux" ];
 };
 
 in

--- a/pkgs/by-name/wa/warp-terminal/update.sh
+++ b/pkgs/by-name/wa/warp-terminal/update.sh
@@ -27,8 +27,12 @@ resolve_url() {
             pkg=macos
             sfx=dmg
             ;;
-        linux)
+        linux_x86_64)
             pkg=pacman
+            sfx=pkg.tar.zst
+            ;;
+        linux_aarch64)
+            pkg=pacman_arm64
             sfx=pkg.tar.zst
             ;;
         *)
@@ -64,7 +68,8 @@ sri_get() {
 }
 
 
-for sys in darwin linux; do
+for sys in darwin linux_x86_64 linux_aarch64; do
+    echo ${sys}
     url=$(resolve_url ${sys})
     version=$(get_version "${url}")
     if [[ ${version} != "$(json_get ".${sys}.version")" ]]; then

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -3,8 +3,12 @@
     "hash": "sha256-EDhj4Gb0ykFX8W2G8osusjggemcuHO7hkUKb151cQ6g=",
     "version": "0.2024.08.20.08.02.stable_00"
   },
-  "linux": {
+  "linux_x86_64": {
     "hash": "sha256-Uk5pSoAvEppjLnskLc5/ftcCaiJnXATJfCPDP2QpBo8=",
+    "version": "0.2024.08.20.08.02.stable_00"
+  },
+  "linux_aarch64": {
+    "hash": "sha256-B0mUAwydIgi7Nhm/iUhEjkV3LL+qLfXZcOz6+7eDZGc=",
     "version": "0.2024.08.20.08.02.stable_00"
   }
 }


### PR DESCRIPTION
## Description of changes

Simple only add aarch64 support

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
