### PR TITLE
ffmpeg: ffmpeg_6 -> ffmpeg_7

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -391,9 +391,6 @@
 - The `services.mxisd` module has been removed as both [mxisd](https://github.com/kamax-matrix/mxisd) and [ma1sd](https://github.com/ma1uta/ma1sd) are not maintained any longer.
   Consequently the package `pkgs.ma1sd` has also been removed.
 
-- `ffmpeg_5` has been removed. Please use the unversioned `ffmpeg`,
-  pin a newer version, or if necessary pin `ffmpeg_4` for compatibility.
-
 - The `xdg.portal.gtkUsePortal` option has been removed, as it had been deprecated for over 2 years. Using the `GTK_USE_PORTAL` environment variable in this manner is not intended nor encouraged by the GTK developers, but can still be done manually via `environment.sessionVariables`.
 
 - The `services.trust-dns` module has been renamed to `services.hickory-dns`.
@@ -424,6 +421,14 @@
 
 - Minimal installer ISOs are no longer built on the small channel.
   Please obtain installer images from the full release channels.
+
+- The default FFmpeg version is now 7, and FFmpeg 5 has been removed.
+  Please prefer using the package variants without a version suffix,
+  or pin FFmpeg 6 or 4 if necessary for compatibility.
+  Note that we keep old versions around only as required
+  to support packages in the tree,
+  and FFmpeg 4 especially should be avoided in favour of newer versions
+  as it may be removed soon.
 
 ## Other Notable Changes {#sec-release-24.11-notable-changes}
 

--- a/nixos/modules/services/video/go2rtc/default.nix
+++ b/nixos/modules/services/video/go2rtc/default.nix
@@ -55,8 +55,8 @@ in
           ffmpeg = {
             bin = mkOption {
               type = path;
-              default = lib.getExe pkgs.ffmpeg_7-headless;
-              defaultText = literalExpression "lib.getExe pkgs.ffmpeg_7-headless";
+              default = lib.getExe pkgs.ffmpeg-headless;
+              defaultText = literalExpression "lib.getExe pkgs.ffmpeg-headless";
               description = ''
                 The ffmpeg package to use for transcoding.
               '';

--- a/pkgs/applications/audio/audacity/default.nix
+++ b/pkgs/applications/audio/audacity/default.nix
@@ -30,7 +30,7 @@
 , libid3tag
 , libopus
 , libuuid
-, ffmpeg_7
+, ffmpeg
 , soundtouch
 , pcre
 , portaudio # given up fighting their portaudio.patch?
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     expat
-    ffmpeg_7
+    ffmpeg
     file
     flac
     gtk3
@@ -179,7 +179,7 @@ stdenv.mkDerivation rec {
   postFixup = lib.optionalString stdenv.isLinux ''
     wrapProgram "$out/bin/audacity" \
       "''${gappsWrapperArgs[@]}" \
-      --prefix LD_LIBRARY_PATH : "$out/lib/audacity":${lib.makeLibraryPath [ ffmpeg_7 ]} \
+      --prefix LD_LIBRARY_PATH : "$out/lib/audacity":${lib.makeLibraryPath [ ffmpeg ]} \
       --suffix AUDACITY_MODULES_PATH : "$out/lib/audacity/modules" \
       --suffix AUDACITY_PATH : "$out/share/audacity"
   '' + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/applications/audio/keyfinder-cli/default.nix
+++ b/pkgs/applications/audio/keyfinder-cli/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ffmpeg_7, libkeyfinder, fftw }:
+{ lib, stdenv, fetchFromGitHub, ffmpeg, libkeyfinder, fftw }:
 
 stdenv.mkDerivation rec {
   pname = "keyfinder-cli";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-9/+wzPTaQ5PfPiqTZ5EuHdswXJgfgnvAul/FeeDbbJA=";
   };
 
-  buildInputs = [ ffmpeg_7 libkeyfinder fftw ];
+  buildInputs = [ ffmpeg libkeyfinder fftw ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/applications/audio/moc/default.nix
+++ b/pkgs/applications/audio/moc/default.nix
@@ -16,7 +16,7 @@
 , musepackSupport ? true, libmpc, libmpcdec, taglib
 , vorbisSupport ? true, libvorbis
 , speexSupport ? true, speex
-, ffmpegSupport ? true, ffmpeg_7
+, ffmpegSupport ? true, ffmpeg
 , sndfileSupport ? true, libsndfile
 , wavpackSupport ? true, wavpack
 # Misc
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
     ++ lib.optionals musepackSupport [ libmpc libmpcdec taglib ]
     ++ lib.optional vorbisSupport libvorbis
     ++ lib.optional speexSupport speex
-    ++ lib.optional ffmpegSupport ffmpeg_7
+    ++ lib.optional ffmpegSupport ffmpeg
     ++ lib.optional sndfileSupport libsndfile
     ++ lib.optional wavpackSupport wavpack
     # Misc

--- a/pkgs/applications/audio/pianobar/default.nix
+++ b/pkgs/applications/audio/pianobar/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, lib, stdenv, pkg-config, libao, json_c, libgcrypt, ffmpeg_7, curl }:
+{ fetchFromGitHub, lib, stdenv, pkg-config, libao, json_c, libgcrypt, ffmpeg, curl }:
 
 stdenv.mkDerivation rec {
   pname = "pianobar";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    libao json_c libgcrypt ffmpeg_7 curl
+    libao json_c libgcrypt ffmpeg curl
   ];
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/applications/emulators/retroarch/default.nix
+++ b/pkgs/applications/emulators/retroarch/default.nix
@@ -8,7 +8,7 @@
 , alsa-lib
 , dbus
 , fetchFromGitHub
-, ffmpeg_7
+, ffmpeg
 , flac
 , freetype
 , gamemode
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     lib.optional (runtimeLibs != [ ]) makeWrapper;
 
   buildInputs = [
-    ffmpeg_7
+    ffmpeg
     flac
     freetype
     libGL

--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch2, copyDesktopItems, makeDesktopItem, qmake
 , qtbase, qtxmlpatterns, qttools, qtwebengine, libGL, fontconfig, openssl, poppler, wrapQtAppsHook
-, ffmpeg_7, libva, alsa-lib, SDL, x264, libvpx, libvorbis, libtheora, libogg
+, ffmpeg, libva, alsa-lib, SDL, x264, libvpx, libvorbis, libtheora, libogg
 , libopus, lame, fdk_aac, libass, quazip, libXext, libXfixes }:
 
 let
@@ -68,7 +68,7 @@ in stdenv.mkDerivation (finalAttrs: {
     fontconfig
     openssl
     poppler
-    ffmpeg_7
+    ffmpeg
     libva
     alsa-lib
     SDL

--- a/pkgs/applications/kde/ffmpegthumbs.nix
+++ b/pkgs/applications/kde/ffmpegthumbs.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib,
   extra-cmake-modules,
-  ffmpeg_7, kio, taglib
+  ffmpeg, kio, taglib
 }:
 
 mkDerivation {
@@ -11,5 +11,5 @@ mkDerivation {
     maintainers = [ lib.maintainers.ttuegel ];
   };
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ ffmpeg_7 kio taglib ];
+  buildInputs = [ ffmpeg kio taglib ];
 }

--- a/pkgs/applications/science/networking/sumo/default.nix
+++ b/pkgs/applications/science/networking/sumo/default.nix
@@ -1,4 +1,4 @@
-{ lib, bzip2, cmake, eigen, fetchFromGitHub, ffmpeg_7, fox_1_6, gdal,
+{ lib, bzip2, cmake, eigen, fetchFromGitHub, ffmpeg, fox_1_6, gdal,
   git, gl2ps, gpp , gtest, jdk, libGL, libGLU, libX11, libjpeg,
   libpng, libtiff, libxcrypt, openscenegraph , proj, python3,
   python3Packages, stdenv, swig, xercesc, xorg, zlib }:
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     bzip2
     eigen
-    ffmpeg_7
+    ffmpeg
     fox_1_6
     gdal
     gl2ps

--- a/pkgs/applications/video/dvdstyler/default.nix
+++ b/pkgs/applications/video/dvdstyler/default.nix
@@ -7,7 +7,7 @@
 , docbook-xsl-nons
 , dvdauthor
 , dvdplusrwtools
-, ffmpeg_7
+, ffmpeg
 , flex
 , fontconfig
 , gettext
@@ -55,7 +55,7 @@ in stdenv.mkDerivation rec {
     cdrtools
     dvdauthor
     dvdplusrwtools
-    ffmpeg_7
+    ffmpeg
     fontconfig
     glib
     libexif

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, stdenv, fetchurl, fetchsvn, pkg-config, freetype, yasm, ffmpeg_7
+{ config, lib, stdenv, fetchurl, fetchsvn, pkg-config, freetype, yasm, ffmpeg
 , aalibSupport ? true, aalib
 , fontconfigSupport ? true, fontconfig, freefont_ttf
 , fribidiSupport ? true, fribidi
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config yasm ];
-  buildInputs = [ freetype ffmpeg_7 ]
+  buildInputs = [ freetype ffmpeg ]
     ++ lib.optional aalibSupport aalib
     ++ lib.optional fontconfigSupport fontconfig
     ++ lib.optional fribidiSupport fribidi

--- a/pkgs/applications/video/simplescreenrecorder/default.nix
+++ b/pkgs/applications/video/simplescreenrecorder/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub, alsa-lib, ffmpeg_7, libjack2, libX11, libXext, libXinerama, qtx11extras
+{ lib, stdenv, mkDerivation, fetchFromGitHub, alsa-lib, ffmpeg, libjack2, libX11, libXext, libXinerama, qtx11extras
 , libXfixes, libGLU, libGL, pkg-config, libpulseaudio, libv4l, qtbase, qttools, cmake, ninja, nix-update-script
 }:
 
@@ -29,7 +29,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config cmake ninja ];
   buildInputs = [
-    alsa-lib ffmpeg_7 libjack2 libX11 libXext libXfixes libXinerama libGLU libGL
+    alsa-lib ffmpeg libjack2 libX11 libXext libXfixes libXinerama libGLU libGL
     libpulseaudio libv4l qtbase qttools qtx11extras
   ];
 

--- a/pkgs/applications/video/webcamoid/default.nix
+++ b/pkgs/applications/video/webcamoid/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, fetchpatch2, pkg-config, libxcb, mkDerivation, cmake
 , qtbase, qtdeclarative, qtquickcontrols, qtquickcontrols2
-, ffmpeg_7, gst_all_1, libpulseaudio, alsa-lib, jack2
+, ffmpeg, gst_all_1, libpulseaudio, alsa-lib, jack2
 , v4l-utils }:
 mkDerivation rec {
   pname = "webcamoid";
@@ -24,7 +24,7 @@ mkDerivation rec {
   buildInputs = [
     libxcb
     qtbase qtdeclarative qtquickcontrols qtquickcontrols2
-    ffmpeg_7
+    ffmpeg
     gst_all_1.gstreamer gst_all_1.gst-plugins-base
     alsa-lib libpulseaudio jack2
     v4l-utils

--- a/pkgs/by-name/at/attract-mode/package.nix
+++ b/pkgs/by-name/at/attract-mode/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   expat,
-  ffmpeg_7,
+  ffmpeg,
   freetype,
   libarchive,
   libjpeg,
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   buildInputs =
     [
       expat
-      ffmpeg_7
+      ffmpeg
       freetype
       libarchive
       libjpeg

--- a/pkgs/by-name/cc/ccextractor/package.nix
+++ b/pkgs/by-name/cc/ccextractor/package.nix
@@ -18,7 +18,7 @@
   zlib,
   utf8proc,
   freetype,
-  ffmpeg_7,
+  ffmpeg,
   libarchive,
   curl,
   libiconv,
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
       zlib
       utf8proc
       freetype
-      ffmpeg_7
+      ffmpeg
       libarchive
       curl
       libiconv
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   env = {
-    FFMPEG_INCLUDE_DIR = "${lib.getDev ffmpeg_7}/include";
+    FFMPEG_INCLUDE_DIR = "${lib.getDev ffmpeg}/include";
 
     # Upstream’s FFmpeg binding crate needs an explicit path to a shared
     # object to do dynamic linking. The key word is *an* explicit path;
@@ -120,7 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
           "swresample"
           "swscale"
         ];
-        ffmpegLibDir = "${lib.getLib ffmpeg_7}/lib";
+        ffmpegLibDir = "${lib.getLib ffmpeg}/lib";
         ffmpegLibExt = stdenv.hostPlatform.extensions.library;
         ffmpegLibPath = ffmpegLibName: "${ffmpegLibDir}/lib${ffmpegLibName}.${ffmpegLibExt}";
         ffmpegLinkerScript = writeTextFile {

--- a/pkgs/by-name/fe/febio-studio/package.nix
+++ b/pkgs/by-name/fe/febio-studio/package.nix
@@ -16,7 +16,7 @@
   tetgenSupport ? true,
   tetgen,
   ffmpegSupport ? true,
-  ffmpeg_7,
+  ffmpeg,
   dicomSupport ? false,
   dcmtk,
   withModelRepo ? true,
@@ -75,7 +75,7 @@ stdenv'.mkDerivation (finalAttrs: {
       libssh
     ]
     ++ lib.optional tetgenSupport tetgen
-    ++ lib.optional ffmpegSupport ffmpeg_7
+    ++ lib.optional ffmpegSupport ffmpeg
     ++ lib.optional dicomSupport dcmtk;
 
   meta = {

--- a/pkgs/by-name/me/metadata/package.nix
+++ b/pkgs/by-name/me/metadata/package.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchFromGitHub
 , pkg-config
-, ffmpeg_7
+, ffmpeg
 , rustPlatform
 , glib
 , installShellFiles
@@ -35,11 +35,11 @@ rustPlatform.buildRustPackage rec {
   '';
 
   buildInputs = [
-    ffmpeg_7
+    ffmpeg
     glib
   ];
 
-  env.FFMPEG_DIR = ffmpeg_7.dev;
+  env.FFMPEG_DIR = ffmpeg.dev;
 
   meta = {
     description = "Media metadata parser and formatter designed for human consumption, powered by FFmpeg";

--- a/pkgs/by-name/mu/musly/package.nix
+++ b/pkgs/by-name/mu/musly/package.nix
@@ -6,7 +6,7 @@
   ninja,
   pkg-config,
   eigen,
-  ffmpeg_7,
+  ffmpeg,
   libresample,
   kissfft,
 }:
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     eigen
-    ffmpeg_7
+    ffmpeg
     libresample
     kissfft
   ];

--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -5,7 +5,7 @@
 , fetchpatch2
 , cmake
 , ninja
-, ffmpeg_7
+, ffmpeg
 , darwin
 , zlib
 }:
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ninja ];
 
-  buildInputs = [ ffmpeg_7 ] ++ lib.optionals stdenv.isDarwin
+  buildInputs = [ ffmpeg ] ++ lib.optionals stdenv.isDarwin
     (with darwin.apple_sdk.frameworks; [ Accelerate CoreGraphics CoreVideo zlib ]);
 
   cmakeFlags = [ "-DBUILD_EXAMPLES=ON" "-DBUILD_TOOLS=ON" ];

--- a/pkgs/development/libraries/ffmpeg/default.nix
+++ b/pkgs/development/libraries/ffmpeg/default.nix
@@ -50,10 +50,16 @@ rec {
   ffmpeg_7-headless = mkFFmpeg v7 "headless";
   ffmpeg_7-full = mkFFmpeg v7 "full";
 
-  # Please make sure this is updated to the latest version on the next major
-  # update to ffmpeg
-  # Packages which use ffmpeg as a library, should pin to the relevant major
-  # version number which the upstream support.
+  # Please make sure this is updated to new major versions once they
+  # build and work on all the major platforms. If absolutely necessary
+  # due to severe breaking changes, the bump can wait a little bit to
+  # give the most proactive users time to migrate, but don’t hold off
+  # for too long.
+  #
+  # Packages which depend on FFmpeg should generally use these
+  # unversioned aliases to allow for quicker migration to new releases,
+  # but can pin one of the versioned variants if they do not work with
+  # the current default version.
   ffmpeg = ffmpeg_7;
   ffmpeg-headless = ffmpeg_7-headless;
   ffmpeg-full = ffmpeg_7-full;

--- a/pkgs/development/libraries/ffmpeg/default.nix
+++ b/pkgs/development/libraries/ffmpeg/default.nix
@@ -54,7 +54,7 @@ rec {
   # update to ffmpeg
   # Packages which use ffmpeg as a library, should pin to the relevant major
   # version number which the upstream support.
-  ffmpeg = ffmpeg_6;
-  ffmpeg-headless = ffmpeg_6-headless;
-  ffmpeg-full = ffmpeg_6-full;
+  ffmpeg = ffmpeg_7;
+  ffmpeg-headless = ffmpeg_7-headless;
+  ffmpeg-full = ffmpeg_7-full;
 }

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -3,7 +3,7 @@
 , cmake
 , fetchFromGitLab
 , fetchpatch2
-, ffmpeg_7
+, ffmpeg
 , glew
 , gsm
 , lib
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     bzrtp
     ortp
 
-    ffmpeg_7
+    ffmpeg
     glew
     libX11
     libXext

--- a/pkgs/development/libraries/pangolin/default.nix
+++ b/pkgs/development/libraries/pangolin/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkg-config, doxygen, libGL, glew
-, xorg, ffmpeg_7, libjpeg, libpng, libtiff, eigen
+, xorg, ffmpeg, libjpeg, libpng, libtiff, eigen
 , Carbon, Cocoa
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     libGL
     glew
     xorg.libX11
-    ffmpeg_7
+    ffmpeg
     libjpeg
     libpng
     libtiff

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -25,7 +25,7 @@
 , ImageCaptureCore, CoreBluetooth, IOBluetooth, CoreWLAN, Quartz, Cocoa, LocalAuthentication
 , MediaPlayer, MediaAccessibility, SecurityInterface, Vision, CoreML, OpenDirectory, Accelerate
 , cups, openbsm, xcbuild, writeScriptBin
-, ffmpeg_7 ? null
+, ffmpeg ? null
 , lib, stdenv
 , version ? null
 , qtCompatVersion
@@ -232,7 +232,7 @@ qtModule ({
     harfbuzz icu
 
     libevent
-    ffmpeg_7
+    ffmpeg
   ] ++ lib.optionals (!stdenv.isDarwin) [
     dbus zlib minizip snappy nss protobuf jsoncpp
 

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
@@ -13,7 +13,7 @@
 , gst-plugins-good
 , gst-libav
 , gst-vaapi
-, ffmpeg_7
+, ffmpeg
 , libva
 , libpulseaudio
 , wayland
@@ -28,7 +28,7 @@
 qtModule {
   pname = "qtmultimedia";
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ffmpeg_7 ]
+  buildInputs = [ ffmpeg ]
     ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [ libunwind orc ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ libpulseaudio alsa-lib wayland libXrandr libva ]
     ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [ elfutils ];

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -50,7 +50,7 @@
 , systemd
 , pipewire
 , gn
-, ffmpeg_7
+, ffmpeg
 , lib
 , stdenv
 , glib
@@ -237,7 +237,7 @@ qtModule {
     lcms2
 
     libevent
-    ffmpeg_7
+    ffmpeg
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [
     dbus
     zlib

--- a/pkgs/development/octave-modules/video/default.nix
+++ b/pkgs/development/octave-modules/video/default.nix
@@ -3,7 +3,7 @@
 , lib
 , fetchFromGitHub
 , pkg-config
-, ffmpeg_7
+, ffmpeg
 }:
 
 buildOctavePackage rec {
@@ -22,7 +22,7 @@ buildOctavePackage rec {
   ];
 
   propagatedBuildInputs = [
-    ffmpeg_7
+    ffmpeg
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/av/default.nix
+++ b/pkgs/development/python-modules/av/default.nix
@@ -6,7 +6,7 @@
   fetchFromGitHub,
   fetchurl,
   linkFarm,
-  ffmpeg_6-headless,
+  ffmpeg-headless,
   numpy,
   pillow,
   pkg-config,
@@ -17,16 +17,16 @@
 
 buildPythonPackage rec {
   pname = "av";
-  version = "12.3.0";
+  version = "13.0.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "PyAV-Org";
     repo = "PyAV";
     rev = "refs/tags/v${version}";
-    hash = "sha256-ezeYv55UzNnnYDjrMz5YS5g2pV6U/Fxx3e2bCoPP3eI=";
+    hash = "sha256-blvtHSUqSl9xAM4t+dFJWmXiOjtnAUC9nicMaUY1zuU=";
   };
 
   build-system = [
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ ffmpeg_6-headless ];
+  buildInputs = [ ffmpeg-headless ];
 
   preCheck =
     let

--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -2,12 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   fetchpatch2,
   setuptools,
   pytestCheckHook,
   pytest-mock,
-  ffmpeg_7,
+  ffmpeg,
 }:
 
 buildPythonPackage {
@@ -23,10 +23,7 @@ buildPythonPackage {
   };
 
   patches = [
-    (substituteAll {
-      src = ./ffmpeg-location.patch;
-      ffmpeg = ffmpeg_7;
-    })
+    (replaceVars ./ffmpeg-location.patch { inherit ffmpeg; })
 
     # Remove dependency on `future`
     # https://github.com/kkroening/ffmpeg-python/pull/795

--- a/pkgs/games/hedgewars/default.nix
+++ b/pkgs/games/hedgewars/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, SDL2_image_2_6, SDL2_ttf, SDL2_net, fpc, haskell, ffmpeg_7, libglut
+{ stdenv, SDL2_image_2_6, SDL2_ttf, SDL2_net, fpc, haskell, ffmpeg, libglut
 , lib, fetchurl, cmake, pkg-config, lua5_1, SDL2, SDL2_mixer
 , zlib, libpng, libGL, libGLU, physfs
 , qtbase, qttools, wrapQtAppsHook
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     SDL2_ttf SDL2_net SDL2 SDL2_mixer SDL2_image_2_6
     fpc lua5_1
     llvm # hard-requirement on aarch64, for some reason not strictly necessary on x86-64
-    ffmpeg_7 libglut physfs
+    ffmpeg libglut physfs
     qtbase
   ] ++ lib.optional withServer ghc;
 

--- a/pkgs/games/ultrastardx/default.nix
+++ b/pkgs/games/ultrastardx/default.nix
@@ -13,7 +13,7 @@
 , SDL2_gfx
 , SDL2_mixer
 , SDL2_net, SDL2_ttf
-, ffmpeg_7
+, ffmpeg
 , sqlite
 , zlib
 , libX11
@@ -25,7 +25,7 @@ let
   sharedLibs = [
     pcre portaudio freetype
     SDL2 SDL2_image SDL2_gfx SDL2_mixer SDL2_net SDL2_ttf
-    sqlite lua zlib libX11 libGLU libGL ffmpeg_7
+    sqlite lua zlib libX11 libGLU libGL ffmpeg
   ];
 
 in stdenv.mkDerivation rec {

--- a/pkgs/misc/screensavers/electricsheep/default.nix
+++ b/pkgs/misc/screensavers/electricsheep/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , autoreconfHook
 , wxGTK32
-, ffmpeg_7
+, ffmpeg
 , lua5_1
 , curl
 , libpng
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     wxGTK32
-    ffmpeg_7
+    ffmpeg
     lua5_1
     curl
     libpng

--- a/pkgs/os-specific/linux/guvcview/default.nix
+++ b/pkgs/os-specific/linux/guvcview/default.nix
@@ -5,7 +5,7 @@
 , pkg-config
 , portaudio
 , SDL2
-, ffmpeg_7
+, ffmpeg
 , udev
 , libusb1
 , libv4l
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     SDL2
     alsa-lib
-    ffmpeg_7
+    ffmpeg
     libusb1
     libv4l
     portaudio

--- a/pkgs/servers/guacamole-server/default.nix
+++ b/pkgs/servers/guacamole-server/default.nix
@@ -6,7 +6,7 @@
 , autoPatchelfHook
 , autoreconfHook
 , cairo
-, ffmpeg_7-headless
+, ffmpeg-headless
 , freerdp
 , libjpeg_turbo
 , libpng
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     cairo
-    ffmpeg_7-headless
+    ffmpeg-headless
     freerdp
     libjpeg_turbo
     libossp_uuid

--- a/pkgs/servers/misc/oven-media-engine/default.nix
+++ b/pkgs/servers/misc/oven-media-engine/default.nix
@@ -6,7 +6,7 @@
 , perl
 , openssl
 , zlib
-, ffmpeg_7
+, ffmpeg
 , libvpx
 , libopus
 , libuuid
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ bc pkg-config perl ];
-  buildInputs = [ openssl srt zlib ffmpeg_7 libvpx libopus srtp jemalloc pcre2 libuuid hiredis ];
+  buildInputs = [ openssl srt zlib ffmpeg libvpx libopus srtp jemalloc pcre2 libuuid hiredis ];
 
   preBuild = ''
     cd src

--- a/pkgs/servers/photoprism/default.nix
+++ b/pkgs/servers/photoprism/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, stdenv, fetchFromGitHub, fetchzip, darktable, rawtherapee, ffmpeg_7, libheif, exiftool, imagemagick, makeWrapper, testers
+{ pkgs, lib, stdenv, fetchFromGitHub, fetchzip, darktable, rawtherapee, ffmpeg, libheif, exiftool, imagemagick, makeWrapper, testers
 , nixosTests
 , librsvg }:
 
@@ -64,7 +64,7 @@ stdenv.mkDerivation {
       --set PHOTOPRISM_RAWTHERAPEE_BIN ${rawtherapee}/bin/rawtherapee-cli \
       --set PHOTOPRISM_HEIFCONVERT_BIN ${libheif}/bin/heif-convert \
       --set PHOTOPRISM_RSVGCONVERT_BIN ${librsvg}/bin/rsvg-convert \
-      --set PHOTOPRISM_FFMPEG_BIN ${ffmpeg_7}/bin/ffmpeg \
+      --set PHOTOPRISM_FFMPEG_BIN ${ffmpeg}/bin/ffmpeg \
       --set PHOTOPRISM_EXIFTOOL_BIN ${exiftool}/bin/exiftool \
       --set PHOTOPRISM_IMAGEMAGICK_BIN ${imagemagick}/bin/convert
 

--- a/pkgs/tools/audio/loudgain/default.nix
+++ b/pkgs/tools/audio/loudgain/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, ffmpeg_7, libebur128
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, ffmpeg, libebur128
 , libresample, taglib, zlib }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ ffmpeg_7 libebur128 libresample taglib zlib ];
+  buildInputs = [ ffmpeg libebur128 libresample taglib zlib ];
 
   postInstall = ''
     sed -e "1aPATH=$out/bin:\$PATH" -i "$out/bin/rgbpm"

--- a/pkgs/tools/graphics/vulkan-cts/default.nix
+++ b/pkgs/tools/graphics/vulkan-cts/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , runCommand
 , cmake
-, ffmpeg_7
+, ffmpeg
 , glslang
 , libdrm
 , libglvnd
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   buildInputs = [
-    ffmpeg_7
+    ffmpeg
     libdrm
     libffi
     libglvnd

--- a/pkgs/tools/video/untrunc-anthwlock/default.nix
+++ b/pkgs/tools/video/untrunc-anthwlock/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ffmpeg_7, libui, unstableGitUpdater, wrapGAppsHook3 }:
+{ lib, stdenv, fetchFromGitHub, ffmpeg, libui, unstableGitUpdater, wrapGAppsHook3 }:
 
 stdenv.mkDerivation {
   pname = "untrunc-anthwlock";
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ wrapGAppsHook3 ];
 
-  buildInputs = [ ffmpeg_7 libui ];
+  buildInputs = [ ffmpeg libui ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/tools/video/xjadeo/default.nix
+++ b/pkgs/tools/video/xjadeo/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, autoreconfHook, fetchFromGitHub, ffmpeg_7, freetype, libGLU
+{ lib, stdenv, autoreconfHook, fetchFromGitHub, ffmpeg, freetype, libGLU
 , libjack2, liblo, libX11, libXv, pkg-config, portmidi, xorg }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [
-    ffmpeg_7
+    ffmpeg
     libjack2
     libX11
     xorg.libXext

--- a/pkgs/tools/wayland/wl-screenrec/default.nix
+++ b/pkgs/tools/wayland/wl-screenrec/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , pkg-config
 , libdrm
-, ffmpeg_7
+, ffmpeg
 , wayland
 }:
 
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     wayland
     libdrm
-    ffmpeg_7
+    ffmpeg
   ];
 
   doCheck = false; # tests use host compositor, etc

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5603,9 +5603,7 @@ with pkgs;
 
   medusa = callPackage ../tools/security/medusa { };
 
-  megasync = libsForQt5.callPackage ../applications/misc/megasync {
-    ffmpeg = ffmpeg_7;
-  };
+  megasync = libsForQt5.callPackage ../applications/misc/megasync { };
 
   megacmd = callPackage ../applications/misc/megacmd { };
 


### PR DESCRIPTION
## Description of changes

It’s finally time! 🎉

This PR is pretty mundane; the main points for review are the changes to the release notes and the comments about updating and pinning FFmpeg, which are based on my experiences getting rid of old FFmpeg dependencies over the past however long it’s been. The real fun will come during the staging cycle. I’ve documented my procedure for handling FFmpeg version problems below for the benefit of people working on the cycle.

I have successfully built `ffmpeg{,4,6}{,-headless,-full}` and `python{311,312}Packages.{av,ffmpeg-python}` on `aarch64-linux`, and am in the process of building them on the other major platforms.

I hope that FFmpeg 6 won’t stick around as long as previous versions have. Major distros like Arch have already moved over to FFmpeg 7 and removed FFmpeg 6, so I anticipate that the vast majority of packages won’t be stuck on 6 for long. I intend to do my bit to ensure we can remove it as soon as possible, although I suspect there’ll be enough stragglers that the 24.11 release will still include it.

### How to fix things this change breaks

First off, everything this breaks should be able to be fixed by pinning FFmpeg 6. If you don’t have the time, just change the dependency to one of the `ffmpeg_6` packages and be done with it. **Please ping me, on Matrix or GitHub, if you notice any suspiciously FFmpeg‐looking failures, or if you open a PR to fix one,** so that I can review and keep track of what packages need looking into.

If you want to do your part to get the package working on FFmpeg 7, though, here’s my procedure:

1. Check if there’s a new upstream stable release that builds with the newer FFmpeg.

2. Check if there’s unreleased upstream commits that fix the build with the newer FFmpeg that we can either patch in or bump to.

3. Check if any other distributions have made downstream patches for FFmpeg support. [Repology](https://repology.org) is good for finding packages here. Arch, Debian, and even Cygwin have helped me here in the past.

4. Check if there are any open pull requests upstream to add support that look high‐quality enough for us to vendor.

5. Consider patching in support yourself, sending it upstream, and vendoring the changes in Nixpkgs for now. FFmpeg breaking changes are rarely very involved to fix, just tedious. (There’s some sharp edges for this bump, though; the channel layout stuff touches on their options API, which is not statically checked, so it’s easy to miss things.)

6. Give up and pin the older version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc