### PR TITLE
neomutt: add `smime_keys` optional

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,8 +1,37 @@
-{ lib, stdenv, fetchFromGitHub, gettext, makeWrapper, tcl, which
-, ncurses, perl , cyrus_sasl, gss, gpgme, libkrb5, libidn2, libxml2, notmuch, openssl
-, lua, lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42, w3m, mailcap, sqlite, zlib, lndir
-, pkg-config, zstd, enableZstd ? true, enableMixmaster ? false, enableLua ? false
-, withContrib ? true
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gettext,
+  makeWrapper,
+  tcl,
+  which,
+  ncurses,
+  perl,
+  cyrus_sasl,
+  gss,
+  gpgme,
+  libkrb5,
+  libidn2,
+  libxml2,
+  notmuch,
+  openssl,
+  lua,
+  lmdb,
+  libxslt,
+  docbook_xsl,
+  docbook_xml_dtd_42,
+  w3m,
+  mailcap,
+  sqlite,
+  zlib,
+  lndir,
+  pkg-config,
+  zstd,
+  enableZstd ? true,
+  enableMixmaster ? false,
+  enableLua ? false,
+  withContrib ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -10,22 +39,38 @@ stdenv.mkDerivation (finalAttrs: {
   version = "20240425";
 
   src = fetchFromGitHub {
-    owner  = "neomutt";
-    repo   = "neomutt";
-    rev    = finalAttrs.version;
-    hash   = "sha256-QBqPFteoAm3AdQN0XTWpho8DEW2BFCCzBcHUZIiSxyQ=";
+    owner = "neomutt";
+    repo = "neomutt";
+    rev = finalAttrs.version;
+    hash = "sha256-QBqPFteoAm3AdQN0XTWpho8DEW2BFCCzBcHUZIiSxyQ=";
   };
 
   buildInputs = [
-    cyrus_sasl gss gpgme libkrb5 libidn2 ncurses
-    notmuch openssl perl lmdb
-    mailcap sqlite
-  ]
-  ++ lib.optional enableZstd zstd
-  ++ lib.optional enableLua lua;
+    cyrus_sasl
+    gss
+    gpgme
+    libkrb5
+    libidn2
+    ncurses
+    notmuch
+    openssl
+    perl
+    lmdb
+    mailcap
+    sqlite
+  ] ++ lib.optional enableZstd zstd ++ lib.optional enableLua lua;
 
   nativeBuildInputs = [
-    docbook_xsl docbook_xml_dtd_42 gettext libxml2 libxslt.bin makeWrapper tcl which zlib w3m
+    docbook_xsl
+    docbook_xml_dtd_42
+    gettext
+    libxml2
+    libxslt.bin
+    makeWrapper
+    tcl
+    which
+    zlib
+    w3m
     pkg-config
   ];
 
@@ -49,31 +94,33 @@ stdenv.mkDerivation (finalAttrs: {
       --replace /etc/mime.types ${mailcap}/etc/mime.types
   '';
 
-  configureFlags = [
-    "--enable-autocrypt"
-    "--gpgme"
-    "--gss"
-    "--lmdb"
-    "--notmuch"
-    "--ssl"
-    "--sasl"
-    "--with-homespool=mailbox"
-    "--with-mailpath="
-    # To make it not reference .dev outputs. See:
-    # https://github.com/neomutt/neomutt/pull/2367
-    "--disable-include-path-in-cflags"
-    "--zlib"
-  ]
-  ++ lib.optional enableZstd "--zstd"
-  ++ lib.optional enableLua "--lua"
-  ++ lib.optional enableMixmaster "--mixmaster";
+  configureFlags =
+    [
+      "--enable-autocrypt"
+      "--gpgme"
+      "--gss"
+      "--lmdb"
+      "--notmuch"
+      "--ssl"
+      "--sasl"
+      "--with-homespool=mailbox"
+      "--with-mailpath="
+      # To make it not reference .dev outputs. See:
+      # https://github.com/neomutt/neomutt/pull/2367
+      "--disable-include-path-in-cflags"
+      "--zlib"
+    ]
+    ++ lib.optional enableZstd "--zstd"
+    ++ lib.optional enableLua "--lua"
+    ++ lib.optional enableMixmaster "--mixmaster";
 
-  postInstall = ''
-    wrapProgram "$out/bin/neomutt" --prefix PATH : "$out/libexec/neomutt"
-  ''
-  # https://github.com/neomutt/neomutt-contrib
-  # Contains vim-keys, keybindings presets and more.
-  + lib.optionalString withContrib "${lib.getExe lndir} ${finalAttrs.passthru.contrib} $out/share/doc/neomutt";
+  postInstall =
+    ''
+      wrapProgram "$out/bin/neomutt" --prefix PATH : "$out/libexec/neomutt"
+    ''
+    # https://github.com/neomutt/neomutt-contrib
+    # Contains vim-keys, keybindings presets and more.
+    + lib.optionalString withContrib "${lib.getExe lndir} ${finalAttrs.passthru.contrib} $out/share/doc/neomutt";
 
   doCheck = true;
 
@@ -111,9 +158,12 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Small but very powerful text-based mail client";
     mainProgram = "neomutt";
-    homepage    = "https://www.neomutt.org";
-    license     = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ erikryb raitobezarius ];
-    platforms   = lib.platforms.unix;
+    homepage = "https://www.neomutt.org";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      erikryb
+      raitobezarius
+    ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -31,6 +31,7 @@
   enableZstd ? true,
   enableMixmaster ? false,
   enableLua ? false,
+  enableSmimeKeys ? true,
   withContrib ? true,
 }:
 
@@ -117,6 +118,11 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall =
     ''
       wrapProgram "$out/bin/neomutt" --prefix PATH : "$out/libexec/neomutt"
+    ''
+    + lib.optionalString enableSmimeKeys ''
+      install -m 755 $src/contrib/smime_keys $out/bin;
+      substituteInPlace $out/bin/smime_keys \
+        --replace-fail '/usr/bin/openssl' '${openssl}/bin/openssl';
     ''
     # https://github.com/neomutt/neomutt-contrib
     # Contains vim-keys, keybindings presets and more.


### PR DESCRIPTION
## Description of changes

This enables `smime_keys` from the neomutt source repository (found under
`/contrib`, not to be confused with the neomutt-contrib repository).

Unlike mutt, which adds `smime_keys` to the build output `/bin` by default,
neomutt currently doesn't even provide an option to expose it, and that is even
though we default to adding `man smime_keys_neomutt`!

I've set this optional to default to `true`, but that can be discussed ofc!

My reasoning was:
- It's prominently displayed on https://neomutt.org/man
- We alrady default to shipping its man pages, it would be confusing (and was
to me) confusing why I didn't have the binary in path.

I've also formatted the source file in a separate preceeding commit, I know
this can be optional, but I do feel it made optionals a lot more readable... so
I'd really prefer to keep it this way >_>

Commits:
- **neomutt: apply nixfmt-rfc-style**
- **neomutt: add `smime_keys` optional**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
