### PR TITLE
Doc: Move "This is equivalent to" into example block

### DIFF
--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -437,7 +437,6 @@ writeScript "my-file"
   Contents of File
   ''
 ```
-:::
 
 This is equivalent to:
 
@@ -450,6 +449,7 @@ writeTextFile {
   executable = true;
 }
 ```
+:::
 
 ### `writeScriptBin` {#trivial-builder-writeScriptBin}
 


### PR DESCRIPTION
This patch moves the code snippet which is shown as equivalent to the example into the actual example block.

Visually, it was not easy to parse that the "equivalent" code piece belonged to the code snippet that was hidden in the example (which is collapsed by default).

By moving it into the example block, the "equivalent" piece is hidden by default as well.

---

Example: Here's the example hidden:

![image](https://github.com/user-attachments/assets/23d650d3-68d9-4597-beb9-ec4f05c570f2)

It is not immediately clear that the `This is equivalent to` part belongs to the (currently hidden) example.

With this patch, the `This is equivalent to` part is moved into the by-default-hidden example block.

---

Pinging the doc maintainers: @NixOS/documentation-team 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
