### PR TITLE
nixos/homepage-dashboard: set an explicit cache dir

### DIFF
--- a/nixos/modules/services/misc/homepage-dashboard.nix
+++ b/nixos/modules/services/misc/homepage-dashboard.nix
@@ -222,6 +222,7 @@ in
 
         environment = {
           HOMEPAGE_CONFIG_DIR = configDir;
+          HOMEPAGE_CACHE_DIR = "/var/cache/homepage-dashboard";
           PORT = toString cfg.listenPort;
           LOG_TARGETS = lib.mkIf managedConfig "stdout";
         };
@@ -231,6 +232,7 @@ in
           DynamicUser = true;
           EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
           StateDirectory = lib.mkIf (!managedConfig) "homepage-dashboard";
+          CacheDirectory = "homepage-dashboard";
           ExecStart = lib.getExe cfg.package;
           Restart = "on-failure";
         };

--- a/pkgs/servers/homepage-dashboard/prerender_cache_path.patch
+++ b/pkgs/servers/homepage-dashboard/prerender_cache_path.patch
@@ -1,0 +1,18 @@
+diff --git a/share/homepage/node_modules/next/dist/server/lib/incremental-cache/file-system-cache.js b/share/homepage/node_modules/next/dist/server/lib/incremental-cache/file-system-cache.js
+index b1b74d8..a46c80b 100644
+--- a/share/homepage/node_modules/next/dist/server/lib/incremental-cache/file-system-cache.js
++++ b/share/homepage/node_modules/next/dist/server/lib/incremental-cache/file-system-cache.js
+@@ -5,11 +5,12 @@ Object.defineProperty(exports, "__esModule", {
+ exports.default = void 0;
+ var _lruCache = _interopRequireDefault(require("next/dist/compiled/lru-cache"));
+ var _path = _interopRequireDefault(require("../../../shared/lib/isomorphic/path"));
++var path = require('node:path');
+ class FileSystemCache {
+     constructor(ctx){
+         this.fs = ctx.fs;
+         this.flushToDisk = ctx.flushToDisk;
+-        this.serverDistDir = ctx.serverDistDir;
++        this.serverDistDir = path.join(process.env.HOMEPAGE_CACHE_DIR, "homepage");
+         this.appDir = !!ctx._appDir;
+         if (ctx.maxMemoryCacheSize) {
+             this.memoryCache = new _lruCache.default({


### PR DESCRIPTION
## Description of changes

Fixes #328621 (I think!).

This commit introduces the patching of the `dist` directory
of NextJS. Without this, homepage-dashboard errors when trying to
write its prerender cache.

This patch ensures that the cache implementation respects the env
variable `HOMEPAGE_CACHE_DIR`, which is set by default in the
wrapper below.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
