### PR TITLE
openblas: Enable s390x-linux

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -114,6 +114,13 @@ let
       DYNAMIC_ARCH = setDynamicArch false;
       USE_OPENMP = true;
     };
+
+    s390x-linux = {
+      BINARY = 64;
+      TARGET = setTarget "ZARCH_GENERIC";
+      DYNAMIC_ARCH = setDynamicArch true;
+      USE_OPENMP = true;
+    };
   };
 in
 


### PR DESCRIPTION
## Description of changes

adding support for the s390x -> ZARCH_GENERIC target for openblas as openblas does support the "System Z"
mainframe architecture as of: https://github.com/OpenMathLib/OpenBLAS/blob/485027563ea3c5f609c75df186d403df4eaec318/TargetList.txt#L116
target list.

without the proposed changes the package can't be build not just as of the assert at
https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/science/math/openblas/default.nix#L123
but also as `TARGET` wouldn't be set to the correct value `ZARCH_GENERIC`

### reasoning for TARGET="ZARCH_GENERIC"/DYNAMIC_ARCH=true

Since members of the Z cpu series (eg z9 z10 ... z16) are all s390x hosts adding ZARCH_GENERIC here is pretty much
the same as adding s390x. Because its not clear which mainframe arch the user may run their code on (in my case z10)
and because openblas only recognizes Z13 and Z14 as target platforms (besides GENERIC) it makes sense to select GENERIC here to cover models other than z13 and 14.  

setting the TARGET to `"ZARCH_GENERIC"` while setting `DYNAMIC_ARCH=true` satisfies the assumption that the
oldest/worst CPU target that is to initially be assumed to run on is ZARCH_GENERIC while still allowing optimized non-generic acceleration paths to be taken in case we find it running on (in this case Z13 Z14 or future versions when added to openblas)

## meta: 

- Built on platform(s)
- [x] s390x-linux
- [x] `sandbox = true`

