### PR TITLE
rust: S390x add native support (bootstrap files)

### DIFF
--- a/pkgs/development/compilers/rust/1_80.nix
+++ b/pkgs/development/compilers/rust/1_80.nix
@@ -119,6 +119,7 @@ import ./default.nix
       aarch64-apple-darwin = "e70a9362975b94df7dbc6e2ed5ceab4254dd32f72ba497ff4a70440ace3f729f";
       powerpc64le-unknown-linux-gnu = "9865eeebb5bb20006367d3148d9116576499ec958d847e22b645f008a1bc4170";
       riscv64gc-unknown-linux-gnu = "c8d38e600ef4dea8b375df2d08153393816ffd3dcab18e4d081ddc19e28b5a40";
+      s390x-unknown-linux-gnu = "1e9f1b27ce47d831108e1d1bb6ef7ab86f95bedfea843318292f821142fe1f6c";
       x86_64-unknown-freebsd = "3c8005f488b8dda0fc6d47928868200852106cac2b568934ae9a2e5c89d3a50d";
     };
 

--- a/pkgs/development/compilers/rust/print-hashes.sh
+++ b/pkgs/development/compilers/rust/print-hashes.sh
@@ -19,6 +19,7 @@ PLATFORMS=(
   aarch64-apple-darwin
   powerpc64le-unknown-linux-gnu
   riscv64gc-unknown-linux-gnu
+  s390x-unknown-linux-gnu
   x86_64-unknown-freebsd
 )
 BASEURL=https://static.rust-lang.org/dist


### PR DESCRIPTION
## Description of changes

added the s390x-linux target to `pkgs/development/compilers/rust/print-hashes.sh` so that upon running the script like

```
./print-hashes.sh 1.79.0
```
to bootstrap 1.80.0 we use 1.79.0 thus with 
with 1.79.0 being the current version we to pass to the script we get the following hash value:
`s390x-unknown-linux-gnu = "1e9f1b27ce47d831108e1d1bb6ef7ab86f95bedfea843318292f821142fe1f6c";`


the hash provided by running the script with the proposed changes was then added to
`pkgs/development/compilers/rust/1_80.nix` so the rust bootstrap files can be retrived when running nix builds natively on
a s390x linux host.

 without the changes we'd get the following error message `error: missing bootstrap url for platform s390x-unknown-linux-gnu` when attempting to build things using rust natively on s390x. 


- Built on platform(s)
  - [x] s390x-linux
  - [x] `sandbox = true`
