### PR TITLE
nixos/programs/yubikey-touch-detector: expose configuration variables

### DIFF
--- a/nixos/modules/programs/yubikey-touch-detector.nix
+++ b/nixos/modules/programs/yubikey-touch-detector.nix
@@ -1,9 +1,44 @@
-{ config, lib, pkgs, ... }:
-let cfg = config.programs.yubikey-touch-detector;
-in {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) types;
+  cfg = config.programs.yubikey-touch-detector;
+in
+{
   options = {
     programs.yubikey-touch-detector = {
+
       enable = lib.mkEnableOption "yubikey-touch-detector";
+
+      libnotify = lib.mkOption {
+        # This used to be true previously and using libnotify would be a sane default.
+        default = true;
+        type = types.bool;
+        description = ''
+          If set to true, yubikey-touch-detctor will send notifications using libnotify
+        '';
+      };
+
+      unixSocket = lib.mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          If set to true, yubikey-touch-detector will send notifications to a unix socket
+        '';
+      };
+
+      verbose = lib.mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enables verbose logging
+        '';
+      };
+
     };
   };
 
@@ -12,6 +47,13 @@ in {
 
     systemd.user.services.yubikey-touch-detector = {
       path = [ pkgs.gnupg ];
+
+      environment = {
+        YUBIKEY_TOUCH_DETECTOR_LIBNOTIFY = builtins.toString cfg.libnotify;
+        YUBIKEY_TOUCH_DETECTOR_NOSOCKET = builtins.toString (!cfg.unixSocket);
+        YUBIKEY_TOUCH_DETECTOR_VERBOSE = builtins.toString cfg.verbose;
+      };
+
       wantedBy = [ "graphical-session.target" ];
     };
     systemd.user.sockets.yubikey-touch-detector = {


### PR DESCRIPTION
Change adds configuration options for the service `yubikey-touch-detector` into the program configuration.


commit [9b4abd6546fb87ab9fac4f2d77598417c6a17803 ](https://github.com/NixOS/nixpkgs/commit/9b4abd6546fb87ab9fac4f2d77598417c6a17803) removed opinionated configuration from the `yubikey-touch-detector` package, this change exposes them via configuration options.

## Description of changes

Added three configurations options to `programs.yubikey-touch-detector`. 
1. `libnotify` -- sends notifications using libnotify
2. `unixSocket` -- sends notifications to a unixSocket
3. `verbose` -- enables verbose logging

The configuration is injected with environment variables, people can still override it with service config files (`.config/yubikey-touch-detector/service.conf`)

Tested with building my system image with the new module code.

I'm not sure if the change is significant enough to warrant a release note (it keeps the functionality before  [9b4abd6546fb87ab9fac4f2d77598417c6a17803 ](https://github.com/NixOS/nixpkgs/commit/9b4abd6546fb87ab9fac4f2d77598417c6a17803)) with default configuration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
