### PR TITLE
libxnd: unstable-2019-08-01 -> 0.2.0-unstable-2023-11-17

### DIFF
--- a/pkgs/development/libraries/libxnd/default.nix
+++ b/pkgs/development/libraries/libxnd/default.nix
@@ -1,18 +1,19 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, libndtypes
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libndtypes,
 }:
 
 stdenv.mkDerivation {
   pname = "libxnd";
-  version = "unstable-2019-08-01";
+  version = "0.2.0-unstable-2023-11-17";
 
   src = fetchFromGitHub {
     owner = "xnd-project";
-    repo = "xnd";
-    rev = "6f305cd40d90b4f3fc2fe51ae144b433d186a6cc";
-    sha256 = "1n31d64qwlc7m3qkzbafhp0dgrvgvkdx89ykj63kll7r1n3yk59y";
+    repo = "libxnd";
+    rev = "e1a06d9f6175f4f4e1da369b7e907ad6b2952c00";
+    hash = "sha256-RWt2Nx0tfMghQES2SM+0jbAU7IunuuTORhBe2tvqVTY=";
   };
 
   buildInputs = [ libndtypes ];
@@ -20,12 +21,12 @@ stdenv.mkDerivation {
   # Override linker with cc (symlink to either gcc or clang)
   # Library expects to use cc for linking
   configureFlags = [
-      # Override linker with cc (symlink to either gcc or clang)
-      # Library expects to use cc for linking
-      "LD=${stdenv.cc.targetPrefix}cc"
-      # needed for tests
-      "--with-includes=${libndtypes}/include"
-      "--with-libs=${libndtypes}/lib"
+    # Override linker with cc (symlink to either gcc or clang)
+    # Library expects to use cc for linking
+    "LD=${stdenv.cc.targetPrefix}cc"
+    # needed for tests
+    "--with-includes=${libndtypes}/include"
+    "--with-libs=${libndtypes}/lib"
   ];
 
   # other packages which depend on libxnd seem to expect overflow.h, but

--- a/pkgs/development/python-modules/xnd/default.nix
+++ b/pkgs/development/python-modules/xnd/default.nix
@@ -20,15 +20,6 @@ buildPythonPackage {
 
   buildInputs = [ libndtypes ];
 
-  patches = [
-    # python311 fixes which are on main. remove on update
-    (fetchpatch {
-      name = "python311.patch";
-      url = "https://github.com/xnd-project/xnd/commit/e1a06d9f6175f4f4e1da369b7e907ad6b2952c00.patch";
-      hash = "sha256-xzrap+FL5be13bVdsJ3zeV7t57ZC4iyhuZhuLsOzHyE=";
-    })
-  ];
-
   postPatch = ''
     substituteInPlace setup.py \
       --replace 'include_dirs = ["libxnd", "ndtypes/python/ndtypes"] + INCLUDES' \


### PR DESCRIPTION
## Description of changes

Apparently the source of `libxnd` used to be the `xnd` repo, however that was renamed to `libxnd` and now the `xnd` repo contains a new project that's actually called `xnd` (and not `libxnd`).

The main motivation behind this PR was to change the `repo` field of `fetchFromGitHub`.

However I also noticed that a patch for the python part of the package was merged in the meantime, so I also bumped the version to not have to fetch the patch in the python package.

Note that I do not use this package, just wanted to do some clean up.
(Still trying to fix the `python312` build of the python package)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
