### PR TITLE
sieve-editor-gui: init at 0.6.1

### DIFF
--- a/pkgs/by-name/si/sieve-editor-gui/package.nix
+++ b/pkgs/by-name/si/sieve-editor-gui/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  electron,
+  nodejs_20,
+  nodePackages,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+buildNpmPackage rec {
+  pname = "sieve-editor-gui";
+  version = "0.6.1-unstable-2024-01-06";
+  nodejs = nodejs_20;
+
+  src = fetchFromGitHub {
+    owner = "thsmi";
+    repo = "sieve";
+    rev = "5879679ed8d16a34af760ee56bfec16a1a322b4e";
+    hash = "sha256-wl6dwKoGan+DrpXk2p1fD/QN/C2qT4h/g3N73gF8sOI=";
+  };
+
+  npmDepsHash = "sha256-a2I9csxFZJekG1uCOHqdRaLLi5v/BLTz4SU+uBd855A=";
+
+  nativeBuildInputs = [
+    electron
+    copyDesktopItems
+    nodePackages.gulp
+  ];
+
+  dontNpmBuild = true;
+
+  buildPhase = ''
+    gulp -LLLL app:package
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mv build/ $out
+    runHook postInstall
+  '';
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "sieve-editor-gui";
+      exec = "sieve-editor-gui";
+      desktopName = "Sieve Editor";
+      icon = "sieve-editor-gui";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  postInstall = ''
+    makeWrapper ${lib.getExe electron} $out/bin/sieve-editor-gui \
+      --add-flags $out/electron/resources/main_esm.js
+  '';
+
+  meta = {
+    description = "Activate, edit, delete and add Sieve scripts with a convenient interface";
+    homepage = "https://github.com/thsmi/sieve";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ Silver-Golden ];
+    platforms = lib.platforms.linux;
+    mainProgram = "sieve-editor-gui";
+  };
+}


### PR DESCRIPTION
## Description of changes

A GUI sieve script editor that integrates with Thunderbird.   
Sieve scripts allow for a user controlled automated processing of mail.  

Previously it used to be a plugin for Thunderbird but got split off into its own thing, partly because plugin support waned in Thunderbird as well as to make it better cross platform compatible.

* Initiated at 0.6.1
* homepage: https://github.com/thsmi/sieve
* I have been personally using it for the last few months without issue.
* Used teh nixfmt in the dev shell.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
