### PR TITLE
dbcsr: fix libxsmm discovery

### DIFF
--- a/pkgs/development/libraries/libxsmm/default.nix
+++ b/pkgs/development/libraries/libxsmm/default.nix
@@ -6,16 +6,20 @@
 
 stdenv.mkDerivation rec {
   pname = "libxsmm";
-  version = "1.16.3";
+  version = "1.17";
 
   src = fetchFromGitHub {
-    owner = "hfp";
+    owner = "libxsmm";
     repo = "libxsmm";
     rev = version;
-    sha256 = "sha256-PpMiD/PeQ0pe5hqFG6VFHWpR8y3wnO2z1dJfHHeItlQ=";
+    sha256 = "sha256-s/NEFU4IwQPLyPLwMmrrpMDd73q22Sk2BNid/kedawY=";
   };
 
+  # Fixes /build references in the rpath
+  patches = [ ./rpath.patch ];
+
   outputs = [ "out" "dev" "doc" ];
+
   nativeBuildInputs = [
     gfortran
     python3
@@ -39,7 +43,7 @@ stdenv.mkDerivation rec {
     mkdir -p $dev/lib/pkgconfig
     mv $out/lib/*.pc $dev/lib/pkgconfig
 
-    moveToOutput "share/libxsmm" "$doc"
+    moveToOutput "share/libxsmm" ''${!outputDoc}
   '';
 
   prePatch = ''

--- a/pkgs/development/libraries/libxsmm/rpath.patch
+++ b/pkgs/development/libraries/libxsmm/rpath.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.inc b/Makefile.inc
+index 424d7b2e4..87934fee0 100644
+--- a/Makefile.inc
++++ b/Makefile.inc
+@@ -918,7 +918,7 @@ ifneq (Darwin,$(UNAME))
+   XLNKVERBOSE := --verbose
+   linkopt = $(if $1,$(XLNKOPT)$(if $2,$1=$(call quote,$2),$1))
+   abslibrpath = $(strip $(if $(findstring .$(ILIBEXT),$1)$(wildcard $1/), \
+-    $(call linkopt,--rpath,$(call qxdir,$(call qapath,$1)))))
++    $(call linkopt,--rpath,$(PREFIX)/lib)))
+   XGROUP_BEGIN := $(call linkopt,--start-group)
+   XGROUP_END := $(call linkopt,--end-group)
+   ifneq (0,$(ASNEEDED))

--- a/pkgs/development/libraries/science/math/dbcsr/default.nix
+++ b/pkgs/development/libraries/science/math/dbcsr/default.nix
@@ -50,10 +50,6 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ mpi ];
 
-  preConfigure = ''
-    export PKG_CONFIG_PATH=${libxsmm}/lib
-  '';
-
   cmakeFlags = [
     "-DUSE_OPENMP=ON"
     "-DUSE_SMM=libxsmm"


### PR DESCRIPTION
## Description of changes

Updates LibXSMM for small matrix multiplications to the latest (3 years old) release. The repo was also moved to the libxsmm organisation.

Fixes LibXSMM discovery in the DBCSR library.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
