### PR TITLE
ride: refactor and improve electron usage

### DIFF
--- a/pkgs/by-name/ri/ride/mk.patch
+++ b/pkgs/by-name/ri/ride/mk.patch
@@ -1,5 +1,5 @@
 diff --git a/mk b/mk
-index a5baa0f8..37cac28e 100755
+index a5baa0f..4ed2350 100644
 --- a/mk
 +++ b/mk
 @@ -25,7 +25,7 @@ const rm = (x) => {
@@ -22,13 +22,40 @@ index a5baa0f8..37cac28e 100755
      },
    };
    wf('_/version.js', `D=${JSON.stringify(vi)}`);
-@@ -50,6 +50,9 @@ const incl = new RegExp('^$'
-   + '|^/style($|/(fonts|img)|.*\\.css$)');
+@@ -51,8 +51,7 @@ const incl = new RegExp('^$'
  const pkg = (x, y, f) => {
    rq('electron-packager')({
-+    asar: true,
-+    electronZipDir: "local-cache",
-+    electronVersion: "@electron_version@",
      dir: '.',
-     platform: x,
-     arch: y,
+-    platform: x,
+-    arch: y,
++    asar: true,
+     tmpdir: '/tmp/ridebuild',
+     out: `_/${pj.name}`,
+     overwrite: true,
+@@ -79,8 +78,8 @@ const pkg = (x, y, f) => {
+       ProductName: 'RIDE',
+       InternalName: 'RIDE',
+     },
+-  }).then(() => {
+-    const d = `_/${pj.name}/${pj.productName}-${x}-${y}`;
++  }).then(paths => {
++    const d = paths[0];
+     rm(`${d}/version`);
+     fs.existsSync(`${d}/LICENSE`) && mv(`${d}/LICENSE`, `${d}/LICENSE.electron`);
+     generateLicenses(`${d}/ThirdPartyNotices.txt`);
+@@ -88,6 +87,7 @@ const pkg = (x, y, f) => {
+   }, e => f(e));
+ };
+ 
++const self = (f) => { b(e => (e ? f(e) : pkg(undefined, undefined, f))); };
+ const l = (f) => { b(e => (e ? f(e) : pkg('linux', 'x64', f))); };
+ const w = (f) => { b(e => (e ? f(e) : pkg('win32', 'ia32', f))); };
+ const o = (f) => { b(e => (e ? f(e) : pkg('darwin', 'x64', f))); };
+@@ -109,6 +109,7 @@ tasks.ma=ma; tasks.masarm = ma;
+ tasks.a = a; tasks.arm = a;
+ tasks.d = d; tasks.dist = d;
+ tasks.c = c; tasks.clean = c;
++tasks.self = self;
+ 
+ async.each(
+   process.argv.length > 2 ? process.argv.slice(2) : ['build'],

--- a/pkgs/by-name/ri/ride/package.nix
+++ b/pkgs/by-name/ri/ride/package.nix
@@ -4,7 +4,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   fetchpatch,
-  substituteAll,
+  replaceVars,
   jq,
   moreutils,
   zip,
@@ -15,24 +15,6 @@
   cctools,
 }:
 
-let
-  platformInfos = {
-    "x86_64-linux" = {
-      zipSuffix = "linux-x64";
-      buildCmd = "linux";
-    };
-    "x86_64-darwin" = {
-      zipSuffix = "darwin-x64";
-      buildCmd = "osx";
-    };
-    "aarch64-darwin" = {
-      zipSuffix = "darwin-arm64";
-      buildCmd = "osxarm";
-    };
-  };
-
-  platformInfo = platformInfos.${stdenv.system};
-in
 buildNpmPackage rec {
   pname = "ride";
   version = "4.5.4097";
@@ -40,7 +22,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "Dyalog";
     repo = "ride";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-xR+HVC1JVrPkgPhIJZxdTVG52+QbanmD1c/uO5l84oc=";
   };
 
@@ -53,11 +35,10 @@ buildNpmPackage rec {
       url = "https://github.com/Dyalog/ride/commit/de42ebbd5036cfe0c7e6604296e87cc57ac9d365.patch";
       hash = "sha256-5iKSNcxOOo2fKNvy3Rv+AlH3psYhLWLWUY0l8M6mAD4=";
     })
-    # Fix info in the "about" page, set electron version, set local-cache as zipdir
-    (substituteAll {
-      src = ./mk.patch;
-      version = version;
-      electron_version = electron.version;
+
+    # Fix info in the "about" page, enable asar, add option to build for the detected system
+    (replaceVars ./mk.patch {
+      inherit version;
     })
   ];
 
@@ -89,7 +70,7 @@ buildNpmPackage rec {
       zip
       makeWrapper
     ]
-    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ copyDesktopItems ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ copyDesktopItems ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
@@ -99,20 +80,23 @@ buildNpmPackage rec {
     stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "11.0"
   ) "-D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION=1";
 
-  npmBuildFlags = platformInfo.buildCmd;
+  # our patch adds the platform detecting build option
+  npmBuildFlags = "self";
 
-  # This package uses electron-packager instead of electron-builder
-  # Here, we create a local cache of electron zip-files, so electron-packager can copy from it
   postConfigure = ''
-    mkdir local-cache
-
     # electron files need to be writable on Darwin
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
     pushd electron-dist
-    zip -qr ../local-cache/electron-v${electron.version}-${platformInfo.zipSuffix}.zip *
+    zip -0Xqr ../electron.zip *
     popd
+
+    rm -r electron-dist
+
+    # force electron-packager to use our electron instead of downloading it, even if it is a different version
+    substituteInPlace node_modules/electron-packager/src/index.js \
+        --replace-fail 'await this.getElectronZipPath(downloadOpts)' '"electron.zip"'
   '';
 
   installPhase = ''
@@ -122,13 +106,13 @@ buildNpmPackage rec {
 
     install -Dm644 ThirdPartyNotices.txt -t $out/share/doc/ride
 
-    ${lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
       install -Dm644 $src/D.png $out/share/icons/hicolor/64x64/apps/ride.png
       install -Dm644 $src/D.svg $out/share/icons/hicolor/scalable/apps/ride.svg
 
       mkdir -p $out/share/ride
       cp -r locales resources{,.pak} $out/share/ride
-      makeWrapper ${lib.getExe electron} $out/bin/ride \
+      makeShellWrapper ${lib.getExe electron} $out/bin/ride \
           --add-flags $out/share/ride/resources/app.asar \
           --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
           --inherit-argv0
@@ -161,7 +145,7 @@ buildNpmPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/Dyalog/ride/releases/tag/${src.rev}";
+    changelog = "https://github.com/Dyalog/ride/releases/tag/v${version}";
     description = "Remote IDE for Dyalog APL";
     homepage = "https://github.com/Dyalog/ride";
     license = lib.licenses.mit;
@@ -170,6 +154,6 @@ buildNpmPackage rec {
       tomasajt
       markus1189
     ];
-    platforms = lib.attrNames platformInfos;
+    platforms = electron.meta.platforms;
   };
 }


### PR DESCRIPTION
## Description of changes

Turns out there's an easier way of specifying which zip to use as an electron archive, so I utilized that instead.
I also improved the patch to not have to specify the platform to build for.
I also did some general refactoring.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
