### PR TITLE
nitrokey-fido2-firmware: init at 2.4.1

### DIFF
--- a/pkgs/by-name/ni/nitrokey-fido2-firmware/package.nix
+++ b/pkgs/by-name/ni/nitrokey-fido2-firmware/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  writeShellScriptBin,
+  gcc-arm-embedded,
+  pynitrokey,
+  python3,
+
+  # The make target to run
+  makeTarget ? "release-buildv",
+  # Whether the firmware should include the production public key for the bootloader
+  release ? true,
+}:
+
+let
+  # The latest release is found on the releases page; do not rely on the latest tag.
+  # They normally contain the suffix `.nitrokey`.
+  # https://github.com/Nitrokey/nitrokey-fido2-firmware/releases
+  version = "2.4.1";
+
+  # The firmware version is pulled from `git` so we stub it here to avoid pulling the whole program.
+  fakeGit = writeShellScriptBin "git" ''
+    echo "${version}.nitrokey"
+  '';
+
+in
+stdenv.mkDerivation {
+  pname = "nitrokey-fido2-firmware";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "Nitrokey";
+    repo = "nitrokey-fido2-firmware";
+    rev = "${version}.nitrokey";
+    hash = "sha256-7AsnxRf8mdybI6Mup2mV01U09r5C/oUX6fG2ymkkOOo=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    # Remove a duplicate firmware_version definition. Without this,
+    # firmware_version is defined multiple times, triggering a build error.
+    substituteInPlace fido2/version.h \
+      --replace-fail "const version_t firmware_version ;" ""
+  '';
+
+  nativeBuildInputs = [
+    fakeGit
+    # only gcc-arm-embedded includes libc_nano.a
+    gcc-arm-embedded
+    pynitrokey
+    python3
+  ];
+
+  preBuild = ''
+    cd targets/stm32l432
+  '';
+
+  makeFlags = [
+    "${makeTarget}"
+    "RELEASE=${toString release}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    cp -r release $out
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Firmware for the Nitrokey FIDO2 device";
+    homepage = "https://github.com/Nitrokey/nitrokey-fido2-firmware";
+    maintainers = with lib.maintainers; [
+      amerino
+      kiike
+      imadnyc
+    ];
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes
This is the firmware for the Nitrokey FIDO2 key, the packaging of which was continued during the Summer of Nix 2024 with sponsorship by NLNET.

This is not an executable, but a binary firmware that can be flashed onto such keys.  According to a discourse thread, inclusion of such artifacts in nixpkgs [shouldn't be an issue](https://discourse.nixos.org/t/inclusion-of-device-firmwares-in-nixpkgs/50980).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @amerinor01 @jleightcap @imadnyc @RCoeurjoly @fricklerhandwerk 

Related PRs:

- #337966
- #337959
- #337956
- #337954
- #337951

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
