### PR TITLE
nitrokey-storage-firmware: init at 0.57

### DIFF
--- a/pkgs/by-name/ni/nitrokey-storage-firmware/package.nix
+++ b/pkgs/by-name/ni/nitrokey-storage-firmware/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  fetchFromGitHub,
+}:
+let
+  pname = "nitrokey-storage-firmware";
+  version = "0.57";
+
+  src = fetchFromGitHub {
+    owner = "Nitrokey";
+    repo = "nitrokey-storage-firmware";
+    rev = "V${version}";
+    hash = "sha256-u8IK57NVS/IOPIE3Ah/O8WuOIr0EY6AF1bEaeDgIBuk=";
+  };
+
+  toolchain = stdenv.mkDerivation (finalAttrs: {
+    pname = "avr32-toolchain";
+    version = "3.0.0.201009140852";
+
+    src = fetchzip {
+      url = "https://ww1.microchip.com/downloads/archive/avr32studio-ide-2.6.0.753-linux.gtk.x86_64.zip";
+      hash = "sha256-MwsaGyNqbO0lBy1rcczuvKOaGbO3f0V+j84sUCkRlxc=";
+    };
+
+    postPatch = ''
+      cp ${src}/pm_240.h plugins/com.atmel.avr.toolchains.linux.x86_64_${finalAttrs.version}/os/linux/x86_64/avr32/include/avr32/pm_231.h
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r plugins/com.atmel.avr.toolchains.linux.x86_64_${finalAttrs.version}/os/linux/x86_64 $out
+      rm -r $out/avr $out/bin/avr-*
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "AVR32 toolchain";
+      homepage = "https://web.archive.org/web/20210419192039/https://www.microchip.com/mplab/avr-support/avr-and-sam-downloads-archive";
+      # The zip does not explicitly say this,
+      # it only mentions the license(s) of AVR32 Studio.
+      # Because it is very clearly a fork of GCC 4.3.3,
+      # it should be licensed under GPLv2+
+      license = lib.licenses.gpl2Plus;
+      platforms = [ "x86_64-linux" ];
+    };
+  });
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  sourceRoot = "source/src";
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail '$(shell git describe)' "V${version}"
+  '';
+
+  makeFlags = [
+    "CC=${toolchain}/bin/avr32-gcc"
+    "nitrokey-storage-V${version}-reproducible.hex"
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D nitrokey-storage-V${version}-reproducible.hex $out/nitrokey-storage-V${version}-reproducible.hex
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Firmware for the Nitrokey Storage device";
+    homepage = "https://github.com/Nitrokey/nitrokey-storage-firmware";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      imadnyc
+      kiike
+      amerino
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


This is the firmware for the Nitrokey Storage key, the packaging of which was continued during the Summer of Nix 2024 with sponsorship by NLNET.

This is not an executable, but a binary firmware that can be flashed onto such keys. According to a discourse thread, inclusion of such artifacts in nixpkgs shouldn't be an issue.

cc @amerinor01 @jleightcap @imadnyc @RCoeurjoly @fricklerhandwerk

Related PRs:

- #337966
- #337959
- #337956
- #337954
- #337951
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
