### PR TITLE
nitrokey-trng-rs232-firmware: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ni/nitrokey-trng-rs232-firmware/package.nix
+++ b/pkgs/by-name/ni/nitrokey-trng-rs232-firmware/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkgsCross,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nitrokey-trng-rs232-firmware";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Nitrokey";
+    repo = "nitrokey-trng-rs232-firmware";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-vY/9KAGB6lTkkjW9zUiHA3wD2d35cEBVBTr12bHCy4k=";
+  };
+
+  nativeBuildInputs = [ pkgsCross.avr.stdenv.cc ];
+
+  sourceRoot = "source/src";
+
+  makeFlags = [ "all" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D TRNGSerial.bin $out/TRNGSerial.bin
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Firmware for the Nitrokey TRNG RS232 device";
+    longDescription = ''
+      This package does not provide an executable. It should be built using `nix-build -A nitrokey-trng-rs232-firmware` or `nix build nixpkgs#nitrokey-trng-rs232-firmware` and flashed using `libnitrokey`
+    '';
+    homepage = "https://github.com/Nitrokey/nitrokey-trng-rs232-firmware";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      amerino
+      imadnyc
+      kiike
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes
This is the firmware for the Nitrokey TRNG RS232 key, the packaging of which was continued during the Summer of Nix 2024 with sponsorship by NLNET.

This is not an executable, but a binary firmware that can be flashed onto such keys. According to a discourse thread, inclusion of such artifacts in nixpkgs shouldn't be an issue.

cc @amerinor01 @jleightcap @imadnyc @RCoeurjoly @fricklerhandwerk
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Related PRs:

- #337966
- #337959
- #337956
- #337954
- #337951

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
