### PR TITLE
CODEOWNERS: add mattpolzin for idris2Packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -254,6 +254,7 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 
 # Idris
 /pkgs/development/idris-modules @Infinisil
+/pkgs/development/compilers/idris2 @mattpolzin
 
 # Bazel
 /pkgs/development/tools/build-managers/bazel @Profpatsch


### PR DESCRIPTION
## Description of changes

I've been maintaining `idris2Packages` since I introduced it and it would be nice to get pinged on changes to the whole directory instead of only the packages within it. I'm not intentionally excluding other maintainers of the `idris2` package, I'm just not assuming they want to get pinged for the whole package-set.

@wchresta @fabianhjr I'd be happy to amend this commit to add either of you as well if you'd like (although as I understand it that would be an honorary comment for `@wchresta` because code owners pings only work for committers).