### PR TITLE
python312Packages.solarlog-cli: 0.1.6 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/curio-compat/default.nix
+++ b/pkgs/development/python-modules/curio-compat/default.nix
@@ -1,0 +1,38 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "curio-compat";
+  version = "1.6.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "klen";
+    repo = "curio";
+    rev = "refs/tags/${version}";
+    hash = "sha256-Crd9r4Icwga85wvtXaePbE56R192o+FXU9Zn+Lc7trI=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "curio" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    # contacts google.com
+    "test_ssl_outgoing"
+  ];
+
+  meta = {
+    description = "Coroutine-based library for concurrent systems programming";
+    homepage = "https://github.com/klen/curio";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-aio/default.nix
+++ b/pkgs/development/python-modules/pytest-aio/default.nix
@@ -2,16 +2,16 @@
   lib,
   anyio,
   buildPythonPackage,
-  curio,
+  curio-compat,
   fetchFromGitHub,
   hypothesis,
   pytest,
   pytestCheckHook,
   pythonOlder,
   poetry-core,
-  sniffio,
   trio,
   trio-asyncio,
+  uvloop,
 }:
 
 buildPythonPackage rec {
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   version = "1.9.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "klen";
@@ -32,16 +32,18 @@ buildPythonPackage rec {
 
   buildInputs = [ pytest ];
 
-  dependencies = [
-    anyio
-    curio
-    hypothesis
-    sniffio
-    trio
-    trio-asyncio
-  ];
+  optional-dependencies = {
+    curio = [ curio-compat ];
+    trio = [ trio ];
+    uvloop = [ uvloop ];
+  };
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    anyio
+    hypothesis
+    pytestCheckHook
+    trio-asyncio
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "pytest_aio" ];
 

--- a/pkgs/development/python-modules/solarlog-cli/default.nix
+++ b/pkgs/development/python-modules/solarlog-cli/default.nix
@@ -5,11 +5,16 @@
   fetchFromGitHub,
   hatchling,
   aiohttp,
+  mashumaro,
+  aioresponses,
+  pytest-aio,
+  pytestCheckHook,
+  syrupy,
 }:
 
 buildPythonPackage rec {
   pname = "solarlog-cli";
-  version = "0.1.6";
+  version = "0.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -18,17 +23,24 @@ buildPythonPackage rec {
     owner = "dontinelli";
     repo = "solarlog_cli";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Bliq1n6xH0cZQHueiGDyalIo0zms8zCSpUGq2KH5xZY=";
+    hash = "sha256-x9MovIKFImu60Ns2sJTy71S22cR9Az/yNMWzGM50y7Y=";
   };
 
   build-system = [ hatchling ];
 
-  dependencies = [ aiohttp ];
+  dependencies = [
+    aiohttp
+    mashumaro
+  ];
 
   pythonImportsCheck = [ "solarlog_cli" ];
 
-  # upstream has no tests
-  doCheck = false;
+  nativeCheckInputs = [
+    aioresponses
+    pytest-aio
+    pytestCheckHook
+    syrupy
+  ];
 
   meta = {
     changelog = "https://github.com/dontinelli/solarlog_cli/releases/tag/v${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2719,6 +2719,8 @@ self: super: with self; {
 
   curio = callPackage ../development/python-modules/curio { };
 
+  curio-compat = callPackage ../development/python-modules/curio-compat { };
+
   curlify = callPackage ../development/python-modules/curlify { };
 
   curl-cffi = callPackage ../development/python-modules/curl-cffi { };


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/dontinelli/solarlog_cli/compare/refs/tags/v0.1.6...v0.2.0

Changelog: https://github.com/dontinelli/solarlog_cli/releases/tag/v0.2.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
