### PR TITLE
python312Packages.aioazuredevops: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/development/python-modules/aioazuredevops/default.nix
+++ b/pkgs/development/python-modules/aioazuredevops/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "aioazuredevops";
-  version = "2.2.0";
+  version = "2.2.1";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -31,12 +31,14 @@ buildPythonPackage rec {
     owner = "timmo001";
     repo = "aioazuredevops";
     rev = "refs/tags/${version}";
-    hash = "sha256-1v58I9WOyyrp9n+qdvVeMZ3EObqP/06XCOZYS0nEvPU=";
+    hash = "sha256-RZBiFPzYtEoc51T3irVHL9xVlZgACyM2lu1TkMoatqU=";
   };
 
   postPatch = ''
     substituteInPlace requirements_setup.txt \
       --replace-fail "==" ">="
+    substituteInPlace aioazuredevops/_version.py \
+      --replace-fail ", dev=0" ""
   '';
 
   build-system = [


### PR DESCRIPTION
<details>
<summary>Tests fail because of a different attribute order.</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.12.4, pytest-8.3.2, pluggy-1.5.0 -- /nix/store/04gg5w1s662l329a8kh9xcwyp0k64v5a-python3-3.12.4/bin/python3.12
cachedir: .pytest_cache
rootdir: /build/source
configfile: pyproject.toml
testpaths: tests
plugins: aiohttp-1.0.5, asyncio-0.23.8, socket-0.7.0, syrupy-4.6.1
asyncio: mode=Mode.AUTO
collected 16 items                                                             

tests/test__version.py::test__version PASSED                             [  6%]
tests/test_client.py::test_authorize PASSED                              [ 12%]
tests/test_client.py::test_get_project FAILED                            [ 18%]
tests/test_client.py::test_get_builds FAILED                             [ 25%]
tests/test_client.py::test_get_build FAILED                              [ 31%]
tests/test_client.py::test_get_iterations PASSED                         [ 37%]
tests/test_client.py::test_get_iteration PASSED                          [ 43%]
tests/test_client.py::test_get_iteration_work_items PASSED               [ 50%]
tests/test_client.py::test_get_work_items_ids PASSED                     [ 56%]
tests/test_client.py::test_get_work_items PASSED                         [ 62%]
tests/test_client.py::test_get_work_item_types PASSED                    [ 68%]
tests/test_helper.py::test_current_iteration PASSED                      [ 75%]
tests/test_helper.py::test_previous_iteration PASSED                     [ 81%]
tests/test_helper.py::test_next_iteration PASSED                         [ 87%]
tests/test_helper.py::test_work_item_types_states_filter PASSED          [ 93%]
tests/test_helper.py::test_work_items_by_type_and_state PASSED           [100%]

=================================== FAILURES ===================================
_______________________________ test_get_project _______________________________

devops_client = <aioazuredevops.client.DevOpsClient object at 0x7ffff65a20c0>
mock_aioresponse = <aioresponses.core.aioresponses object at 0x7ffff56b4950>
snapshot = Project(id='testid', name='testname', description='testdescription', url='testurl', state='teststate', revision=1, vis...lection(href='testweb')), default_team=DefaultTeam(id='testid', name='testname', url='testurl'), last_update_time=None)

    @pytest.mark.asyncio
    async def test_get_project(
        devops_client: DevOpsClient,
        mock_aioresponse: aioresponses,
        snapshot: SnapshotAssertion,
    ) -> None:
        """Test the get_project method."""
        project = await devops_client.get_project(
            organization=ORGANIZATION,
            project=PROJECT,
        )
    
>       assert project == snapshot(
            name="project",
        )
E       AssertionError: assert [+ received] == [- snapshot]
E         - Project(id='testid', name='testname', description='testdescription', url='testurl', state='teststate', revision=1, visibility='testvisibility', capabilities=Capabilities(process_template=ProcessTemplate(template_name='Agile', template_type_id='abc123-abc1-abc1-abc1-abc123456789'), versioncontrol=VersionControl(source_control_type='Git', git_enabled='True', tfvc_enabled='False')), links=Links(links_self=LinkCollection(href='testself'), collection=LinkCollection(href='testcollection'), web=LinkCollection(href='testweb')), default_team=DefaultTeam(id='testid', name='testname', url='testurl'), last_update_time=None)
E         + Project(id='testid', name='testname', url='testurl', state='teststate', revision=1, visibility='testvisibility', description='testdescription', capabilities=Capabilities(process_template=ProcessTemplate(template_name='Agile', template_type_id='abc123-abc1-abc1-abc1-abc123456789'), versioncontrol=VersionControl(source_control_type='Git', git_enabled='True', tfvc_enabled='False')), links=Links(links_self=LinkCollection(href='testself'), collection=LinkCollection(href='testcollection'), web=LinkCollection(href='testweb')), default_team=DefaultTeam(id='testid', name='testname', url='testurl'), last_update_time=None)

tests/test_client.py:61: AssertionError
_______________________________ test_get_builds ________________________________

devops_client = <aioazuredevops.client.DevOpsClient object at 0x7ffff5427b90>
mock_aioresponse = <aioresponses.core.aioresponses object at 0x7ffff5426300>
snapshot = list([
  Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='te...b='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge')),
])

    @pytest.mark.asyncio
    async def test_get_builds(
        devops_client: DevOpsClient,
        mock_aioresponse: aioresponses,
        snapshot: SnapshotAssertion,
    ) -> None:
        """Test the get_builds method."""
        builds = await devops_client.get_builds(
            organization=ORGANIZATION,
            project=PROJECT,
            parameters="",
        )
    
>       assert builds == snapshot(
            name="builds",
        )
E       AssertionError: assert [+ received] == [- snapshot]
E           list([
E         -   Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='testsourcebranch', source_version='testsourceversion', priority='testpriority', reason='testreason', queue_time='testqueuetime', start_time='teststarttime', finish_time='teststarttime', definition=BuildDefinition(build_id=1, name='testname', url='testurl', path='testpath', build_type='testtype', queue_status='testqueuestatus', revision=1), project=Project(id='testid', name='testname', description='testdescription', url='testurl', state='teststate', revision=1, visibility='testvisibility', capabilities=None, links=None, default_team=None, last_update_time=None), links=BuildLinks(l_self='testself', web='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge')),
E         +   Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='testsourcebranch', source_version='testsourceversion', priority='testpriority', reason='testreason', queue_time='testqueuetime', start_time='teststarttime', finish_time='teststarttime', definition=BuildDefinition(build_id=1, name='testname', url='testurl', path='testpath', build_type='testtype', queue_status='testqueuestatus', revision=1), project=Project(id='testid', name='testname', url='testurl', state='teststate', revision=1, visibility='testvisibility', description='testdescription', capabilities=None, links=None, default_team=None, last_update_time=None), links=BuildLinks(l_self='testself', web='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge')),
E           ])

tests/test_client.py:117: AssertionError
________________________________ test_get_build ________________________________

devops_client = <aioazuredevops.client.DevOpsClient object at 0x7ffff57935f0>
mock_aioresponse = <aioresponses.core.aioresponses object at 0x7ffff5374500>
snapshot = Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='testsourceb..., web='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge'))

    @pytest.mark.asyncio
    async def test_get_build(
        devops_client: DevOpsClient,
        mock_aioresponse: aioresponses,
        snapshot: SnapshotAssertion,
    ) -> None:
        """Test the get_build method."""
        build = await devops_client.get_build(
            organization=ORGANIZATION,
            project=PROJECT,
            build_id=1,
        )
    
>       assert build == snapshot(
            name="build",
        )
E       AssertionError: assert [+ received] == [- snapshot]
E         - Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='testsourcebranch', source_version='testsourceversion', priority='testpriority', reason='testreason', queue_time='testqueuetime', start_time='teststarttime', finish_time='teststarttime', definition=BuildDefinition(build_id=1, name='testname', url='testurl', path='testpath', build_type='testtype', queue_status='testqueuestatus', revision=1), project=Project(id='testid', name='testname', description='testdescription', url='testurl', state='teststate', revision=1, visibility='testvisibility', capabilities=None, links=None, default_team=None, last_update_time=None), links=BuildLinks(l_self='testself', web='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge'))
E         + Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='testsourcebranch', source_version='testsourceversion', priority='testpriority', reason='testreason', queue_time='testqueuetime', start_time='teststarttime', finish_time='teststarttime', definition=BuildDefinition(build_id=1, name='testname', url='testurl', path='testpath', build_type='testtype', queue_status='testqueuestatus', revision=1), project=Project(id='testid', name='testname', url='testurl', state='teststate', revision=1, visibility='testvisibility', description='testdescription', capabilities=None, links=None, default_team=None, last_update_time=None), links=BuildLinks(l_self='testself', web='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge'))

tests/test_client.py:164: AssertionError
--------------------------- snapshot report summary ----------------------------
3 snapshots failed. 15 snapshots passed.
=========================== short test summary info ============================
FAILED tests/test_client.py::test_get_project - AssertionError: assert [+ received] == [- snapshot]
  - Project(id='testid', name='testname', description='testdescription', url='testurl', state='teststate', revision=1, visibility='testvisibility', capabilities=Capabilities(process_template=ProcessTemplate(template_name='Agile', template_type_id='abc123-abc1-abc1-abc1-abc123456789'), versioncontrol=VersionControl(source_control_type='Git', git_enabled='True', tfvc_enabled='False')), links=Links(links_self=LinkCollection(href='testself'), collection=LinkCollection(href='testcollection'), web=LinkCollection(href='testweb')), default_team=DefaultTeam(id='testid', name='testname', url='testurl'), last_update_time=None)
  + Project(id='testid', name='testname', url='testurl', state='teststate', revision=1, visibility='testvisibility', description='testdescription', capabilities=Capabilities(process_template=ProcessTemplate(template_name='Agile', template_type_id='abc123-abc1-abc1-abc1-abc123456789'), versioncontrol=VersionControl(source_control_type='Git', git_enabled='True', tfvc_enabled='False')), links=Links(links_self=LinkCollection(href='testself'), collection=LinkCollection(href='testcollection'), web=LinkCollection(href='testweb')), default_team=DefaultTeam(id='testid', name='testname', url='testurl'), last_update_time=None)
FAILED tests/test_client.py::test_get_builds - AssertionError: assert [+ received] == [- snapshot]
    list([
  -   Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='testsourcebranch', source_version='testsourceversion', priority='testpriority', reason='testreason', queue_time='testqueuetime', start_time='teststarttime', finish_time='teststarttime', definition=BuildDefinition(build_id=1, name='testname', url='testurl', path='testpath', build_type='testtype', queue_status='testqueuestatus', revision=1), project=Project(id='testid', name='testname', description='testdescription', url='testurl', state='teststate', revision=1, visibility='testvisibility', capabilities=None, links=None, default_team=None, last_update_time=None), links=BuildLinks(l_self='testself', web='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge')),
  +   Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='testsourcebranch', source_version='testsourceversion', priority='testpriority', reason='testreason', queue_time='testqueuetime', start_time='teststarttime', finish_time='teststarttime', definition=BuildDefinition(build_id=1, name='testname', url='testurl', path='testpath', build_type='testtype', queue_status='testqueuestatus', revision=1), project=Project(id='testid', name='testname', url='testurl', state='teststate', revision=1, visibility='testvisibility', description='testdescription', capabilities=None, links=None, default_team=None, last_update_time=None), links=BuildLinks(l_self='testself', web='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge')),
    ])
FAILED tests/test_client.py::test_get_build - AssertionError: assert [+ received] == [- snapshot]
  - Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='testsourcebranch', source_version='testsourceversion', priority='testpriority', reason='testreason', queue_time='testqueuetime', start_time='teststarttime', finish_time='teststarttime', definition=BuildDefinition(build_id=1, name='testname', url='testurl', path='testpath', build_type='testtype', queue_status='testqueuestatus', revision=1), project=Project(id='testid', name='testname', description='testdescription', url='testurl', state='teststate', revision=1, visibility='testvisibility', capabilities=None, links=None, default_team=None, last_update_time=None), links=BuildLinks(l_self='testself', web='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge'))
  + Build(build_id=1, build_number='testbuildnumber', status='teststatus', result='testresult', source_branch='testsourcebranch', source_version='testsourceversion', priority='testpriority', reason='testreason', queue_time='testqueuetime', start_time='teststarttime', finish_time='teststarttime', definition=BuildDefinition(build_id=1, name='testname', url='testurl', path='testpath', build_type='testtype', queue_status='testqueuestatus', revision=1), project=Project(id='testid', name='testname', url='testurl', state='teststate', revision=1, visibility='testvisibility', description='testdescription', capabilities=None, links=None, default_team=None, last_update_time=None), links=BuildLinks(l_self='testself', web='testweb', source_version_display_uri='testsourceversiondisplayuri', timeline='testtimeline', badge='testbadge'))
========================= 3 failed, 13 passed in 0.27s =========================
```
</details>

## Description of changes
Diff: https://github.com/timmo001/aioazuredevops/compare/refs/tags/2.2.0...2.2.1

Changelog: https://github.com/timmo001/aioazuredevops/releases/tag/2.2.1

Home Assistant PR: https://github.com/home-assistant/core/pull/124788

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
