### PR TITLE
[WIP] libcapsule: init at 0.20240806.0; libglcapsule: init; libGL: point to libglcapsule and make supporting changes

### DIFF
--- a/pkgs/by-name/li/libcapsule/mkCapsule.nix
+++ b/pkgs/by-name/li/libcapsule/mkCapsule.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  runCommand,
+  autoreconfHook,
+  autoconf,
+  automake,
+  getopt,
+  pkg-config,
+  libcapsule,
+  libtool,
+}:
+
+{
+  pname,
+  dependencies,
+  objects,
+  meta ? {},
+}@args:
+
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname;
+  inherit (libcapsule) version;
+
+  outputs = [ "out" "dev" ];
+
+  src = runCommand "${pname}-src" {
+    nativeBuildInputs = [
+      autoconf
+      automake
+      libtool
+      pkg-config
+    ];
+    buildInputs = [
+      libcapsule
+    ];
+    LD_LIBRARY_PATH = lib.makeLibraryPath dependencies;
+  } ''
+    capsule-init-project --destination=$out --package-name=${pname} --runtime-tree="/" ${lib.concatStringsSep " " objects}
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    getopt
+  ];
+  buildInputs = [
+    libcapsule
+  ];
+
+  # Do hacky stuff to pull dev outputs from dependencies that have them
+  postInstall = ''
+    mkdir -p $dev/include $dev/lib/pkgconfig
+  '' + (lib.concatStringsSep "\n" (builtins.map (dep: ''
+    cp -r ${dep.dev}/include/. $dev/include/
+    for pc in $(find ${dep.dev}/lib/pkgconfig -printf "%P\n"); do
+      cat "${dep.dev}/lib/pkgconfig/$pc" | sed "s|${dep}|$out|g" | sed "s|${dep.dev}|$dev|g" > $dev/lib/pkgconfig/$pc
+    done
+  '') (builtins.filter (dep: builtins.hasAttr "dev" dep) dependencies)));
+
+  meta = {
+    description = "libcapsule-wrapped ${lib.concatStringsSep ", " objects}";
+    license = lib.licenses.gpl3Plus;
+  } // meta;
+})

--- a/pkgs/by-name/li/libcapsule/package.nix
+++ b/pkgs/by-name/li/libcapsule/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  autoconf-archive,
+  elfutils,
+  getopt,
+  gtk-doc,
+  intltool,
+  libtool,
+  makeWrapper,
+  patchelf,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libcapsule";
+  version = "0.20240806.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.collabora.com";
+    owner = "vivek";
+    repo = "libcapsule";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-aJV1u047hCVZhuLvAKe8JvoLe/vGkuuCs/LvD+bLTGU=";
+  };
+  
+  postPatch = ''
+    patchShebangs data
+  '';
+
+  configureFlags = [ "--enable-host-prefix=no" ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    getopt
+    gtk-doc
+    intltool
+    libtool
+    makeWrapper
+    patchelf
+    pkg-config
+  ];
+
+  buildInputs = [
+    elfutils
+  ];
+
+  postInstall = ''
+    # Manually remove /build/source/tests/.libs from the rpath of this specific test binary
+    patchelf --shrink-rpath --allowed-rpath-prefixes /nix/store $out/libexec/installed-tests/libcapsule/tests/libcapsule-test-dependent-runpath.so.1
+
+    # Tell programs where to find files
+    wrapProgram $out/bin/capsule-init-project \
+      --prefix PATH : ${lib.makeBinPath [ getopt pkg-config ]} \
+      --set CAPSULE_MKINC $out/share/libcapsule/ \
+      --set CAPSULE_SYMBOLS_TOOL $out/bin/capsule-symbols \
+      --set CAPSULE_VERSION_TOOL $out/bin/capsule-version
+    wrapProgram $out/bin/capsule-mkstublib \
+      --prefix PATH : ${lib.makeBinPath [ pkg-config ]} \
+      --set CAPSULE_SYMBOLS_TOOL $out/bin/capsule-symbols
+  '';
+
+  meta = {
+    description = "Segregated dynamic linking library";
+    homepage = "https://gitlab.collabora.com/vivek/libcapsule";
+    mainProgram = "capsule-init-project";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+})

--- a/pkgs/by-name/li/libglcapsule/package.nix
+++ b/pkgs/by-name/li/libglcapsule/package.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  mkCapsule,
+  libglvnd,
+}:
+
+mkCapsule {
+  pname = "libglcapsule";
+  dependencies = [ libglvnd ];
+  objects = [ "libGL.so" "libEGL.so" "libGLESv1_CM.so" "libGLESv2.so" "libGLX.so" "libOpenGL.so" ];
+  meta = {
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10093,6 +10093,8 @@ with pkgs;
     faslExt = "fas";
   };
 
+  mkCapsule = callPackage ../../pkgs/by-name/li/libcapsule/mkCapsule.nix { };
+
   # Steel Bank Common Lisp
   sbcl_2_4_6 = wrapLisp {
     pkg = callPackage ../development/compilers/sbcl { version = "2.4.6"; };


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/9415

Fixes https://github.com/NixOS/nixpkgs/issues/31189

This will allow for applications that depend on libGL to be run on non-NixOS platforms. This will particularly be useful in the context of nix bundlers, such as https://github.com/ralismark/nix-appimage.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
