### PR TITLE
nixos/services.mediatomb: remove `with lib;`

### DIFF
--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -1,7 +1,4 @@
 { config, lib, options, pkgs, ... }:
-
-with lib;
-
 let
 
   gid = config.ids.gids.mediatomb;
@@ -13,19 +10,19 @@ let
   # configuration on media directory
   mediaDirectory = {
     options = {
-      path = mkOption {
-        type = types.str;
+      path = lib.mkOption {
+        type = lib.types.str;
         description = ''
           Absolute directory path to the media directory to index.
         '';
       };
-      recursive = mkOption {
-        type = types.bool;
+      recursive = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Whether the indexation must take place recursively or not.";
       };
-      hidden-files = mkOption {
-        type = types.bool;
+      hidden-files = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = "Whether to index the hidden files or not.";
       };
@@ -66,7 +63,7 @@ let
     </transcoding>
 '';
 
-  configText = optionalString (! cfg.customCfg) ''
+  configText = lib.optionalString (! cfg.customCfg) ''
 <?xml version="1.0" encoding="UTF-8"?>
 <config version="2" xmlns="http://mediatomb.cc/config/2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mediatomb.cc/config/2 http://mediatomb.cc/config/2.xsd">
     <server>
@@ -87,7 +84,7 @@ let
         </sqlite3>
       </storage>
       <protocolInfo extend="${optionYesNo cfg.ps3Support}"/>
-      ${optionalString cfg.dsmSupport ''
+      ${lib.optionalString cfg.dsmSupport ''
       <custom-http-headers>
         <add header="X-User-Agent: redsonic"/>
       </custom-http-headers>
@@ -95,7 +92,7 @@ let
       <manufacturerURL>redsonic.com</manufacturerURL>
       <modelNumber>105</modelNumber>
       ''}
-        ${optionalString cfg.tg100Support ''
+        ${lib.optionalString cfg.tg100Support ''
       <upnp-string-limit>101</upnp-string-limit>
       ''}
       <extended-runtime-options>
@@ -109,7 +106,7 @@ let
     </server>
     <import hidden-files="no">
       <autoscan use-inotify="auto">
-      ${concatMapStrings toMediaDirectory cfg.mediaDirectories}
+      ${lib.concatMapStrings toMediaDirectory cfg.mediaDirectories}
       </autoscan>
       <scripting script-charset="UTF-8">
         <common-script>${pkg}/share/${name}/js/common.js</common-script>
@@ -139,10 +136,10 @@ let
           <map from="flv" to="video/x-flv"/>
           <map from="mkv" to="video/x-matroska"/>
           <map from="mka" to="audio/x-matroska"/>
-          ${optionalString cfg.ps3Support ''
+          ${lib.optionalString cfg.ps3Support ''
           <map from="avi" to="video/divx"/>
           ''}
-          ${optionalString cfg.dsmSupport ''
+          ${lib.optionalString cfg.dsmSupport ''
           <map from="avi" to="video/avi"/>
           ''}
         </extension-mimetype>
@@ -199,26 +196,26 @@ in {
 
     services.mediatomb = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable the Gerbera/Mediatomb DLNA server.
         '';
       };
 
-      serverName = mkOption {
-        type = types.str;
+      serverName = lib.mkOption {
+        type = lib.types.str;
         default = "Gerbera (Mediatomb)";
         description = ''
           How to identify the server on the network.
         '';
       };
 
-      package = mkPackageOption pkgs "gerbera" { };
+      package = lib.mkPackageOption pkgs "gerbera" { };
 
-      ps3Support = mkOption {
-        type = types.bool;
+      ps3Support = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable ps3 specific tweaks.
@@ -226,8 +223,8 @@ in {
         '';
       };
 
-      dsmSupport = mkOption {
-        type = types.bool;
+      dsmSupport = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable D-Link DSM 320 specific tweaks.
@@ -235,69 +232,69 @@ in {
         '';
       };
 
-      tg100Support = mkOption {
-        type = types.bool;
+      tg100Support = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable Telegent TG100 specific tweaks.
         '';
       };
 
-      transcoding = mkOption {
-        type = types.bool;
+      transcoding = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable transcoding.
         '';
       };
 
-      dataDir = mkOption {
-        type = types.path;
+      dataDir = lib.mkOption {
+        type = lib.types.path;
         default = "/var/lib/${name}";
-        defaultText = literalExpression ''"/var/lib/''${config.${opt.package}.pname}"'';
+        defaultText = lib.literalExpression ''"/var/lib/''${config.${opt.package}.pname}"'';
         description = ''
           The directory where Gerbera/Mediatomb stores its state, data, etc.
         '';
       };
 
-      pcDirectoryHide = mkOption {
-        type = types.bool;
+      pcDirectoryHide = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Whether to list the top-level directory or not (from upnp client standpoint).
         '';
       };
 
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = "mediatomb";
         description = "User account under which the service runs.";
       };
 
-      group = mkOption {
-        type = types.str;
+      group = lib.mkOption {
+        type = lib.types.str;
         default = "mediatomb";
         description = "Group account under which the service runs.";
       };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 49152;
         description = ''
           The network port to listen on.
         '';
       };
 
-      interface = mkOption {
-        type = types.str;
+      interface = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = ''
           A specific interface to bind to.
         '';
       };
 
-      openFirewall = mkOption {
-        type = types.bool;
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           If false (the default), this is up to the user to declare the firewall rules.
@@ -310,16 +307,16 @@ in {
         '';
       };
 
-      uuid = mkOption {
-        type = types.str;
+      uuid = lib.mkOption {
+        type = lib.types.str;
         default = "fdfc8a4e-a3ad-4c1d-b43d-a2eedb03a687";
         description = ''
           A unique (on your network) to identify the server by.
         '';
       };
 
-      mediaDirectories = mkOption {
-        type = with types; listOf (submodule mediaDirectory);
+      mediaDirectories = lib.mkOption {
+        type = with lib.types; listOf (submodule mediaDirectory);
         default = [];
         description = ''
           Declare media directories to index.
@@ -330,8 +327,8 @@ in {
         ];
       };
 
-      customCfg = mkOption {
-        type = types.bool;
+      customCfg = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Allow the service to create and use its own config file inside the `dataDir` as
@@ -350,9 +347,9 @@ in {
   ###### implementation
 
   config = let binaryCommand = "${pkg}/bin/${name}";
-               interfaceFlag = optionalString ( cfg.interface != "") "--interface ${cfg.interface}";
-               configFlag = optionalString (! cfg.customCfg) "--config ${pkgs.writeText "config.xml" configText}";
-    in mkIf cfg.enable {
+               interfaceFlag = lib.optionalString ( cfg.interface != "") "--interface ${cfg.interface}";
+               configFlag = lib.optionalString (! cfg.customCfg) "--config ${pkgs.writeText "config.xml" configText}";
+    in lib.mkIf cfg.enable {
     systemd.services.mediatomb = {
       description = "${cfg.serverName} media Server";
       # Gerbera might fail if the network interface is not available on startup
@@ -365,11 +362,11 @@ in {
       serviceConfig.Group = cfg.group;
     };
 
-    users.groups = optionalAttrs (cfg.group == "mediatomb") {
+    users.groups = lib.optionalAttrs (cfg.group == "mediatomb") {
       mediatomb.gid = gid;
     };
 
-    users.users = optionalAttrs (cfg.user == "mediatomb") {
+    users.users = lib.optionalAttrs (cfg.user == "mediatomb") {
       mediatomb = {
         isSystemUser = true;
         group = cfg.group;
@@ -380,11 +377,11 @@ in {
     };
 
     # Open firewall only if users enable it
-    networking.firewall = mkMerge [
-      (mkIf (cfg.openFirewall && cfg.interface != "") {
+    networking.firewall = lib.mkMerge [
+      (lib.mkIf (cfg.openFirewall && cfg.interface != "") {
         interfaces."${cfg.interface}" = defaultFirewallRules;
       })
-      (mkIf (cfg.openFirewall && cfg.interface == "") defaultFirewallRules)
+      (lib.mkIf (cfg.openFirewall && cfg.interface == "") defaultFirewallRules)
     ];
   };
 }


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
