### PR TITLE
bats.libraries.bats-detik: 1.3.0 -> 1.3.2

### DIFF
--- a/pkgs/development/interpreters/bats/libraries.nix
+++ b/pkgs/development/interpreters/bats/libraries.nix
@@ -21,7 +21,7 @@
       platforms = lib.platforms.all;
       homepage = "https://github.com/bats-core/bats-assert";
       license = lib.licenses.cc0;
-      maintainers = [ ];
+      maintainers = with lib.maintainers; [ brokenpip3 ];
     };
   });
 
@@ -47,7 +47,7 @@
       platforms = lib.platforms.all;
       homepage = "https://github.com/bats-core/bats-file";
       license = lib.licenses.cc0;
-      maintainers = [ ];
+      maintainers = with lib.maintainers; [ brokenpip3 ];
     };
   });
 
@@ -98,7 +98,7 @@
       platforms = lib.platforms.all;
       homepage = "https://github.com/bats-core/bats-support";
       license = lib.licenses.cc0;
-      maintainers = [ ];
+      maintainers = with lib.maintainers; [ brokenpip3 ];
     };
   });
 }

--- a/pkgs/development/interpreters/bats/libraries.nix
+++ b/pkgs/development/interpreters/bats/libraries.nix
@@ -53,12 +53,12 @@
 
   bats-detik = stdenv.mkDerivation (finalAttrs: {
     pname = "bats-detik";
-    version = "1.3.0";
+    version = "1.3.2";
     src = fetchFromGitHub {
       owner = "bats-core";
       repo = "bats-detik";
       rev = "v${finalAttrs.version}";
-      hash = "sha256-cbWNZ9a/Q9reJLQxUyTdqfLykOJcJKnoKB123ao8/xM=";
+      hash = "sha256-Lz5BPKHtgdakKRALPZFFgz91d07Ubk5rUgA+Ep2aoG8=";
     };
     dontBuild = true;
     installPhase = ''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* New version: https://github.com/bats-core/bats-detik/releases/tag/v1.3.2

* Also since there where no maintainers anymore I added myself, I can easily maintain the bats libraries if necessary 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
