### PR TITLE
nixos/fonts.fontconfig: remove `with lib;`

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -23,13 +23,10 @@ And do not repeat our mistakes.
 */
 
 { config, pkgs, lib, ... }:
-
-with lib;
-
 let
   cfg = config.fonts.fontconfig;
 
-  fcBool = x: "<bool>" + (boolToString x) + "</bool>";
+  fcBool = x: "<bool>" + (lib.boolToString x) + "</bool>";
   pkg = pkgs.fontconfig;
 
   # configuration file to read fontconfig cache
@@ -51,11 +48,11 @@ let
       <!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
       <fontconfig>
         <!-- Font directories -->
-        ${concatStringsSep "\n" (map (font: "<dir>${font}</dir>") config.fonts.packages)}
-        ${optionalString (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) ''
+        ${lib.concatStringsSep "\n" (map (font: "<dir>${font}</dir>") config.fonts.packages)}
+        ${lib.optionalString (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) ''
         <!-- Pre-generated font caches -->
         <cachedir>${cache}</cachedir>
-        ${optionalString (pkgs.stdenv.isx86_64 && cfg.cache32Bit) ''
+        ${lib.optionalString (pkgs.stdenv.isx86_64 && cfg.cache32Bit) ''
           <cachedir>${cache32}</cachedir>
         ''}
         ''}
@@ -89,11 +86,11 @@ let
   # priority 52
   defaultFontsConf =
     let genDefault = fonts: name:
-      optionalString (fonts != []) ''
+      lib.optionalString (fonts != []) ''
         <alias binding="same">
           <family>${name}</family>
           <prefer>
-          ${concatStringsSep ""
+          ${lib.concatStringsSep ""
           (map (font: ''
             <family>${font}</family>
           '') fonts)}
@@ -125,7 +122,7 @@ let
     <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
     <fontconfig>
 
-    ${optionalString (!cfg.allowBitmaps) ''
+    ${lib.optionalString (!cfg.allowBitmaps) ''
     <!-- Reject bitmap fonts -->
     <selectfont>
       <rejectfont>
@@ -191,22 +188,22 @@ let
     ln -s ${pkg.out}/etc/fonts/conf.d/*.conf \
           $dst/
 
-    ${optionalString (!cfg.antialias)
+    ${lib.optionalString (!cfg.antialias)
       (replaceDefaultConfig "10-yes-antialias.conf"
         "10-no-antialias.conf")
     }
 
-    ${optionalString (cfg.hinting.style != "slight")
+    ${lib.optionalString (cfg.hinting.style != "slight")
       (replaceDefaultConfig "10-hinting-slight.conf"
         "10-hinting-${cfg.hinting.style}.conf")
     }
 
-    ${optionalString (cfg.subpixel.rgba != "none")
+    ${lib.optionalString (cfg.subpixel.rgba != "none")
       (replaceDefaultConfig "10-sub-pixel-none.conf"
         "10-sub-pixel-${cfg.subpixel.rgba}.conf")
     }
 
-    ${optionalString (cfg.subpixel.lcdfilter != "default")
+    ${lib.optionalString (cfg.subpixel.lcdfilter != "default")
       (replaceDefaultConfig "11-lcdfilter-default.conf"
         "11-lcdfilter-${cfg.subpixel.lcdfilter}.conf")
     }
@@ -218,12 +215,12 @@ let
     ln -s ${renderConf}       $dst/10-nixos-rendering.conf
 
     # 50-user.conf
-    ${optionalString (!cfg.includeUserConf) ''
+    ${lib.optionalString (!cfg.includeUserConf) ''
     rm $dst/50-user.conf
     ''}
 
     # local.conf (indirect priority 51)
-    ${optionalString (cfg.localConf != "") ''
+    ${lib.optionalString (cfg.localConf != "") ''
     ln -s ${localConf}        $dst/../local.conf
     ''}
 
@@ -233,7 +230,7 @@ let
     # 53-no-bitmaps.conf
     ln -s ${rejectBitmaps} $dst/53-no-bitmaps.conf
 
-    ${optionalString (!cfg.allowType1) ''
+    ${lib.optionalString (!cfg.allowType1) ''
     # 53-nixos-reject-type1.conf
     ln -s ${rejectType1} $dst/53-nixos-reject-type1.conf
     ''}
@@ -251,16 +248,16 @@ let
 in
 {
   imports = [
-    (mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "allowBitmaps" ] [ "fonts" "fontconfig" "allowBitmaps" ])
-    (mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "allowType1" ] [ "fonts" "fontconfig" "allowType1" ])
-    (mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "useEmbeddedBitmaps" ] [ "fonts" "fontconfig" "useEmbeddedBitmaps" ])
-    (mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "forceAutohint" ] [ "fonts" "fontconfig" "forceAutohint" ])
-    (mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "renderMonoTTFAsBitmap" ] [ "fonts" "fontconfig" "renderMonoTTFAsBitmap" ])
-    (mkRemovedOptionModule [ "fonts" "fontconfig" "forceAutohint" ] "")
-    (mkRemovedOptionModule [ "fonts" "fontconfig" "renderMonoTTFAsBitmap" ] "")
-    (mkRemovedOptionModule [ "fonts" "fontconfig" "dpi" ] "Use display server-specific options")
-    (mkRemovedOptionModule [ "hardware" "video" "hidpi" "enable" ] fontconfigNote)
-    (mkRemovedOptionModule [ "fonts" "optimizeForVeryHighDPI" ] fontconfigNote)
+    (lib.mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "allowBitmaps" ] [ "fonts" "fontconfig" "allowBitmaps" ])
+    (lib.mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "allowType1" ] [ "fonts" "fontconfig" "allowType1" ])
+    (lib.mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "useEmbeddedBitmaps" ] [ "fonts" "fontconfig" "useEmbeddedBitmaps" ])
+    (lib.mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "forceAutohint" ] [ "fonts" "fontconfig" "forceAutohint" ])
+    (lib.mkRenamedOptionModule [ "fonts" "fontconfig" "ultimate" "renderMonoTTFAsBitmap" ] [ "fonts" "fontconfig" "renderMonoTTFAsBitmap" ])
+    (lib.mkRemovedOptionModule [ "fonts" "fontconfig" "forceAutohint" ] "")
+    (lib.mkRemovedOptionModule [ "fonts" "fontconfig" "renderMonoTTFAsBitmap" ] "")
+    (lib.mkRemovedOptionModule [ "fonts" "fontconfig" "dpi" ] "Use display server-specific options")
+    (lib.mkRemovedOptionModule [ "hardware" "video" "hidpi" "enable" ] fontconfigNote)
+    (lib.mkRemovedOptionModule [ "fonts" "optimizeForVeryHighDPI" ] fontconfigNote)
   ] ++ lib.forEach [ "enable" "substitutions" "preset" ]
      (opt: lib.mkRemovedOptionModule [ "fonts" "fontconfig" "ultimate" "${opt}" ] ''
        The fonts.fontconfig.ultimate module and configuration is obsolete.
@@ -275,8 +272,8 @@ in
     fonts = {
 
       fontconfig = {
-        enable = mkOption {
-          type = types.bool;
+        enable = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             If enabled, a Fontconfig configuration file will be built
@@ -287,17 +284,17 @@ in
           '';
         };
 
-        confPackages = mkOption {
+        confPackages = lib.mkOption {
           internal = true;
-          type     = with types; listOf path;
+          type     = with lib.types; listOf path;
           default  = [ ];
           description = ''
             Fontconfig configuration packages.
           '';
         };
 
-        antialias = mkOption {
-          type = types.bool;
+        antialias = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Enable font antialiasing. At high resolution (> 200 DPI),
@@ -306,8 +303,8 @@ in
           '';
         };
 
-        localConf = mkOption {
-          type = types.lines;
+        localConf = lib.mkOption {
+          type = lib.types.lines;
           default = "";
           description = ''
             System-wide customization file contents, has higher priority than
@@ -316,8 +313,8 @@ in
         };
 
         defaultFonts = {
-          monospace = mkOption {
-            type = types.listOf types.str;
+          monospace = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
             default = ["DejaVu Sans Mono"];
             description = ''
               System-wide default monospace font(s). Multiple fonts may be
@@ -325,8 +322,8 @@ in
             '';
           };
 
-          sansSerif = mkOption {
-            type = types.listOf types.str;
+          sansSerif = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
             default = ["DejaVu Sans"];
             description = ''
               System-wide default sans serif font(s). Multiple fonts may be
@@ -334,8 +331,8 @@ in
             '';
           };
 
-          serif = mkOption {
-            type = types.listOf types.str;
+          serif = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
             default = ["DejaVu Serif"];
             description = ''
               System-wide default serif font(s). Multiple fonts may be listed
@@ -343,8 +340,8 @@ in
             '';
           };
 
-          emoji = mkOption {
-            type = types.listOf types.str;
+          emoji = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
             default = ["Noto Color Emoji"];
             description = ''
               System-wide default emoji font(s). Multiple fonts may be listed
@@ -360,8 +357,8 @@ in
         };
 
         hinting = {
-          enable = mkOption {
-            type = types.bool;
+          enable = lib.mkOption {
+            type = lib.types.bool;
             default = true;
             description = ''
               Enable font hinting. Hinting aligns glyphs to pixel boundaries to
@@ -371,8 +368,8 @@ in
             '';
           };
 
-          autohint = mkOption {
-            type = types.bool;
+          autohint = lib.mkOption {
+            type = lib.types.bool;
             default = false;
             description = ''
               Enable the autohinter in place of the default interpreter.
@@ -381,8 +378,8 @@ in
             '';
           };
 
-          style = mkOption {
-            type = types.enum ["none" "slight" "medium" "full"];
+          style = lib.mkOption {
+            type = lib.types.enum ["none" "slight" "medium" "full"];
             default = "slight";
             description = ''
               Hintstyle is the amount of font reshaping done to line up
@@ -404,8 +401,8 @@ in
           };
         };
 
-        includeUserConf = mkOption {
-          type = types.bool;
+        includeUserConf = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Include the user configuration from
@@ -416,9 +413,9 @@ in
 
         subpixel = {
 
-          rgba = mkOption {
+          rgba = lib.mkOption {
             default = "none";
-            type = types.enum ["rgb" "bgr" "vrgb" "vbgr" "none"];
+            type = lib.types.enum ["rgb" "bgr" "vrgb" "vbgr" "none"];
             description = ''
               Subpixel order. The overwhelming majority of displays are
               `rgb` in their normal orientation. Select
@@ -432,9 +429,9 @@ in
             '';
           };
 
-          lcdfilter = mkOption {
+          lcdfilter = lib.mkOption {
             default = "default";
-            type = types.enum ["none" "default" "light" "legacy"];
+            type = lib.types.enum ["none" "default" "light" "legacy"];
             description = ''
               FreeType LCD filter. At high resolution (> 200 DPI), LCD filtering
               has no visible effect; users of such displays may want to select
@@ -444,16 +441,16 @@ in
 
         };
 
-        cache32Bit = mkOption {
+        cache32Bit = lib.mkOption {
           default = false;
-          type = types.bool;
+          type = lib.types.bool;
           description = ''
             Generate system fonts cache for 32-bit applications.
           '';
         };
 
-        allowBitmaps = mkOption {
-          type = types.bool;
+        allowBitmaps = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Allow bitmap fonts. Set to `false` to ban all
@@ -461,8 +458,8 @@ in
           '';
         };
 
-        allowType1 = mkOption {
-          type = types.bool;
+        allowType1 = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Allow Type-1 fonts. Default is `false` because of
@@ -470,8 +467,8 @@ in
           '';
         };
 
-        useEmbeddedBitmaps = mkOption {
-          type = types.bool;
+        useEmbeddedBitmaps = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = "Use embedded bitmaps in fonts like Calibri.";
         };
@@ -481,8 +478,8 @@ in
     };
 
   };
-  config = mkMerge [
-    (mkIf cfg.enable {
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
       environment.systemPackages    = [ pkgs.fontconfig ];
       environment.etc.fonts.source  = "${fontconfigEtc}/etc/fonts/";
       security.apparmor.includes."abstractions/fonts" = ''
@@ -499,12 +496,12 @@ in
         r ${renderConf},
 
         # 50-user.conf
-        ${optionalString cfg.includeUserConf ''
+        ${lib.optionalString cfg.includeUserConf ''
         r ${pkg.out}/etc/fonts/conf.d.bak/50-user.conf,
         ''}
 
         # local.conf (indirect priority 51)
-        ${optionalString (cfg.localConf != "") ''
+        ${lib.optionalString (cfg.localConf != "") ''
         r ${localConf},
         ''}
 
@@ -514,13 +511,13 @@ in
         # 53-no-bitmaps.conf
         r ${rejectBitmaps},
 
-        ${optionalString (!cfg.allowType1) ''
+        ${lib.optionalString (!cfg.allowType1) ''
         # 53-nixos-reject-type1.conf
         r ${rejectType1},
         ''}
       '';
     })
-    (mkIf cfg.enable {
+    (lib.mkIf cfg.enable {
       fonts.fontconfig.confPackages = [ confPkg ];
     })
   ];


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
