### PR TITLE
nixos/security.sudo-rs: remove `with lib;`

### DIFF
--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -1,21 +1,18 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
 
   cfg = config.security.sudo-rs;
 
-  toUserString = user: if (isInt user) then "#${toString user}" else "${user}";
-  toGroupString = group: if (isInt group) then "%#${toString group}" else "%${group}";
+  toUserString = user: if (lib.isInt user) then "#${toString user}" else "${user}";
+  toGroupString = group: if (lib.isInt group) then "%#${toString group}" else "%${group}";
 
   toCommandOptionsString = options:
-    "${concatStringsSep ":" options}${optionalString (length options != 0) ":"} ";
+    "${lib.concatStringsSep ":" options}${lib.optionalString (lib.length options != 0) ":"} ";
 
   toCommandsString = commands:
-    concatStringsSep ", " (
+    lib.concatStringsSep ", " (
       map (command:
-        if (isString command) then
+        if (lib.isString command) then
           command
         else
           "${toCommandOptionsString command.options}${command.command}"
@@ -30,8 +27,8 @@ in
 
   options.security.sudo-rs = {
 
-    defaultOptions = mkOption {
-      type = with types; listOf str;
+    defaultOptions = lib.mkOption {
+      type = with lib.types; listOf str;
       default = [];
       description = ''
         Options used for the default rules, granting `root` and the
@@ -39,15 +36,15 @@ in
       '';
     };
 
-    enable = mkEnableOption ''
+    enable = lib.mkEnableOption ''
       a memory-safe implementation of the {command}`sudo` command,
       which allows non-root users to execute commands as root
     '';
 
-    package = mkPackageOption pkgs "sudo-rs" { };
+    package = lib.mkPackageOption pkgs "sudo-rs" { };
 
-    wheelNeedsPassword = mkOption {
-      type = types.bool;
+    wheelNeedsPassword = lib.mkOption {
+      type = lib.types.bool;
       default = true;
       description = ''
         Whether users of the `wheel` group must
@@ -55,8 +52,8 @@ in
       '';
       };
 
-    execWheelOnly = mkOption {
-      type = types.bool;
+    execWheelOnly = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Only allow members of the `wheel` group to execute sudo by
@@ -66,8 +63,8 @@ in
       '';
     };
 
-    configFile = mkOption {
-      type = types.lines;
+    configFile = lib.mkOption {
+      type = lib.types.lines;
       # Note: if syntax errors are detected in this file, the NixOS
       # configuration will fail to build.
       description = ''
@@ -76,15 +73,15 @@ in
       '';
     };
 
-    extraRules = mkOption {
+    extraRules = lib.mkOption {
       description = ''
         Define specific rules to be in the {file}`sudoers` file.
         More specific rules should come after more general ones in order to
-        yield the expected behavior. You can use mkBefore/mkAfter to ensure
+        yield the expected behavior. You can use `lib.mkBefore`/`lib.mkAfter` to ensure
         this is the case when configuration options are merged.
       '';
       default = [];
-      example = literalExpression ''
+      example = lib.literalExpression ''
         [
           # Allow execution of any command by all users in group sudo,
           # requiring a password.
@@ -103,34 +100,34 @@ in
                   { command = '''/home/baz/cmd2.sh ""'''; options = [ "SETENV" ]; } ]; }
         ]
       '';
-      type = with types; listOf (submodule {
+      type = with lib.types; listOf (submodule {
         options = {
-          users = mkOption {
-            type = with types; listOf (either str int);
+          users = lib.mkOption {
+            type = with lib.types; listOf (either str int);
             description = ''
               The usernames / UIDs this rule should apply for.
             '';
             default = [];
           };
 
-          groups = mkOption {
-            type = with types; listOf (either str int);
+          groups = lib.mkOption {
+            type = with lib.types; listOf (either str int);
             description = ''
               The groups / GIDs this rule should apply for.
             '';
             default = [];
           };
 
-          host = mkOption {
-            type = types.str;
+          host = lib.mkOption {
+            type = lib.types.str;
             default = "ALL";
             description = ''
               For what host this rule should apply.
             '';
           };
 
-          runAs = mkOption {
-            type = with types; str;
+          runAs = lib.mkOption {
+            type = with lib.types; str;
             default = "ALL:ALL";
             description = ''
               Under which user/group the specified command is allowed to run.
@@ -141,15 +138,15 @@ in
             '';
           };
 
-          commands = mkOption {
+          commands = lib.mkOption {
             description = ''
               The commands for which the rule should apply.
             '';
-            type = with types; listOf (either str (submodule {
+            type = with lib.types; listOf (either str (submodule {
 
               options = {
-                command = mkOption {
-                  type = with types; str;
+                command = lib.mkOption {
+                  type = with lib.types; str;
                   description = ''
                     A command being either just a path to a binary to allow any arguments,
                     the full command with arguments pre-set or with `""` used as the argument,
@@ -157,8 +154,8 @@ in
                   '';
                 };
 
-                options = mkOption {
-                  type = with types; listOf (enum [ "NOPASSWD" "PASSWD" "NOEXEC" "EXEC" "SETENV" "NOSETENV" "LOG_INPUT" "NOLOG_INPUT" "LOG_OUTPUT" "NOLOG_OUTPUT" ]);
+                options = lib.mkOption {
+                  type = with lib.types; listOf (enum [ "NOPASSWD" "PASSWD" "NOEXEC" "EXEC" "SETENV" "NOSETENV" "LOG_INPUT" "NOLOG_INPUT" "LOG_OUTPUT" "NOLOG_OUTPUT" ]);
                   description = ''
                     Options for running the command. Refer to the [sudo manual](https://www.sudo.ws/man/1.7.10/sudoers.man.html).
                   '';
@@ -172,8 +169,8 @@ in
       });
     };
 
-    extraConfig = mkOption {
-      type = types.lines;
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
       default = "";
       description = ''
         Extra configuration text appended to {file}`sudoers`.
@@ -184,12 +181,12 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [ {
       assertion = ! config.security.sudo.enable;
       message = "`security.sudo` and `security.sudo-rs` cannot both be enabled";
     }];
-    security.sudo.enable = mkDefault false;
+    security.sudo.enable = lib.mkDefault false;
 
     security.sudo-rs.extraRules =
       let
@@ -200,35 +197,35 @@ in
             options = opts ++ cfg.defaultOptions;
           } ];
         } ];
-      in mkMerge [
-        # This is ordered before users' `mkBefore` rules,
+      in lib.mkMerge [
+        # This is ordered before users' `lib.mkBefore` rules,
         # so as not to introduce unexpected changes.
-        (mkOrder 400 (defaultRule { users = [ "root" ]; }))
+        (lib.mkOrder 400 (defaultRule { users = [ "root" ]; }))
 
         # This is ordered to show before (most) other rules, but
-        # late-enough for a user to `mkBefore` it.
-        (mkOrder 600 (defaultRule {
+        # late-enough for a user to `lib.mkBefore` it.
+        (lib.mkOrder 600 (defaultRule {
           groups = [ "wheel" ];
-          opts = (optional (!cfg.wheelNeedsPassword) "NOPASSWD");
+          opts = (lib.optional (!cfg.wheelNeedsPassword) "NOPASSWD");
         }))
       ];
 
-    security.sudo-rs.configFile = concatStringsSep "\n" (filter (s: s != "") [
+    security.sudo-rs.configFile = lib.concatStringsSep "\n" (lib.filter (s: s != "") [
       ''
         # Don't edit this file. Set the NixOS options ‘security.sudo-rs.configFile’
         # or ‘security.sudo-rs.extraRules’ instead.
       ''
-      (pipe cfg.extraRules [
-        (filter (rule: length rule.commands != 0))
+      (lib.pipe cfg.extraRules [
+        (lib.filter (rule: lib.length rule.commands != 0))
         (map (rule: [
           (map (user: "${toUserString user}     ${rule.host}=(${rule.runAs})    ${toCommandsString rule.commands}") rule.users)
           (map (group: "${toGroupString group}  ${rule.host}=(${rule.runAs})    ${toCommandsString rule.commands}") rule.groups)
         ]))
-        flatten
-        (concatStringsSep "\n")
+        lib.flatten
+        (lib.concatStringsSep "\n")
       ])
       "\n"
-      (optionalString (cfg.extraConfig != "") ''
+      (lib.optionalString (cfg.extraConfig != "") ''
         # extraConfig
         ${cfg.extraConfig}
       '')


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
