### PR TITLE
nixos/services.hydra: remove `with lib;`

### DIFF
--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -1,7 +1,4 @@
 { config, pkgs, lib, ... }:
-
-with lib;
-
 let
 
   cfg = config.services.hydra;
@@ -20,8 +17,8 @@ let
     { NIX_REMOTE = "daemon";
       SSL_CERT_FILE = "/etc/ssl/certs/ca-certificates.crt"; # Remove in 16.03
       PGPASSFILE = "${baseDir}/pgpass";
-      NIX_REMOTE_SYSTEMS = concatStringsSep ":" cfg.buildMachinesFiles;
-    } // optionalAttrs (cfg.smtpHost != null) {
+      NIX_REMOTE_SYSTEMS = lib.concatStringsSep ":" cfg.buildMachinesFiles;
+    } // lib.optionalAttrs (cfg.smtpHost != null) {
       EMAIL_SENDER_TRANSPORT = "SMTP";
       EMAIL_SENDER_TRANSPORT_host = cfg.smtpHost;
     } // hydraEnv // cfg.extraEnv;
@@ -31,7 +28,7 @@ let
       XDG_CACHE_HOME = "${baseDir}/www/.cache";
       COLUMNS = "80";
       PGPASSFILE = "${baseDir}/pgpass-www"; # grrr
-    } // (optionalAttrs cfg.debugServer { DBIC_TRACE = "1"; });
+    } // (lib.optionalAttrs cfg.debugServer { DBIC_TRACE = "1"; });
 
   localDB = "dbi:Pg:dbname=hydra;user=hydra;";
 
@@ -39,7 +36,7 @@ let
 
   hydra-package =
   let
-    makeWrapperArgs = concatStringsSep " " (mapAttrsToList (key: value: "--set-default \"${key}\" \"${value}\"") hydraEnv);
+    makeWrapperArgs = lib.concatStringsSep " " (lib.mapAttrsToList (key: value: "--set-default \"${key}\" \"${value}\"") hydraEnv);
   in pkgs.buildEnv rec {
     name = "hydra-env";
     nativeBuildInputs = [ pkgs.makeWrapper ];
@@ -51,7 +48,7 @@ let
       fi
       mkdir -p "$out/bin"
 
-      for path in ${concatStringsSep " " paths}; do
+      for path in ${lib.concatStringsSep " " paths}; do
         if [ -d "$path/bin" ]; then
           cd "$path/bin"
           for prg in *; do
@@ -75,16 +72,16 @@ in
 
     services.hydra = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to run Hydra services.
         '';
       };
 
-      dbi = mkOption {
-        type = types.str;
+      dbi = lib.mkOption {
+        type = lib.types.str;
         default = localDB;
         example = "dbi:Pg:dbname=hydra;host=postgres.example.org;user=foo;";
         description = ''
@@ -97,17 +94,17 @@ in
         '';
       };
 
-      package = mkPackageOption pkgs "hydra" { };
+      package = lib.mkPackageOption pkgs "hydra" { };
 
-      hydraURL = mkOption {
-        type = types.str;
+      hydraURL = lib.mkOption {
+        type = lib.types.str;
         description = ''
           The base URL for the Hydra webserver instance. Used for links in emails.
         '';
       };
 
-      listenHost = mkOption {
-        type = types.str;
+      listenHost = lib.mkOption {
+        type = lib.types.str;
         default = "*";
         example = "localhost";
         description = ''
@@ -116,39 +113,39 @@ in
         '';
       };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 3000;
         description = ''
           TCP port the web server should listen to.
         '';
       };
 
-      minimumDiskFree = mkOption {
-        type = types.int;
+      minimumDiskFree = lib.mkOption {
+        type = lib.types.int;
         default = 0;
         description = ''
           Threshold of minimum disk space (GiB) to determine if the queue runner should run or not.
         '';
       };
 
-      minimumDiskFreeEvaluator = mkOption {
-        type = types.int;
+      minimumDiskFreeEvaluator = lib.mkOption {
+        type = lib.types.int;
         default = 0;
         description = ''
           Threshold of minimum disk space (GiB) to determine if the evaluator should run or not.
         '';
       };
 
-      notificationSender = mkOption {
-        type = types.str;
+      notificationSender = lib.mkOption {
+        type = lib.types.str;
         description = ''
           Sender email address used for email notifications.
         '';
       };
 
-      smtpHost = mkOption {
-        type = types.nullOr types.str;
+      smtpHost = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "localhost";
         description = ''
@@ -156,73 +153,73 @@ in
         '';
       };
 
-      tracker = mkOption {
-        type = types.str;
+      tracker = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = ''
           Piece of HTML that is included on all pages.
         '';
       };
 
-      logo = mkOption {
-        type = types.nullOr types.path;
+      logo = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = null;
         description = ''
           Path to a file containing the logo of your Hydra instance.
         '';
       };
 
-      debugServer = mkOption {
-        type = types.bool;
+      debugServer = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Whether to run the server in debug mode.";
       };
 
-      maxServers = mkOption {
-        type = types.int;
+      maxServers = lib.mkOption {
+        type = lib.types.int;
         default = 25;
         description = "Maximum number of starman workers to spawn.";
       };
 
-      minSpareServers = mkOption {
-        type = types.int;
+      minSpareServers = lib.mkOption {
+        type = lib.types.int;
         default = 4;
         description = "Minimum number of spare starman workers to keep.";
       };
 
-      maxSpareServers = mkOption {
-        type = types.int;
+      maxSpareServers = lib.mkOption {
+        type = lib.types.int;
         default = 5;
         description = "Maximum number of spare starman workers to keep.";
       };
 
-      extraConfig = mkOption {
-        type = types.lines;
+      extraConfig = lib.mkOption {
+        type = lib.types.lines;
         description = "Extra lines for the Hydra configuration.";
       };
 
-      extraEnv = mkOption {
-        type = types.attrsOf types.str;
+      extraEnv = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
         default = {};
         description = "Extra environment variables for Hydra.";
       };
 
-      gcRootsDir = mkOption {
-        type = types.path;
+      gcRootsDir = lib.mkOption {
+        type = lib.types.path;
         default = "/nix/var/nix/gcroots/hydra";
         description = "Directory that holds Hydra garbage collector roots.";
       };
 
-      buildMachinesFiles = mkOption {
-        type = types.listOf types.path;
-        default = optional (config.nix.buildMachines != []) "/etc/nix/machines";
-        defaultText = literalExpression ''optional (config.nix.buildMachines != []) "/etc/nix/machines"'';
+      buildMachinesFiles = lib.mkOption {
+        type = lib.types.listOf lib.types.path;
+        default = lib.optional (config.nix.buildMachines != []) "/etc/nix/machines";
+        defaultText = lib.literalExpression ''lib.optional (config.nix.buildMachines != []) "/etc/nix/machines"'';
         example = [ "/etc/nix/machines" "/var/lib/hydra/provisioner/machines" ];
         description = "List of files containing build machines.";
       };
 
-      useSubstitutes = mkOption {
-        type = types.bool;
+      useSubstitutes = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to use binary caches for downloading store paths. Note that
@@ -241,7 +238,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.maxServers != 0 && cfg.maxSpareServers != 0 && cfg.minSpareServers != 0;
@@ -287,7 +284,7 @@ in
         base_uri = ${cfg.hydraURL}
         notification_sender = ${cfg.notificationSender}
         max_servers = ${toString cfg.maxServers}
-        ${optionalString (cfg.logo != null) ''
+        ${lib.optionalString (cfg.logo != null) ''
           hydra_logo = ${cfg.logo}
         ''}
         gc_roots_dir = ${cfg.gcRootsDir}
@@ -298,14 +295,14 @@ in
 
     environment.variables = hydraEnv;
 
-    nix.settings = mkMerge [
+    nix.settings = lib.mkMerge [
       {
         keep-outputs = true;
         keep-derivations = true;
         trusted-users = [ "hydra-queue-runner" ];
       }
 
-      (mkIf (versionOlder (getVersion config.nix.package.out) "2.4pre")
+      (lib.mkIf (lib.versionOlder (lib.getVersion config.nix.package.out) "2.4pre")
         {
           # The default (`true') slows Nix down a lot since the build farm
           # has so many GC roots.
@@ -316,8 +313,8 @@ in
 
     systemd.services.hydra-init =
       { wantedBy = [ "multi-user.target" ];
-        requires = optional haveLocalDB "postgresql.service";
-        after = optional haveLocalDB "postgresql.service";
+        requires = lib.optional haveLocalDB "postgresql.service";
+        after = lib.optional haveLocalDB "postgresql.service";
         environment = env // {
           HYDRA_DBI = "${env.HYDRA_DBI};application_name=hydra-init";
         };
@@ -340,7 +337,7 @@ in
             ${baseDir}/build-logs \
             ${baseDir}/runcommand-logs
 
-          ${optionalString haveLocalDB ''
+          ${lib.optionalString haveLocalDB ''
             if ! [ -e ${baseDir}/.db-created ]; then
               runuser -u ${config.services.postgresql.superUser} ${config.services.postgresql.package}/bin/createuser hydra
               runuser -u ${config.services.postgresql.superUser} ${config.services.postgresql.package}/bin/createdb -- -O hydra hydra
@@ -388,7 +385,7 @@ in
           { ExecStart =
               "@${hydra-package}/bin/hydra-server hydra-server -f -h '${cfg.listenHost}' "
               + "-p ${toString cfg.port} --min_spare_servers ${toString cfg.minSpareServers} --max_spare_servers ${toString cfg.maxSpareServers} "
-              + "--max_servers ${toString cfg.maxServers} --max_requests 100 ${optionalString cfg.debugServer "-d"}";
+              + "--max_servers ${toString cfg.maxServers} --max_requests 100 ${lib.optionalString cfg.debugServer "-d"}";
             User = "hydra-www";
             PermissionsStartOnly = true;
             Restart = "always";
@@ -514,9 +511,9 @@ in
         startAt = "Sun 01:45";
       };
 
-    services.postgresql.enable = mkIf haveLocalDB true;
+    services.postgresql.enable = lib.mkIf haveLocalDB true;
 
-    services.postgresql.identMap = optionalString haveLocalDB
+    services.postgresql.identMap = lib.optionalString haveLocalDB
       ''
         hydra-users hydra hydra
         hydra-users hydra-queue-runner hydra
@@ -526,7 +523,7 @@ in
         hydra-users postgres postgres
       '';
 
-    services.postgresql.authentication = optionalString haveLocalDB
+    services.postgresql.authentication = lib.optionalString haveLocalDB
       ''
         local hydra all ident map=hydra-users
       '';


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
