### PR TITLE
nixos/services.zammad: remove `with lib;`

### DIFF
--- a/nixos/modules/services/development/zammad.nix
+++ b/nixos/modules/services/development/zammad.nix
@@ -1,11 +1,8 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.zammad;
   settingsFormat = pkgs.formats.yaml { };
-  filterNull = filterAttrs (_: v: v != null);
+  filterNull = lib.filterAttrs (_: v: v != null);
   serviceConfig = {
     Type = "simple";
     Restart = "always";
@@ -29,88 +26,88 @@ in
 
   options = {
     services.zammad = {
-      enable = mkEnableOption "Zammad, a web-based, open source user support/ticketing solution";
+      enable = lib.mkEnableOption "Zammad, a web-based, open source user support/ticketing solution";
 
-      package = mkPackageOption pkgs "zammad" { };
+      package = lib.mkPackageOption pkgs "zammad" { };
 
-      dataDir = mkOption {
-        type = types.path;
+      dataDir = lib.mkOption {
+        type = lib.types.path;
         default = "/var/lib/zammad";
         description = ''
           Path to a folder that will contain Zammad working directory.
         '';
       };
 
-      host = mkOption {
-        type = types.str;
+      host = lib.mkOption {
+        type = lib.types.str;
         default = "127.0.0.1";
         example = "192.168.23.42";
         description = "Host address.";
       };
 
-      openPorts = mkOption {
-        type = types.bool;
+      openPorts = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Whether to open firewall ports for Zammad";
       };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 3000;
         description = "Web service port.";
       };
 
-      websocketPort = mkOption {
-        type = types.port;
+      websocketPort = lib.mkOption {
+        type = lib.types.port;
         default = 6042;
         description = "Websocket service port.";
       };
 
       redis = {
-        createLocally = mkOption {
-          type = types.bool;
+        createLocally = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = "Whether to create a local redis automatically.";
         };
 
-        name = mkOption {
-          type = types.str;
+        name = lib.mkOption {
+          type = lib.types.str;
           default = "zammad";
           description = ''
             Name of the redis server. Only used if `createLocally` is set to true.
           '';
         };
 
-        host = mkOption {
-          type = types.str;
+        host = lib.mkOption {
+          type = lib.types.str;
           default = "localhost";
           description = ''
             Redis server address.
           '';
         };
 
-        port = mkOption {
-          type = types.port;
+        port = lib.mkOption {
+          type = lib.types.port;
           default = 6379;
           description = "Port of the redis server.";
         };
       };
 
       database = {
-        type = mkOption {
-          type = types.enum [ "PostgreSQL" "MySQL" ];
+        type = lib.mkOption {
+          type = lib.types.enum [ "PostgreSQL" "MySQL" ];
           default = "PostgreSQL";
           example = "MySQL";
           description = "Database engine to use.";
         };
 
-        host = mkOption {
-          type = types.nullOr types.str;
+        host = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = {
             PostgreSQL = "/run/postgresql";
             MySQL = "localhost";
           }.${cfg.database.type};
-          defaultText = literalExpression ''
+          defaultText = lib.literalExpression ''
             {
               PostgreSQL = "/run/postgresql";
               MySQL = "localhost";
@@ -121,28 +118,28 @@ in
           '';
         };
 
-        port = mkOption {
-          type = types.nullOr types.port;
+        port = lib.mkOption {
+          type = lib.types.nullOr lib.types.port;
           default = null;
           description = "Database port. Use `null` for default port.";
         };
 
-        name = mkOption {
-          type = types.str;
+        name = lib.mkOption {
+          type = lib.types.str;
           default = "zammad";
           description = ''
             Database name.
           '';
         };
 
-        user = mkOption {
-          type = types.nullOr types.str;
+        user = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = "zammad";
           description = "Database user.";
         };
 
-        passwordFile = mkOption {
-          type = types.nullOr types.path;
+        passwordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
           default = null;
           example = "/run/keys/zammad-dbpassword";
           description = ''
@@ -150,16 +147,16 @@ in
           '';
         };
 
-        createLocally = mkOption {
-          type = types.bool;
+        createLocally = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = "Whether to create a local database automatically.";
         };
 
-        settings = mkOption {
+        settings = lib.mkOption {
           type = settingsFormat.type;
           default = { };
-          example = literalExpression ''
+          example = lib.literalExpression ''
             {
             }
           '';
@@ -171,8 +168,8 @@ in
         };
       };
 
-      secretKeyBaseFile = mkOption {
-        type = types.nullOr types.path;
+      secretKeyBaseFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = null;
         example = "/run/keys/secret_key_base";
         description = ''
@@ -197,10 +194,10 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     services.zammad.database.settings = {
-      production = mapAttrs (_: v: mkDefault v) (filterNull {
+      production = lib.mapAttrs (_: v: lib.mkDefault v) (filterNull {
         adapter = {
           PostgreSQL = "postgresql";
           MySQL = "mysql2";
@@ -215,7 +212,7 @@ in
       });
     };
 
-    networking.firewall.allowedTCPPorts = mkIf cfg.openPorts [
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openPorts [
       config.services.zammad.port
       config.services.zammad.websocketPort
     ];
@@ -243,9 +240,9 @@ in
       }
     ];
 
-    services.mysql = optionalAttrs (cfg.database.createLocally && cfg.database.type == "MySQL") {
+    services.mysql = lib.optionalAttrs (cfg.database.createLocally && cfg.database.type == "MySQL") {
       enable = true;
-      package = mkDefault pkgs.mariadb;
+      package = lib.mkDefault pkgs.mariadb;
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [
         {
@@ -255,7 +252,7 @@ in
       ];
     };
 
-    services.postgresql = optionalAttrs (cfg.database.createLocally && cfg.database.type == "PostgreSQL") {
+    services.postgresql = lib.optionalAttrs (cfg.database.createLocally && cfg.database.type == "PostgreSQL") {
       enable = true;
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [
@@ -266,7 +263,7 @@ in
       ];
     };
 
-    services.redis = optionalAttrs cfg.redis.createLocally {
+    services.redis = lib.optionalAttrs cfg.redis.createLocally {
       servers."${cfg.redis.name}" = {
         enable = true;
         port = cfg.redis.port;
@@ -282,7 +279,7 @@ in
       after = [
         "network.target"
         "postgresql.service"
-      ] ++ optionals cfg.redis.createLocally [
+      ] ++ lib.optionals cfg.redis.createLocally [
         "redis-${cfg.redis.name}.service"
       ];
       requires = [
@@ -301,13 +298,13 @@ in
         # config file
         cp ${databaseConfig} ./config/database.yml
         chmod -R +w .
-        ${optionalString (cfg.database.passwordFile != null) ''
+        ${lib.optionalString (cfg.database.passwordFile != null) ''
         {
           echo -n "  password: "
           cat ${cfg.database.passwordFile}
         } >> ./config/database.yml
         ''}
-        ${optionalString (cfg.secretKeyBaseFile != null) ''
+        ${lib.optionalString (cfg.secretKeyBaseFile != null) ''
         {
           echo "production: "
           echo -n "  secret_key_base: "
@@ -317,7 +314,7 @@ in
 
         if [ `${config.services.postgresql.package}/bin/psql \
                   --host ${cfg.database.host} \
-                  ${optionalString
+                  ${lib.optionalString
                     (cfg.database.port != null)
                     "--port ${toString cfg.database.port}"} \
                   --username ${cfg.database.user} \


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
