### PR TITLE
nixos/services.factorio: remove `with lib;`

### DIFF
--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -1,7 +1,4 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.factorio;
   name = "Factorio";
@@ -37,7 +34,7 @@ let
     autosave_only_on_server = true;
     non_blocking_saving = cfg.nonBlockingSaving;
   } // cfg.extraSettings;
-  serverSettingsString = builtins.toJSON (filterAttrsRecursive (n: v: v != null) serverSettings);
+  serverSettingsString = builtins.toJSON (lib.filterAttrsRecursive (n: v: v != null) serverSettings);
   serverSettingsFile = pkgs.writeText "server-settings.json" serverSettingsString;
   serverAdminsFile = pkgs.writeText "server-adminlist.json" (builtins.toJSON cfg.admins);
   modDir = pkgs.factorio-utils.mkModDirDrv cfg.mods cfg.mods-dat;
@@ -45,25 +42,25 @@ in
 {
   options = {
     services.factorio = {
-      enable = mkEnableOption name;
-      port = mkOption {
-        type = types.port;
+      enable = lib.mkEnableOption name;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 34197;
         description = ''
           The port to which the service should bind.
         '';
       };
 
-      bind = mkOption {
-        type = types.str;
+      bind = lib.mkOption {
+        type = lib.types.str;
         default = "0.0.0.0";
         description = ''
           The address to which the service should bind.
         '';
       };
 
-      admins = mkOption {
-        type = types.listOf types.str;
+      admins = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
         default = [];
         example = [ "username" ];
         description = ''
@@ -71,15 +68,15 @@ in
         '';
       };
 
-      openFirewall = mkOption {
-        type = types.bool;
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to automatically open the specified UDP port in the firewall.
         '';
       };
-      saveName = mkOption {
-        type = types.str;
+      saveName = lib.mkOption {
+        type = lib.types.str;
         default = "default";
         description = ''
           The name of the savegame that will be used by the server.
@@ -88,8 +85,8 @@ in
           a new map with default settings will be generated before starting the service.
         '';
       };
-      loadLatestSave = mkOption {
-        type = types.bool;
+      loadLatestSave = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Load the latest savegame on startup. This overrides saveName, in that the latest
@@ -104,10 +101,10 @@ in
       # TODO XXX The server tries to copy a newly created config file over the old one
       #   on shutdown, but fails, because it's in the nix store. When is this needed?
       #   Can an admin set options in-game and expect to have them persisted?
-      configFile = mkOption {
-        type = types.path;
+      configFile = lib.mkOption {
+        type = lib.types.path;
         default = configFile;
-        defaultText = literalExpression "configFile";
+        defaultText = lib.literalExpression "configFile";
         description = ''
           The server's configuration file.
 
@@ -116,8 +113,8 @@ in
           customizations.
         '';
       };
-      extraSettingsFile = mkOption {
-        type = types.nullOr types.path;
+      extraSettingsFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = null;
         description = ''
           File, which is dynamically applied to server-settings.json before
@@ -133,8 +130,8 @@ in
           ```
         '';
       };
-      stateDirName = mkOption {
-        type = types.str;
+      stateDirName = lib.mkOption {
+        type = lib.types.str;
         default = "factorio";
         description = ''
           Name of the directory under /var/lib holding the server's data.
@@ -142,8 +139,8 @@ in
           The configuration and map will be stored here.
         '';
       };
-      mods = mkOption {
-        type = types.listOf types.package;
+      mods = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
         default = [];
         description = ''
           Mods the server should install and activate.
@@ -154,8 +151,8 @@ in
           derivations via nixos-channel. Until then, this is for experts only.
         '';
       };
-      mods-dat = mkOption {
-        type = types.nullOr types.path;
+      mods-dat = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = null;
         description = ''
           Mods settings can be changed by specifying a dat file, in the [mod
@@ -163,44 +160,44 @@ in
           format](https://wiki.factorio.com/Mod_settings_file_format).
         '';
       };
-      game-name = mkOption {
-        type = types.nullOr types.str;
+      game-name = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = "Factorio Game";
         description = ''
           Name of the game as it will appear in the game listing.
         '';
       };
-      description = mkOption {
-        type = types.nullOr types.str;
+      description = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = "";
         description = ''
           Description of the game that will appear in the listing.
         '';
       };
-      extraSettings = mkOption {
-        type = types.attrs;
+      extraSettings = lib.mkOption {
+        type = lib.types.attrs;
         default = {};
         example = { admins = [ "username" ];};
         description = ''
           Extra game configuration that will go into server-settings.json
         '';
       };
-      public = mkOption {
-        type = types.bool;
+      public = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Game will be published on the official Factorio matching server.
         '';
       };
-      lan = mkOption {
-        type = types.bool;
+      lan = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Game will be broadcast on LAN.
         '';
       };
-      username = mkOption {
-        type = types.nullOr types.str;
+      username = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           Your factorio.com login credentials. Required for games with visibility public.
@@ -208,11 +205,11 @@ in
           This option is insecure. Use extraSettingsFile instead.
         '';
       };
-      package = mkPackageOption pkgs "factorio-headless" {
+      package = lib.mkPackageOption pkgs "factorio-headless" {
         example = "factorio-headless-experimental";
       };
-      password = mkOption {
-        type = types.nullOr types.str;
+      password = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           Your factorio.com login credentials. Required for games with visibility public.
@@ -220,15 +217,15 @@ in
           This option is insecure. Use extraSettingsFile instead.
         '';
       };
-      token = mkOption {
-        type = types.nullOr types.str;
+      token = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           Authentication token. May be used instead of 'password' above.
         '';
       };
-      game-password = mkOption {
-        type = types.nullOr types.str;
+      game-password = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           Game password.
@@ -236,23 +233,23 @@ in
           This option is insecure. Use extraSettingsFile instead.
         '';
       };
-      requireUserVerification = mkOption {
-        type = types.bool;
+      requireUserVerification = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           When set to true, the server will only allow clients that have a valid factorio.com account.
         '';
       };
-      autosave-interval = mkOption {
-        type = types.nullOr types.int;
+      autosave-interval = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
         default = null;
         example = 10;
         description = ''
           Autosave interval in minutes.
         '';
       };
-      nonBlockingSaving = mkOption {
-        type = types.bool;
+      nonBlockingSaving = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Highly experimental feature, enable only at your own risk of losing your saves.
@@ -263,7 +260,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.factorio = {
       description   = "Factorio headless server";
       wantedBy      = [ "multi-user.target" ];
@@ -276,9 +273,9 @@ in
           "${cfg.package}/bin/factorio"
           "--config=${cfg.configFile}"
           "--create=${mkSavePath cfg.saveName}"
-          (optionalString (cfg.mods != []) "--mod-directory=${modDir}")
+          (lib.optionalString (cfg.mods != []) "--mod-directory=${modDir}")
         ])
-        + (optionalString (cfg.extraSettingsFile != null) ("\necho ${lib.strings.escapeShellArg serverSettingsString}"
+        + (lib.optionalString (cfg.extraSettingsFile != null) ("\necho ${lib.strings.lib.escapeShellArg serverSettingsString}"
           + " \"$(cat ${cfg.extraSettingsFile})\" | ${lib.getExe pkgs.jq} -s add"
           + " > ${stateDir}/server-settings.json"));
 
@@ -293,15 +290,15 @@ in
           "--config=${cfg.configFile}"
           "--port=${toString cfg.port}"
           "--bind=${cfg.bind}"
-          (optionalString (!cfg.loadLatestSave) "--start-server=${mkSavePath cfg.saveName}")
+          (lib.optionalString (!cfg.loadLatestSave) "--start-server=${mkSavePath cfg.saveName}")
           "--server-settings=${
             if (cfg.extraSettingsFile != null)
             then "${stateDir}/server-settings.json"
             else serverSettingsFile
           }"
-          (optionalString cfg.loadLatestSave "--start-server-load-latest")
-          (optionalString (cfg.mods != []) "--mod-directory=${modDir}")
-          (optionalString (cfg.admins != []) "--server-adminlist=${serverAdminsFile}")
+          (lib.optionalString cfg.loadLatestSave "--start-server-load-latest")
+          (lib.optionalString (cfg.mods != []) "--mod-directory=${modDir}")
+          (lib.optionalString (cfg.admins != []) "--server-adminlist=${serverAdminsFile}")
         ];
 
         # Sandboxing
@@ -320,6 +317,6 @@ in
       };
     };
 
-    networking.firewall.allowedUDPPorts = optional cfg.openFirewall cfg.port;
+    networking.firewall.allowedUDPPorts = lib.optional cfg.openFirewall cfg.port;
   };
 }


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
