### PR TITLE
nixos/services.teeworlds: remove `with lib;`

### DIFF
--- a/nixos/modules/services/games/teeworlds.nix
+++ b/nixos/modules/services/games/teeworlds.nix
@@ -1,13 +1,10 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.teeworlds;
   register = cfg.register;
 
   bool = b: if b != null && b then "1" else "0";
-  optionalSetting = s: setting: optionalString (s != null) "${setting} ${s}";
+  optionalSetting = s: setting: lib.optionalString (s != null) "${setting} ${s}";
   lookup = attrs: key: default: if attrs ? key then attrs."${key}" else default;
 
   inactivePenaltyOptions = {
@@ -86,33 +83,33 @@ let
     sv_vote_kick_bantime ${toString cfg.game.voteKickBanTime}
     sv_vote_kick_min ${toString cfg.game.voteKickMinimumPlayers}
 
-    ${concatStringsSep "\n" cfg.extraOptions}
+    ${lib.concatStringsSep "\n" cfg.extraOptions}
   '';
 
 in
 {
   options = {
     services.teeworlds = {
-      enable = mkEnableOption "Teeworlds Server";
+      enable = lib.mkEnableOption "Teeworlds Server";
 
-      package = mkPackageOption pkgs "teeworlds-server" { };
+      package = lib.mkPackageOption pkgs "teeworlds-server" { };
 
-      openPorts = mkOption {
-        type = types.bool;
+      openPorts = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Whether to open firewall ports for Teeworlds.";
       };
 
-      name = mkOption {
-        type = types.str;
+      name = lib.mkOption {
+        type = lib.types.str;
         default = "unnamed server";
         description = ''
           Name of the server.
         '';
       };
 
-      register = mkOption {
-        type = types.bool;
+      register = lib.mkOption {
+        type = lib.types.bool;
         example = true;
         default = false;
         description = ''
@@ -120,40 +117,40 @@ in
         '';
       };
 
-      motd = mkOption {
-        type = types.nullOr types.str;
+      motd = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           The server's message of the day text.
         '';
       };
 
-      password = mkOption {
-        type = types.nullOr types.str;
+      password = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           Password to connect to the server.
         '';
       };
 
-      rconPassword = mkOption {
-        type = types.nullOr types.str;
+      rconPassword = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           Password to access the remote console. If not set, a randomly generated one is displayed in the server log.
         '';
       };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 8303;
         description = ''
           Port the server will listen on.
         '';
       };
 
-      extraOptions = mkOption {
-        type = types.listOf types.str;
+      extraOptions = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
         default = [];
         description = ''
           Extra configuration lines for the {file}`teeworlds.cfg`. See [Teeworlds Documentation](https://www.teeworlds.com/?page=docs&wiki=server_settings).
@@ -162,32 +159,32 @@ in
       };
 
       server = {
-        bindAddr = mkOption {
-          type = types.nullOr types.str;
+        bindAddr = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = null;
           description = ''
             The address the server will bind to.
           '';
         };
 
-        enableHighBandwidth = mkOption {
-          type = types.bool;
+        enableHighBandwidth = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Whether to enable high bandwidth mode on LAN servers. This will double the amount of bandwidth required for running the server.
           '';
         };
 
-        hostName = mkOption {
-          type = types.nullOr types.str;
+        hostName = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = null;
           description = ''
             Hostname for the server.
           '';
         };
 
-        inactivePenalty = mkOption {
-          type = types.enum [ "spectator" "spectator/kick" "kick" ];
+        inactivePenalty = lib.mkOption {
+          type = lib.types.enum [ "spectator" "spectator/kick" "kick" ];
           example = "spectator";
           default = "spectator/kick";
           description = ''
@@ -201,48 +198,48 @@ in
           '';
         };
 
-        kickInactiveSpectators = mkOption {
-          type = types.bool;
+        kickInactiveSpectators = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Whether to kick inactive spectators.
           '';
         };
 
-        inactiveTime = mkOption {
-          type = types.ints.unsigned;
+        inactiveTime = lib.mkOption {
+          type = lib.types.ints.unsigned;
           default = 3;
           description = ''
             The amount of minutes a client has to idle before it is considered inactive.
           '';
         };
 
-        maxClients = mkOption {
-          type = types.ints.unsigned;
+        maxClients = lib.mkOption {
+          type = lib.types.ints.unsigned;
           default = 12;
           description = ''
             The maximum amount of clients that can be connected to the server at the same time.
           '';
         };
 
-        maxClientsPerIP = mkOption {
-          type = types.ints.unsigned;
+        maxClientsPerIP = lib.mkOption {
+          type = lib.types.ints.unsigned;
           default = 12;
           description = ''
             The maximum amount of clients with the same IP address that can be connected to the server at the same time.
           '';
         };
 
-        skillLevel = mkOption {
-          type = types.enum [ "casual" "normal" "competitive" ];
+        skillLevel = lib.mkOption {
+          type = lib.types.enum [ "casual" "normal" "competitive" ];
           default = "normal";
           description = ''
             The skill level shown in the server browser.
           '';
         };
 
-        enableSpamProtection = mkOption {
-          type = types.bool;
+        enableSpamProtection = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Whether to enable chat spam protection.
@@ -251,8 +248,8 @@ in
       };
 
       game = {
-        gameType = mkOption {
-          type = types.str;
+        gameType = lib.mkOption {
+          type = lib.types.str;
           example = "ctf";
           default = "dm";
           description = ''
@@ -262,8 +259,8 @@ in
           '';
         };
 
-        map = mkOption {
-          type = types.str;
+        map = lib.mkOption {
+          type = lib.types.str;
           example = "ctf5";
           default = "dm1";
           description = ''
@@ -271,16 +268,16 @@ in
           '';
         };
 
-        swapTeams = mkOption {
-          type = types.bool;
+        swapTeams = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Whether to swap teams each round.
           '';
         };
 
-        enableReadyMode = mkOption {
-          type = types.bool;
+        enableReadyMode = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Whether to enable "ready mode"; where players can pause/unpause the game
@@ -288,24 +285,24 @@ in
           '';
         };
 
-        playerSlots = mkOption {
-          type = types.ints.unsigned;
+        playerSlots = lib.mkOption {
+          type = lib.types.ints.unsigned;
           default = 8;
           description = ''
             The amount of slots to reserve for players (as opposed to spectators).
           '';
         };
 
-        enablePowerups = mkOption {
-          type = types.bool;
+        enablePowerups = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Whether to allow powerups such as the ninja.
           '';
         };
 
-        scoreLimit = mkOption {
-          type = types.ints.unsigned;
+        scoreLimit = lib.mkOption {
+          type = lib.types.ints.unsigned;
           example = 400;
           default = 20;
           description = ''
@@ -313,24 +310,24 @@ in
           '';
         };
 
-        restrictSpectators = mkOption {
-          type = types.bool;
+        restrictSpectators = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Whether to restrict access to information such as health, ammo and armour in spectator mode.
           '';
         };
 
-        enableTeamDamage = mkOption {
-          type = types.bool;
+        enableTeamDamage = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Whether to enable team damage; whether to allow team mates to inflict damage on one another.
           '';
         };
 
-        timeLimit = mkOption {
-          type = types.ints.unsigned;
+        timeLimit = lib.mkOption {
+          type = lib.types.ints.unsigned;
           default = 0;
           description = ''
             Time limit of the game. In cases of equal points, there will be sudden death.
@@ -338,8 +335,8 @@ in
           '';
         };
 
-        tournamentMode = mkOption {
-          type = types.enum [ "disable" "enable" "restrictSpectators" ];
+        tournamentMode = lib.mkOption {
+          type = lib.types.enum [ "disable" "enable" "restrictSpectators" ];
           default = "disable";
           description = ''
             Whether to enable tournament mode. In tournament mode, players join as spectators.
@@ -347,24 +344,24 @@ in
           '';
         };
 
-        enableVoteKick = mkOption {
-          type = types.bool;
+        enableVoteKick = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Whether to enable voting to kick players.
           '';
         };
 
-        voteKickBanTime = mkOption {
-          type = types.ints.unsigned;
+        voteKickBanTime = lib.mkOption {
+          type = lib.types.ints.unsigned;
           default = 5;
           description = ''
             The amount of minutes that a player is banned for if they get kicked by a vote.
           '';
         };
 
-        voteKickMinimumPlayers = mkOption {
-          type = types.ints.unsigned;
+        voteKickMinimumPlayers = lib.mkOption {
+          type = lib.types.ints.unsigned;
           default = 5;
           description = ''
             The minimum amount of players required to start a kick vote.
@@ -374,8 +371,8 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    networking.firewall = mkIf cfg.openPorts {
+  config = lib.mkIf cfg.enable {
+    networking.firewall = lib.mkIf cfg.openPorts {
       allowedUDPPorts = [ cfg.port ];
     };
 


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
