### PR TITLE
zeromq: enable curve support

### DIFF
--- a/pkgs/development/libraries/zeromq/4.x.nix
+++ b/pkgs/development/libraries/zeromq/4.x.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = false; # fails all the tests (ctest)
 
   cmakeFlags = [
+    (lib.cmakeBool "WITH_LIBSODIUM" true)
+    (lib.cmakeBool "ENABLE_CURVE" true)
     (lib.cmakeBool "ENABLE_DRAFTS" enableDrafts)
   ];
 

--- a/pkgs/development/libraries/zeromq/4.x.nix
+++ b/pkgs/development/libraries/zeromq/4.x.nix
@@ -8,6 +8,13 @@
   asciidoc,
   xmlto,
   enableDrafts ? false,
+  # for passthru.tests
+  azmq,
+  cppzmq,
+  czmq,
+  zmqpp,
+  ffmpeg,
+  python3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -64,6 +71,17 @@ stdenv.mkDerivation (finalAttrs: {
     install -vDm644 -t "$out/share/man/man3" ../doc/*.3
     install -vDm644 -t "$out/share/man/man7" ../doc/*.7
   '';
+
+  passthru.tests = {
+    inherit
+      azmq
+      cppzmq
+      czmq
+      zmqpp
+      ;
+    pyzmq = python3.pkgs.pyzmq;
+    ffmpeg = ffmpeg.override { withZmq = true; };
+  };
 
   meta = {
     branch = "4";

--- a/pkgs/development/libraries/zeromq/4.x.nix
+++ b/pkgs/development/libraries/zeromq/4.x.nix
@@ -1,30 +1,38 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, asciidoc
-, pkg-config
-, libsodium
-, enableDrafts ? false
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  libsodium,
+  asciidoc,
+  enableDrafts ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zeromq";
   version = "4.3.5";
 
   src = fetchFromGitHub {
     owner = "zeromq";
     repo = "libzmq";
-    rev = "v${version}";
-    sha256 = "sha256-q2h5y0Asad+fGB9haO4Vg7a1ffO2JSb7czzlhmT3VmI=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-q2h5y0Asad+fGB9haO4Vg7a1ffO2JSb7czzlhmT3VmI=";
   };
 
-  nativeBuildInputs = [ cmake asciidoc pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    asciidoc
+  ];
+
   buildInputs = [ libsodium ];
 
   doCheck = false; # fails all the tests (ctest)
 
-  cmakeFlags = lib.optional enableDrafts "-DENABLE_DRAFTS=ON";
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_DRAFTS" enableDrafts)
+  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
@@ -32,12 +40,12 @@ stdenv.mkDerivation rec {
       --replace '$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
   '';
 
-  meta = with lib; {
+  meta = {
     branch = "4";
     homepage = "http://www.zeromq.org";
     description = "Intelligent Transport Layer";
-    license = licenses.mpl20;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ fpletz ];
+    license = lib.licenses.mpl20;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ fpletz ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

- Modernize the derivation.
- Create and install man pages (not done when using CMake)
- Enable Curve support

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #337508

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
