### PR TITLE
[Backport release-24.05] _86Box: 4.1.1 -> 4.2

### DIFF
--- a/pkgs/applications/emulators/86box/darwin.patch
+++ b/pkgs/applications/emulators/86box/darwin.patch
@@ -1,0 +1,15 @@
+diff --git a/src/qt/qt_platform.cpp b/src/qt/qt_platform.cpp
+index 824f71023..1f38e4b5f 100644
+--- a/src/qt/qt_platform.cpp
++++ b/src/qt/qt_platform.cpp
+@@ -673,6 +673,10 @@ plat_init_rom_paths(void)
+         rom_add_path(QDir(path).filePath("86Box/roms").toUtf8().constData());
+ #endif
+     }
++
++    #ifdef __APPLE__
++    rom_add_path("@out@/share/86Box/roms/");
++    #endif
+ }
+ 
+ void

--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -1,8 +1,11 @@
 {
   stdenv,
+  darwin,
+  overrideSDK,
   lib,
   fetchFromGitHub,
   cmake,
+  extra-cmake-modules,
   pkg-config,
   makeWrapper,
   freetype,
@@ -19,46 +22,79 @@
   discord-gamesdk,
   libpcap,
   libslirp,
+  wayland,
+  wayland-scanner,
+  libsndfile,
+  flac,
+  libogg,
+  libvorbis,
+  libopus,
+  libmpg123,
 
   enableDynarec ? with stdenv.hostPlatform; isx86 || isAarch,
   enableNewDynarec ? enableDynarec && stdenv.hostPlatform.isAarch,
   enableVncRenderer ? false,
+  enableWayland ? stdenv.isLinux,
   unfreeEnableDiscord ? false,
   unfreeEnableRoms ? false,
 }:
-
-stdenv.mkDerivation (finalAttrs: {
+let
+  stdenv' = if stdenv.isDarwin && stdenv.isx86_64 then overrideSDK stdenv "11.0" else stdenv;
+in
+stdenv'.mkDerivation (finalAttrs: {
   pname = "86Box";
-  version = "4.1.1";
+  version = "4.2";
 
   src = fetchFromGitHub {
     owner = "86Box";
     repo = "86Box";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ioE0EVIXv/biXXvLqwhmtZ/RJM0nLqcE+i+CU+WXBY4=";
+    hash = "sha256-hXupMQ+i27sw3XOweZGatdRCUlp7weGR/PqCLAw/8fo=";
   };
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-    makeWrapper
-    qt5.wrapQtAppsHook
-  ];
+  patches = [ ./darwin.patch ];
 
-  buildInputs = [
-    freetype
-    fluidsynth
-    SDL2
-    glib
-    openal
-    rtmidi
-    pcre2
-    jack2
-    libpcap
-    libslirp
-    qt5.qtbase
-    qt5.qttools
-  ] ++ lib.optional stdenv.isLinux alsa-lib ++ lib.optional enableVncRenderer libvncserver;
+  postPatch = ''
+    substituteAllInPlace src/qt/qt_platform.cpp
+  '';
+
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+      makeWrapper
+      qt5.wrapQtAppsHook
+    ]
+    ++ lib.optionals enableWayland [
+      extra-cmake-modules
+      wayland-scanner
+    ];
+
+  buildInputs =
+    [
+      freetype
+      fluidsynth
+      SDL2
+      glib
+      openal
+      rtmidi
+      pcre2
+      jack2
+      libpcap
+      libslirp
+      qt5.qtbase
+      qt5.qttools
+      libsndfile
+      flac.dev
+      libogg.dev
+      libvorbis.dev
+      libopus.dev
+      libmpg123.dev
+    ]
+    ++ lib.optional stdenv.isLinux alsa-lib
+    ++ lib.optional enableWayland wayland
+    ++ lib.optional enableVncRenderer libvncserver
+    ++ lib.optional stdenv.isDarwin darwin.apple_sdk_11_0.libs.xpc;
 
   cmakeFlags =
     lib.optional stdenv.isDarwin "-DCMAKE_MACOSX_BUNDLE=OFF"
@@ -86,8 +122,9 @@ stdenv.mkDerivation (finalAttrs: {
       owner = "86Box";
       repo = "roms";
       rev = "v${finalAttrs.version}";
-      hash = "sha256-58nNTOLund/KeDlNwzwwihjFVigs/P0K8SN07zExE2c=";
+      hash = "sha256-WdQebSBuw2Wtz8ggMnGuxGoi2EKtNub3S8JKa6ZmdU8=";
     };
+    updateScript = ./update.sh;
   };
 
   # Some libraries are loaded dynamically, but QLibrary doesn't seem to search
@@ -101,12 +138,17 @@ stdenv.mkDerivation (finalAttrs: {
       makeWrapperArgs+=(--prefix ${libPathVar} : "${libPath}")
     '';
 
-  meta = with lib; {
-    description = "Emulator of x86-based machines based on PCem.";
+  meta = {
+    description = "Emulator of x86-based machines based on PCem";
     mainProgram = "86Box";
     homepage = "https://86box.net/";
-    license = with licenses; [ gpl2Only ] ++ optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
-    maintainers = [ maintainers.jchw ];
-    platforms = platforms.linux;
+    license =
+      with lib.licenses;
+      [ gpl2Only ] ++ lib.optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
+    maintainers = with lib.maintainers; [
+      jchw
+      matteopacini
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/applications/emulators/86box/update.sh
+++ b/pkgs/applications/emulators/86box/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq nix-prefetch-github common-updater-scripts
+
+set -euo pipefail
+
+latest_release=$(curl --silent https://api.github.com/repos/86Box/86Box/releases/latest)
+version=$(jq -r '.tag_name' <<<"$latest_release" | cut -c2-)
+main_hash=$(nix-prefetch-github --json --rev "v$version" 86Box 86Box | jq -r '.hash')
+roms_hash=$(nix-prefetch-github --json --rev "v$version" 86Box roms | jq -r '.hash')
+
+update-source-version _86Box "_$version" "$main_hash"
+update-source-version _86Box "$version" "$roms_hash" --source-key=roms


### PR DESCRIPTION
## Description of changes

- Manual backport of the latest version to `24.05` as the automated one failed: https://github.com/NixOS/nixpkgs/pull/337701#issuecomment-2315659749

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
