### PR TITLE
fcitx5-im-emoji-picker: init at 1.1.0

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -33,6 +33,8 @@
 , xcb-imdkit
 , libxkbfile
 , nixosTests
+, qtwayland
+, wrapQtAppsHook
 }:
 let
   enDictVer = "20121020";
@@ -60,6 +62,7 @@ stdenv.mkDerivation rec {
     cmake
     extra-cmake-modules
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -90,6 +93,7 @@ stdenv.mkDerivation rec {
     xcb-imdkit
     xkeyboard_config
     libxkbfile
+    qtwayland
   ];
 
   passthru = {

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-im-emoji-picker.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-im-emoji-picker.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  fcitx5,
+  pkg-config,
+  qtbase,
+  wrapQtAppsHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fcitx5-im-emoji-picker";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "GaZaTu";
+    repo = "im-emoji-picker";
+    rev = "v${version}";
+    hash = "sha256-ha0okJz/WEdhrNTZr5ZdbqBypS0gEnPpu7zrPfQGl78=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    fcitx5
+    qtbase
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "ONLY_FCITX5" true)
+  ];
+
+  preConfigure = ''
+    # Remove hardcoded install prefix
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "set(CMAKE_INSTALL_PREFIX /usr)" ""
+  '';
+
+  meta = with lib; {
+    description = "Emoji picker compatible with Linux systems using either XServer or Wayland";
+    homepage = "https://github.com/GaZaTu/im-emoji-picker";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nickhu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7652,7 +7652,7 @@ with pkgs;
 
   chewing-editor = libsForQt5.callPackage ../applications/misc/chewing-editor { };
 
-  fcitx5 = callPackage ../tools/inputmethods/fcitx5 { };
+  fcitx5 = libsForQt5.callPackage ../tools/inputmethods/fcitx5 { };
 
   fcitx5-bamboo = callPackage ../tools/inputmethods/fcitx5/fcitx5-bamboo.nix { };
 
@@ -7677,6 +7677,8 @@ with pkgs;
   fcitx5-gtk = callPackage ../tools/inputmethods/fcitx5/fcitx5-gtk.nix { };
 
   fcitx5-hangul = callPackage ../tools/inputmethods/fcitx5/fcitx5-hangul.nix { };
+
+  fcitx5-im-emoji-picker = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-im-emoji-picker.nix { };
 
   fcitx5-rime = callPackage ../tools/inputmethods/fcitx5/fcitx5-rime.nix { };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds support for the fcitx5 version of [im-emoji-picker](https://github.com/GaZaTu/im-emoji-picker).
I also made fcitx5 use the Qt wrapper as this plugin requires Qt platform plugins to work; not having this makes fcitx5 crash as follows:

```
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
