### PR TITLE
mpvScripts.mpv-notify-send: 0-unstable-2020-02-24 -> 0-unstable-2024-07-11, modernise

### DIFF
--- a/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
@@ -31,7 +31,7 @@ buildLua rec {
     "--prefix"
     "PATH"
     ":"
-    (lib.makeBinPath libnotify)
+    (lib.makeBinPath [ libnotify ])
   ];
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
@@ -13,9 +13,9 @@ buildLua rec {
 
   src = fetchFromGitHub {
     owner = "emilazy";
-    repo = pname;
+    repo = "mpv-notify-send";
     rev = "a2bab8b2fd8e8d14faa875b5cc3a73f1276cd88a";
-    sha256 = "sha256-EwVkhyB87TJ3i9xJmmZMSTMUKvfbImI1S+y1vgRWbDk=";
+    hash = "sha256-EwVkhyB87TJ3i9xJmmZMSTMUKvfbImI1S+y1vgRWbDk=";
   };
 
   patches = [
@@ -36,10 +36,10 @@ buildLua rec {
 
   passthru.updateScript = unstableGitUpdater { };
 
-  meta = with lib; {
+  meta = {
     description = "Lua script for mpv to send notifications with notify-send";
     homepage = "https://github.com/emilazy/mpv-notify-send";
-    license = licenses.wtfpl;
-    maintainers = with maintainers; [ r3n3gad3p3arl ];
+    license = lib.licenses.wtfpl;
+    maintainers = with lib.maintainers; [ r3n3gad3p3arl ];
   };
 }

--- a/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
@@ -12,7 +12,7 @@ buildLua rec {
   version = "0-unstable-2020-02-24";
 
   src = fetchFromGitHub {
-    owner = "emilazy";
+    owner = "Parranoh";
     repo = "mpv-notify-send";
     rev = "a2bab8b2fd8e8d14faa875b5cc3a73f1276cd88a";
     hash = "sha256-EwVkhyB87TJ3i9xJmmZMSTMUKvfbImI1S+y1vgRWbDk=";
@@ -38,7 +38,7 @@ buildLua rec {
 
   meta = {
     description = "Lua script for mpv to send notifications with notify-send";
-    homepage = "https://github.com/emilazy/mpv-notify-send";
+    homepage = "https://github.com/Parranoh/mpv-notify-send";
     license = lib.licenses.wtfpl;
     maintainers = with lib.maintainers; [ r3n3gad3p3arl ];
   };

--- a/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
@@ -9,23 +9,14 @@
 
 buildLua rec {
   pname = "mpv-notify-send";
-  version = "0-unstable-2020-02-24";
+  version = "0-unstable-2024-07-11";
 
   src = fetchFromGitHub {
     owner = "Parranoh";
     repo = "mpv-notify-send";
-    rev = "a2bab8b2fd8e8d14faa875b5cc3a73f1276cd88a";
-    hash = "sha256-EwVkhyB87TJ3i9xJmmZMSTMUKvfbImI1S+y1vgRWbDk=";
+    rev = "d98d9fe566b222c5b909e3905e9e201eaec34959";
+    hash = "sha256-H8WIKfQnle27eiwnz2sxC8D1EwQplY4N7Qg5+c1e/uU=";
   };
-
-  patches = [
-    # show title of online videos instead of url
-    (fetchpatch {
-      name = "6.patch"; # https://github.com/emilazy/mpv-notify-send/pull/6
-      url = "https://github.com/emilazy/mpv-notify-send/commit/948347e14890e15e89cd1e069beb1140e2d01dce.patch";
-      hash = "sha256-7aXQ8qeqG4yX0Uyn09xCIESnwPZsb6Frd7C49XgbpFw=";
-    })
-  ];
 
   passthru.extraWrapperArgs = [
     "--prefix"


### PR DESCRIPTION
## Description of changes

- fix build when wrapping
  - fixes #338170
- modernise
- update repo URL due to ownership transfer
- 0-unstable-2020-02-24 -> 0-unstable-2024-07-11

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
