### PR TITLE
`tmp.nix`: mount `/tmp` on a `tmpfs`

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -359,6 +359,9 @@
 - The `antennas` package and the `services.antennas` module have been
   removed as they only work with `tvheadend` (see above).
 
+- `/tmp` is now mounted on a `tmpfs`, which is more in-line with both the File Hierarchy Standard (FHS) and most distros.
+  - `nix-daemon` will be manually set to use `/var/tmp` on Linux, although this should ultimately be configured better by `nix` itself.
+
 ## Other Notable Changes {#sec-release-24.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -33,7 +33,8 @@ in
 
       useTmpfs = mkOption {
         type = types.bool;
-        default = false;
+        default = lib.versionAtLeast config.system.stateVersion "24.11";
+        defaultText = literalExpression "`true` if stateVersion is at least 24.11";
         description = ''
            Whether to mount a tmpfs on {file}`/tmp` during boot.
 


### PR DESCRIPTION
## Description of changes
Change the default config to clean `/tmp/` on boot, to be more in line with both the File Hierarchy Standard (FHS) and behavior of other large distros.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
`boot.tmp.cleanOnBoot` has had its default changed from `false` to `true`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
