### PR TITLE
tome2: 2.4 -> 2.4-unstable-2025-02-17

### DIFF
--- a/pkgs/by-name/to/tome2/package.nix
+++ b/pkgs/by-name/to/tome2/package.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "tome2";
     repo = "tome2";
-    rev = "4e6a906c80ff07b75a6acf4ff585b47303805e46";
-    sha256 = "06bddj55y673d7bnzblk8n01z32l6k2rad3bpzr8dmw464hx4wwf";
+    rev = "2209ab83f31967b6ca0b1ba6ef298bde5a82fbd4";
+    hash = "sha256-bZx+v7soiRqsfpeNZBJmtyVXBSIjujRZ+SypEuctIG8=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/to/tome2/package.nix
+++ b/pkgs/by-name/to/tome2/package.nix
@@ -30,13 +30,13 @@ let
 in
 stdenv.mkDerivation {
   inherit pname;
-  version = "2.4";
+  version = "2.4-unstable-2025-02-17";
 
   src = fetchFromGitHub {
     owner = "tome2";
     repo = "tome2";
-    rev = "2209ab83f31967b6ca0b1ba6ef298bde5a82fbd4";
-    hash = "sha256-bZx+v7soiRqsfpeNZBJmtyVXBSIjujRZ+SypEuctIG8=";
+    rev = "3892fbcb1c2446afcb0c34f59e2a24f78ae672c4";
+    hash = "sha256-E6T5ZnsAzZ4cy2S8WvB0k3W4XGFsiA3TKTCSBqje+tw=";
   };
 
   buildInputs = [


### PR DESCRIPTION
## Description of changes

Updated tome2 upstream version.
Fixes compilation with modern compilers.
Fixes crash during startup of tome-x11 on Wayland.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
