### PR TITLE
cups vm tests: fix race condition, add more tests

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -827,8 +827,10 @@ in {
   predictable-interface-names = handleTest ./predictable-interface-names.nix {};
   pretalx = runTest ./web-apps/pretalx.nix;
   pretix = runTest ./web-apps/pretix.nix;
-  printing-socket = handleTest ./printing.nix { socket = true; };
-  printing-service = handleTest ./printing.nix { socket = false; };
+  printing-socket = handleTest ./printing.nix { socket = true; listenTcp = true; };
+  printing-service = handleTest ./printing.nix { socket = false; listenTcp = true; };
+  printing-socket-notcp = handleTest ./printing.nix { socket = true; listenTcp = false; };
+  printing-service-notcp = handleTest ./printing.nix { socket = false; listenTcp = false; };
   private-gpt = handleTest ./private-gpt.nix {};
   privatebin = runTest ./privatebin.nix;
   privoxy = handleTest ./privoxy.nix {};

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -54,8 +54,8 @@ import ./make-test-python.nix (
     start_all()
 
     with subtest("Make sure that cups is up on both sides and printers are set up"):
-        server.wait_for_unit("cups.${if socket then "socket" else "service"}")
-        client.wait_for_unit("cups.${if socket then "socket" else "service"}")
+        server.wait_for_unit("ensure-printers.service")
+        client.wait_for_unit("ensure-printers.service")
 
     assert "scheduler is running" in client.succeed("lpstat -r")
 

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -6,9 +6,13 @@ import ./make-test-python.nix (
 , ...
 }:
 
+let
+  inherit (pkgs) lib;
+in
+
 {
   name = "printing";
-  meta = with pkgs.lib.maintainers; {
+  meta = with lib.maintainers; {
     maintainers = [ domenkozar matthewbauer ];
   };
 

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -138,6 +138,7 @@ stdenv.mkDerivation rec {
 
   passthru.tests = {
     inherit (nixosTests)
+      cups-pdf
       printing-service
       printing-socket
     ;

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -141,6 +141,8 @@ stdenv.mkDerivation rec {
       cups-pdf
       printing-service
       printing-socket
+      printing-service-notcp
+      printing-socket-notcp
     ;
   };
 


### PR DESCRIPTION
## Description of changes

Motivated by https://github.com/NixOS/nixpkgs/pull/337748#issuecomment-2313621353 , this adds

*   `cups-pdf` to cups' `passthru.tests`
*   two additional cups vm tests that ensure it works even with `listenAddresses = []`

While developing the new tests, I hit a rare race condition in the existing vm tests, which is also fixed as part of this pull request.  Details are explained in the respective commit message.

Notifying maintainers @domenkozar @matthewbauer and inspirator @risicle

Note: Although the [inspiring bug](https://github.com/NixOS/nixpkgs/pull/337748) occured on NixOS 24.05, I don't think this should be backported, as it's quite unlikely that such a bug happens again during the remaining lifetime of NixOS 24.05.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable ( **including added tests** ):
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

(nothing)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
