### PR TITLE
tailscale: only autoconnect after backend is up

### DIFF
--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -121,10 +121,16 @@ in {
       serviceConfig = {
         Type = "oneshot";
       };
-      script = ''
-        status=$(${config.systemd.package}/bin/systemctl show -P StatusText tailscaled.service)
-        if [[ $status != Connected* ]]; then
-          ${cfg.package}/bin/tailscale up --auth-key 'file:${cfg.authKeyFile}' ${escapeShellArgs cfg.extraUpFlags}
+      # https://github.com/tailscale/tailscale/blob/v1.72.1/ipn/backend.go#L24-L32
+      script = let
+        statusCommand = "${lib.getExe cfg.package} status --json | ${lib.getExe pkgs.jq} -r '.BackendState'";
+      in ''
+        while [[ "$(${statusCommand})" == "NoState" ]]; do
+          sleep 0.5
+        done
+        status=$(${statusCommand})
+        if [[ "$status" == "NeedsLogin" || "$status" == "NeedsMachineAuth" ]]; then
+          ${lib.getExe cfg.package} up --auth-key 'file:${cfg.authKeyFile}' ${escapeShellArgs cfg.extraUpFlags}
         fi
       '';
     };
@@ -137,7 +143,7 @@ in {
         Type = "oneshot";
       };
       script = ''
-        ${cfg.package}/bin/tailscale set ${escapeShellArgs cfg.extraSetFlags}
+        ${lib.getExe cfg.package} set ${escapeShellArgs cfg.extraSetFlags}
       '';
     };
 

--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -123,7 +123,7 @@ in {
       };
       # https://github.com/tailscale/tailscale/blob/v1.72.1/ipn/backend.go#L24-L32
       script = let
-        statusCommand = "${lib.getExe cfg.package} status --json | ${lib.getExe pkgs.jq} -r '.BackendState'";
+        statusCommand = "${lib.getExe cfg.package} status --json --peers=false | ${lib.getExe pkgs.jq} -r '.BackendState'";
       in ''
         while [[ "$(${statusCommand})" == "NoState" ]]; do
           sleep 0.5


### PR DESCRIPTION
## Description of changes

Previously, if this service started before the backend is up, `StatusText` would be empty leading to the service trying to run `tailscale up` even if this device is already logged in.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
