### PR TITLE
treewide: use a consistent meta.priority default

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -133,12 +133,17 @@ rec {
   mapDerivationAttrset = f: set: lib.mapAttrs (name: pkg: if lib.isDerivation pkg then (f pkg) else pkg) set;
 
   /**
-    Set the nix-env priority of the package.
+    The default priority of packages in Nix. See `defaultPriority` in [`src/nix/profile.cc`](https://github.com/NixOS/nix/blob/master/src/nix/profile.cc#L47).
+   */
+  defaultPriority = 5;
+
+  /**
+    Set the nix-env priority of the package. Note that higher values are lower priority, and vice versa.
 
     # Inputs
 
     `priority`
-    : 1\. Function argument
+    : 1\. The priority to set.
 
     `drv`
     : 2\. Function argument
@@ -159,8 +164,7 @@ rec {
   lowPrio = setPrio 10;
 
   /**
-    Apply lowPrio to an attrset with derivations
-
+    Apply lowPrio to an attrset with derivations.
 
     # Inputs
 
@@ -184,8 +188,7 @@ rec {
   hiPrio = setPrio (-10);
 
   /**
-    Apply hiPrio to an attrset with derivations
-
+    Apply hiPrio to an attrset with derivations.
 
     # Inputs
 

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -7,7 +7,7 @@ with lib;
 
 let
 
-  requiredPackages = map (pkg: setPrio ((pkg.meta.priority or 5) + 3) pkg)
+  requiredPackages = map (pkg: setPrio ((pkg.meta.priority or lib.meta.defaultPriority) + 3) pkg)
     [ pkgs.acl
       pkgs.attr
       pkgs.bashInteractive # bash with ncurses support
@@ -48,7 +48,7 @@ let
     ];
   defaultPackages =
     map
-      (n: let pkg = pkgs.${n}; in setPrio ((pkg.meta.priority or 5) + 3) pkg)
+      (n: let pkg = pkgs.${n}; in setPrio ((pkg.meta.priority or lib.meta.defaultPriority) + 3) pkg)
       defaultPackageNames;
   defaultPackagesText = "[ ${concatMapStringsSep " " (n: "pkgs.${n}") defaultPackageNames } ]";
 

--- a/pkgs/applications/editors/kakoune/wrapper.nix
+++ b/pkgs/applications/editors/kakoune/wrapper.nix
@@ -1,4 +1,4 @@
-{ symlinkJoin, makeWrapper, kakoune, plugins ? [], configure ? {} }:
+{ lib, symlinkJoin, makeWrapper, kakoune, plugins ? [], configure ? {} }:
 
 let
   # "plugins" is the preferred way, but some configurations may be
@@ -34,5 +34,5 @@ in
       rm -Rf "$out/DELETE_ME"
     '';
 
-    meta = kakoune.meta // { priority = (kakoune.meta.priority or 0) - 1; };
+    meta = kakoune.meta // { priority = (kakoune.meta.priority or lib.meta.defaultPriority) - 1; };
   }

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -214,7 +214,7 @@ let
       # To prevent builds on hydra
       hydraPlatforms = [];
       # prefer wrapper over the package
-      priority = (neovim-unwrapped.meta.priority or 0) - 1;
+      priority = (neovim-unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
     };
   });
 in

--- a/pkgs/applications/misc/rofi/wrapper.nix
+++ b/pkgs/applications/misc/rofi/wrapper.nix
@@ -37,6 +37,6 @@ symlinkJoin {
   '';
 
   meta = rofi-unwrapped.meta // {
-    priority = (rofi-unwrapped.meta.priority or 0) - 1;
+    priority = (rofi-unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
   };
 }

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -421,7 +421,7 @@ let
         inherit (browser.meta) description;
         mainProgram = launcherName;
         hydraPlatforms = [];
-        priority = (browser.meta.priority or 0) - 1; # prefer wrapper over the package
+        priority = (browser.meta.priority or lib.meta.defaultPriority) - 1; # prefer wrapper over the package
       };
     };
 in lib.makeOverridable wrapper

--- a/pkgs/applications/networking/cluster/helm/wrapper.nix
+++ b/pkgs/applications/networking/cluster/helm/wrapper.nix
@@ -40,7 +40,7 @@ in
       # To prevent builds on hydra
       hydraPlatforms = [];
       # prefer wrapper over the package
-      priority = (helm.meta.priority or 0) - 1;
+      priority = (helm.meta.priority or lib.meta.defaultPriority) - 1;
     };
   };
 in

--- a/pkgs/applications/window-managers/wayfire/wrapper.nix
+++ b/pkgs/applications/window-managers/wayfire/wrapper.nix
@@ -27,6 +27,6 @@ symlinkJoin {
     # To prevent builds on hydra
     hydraPlatforms = [];
     # prefer wrapper over the package
-    priority = (wayfire.meta.priority or 0) - 1;
+    priority = (wayfire.meta.priority or lib.meta.defaultPriority) - 1;
   };
 }

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -68,7 +68,7 @@ runCommand name
         # Add any extra outputs specified by the caller of `buildEnv`.
         ++ lib.filter (p: p!=null)
           (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
-      priority = drv.meta.priority or 5;
+      priority = drv.meta.priority or lib.meta.defaultPriority;
     }) paths);
     preferLocalBuild = true;
     allowSubstitutes = false;

--- a/pkgs/data/fonts/powerline-symbols/default.nix
+++ b/pkgs/data/fonts/powerline-symbols/default.nix
@@ -5,7 +5,7 @@ let
 in runCommand "powerline-symbols-${version}" {
   meta = {
     inherit (powerline.meta) license;
-    priority = (powerline.meta.priority or 0) + 1;
+    priority = (powerline.meta.priority or lib.meta.defaultPriority) + 1;
     maintainers = with lib.maintainers; [ midchildan ];
   };
 } ''

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
@@ -65,6 +65,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = lomiri-system-settings-unwrapped.meta // {
     description = "System Settings application for Lomiri (wrapped)";
-    priority = (lomiri-system-settings-unwrapped.meta.priority or 0) - 1;
+    priority = (lomiri-system-settings-unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
   };
 })

--- a/pkgs/development/python-modules/dnf4/wrapper.nix
+++ b/pkgs/development/python-modules/dnf4/wrapper.nix
@@ -51,6 +51,6 @@ stdenv.mkDerivation {
   };
 
   meta = dnf4-unwrapped.meta // {
-    priority = (dnf4-unwrapped.meta.priority or 0) - 1;
+    priority = (dnf4-unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
   };
 }

--- a/pkgs/development/r-modules/wrapper-radian.nix
+++ b/pkgs/development/r-modules/wrapper-radian.nix
@@ -22,7 +22,7 @@ runCommand (radian.name + "-wrapper") {
     # To prevent builds on hydra
     hydraPlatforms = [ ];
     # prefer wrapper over the package
-    priority = (radian.meta.priority or 0) - 1;
+    priority = (radian.meta.priority or lib.meta.defaultPriority) - 1;
   };
 } (''
   makeWrapper "${radian}/bin/radian" "$out/bin/radian" \

--- a/pkgs/development/r-modules/wrapper.nix
+++ b/pkgs/development/r-modules/wrapper.nix
@@ -1,4 +1,4 @@
-{ symlinkJoin, R, makeWrapper, recommendedPackages, packages }:
+{ lib, symlinkJoin, R, makeWrapper, recommendedPackages, packages }:
 symlinkJoin {
   name = R.name + "-wrapper";
   preferLocalBuild = true;
@@ -26,6 +26,6 @@ symlinkJoin {
       # To prevent builds on hydra
       hydraPlatforms = [];
       # prefer wrapper over the package
-      priority = (R.meta.priority or 0) - 1;
+      priority = (R.meta.priority or lib.meta.defaultPriority) - 1;
     };
 }

--- a/pkgs/development/tools/analysis/rizin/wrapper.nix
+++ b/pkgs/development/tools/analysis/rizin/wrapper.nix
@@ -39,6 +39,6 @@ symlinkJoin {
 
   meta = unwrapped.meta // {
     # prefer wrapped over unwrapped
-    priority = (unwrapped.meta.priority or 0) - 1;
+    priority = (unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
   };
 }

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -217,7 +217,7 @@ rec {
       meta = gradle.meta // {
         # prefer normal gradle/mitm-cache over this wrapper, this wrapper only provides the setup hook
         # and passthru
-        priority = (gradle.meta.priority or 0) + 1;
+        priority = (gradle.meta.priority or lib.meta.defaultPriority) + 1;
       };
     }) { };
 }

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -93,10 +93,7 @@ stdenv.mkDerivation rec {
       The `logger` binary from `util-linux` is preferred over `inetutils`.
       To instead prioritize this package, set a _lower_ `meta.priority`, or
       use e.g. `lib.setPrio 5 inetutils`.
-
-      Note that the default `meta.priority` is defined in `buildEnv` and is
-      currently 5.
     */
-    priority = (util-linux.meta.priority or 5) + 1;
+    priority = (util-linux.meta.priority or lib.meta.defaultPriority) + 1;
   };
 }

--- a/pkgs/tools/networking/maubot/wrapper.nix
+++ b/pkgs/tools/networking/maubot/wrapper.nix
@@ -64,7 +64,7 @@ let wrapper = { pythonPackages ? (_: [ ]), plugins ? (_: [ ]), baseConfig ? null
       };
     };
 
-    meta.priority = (unwrapped.meta.priority or 0) - 1;
+    meta.priority = (unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
   };
 in
 wrapper

--- a/pkgs/tools/networking/openssh/copyid.nix
+++ b/pkgs/tools/networking/openssh/copyid.nix
@@ -1,9 +1,9 @@
-{ runCommand, openssh }:
+{ lib, runCommand, openssh }:
 
 runCommand "ssh-copy-id-${openssh.version}" {
   meta = openssh.meta // {
     description = "Tool to copy SSH public keys to a remote machine";
-    priority = (openssh.meta.priority or 0) - 1;
+    priority = (openssh.meta.priority or lib.meta.defaultPriority) - 1;
   };
 } ''
   install -Dm 755 {${openssh},$out}/bin/ssh-copy-id


### PR DESCRIPTION
## Motivation for change

There are two main constants that are used for the "default priority" in Nixpkgs: 0 and 5. One of these is actually the Nix default (5). Let's unify on that.

## Description of changes

- [x] Searched for `priority or` treewide, adjusted as needed.

## Things done

From `nixpkgs-review rev HEAD`, I see the following rebuilds:

<dl>
    <dt>nixos-install-tools</dt><dd>Rebuilt because it depends on the nixos tree</dd>
    <dt>disko</dt><dd>Rebuilt because of `nixos-install-tools`</dd>
    <dt>dropbox</dt><dd>`nix-diff` says the outPath changed but nothing else. 🤔 </dd>
    <dt>dropbox-cli</dt><dd>Because `dropbox`</dd>
    <dt>dropbox-cli.nautilusExtension</dt><dd>Because `dropbox`</dd>
    <dt>mate.caja-dropbox</dt><dd>Because `dropbox`</dd>
    <dt>nixpkgs-manual</dt><dd>Because `lib.meta` addition</dd>
</dl>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).