### PR TITLE
angryipscanner: Fix to patch swt error

### DIFF
--- a/pkgs/tools/security/ipscan/default.nix
+++ b/pkgs/tools/security/ipscan/default.nix
@@ -7,6 +7,8 @@
 , makeWrapper
 , xorg
 , dpkg
+, gtk3
+, glib
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +32,7 @@ stdenv.mkDerivation rec {
     cp usr/lib/ipscan/ipscan-linux64-${version}.jar $out/share/${pname}-${version}.jar
 
     makeWrapper ${jre}/bin/java $out/bin/ipscan \
-      --prefix LD_LIBRARY_PATH : "$out/lib/:${lib.makeLibraryPath [ swt xorg.libXtst ]}" \
+      --prefix LD_LIBRARY_PATH : "$out/lib/:${lib.makeLibraryPath [ swt xorg.libXtst gtk3 glib ]}" \
       --add-flags "-Xmx256m -cp $out/share/${pname}-${version}.jar:${swt}/jars/swt.jar net.azib.ipscan.Main"
 
     mkdir -p $out/share/applications


### PR DESCRIPTION

## Description of changes
Without patch it gives the following error:

This is similar to the fix for dbeaver in #335633

SWT OS.java Error: Failed to load swt-pi3, loading swt-pi4 as fallback.
java.lang.UnsatisfiedLinkError: Could not load SWT library. Reasons:
	no swt-pi4-gtk-4956r13 in java.library.path: /nix/store/xfw3cclmcbwq94l46n1qlkq1sdg2mss8-ipscan-3.9.1/lib/:/nix/store/kdnmlrnhb1nz2p79braw5s4g1marf0jg-swt-4.5/lib:/nix/store/qqqh9hpg76q3mgaphgvkly54gkq0k3sy-libXtst-1.2.4/lib:/etc/sane-libs:/nix/store/lf74q3c06wr7c0mcb4zcl9n27hqvq2wv-gpaste-45.1/lib:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
	no swt-pi4-gtk in java.library.path: /nix/store/xfw3cclmcbwq94l46n1qlkq1sdg2mss8-ipscan-3.9.1/lib/:/nix/store/kdnmlrnhb1nz2p79braw5s4g1marf0jg-swt-4.5/lib:/nix/store/qqqh9hpg76q3mgaphgvkly54gkq0k3sy-libXtst-1.2.4/lib:/etc/sane-libs:/nix/store/lf74q3c06wr7c0mcb4zcl9n27hqvq2wv-gpaste-45.1/lib:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
	no swt-pi4 in java.library.path: /nix/store/xfw3cclmcbwq94l46n1qlkq1sdg2mss8-ipscan-3.9.1/lib/:/nix/store/kdnmlrnhb1nz2p79braw5s4g1marf0jg-swt-4.5/lib:/nix/store/qqqh9hpg76q3mgaphgvkly54gkq0k3sy-libXtst-1.2.4/lib:/etc/sane-libs:/nix/store/lf74q3c06wr7c0mcb4zcl9n27hqvq2wv-gpaste-45.1/lib:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
	Can't load library: /home/maciej/.swt/lib/linux/x86_64/libswt-pi4-gtk-4956r13.so
	Can't load library: /home/maciej/.swt/lib/linux/x86_64/libswt-pi4-gtk.so
	Can't load library: /home/maciej/.swt/lib/linux/x86_64/libswt-pi4.so

	at org.eclipse.swt.internal.Library.loadLibrary(Library.java:346)
	at org.eclipse.swt.internal.Library.loadLibrary(Library.java:255)
	at org.eclipse.swt.internal.gtk.OS.<clinit>(OS.java:97)
	at org.eclipse.swt.internal.Converter.wcsToMbcs(Converter.java:209)
	at org.eclipse.swt.internal.Converter.wcsToMbcs(Converter.java:155)
	at org.eclipse.swt.widgets.Display.<clinit>(Display.java:169)
	at net.azib.ipscan.gui.GUI.<init>(GUI.java:29)
	at net.azib.ipscan.Main.main(Main.java:50)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
