### PR TITLE
meli: 0.8.6 -> 0.8.7

### DIFF
--- a/pkgs/by-name/me/meli/package.nix
+++ b/pkgs/by-name/me/meli/package.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchzip
+, fetchpatch
 , rustPlatform
 
 # native build inputs
@@ -23,7 +24,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "meli";
-  version = "0.8.6";
+  version = "0.8.7";
 
   src = fetchzip {
     urls = [
@@ -31,10 +32,19 @@ rustPlatform.buildRustPackage rec {
       "https://codeberg.org/meli/meli/archive/v${version}.tar.gz"
       "https://github.com/meli/meli/archive/refs/tags/v${version}.tar.gz"
     ];
-    hash = "sha256-7lSxXv2i8B6vRWIJqMiXlMqHH6fmgACy9X5qNKuj+IU=";
+    hash = "sha256-2+JIehi2wuWdARbhFPvNPIJ9ucZKWjNSORszEG9lyjw=";
   };
 
-  cargoHash = "sha256-vZkMfaALnRBK9ZwMB2uvvJgQq+BdUX7enNnr9t5H+MY=";
+  cargoHash = "sha256-ZVhUkpiiPKbWcf56cXFgn3Nyr63STHLlD7mpYEetNIY=";
+
+  cargoPatches = [
+    (fetchpatch {
+      # https://github.com/NixOS/nixpkgs/issues/332957#issuecomment-2278578811
+      name = "fix-rust-1.80-compat.patch";
+      url = "https://git.meli-email.org/meli/meli/commit/6b05279a0987315c401516cac8ff0b016a8e02a8.patch";
+      hash = "sha256-mh8H7wmHMXAe01UTvdY8vJeeLyH6ZFwylNLFFL+4LO0=";
+    })
+  ];
 
   # Needed to get openssl-sys to use pkg-config
   OPENSSL_NO_VENDOR=1;
@@ -55,6 +65,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeCheckInputs = [
     file
+    gnum4
   ];
 
   postInstall = ''
@@ -70,10 +81,9 @@ rustPlatform.buildRustPackage rec {
   '';
 
   checkFlags = [
-    "--skip=conf::test_config_parse"        # panicking due to sandbox
-    "--skip=smtp::test::test_smtp"          # requiring network
-    "--skip=utils::xdg::query_default_app"  # doesn't build
-    "--skip=utils::xdg::query_mime_info"    # doesn't build
+    "--skip=conf::tests::test_config_parse"            # panicking due to sandbox
+    "--skip=utils::tests::test_shellexpandtrait_impls" # panicking due to sandbox
+    "--skip=utils::tests::test_shellexpandtrait"       # panicking due to sandbox
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release notes: https://git.meli-email.org/meli/meli/releases/tag/v0.8.7

Include Cargo.lock patch to allow building with Rust 1.80,
cf. https://github.com/NixOS/nixpkgs/issues/332957#issuecomment-2278578811
and https://git.meli-email.org/meli/meli/commit/6b05279a0987315c401516cac8ff0b016a8e02a8

Closes: https://github.com/NixOS/nixpkgs/issues/338191

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
