### PR TITLE
fleeting-plugin-aws: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4602,6 +4602,11 @@
     githubId = 87764;
     name = "Ben Ford";
   };
+  commiterate = {
+    github = "commiterate";
+    githubId = 111539270;
+    name = "commiterate";
+  };
   CompEng0001 = {
     email = "sb1501@canterbury.ac.uk";
     github = "CompEng0001";

--- a/pkgs/by-name/fl/fleeting-plugin-aws/package.nix
+++ b/pkgs/by-name/fl/fleeting-plugin-aws/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitLab,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "fleeting-plugin-aws";
+  version = "1.0.0";
+
+  src = fetchFromGitLab {
+    owner = "gitlab-org/fleeting/plugins";
+    repo = "aws";
+    tag = "v${version}";
+    hash = "sha256-8vEduf+xh9R3+GoouXJS2h/ELlzKXDmLBLekaXGn7SE=";
+  };
+
+  vendorHash = "sha256-bfEzPPP280peOK4Jyu1fyfFCaFnRLoPmsjJ+G1BoVW4=";
+
+  subPackages = [ "cmd/fleeting-plugin-aws" ];
+
+  # See https://gitlab.com/gitlab-org/fleeting/plugins/aws/-/blob/v1.0.0/Makefile?ref_type=tags#L20-22.
+  #
+  # Needed for "fleeting-plugin-aws version" to not show "dev".
+  ldflags =
+    let
+      # See https://gitlab.com/gitlab-org/fleeting/plugins/aws/-/blob/v1.0.0/Makefile?ref_type=tags#L14.
+      #
+      # Couldn't find a way to substitute "go list ." into "ldflags".
+      ldflagsPackageVariablePrefix = "gitlab.com/gitlab-org/fleeting/plugins/aws";
+    in
+    [
+      "-X ${ldflagsPackageVariablePrefix}.NAME=fleeting-plugin-aws"
+      "-X ${ldflagsPackageVariablePrefix}.VERSION=v${version}"
+      "-X ${ldflagsPackageVariablePrefix}.REVISION=${src.rev}"
+    ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgram = "${builtins.placeholder "out"}/bin/fleeting-plugin-aws";
+
+  versionCheckProgramArg = "version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "GitLab fleeting plugin for AWS";
+    homepage = "https://gitlab.com/gitlab-org/fleeting/plugins/aws";
+    license = lib.licenses.mit;
+    mainProgram = "fleeting-plugin-aws";
+    maintainers = with lib.maintainers; [ commiterate ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Initialize [fleeting-plugin-aws](https://gitlab.com/gitlab-org/fleeting/plugins/aws) at [1.0.0](https://gitlab.com/gitlab-org/fleeting/plugins/aws/-/releases/v1.0.0).

[Fleeting](https://docs.gitlab.com/runner/fleet_scaling/fleeting.html) is used for [auto-scaling GitLab runners](https://docs.gitlab.com/runner/runner_autoscale) in cloud providers (e.g. AWS, Google Cloud, Azure).

The runner manager/autoscaler needs to have GitLab Runner and the appropriate fleeting plugin installed. GitLab Runner can discover fleeting plugins as long as they're on `PATH`.

For NixOS users, this probably means a NixOS configuration like this:

`configuration.nix`

```nix
{
  config,
  pkgs,
  ...
}:

{
  # ...

  # If you run GitLab Runner as a systemd unit.
  services = {
    gitlab-runner = {
      enable = true;
      extraPackages = with pkgs; [ fleeting-plugin-aws ];

      # ...
    };
  };

  # If you run GitLab Runner via the CLI. This or a user-specific package list with Home Manager.
  environment = {
    systemPackages = with pkgs; [
      gitlab-runner
      fleeting-plugin-aws
    ];
  };

  # ...
}
```

Tested the binary to ensure the Go variable flags used for the `fleeting-plugin-aws version` command works correctly.

```shell
% nix-build -A fleeting-plugin-aws
/nix/store/2hb3yyq8mr4qik4r9gclppgfp3qqac7b-fleeting-plugin-aws-1.0.0

% tree /nix/store/2hb3yyq8mr4qik4r9gclppgfp3qqac7b-fleeting-plugin-aws-1.0.0
/nix/store/2hb3yyq8mr4qik4r9gclppgfp3qqac7b-fleeting-plugin-aws-1.0.0
└── bin
    └── fleeting-plugin-aws

% /nix/store/2hb3yyq8mr4qik4r9gclppgfp3qqac7b-fleeting-plugin-aws-1.0.0/bin/fleeting-plugin-aws version
Name:         fleeting-plugin-aws
Version:      v1.0.0
Git revision: refs/tags/v1.0.0
Git ref:      HEAD
GO version:   go1.22.5
Built:        now
OS/Arch:      darwin/arm64
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
