### PR TITLE
sgx-dcap-default-qpl: init at version 1.21

### DIFF
--- a/pkgs/by-name/sg/sgx-dcap-default-qpl/package.nix
+++ b/pkgs/by-name/sg/sgx-dcap-default-qpl/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  pkg-config,
+  curl,
+  openssl,
+  boost,
+  sgx-sdk,
+}:
+stdenv.mkDerivation rec {
+  pname = "sgx-dcap-default-qpl";
+  version = "1.21";
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "SGXDataCenterAttestationPrimitives";
+    tag = "dcap_${version}_reproducible";
+    hash = "sha256-2ZMu9F46yR4KmTV8Os3fcjgF1uoXxBT50aLx72Ri/WY=";
+    fetchSubmodules = true;
+  };
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    curl
+    openssl
+    boost
+    sgx-sdk
+  ];
+  outputs = [ "out" ];
+  preBuild = ''
+    source ${sgx-sdk}/sgxsdk/environment
+  '';
+  makeFlags = [
+    "-C QuoteGeneration"
+    "qpl_wrapper"
+  ];
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    mv QuoteGeneration/build/linux/* $out/lib
+    ln -s $out/lib/libdcap_quoteprov.so $out/lib/libdcap_quoteprov.so.1
+    ln -s $out/lib/libsgx_default_qcnl_wrapper.so $out/lib/libsgx_default_qcnl_wrapper.so.1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Intel(R) Software Guard Extensions Data Center Attestation Primitives (Intel(R) SGX DCAP) Quote Generation Library";
+    homepage = "https://github.com/intel/SGXDataCenterAttestationPrimitives";
+    maintainers = [ lib.maintainers.ozwaldorf ];
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.bsd3;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Aesmd supports loading in different `libdcap_quoteprov.so` provider plugins. Of which, Intel provides a default quote provisioning library for DCAP remote attestations. However currently, nixpkgs only provides `sgx-azure-dcap-client`.

The intel-provided ubuntu package for the default provider can be found here: https://download.01.org/intel-sgx/sgx_repo/ubuntu/pool/main/libs/libsgx-dcap-default-qpl/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
