### PR TITLE
nesting: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ne/nesting/package.nix
+++ b/pkgs/by-name/ne/nesting/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  # Need macOS 15+ for nested virtualization.
+  apple-sdk_15,
+  buildGoModule,
+  fetchFromGitLab,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "nesting";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    group = "gitlab-org";
+    owner = "fleeting";
+    repo = "nesting";
+    tag = "v${version}";
+    hash = "sha256-ejoLld1TmwaqTlSyuzyEVEqLyEehu6g7yc0H0Cvkqp4=";
+  };
+
+  vendorHash = "sha256-CyXlK/0VWMFlwSfisoaNCRdknasp8faN/K/zdyRhAQQ=";
+
+  subPackages = [ "cmd/nesting" ];
+
+  # See https://gitlab.com/gitlab-org/fleeting/nesting/-/blob/v0.3.0/Makefile?ref_type=tags#L22-24.
+  #
+  # Needed for "nesting version" to not show "dev".
+  ldflags = [
+    "-X gitlab.com/gitlab-org/fleeting/nesting.NAME=nesting"
+    "-X gitlab.com/gitlab-org/fleeting/nesting.VERSION=v${version}"
+    "-X gitlab.com/gitlab-org/fleeting/nesting.REVISION=${src.rev}"
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgramArg = "version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Basic and opinionated daemon that sits in front of virtualization platforms";
+    homepage = "https://gitlab.com/gitlab-org/fleeting/nesting";
+    license = lib.licenses.mit;
+    mainProgram = "nesting";
+    maintainers = with lib.maintainers; [ commiterate ];
+    badPlatforms = [
+      # Only supports AArch64 for Darwin.
+      "x86_64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Initialize [nesting](https://gitlab.com/gitlab-org/fleeting/nesting) at [0.3.0](https://gitlab.com/gitlab-org/fleeting/nesting/-/releases/v0.3.0).

This is used by GitLab Runner for nested virtualization ([example](https://docs.gitlab.com/runner/executors/instance.html#two-jobs-per-instance-unlimited-uses-nested-virtualization-on-ec2-mac-instances)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
