### PR TITLE
python3Packages: don't propagate numpy_1 if also numpy_2 is supported

### DIFF
--- a/pkgs/development/python-modules/contourpy/default.nix
+++ b/pkgs/development/python-modules/contourpy/default.nix
@@ -46,7 +46,9 @@ let
       pybind11
     ];
 
-    propagatedBuildInputs = [ numpy ];
+    # Intentionally not propagating it, so users will be able to use either
+    # numpy_1 or numpy_2
+    buildInputs = [ numpy ];
 
     passthru.optional-depdendencies = {
       bokeh = [

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -73,10 +73,15 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  buildInputs = [ hdf5 ] ++ lib.optional mpiSupport mpi;
+  buildInputs = [
+    hdf5
+    # intentionally not propagating it, to allow anyone to use either numpy_1
+    # or numpy_2
+    numpy
+  ] ++ lib.optional mpiSupport mpi;
 
   propagatedBuildInputs =
-    [ numpy ]
+    [ ]
     ++ lib.optionals mpiSupport [
       mpi4py
       openssh

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -125,6 +125,9 @@ buildPythonPackage rec {
 
   buildInputs =
     [
+      # Intentionally not propagating it, so users will be able to use either
+      # numpy_1 or numpy_2
+      numpy
       ffmpeg-headless
       freetype
       qhull
@@ -159,7 +162,6 @@ buildPythonPackage rec {
       cycler
       fonttools
       kiwisolver
-      numpy
       packaging
       pillow
       pyparsing

--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -185,6 +185,7 @@ buildPythonPackage rec {
     blas = blas.provider;
     blasImplementation = blas.implementation;
     inherit cfg;
+    isNumpy2 = false;
     tests = {
       inherit sage;
     };

--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchPypi,
   python,
+  numpy_1,
   pythonAtLeast,
   pythonOlder,
   buildPythonPackage,
@@ -186,6 +187,7 @@ buildPythonPackage rec {
     blasImplementation = blas.implementation;
     inherit cfg;
     isNumpy2 = false;
+    coreIncludeDir = "${numpy_1}/${python.sitePackages}/numpy/core/include";
     tests = {
       inherit sage;
     };

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -166,6 +166,7 @@ buildPythonPackage rec {
     blas = blas.provider;
     blasImplementation = blas.implementation;
     inherit cfg;
+    isNumpy2 = true;
     tests = {
       inherit sage;
     };

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchPypi,
   python,
+  numpy_2,
   pythonAtLeast,
   pythonOlder,
   buildPythonPackage,
@@ -167,6 +168,7 @@ buildPythonPackage rec {
     blasImplementation = blas.implementation;
     inherit cfg;
     isNumpy2 = true;
+    coreIncludeDir = "${numpy_2}/${python.sitePackages}/numpy/_core/include";
     tests = {
       inherit sage;
     };

--- a/pkgs/development/python-modules/pythran/default.nix
+++ b/pkgs/development/python-modules/pythran/default.nix
@@ -61,10 +61,23 @@ buildPythonPackage rec {
   dependencies = [
     ply
     gast
-    numpy
     beniget
     setuptools
   ];
+  buildInputs = [
+    numpy
+  ];
+  outputs = [
+    "out"
+    # The pythran{,-config} executables are not meant to be functional, unless
+    # used within an environment that incldues numpy, which is intentionally
+    # not propagated.
+    "bin"
+  ];
+  postInstall = ''
+    moveToOutput bin/pythran "''${!outputBin}"
+    moveToOutput bin/pythran-config "''${!outputBin}"
+  '';
 
   pythonImportsCheck = [
     "pythran"

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -65,7 +65,7 @@ let
   # Additional cross compilation related properties that scipy reads in scipy/meson.build
   crossFileScipy = writeText "cross-file-scipy.conf" ''
     [properties]
-    numpy-include-dir = '${numpy}/${python.sitePackages}/numpy/core/include'
+    numpy-include-dir = '${numpy.coreIncludeDir}'
     pythran-include-dir = '${pythran}/${python.sitePackages}/pythran'
     host-python-path = '${python.interpreter}'
     host-python-version = '${python.pythonVersion}'

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -39,6 +39,9 @@
 
   # Reverse dependency
   sage,
+  # Tests (temporary)
+  scipy,
+  numpy_1,
 }:
 
 let
@@ -221,6 +224,9 @@ buildPythonPackage {
       ++ (builtins.attrNames datasetsHashes);
     tests = {
       inherit sage;
+      withNumpy_1 = scipy.override {
+        numpy = numpy_1;
+      };
     };
   };
 

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -131,9 +131,11 @@ buildPythonPackage {
     pybind11
     pooch
     xsimd
+    # Intentionally not propagating it, so users will be able to use either
+    # numpy_1 or numpy_2, although only a specific numpy's headers are used
+    # during compilation.
+    numpy
   ];
-
-  dependencies = [ numpy ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -109,6 +109,8 @@ buildPythonPackage {
       meson-python
       nukeReferences
       pythran
+      # For the f2py executable
+      numpy
       pkg-config
       setuptools
     ]

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -96,12 +96,15 @@ buildPythonPackage {
   # both numpy 2 and numpy 1 should work, but they seem to worry about numpy
   # incompatibilities that we here with Nixpkgs' Python ecosystem, shouldn't
   # experience.
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'numpy>=2.0.0rc1,' 'numpy' \
-      --replace-fail "pybind11>=2.12.0,<2.13.0" "pybind11>=2.12.0" \
-  '';
-
+  postPatch =
+    ''
+      substituteInPlace pyproject.toml \
+        --replace-fail "pybind11>=2.12.0,<2.13.0" "pybind11>=2.12.0"
+    ''
+    + lib.optionalString (!numpy.isNumpy2) ''
+      substituteInPlace pyproject.toml \
+        --replace-fail 'numpy>=2.0.0rc1,' 'numpy'
+    '';
   build-system =
     [
       cython

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14204,7 +14204,9 @@ self: super: with self; {
 
   scikit-tda = callPackage ../development/python-modules/scikit-tda { };
 
-  scipy = callPackage ../development/python-modules/scipy { };
+  scipy = callPackage ../development/python-modules/scipy {
+    numpy = numpy_2;
+  };
 
   scmrepo = callPackage ../development/python-modules/scmrepo { };
 


### PR DESCRIPTION
Many Python packages nowadays support both numpy versions, and even when they have components compiled against either, they don't retain references to either numpy, unless of course the numpy used is propagated. Hence it would be nice to enable users to choose either, and not force them to stick them to numpy_1 just because some dependency is propagating numpy_1 and you don't want multiple numpy versions in your nix shell or whatever.

## Description of changes

- **python312Packages.numpy_1: add an isNumpy2 passthru attribute**
- **python312Packages.numpy_2: add an isNumpy2 passthru attribute**
- **python312Packages.numpy_1: add a coreIncludeDir passthru attribute**
- **python312Packages.numpy_2: add a coreIncludeDir passthru attribute**
- **python312Packages.h5py: don't propagate numpy_1**
- **python312Packages.scipy: use numpy.coreIncludeDir**
- **python312Packages.scipy: don't propagate numpy_1**
- **python312Packages.contourpy: don't propagate numpy_1**
- **python312Packages.matplotlib: don't propagate numpy_1**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
