### PR TITLE
lib.platforms.mesaPlatforms: remove

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -114,6 +114,4 @@ in {
   genode        = filterDoubles predicates.isGenode;
 
   embedded      = filterDoubles predicates.isNone;
-
-  mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "armv7a-linux" "aarch64-linux" "powerpc64-linux" "powerpc64le-linux" "aarch64-darwin" "riscv64-linux"];
 }

--- a/pkgs/applications/science/astronomy/gravit/default.nix
+++ b/pkgs/applications/science/astronomy/gravit/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, SDL, SDL_ttf, SDL_image, libSM, libICE, libGLU, libGL, libpng, lua5, autoconf, automake }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, SDL, SDL_ttf, SDL_image, libSM, libICE, libGLU, libGL, libpng, lua5, autoconf, automake, mesa }:
 
 stdenv.mkDerivation rec {
   pname = "gravit";
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
       view in 3D and zoom in and out.
     '';
 
-    platforms = lib.platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     hydraPlatforms = lib.platforms.linux; # darwin times out
   };
 }

--- a/pkgs/applications/science/chemistry/avogadro2/default.nix
+++ b/pkgs/applications/science/chemistry/avogadro2/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, eigen, avogadrolibs, molequeue, hdf5
-, openbabel, qttools, wrapQtAppsHook
+, openbabel, qttools, wrapQtAppsHook, mesa
 }:
 
 let
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
     mainProgram = "avogadro2";
     maintainers = with maintainers; [ sheepforce ];
     homepage = "https://github.com/OpenChemistry/avogadroapp";
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   nix-update-script,
   pkg-config,
-  libGLSupported ? lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms,
+  libGLSupported ? lib.elem stdenv.hostPlatform.system mesa.meta.platforms,
   openglSupport ? libGLSupported,
   libGL,
   alsaSupport ? stdenv.isLinux && !stdenv.hostPlatform.isAndroid,

--- a/pkgs/development/libraries/SDL_compat/default.nix
+++ b/pkgs/development/libraries/SDL_compat/default.nix
@@ -7,7 +7,8 @@
 , libiconv
 , Cocoa
 , autoSignDarwinBinariesHook
-, libGLSupported ? lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms
+, mesa
+, libGLSupported ? lib.elem stdenv.hostPlatform.system mesa.meta.platforms
 , openglSupport ? libGLSupported
 , libGLU
 }:

--- a/pkgs/development/libraries/fox/fox-1.6.nix
+++ b/pkgs/development/libraries/fox/fox-1.6.nix
@@ -13,6 +13,7 @@
 , libXext
 , libXft
 , libXfixes
+, mesa
 , xinput
 , CoreServices
 }:
@@ -50,6 +51,6 @@ stdenv.mkDerivation rec {
     homepage = "http://fox-toolkit.org";
     license = lib.licenses.lgpl3;
     maintainers = [ ];
-    platforms = lib.platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
   };
 }

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl, libGLU, libXmu, libXi, libXext
 , AGL, OpenGL
 , testers
+, mesa
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -52,6 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.free; # different files under different licenses
       #["BSD" "GLX" "SGI-B" "GPL2"]
     pkgConfigModules = [ "glew" ];
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
   };
 })

--- a/pkgs/development/libraries/glew/default.nix
+++ b/pkgs/development/libraries/glew/default.nix
@@ -10,6 +10,7 @@
 , OpenGL
 , enableEGL ? (!stdenv.isDarwin)
 , testers
+, mesa
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -74,8 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkgConfigModules = [ "glew" ];
     platforms = with platforms;
       if enableEGL then
-        subtractLists darwin mesaPlatforms
+        subtractLists darwin mesa.meta.platforms
       else
-        mesaPlatforms;
+        mesa.meta.platforms;
   };
 })

--- a/pkgs/development/libraries/libdevil/default.nix
+++ b/pkgs/development/libraries/libdevil/default.nix
@@ -15,6 +15,7 @@
 , runtimeShell
 , withXorg ? true
 , testers
+, mesa
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -65,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "ilur";
     license = licenses.lgpl2;
     pkgConfigModules = [ "IL" ];
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = [ ];
   };
 })

--- a/pkgs/development/libraries/mesa/common.nix
+++ b/pkgs/development/libraries/mesa/common.nix
@@ -29,7 +29,11 @@ rec {
     homepage = "https://www.mesa3d.org/";
     changelog = "https://www.mesa3d.org/relnotes/${version}.html";
     license = with lib.licenses; [ mit ]; # X11 variant, in most files
-    platforms = lib.platforms.mesaPlatforms;
+    platforms = [
+      "i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux"
+      "armv6l-linux" "armv7l-linux" "armv7a-linux" "aarch64-linux"
+      "powerpc64-linux" "powerpc64le-linux" "aarch64-darwin" "riscv64-linux"
+    ];
     maintainers = with lib.maintainers; [ primeos vcunat ]; # Help is welcome :)
   };
 }

--- a/pkgs/development/libraries/waffle/default.nix
+++ b/pkgs/development/libraries/waffle/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
     mainProgram = "wflinfo";
     homepage = "https://www.waffle-gl.org/";
     license = licenses.bsd2;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = with maintainers; [ Flakebi ];
   };
 }

--- a/pkgs/development/python-modules/moderngl-window/default.nix
+++ b/pkgs/development/python-modules/moderngl-window/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   setuptools,
   glfw,
+  mesa,
   moderngl,
   numpy,
   pillow,
@@ -70,7 +71,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/moderngl/moderngl-window/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ c0deaddict ];
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/moderngl/default.nix
+++ b/pkgs/development/python-modules/moderngl/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/moderngl/moderngl/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ c0deaddict ];
-    # should be mesaPlatforms, darwin build breaks.
+    # should be mesa.meta.platforms, darwin build breaks.
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/pyglet/default.nix
+++ b/pkgs/development/python-modules/pyglet/default.nix
@@ -17,6 +17,7 @@
   ffmpeg-full,
   openal,
   libpulseaudio,
+  mesa,
 }:
 
 buildPythonPackage rec {
@@ -109,6 +110,6 @@ buildPythonPackage rec {
     homepage = "http://www.pyglet.org/";
     description = "Cross-platform windowing and multimedia library";
     license = licenses.bsd3;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
   };
 }

--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -5,6 +5,7 @@
   fetchPypi,
   pkgs,
   pillow,
+  mesa,
 }:
 
 buildPythonPackage rec {
@@ -80,6 +81,6 @@ buildPythonPackage rec {
       liberal BSD-style Open-Source license.
     '';
     license = licenses.bsd3;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
   };
 }

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -13,6 +13,7 @@
   pyqt5-sip,
   pyqt-builder,
   libsForQt5,
+  mesa,
   enableVerbose ? true,
   withConnectivity ? false,
   withMultimedia ? false,
@@ -201,7 +202,7 @@ buildPythonPackage rec {
     description = "Python bindings for Qt5";
     homepage = "https://riverbankcomputing.com/";
     license = licenses.gpl3Only;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = with maintainers; [ sander ];
   };
 }

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -13,6 +13,7 @@
   pyqt-builder,
   qt6Packages,
   pythonOlder,
+  mesa,
   withMultimedia ? true,
   withWebSockets ? true,
   withLocation ? true,
@@ -150,7 +151,7 @@ buildPythonPackage rec {
     description = "Python bindings for Qt6";
     homepage = "https://riverbankcomputing.com/";
     license = licenses.gpl3Only;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = with maintainers; [ LunNova ];
   };
 }

--- a/pkgs/development/python-modules/pyqt/pyqt6-sip.nix
+++ b/pkgs/development/python-modules/pyqt/pyqt6-sip.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  mesa,
 }:
 
 buildPythonPackage rec {
@@ -23,7 +24,7 @@ buildPythonPackage rec {
     description = "Python bindings for Qt5";
     homepage = "https://www.riverbankcomputing.com/software/sip/";
     license = licenses.gpl3Only;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = with maintainers; [ LunNova ];
   };
 }

--- a/pkgs/development/python-modules/pyqt/sip.nix
+++ b/pkgs/development/python-modules/pyqt/sip.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  mesa,
 }:
 
 buildPythonPackage rec {
@@ -23,7 +24,7 @@ buildPythonPackage rec {
     description = "Python bindings for Qt5";
     homepage = "https://www.riverbankcomputing.com/software/sip/";
     license = licenses.gpl3Only;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = with maintainers; [ sander ];
   };
 }

--- a/pkgs/development/python-modules/pyqt6-charts/default.nix
+++ b/pkgs/development/python-modules/pyqt6-charts/default.nix
@@ -8,6 +8,7 @@
   pythonOlder,
   pyqt6,
   python,
+  mesa,
 }:
 
 buildPythonPackage rec {
@@ -67,7 +68,7 @@ buildPythonPackage rec {
     description = "Python bindings for Qt6 QtCharts";
     homepage = "https://riverbankcomputing.com/";
     license = licenses.gpl3Only;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = with maintainers; [ dandellion ];
   };
 }

--- a/pkgs/development/python-modules/pyqt6-webengine/default.nix
+++ b/pkgs/development/python-modules/pyqt6-webengine/default.nix
@@ -10,6 +10,7 @@
   pythonOlder,
   pyqt6,
   python,
+  mesa,
 }:
 
 buildPythonPackage rec {
@@ -84,7 +85,7 @@ buildPythonPackage rec {
     description = "Python bindings for Qt6 WebEngine";
     homepage = "https://riverbankcomputing.com/";
     license = licenses.gpl3Only;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = with maintainers; [
       LunNova
       nrdxp

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -12,6 +12,7 @@
   pyqt5,
   sip,
   pyqt-builder,
+  mesa,
 }:
 
 let
@@ -98,7 +99,7 @@ buildPythonPackage (
       description = "Python bindings for Qt5";
       homepage = "http://www.riverbankcomputing.co.uk";
       license = lib.licenses.gpl3;
-      hydraPlatforms = lib.lists.intersectLists libsForQt5.qtwebengine.meta.platforms lib.platforms.mesaPlatforms;
+      hydraPlatforms = lib.lists.intersectLists libsForQt5.qtwebengine.meta.platforms mesa.meta.platforms;
     };
   }
   // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -25,6 +25,8 @@
   AVKit,
   CoreAudio,
   swift,
+
+  mesa,
 }:
 
 let
@@ -336,7 +338,7 @@ python3.pkgs.buildPythonApplication {
     '';
     homepage = "https://apps.ankiweb.net";
     license = licenses.agpl3Plus;
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = with maintainers; [
       euank
       oxij

--- a/pkgs/tools/graphics/piglit/default.nix
+++ b/pkgs/tools/graphics/piglit/default.nix
@@ -16,6 +16,7 @@
 , libXrender
 , libxcb
 , libxkbcommon
+, mesa
 }:
 
 stdenv.mkDerivation rec {
@@ -71,7 +72,7 @@ stdenv.mkDerivation rec {
     description = "OpenGL test suite, and test-suite runner";
     homepage = "https://gitlab.freedesktop.org/mesa/piglit";
     license = licenses.free; # custom license. See COPYING in the source repo.
-    platforms = platforms.mesaPlatforms;
+    inherit (mesa.meta) platforms;
     maintainers = with maintainers; [ Flakebi ];
     mainProgram = "piglit";
   };

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -178,7 +178,7 @@ let
 
 in {
   /* Common platform groups on which to test packages. */
-  inherit (platforms) unix linux darwin cygwin all mesaPlatforms;
+  inherit (platforms) unix linux darwin cygwin all;
 
   inherit
     assertTrue


### PR DESCRIPTION
## Description of changes

Mesa is a package like any other.  There's no reason for it to be a special case with its platforms listed in lib, because if other packages want to refer to mesa's platforms, they can access the platforms from the package meta like they would for any other package.

This is quite similar to #234491, but more conservative -- no platform values are changed at this stage.

I don't think it's feasible to do a proper deprecation for this because that's hard in this part of lib, but I don't expect much out of tree usage, and the fix is very simple (and compatible with 24.05) if it is.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
