### PR TITLE
libogg: allow dependents to find it with cmake

### DIFF
--- a/pkgs/development/libraries/libogg/default.nix
+++ b/pkgs/development/libraries/libogg/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -17,6 +18,14 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
     "doc"
+  ];
+
+  nativeBuildInputs = [
+    # Can also be built with the `./configure` script available in the release,
+    # however using cmake makes sure the resulting tree would include
+    # `OggConfig.cmake` and other cmake files useful when packages try to look it
+    # up with cmake.
+    cmake
   ];
 
   meta = {

--- a/pkgs/development/libraries/libogg/default.nix
+++ b/pkgs/development/libraries/libogg/default.nix
@@ -1,17 +1,25 @@
-{ lib, stdenv, fetchurl }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libogg";
   version = "1.3.5";
 
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/ogg/${pname}-${version}.tar.xz";
+    url = "http://downloads.xiph.org/releases/ogg/libogg-${finalAttrs.version}.tar.xz";
     sha256 = "01b7050bghdvbxvw0gzv588fn4a27zh42ljpwzm4vrf8dziipnf4";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "Media container library to manipulate Ogg files";
     longDescription = ''
       Library to work with Ogg multimedia container format.
@@ -19,8 +27,8 @@ stdenv.mkDerivation rec {
       plethora of codecs. Open format free for anyone to use.
     '';
     homepage = "https://xiph.org/ogg/";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.ehmry ];
-    platforms = platforms.all;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ehmry ];
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
