### PR TITLE
igv: only replace actual java commands with the full path

### DIFF
--- a/pkgs/applications/science/biology/igv/default.nix
+++ b/pkgs/applications/science/biology/igv/default.nix
@@ -13,10 +13,10 @@ stdenv.mkDerivation rec {
     cp -Rv * $out/share/
 
     sed -i "s#prefix=.*#prefix=$out/share#g" $out/share/igv.sh
-    sed -i 's#java#${jdk17}/bin/java#g' $out/share/igv.sh
+    sed -i 's#\bjava\b#${jdk17}/bin/java#g' $out/share/igv.sh
 
     sed -i "s#prefix=.*#prefix=$out/share#g" $out/share/igvtools
-    sed -i 's#java#${jdk17}/bin/java#g' $out/share/igvtools
+    sed -i 's#\bjava\b#${jdk17}/bin/java#g' $out/share/igvtools
 
     ln -s $out/share/igv.sh $out/bin/igv
     ln -s $out/share/igvtools $out/bin/igvtools


### PR DESCRIPTION
## Description of changes

The installPhase script for IGV patches multiple shell scripts (included in the [upstream package](https://github.com/igvteam/igv/blob/main/scripts/igv.sh#L30)) with full paths to the Java binary. Unfortunately, the regex used for that is too broad, and unintentionally overwrites parameters containing the "java" substring.

This change updates the regex to only match on word boundaries.

Before:

```
# Check if there is a user-specified Java arguments file
if [ -e "$HOME/.igv//nix/store/9d9qfkz7c68wxx5ip31bxkl8jsqqqnrg-openjdk-17.0.7+7/bin/java_arguments" ]; then
    /nix/store/9d9qfkz7c68wxx5ip31bxkl8jsqqqnrg-openjdk-17.0.7+7/bin/java --module-path="${prefix}/lib" -Xmx8g \
        @"${prefix}/igv.args" \
        -Dapple.laf.useScreenMenuBar=true \
        -D/nix/store/9d9qfkz7c68wxx5ip31bxkl8jsqqqnrg-openjdk-17.0.7+7/bin/java.net.preferIPv4Stack=true \
        -D/nix/store/9d9qfkz7c68wxx5ip31bxkl8jsqqqnrg-openjdk-17.0.7+7/bin/java.net.useSystemProxies=true \
        @"$HOME/.igv//nix/store/9d9qfkz7c68wxx5ip31bxkl8jsqqqnrg-openjdk-17.0.7+7/bin/java_arguments" \
        --module=org.igv/org.broad.igv.ui.Main "$@"
```

after:

```
# Check if there is a user-specified Java arguments file
if [ -e "$HOME/.igv/java_arguments" ]; then
    /nix/store/zv325ff26ahbywl59q8cj9vm63sisna6-openjdk-17.0.11+9/bin/java --module-path="${prefix}/lib" -Xmx8g \
        @"${prefix}/igv.args" \
        -Dapple.laf.useScreenMenuBar=true \
        -Djava.net.preferIPv4Stack=true \
        -Djava.net.useSystemProxies=true \
        @"$HOME/.igv/java_arguments" \
        --module=org.igv/org.broad.igv.ui.Main "$@"
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
