### PR TITLE
tuir: use the maintained fork and update 1.29.0 -> 1.31.0

### DIFF
--- a/pkgs/applications/misc/tuir/default.nix
+++ b/pkgs/applications/misc/tuir/default.nix
@@ -28,6 +28,6 @@ buildPythonApplication rec {
     mainProgram = "tuir";
     homepage = "https://gitlab.com/Chocimier/tuir";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne matthiasbeyer ];
+    maintainers = with maintainers; [ Br1ght0ne matthiasbeyer brokenpip3 ];
   };
 }

--- a/pkgs/applications/misc/tuir/default.nix
+++ b/pkgs/applications/misc/tuir/default.nix
@@ -3,13 +3,13 @@
 with python3Packages;
 buildPythonApplication rec {
   pname = "tuir";
-  version = "1.29.0";
+  version = "1.31.0";
 
   src = fetchFromGitLab {
-    owner = "ajak";
+    owner = "Chocimier";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1fqp6bvq8kzdsf3nna4mn1phdcixpx76bya43xrivxjbzsfl59ib";
+    hash = "sha256-VYBtD3Ex6+iIRNvX6jF0b0iPvno41/58xCRydiyssvk=";
   };
 
   # Tests try to access network
@@ -21,12 +21,12 @@ buildPythonApplication rec {
 
   nativeCheckInputs = [ coverage coveralls docopt mock pylint pytest vcrpy ];
 
-  propagatedBuildInputs = [ beautifulsoup4 decorator kitchen requests six ];
+  propagatedBuildInputs = [ beautifulsoup4 decorator kitchen mailcap-fix requests six ];
 
   meta = with lib; {
     description = "Browse Reddit from your Terminal (fork of rtv)";
     mainProgram = "tuir";
-    homepage = "https://gitlab.com/ajak/tuir/";
+    homepage = "https://gitlab.com/Chocimier/tuir";
     license = licenses.mit;
     maintainers = with maintainers; [ Br1ght0ne matthiasbeyer ];
   };


### PR DESCRIPTION
## Description of changes

The latest commit of original forked from rtv tuir is more than 4 years ago: https://gitlab.com/ajak/tuir. Also that version currently does not allow to login and comment/post in reddit and have some navigation bug.
Recently arise a actively supported fork from [Chocimier](https://github.com/Chocimie): https://gitlab.com/Chocimier/tuir that is also listed here: https://gist.github.com/michael-lazar/8c31b9f637c3b9d7fbdcbb0eebcf2b0a
I reviewed the latest [changes](https://gitlab.com/Chocimier/tuir/-/compare/master...master?from_project_id=12748921) from upstream and tested it with a derivation, everything is working again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
