### PR TITLE
ibmcloud-cli: 2.17.0 -> 2.27.0

### DIFF
--- a/pkgs/tools/admin/ibmcloud-cli/default.nix
+++ b/pkgs/tools/admin/ibmcloud-cli/default.nix
@@ -16,18 +16,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ibmcloud-cli";
-  version = "2.17.0";
+  version = "2.27.0";
 
   src = fetchurl {
     url = "https://download.clis.cloud.ibm.com/ibm-cloud-cli/${finalAttrs.version}/binaries/IBM_Cloud_CLI_${finalAttrs.version}_${platform}.tgz";
     sha256 = {
-      "x86_64-darwin"     = "18f0dylgwwn9p1jmchqhq061s435n85qr2872i532whbrziwwjf3";
-      "aarch64-darwin"    = "1rid6rv601z4ayd3yi5srqbfn5bspypxarikvm563ygxawh1bxyi";
-      "x86_64-linux"      = "0ry8ix5id2zk04w9d9581g127f9jpj7bwg3x0pk3n9yfwn61g96d";
-      "aarch64-linux"     = "0s5jaqhyl234670q1mg89in2g5b9w3gzvnzl8qmlmgqkaxvzxj94";
-      "i686-linux"        = "0iw8y7iy9yx7y8v8b2wfl24f2rv9r20yj7l4sislxspfyvqv54p2";
-      "powerpc64le-linux" = "19ac0na163l9h7ygbf3jwwv7zf0wagqvn6kcdh871c690i86wg9z";
-      "s390x-linux"       = "1zvy28jpxijzgdbr9q4rfyx6mk295mqp4nk8z299nm9ryk4q81lv";
+      "x86_64-darwin"     = "0af5f110e094e7bf710c86d1e35af23ebbbc9ad8a4baf2a67895354b415618f6";
+      "aarch64-darwin"    = "1175977597102282cf7c1fd017ec4bdbc041ce367360204852d0798846cd21e4";
+      "x86_64-linux"      = "3c024bcb27519c8ed916ebc0266248249c127bbe93c343807e07d707cf159bb1";
+      "aarch64-linux"     = "bd2a6a3c4428061f17ac8b801b27d9700bf333284294e2834c34b4237f530256";
+      "i686-linux"        = "40dc32b2a76541847fd55b5b587105c90956468baf14016e4628bb8a2a3d73fa";
+      "powerpc64le-linux" = "e758a60d7de32f4dfc8c944edb8e45bbed41de2fcb1e12bcf6b4e2b35d09f9d5";
+      "s390x-linux"       = "dbee26a3c4be2dcaad28b110e309283c141d55ac923b9d0420ac62b25c8eb9c0";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 


### PR DESCRIPTION
## Description of changes

This pkg hasn't been updated since its initial nixpkgs release at [v2.17.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.17.0). Updating it to the latest available [v2.27.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.27.0), which encompasses the following releases (link to changelogs):

| RELEASE URL                                                                        | DATE       |
| ---------------------------------------------------------------------------------- | ---------- |
| [v2.27.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.27.0) | 2024-07-10 |
| [v2.26.1](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.26.1) | 2024-06-19 |
| [v2.26.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.26.0) | 2024-06-17 |
| [v2.25.1](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.25.1) | 2024-05-31 |
| [v2.25.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.25.0) | 2024-05-16 |
| [v2.24.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.24.0) | 2024-03-25 |
| [v2.23.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.23.0) | 2024-02-05 |
| [v2.22.1](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.22.1) | 2023-12-13 |
| [v2.22.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.22.0) | 2023-12-08 |
| [v2.21.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.21.0) | 2023-10-27 |
| [v2.20.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.20.0) | 2023-09-21 |
| [v2.19.1](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.19.1) | 2023-09-11 |
| [v2.19.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.19.0) | 2023-09-05 |
| [v2.18.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.18.0) | 2023-07-26 |
| [v2.17.1](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v2.17.1) | 2023-06-23 |


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).