### PR TITLE
build-dotnet-module: reintroduce tmpdir fix

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/fetch-deps.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/fetch-deps.sh
@@ -7,7 +7,7 @@ if [[ ${TMPDIR:-} == /run/user/* ]]; then
     unset TMPDIR
 fi
 
-tmp=$(mktemp -d)
+tmp=$(mktemp -dt "dotnet-deps.XXXXX")
 trap 'rm -rf "$tmp"' EXIT
 
 HOME=$tmp/.home

--- a/pkgs/build-support/dotnet/build-dotnet-module/fetch-deps.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/fetch-deps.sh
@@ -8,7 +8,7 @@ if [[ ${TMPDIR:-} == /run/user/* ]]; then
 fi
 
 tmp=$(mktemp -d)
-trap 'chmod -R +w "$tmp" && rm -fr "$tmp"' EXIT
+trap 'rm -rf "$tmp"' EXIT
 
 HOME=$tmp/.home
 cd "$tmp"

--- a/pkgs/build-support/dotnet/build-dotnet-module/fetch-deps.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/fetch-deps.sh
@@ -1,5 +1,12 @@
 set -e
 
+if [[ ${TMPDIR:-} == /run/user/* ]]; then
+    # /run/user is usually a tmpfs in RAM, which may be too small
+    # to store all downloaded dotnet packages
+    # `TMPDIR` is used by `mktemp` below.
+    unset TMPDIR
+fi
+
 tmp=$(mktemp -d)
 trap 'chmod -R +w "$tmp" && rm -fr "$tmp"' EXIT
 


### PR DESCRIPTION
Reintroduce the fix from #209357 which was deleted in #327651.

@corngood, was there a reason for deleting this?