### PR TITLE
nekoray: refactor source fetching and geodata copying

### DIFF
--- a/pkgs/by-name/ne/nekoray/nekobox-core.nix
+++ b/pkgs/by-name/ne/nekoray/nekobox-core.nix
@@ -2,20 +2,13 @@
   buildGoModule,
   version,
   src,
-  extraSources,
 }:
 
 buildGoModule rec {
   pname = "nekobox-core";
   inherit version src;
-  sourceRoot = "${src.name}/go/cmd/nekobox_core";
 
-  postPatch = ''
-    cp -r --no-preserve=all ${extraSources.libneko} ../../../../libneko
-    cp -r --no-preserve=all ${extraSources.sing-box-extra} ../../../../sing-box-extra
-    cp -r --no-preserve=all ${extraSources.sing-box} ../../../../sing-box
-    cp -r --no-preserve=all ${extraSources.sing-quic} ../../../../sing-quic
-  '';
+  sourceRoot = "${src.name}/nekoray/go/cmd/nekobox_core";
 
   vendorHash = "sha256-q/Co67AwJVElJnEY2O0SLLUzwlGiqazKu+fD/nnbrTk=";
 

--- a/pkgs/by-name/ne/nekoray/nekoray-core.nix
+++ b/pkgs/by-name/ne/nekoray/nekoray-core.nix
@@ -2,18 +2,13 @@
   buildGoModule,
   version,
   src,
-  extraSources,
 }:
 
 buildGoModule rec {
   pname = "nekoray-core";
   inherit version src;
-  sourceRoot = "${src.name}/go/cmd/nekoray_core";
 
-  postPatch = ''
-    cp -r --no-preserve=all ${extraSources.libneko} ../../../../libneko
-    cp -r --no-preserve=all ${extraSources.Xray-core} ../../../../Xray-core
-  '';
+  sourceRoot = "${src.name}/nekoray/go/cmd/nekoray_core";
 
   vendorHash = "sha256-gxp5oI7qO+bdSe8Yrb9I4Wkl5TqqZeIhzcQDg1OpRkc=";
 
@@ -21,6 +16,6 @@ buildGoModule rec {
     "-w"
     "-s"
     "-X github.com/matsuridayo/libneko/neko_common.Version_neko=${version}"
-    "-X github.com/matsuridayo/libneko/neko_common.Version_v2ray=${extraSources.Xray-core.rev}"
+    "-X github.com/matsuridayo/libneko/neko_common.Version_v2ray=???"
   ];
 }

--- a/pkgs/by-name/ne/nekoray/package.nix
+++ b/pkgs/by-name/ne/nekoray/package.nix
@@ -18,71 +18,39 @@
   sing-geosite,
 }:
 
-let
-  fetchSource =
-    args:
-    fetchFromGitHub (
-      args
-      // {
-        owner = "MatsuriDayo";
-        repo = args.name;
-      }
-    );
-
-  extraSources = {
-    # revs found in https://github.com/MatsuriDayo/nekoray/blob/<version>/libs/get_source_env.sh
-    Xray-core = fetchSource {
-      name = "Xray-core";
-      rev = "01208225ee7e508044cca8eb6776a117bcecd997";
-      hash = "sha256-R66i9MITdE9JlhD4wV0EitKPxyahQqDNpunUxVTmupA=";
-    };
-    sing-box-extra = fetchSource {
-      name = "sing-box-extra";
-      rev = "d31d6da26a51a929349e0d75fd89dccbe20d1268";
-      hash = "sha256-YlzMAff8VOZGyCP7ksjcmoBDHT5llTYwwXIrs+qO5P4=";
-    };
-
-    # revs found in https://github.com/MatsuriDayo/sing-box-extra/blob/<sing-box-extra.rev>/libs/get_source_env.sh
-    sing-box = fetchSource {
-      name = "sing-box";
-      rev = "64f4eed2c667d9ff1e52a84233dee0e2ca32c17e";
-      hash = "sha256-jIg/+fvTn46h6tE6YXtov+ZaBD/ywApTZbzHlT5v4lM=";
-    };
-    sing-quic = fetchSource {
-      name = "sing-quic";
-      rev = "e396733db4de15266f0cfdb43c392aca0759324a";
-      hash = "sha256-un5NtZPRx1QAjwNhXkR9OVGldtfM1jQoNRUzt9oilUE=";
-    };
-    libneko = fetchSource {
-      name = "libneko";
-      rev = "5277a5bfc889ee7a89462695b0e678c1bd4909b1";
-      hash = "sha256-6dlWDzI9ox4PQzEtJNgwA0pXmPC7fGrGId88Zl+1gpw=";
-    };
-  };
-
-  geodata = {
-    "geoip.dat" = "${v2ray-geoip}/share/v2ray/geoip.dat";
-    "geosite.dat" = "${v2ray-domain-list-community}/share/v2ray/geosite.dat";
-    "geoip.db" = "${sing-geoip}/share/sing-box/geoip.db";
-    "geosite.db" = "${sing-geosite}/share/sing-box/geosite.db";
-  };
-
-  installGeodata = lib.concatStringsSep "\n" (
-    lib.mapAttrsToList (filename: file: ''
-      install -Dm644 ${file} "$out/share/nekoray/${filename}"
-    '') geodata
-  );
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nekoray";
   version = "3.26";
 
-  src = fetchSource {
-    name = "nekoray";
+  # the actual nekoray sources will be under the /nekoray subdirectory
+  # the sources of the fetched dependencies will be siblings of it
+  src = fetchFromGitHub {
+    owner = "MatsuriDayo";
+    repo = "nekoray";
     rev = finalAttrs.version;
-    hash = "sha256-fDm6fCI6XA4DHKCN3zm9B7Qbdh3LTHYGK8fPmeEnhjI=";
+    hash = "sha256-4zXVjFS4gYdegkR7uPFSvcxjorCBbecL9lkYZXJ5VSo=";
     fetchSubmodules = true;
+
+    postFetch = ''
+      mv $out nekoray
+      mkdir $out
+      mv nekoray $out/nekoray
+      cd $out/nekoray
+
+      substituteInPlace libs/get_source.sh --replace-fail \
+          './libs/get_source.sh' '. ./libs/get_source.sh'
+      . ./libs/get_source.sh
+
+      cd ..
+
+      find -type d -name .git -prune -execdir rm -r {} +
+
+      # upstream has some references to /nix/store inside this file for some reason
+      rm sing-box/.goreleaser.yaml
+    '';
   };
+
+  sourceRoot = "${finalAttrs.src.name}/nekoray";
 
   strictDeps = true;
 
@@ -111,16 +79,20 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     install -Dm755 nekoray "$out/share/nekoray/nekoray"
-    mkdir -p "$out/bin"
-    ln -s "$out/share/nekoray/nekoray" "$out/bin"
 
     # nekoray looks for other files and cores in the same directory it's located at
     ln -s ${finalAttrs.passthru.nekoray-core}/bin/nekoray_core "$out/share/nekoray/nekoray_core"
     ln -s ${finalAttrs.passthru.nekobox-core}/bin/nekobox_core "$out/share/nekoray/nekobox_core"
 
-    ${installGeodata}
+    install -Dm644 ${v2ray-geoip}/share/v2ray/geoip.dat "$out/share/nekoray/geoip.dat"
+    install -Dm644 ${v2ray-domain-list-community}/share/v2ray/geosite.dat "$out/share/nekoray/geosite.dat"
+    install -Dm644 ${sing-geoip}/share/sing-box/geoip.db "$out/share/nekoray/geoip.db"
+    install -Dm644 ${sing-geosite}/share/sing-box/geosite.db "$out/share/nekoray/geosite.db"
 
-    install -Dm644 "$src/res/public/nekoray.png" "$out/share/icons/hicolor/256x256/apps/nekoray.png"
+    install -Dm644 "$src/nekoray/res/public/nekoray.png" "$out/share/icons/hicolor/256x256/apps/nekoray.png"
+
+    mkdir -p "$out/bin"
+    ln -s "$out/share/nekoray/nekoray" "$out/bin/nekoray"
 
     runHook postInstall
   '';
@@ -128,27 +100,18 @@ stdenv.mkDerivation (finalAttrs: {
   desktopItems = [
     (makeDesktopItem {
       name = "nekoray";
-      desktopName = "nekoray";
+      desktopName = "NekoRay";
       exec = "nekoray";
       icon = "nekoray";
       comment = finalAttrs.meta.description;
       terminal = false;
-      categories = [
-        "Network"
-        "Application"
-      ];
+      categories = [ "Network" ];
     })
   ];
 
   passthru = {
-    nekobox-core = callPackage ./nekobox-core.nix {
-      inherit (finalAttrs) src version;
-      inherit extraSources;
-    };
-    nekoray-core = callPackage ./nekoray-core.nix {
-      inherit (finalAttrs) src version;
-      inherit extraSources;
-    };
+    nekobox-core = callPackage ./nekobox-core.nix { inherit (finalAttrs) version src; };
+    nekoray-core = callPackage ./nekoray-core.nix { inherit (finalAttrs) version src; };
   };
 
   meta = {


### PR DESCRIPTION
## Description of changes

This PR simplifies the fetching of the sources of `nekoray` by using the provided shell scripts in the repo itself. The shell script uses hard-coded revision numbers so this should be deterministic.

Also, `installGeodata` was not really necessary anymore. So I expanded it directly into the `installPhase`.

This PR should be NOOP functionality-wise.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
