### PR TITLE
Sirius python module

### DIFF
--- a/pkgs/by-name/si/sirius/package.nix
+++ b/pkgs/by-name/si/sirius/package.nix
@@ -21,6 +21,8 @@
 , boost
 , eigen
 , libvdwxc
+, enablePython ? false
+, pythonPackages ? null
 , llvmPackages
 , cudaPackages
 , rocmPackages
@@ -35,6 +37,7 @@
 }:
 
 assert builtins.elem gpuBackend [ "none" "cuda" "rocm" ];
+assert enablePython -> pythonPackages != null;
 
 stdenv.mkDerivation rec {
   pname = "SIRIUS";
@@ -81,10 +84,23 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (gpuBackend == "rocm") [
     rocmPackages.clr
     rocmPackages.rocblas
-  ] ++ lib.optional stdenv.isDarwin llvmPackages.openmp
-  ;
+  ] ++ lib.optionals stdenv.isDarwin [
+    llvmPackages.openmp
+  ] ++ lib.optionals enablePython (with pythonPackages; [
+    python
+    pybind11
+  ]);
 
-  propagatedBuildInputs = [ (lib.getBin mpi) ];
+  propagatedBuildInputs = [
+    (lib.getBin mpi)
+  ] ++ lib.optionals enablePython (with pythonPackages; [
+    mpi4py
+    voluptuous
+    numpy
+    h5py
+    scipy
+    pyyaml
+  ]);
 
   CXXFLAGS = [
     # GCC 13: error: 'uintptr_t' in namespace 'std' does not name a type
@@ -92,20 +108,20 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DUSE_SCALAPACK=ON"
+    "-DSIRIUS_USE_SCALAPACK=ON"
+    "-DSIRIUS_USE_VDWXC=ON"
+    "-DSIRIUS_CREATE_FORTRAN_BINDINGS=ON"
+    "-DSIRIUS_USE_OPENMP=ON"
     "-DBUILD_TESTING=ON"
-    "-DUSE_VDWXC=ON"
-    "-DCREATE_FORTRAN_BINDINGS=ON"
-    "-DUSE_OPENMP=ON"
-    "-DBUILD_TESTING=ON"
-  ]
-  ++ lib.optionals (gpuBackend == "cuda") [
-    "-DUSE_CUDA=ON"
+  ] ++ lib.optionals (gpuBackend == "cuda") [
+    "-DSIRIUS_USE_CUDA=ON"
     "-DCUDA_TOOLKIT_ROOT_DIR=${cudaPackages.cudatoolkit}"
-  ]
-  ++ lib.optionals (gpuBackend == "rocm") [
-    "-DUSE_ROCM=ON"
+    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
+  ] ++ lib.optionals (gpuBackend == "rocm") [
+    "-DSIRIUS_USE_ROCM=ON"
     "-DHIP_ROOT_DIR=${rocmPackages.clr}"
+  ] ++ lib.optionals enablePython [
+    "-DSIRIUS_CREATE_PYTHON_MODULE=ON"
   ];
 
   doCheck = true;

--- a/pkgs/by-name/um/umpire/package.nix
+++ b/pkgs/by-name/um/umpire/package.nix
@@ -2,7 +2,12 @@
 , lib
 , fetchFromGitHub
 , cmake
+, config
+, cudaSupport ? config.cudaSupport
+, cudaPackages ? null
 }:
+
+assert cudaSupport -> cudaPackages != null;
 
 stdenv.mkDerivation rec {
   pname = "umpire";
@@ -16,7 +21,22 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = lib.optionals cudaSupport (with cudaPackages; [
+    cudatoolkit
+    cuda_cudart
+  ]);
+
+  cmakeFlags = lib.optionals cudaSupport [
+    "-DCUDA_TOOLKIT_ROOT_DIR=${cudaPackages.cudatoolkit}"
+    "-DENABLE_CUDA=ON"
+    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
+  ];
 
   meta = with lib; {
     description = "Application-focused API for memory management on NUMA & GPU architectures";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14532,6 +14532,11 @@ self: super: with self; {
 
   sipyco = callPackage ../development/python-modules/sipyco { };
 
+  sirius = toPythonModule (pkgs.sirius.override {
+    enablePython = true;
+    pythonPackages = self;
+  });
+
   sismic = callPackage ../development/python-modules/sismic { };
 
   sisyphus-control = callPackage ../development/python-modules/sisyphus-control { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I added a Python package for SIRIUS.  
While testing I noticed that the previous SIRIUS implementation did not actually compile with CUDA support because CMake flags were missing a `SIRIUS_` prefix. 
I also needed to enable CUDA support int umpire to prevent run-time errors.


I confirmed that SIRIUS now runs on CUDA GPUs. Unfortunately, I am at the moment not able to test the ROCM version. 
 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
