### PR TITLE
nixos/v2ray: pass the config to the service as a credential

### DIFF
--- a/nixos/modules/services/networking/v2ray.nix
+++ b/nixos/modules/services/networking/v2ray.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
@@ -35,14 +40,14 @@ with lib;
         type = types.nullOr (types.attrsOf types.unspecified);
         default = null;
         example = {
-          inbounds = [{
-            port = 1080;
-            listen = "127.0.0.1";
-            protocol = "http";
-          }];
-          outbounds = [{
-            protocol = "freedom";
-          }];
+          inbounds = [
+            {
+              port = 1080;
+              listen = "127.0.0.1";
+              protocol = "http";
+            }
+          ];
+          outbounds = [ { protocol = "freedom"; } ];
         };
         description = ''
           The configuration object.
@@ -56,35 +61,49 @@ with lib;
 
   };
 
-  config = let
-    cfg = config.services.v2ray;
-    configFile = if cfg.configFile != null
-      then cfg.configFile
-      else pkgs.writeTextFile {
-        name = "v2ray.json";
-        text = builtins.toJSON cfg.config;
-        checkPhase = ''
-          ${cfg.package}/bin/v2ray test -c $out
-        '';
+  config =
+    let
+      cfg = config.services.v2ray;
+      configFile =
+        if cfg.configFile != null then
+          cfg.configFile
+        else
+          pkgs.writeTextFile {
+            name = "v2ray.json";
+            text = builtins.toJSON cfg.config;
+            checkPhase = ''
+              ${cfg.package}/bin/v2ray test -c $out
+            '';
+          };
+
+    in
+    mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = (cfg.configFile == null) != (cfg.config == null);
+          message = "Either but not both `configFile` and `config` should be specified for v2ray.";
+        }
+      ];
+
+      environment.etc."v2ray/config.json".source = configFile;
+
+      systemd.packages = [ cfg.package ];
+
+      systemd.services.v2ray = {
+        restartTriggers = [ config.environment.etc."v2ray/config.json".source ];
+
+        # Workaround: https://github.com/NixOS/nixpkgs/issues/81138
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          # Pass the config file to the service as a credential (https://systemd.io/CREDENTIALS/)
+          # to ensure the service's dynamic user can read the config (which may not be world-readable).
+          LoadCredential = "config.json:${configFile}";
+          ExecStart = [
+            "" # Clear the upstream definition
+            "${cfg.package}/bin/v2ray run -config %d/config.json"
+          ];
+        };
       };
-
-  in mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = (cfg.configFile == null) != (cfg.config == null);
-        message = "Either but not both `configFile` and `config` should be specified for v2ray.";
-      }
-    ];
-
-    environment.etc."v2ray/config.json".source = configFile;
-
-    systemd.packages = [ cfg.package ];
-
-    systemd.services.v2ray = {
-      restartTriggers = [ config.environment.etc."v2ray/config.json".source ];
-
-      # Workaround: https://github.com/NixOS/nixpkgs/issues/81138
-      wantedBy = [ "multi-user.target" ];
     };
-  };
 }


### PR DESCRIPTION
If `config.services.v2ray.configFile` points to a file which is not world-readable (e.g., it belongs to and can be readable by `root` only), the service would fail to start with the following error:

> Failed to start: main/commands: failed to load config: \[/etc/v2ray/config.json\] > fail to load /etc/v2ray/config.json: open /etc/v2ray/config.json: permission denied

This can happen, for example, if you use tools like agenix/ragenix ([1]) to decrypt config files stored in a Git repo encrypted:

```nix
    config = {
      # ...
      age.secrets = {
        v2ray = {
          file = ../../secrets/v2ray/server.age;
          mode = "400";
        };
      };
      # ...
      services.v2ray = {
        enable = true;
        configFile = config.age.secrets.v2ray.path;
      };
      # ...
    };
```

Agenix would decrypt `../../secrets/v2ray/server.age` using the private SSH keys on that machine on system activation and mount them to a well- known path (exposed as `config.age.secrets.v2ray.path`). In this example, the decrypted file would be readable by `root` only.

Since the systemd service is started with a dynamically allocated user ([2]), it cannot read the config file and fails.

[1]: https://github.com/ryantm/agenix
[2]: https://github.com/NixOS/nixpkgs/blob/b956c2f42a5d0c9fbbfd8b2a9cf3bb5f0a6fcf41/pkgs/tools/networking/v2ray/default.nix#L45
[3]: https://systemd.io/CREDENTIALS/

## Description of changes

In this PR I utilize service credentials ([3]) (namely, `LoadCredential=`) to pass the config file to the service, which allows the dynamic service user to be able to read it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) &mdash; run `nix-build -A nixosTests.v2ray`.
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
