### PR TITLE
pgcat: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/servers/sql/pgcat/default.nix
+++ b/pkgs/servers/sql/pgcat/default.nix
@@ -1,22 +1,26 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, rustPlatform
-, darwin
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  darwin,
+  nix-update-script,
+  testers,
+  pgcat,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "pgcat";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "postgresml";
     repo = "pgcat";
     rev = "v${version}";
-    hash = "sha256-BERxdGgPk8POnhLsyy4lKV4LCoHsJTmv2OhAOz6CKKc=";
+    hash = "sha256-DHXUhAAOmPSt4aVp93I1y69of+MEboXJBZH50mzQTm8=";
   };
 
-  cargoHash = "sha256-GwcqR8pEvz42NEmcuXpcoPdChzRBYsDEnllX62T8ulQ=";
+  cargoHash = "sha256-QqwUEbWKSUuxzYjWpVpQuKZDiNib1gM2eZJ4y7XIzXY=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
@@ -24,28 +28,21 @@ rustPlatform.buildRustPackage rec {
 
   checkFlags = [
     # requires network access
-    "--skip=dns_cache::CachedResolver::lookup_ip"
-    "--skip=dns_cache::CachedResolver::new"
-    "--skip=dns_cache::CachedResolver"
-    "--skip=dns_cache::tests::has_changed"
-    "--skip=dns_cache::tests::incorrect_address"
-    "--skip=dns_cache::tests::lookup_ip"
-    "--skip=dns_cache::tests::new"
-    "--skip=dns_cache::tests::thread"
-    "--skip=dns_cache::tests::unknown_host"
+    "--skip=dns_cache"
   ];
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/pgcat --version | grep "pgcat ${version}"
-  '';
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = pgcat; };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/postgresml/pgcat";
     description = "PostgreSQL pooler with sharding, load balancing and failover support";
-    license = with licenses; [mit];
+    changelog = "https://github.com/postgresml/pgcat/releases";
+    license = with licenses; [ mit ];
     platforms = platforms.unix;
-    maintainers = with maintainers; [cathalmullan];
+    maintainers = with maintainers; [ cathalmullan ];
     mainProgram = "pgcat";
   };
 }


### PR DESCRIPTION
## Description of changes

- updated pgcat to v1.2.0
- added changelog
- replaced installCheck with passthru version check
- added passthru update script
- formatted using nixfmt

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
