### PR TITLE
nixos/release-small: remove minimal installer ISOs

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -407,6 +407,9 @@
 
 - The NixOS installation media no longer support the ReiserFS or JFS file systems by default.
 
+- Minimal installer ISOs are no longer built on the small channel.
+  Please obtain installer images from the full release channels.
+
 ## Other Notable Changes {#sec-release-24.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -86,6 +86,7 @@ in rec {
         # Upstream issue: https://gitlab.com/qemu-project/qemu/-/issues/2321
         # (onSystems ["x86_64-linux"] "nixos.tests.hibernate")
         (onFullSupported "nixos.tests.i3wm")
+        (onSystems ["aarch64-linux"] "nixos.tests.installer.simpleUefiSystemdBoot")
         (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSimple")
         (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSubvolDefault")
         (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSubvolEscape")

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -53,12 +53,8 @@ in rec {
         inherit (nixos'.tests.installer)
           lvm
           separateBoot
-          simple;
-      };
-      boot = {
-        inherit (nixos'.tests.boot)
-          biosCdrom
-          uefiCdrom;
+          simple
+          simpleUefiSystemdBoot;
       };
     };
   };
@@ -107,18 +103,16 @@ in rec {
         "nixpkgs.tarball"
         "nixpkgs.release-checks"
       ]
+      (onSystems [ "aarch64-linux" ] "nixos.tests.installer.simpleUefiSystemdBoot")
       (map (onSystems [ "x86_64-linux" ]) [
-        "nixos.tests.boot.biosCdrom"
         "nixos.tests.installer.lvm"
         "nixos.tests.installer.separateBoot"
         "nixos.tests.installer.simple"
       ])
       (map onSupported [
         "nixos.dummy"
-        "nixos.iso_minimal"
         "nixos.manual"
         "nixos.tests.acme"
-        "nixos.tests.boot.uefiCdrom"
         "nixos.tests.containers-imperative"
         "nixos.tests.containers-ip"
         "nixos.tests.firewall"


### PR DESCRIPTION
## Description of changes

These take up 2 GiB every time anything in the minimal installer changes, or up to 4 GiB per day. We already stopped building Amazon images in 9426d90c6784aa19f11a8cfc5171a46f0b21cd94. Meaningful installer changes are rare enough, and the couple of days it takes for them to trickle down to the large channel acceptable enough, that this is mostly a waste of space.

This should buy enough slack to build `stdenv` on `staging` without contributing to cache size growth.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
