### PR TITLE
librewolf-bin: init at 129.0.2.1

### DIFF
--- a/pkgs/by-name/li/librewolf-bin/package.nix
+++ b/pkgs/by-name/li/librewolf-bin/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+let
+  pname = "librewolf-bin";
+  upstreamVersion = "129.0.2-1";
+  version = lib.replaceStrings [ "-" ] [ "." ] upstreamVersion;
+  src = fetchurl {
+    url = "https://gitlab.com/api/v4/projects/24386000/packages/generic/librewolf/${upstreamVersion}/LibreWolf.x86_64.AppImage";
+    hash = "sha256-h4SZnI2BwCSsLADYIxTXu82Jyst1hqYGHt54MnluLss=";
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    mv $out/bin/{${pname},librewolf}
+    install -Dm444 ${appimageContents}/io.gitlab.LibreWolf.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/librewolf.png -t $out/share/pixmaps
+  '';
+
+  meta = {
+    description = "Fork of Firefox, focused on privacy, security and freedom (upstream AppImage release)";
+    homepage = "https://librewolf.net";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ eclairevoyant ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "librewolf";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds librewolf as packaged by upstream via their AppImage.
Mitigates issues such as #338439 that can arise due to packaging differences, and ensures that users have a browser that's as identical to the upstream intent as possible (to minimise the possibility of data privacy leakage).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
