### PR TITLE
nixos/tailscale: add authKeyParameters

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -516,6 +516,9 @@
 
 - `lib.misc.mapAttrsFlatten` is now formally deprecated and will be removed in future releases; use the identical [`lib.attrsets.mapAttrsToList`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.attrsets.mapAttrsToList) instead.
 
+- Tailscale's `authKeyFile` can now have its corresponding parameters set through `config.services.tailscale.authKeyParameters`, allowing for non-ephemeral unsupervised deployment and more.
+  See [Registering new nodes using OAuth credentials](https://tailscale.com/kb/1215/oauth-clients#registering-new-nodes-using-oauth-credentials) for the supported options.
+
 - `nixosTests` now provide a working IPv6 setup for VLAN 1 by default.
 
 - Kanidm can now be provisioned using the new [`services.kanidm.provision`] option, but requires using a patched version available via `pkgs.kanidm.withSecretProvisioning`.


### PR DESCRIPTION
Adds `config.services.tailscale.authKeyParameters`

## Description of changes

nixos/tailscale: add authKeyParameters setting

While working on setting up unattended tailscale deployment, I stumbled upon `config.services.tailscale.authKeyFile`. It 
seemed to fit the bill perfectly at first, allowing me to use my personal OAuth secret to provision any new node as desired.
While that mechanism did work great, I quickly found myself wishing I could set the corresponding parameters as seen [here](https://tailscale.com/kb/1215/oauth-clients#registering-new-nodes-using-oauth-credentials).
When using OAuth keys, they are required  for deploying non-ephemeral/preauthorized nodes, or to specify a custom base 
API URL.

Basically, I needed to set the corresponding command line argument to something like
```sh
--auth-key my-oauth-secret?ephemeral=false&preauthorized=true
```
while the tailscale module currently  only supports setting it to
```sh
--auth-key file:${cfg.authKeyFile}
```

Furthermore, it doesn't seem to be possible to point to a file with the `file:` prefix and simultaneosuly specify parameters, so I 
opted to set it up as shown below, where params is built from typed options and in this example would evaluate to
`?ephemeral=false&preauthorized=true`:
```sh
--auth-key "$(cat ${cfg.authKeyFile})${params}"

```

Below is a working snippet from my NixOS configuration as an example
```nix
config.services.tailscale = {
  enable = true;
  authKeyFile = config.sops.secrets."tailscale/oauth/secret".path;
  authKeyParameters = {
    ephemeral = false;
    preauthorized = true;
  };
  extraUpFlags = [
    "--accept-dns"
    "--accept-routes"
    "--advertise-exit-node"
    "--advertise-tags=tag:nixos"
    "--reset" # Forces unspecified arguments to default values
    "--ssh"
  ];
  openFirewall = true;
  useRoutingFeatures = "both";
};  
```

That makes it so my nodes are up and running with no further interaction required, and keeps full backwards compatibility with 
the original behavior if the new, optional parameters are omitted.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
