### PR TITLE
apr: 1.7.4 -> 1.7.5

### DIFF
--- a/pkgs/development/libraries/apr/default.nix
+++ b/pkgs/development/libraries/apr/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "apr";
-  version = "1.7.4";
+  version = "1.7.5";
 
   src = fetchurl {
     url = "mirror://apache/apr/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-/GSN6YPzoqbJ543qHxgGOb0vrWwG1VbUNnpwH+XDVXc=";
+    hash = "sha256-zQ9dUrmrFwTHIWDF7j7V09TKLfSn+KtWTjyzUrZyMvI=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

Fixes CVE-2023-49582.

Changes:
https://downloads.apache.org/apr/CHANGES-APR-1.7
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>kdePackages.umbrello</li>
    <li>kdePackages.umbrello.debug</li>
    <li>kdePackages.umbrello.dev</li>
    <li>kdePackages.umbrello.devtools</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>apacheHttpdPackages.mod_python</li>
    <li>davinci-resolve-studio</li>
  </ul>
</details>
<details>
  <summary>149 packages built:</summary>
  <ul>
    <li>apacheHttpd</li>
    <li>apacheHttpd.dev</li>
    <li>apacheHttpd.doc</li>
    <li>apacheHttpd.man</li>
    <li>apacheHttpdPackages.mod_auth_mellon</li>
    <li>apacheHttpdPackages.mod_ca</li>
    <li>apacheHttpdPackages.mod_crl</li>
    <li>apacheHttpdPackages.mod_cspnonce</li>
    <li>apacheHttpdPackages.mod_csr</li>
    <li>apacheHttpdPackages.mod_dnssd</li>
    <li>apacheHttpdPackages.mod_fastcgi</li>
    <li>apacheHttpdPackages.mod_itk</li>
    <li>apacheHttpdPackages.mod_jk</li>
    <li>apacheHttpdPackages.mod_mbtiles</li>
    <li>apacheHttpdPackages.mod_ocsp</li>
    <li>apacheHttpdPackages.mod_perl</li>
    <li>apacheHttpdPackages.mod_pkcs12</li>
    <li>apacheHttpdPackages.mod_scep</li>
    <li>apacheHttpdPackages.mod_spkac</li>
    <li>apacheHttpdPackages.mod_tile</li>
    <li>apacheHttpdPackages.mod_timestamp</li>
    <li>apacheHttpdPackages.mod_wsgi3</li>
    <li>apacheHttpdPackages.subversion</li>
    <li>apacheHttpdPackages.subversion.dev</li>
    <li>apacheHttpdPackages.subversion.man</li>
    <li>apr</li>
    <li>apr.dev</li>
    <li>aprutil</li>
    <li>aprutil.dev</li>
    <li>budgie-control-center</li>
    <li>budgie-control-center.debug</li>
    <li>cabal2nix</li>
    <li>cinnamon-gsettings-overrides</li>
    <li>collision</li>
    <li>davinci-resolve</li>
    <li>dropbox-cli</li>
    <li>dropbox-cli.nautilusExtension</li>
    <li>eiciel</li>
    <li>eiciel.nautilusExtension</li>
    <li>file-roller</li>
    <li>flightgear</li>
    <li>git-doc (git-doc.debug ,git-doc.doc ,gitFull.doc)</li>
    <li>gitFull</li>
    <li>gitFull.debug</li>
    <li>gitSVN</li>
    <li>gitSVN.debug</li>
    <li>gitSVN.doc</li>
    <li>gnome-terminal</li>
    <li>gnome-user-share</li>
    <li>gnome.gnome-control-center</li>
    <li>gnome.gnome-control-center.debug</li>
    <li>gnomeExtensions.gtk4-desktop-icons-ng-ding</li>
    <li>haxe</li>
    <li>haxePackages.format</li>
    <li>haxePackages.heaps</li>
    <li>haxePackages.hlopenal</li>
    <li>haxePackages.hlsdl</li>
    <li>haxePackages.hxcpp</li>
    <li>haxePackages.hxcs</li>
    <li>haxePackages.hxjava</li>
    <li>haxePackages.hxnodejs_4</li>
    <li>haxe_4_0</li>
    <li>haxe_4_1</li>
    <li>hydra</li>
    <li>ikiwiki-full</li>
    <li>insync-nautilus</li>
    <li>kdePackages.kdev-php</li>
    <li>kdePackages.kdev-php.debug</li>
    <li>kdePackages.kdev-php.dev</li>
    <li>kdePackages.kdev-php.devtools</li>
    <li>kdePackages.kdev-python</li>
    <li>kdePackages.kdev-python.debug</li>
    <li>kdePackages.kdev-python.dev</li>
    <li>kdePackages.kdev-python.devtools</li>
    <li>kdePackages.kdevelop</li>
    <li>kdePackages.kdevelop.debug</li>
    <li>kdePackages.kdevelop.dev</li>
    <li>kdePackages.kdevelop.devtools</li>
    <li>log4cxx</li>
    <li>luarocks-packages-updater</li>
    <li>mapcache</li>
    <li>mate.mate-user-share</li>
    <li>modsecurity_standalone</li>
    <li>modsecurity_standalone.nginx</li>
    <li>nautilus</li>
    <li>nautilus-open-any-terminal</li>
    <li>nautilus-open-any-terminal.dist</li>
    <li>nautilus-open-in-blackbox</li>
    <li>nautilus-python</li>
    <li>nautilus-python.dev</li>
    <li>nautilus-python.devdoc</li>
    <li>nautilus-python.doc</li>
    <li>nautilus.dev</li>
    <li>nautilus.devdoc</li>
    <li>neko</li>
    <li>nemo-fileroller</li>
    <li>nemo-with-extensions</li>
    <li>nix-prefetch-scripts</li>
    <li>nix-prefetch-svn</li>
    <li>nix-update-source</li>
    <li>nix-update-source.dist</li>
    <li>pantheon.file-roller-contract</li>
    <li>papers</li>
    <li>papers.dev</li>
    <li>papers.devdoc</li>
    <li>patroni</li>
    <li>patroni.dist</li>
    <li>perl536Packages.GoferTransporthttp</li>
    <li>perl536Packages.GoferTransporthttp.devdoc</li>
    <li>perl536Packages.SVNSimple</li>
    <li>perl536Packages.SVNSimple.devdoc</li>
    <li>perl536Packages.libapreq2</li>
    <li>perl536Packages.mod_perl2</li>
    <li>perl536Packages.mod_perl2.devdoc</li>
    <li>perl538Packages.GoferTransporthttp</li>
    <li>perl538Packages.GoferTransporthttp.devdoc</li>
    <li>perl538Packages.SVNSimple</li>
    <li>perl538Packages.SVNSimple.devdoc</li>
    <li>perl538Packages.libapreq2</li>
    <li>perl538Packages.mod_perl2</li>
    <li>perl538Packages.mod_perl2.devdoc</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>python311Packages.pysvn</li>
    <li>python311Packages.ydiff</li>
    <li>python311Packages.ydiff.dist</li>
    <li>python312Packages.pysvn</li>
    <li>ydiff (python312Packages.ydiff)</li>
    <li>ydiff.dist (python312Packages.ydiff.dist)</li>
    <li>rapidsvn</li>
    <li>redwax-tool</li>
    <li>serf</li>
    <li>simgear</li>
    <li>subversion</li>
    <li>subversion.dev</li>
    <li>subversion.man</li>
    <li>subversionClient</li>
    <li>subversionClient.dev</li>
    <li>subversionClient.man</li>
    <li>svn-all-fast-export</li>
    <li>svn2git</li>
    <li>svnfs</li>
    <li>thcrap-steam-proton-wrapper</li>
    <li>tomcat-native</li>
    <li>vcstool</li>
    <li>vcstool.dist</li>
    <li>wp4nix</li>
    <li>xsecurelock</li>
    <li>zkfuse</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
