### PR TITLE
nixos/hydra: add system-hydra.slice, fix typo

### DIFF
--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -311,6 +311,11 @@ in
       )
     ];
 
+    systemd.slices.system-hydra = {
+      description = "Hydra Slice";
+      documentation = [ "file://${cfg.package}/share/doc/hydra/index.html" "https://nixos.org/hydra/manual/" ];
+    };
+
     systemd.services.hydra-init =
       { wantedBy = [ "multi-user.target" ];
         requires = lib.optional haveLocalDB "postgresql.service";
@@ -371,6 +376,7 @@ in
         serviceConfig.User = "hydra";
         serviceConfig.Type = "oneshot";
         serviceConfig.RemainAfterExit = true;
+        serviceConfig.Slice = "system-hydra.slice";
       };
 
     systemd.services.hydra-server =
@@ -389,6 +395,7 @@ in
             User = "hydra-www";
             PermissionsStartOnly = true;
             Restart = "always";
+            Slice = "system-hydra.slice";
           };
       };
 
@@ -408,6 +415,7 @@ in
             ExecStopPost = "${hydra-package}/bin/hydra-queue-runner --unlock";
             User = "hydra-queue-runner";
             Restart = "always";
+            Slice = "system-hydra.slice";
 
             # Ensure we can get core dumps.
             LimitCORE = "infinity";
@@ -430,6 +438,7 @@ in
             User = "hydra";
             Restart = "always";
             WorkingDirectory = baseDir;
+            Slice = "system-hydra.slice";
           };
       };
 
@@ -442,6 +451,7 @@ in
         serviceConfig =
           { ExecStart = "@${hydra-package}/bin/hydra-update-gc-roots hydra-update-gc-roots";
             User = "hydra";
+            Slice = "system-hydra.slice";
           };
         startAt = "2,14:15";
       };
@@ -455,6 +465,7 @@ in
         serviceConfig =
           { ExecStart = "@${hydra-package}/bin/hydra-send-stats hydra-send-stats";
             User = "hydra";
+            Slice = "system-hydra.slice";
           };
       };
 
@@ -474,6 +485,7 @@ in
             User = "hydra-queue-runner";
             Restart = "always";
             RestartSec = 5;
+            Slice = "system-hydra.slice";
           };
       };
 
@@ -492,6 +504,7 @@ in
             fi
           '';
         startAt = "*:0/5";
+        serviceConfig.Slice = "system-hydra.slice";
       };
 
     # Periodically compress build logs. The queue runner compresses
@@ -509,6 +522,7 @@ in
             find ${baseDir}/build-logs -type f -name "*.drv" -mtime +3 -size +0c | xargs -r $compression --force --quiet
           '';
         startAt = "Sun 01:45";
+        serviceConfig.Slice = "system-hydra.slice";
       };
 
     services.postgresql.enable = lib.mkIf haveLocalDB true;

--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -246,7 +246,7 @@ in
       }
       {
         assertion = cfg.minSpareServers < cfg.maxSpareServers;
-        message = "services.hydra.minSpareServers cannot be bigger than servives.hydra.maxSpareServers";
+        message = "services.hydra.minSpareServers cannot be bigger than services.hydra.maxSpareServers";
       }
     ];
 


### PR DESCRIPTION
## Description of changes

Part of #279915

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
