### PR TITLE
svt-av1-psy: init at 2.2.1

### DIFF
--- a/pkgs/by-name/sv/svt-av1-psy/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psy/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  nasm,
+  libdovi,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "svt-av1-psy";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "gianni-rosato";
+    repo = "svt-av1-psy";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-4ds7yrUMp0O5/aWOkdnrANR1D3djajU/0ZeY6xJnpHI=";
+  };
+
+  cmakeBuildType = "Release";
+
+  cmakeFlags = lib.mapAttrsToList lib.cmakeFeature {
+    LIBDOVI_FOUND = lib.boolToString true;
+    # enable when libhdr10plus is available
+    # LIBHDR10PLUS_RS_FOUND = lib.boolToString true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    nasm
+  ];
+
+  buildInputs = [
+    libdovi
+  ];
+
+  meta = {
+    homepage = "https://github.com/gianni-rosato/svt-av1-psy";
+    description = "Scalable Video Technology AV1 Encoder and Decoder";
+
+    longDescription = ''
+      SVT-AV1-PSY is the Scalable Video Technology for AV1 (SVT-AV1 Encoder and Decoder)
+      with perceptual enhancements for psychovisually optimal AV1 encoding.
+      The goal is to create the best encoding implementation for perceptual quality with AV1.
+    '';
+
+    license = with lib.licenses; [
+      aom
+      bsd3
+    ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ johnrtitor ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Homepage:- https://github.com/gianni-rosato/svt-av1-psy

Description:- SVT-AV1-PSY is the Scalable Video Technology for AV1 (SVT-AV1 Encoder and Decoder) with perceptual enhancements for psychovisually optimal AV1 encoding. It aims to create the best encoding implementation for perceptual quality with AV1.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
