### PR TITLE
home-assistant-custom-components.garmin_connect: init at unstable-2024-08-31

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -22,6 +22,8 @@
 
   frigate = callPackage ./frigate {};
 
+  garmin_connect = callPackage ./garmin_connect {};
+
   govee-lan = callPackage ./govee-lan {};
 
   gpio = callPackage ./gpio {};

--- a/pkgs/servers/home-assistant/custom-components/garmin_connect/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/garmin_connect/default.nix
@@ -26,7 +26,10 @@ buildHomeAssistantComponent {
   meta = with lib; {
     description = "The Garmin Connect integration allows you to expose data from Garmin Connect to Home Assistant";
     homepage = "https://github.com/cyberjunky/home-assistant-garmin_connect";
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [
+      matthiasbeyer
+      dmadisetti
+    ];
     license = licenses.mit;
   };
 }

--- a/pkgs/servers/home-assistant/custom-components/garmin_connect/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/garmin_connect/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  garminconnect,
+  tzlocal,
+}:
+
+buildHomeAssistantComponent {
+  owner = "cyberjunky";
+  domain = "garmin_connect";
+  version = "unstable-2024-08-31";
+
+  src = fetchFromGitHub {
+    owner = "cyberjunky";
+    repo = "home-assistant-garmin_connect";
+    rev = "d42edcabc67ba6a7f960e849c8aaec1aabef87c0";
+    hash = "sha256-KqbP6TpH9B0/AjtsW5TcWSNgUhND+w8rO6X8fHqtsDI=";
+  };
+
+  propagatedBuildInputs = [
+    garminconnect
+    tzlocal
+  ];
+
+  meta = with lib; {
+    description = "The Garmin Connect integration allows you to expose data from Garmin Connect to Home Assistant";
+    homepage = "https://github.com/cyberjunky/home-assistant-garmin_connect";
+    maintainers = with maintainers; [ matthiasbeyer ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
This packages the garmin_connect component from cyberjunky.

I decided to not package the latest release, but the master branch, because the latest release hard depends on a specific version of python3Packages.garminconnect. The master branch does not.

--

Opening this as draft until I confirmed it works (or someone else has).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
