### PR TITLE
ceph.tests: Fix maintainer eval

### DIFF
--- a/nixos/tests/ceph-single-node-bluestore-dmcrypt.nix
+++ b/nixos/tests/ceph-single-node-bluestore-dmcrypt.nix
@@ -17,7 +17,7 @@ import ./make-test-python.nix (
   {
     name = "basic-single-node-ceph-cluster-bluestore-dmcrypt";
     meta = with pkgs.lib.maintainers; {
-      maintainers = [ benaryorg nh2 ];
+      maintainers = [ nh2 ];
     };
 
     nodes = {


### PR DESCRIPTION
## Description of changes

In https://github.com/NixOS/nixpkgs/pull/335684#issuecomment-2322864461 I added @benaryorg as maintainer (thanks for the contributed VM test!) without being in the maintainer list (I didn't notice that).

Removing until added to fix the eval.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Eval-only change
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
