### PR TITLE
nixos/soju: use message-store instead of deprecated log in config

### DIFF
--- a/nixos/modules/services/networking/soju.nix
+++ b/nixos/modules/services/networking/soju.nix
@@ -12,7 +12,7 @@ let
   tlsCfg = optionalString (cfg.tlsCertificate != null)
     "tls ${cfg.tlsCertificate} ${cfg.tlsCertificateKey}";
   logCfg = optionalString cfg.enableMessageLogging
-    "log fs ${stateDir}/logs";
+    "message-store fs ${stateDir}/logs";
 
   configFile = pkgs.writeText "soju.conf" ''
     ${listenCfg}


### PR DESCRIPTION
From message-store section in https://soju.im/doc/soju.1.html :

"(log is a deprecated alias for this directive.)"