### PR TITLE
etesync-dav: 0.32.1 -> 0.32.1-unstable-2024-09-02

### DIFF
--- a/pkgs/applications/misc/etesync-dav/default.nix
+++ b/pkgs/applications/misc/etesync-dav/default.nix
@@ -1,28 +1,21 @@
 { lib
 , stdenv
-, fetchpatch
 , nixosTests
 , python3
-, fetchPypi
+, fetchFromGitHub
 , radicale3
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication {
   pname = "etesync-dav";
-  version = "0.32.1";
+  version = "0.32.1-unstable-2024-09-02";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-pOLug5MnVdKaw5wedABewomID9LU0hZPCf4kZKKU1yA=";
+  src = fetchFromGitHub {
+    owner = "etesync";
+    repo = "etesync-dav";
+    rev = "b9b23bf6fba60d42012008ba06023bccd9109c08";
+    hash = "sha256-wWhwnOlwE1rFgROTSj90hlSw4k48fIEdk5CJOXoecuQ=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "add-missing-comma-in-setup.py.patch";
-      url = "https://github.com/etesync/etesync-dav/commit/040cb7b57205e70515019fb356e508a6414da11e.patch";
-      hash = "sha256-87IpIQ87rgpinvbRwUlWd0xeegn0zfVSiDFYNUqPerg=";
-    })
-  ];
 
   propagatedBuildInputs = with python3.pkgs; [
     appdirs


### PR DESCRIPTION
Diff: https://github.com/etesync/etesync-dav/compare/v0.32.1...b9b23bf6fba60d42012008ba06023bccd9109c08

- contains commit pulled previously pulled with fetchpatch:
https://www.github.com/etesync/etesync-dav/commit/040cb7b57205e70515019fb356e508a6414da11e
- contains commit with changes to log.set_level() from radicale 3.2.2 update (additional second arg - backtrace_on_debug):
https://www.github.com/Kozea/Radicale/pull/1519
https://www.github.com/etesync/etesync-dav/pull/318

## Description of changes

Since `radicale` update to 3.2.2 (https://github.com/NixOS/nixpkgs/pull/321108) `etesync-dav` fails during runtime with error related to changes to `log.set_level` (additional second arg).

Fixes test run of `nixosTests.etesync-dav` (fails since `2024-06-20` - merge of `radicale` update):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.etesync-dav.x86_64-linux
https://hydra.nixos.org/build/270729013

Error log:
```text
machine # Traceback (most recent call last):
machine #   File "/nix/store/wd2by7xjf0cx15nwdxg395x0zsfja50g-etesync-dav-0.32.1/bin/.etesync-dav-wrapped", line 164, in <module>
machine #     radicale_main.run(radicale_args + sys.argv[1:])
machine #   File "/nix/store/wd2by7xjf0cx15nwdxg395x0zsfja50g-etesync-dav-0.32.1/lib/python3.12/site-packages/etesync_dav/radicale_main/__init__.py", line 136, in run
machine #     log.set_level(configuration.get("logging", "level"))
machine # TypeError: set_level() missing 1 required positional argument: 'backtrace_on_debug'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
