### PR TITLE
nixos/iso-image: Compress squashfs with zstd 19

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -506,12 +506,7 @@ in
     };
 
     isoImage.squashfsCompression = mkOption {
-      default = with pkgs.stdenv.hostPlatform; "xz -Xdict-size 100% "
-                + lib.optionalString isx86 "-Xbcj x86"
-                # Untested but should also reduce size for these platforms
-                + lib.optionalString isAarch "-Xbcj arm"
-                + lib.optionalString (isPower && is32bit && isBigEndian) "-Xbcj powerpc"
-                + lib.optionalString (isSparc) "-Xbcj sparc";
+      default = "zstd -Xcompression-level 19";
       type = lib.types.nullOr lib.types.str;
       description = ''
         Compression settings to use for the squashfs nix store.


### PR DESCRIPTION
## Description of changes

I tested building the ISO with these compression settings, and measured their sizes and how long they took to build, boot, and install. The ISOs were built on my Ryzen 7950X desktop, with 64G of RAM, on a Samsung 980 Pro SSD. The ISOs were booted and installed in a `libvirtd` VM with 8 cores and 8G of RAM. Notably, this means the ISOs were booted from the host SSD, not something like a USB stick; this should better compare decompression overhead rather than IO bottlenecks. Boot time was measured from the time I hit enter in Grub to the time the Calamares GUI installer became responsive. Install time was measured from the time I hit the final "Install" button (i.e. _after_ stepping through the GUI configuration).

### xz (current)
- **build:** 2m55s
- **size:** 2.5G
- **boot:** 29s
- **install:** 13m22s

### zstd-3
- **build:** 1m8s
- **size:** 3.0G
- **boot:** 10s
- **install:** 2m05s

### zstd-15
- **build:** 1m35s
- **size:** 2.9G
- **boot:** 10s
- **install:** 1m59s

### zstd-19
- **build:** 2m20s
- **size:** 2.7G
- **boot:** 10s
- **install:** 2m13s

---

Based on this, I think the zstd-19 result is probably the most favorable. It's not as great a reduction in build time as zstd-15 would be, but it *is* still a reduction (note that with a 16 core / 32 thread CPU, these build times are much faster than we would see on Hydra). And while the resulting ISO is not significantly smaller than zstd-15, it *is* still smaller. Not quite as small as `xz`, but I think the 6x improvement in installation speed is well worth it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
