### PR TITLE
amtterm: enable SSL support

### DIFF
--- a/pkgs/tools/system/amtterm/default.nix
+++ b/pkgs/tools/system/amtterm/default.nix
@@ -1,27 +1,29 @@
-{ fetchurl, lib, stdenv, makeWrapper, perl, perlPackages }:
+{ fetchFromGitHub, lib, stdenv, makeWrapper, openssl, perl, perlPackages, pkg-config }:
 
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "amtterm";
-  version = "1.7-1";
+  version = "1.7-1-unstable-2023-10-27";
 
-  buildInputs = with perlPackages; [ perl SOAPLite ];
-  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = (with perlPackages; [ perl SOAPLite ]) ++ [ openssl ];
+  nativeBuildInputs = [ makeWrapper pkg-config ];
 
-  src = fetchurl {
-    url = "https://www.kraxel.org/cgit/amtterm/snapshot/amtterm-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-WrYWAXLW74hb/DfSiPyiFIGAUfDQFdNEPx+XevZYcyk=";
+  src = fetchFromGitHub {
+    owner = "kraxel";
+    repo = "amtterm";
+    rev = "ed5da502cbb150982ad982211ad9475414b8689a";
+    hash = "sha256-JwS2agmJJ6VcGLkNbkFRb5bzKV8el1DMDjalmLnOdE8=";
   };
 
-  makeFlags = [ "prefix=$(out)" "STRIP=" ];
+  makeFlags = [ "prefix=$(out)" "STRIP=" "USE_OPENSSL=1" ];
 
   postInstall =
     "wrapProgram $out/bin/amttool --prefix PERL5LIB : $PERL5LIB";
 
-  meta = with lib;
-    { description = "Intel AMT® SoL client + tools";
-      homepage = "https://www.kraxel.org/cgit/amtterm/";
-      license = licenses.gpl2Plus;
-      platforms = platforms.linux;
-    };
+  meta = {
+    description = "Intel AMT® SoL client + tools";
+    homepage = "https://www.kraxel.org/cgit/amtterm/";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+  };
 })


### PR DESCRIPTION
Current versions of Intel AMT/vPro only support connecting over SSL, but our current amtterm version isn't built with SSL support.

Set the `USE_OPENSSL=1` makeFlag and add openssl and pkg-config.

It adds an additional `-C cacert` parameter, which needs to point to a previously downloaded server certificate.

The server certificate can be retrieved with
`openssl s_client -showcerts -connect $host:16995`.

However, due to the use of `UnsafeLegacyRenegotiation`, `OPENSSL_CONF` needs to point to a text file explicitly allowing this:

```
openssl_conf = default_conf

[ default_conf ]
ssl_conf = ssl_sect

[ssl_sect]
system_default = ssl_default_sect

[ssl_default_sect]
Options = UnsafeLegacyRenegotiation
```

With this, I'm able to connect to `/dev/ttyS2` inside the host:

```
❯ AMT_PASSWORD='supersecret' amtterm $host 16995 -C cert.pem
amtterm: NONE -> CONNECT (connection to host)
ipv4 $ip [$ip] 16995 open
amtterm: CONNECT -> INIT (redirection initialization)
amtterm: INIT -> AUTH (session authentication)
amtterm: AUTH -> INIT_SOL (serial-over-lan initialization)
amtterm: INIT_SOL -> RUN_SOL (serial-over-lan active)
serial-over-lan redirection ok
connected now, use ^] to escape
Hello World
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
