### PR TITLE
python3: get the triple from the build system

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -206,81 +206,29 @@ let
     inherit hash;
   };
 
-  # The CPython interpreter contains a _sysconfigdata_<platform specific suffix>
-  # module that is imported by the sysconfig and distutils.sysconfig modules.
-  # The sysconfigdata module is generated at build time and contains settings
-  # required for building Python extension modules, such as include paths and
-  # other compiler flags. By default, the sysconfigdata module is loaded from
-  # the currently running interpreter (ie. the build platform interpreter), but
-  # when cross-compiling we want to load it from the host platform interpreter.
-  # This can be done using the _PYTHON_SYSCONFIGDATA_NAME environment variable.
-  # The _PYTHON_HOST_PLATFORM variable also needs to be set to get the correct
-  # platform suffix on extension modules. The correct values for these variables
-  # are not documented, and must be derived from the configure script (see links
-  # below).
-  sysconfigdataHook = with stdenv.hostPlatform; with passthru; let
-    machdep = if isWindows then "win32" else parsed.kernel.name; # win32 is added by Fedora’s patch
+  # win32 is added by Fedora’s patch
+  machdep = if stdenv.hostPlatform.isWindows then
+    "win32"
+  else
+    stdenv.hostPlatform.parsed.kernel.name;
 
-    # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L428
-    # The configure script uses "arm" as the CPU name for all 32-bit ARM
-    # variants when cross-compiling, but native builds include the version
-    # suffix, so we do the same.
-    pythonHostPlatform = let
-      cpu = {
-        # According to PEP600, Python's name for the Power PC
-        # architecture is "ppc", not "powerpc".  Without the Rosetta
-        # Stone below, the PEP600 requirement that "${ARCH} matches
-        # the return value from distutils.util.get_platform()" fails.
-        # https://peps.python.org/pep-0600/
-        powerpc = "ppc";
-        powerpcle = "ppcle";
-        powerpc64 = "ppc64";
-        powerpc64le = "ppc64le";
-      }.${parsed.cpu.name} or parsed.cpu.name;
-    in "${machdep}-${cpu}";
-
-    # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L724
-    multiarchCpu =
-      if isAarch32 then
-        if parsed.cpu.significantByte.name == "littleEndian" then "arm" else "armeb"
-      else if isx86_32 then "i386"
-      else parsed.cpu.name;
-
-    pythonAbiName = let
-      # python's build doesn't match the nixpkgs abi in some cases.
-      # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L724
-      nixpkgsPythonAbiMappings = {
-        "gnuabielfv2" = "gnu";
-        "muslabielfv2" = "musl";
-      };
-      pythonAbi = nixpkgsPythonAbiMappings.${parsed.abi.name} or parsed.abi.name;
-    in
-      # Python <3.11 doesn't distinguish musl and glibc and always prefixes with "gnu"
-      if versionOlder version "3.11" then
-        replaceStrings [ "musl" ] [ "gnu" ] pythonAbi
-      else
-        pythonAbi;
-
-    multiarch =
-      if isDarwin then "darwin"
-      else if isFreeBSD then ""
-      else if isWindows then ""
-      else "${multiarchCpu}-${machdep}-${pythonAbiName}";
-
-    abiFlags = optionalString isPy37 "m";
-
-    # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L78
-    pythonSysconfigdataName = "_sysconfigdata_${abiFlags}_${machdep}_${multiarch}";
-  in ''
-    sysconfigdataHook() {
-      if [ "$1" = '${placeholder "out"}' ]; then
-        export _PYTHON_HOST_PLATFORM='${pythonHostPlatform}'
-        export _PYTHON_SYSCONFIGDATA_NAME='${pythonSysconfigdataName}'
-      fi
-    }
-
-    addEnvHooks "$hostOffset" sysconfigdataHook
-  '';
+  # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L428
+  # The configure script uses "arm" as the CPU name for all 32-bit ARM
+  # variants when cross-compiling, but native builds include the version
+  # suffix, so we do the same.
+  pythonHostPlatform = let
+    cpu = {
+      # According to PEP600, Python's name for the Power PC
+      # architecture is "ppc", not "powerpc".  Without the Rosetta
+      # Stone below, the PEP600 requirement that "${ARCH} matches
+      # the return value from distutils.util.get_platform()" fails.
+      # https://peps.python.org/pep-0600/
+      powerpc = "ppc";
+      powerpcle = "ppcle";
+      powerpc64 = "ppc64";
+      powerpc64le = "ppc64le";
+    }.${stdenv.hostPlatform.parsed.cpu.name} or stdenv.hostPlatform.parsed.cpu.name;
+  in "${machdep}-${cpu}";
 
   execSuffix = stdenv.hostPlatform.extensions.executable;
 in with passthru; stdenv.mkDerivation (finalAttrs: {
@@ -615,8 +563,31 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
   # Add CPython specific setup-hook that configures distutils.sysconfig to
   # always load sysconfigdata from host Python.
   postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    cat << "EOF" >> "$out/nix-support/setup-hook"
-    ${sysconfigdataHook}
+    # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L78
+    sysconfigdataName="$(make --eval $'print-sysconfigdata-name:
+    \t@echo _sysconfigdata_$(ABIFLAGS)_$(MACHDEP)_$(MULTIARCH) ' print-sysconfigdata-name)"
+
+    # The CPython interpreter contains a _sysconfigdata_<platform specific suffix>
+    # module that is imported by the sysconfig and distutils.sysconfig modules.
+    # The sysconfigdata module is generated at build time and contains settings
+    # required for building Python extension modules, such as include paths and
+    # other compiler flags. By default, the sysconfigdata module is loaded from
+    # the currently running interpreter (ie. the build platform interpreter), but
+    # when cross-compiling we want to load it from the host platform interpreter.
+    # This can be done using the _PYTHON_SYSCONFIGDATA_NAME environment variable.
+    # The _PYTHON_HOST_PLATFORM variable also needs to be set to get the correct
+    # platform suffix on extension modules. The correct values for these variables
+    # are not documented, and must be derived from the configure script (see links
+    # below).
+    cat <<EOF >> "$out/nix-support/setup-hook"
+    sysconfigdataHook() {
+      if [ "\$1" = '$out' ]; then
+        export _PYTHON_HOST_PLATFORM='${pythonHostPlatform}'
+        export _PYTHON_SYSCONFIGDATA_NAME='$sysconfigdataName'
+      fi
+    }
+
+    addEnvHooks "\$hostOffset" sysconfigdataHook
     EOF
   '';
 


### PR DESCRIPTION
We don't need the sysconfigdata name at eval time, so trying to reimplement platform_triplet.c in Nix is unnecessarily painful compared to just getting it from the build system after the fact.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
