### PR TITLE
nixos/tests/plotinus: fix build

### DIFF
--- a/nixos/tests/plotinus.nix
+++ b/nixos/tests/plotinus.nix
@@ -2,6 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
   name = "plotinus";
   meta = {
     maintainers = pkgs.plotinus.meta.maintainers;
+    timeout = 600;
   };
 
   nodes.machine =
@@ -9,20 +10,23 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
     { imports = [ ./common/x11.nix ];
       programs.plotinus.enable = true;
-      environment.systemPackages = [ pkgs.gnome-calculator pkgs.xdotool ];
+      environment.systemPackages = [
+        pkgs.gnome-pomodoro
+        pkgs.xdotool
+      ];
     };
 
   testScript = ''
     machine.wait_for_x()
-    machine.succeed("gnome-calculator >&2 &")
-    machine.wait_for_window("gnome-calculator")
+    machine.succeed("gnome-pomodoro >&2 &")
+    machine.wait_for_window("Pomodoro", timeout=120)
     machine.succeed(
-        "xdotool search --sync --onlyvisible --class gnome-calculator "
+        "xdotool search --sync --onlyvisible --class gnome-pomodoro "
         + "windowfocus --sync key --clearmodifiers --delay 1 'ctrl+shift+p'"
     )
     machine.sleep(5)  # wait for the popup
+    machine.screenshot("popup")
     machine.succeed("xdotool key --delay 100 p r e f e r e n c e s Return")
-    machine.wait_for_window("Preferences")
-    machine.screenshot("screen")
+    machine.wait_for_window("Preferences", timeout=120)
   '';
 })


### PR DESCRIPTION
## Description of changes

- change tested app from gnome-calculator to gnome-pomodoro as plotinus only works on gtk3 apps
- change screenshot result to one that shows popup from plotinus instead of preferences window
- add 2 minute timeouts waiting for windows
- add 10 minute timeout for full test

Fixes build of `nixosTests.plotinus` (fails since `2021-09-22`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.plotinus.x86_64-linux
https://hydra.nixos.org/build/270730586

Log:
```
machine: waiting for a window to appear
machine: must succeed: xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'
(finished: must succeed: xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d', in 0.05 seconds)
...
(finished: must succeed: xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d', in 0.04 seconds)
machine: Last chance to match Preferences on the window list, which currently contains: gnome-calculator, gnome-calculator, YXTrayProxy, IceRootProxy, IceTopWin, IceEdge, Frame, TaskBarFrame, TaskBar, SystemTray, TrayPane, TaskPane, AddressBar, Workspaces,  4 ,  3 ,  2 ,  1 , ShowDesktop, ShowWindowList, IceToolbar, Web browser, xterm, TaskBarMenu, Clock, NET-eth0, NET-eth1, CPU-1, MEM, Frame, Container, Calculator, IceBottom, IceWM 3.6.0 (Linux/x86_64)
cleanup
kill machine (pid 9)
```
(could not wait for "Preferences" window, because plotinus does not work in gnome-calculator)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc