### PR TITLE
nixos/doc/rl-2411: warn about upcoming macOS version requirement

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -4,6 +4,12 @@
 
 ## Highlights {#sec-release-24.11-highlights}
 
+- **This will be the latest version of Nixpkgs to support macOS 10.12 (Sierra).**
+  Starting with release 25.05, the minimum supported version will be macOS 11 (Big Sur).
+  From that point on, packages may or may not work on older releases of macOS.
+  Users on old macOS versions should consider upgrading to a supported OS release (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
+  If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports back to OS X 10.6 (Snow Leopard).
+
 - Convenience options for `amdgpu`, open source driver for Radeon cards, is now available under `hardware.amdgpu`.
 
 - [AMDVLK](https://github.com/GPUOpen-Drivers/AMDVLK), AMD's open source Vulkan driver, is now available to be configured as `hardware.amdgpu.amdvlk` option.


### PR DESCRIPTION
## Description of changes

For a long time now, the SDK and minimum target version for `x86_64-darwin` has been stuck on macOS 10.12. In the past, the minimum SDK was updated quite regularly; at first, the current situation was just because updating the SDKs was excessively burdensome and nobody was up for doing the work, but the introduction of `aarch64-darwin` with its macOS 11 default SDK has resulted in a long‐term fracture of the two platforms.

Per <https://endoflife.date/macos>, macOS 10.12 has not received an update since 2017 and went out of security support 5 years ago. Trying to support it in Nixpkgs has been a large burden on the Darwin maintainers, resulting in workarounds, porting work, and even patching functionality out of applications. The existence of Nix users using a macOS version this old is, to my knowledge, entirely theoretical, and we pay in both maintenance costs and functionality: for instance, applications built for `x86_64-darwin` do not support automatic dark mode switching by default.

This situation has always been suboptimal, but it is now becoming untenable. Python, a critical component of the Nixpkgs standard environment for builds, is dropping support for versions older than 10.13 in 3.13: <https://www.python.org/downloads/release/python-3130rc1/>. Qt 6 only supports macOS 11 and newer. libuv only supports the versions Apple does, and is a ticking time bomb due to its use in the standard environment. QEMU only supports the last two macOS releases, and won’t build with an SDK older than macOS 12; we previously vendored a set of backporting changes and functionality‐removing reverts to keep it building for 10.12, but this also became overly onerous, and we gave up in <https://github.com/NixOS/nixpkgs/pull/338598>.

`x86_64-darwin` is a platform with a limited upstream future. Apple no longer sells any hardware that runs it natively, and it is unclear how much longer they will support it in the operating system. There are still many users of the platform, myself included, so we shouldn’t drop support for it prematurely, but it’s unreasonable to try and patch the entire world to keep it supporting insecure versions of the OS that only run on hardware that is no longer sold.

Therefore, this adds a release note to warn users ahead of time that 25.05 will only support macOS 11 and newer, as suggested by the 24.05 release team when the possibility of bumping the required version was raised.

Why target Big Sur, rather than any other version? The reason is simple: it’s the same SDK and deployment target as `aarch64-darwin`. There are many packages that work on `aarch64-darwin` but not `x86_64-darwin`, and Darwin maintainers frequently need to be called in to fix things that work fine on the newer platform but not the older one. This change will increase the health of `x86_64-darwin` by aligning the SDK versions and support between the two platforms; the vast majority of packages that work on one will Just Work on the other. macOS 11 is almost four years old and has itself been out of security support for a year now, but as the first version to support Apple Silicon, it’s a far more compatible base for us to build our Darwin packages for. Any future change in supported versions should be synchronized between the two Darwin architectures.

When 25.05 is released, users on old, unsupported versions of macOS will have the following options:

* Update to a new macOS version. For users that are on hardware that Apple has dropped support for, OpenCore Legacy Patcher (<https://dortania.github.io/OpenCore-Legacy-Patcher/>) can enable the use of newer macOS versions on hardware even older than 10.12 supports.

* Install NixOS. That obviously precludes the use of macOS software (though most of that software has already dropped support for 10.12), but will give users a secure, supported operating system that we can actually own the support for going forward.

* Keep using 24.11 forever. Since they’re not getting updates to their OS and core applications anyway, this is likely to be acceptable to many users.

* Switch to MacPorts. They support all the way back to 10.6 for `x86_64-darwin` by building packages separately for every OS release, though not every package is available for every version.

* Send patches. We *may* accept non‐invasive patches to keep certain critical packages (such as the core `stdenv` packages) building for old OS versions, on a case‐by‐case basis, but we can’t guarantee it. This will ultimately have to be a decision made by package maintainers and personally I doubt this will be a viable path to sustainably support older versions.

cc @NixOS/darwin-maintainers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
