### PR TITLE
libkeyfinder: 2.2.6 -> 2.2.8; keyfinder-cli: 1.1.1 -> 1.1.2

### DIFF
--- a/pkgs/applications/audio/keyfinder-cli/default.nix
+++ b/pkgs/applications/audio/keyfinder-cli/default.nix
@@ -1,17 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, ffmpeg, libkeyfinder }:
+{ lib, stdenv, fetchFromGitHub, ffmpeg_7, libkeyfinder, fftw }:
 
 stdenv.mkDerivation rec {
   pname = "keyfinder-cli";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     repo = "keyfinder-cli";
     owner = "EvanPurkhiser";
     rev = "v${version}";
-    sha256 = "1mlcygbj3gqii3cz8jd6ks1lz612i4jp0343qjg293xm39fg47ns";
+    hash = "sha256-9/+wzPTaQ5PfPiqTZ5EuHdswXJgfgnvAul/FeeDbbJA=";
   };
 
-  buildInputs = [ ffmpeg libkeyfinder ];
+  buildInputs = [ ffmpeg_7 libkeyfinder fftw ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/development/libraries/audio/libkeyfinder/default.nix
+++ b/pkgs/development/libraries/audio/libkeyfinder/default.nix
@@ -1,30 +1,21 @@
-{ lib, stdenv, fetchpatch, fetchFromGitHub, cmake, fftw, catch2 }:
+{ lib, stdenv, fetchpatch, fetchFromGitHub, cmake, fftw, catch2_3 }:
 
 stdenv.mkDerivation rec {
   pname = "libkeyfinder";
-  version = "2.2.6";
+  version = "2.2.8";
 
   src = fetchFromGitHub {
     owner = "mixxxdj";
     repo = "libkeyfinder";
-    rev = "v${version}";
-    sha256 = "sha256-7w/Wc9ncLinbnM2q3yv5DBtFoJFAM2e9xAUTsqvE9mg=";
+    rev = version;
+    hash = "sha256-Et8u5j/ke9u2bwHFriPCCBiXkPel37gwx+kwuViAr4o=";
   };
-
-  # in main post 2.2.6, see https://github.com/mixxxdj/libkeyfinder/issues/21
-  patches = [
-    (fetchpatch {
-      name = "fix-pkg-config";
-      url = "https://github.com/mixxxdj/libkeyfinder/commit/4e1a5022d4c91e3ecfe9be5c3ac7cc488093bd2e.patch";
-      sha256 = "08llmgp6r11bq5s820j3fs9bgriaibkhq8r3v2av064w66mwp48x";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ fftw ];
 
-  nativeCheckInputs = [ catch2 ];
+  nativeCheckInputs = [ catch2_3 ];
 
   doCheck = true;
 


### PR DESCRIPTION
## Description of changes

Includes fixes for FFmpeg 7.

I confirmed that `mixxx` still builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
