### PR TITLE
ieda: init at 0-unstable-2024-10-11

### DIFF
--- a/pkgs/by-name/ie/ieda/fix-bump-gcc.patch
+++ b/pkgs/by-name/ie/ieda/fix-bump-gcc.patch
@@ -1,0 +1,409 @@
+From bce09ab2a483a29479518e28511a99a56c0ac943 Mon Sep 17 00:00:00 2001
+From: xinyangli <lixinyang411@gmail.com>
+Date: Sun, 1 Sep 2024 16:39:29 +0800
+Subject: [PATCH 1/3] refactor:use gtest instead of libgtest.a, .so can be used
+ if provided
+
+---
+ .../iNO/external_libs/ino_test_external_libs.cmake    | 11 ++++++-----
+ .../iPL/external_libs/ipl_test_external_libs.cmake    |  7 ++++---
+ .../iTO/external_libs/ito_test_external_libs.cmake    | 11 ++++++-----
+ 3 files changed, 16 insertions(+), 13 deletions(-)
+
+diff --git a/src/operation/iNO/external_libs/ino_test_external_libs.cmake b/src/operation/iNO/external_libs/ino_test_external_libs.cmake
+index be5764cc..cc3460a6 100644
+--- a/src/operation/iNO/external_libs/ino_test_external_libs.cmake
++++ b/src/operation/iNO/external_libs/ino_test_external_libs.cmake
+@@ -1,8 +1,9 @@
+ add_library(ino_test_external_libs INTERFACE)
+ 
+-target_link_libraries(ino_test_external_libs 
++target_link_libraries(ino_test_external_libs
+     INTERFACE
+-        libgtest.a 
+-        libgtest_main.a 
+-        pthread 
+-)
+\ No newline at end of file
++        gtest
++        gtest_main
++        pthread
++)
++
+diff --git a/src/operation/iPL/external_libs/ipl_test_external_libs.cmake b/src/operation/iPL/external_libs/ipl_test_external_libs.cmake
+index 9accbee5..b763f91e 100644
+--- a/src/operation/iPL/external_libs/ipl_test_external_libs.cmake
++++ b/src/operation/iPL/external_libs/ipl_test_external_libs.cmake
+@@ -2,7 +2,8 @@ add_library(ipl-test_external_libs INTERFACE)
+ 
+ target_link_libraries(ipl-test_external_libs
+     INTERFACE
+-        libgtest.a
+-        libgtest_main.a
++        gtest
++        gtest_main
+         pthread
+-)
+\ No newline at end of file
++)
++
+diff --git a/src/operation/iTO/external_libs/ito_test_external_libs.cmake b/src/operation/iTO/external_libs/ito_test_external_libs.cmake
+index 9382d2e3..582e7abc 100644
+--- a/src/operation/iTO/external_libs/ito_test_external_libs.cmake
++++ b/src/operation/iTO/external_libs/ito_test_external_libs.cmake
+@@ -1,8 +1,9 @@
+ add_library(ito_test_external_libs INTERFACE)
+ 
+-target_link_libraries(ito_test_external_libs 
++target_link_libraries(ito_test_external_libs
+     INTERFACE
+-        libgtest.a 
+-        libgtest_main.a 
+-        pthread 
+-)
+\ No newline at end of file
++        gtest
++        gtest_main
++        pthread
++)
++
+-- 
+2.47.0
+
+
+From 56cd8a3c510b884cca7ef2bbc9e279feb57a3041 Mon Sep 17 00:00:00 2001
+From: xinyangli <lixinyang411@gmail.com>
+Date: Sun, 1 Sep 2024 16:44:07 +0800
+Subject: [PATCH 2/3] fix:missing headers in gcc 13
+
+---
+ src/database/basic/geometry/IdbGeometry.h                    | 1 +
+ src/database/basic/geometry/IdbLayerShape.h                  | 3 ++-
+ src/feature/database/feature_db.h                            | 1 +
+ .../iCTS/source/data_manager/database/CtsCellLib.hh          | 3 ++-
+ .../iCTS/source/data_manager/io/report/CtsReport.hh          | 3 ++-
+ src/operation/iCTS/source/solver/database/Net.hh             | 5 ++++-
+ src/operation/iFP/source/module/tap_cell/tapcell.h           | 4 +++-
+ src/operation/iPDN/source/module/pdn_plan/pdn_plan.h         | 4 ++--
+ src/operation/iPDN/source/module/pdn_via/pdn_via.h           | 3 ++-
+ .../iPL/source/module/detail_placer/database/DPNet.hh        | 3 ++-
+ .../iPL/source/module/detail_placer/database/DPPin.cc        | 4 +++-
+ src/operation/iRT/interface/RTInterface.hpp                  | 1 +
+ src/third_party/CMakeLists.txt                               | 2 +-
+ src/third_party/salt/refine/flip.cpp                         | 3 ++-
+ 14 files changed, 28 insertions(+), 12 deletions(-)
+
+diff --git a/src/database/basic/geometry/IdbGeometry.h b/src/database/basic/geometry/IdbGeometry.h
+index ec16907c..a8b8a360 100644
+--- a/src/database/basic/geometry/IdbGeometry.h
++++ b/src/database/basic/geometry/IdbGeometry.h
+@@ -34,6 +34,7 @@
+ ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ 
++#include <cstdint>
+ #include <iostream>
+ #include <string>
+ #include <vector>
+diff --git a/src/database/basic/geometry/IdbLayerShape.h b/src/database/basic/geometry/IdbLayerShape.h
+index 8c7ac435..35981708 100644
+--- a/src/database/basic/geometry/IdbLayerShape.h
++++ b/src/database/basic/geometry/IdbLayerShape.h
+@@ -31,6 +31,7 @@
+ ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ 
++#include <cstdint>
+ #include <iostream>
+ #include <string>
+ #include <vector>
+@@ -110,4 +111,4 @@ class IdbLayerShape
+   IdbLayer* _layer;
+   std::vector<IdbRect*> _rect_list;
+ };
+-}  // namespace idb
+\ No newline at end of file
++}  // namespace idb
+diff --git a/src/feature/database/feature_db.h b/src/feature/database/feature_db.h
+index 53ee71ca..71d8c3f3 100644
+--- a/src/feature/database/feature_db.h
++++ b/src/feature/database/feature_db.h
+@@ -31,6 +31,7 @@
+ ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ 
+ #include <cmath>
++#include <cstdint>
+ #include <iostream>
+ #include <string>
+ #include <vector>
+diff --git a/src/operation/iCTS/source/data_manager/database/CtsCellLib.hh b/src/operation/iCTS/source/data_manager/database/CtsCellLib.hh
+index 43699ff5..b103a702 100644
+--- a/src/operation/iCTS/source/data_manager/database/CtsCellLib.hh
++++ b/src/operation/iCTS/source/data_manager/database/CtsCellLib.hh
+@@ -26,6 +26,7 @@
+ #include <map>
+ #include <span>
+ #include <tuple>
++#include <unordered_map>
+ #include <vector>
+ 
+ #include "ModelFactory.hh"
+@@ -187,4 +188,4 @@ class CtsLibs
+   std::unordered_map<std::string, ModelBase*> _model_maps;
+ #endif
+ };
+-}  // namespace icts
+\ No newline at end of file
++}  // namespace icts
+diff --git a/src/operation/iCTS/source/data_manager/io/report/CtsReport.hh b/src/operation/iCTS/source/data_manager/io/report/CtsReport.hh
+index 8798e50e..b88df74c 100644
+--- a/src/operation/iCTS/source/data_manager/io/report/CtsReport.hh
++++ b/src/operation/iCTS/source/data_manager/io/report/CtsReport.hh
+@@ -23,6 +23,7 @@
+ #include <fstream>
+ #include <iostream>
+ #include <map>
++#include <memory>
+ #include <string>
+ #include <utility>
+ #include <vector>
+@@ -70,4 +71,4 @@ class CtsReportTable : public ieda::ReportTable
+   static std::unique_ptr<CtsReportTable> createReportTable(const std::string& tbl_name, const CtsReportType& type);
+ };
+ 
+-}  // namespace icts
+\ No newline at end of file
++}  // namespace icts
+diff --git a/src/operation/iCTS/source/solver/database/Net.hh b/src/operation/iCTS/source/solver/database/Net.hh
+index 85c1751b..5cbc0470 100644
+--- a/src/operation/iCTS/source/solver/database/Net.hh
++++ b/src/operation/iCTS/source/solver/database/Net.hh
+@@ -20,6 +20,9 @@
+  */
+ #pragma once
+ class Pin;
++#include <algorithm>
++#include <cstdint>
++
+ #include "CTSAPI.hh"
+ #include "Pin.hh"
+ 
+@@ -70,4 +73,4 @@ class Net
+   Pin* _driver_pin = nullptr;
+   std::vector<Pin*> _load_pins = {};
+ };
+-}  // namespace icts
+\ No newline at end of file
++}  // namespace icts
+diff --git a/src/operation/iFP/source/module/tap_cell/tapcell.h b/src/operation/iFP/source/module/tap_cell/tapcell.h
+index 4af86b51..e15ba4a3 100644
+--- a/src/operation/iFP/source/module/tap_cell/tapcell.h
++++ b/src/operation/iFP/source/module/tap_cell/tapcell.h
+@@ -16,6 +16,8 @@
+ // ***************************************************************************************
+ #pragma once
+ 
++#include <stdint.h>
++
+ #include <iostream>
+ #include <string>
+ #include <vector>
+@@ -58,4 +60,4 @@ class TapCellPlacer
+   int32_t getCellMasterWidthByOrient(idb::IdbCellMaster* cell_master, idb::IdbOrient orinet);
+ };
+ 
+-}  // namespace ifp
+\ No newline at end of file
++}  // namespace ifp
+diff --git a/src/operation/iPDN/source/module/pdn_plan/pdn_plan.h b/src/operation/iPDN/source/module/pdn_plan/pdn_plan.h
+index e46b5c34..82de562b 100644
+--- a/src/operation/iPDN/source/module/pdn_plan/pdn_plan.h
++++ b/src/operation/iPDN/source/module/pdn_plan/pdn_plan.h
+@@ -16,13 +16,13 @@
+ // ***************************************************************************************
+ #pragma once
+ 
++#include <cstdint>
+ #include <map>
+ #include <string>
+ #include <vector>
+ 
+ #include "ipdn_basic.h"
+ #include "pdn_cut_stripe.h"
+-
+ namespace idb {
+ class IdbLayer;
+ class IdbSpecialWireSegment;
+@@ -108,4 +108,4 @@ class PdnPlan
+                               std::vector<idb::IdbSpecialWireSegment*>& segment_list_bottom);
+ };
+ 
+-}  // namespace ipdn
+\ No newline at end of file
++}  // namespace ipdn
+diff --git a/src/operation/iPDN/source/module/pdn_via/pdn_via.h b/src/operation/iPDN/source/module/pdn_via/pdn_via.h
+index 837399ce..e0fe85bf 100644
+--- a/src/operation/iPDN/source/module/pdn_via/pdn_via.h
++++ b/src/operation/iPDN/source/module/pdn_via/pdn_via.h
+@@ -16,6 +16,7 @@
+ // ***************************************************************************************
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 
+@@ -64,4 +65,4 @@ class PdnVia
+   int32_t transUnitDB(double value);
+ };
+ 
+-}  // namespace ipdn
+\ No newline at end of file
++}  // namespace ipdn
+diff --git a/src/operation/iPL/source/module/detail_placer/database/DPNet.hh b/src/operation/iPL/source/module/detail_placer/database/DPNet.hh
+index f0013433..890111c5 100644
+--- a/src/operation/iPL/source/module/detail_placer/database/DPNet.hh
++++ b/src/operation/iPL/source/module/detail_placer/database/DPNet.hh
+@@ -27,6 +27,7 @@
+ #ifndef IPL_DPNET_H
+ #define IPL_DPNET_H
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 
+@@ -92,4 +93,4 @@ class DPNet
+   std::vector<DPPin*> _pins;
+ };
+ }  // namespace ipl
+-#endif
+\ No newline at end of file
++#endif
+diff --git a/src/operation/iPL/source/module/detail_placer/database/DPPin.cc b/src/operation/iPL/source/module/detail_placer/database/DPPin.cc
+index 93aea277..537b1282 100644
+--- a/src/operation/iPL/source/module/detail_placer/database/DPPin.cc
++++ b/src/operation/iPL/source/module/detail_placer/database/DPPin.cc
+@@ -16,6 +16,8 @@
+ // ***************************************************************************************
+ #include "DPPin.hh"
+ 
++#include <cstdint>
++
+ namespace ipl {
+ 
+ DPPin::DPPin(std::string name)
+@@ -35,4 +37,4 @@ DPPin::~DPPin()
+ {
+ }
+ 
+-}  // namespace ipl
+\ No newline at end of file
++}  // namespace ipl
+diff --git a/src/operation/iRT/interface/RTInterface.hpp b/src/operation/iRT/interface/RTInterface.hpp
+index 5a6c3c18..45a4952e 100644
+--- a/src/operation/iRT/interface/RTInterface.hpp
++++ b/src/operation/iRT/interface/RTInterface.hpp
+@@ -17,6 +17,7 @@
+ #pragma once
+ 
+ #include <any>
++#include <cstdint>
+ #include <map>
+ #include <set>
+ #include <string>
+diff --git a/src/third_party/CMakeLists.txt b/src/third_party/CMakeLists.txt
+index cb66c339..29f6b02d 100644
+--- a/src/third_party/CMakeLists.txt
++++ b/src/third_party/CMakeLists.txt
+@@ -12,4 +12,4 @@ add_subdirectory(yaml-cpp)
+ # add_subdirectory(mt-kahypar)
+ if(BUILD_GUI)
+ add_subdirectory(tcl_qt)
+-endif()
+\ No newline at end of file
++endif()
+diff --git a/src/third_party/salt/refine/flip.cpp b/src/third_party/salt/refine/flip.cpp
+index 5dad3766..73743f3c 100644
+--- a/src/third_party/salt/refine/flip.cpp
++++ b/src/third_party/salt/refine/flip.cpp
+@@ -3,6 +3,7 @@
+ #include "salt/base/eval.h"
+ 
+ #include <algorithm>
++#include <array>
+ 
+ namespace salt {
+ 
+@@ -197,4 +198,4 @@ void Refine::flip(Tree& tree) {
+     } while (cur.wireLength < pre.wireLength);
+ }
+ 
+-}  // namespace salt
+\ No newline at end of file
++}  // namespace salt
+-- 
+2.47.0
+
+
+From 55e689db3a9d2a51828806ab46ff655cc4c1193c Mon Sep 17 00:00:00 2001
+From: xinyangli <lixinyang411@gmail.com>
+Date: Sun, 1 Sep 2024 17:00:37 +0800
+Subject: [PATCH 3/3] fix:glog force size_t on sighandler from 0.6
+
+---
+ src/operation/iPL/source/module/logger/Log.cc | 5 +++--
+ src/utility/log/Log.cc                        | 3 ++-
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/operation/iPL/source/module/logger/Log.cc b/src/operation/iPL/source/module/logger/Log.cc
+index c94d3907..2fc70b31 100644
+--- a/src/operation/iPL/source/module/logger/Log.cc
++++ b/src/operation/iPL/source/module/logger/Log.cc
+@@ -26,6 +26,7 @@
+ 
+ #include "Log.hh"
+ 
++#include <cstddef>
+ #include <filesystem>
+ #include <fstream>
+ #include <functional>
+@@ -40,7 +41,7 @@ namespace ipl {
+  * @param {int} size
+  * @return {*}
+  */
+-void SignalHandle(const char* data, int size)
++void SignalHandle(const char* data, std::size_t size)
+ {
+   std::ofstream fs("glog_dump.log", std::ios::app);
+   std::string str = std::string(data, size);
+@@ -101,4 +102,4 @@ void Log::makeSureDirectoryExist(std::string directory_path)
+   std::filesystem::create_directories(directory_path.c_str());
+ }
+ 
+-}  // namespace ipl
+\ No newline at end of file
++}  // namespace ipl
+diff --git a/src/utility/log/Log.cc b/src/utility/log/Log.cc
+index 42d43041..190566a3 100644
+--- a/src/utility/log/Log.cc
++++ b/src/utility/log/Log.cc
+@@ -24,6 +24,7 @@
+ 
+ #include "Log.hh"
+ 
++#include <cstddef>
+ #include <fstream>
+ #include <functional>
+ #include <iostream>
+@@ -39,7 +40,7 @@ namespace ieda {
+  * @param data
+  * @param size
+  */
+-void SignalHandle(const char* data, int size)
++void SignalHandle(const char* data, std::size_t size)
+ {
+   std::ofstream fs("glog_dump.log", std::ios::app);
+   std::string str = std::string(data, size);
+-- 
+2.47.0
+

--- a/pkgs/by-name/ie/ieda/package.nix
+++ b/pkgs/by-name/ie/ieda/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  callPackages,
+  cmake,
+  ninja,
+  flex,
+  bison,
+  zlib,
+  tcl,
+  boost,
+  eigen,
+  yaml-cpp,
+  libunwind,
+  glog,
+  gtest,
+  gflags,
+  metis,
+  gmp,
+  python3,
+  onnxruntime,
+}:
+let
+  rootSrc = stdenv.mkDerivation {
+    pname = "iEDA-src";
+    version = "2024-09-10";
+    src = fetchgit {
+      url = "https://gitee.com/oscc-project/iEDA";
+      rev = "a68b691b9d25fafd8c10fae3df7ef3837a42e052";
+      sha256 = "sha256-0rSESfNqI3ALipNAInwcYSccq9C0WuXI9na44TyYAgY=";
+    };
+
+    patches = [
+      ./fix-bump-gcc.patch
+
+      # We need to build rust projects with rustPlatform
+      # and remove hard coded linking to libonnxruntime
+      ./remove-subprojects-from-cmake.patch
+    ];
+
+    postPatch = ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'set(CMAKE_CXX_FLAGS_RELEASE "$ENV{CXXFLAGS} -O3 -Wall")' 'set(CMAKE_CXX_FLAGS_RELEASE "$ENV{CXXFLAGS} -O2")'
+    '';
+
+    dontBuild = true;
+    dontFixup = true;
+    installPhase = ''
+      cp -r . $out
+    '';
+
+  };
+
+  rustpkgs = callPackages ./rustpkgs.nix { inherit rootSrc; };
+in
+stdenv.mkDerivation {
+  pname = "iEDA";
+  version = "0-unstable-2024-10-11";
+
+  src = rootSrc;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    flex
+    bison
+    python3
+    tcl
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CMD_BUILD" true)
+    (lib.cmakeBool "SANITIZER" false)
+    (lib.cmakeBool "BUILD_STATIC_LIB" false)
+  ];
+
+  preConfigure = ''
+    cmakeFlags+=" -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:FILEPATH=$out/bin -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:FILEPATH=$out/lib"
+  '';
+
+  buildInputs = [
+    rustpkgs.iir-rust
+    rustpkgs.sdf_parse
+    rustpkgs.spef-parser
+    rustpkgs.vcd_parser
+    rustpkgs.verilog-parser
+    rustpkgs.liberty-parser
+    gtest
+    glog
+    gflags
+    boost
+    onnxruntime
+    eigen
+    yaml-cpp
+    libunwind
+    metis
+    gmp
+    tcl
+    zlib
+  ];
+
+  postInstall = ''
+    # Tests rely on hardcoded path, so they should not be included
+    rm $out/bin/*test $out/bin/*Test $out/bin/test_* $out/bin/*_app
+  '';
+
+  enableParallelBuild = true;
+
+  meta = {
+    description = "Open-source EDA infracstructure and tools from Netlist to GDS for ASIC design";
+    homepage = "https://gitee.com/oscc-project/iEDA";
+    license = lib.licenses.mulan-psl2;
+    maintainers = with lib.maintainers; [ xinyangli ];
+    mainProgram = "iEDA";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/ie/ieda/remove-subprojects-from-cmake.patch
+++ b/pkgs/by-name/ie/ieda/remove-subprojects-from-cmake.patch
@@ -1,0 +1,166 @@
+From 170a842da107e937c1c62c2a318ef84d49e1d292 Mon Sep 17 00:00:00 2001
+From: xinyangli <lixinyang411@gmail.com>
+Date: Fri, 30 Aug 2024 17:33:15 +0800
+Subject: [PATCH 1/2] fix:wrong headers in nix
+
+---
+ src/operation/iCTS/api/CTSAPI.hh | 1 +
+ src/utility/tcl/ScriptEngine.hh  | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/operation/iCTS/api/CTSAPI.hh b/src/operation/iCTS/api/CTSAPI.hh
+index c0881dc0..85c38728 100644
+--- a/src/operation/iCTS/api/CTSAPI.hh
++++ b/src/operation/iCTS/api/CTSAPI.hh
+@@ -28,6 +28,7 @@
+ #include <string_view>
+ #include <type_traits>
+ #include <vector>
++#include <optional>
+ 
+ #include "../../../database/interaction/ids.hpp"
+ 
+diff --git a/src/utility/tcl/ScriptEngine.hh b/src/utility/tcl/ScriptEngine.hh
+index 3e679de2..78e9d24d 100644
+--- a/src/utility/tcl/ScriptEngine.hh
++++ b/src/utility/tcl/ScriptEngine.hh
+@@ -24,7 +24,7 @@
+ 
+ #pragma once
+ 
+-#include <tcl8.6/tcl.h>
++#include <tcl.h>
+ 
+ #include <memory>
+ #include <mutex>
+-- 
+2.47.0
+
+
+From 66e3e69aa12a331d3724314ac06cd713ebb152d9 Mon Sep 17 00:00:00 2001
+From: xinyangli <lixinyang411@gmail.com>
+Date: Sat, 31 Aug 2024 23:28:30 +0800
+Subject: [PATCH 2/2] remove rust packages and onnxruntime lib from cmake
+
+---
+ src/database/manager/parser/liberty/CMakeLists.txt | 6 +++---
+ src/database/manager/parser/spef/CMakeLists.txt    | 4 ++--
+ src/database/manager/parser/vcd/CMakeLists.txt     | 6 +++---
+ src/database/manager/parser/verilog/CMakeLists.txt | 6 +++---
+ src/operation/iIR/source/iir-rust/CMakeLists.txt   | 4 ++--
+ src/operation/iSTA/CMakeLists.txt                  | 2 +-
+ 6 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/src/database/manager/parser/liberty/CMakeLists.txt b/src/database/manager/parser/liberty/CMakeLists.txt
+index cf9ee880..c03f9dbe 100644
+--- a/src/database/manager/parser/liberty/CMakeLists.txt
++++ b/src/database/manager/parser/liberty/CMakeLists.txt
+@@ -22,9 +22,9 @@ endif()
+ 
+ message("liberty parser rust lib path ${RUST_LIB_PATH}")
+ 
+-ADD_EXTERNAL_PROJ(liberty)
++# ADD_EXTERNAL_PROJ(liberty)
+ 
+-target_link_libraries(liberty str sta-solver log ${RUST_LIB_PATH} dl)
++target_link_libraries(liberty str sta-solver log liberty_parser dl)
+ 
+ target_include_directories(liberty PUBLIC 
+     ${CMAKE_CURRENT_SOURCE_DIR} 
+@@ -35,4 +35,4 @@ target_link_libraries(test_lib liberty)
+ target_include_directories(test_lib PUBLIC 
+     ${CMAKE_CURRENT_SOURCE_DIR})
+ 
+-install(TARGETS test_lib DESTINATION /home/taosimin/bin/iEDA_bin)
+\ No newline at end of file
++# install(TARGETS test_lib DESTINATION /home/taosimin/bin/iEDA_bin)
+diff --git a/src/database/manager/parser/spef/CMakeLists.txt b/src/database/manager/parser/spef/CMakeLists.txt
+index 0d8672ed..9e27083b 100644
+--- a/src/database/manager/parser/spef/CMakeLists.txt
++++ b/src/database/manager/parser/spef/CMakeLists.txt
+@@ -22,9 +22,9 @@ endif()
+ 
+ message("spef parser rust lib path ${RUST_LIB_PATH}")
+ 
+-ADD_EXTERNAL_PROJ(spef)
++# ADD_EXTERNAL_PROJ(spef)
+ 
+-target_link_libraries(spef log ${RUST_LIB_PATH} dl)
++target_link_libraries(spef log spef_parser dl)
+ target_include_directories(spef PUBLIC 
+     ${CMAKE_CURRENT_SOURCE_DIR})
+ 
+diff --git a/src/database/manager/parser/vcd/CMakeLists.txt b/src/database/manager/parser/vcd/CMakeLists.txt
+index 3a9cfddb..89bad504 100644
+--- a/src/database/manager/parser/vcd/CMakeLists.txt
++++ b/src/database/manager/parser/vcd/CMakeLists.txt
+@@ -21,9 +21,9 @@ endif()
+ 
+ message("vcd parser rust lib path ${RUST_LIB_PATH}")
+ 
+-ADD_EXTERNAL_PROJ(vcd)
++# ADD_EXTERNAL_PROJ(vcd)
+ 
+-target_link_libraries(vcd ${RUST_LIB_PATH} dl)
++target_link_libraries(vcd vcd_parser dl)
+ target_include_directories(vcd PUBLIC 
+     ${CMAKE_CURRENT_SOURCE_DIR})
+ 
+@@ -31,4 +31,4 @@ add_executable(test_vcd ${CMAKE_CURRENT_SOURCE_DIR}/vcd_parser/test/test.cpp)
+ target_link_libraries(test_vcd vcd)
+ target_include_directories(test_vcd PUBLIC 
+         ${CMAKE_CURRENT_SOURCE_DIR})
+-    
+\ No newline at end of file
++    
+diff --git a/src/database/manager/parser/verilog/CMakeLists.txt b/src/database/manager/parser/verilog/CMakeLists.txt
+index a3f21183..e2a55cfc 100644
+--- a/src/database/manager/parser/verilog/CMakeLists.txt
++++ b/src/database/manager/parser/verilog/CMakeLists.txt
+@@ -25,12 +25,12 @@ endif()
+ 
+ message("verilog parser rust lib path ${RUST_LIB_PATH}")
+ 
+-ADD_EXTERNAL_PROJ(verilog)
++# ADD_EXTERNAL_PROJ(verilog)
+ 
+-target_link_libraries(verilog str log ${ZLIB_LIBRARIES} ${RUST_LIB_PATH} dl) 
++target_link_libraries(verilog str log ${ZLIB_LIBRARIES} verilog_parser dl) 
+ 
+ target_include_directories(verilog
+     PUBLIC
+         ${HOME_OPERATION}/iSTA/include
+         ${CMAKE_CURRENT_SOURCE_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/src/operation/iIR/source/iir-rust/CMakeLists.txt b/src/operation/iIR/source/iir-rust/CMakeLists.txt
+index 69e7009c..049c0012 100644
+--- a/src/operation/iIR/source/iir-rust/CMakeLists.txt
++++ b/src/operation/iIR/source/iir-rust/CMakeLists.txt
+@@ -22,6 +22,6 @@ endif()
+ 
+ message("iIR rust lib path ${RUST_LIB_PATH}")
+ 
+-ADD_EXTERNAL_PROJ(iir)
++# ADD_EXTERNAL_PROJ(iir)
+ 
+-target_link_libraries(iIR-Rust PRIVATE ${RUST_LIB_PATH} dl)
+\ No newline at end of file
++target_link_libraries(iIR-Rust PRIVATE iir dl)
+diff --git a/src/operation/iSTA/CMakeLists.txt b/src/operation/iSTA/CMakeLists.txt
+index 31563917..9a1207a5 100644
+--- a/src/operation/iSTA/CMakeLists.txt
++++ b/src/operation/iSTA/CMakeLists.txt
+@@ -24,7 +24,7 @@ include_directories(${HOME_THIRDPARTY}/yaml-cpp/include)
+ include(${HOME_CMAKE}/operation/idb.cmake)
+ 
+ link_directories(${CMAKE_BINARY_DIR}/lib)
+-link_directories(${HOME_THIRDPARTY}/onnxruntime/)
++# link_directories(${HOME_THIRDPARTY}/onnxruntime/)
+ 
+ find_package(Eigen3 REQUIRED)
+ 
+-- 
+2.47.0
+

--- a/pkgs/by-name/ie/ieda/rustpkgs.nix
+++ b/pkgs/by-name/ie/ieda/rustpkgs.nix
@@ -1,0 +1,68 @@
+{ rustPlatform, rootSrc }:
+let
+  mkRustpkgs = _: p: rustPlatform.buildRustPackage p;
+in
+(builtins.mapAttrs mkRustpkgs {
+  iir-rust = rec {
+    pname = "iir-rust";
+    version = "0.1.3";
+    src = rootSrc;
+    sourceRoot = "${src.name}/src/operation/iIR/source/iir-rust/iir";
+    cargoHash = "sha256-ka91IsmBGBYts4U9X4uZDUMeS9adPn3MKl2BY4ZKDCY=";
+
+    doCheck = false;
+
+    nativeBuildInputs = [ rustPlatform.bindgenHook ];
+  };
+  liberty-parser = rec {
+    pname = "liberty-parser";
+    version = "0.1.0";
+    src = rootSrc;
+    sourceRoot = "${src.name}/src/database/manager/parser/liberty/lib-rust/liberty-parser";
+    cargoHash = "sha256-7yUD8M3efisuVoH3/R+Pk2CP4mizSinrqeuy3uqkq2c=";
+
+    doCheck = false;
+
+    nativeBuildInputs = [ rustPlatform.bindgenHook ];
+  };
+  sdf_parse = rec {
+    pname = "sdf_parse";
+    version = "0.1.0";
+    src = rootSrc;
+    sourceRoot = "${src.name}/src/database/manager/parser/sdf/sdf_parse";
+    cargoHash = "sha256-6uzufy3S21vHJYgx9sItxQyccG0g/Zz1r2xHsYoQPRM=";
+
+    nativeBuildInputs = [ rustPlatform.bindgenHook ];
+  };
+  spef-parser = rec {
+    pname = "spef-parser";
+    version = "0.2.4";
+    src = rootSrc;
+    sourceRoot = "${src.name}/src/database/manager/parser/spef/spef-parser";
+    cargoHash = "sha256-KTd3HVKV8hRCXf56FPksYGVJNDdlmMMIcSEk1MMGLsw=";
+
+    nativeBuildInputs = [ rustPlatform.bindgenHook ];
+  };
+  vcd_parser = rec {
+    pname = "vcd_parser";
+    version = "0.1.0";
+    src = rootSrc;
+    sourceRoot = "${src.name}/src/database/manager/parser/vcd/vcd_parser";
+    cargoHash = "sha256-1y1nPNfx23MyIJUV+E6mMuDOhdob0BDGuQwOl0Le/lE=";
+
+    doCheck = false;
+
+    nativeBuildInputs = [ rustPlatform.bindgenHook ];
+  };
+  verilog-parser = rec {
+    pname = "verilog-parser";
+    version = "0.1.0";
+    src = rootSrc;
+    sourceRoot = "${src.name}/src/database/manager/parser/verilog/verilog-rust/verilog-parser";
+    cargoHash = "sha256-Z/LXQzQ0m1lQdIPaWQ5rs2EAu/mbyi2JvrjGYVmKONs=";
+
+    doCheck = false;
+
+    nativeBuildInputs = [ rustPlatform.bindgenHook ];
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

iEDA is a collection of open source EDA tools. Checkout it's official website at: https://ieda.oscc.cc/en/

It's a project written in cpp and rust, so I just package it's rust sub-projects and remove building process of rust packages from cmake. I'm not sure if this is the best practice? Let me know if there are better approaches.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
