### PR TITLE
wg-netns: init at 2.3.4

### DIFF
--- a/pkgs/by-name/wg/wg-netns/package.nix
+++ b/pkgs/by-name/wg/wg-netns/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  iproute2,
+  wireguard-tools,
+  socat,
+  getent,
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "wg-netns";
+  version = "2.3.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dadevel";
+    repo = "wg-netns";
+    rev = "v${version}";
+    hash = "sha256-N5MY7EoskrOR3eMrt8Y2GcIJhIvyAjQyhttT/5bWhEg=";
+  };
+
+  build-system = [
+    python3.pkgs.poetry-core
+  ];
+
+  dependencies = [
+    python3.pkgs.pyyaml
+    iproute2
+    wireguard-tools
+    socat
+    getent
+  ];
+
+  postInstall = ''
+    install -Dm600 extras/wg-netns@.service -t $out/lib/systemd/system
+    substituteInPlace $out/lib/systemd/system/wg-netns@.service \
+      --replace "ExecStart=wg-netns" "ExecStart=$out/bin/wg-netns"
+    substituteInPlace $out/lib/systemd/system/wg-netns@.service \
+      --replace "ExecStop=wg-netns" "ExecStop=$out/bin/wg-netns"
+
+    install -Dm755 extras/netns-publish.sh -t $out/bin
+    wrapProgram $out/bin/netns-publish.sh --prefix PATH : ${lib.makeBinPath [ socat ]}
+  '';
+
+  meta = {
+    description = "WireGuard with Linux Network Namespaces";
+
+    longDescription = ''
+      With wg-netns you can setup Wireguard tunnels in network namespaces,
+      which then can be used by containers, systemd services etc.
+      Works similar to wg-quick and implements the steps described at wireguard.com/netns.
+    '';
+    platforms = lib.platforms.linux;
+    homepage = "https://github.com/dadevel/wg-netns";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.claes ];
+  };
+}


### PR DESCRIPTION
## Description of changes

wg-netns: WireGuard with Linux Network Namespaces

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
