### PR TITLE
haskell.compiler.ghc*: use matching CLANG & CC on Darwin with LLVM

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -320,6 +320,9 @@ let
           if stdenv.targetPlatform.isDarwin
           then cc.bintools
           else cc.bintools.bintools;
+
+        # clang is used as an assembler on darwin with the LLVM backend
+        clang = cc;
       }.${name};
     in
     "${tools}/bin/${tools.targetPrefix}${name}";
@@ -409,7 +412,17 @@ stdenv.mkDerivation ({
     export OPT="${lib.getBin buildTargetLlvmPackages.llvm}/bin/opt"
   '' + lib.optionalString (useLLVM && stdenv.targetPlatform.isDarwin) ''
     # LLVM backend on Darwin needs clang: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
-    export CLANG="${buildTargetLlvmPackages.clang}/bin/${buildTargetLlvmPackages.clang.targetPrefix}clang"
+    # The executable we specify via $CLANG is used as an assembler (exclusively, it seems, but this isn't
+    # clarified in any user facing documentation). As such, it'll be called on assembly produced by $CC
+    # which usually comes from the darwin stdenv. To prevent a situation where $CLANG doesn't understand
+    # the assembly it is given, we need to make sure that it matches the LLVM version of $CC if possible.
+    # It is unclear (at the time of writing 2024-09-01)  whether $CC should match the LLVM version we use
+    # for llc and opt which would require using a custom darwin stdenv for targetCC.
+    export CLANG="${
+      if targetCC.isClang
+      then toolPath "clang" targetCC
+      else "${buildTargetLlvmPackages.clang}/bin/${buildTargetLlvmPackages.clang.targetPrefix}clang"
+    }"
   '' +
   lib.optionalString (stdenv.isLinux && hostPlatform.libc == "glibc") ''
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
@@ -627,10 +640,14 @@ stdenv.mkDerivation ({
       "LLVM llc command" "${lib.getBin llvmPackages.llvm}/bin/llc" \
       "LLVM opt command" "${lib.getBin llvmPackages.llvm}/bin/opt"
   ''
-  # FIXME(@sternenseemann): use installCC instead if possible
   + lib.optionalString (useLLVM && stdenv.targetPlatform.isDarwin) ''
     ghc-settings-edit "$settingsFile" \
-      "LLVM clang command" "${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
+      "LLVM clang command" "${
+        # See comment for CLANG in preConfigure
+        if installCC.isClang
+        then toolPath "clang" installCC
+        else "${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
+      }"
   ''
   # Work around a GHC bug which causes unlit to be installed under a different
   # name than is used in the settings file.

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -187,6 +187,9 @@ let
           if stdenv.targetPlatform.isDarwin
           then cc.bintools
           else cc.bintools.bintools;
+
+        # clang is used as an assembler on darwin with the LLVM backend
+        clang = cc;
       }.${name};
     in
     "${tools}/bin/${tools.targetPrefix}${name}";
@@ -335,7 +338,17 @@ stdenv.mkDerivation (rec {
     export OPT="${lib.getBin buildTargetLlvmPackages.llvm}/bin/opt"
   '' + lib.optionalString (useLLVM && stdenv.targetPlatform.isDarwin) ''
     # LLVM backend on Darwin needs clang: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
-    export CLANG="${buildTargetLlvmPackages.clang}/bin/${buildTargetLlvmPackages.clang.targetPrefix}clang"
+    # The executable we specify via $CLANG is used as an assembler (exclusively, it seems, but this isn't
+    # clarified in any user facing documentation). As such, it'll be called on assembly produced by $CC
+    # which usually comes from the darwin stdenv. To prevent a situation where $CLANG doesn't understand
+    # the assembly it is given, we need to make sure that it matches the LLVM version of $CC if possible.
+    # It is unclear (at the time of writing 2024-09-01)  whether $CC should match the LLVM version we use
+    # for llc and opt which would require using a custom darwin stdenv for targetCC.
+    export CLANG="${
+      if targetCC.isClang
+      then toolPath "clang" targetCC
+      else "${buildTargetLlvmPackages.clang}/bin/${buildTargetLlvmPackages.clang.targetPrefix}clang"
+    }"
   ''
   + ''
     # No need for absolute paths since these tools only need to work during the build
@@ -494,10 +507,14 @@ stdenv.mkDerivation (rec {
       "LLVM llc command" "${lib.getBin llvmPackages.llvm}/bin/llc" \
       "LLVM opt command" "${lib.getBin llvmPackages.llvm}/bin/opt"
   ''
-  # FIXME(@sternenseemann): use installCC instead if possible
   + lib.optionalString (useLLVM && stdenv.targetPlatform.isDarwin) ''
     ghc-settings-edit "$settingsFile" \
-      "LLVM clang command" "${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
+      "LLVM clang command" "${
+        # See comment for CLANG in preConfigure
+        if installCC.isClang
+        then toolPath "clang" installCC
+        else "${llvmPackages.clang}/bin/${llvmPackages.clang.targetPrefix}clang"
+      }"
   ''
   + ''
 


### PR DESCRIPTION
The Darwin LLVM backend of GHC (which is mostly interesting for GHC < 9.2) uses clang as configured via the CLANG environment variable as an assembler. Since it processes outputs of clang as configured via the CC variable, we need to make sure these versions match or risk CLANG clang not understanding the output of CC clang.

In the past this wasn't really a problem as due to the fairly old default clang version in the stdenv, clang 11 would be used for CC. CLANG would always be a newer version and deal with the output without any problems.

Ever since the upgrade of the default clang version for darwin (bcbdb800cf7659d6ff36ac114121a056fe8c9656), CC would often be a newer version of clang than CLANG, causing build problems in some packages like crypton (for GHC 8.10.7 and 9.0.2 on aarch64-darwin where the darwin LLVM backend was actually used).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
