### PR TITLE
meson: use nix*Log functions

### DIFF
--- a/pkgs/by-name/me/meson/setup-hook.sh
+++ b/pkgs/by-name/me/meson/setup-hook.sh
@@ -26,21 +26,23 @@ mesonConfigurePhase() {
 
     concatTo flagsArray mesonFlags mesonFlagsArray
 
-    echoCmd 'mesonConfigurePhase flags' "${flagsArray[@]}"
+    nixInfoLog "${FUNCNAME[0]}: flagsArray: ${flagsArray[@]}"
 
     meson setup build "${flagsArray[@]}"
-    cd build || { echoCmd 'mesonConfigurePhase' "could not cd to build"; exit 1; }
+    cd build || { nixErrorLog "${FUNCNAME[0]}: could not cd to build"; exit 1; }
 
     if ! [[ -v enableParallelBuilding ]]; then
         enableParallelBuilding=1
-        echoCmd 'mesonConfigurePhase' "enabled parallel building"
+        nixInfoLog "${FUNCNAME[0]}: enabled parallel building"
     fi
 
     if [[ ${checkPhase-ninjaCheckPhase} = ninjaCheckPhase && -z $dontUseMesonCheck ]]; then
         checkPhase=mesonCheckPhase
+        nixInfoLog "${FUNCNAME[0]}: set checkPhase to mesonCheckPhase"
     fi
     if [[ ${installPhase-ninjaInstallPhase} = ninjaInstallPhase && -z $dontUseMesonInstall ]]; then
         installPhase=mesonInstallPhase
+        nixInfoLog "${FUNCNAME[0]}: set installPhase to mesonInstallPhase"
     fi
 
     runHook postConfigure
@@ -52,7 +54,7 @@ mesonCheckPhase() {
     local flagsArray=()
     concatTo flagsArray mesonCheckFlags mesonCheckFlagsArray
 
-    echoCmd 'mesonCheckPhase flags' "${flagsArray[@]}"
+    nixInfoLog "${FUNCNAME[0]}: flagsArray: ${flagsArray[@]}"
     meson test --no-rebuild --print-errorlogs "${flagsArray[@]}"
 
     runHook postCheck
@@ -68,7 +70,7 @@ mesonInstallPhase() {
     fi
     concatTo flagsArray mesonInstallFlags mesonInstallFlagsArray
 
-    echoCmd 'mesonInstallPhase flags' "${flagsArray[@]}"
+    nixInfoLog "${FUNCNAME[0]}: flagsArray: ${flagsArray[@]}"
     meson install --no-rebuild "${flagsArray[@]}"
 
     runHook postInstall
@@ -78,4 +80,5 @@ if [ -z "${dontUseMesonConfigure-}" ] && [ -z "${configurePhase-}" ]; then
     # shellcheck disable=SC2034
     setOutputFlags=
     configurePhase=mesonConfigurePhase
+    nixInfoLog "${FUNCNAME[0]}: set configurePhase to mesonConfigurePhase"
 fi


### PR DESCRIPTION
They are cleaner than echoCmd.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
