### PR TITLE
x2t: init at 8.3.2

### DIFF
--- a/nixos/modules/services/web-apps/onlyoffice.nix
+++ b/nixos/modules/services/web-apps/onlyoffice.nix
@@ -31,6 +31,8 @@ in
 
     package = lib.mkPackageOption pkgs "onlyoffice-documentserver" { };
 
+    x2t = lib.mkPackageOption pkgs "x2t" { };
+
     port = lib.mkOption {
       type = lib.types.port;
       default = 8000;
@@ -104,34 +106,53 @@ in
 
         virtualHosts.${cfg.hostname} = {
           locations = {
+            # resources that are generated and thus cannot be taken from the cfg.package yet:
+            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?\\/(sdkjs/common/AllFonts.js)$".extraConfig = ''
+              proxy_pass http://onlyoffice-docservice/$2$3;
+            '';
+            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?\\/(fonts/.*)$".extraConfig = ''
+              proxy_pass http://onlyoffice-docservice/$2$3;
+            '';
             # /etc/nginx/includes/ds-docservice.conf
-            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\d]+)?\\/(web-apps\\/apps\\/api\\/documents\\/api\\.js)$".extraConfig =
+            #disable caching for api.js
+            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?\\/(web-apps\\/apps\\/api\\/documents\\/api\\.js)$".extraConfig =
               ''
                 expires -1;
+                # gzip_static on;
                 alias ${cfg.package}/var/www/onlyoffice/documentserver/$2;
               '';
-            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\d]+)?\\/(web-apps)(\\/.*\\.json)$".extraConfig = ''
-              expires 365d;
-              error_log /dev/null crit;
-              alias ${cfg.package}/var/www/onlyoffice/documentserver/$2$3;
-            '';
-            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\d]+)?\\/(sdkjs-plugins)(\\/.*\\.json)$".extraConfig = ''
-              expires 365d;
-              error_log /dev/null crit;
-              alias ${cfg.package}/var/www/onlyoffice/documentserver/$2$3;
-            '';
-            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\d]+)?\\/(web-apps|sdkjs|sdkjs-plugins|fonts)(\\/.*)$".extraConfig =
+            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?\\/(document_editor_service_worker\\.js)$".extraConfig =
               ''
                 expires 365d;
+                # gzip_static on;
+                alias  ${cfg.package}/var/www/onlyoffice/documentserver/sdkjs/common/serviceworker/$2;
+              '';
+            #suppress logging the unsupported locale error in web-apps
+            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?\\/(web-apps)(\\/.*\\.json)$".extraConfig = ''
+              expires 365d;
+              error_log /dev/null crit;
+              alias ${cfg.package}/var/www/onlyoffice/documentserver/$2$3;
+            '';
+            #suppress logging the unsupported locale error in plugins
+            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?\\/(sdkjs-plugins)(\\/.*\\.json)$".extraConfig = ''
+              expires 365d;
+              error_log /dev/null crit;
+              # gzip_static on;
+              alias ${cfg.package}/var/www/onlyoffice/documentserver/$2$3;
+            '';
+            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?\\/(web-apps|sdkjs|sdkjs-plugins|fonts|dictionaries)(\\/.*)$".extraConfig =
+              ''
+                expires 365d;
+                # gzip_static on;
                 alias ${cfg.package}/var/www/onlyoffice/documentserver/$2$3;
               '';
             "~* ^(\\/cache\\/files.*)(\\/.*)".extraConfig = ''
               alias /var/lib/onlyoffice/documentserver/App_Data$1;
               add_header Content-Disposition "attachment; filename*=UTF-8''$arg_filename";
 
-              set $secret_string verysecretstring;
+              set $secure_link_secret verysecretstring;
               secure_link $arg_md5,$arg_expires;
-              secure_link_md5 "$secure_link_expires$uri$secret_string";
+              secure_link_md5 "$secure_link_expires$uri$secure_link_secret";
 
               if ($secure_link = "") {
                 return 403;
@@ -141,12 +162,17 @@ in
                 return 410;
               }
             '';
-            "~* ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\d]+)?\\/(internal)(\\/.*)$".extraConfig = ''
+            # Allow "/internal" interface only from 127.0.0.1
+            # Don't comment out the section below for the security reason!
+            "~* ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?\\/(internal)(\\/.*)$".extraConfig = ''
               allow 127.0.0.1;
               deny all;
               proxy_pass http://onlyoffice-docservice/$2$3;
             '';
-            "~* ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\d]+)?\\/(info)(\\/.*)$".extraConfig = ''
+            # Allow "/info" interface only from 127.0.0.1 by default
+            # Comment out lines allow 127.0.0.1; and deny all;
+            # of below section to turn on the info page
+            "~* ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?\\/(info)(\\/.*)$".extraConfig = ''
               allow 127.0.0.1;
               deny all;
               proxy_pass http://onlyoffice-docservice/$2$3;
@@ -154,19 +180,16 @@ in
             "/".extraConfig = ''
               proxy_pass http://onlyoffice-docservice;
             '';
-            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\d]+)?(\\/doc\\/.*)".extraConfig = ''
-              proxy_pass http://onlyoffice-docservice$2;
+            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\w]+)?(\\/(doc|downloadas)\\/.*)".extraConfig = ''
+              proxy_pass http://onlyoffice-docservice$2$is_args$args;
               proxy_http_version 1.1;
             '';
+            # end of /etc/nginx/includes/ds-docservice.conf
             "/${cfg.package.version}/".extraConfig = ''
               proxy_pass http://onlyoffice-docservice/;
             '';
-            "~ ^(\\/[\\d]+\\.[\\d]+\\.[\\d]+[\\.|-][\\d]+)?\\/(dictionaries)(\\/.*)$".extraConfig = ''
-              expires 365d;
-              alias ${cfg.package}/var/www/onlyoffice/documentserver/$2$3;
-            '';
             # /etc/nginx/includes/ds-example.conf
-            "~ ^(\\/welcome\\/.*)$".extraConfig = ''
+            "~ ^(\\/welcome\\/.*)$".extraConfig = lib.mkIf cfg.enableExampleServer ''
               expires 365d;
               alias ${cfg.package}/var/www/onlyoffice/documentserver-example$1;
               index docker.html;
@@ -277,6 +300,11 @@ in
             ''}
               .rabbitmq.url = "${cfg.rabbitmqUrl}"
               ' /run/onlyoffice/config/default.json | sponge /run/onlyoffice/config/default.json
+
+            chmod u+w /run/onlyoffice/config/production-linux.json
+            jq '
+              .FileConverter.converter.x2tPath = "${cfg.x2t}/bin/x2t"
+              ' /run/onlyoffice/config/production-linux.json | sponge /run/onlyoffice/config/production-linux.json
 
             if psql -d onlyoffice -c "SELECT 'task_result'::regclass;" >/dev/null; then
               psql -f ${cfg.package}/var/www/onlyoffice/documentserver/server/schema/postgresql/removetbl.sql

--- a/pkgs/by-name/on/onlyoffice-documentserver/package.nix
+++ b/pkgs/by-name/on/onlyoffice-documentserver/package.nix
@@ -16,17 +16,17 @@ let
   # var/www/onlyoffice/documentserver/server/DocService/docservice
   onlyoffice-documentserver = stdenv.mkDerivation rec {
     pname = "onlyoffice-documentserver";
-    version = "8.1.3";
+    version = "8.3.2";
 
     src = fetchurl (
       {
         "aarch64-linux" = {
           url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${version}/onlyoffice-documentserver_arm64.deb";
-          sha256 = "sha256-+7hHz1UcnlJNhBAVaYQwK0m2tkgsfbjqY3oa8XU0yxo=";
+          sha256 = "sha256-fyxk7FiBhTRTy8f5Wx6Rp0MPX45O5Q05ZS17Krp05P0=";
         };
         "x86_64-linux" = {
           url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${version}/onlyoffice-documentserver_amd64.deb";
-          sha256 = "sha256-jCwcXb97Z9/ZofKLYneJxKAnaZE/Hwvm34GLQu/BoUM=";
+          sha256 = "sha256-dBA/TlTwG+9eRY5QdqVw0cghnXPRNCUfs9QoaNFFLB0=";
         };
       }
       .${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}")
@@ -42,7 +42,7 @@ let
 
     installPhase = ''
       # replace dangling symlinks which are not copied into fhs with actually files
-      rm lib/*.so*
+      mkdir lib
       for file in var/www/onlyoffice/documentserver/server/FileConverter/bin/*.so* ; do
         ln -rs "$file" lib/$(basename "$file")
       done
@@ -59,6 +59,11 @@ let
 
       # required for bwrap --bind
       mkdir -p var/lib/onlyoffice/ var/www/onlyoffice/documentserver/fonts/
+
+      # see usr/bin/documentserver-flush-cache.sh
+      cp var/www/onlyoffice/documentserver/web-apps/apps/api/documents/api.js.tpl var/www/onlyoffice/documentserver/web-apps/apps/api/documents/api.js
+      HASH=$(basename $out | cut -d '-' -f 1)
+      sed -i "s/{{HASH_POSTFIX}}/$HASH/g" var/www/onlyoffice/documentserver/web-apps/apps/api/documents/api.js
 
       mv * $out/
     '';

--- a/pkgs/by-name/x2/x2t/MsBinaryFile-pragma-regions.patch
+++ b/pkgs/by-name/x2/x2t/MsBinaryFile-pragma-regions.patch
@@ -1,0 +1,47 @@
+diff --git a/MsBinaryFile/XlsFile/Format/Logic/Biff_structures/StringPtgParser.cpp b/MsBinaryFile/XlsFile/Format/Logic/Biff_structures/StringPtgParser.cpp
+index 08f56fb64e..dfbc4e4e15 100644
+--- a/MsBinaryFile/XlsFile/Format/Logic/Biff_structures/StringPtgParser.cpp
++++ b/MsBinaryFile/XlsFile/Format/Logic/Biff_structures/StringPtgParser.cpp
+@@ -73,7 +73,6 @@ const bool StringPtgParser::parseToPtgs(const std::wstring& assembled_formula, R
+ 
+     for(std::wstring::const_iterator it = assembled_formula.begin(), itEnd = assembled_formula.end(); it != itEnd;)
+     {
+-        #pragma region Operators
+         if(SyntaxPtg::is_operators(it, itEnd) || SyntaxPtg::is_PtgIsect(it, itEnd))
+         {
+             OperatorPtgPtr found_operator;
+@@ -182,8 +181,6 @@ const bool StringPtgParser::parseToPtgs(const std::wstring& assembled_formula, R
+             ptg_stack.push(found_operator);
+             last_ptg = found_operator;
+         }
+-        #pragma endregion
+-        #pragma region Parenthesis
+         else if(SyntaxPtg::extract_LeftParenthesis(it, itEnd))
+         {
+             PtgFuncPtr func;
+@@ -246,8 +243,6 @@ const bool StringPtgParser::parseToPtgs(const std::wstring& assembled_formula, R
+             rgce.addPtg(last_ptg);
+             operand_expected = false;
+         }
+-        #pragma endregion
+-        #pragma region Comma and PtgUnion
+         else if(SyntaxPtg::extract_comma(it, itEnd))
+         {
+             PtgParenPtr left_p;
+@@ -271,8 +266,6 @@ const bool StringPtgParser::parseToPtgs(const std::wstring& assembled_formula, R
+             last_ptg = left_p; // PtgParen. Mostly to differ unary and binary minuses and pluses
+             operand_expected = true;
+         }
+-        #pragma endregion
+-        #pragma region Operands
+         else
+         {
+             OperandPtgPtr found_operand;
+@@ -401,7 +394,6 @@ const bool StringPtgParser::parseToPtgs(const std::wstring& assembled_formula, R
+             last_ptg = found_operand;
+             operand_expected = false;
+         }
+-        #pragma endregion
+     }
+ 
+     while(ptg_stack.size())

--- a/pkgs/by-name/x2/x2t/common-cpp20.patch
+++ b/pkgs/by-name/x2/x2t/common-cpp20.patch
@@ -1,0 +1,13 @@
+diff --git a/Common/base.pri b/Common/base.pri
+index e8dc81b132..a1049b8af1 100644
+--- a/Common/base.pri
++++ b/Common/base.pri
+@@ -414,7 +414,7 @@ core_windows:CONFIG += no_batch
+ message($$CORE_BUILDS_PLATFORM_PREFIX/$$CORE_BUILDS_CONFIGURATION_PREFIX)
+ 
+ # COMPILER
+-CONFIG += c++11
++CONFIG += c++20
+ 
+ !core_windows {
+ 	QMAKE_CXXFLAGS += -Wno-register

--- a/pkgs/by-name/x2/x2t/common-pole-c20.patch
+++ b/pkgs/by-name/x2/x2t/common-pole-c20.patch
@@ -1,0 +1,35 @@
+diff --git a/Common/3dParty/pole/pole.cpp b/Common/3dParty/pole/pole.cpp
+index fbbd2a4b3d..d229e9cf31 100644
+--- a/Common/3dParty/pole/pole.cpp
++++ b/Common/3dParty/pole/pole.cpp
+@@ -1283,19 +1283,19 @@ void DirTree::debug()
+     DirEntry* e = entry( i );
+     if( !e ) continue;
+     std::cout << i << ": ";
+-	if( !e->valid ) std::cout << L"INVALID ";
++	if( !e->valid ) std::wcout << L"INVALID ";
+     std::wcout << e->name << L" ";
+-    if( e->dir ) std::cout << L"(Dir) ";
+-    else std::cout << L"(File) ";
+-    std::cout << e->size << L" ";
+-	std::cout << L"s:" << e->start << L" ";
+-    std::cout << L"(";
+-    if( e->child == End ) std::cout << L"-"; else std::cout << e->child;
++    if( e->dir ) std::wcout << L"(Dir) ";
++    else std::wcout << L"(File) ";
++    std::wcout << e->size << L" ";
++	std::wcout << L"s:" << e->start << L" ";
++    std::wcout << L"(";
++    if( e->child == End ) std::wcout << L"-"; else std::cout << e->child;
+     std::cout << " ";
+-    if( e->prev == End ) std::cout << L"-"; else std::cout << e->prev;
+-    std::cout << L":";
+-    if( e->next == End ) std::cout << L"-"; else std::cout << e->next;
+-    std::cout << L")";    
++    if( e->prev == End ) std::wcout << L"-"; else std::cout << e->prev;
++    std::wcout << L":";
++    if( e->next == End ) std::wcout << L"-"; else std::cout << e->next;
++    std::wcout << L")";    
+     std::cout << std::endl;
+   }
+ }

--- a/pkgs/by-name/x2/x2t/common-v8-no-compress-pointers.patch
+++ b/pkgs/by-name/x2/x2t/common-v8-no-compress-pointers.patch
@@ -1,0 +1,23 @@
+diff --git a/Common/3dParty/v8/v8.pri b/Common/3dParty/v8/v8.pri
+index 11c7c72d1b..b945146161 100644
+--- a/Common/3dParty/v8/v8.pri
++++ b/Common/3dParty/v8/v8.pri
+@@ -15,7 +15,8 @@ v8_version_89 {
+         isEqual(CORE_BUILDS_PLATFORM_PREFIX, android_x86):CONFIG += build_platform_32
+     }
+ 
+-    !build_platform_32:DEFINES += V8_COMPRESS_POINTERS
++    # seems v8 from nodejs is built without compressed pointers
++    #!build_platform_32:DEFINES += V8_COMPRESS_POINTERS
+ 
+     CORE_V8_PATH_OVERRIDE = $$PWD/../v8_89
+ }
+@@ -57,7 +58,7 @@ core_windows {
+ 
+ core_linux {
+     use_v8_monolith {
+-        LIBS += -L$$CORE_V8_PATH_LIBS -lv8_monolith
++        LIBS += -L$$CORE_V8_PATH_LIBS -lv8
+     } else {
+         SNAPSHOT_LIB=v8_snapshot
+         !exists($$CORE_V8_PATH_LIBS/libv8_snapshot.a) {

--- a/pkgs/by-name/x2/x2t/common-v8-no-snapshots.patch
+++ b/pkgs/by-name/x2/x2t/common-v8-no-snapshots.patch
@@ -1,0 +1,12 @@
+diff --git a/Common/3dParty/v8/v8.pri b/Common/3dParty/v8/v8.pri
+index 11c7c72d1b..d4a55daa2f 100644
+--- a/Common/3dParty/v8/v8.pri
++++ b/Common/3dParty/v8/v8.pri
+@@ -5,7 +5,6 @@ v8_version_89 {
+     CONFIG += c++14
+     CONFIG += use_v8_monolith
+     DEFINES += V8_VERSION_89_PLUS
+-	DEFINES += V8_SUPPORT_SNAPSHOTS
+ 
+     core_win_32:CONFIG += build_platform_32
+     core_linux_32:CONFIG += build_platform_32

--- a/pkgs/by-name/x2/x2t/cximage-types.patch
+++ b/pkgs/by-name/x2/x2t/cximage-types.patch
@@ -1,0 +1,76 @@
+diff --git a/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.c b/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.c
+index 00d406d948..afe7283373 100644
+--- a/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.c
++++ b/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.c
+@@ -83,6 +83,7 @@
+ #include "jasper/jas_malloc.h"
+ #include "jasper/jas_math.h"
+ 
++#include "jpc_fix.h"
+ #include "jpc_qmfb.h"
+ #include "jpc_tsfb.h"
+ #include "jpc_math.h"
+@@ -96,7 +97,7 @@
+ 
+ int jpc_ft_analyze(jpc_fix_t *a, int xstart, int ystart, int width, int height,
+   int stride);
+-int jpc_ft_synthesize(int *a, int xstart, int ystart, int width, int height,
++int jpc_ft_synthesize(jpc_fix_t *a, int xstart, int ystart, int width, int height,
+   int stride);
+ 
+ int jpc_ns_analyze(jpc_fix_t *a, int xstart, int ystart, int width, int height,
+@@ -1592,7 +1593,7 @@ int jpc_ft_analyze(jpc_fix_t *a, int xstart, int ystart, int width, int height,
+ 
+ }
+ 
+-int jpc_ft_synthesize(int *a, int xstart, int ystart, int width, int height,
++int jpc_ft_synthesize(jpc_fix_t *a, int xstart, int ystart, int width, int height,
+   int stride)
+ {
+ 	int numrows = height;
+diff --git a/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.h b/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.h
+index 4f43440bca..eb431d4213 100644
+--- a/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.h
++++ b/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.h
+@@ -76,6 +76,8 @@
+ 
+ #include "jasper/jas_seq.h"
+ 
++#include "jpc_fix.h"
++
+ /******************************************************************************\
+ * Constants.
+ \******************************************************************************/
+@@ -101,8 +103,8 @@ any particular platform.  Hopefully, it is not too unreasonable, however. */
+ #endif
+ 
+ typedef struct {
+-	int (*analyze)(int *, int, int, int, int, int);
+-	int (*synthesize)(int *, int, int, int, int, int);
++	int (*analyze)(jpc_fix_t *, int, int, int, int, int);
++	int (*synthesize)(jpc_fix_t *, int, int, int, int, int);
+ 	double *lpenergywts;
+ 	double *hpenergywts;
+ } jpc_qmfb2d_t;
+diff --git a/DesktopEditor/cximage/jasper/jpc/jpc_tsfb.c b/DesktopEditor/cximage/jasper/jpc/jpc_tsfb.c
+index 2a4eaee670..f5ac889c21 100644
+--- a/DesktopEditor/cximage/jasper/jpc/jpc_tsfb.c
++++ b/DesktopEditor/cximage/jasper/jpc/jpc_tsfb.c
+@@ -119,7 +119,7 @@ void jpc_tsfb_destroy(jpc_tsfb_t *tsfb)
+ 	free(tsfb);
+ }
+ 
+-int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
++int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, jpc_fix_t *a, int xstart, int ystart,
+   int width, int height, int stride, int numlvls)
+ {
+ 	if (width > 0 && height > 0) {
+@@ -150,7 +150,7 @@ int jpc_tsfb_analyze(jpc_tsfb_t *tsfb, jas_seq2d_t *a)
+ #endif
+ }
+ 
+-int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
++int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, jpc_fix_t *a, int xstart, int ystart,
+   int width, int height, int stride, int numlvls)
+ {
+ 	if (numlvls > 0) {

--- a/pkgs/by-name/x2/x2t/doctrenderer-config-dir.patch
+++ b/pkgs/by-name/x2/x2t/doctrenderer-config-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/DesktopEditor/doctrenderer/doctrenderer.cpp b/DesktopEditor/doctrenderer/doctrenderer.cpp
+index ac24efa8b2..f6de72cc2a 100644
+--- a/DesktopEditor/doctrenderer/doctrenderer.cpp
++++ b/DesktopEditor/doctrenderer/doctrenderer.cpp
+@@ -238,7 +238,7 @@ namespace NSDoctRenderer
+ 	public:
+ 		CDoctRenderer_Private(const std::wstring& sAllFontsPath = L"") : CDoctRendererConfig()
+ 		{
+-			LoadConfig(NSFile::GetProcessDirectory(), sAllFontsPath);
++			LoadConfig(NSFile::GetProcessDirectory() + L"/../etc", sAllFontsPath);
+ 			m_pDrawingFile = NULL;
+ 		}
+ 		~CDoctRenderer_Private()

--- a/pkgs/by-name/x2/x2t/doctrenderer-format-security.patch
+++ b/pkgs/by-name/x2/x2t/doctrenderer-format-security.patch
@@ -1,0 +1,26 @@
+diff --git a/DesktopEditor/doctrenderer/docbuilder_p.h b/DesktopEditor/doctrenderer/docbuilder_p.h
+index d955b3fb33..64ece3555a 100644
+--- a/DesktopEditor/doctrenderer/docbuilder_p.h
++++ b/DesktopEditor/doctrenderer/docbuilder_p.h
+@@ -1400,7 +1400,7 @@ namespace NSDoctRenderer
+ 			FILE* pFile = oFile.OpenFileNative(sFile, append ? L"a+" : L"a");
+ 			if (pFile)
+ 			{
+-				fprintf(pFile, sValueA.c_str());
++				fprintf(pFile, "%s", sValueA.c_str());
+ 				fclose(pFile);
+ 			}
+ 		}
+diff --git a/DesktopEditor/doctrenderer/js_internal/js_logger.cpp b/DesktopEditor/doctrenderer/js_internal/js_logger.cpp
+index b59ce98b0d..795dcb9ec0 100644
+--- a/DesktopEditor/doctrenderer/js_internal/js_logger.cpp
++++ b/DesktopEditor/doctrenderer/js_internal/js_logger.cpp
+@@ -21,7 +21,7 @@ namespace NSJSBase
+ 
+ 		if (g_logger_file.length() == 1)
+ 		{
+-			printf(details);
++			printf("%s", details);
+ 			printf(": %d\n", (int)(dwCur - g_logger_time));
+ 		}
+ 		else

--- a/pkgs/by-name/x2/x2t/fontengine-format-security.patch
+++ b/pkgs/by-name/x2/x2t/fontengine-format-security.patch
@@ -1,0 +1,13 @@
+diff --git a/DesktopEditor/fontengine/MemoryStream.h b/DesktopEditor/fontengine/MemoryStream.h
+index 4abebc1290..9f4a61ee5d 100644
+--- a/DesktopEditor/fontengine/MemoryStream.h
++++ b/DesktopEditor/fontengine/MemoryStream.h
+@@ -59,7 +59,7 @@ static void LOGGING(const std::string& strFile, const std::wstring& strMessage)
+ 	NSFile::CUtf8Converter::GetUtf8StringFromUnicode(strMessage.c_str(), (LONG)strMessage.length(), pData, lLen);
+ 	pData[lLen] = 0;
+ 
+-	fprintf(f, (char*)pData);
++	fprintf(f, "%s", (char*)pData);
+ 	fprintf(f, "\n");
+ 	fclose(f);
+ 

--- a/pkgs/by-name/x2/x2t/package.nix
+++ b/pkgs/by-name/x2/x2t/package.nix
@@ -1,0 +1,608 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  boost,
+  icu,
+  qt5,
+  harfbuzz,
+  # needs to be static and built with MD2 support!
+  openssl,
+  runCommand,
+  nodejs,
+  onlyoffice-documentserver,
+  writeScript,
+  x2t,
+}:
+
+let
+  qmake = qt5.qmake;
+  libv8 = nodejs.libv8;
+  fixIcu = writeScript "fix-icu.sh" ''
+    substituteInPlace \
+      $BUILDRT/Common/3dParty/icu/icu.pri \
+      --replace-fail "ICU_MAJOR_VER = 58" "ICU_MAJOR_VER = ${lib.versions.major icu.version}"
+
+    mkdir $BUILDRT/Common/3dParty/icu/linux_64
+    ln -s ${icu}/lib $BUILDRT/Common/3dParty/icu/linux_64/build
+  '';
+  # see core/Common/3dParty/html/fetch.sh
+  katana-parser-src = fetchFromGitHub {
+    owner = "jasenhuang";
+    repo = "katana-parser";
+    rev = "be6df458d4540eee375c513958dcb862a391cdd1";
+    hash = "sha256-SYJFLtrg8raGyr3zQIEzZDjHDmMmt+K0po3viipZW5c=";
+  };
+  # 'latest' version
+  # (see build_tools scripts/core_common/modules/hyphen.py)
+  hyphen-src = fetchFromGitHub {
+    owner = "hunspell";
+    repo = "hyphen";
+    rev = "73dd2967c8e1e4f6d7334ee9e539a323d6e66cbd";
+    hash = "sha256-WIHpSkOwHkhMvEKxOlgf6gsPs9T3xkzguD8ONXARf1U=";
+  };
+  # see core/Common/3dParty/html/fetch.py
+  gumbo-parser-src = fetchFromGitHub {
+    owner = "google";
+    repo = "gumbo-parser";
+    rev = "aa91b27b02c0c80c482e24348a457ed7c3c088e0";
+    hash = "sha256-+607iXJxeWKoCwb490pp3mqRZ1fWzxec0tJOEFeHoCs=";
+  };
+  # core/Common/3dParty/apple/fetch.py
+  libodfgen-src = fetchFromGitHub {
+    owner = "DistroTech";
+    repo = "libodfgen";
+    rev = "8ef8c171ebe3c5daebdce80ee422cf7bb96aa3bc";
+    hash = "sha256-Bv/smZFmZn4PEAcOlXD2Z4k96CK7A7YGDHFDsqZpuiE=";
+  };
+  mdds-src = fetchFromGitHub {
+    owner = "kohei-us";
+    repo = "mdds";
+    rev = "0783158939c6ce4b0b1b89e345ab983ccb0f0ad0";
+    hash = "sha256-HMGMxMRO6SadisUjZ0ZNBGQqksNDFkEh3yaQGet9rc0=";
+  };
+  glm-src = fetchFromGitHub {
+    owner = "g-truc";
+    repo = "glm";
+    rev = "33b4a621a697a305bc3a7610d290677b96beb181";
+    hash = "sha256-wwGI17vlQzL/x1O0ANr5+KgU1ETnATpLw3njpKfjnKQ=";
+  };
+  librevenge-src = fetchFromGitHub {
+    owner = "DistroTech";
+    repo = "librevenge";
+    rev = "becd044b519ab83893ad6398e3cbb499a7f0aaf4";
+    hash = "sha256-2YRxuMYzKvvQHiwXH08VX6GRkdXnY7q05SL05Vbn0Vs=";
+  };
+  libetonyek-src = fetchFromGitHub {
+    owner = "LibreOffice";
+    repo = "libetonyek";
+    rev = "cb396b4a9453a457469b62a740d8fb933c9442c3";
+    hash = "sha256-nFYI7PbcLyquhAWVGkjNLHp+tymv+Pzvfa5DNPeqZiw=";
+  };
+  #qmakeFlags = [ "CONFIG+=debug" ];
+  qmakeFlags = [ ];
+  dontStrip = false;
+  core = fetchFromGitHub {
+    owner = "ONLYOFFICE";
+    repo = "core";
+    # rev that the 'core' submodule in documentserver points at
+    rev = "d257c68d5fdd71a33776a291914f2c856426c259";
+    hash = "sha256-EXeqG8MJWS1asjFihnuMnDSHeKt2x+Ui+8MYK50AnSY=";
+  };
+  buildCoreComponent =
+    rootdir: attrs:
+    stdenv.mkDerivation (
+      finalAttrs:
+      {
+        name = "onlyoffice-core-${rootdir}";
+        src = core;
+        sourceRoot = "${finalAttrs.src.name}/${rootdir}";
+        dontWrapQtApps = true;
+        nativeBuildInputs = [
+          qmake
+        ];
+        inherit dontStrip qmakeFlags;
+        prePatch = ''
+          export SRCRT=$(pwd)
+          cd $(echo "${rootdir}" | sed -s "s/[^/]*/../g")
+          export BUILDRT=$(pwd)
+          ln -s ../source ../core
+          chmod -R u+w .
+        '';
+        postPatch = ''
+          cd $SRCRT
+        '';
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out/lib
+          # debug builds are a level deeper than release builds
+          find $BUILDRT/build -type f -exec cp {} $out/lib \;
+
+          runHook postInstall
+        '';
+      }
+      // attrs
+    );
+  buildCoreTests =
+    rootdir: attrs:
+    (buildCoreComponent (rootdir + "/test") (
+      {
+        doCheck = true;
+        checkPhase = ''
+          runHook preCheck
+          ./build/linux_64/test
+          runHook postCheck
+        '';
+        installPhase = ''
+          touch $out
+        '';
+      }
+      // attrs
+    ));
+  unicodeConverter = buildCoreComponent "UnicodeConverter" {
+    patches = [
+      # icu needs c++20 for include/unicode/localpointer.h
+      ./common-cpp20.patch
+    ];
+    preConfigure = ''
+      source ${fixIcu}
+
+      # https://github.com/ONLYOFFICE/core/pull/1637
+      # (but not as patch because line endings)
+      substituteInPlace \
+        UnicodeConverter.cpp \
+        --replace-fail "TRUE" "true"
+    '';
+  };
+  kernel = buildCoreComponent "Common" {
+    patches = [
+      ./zlib-cstd.patch
+    ];
+    buildInputs = [
+      unicodeConverter
+    ];
+  };
+  unicodeConverterTests = buildCoreComponent "UnicodeConverter/test" {
+    buildInputs = [
+      unicodeConverter
+      kernel
+      icu
+    ];
+    preConfigure = ''
+      source ${fixIcu}
+
+      # adds includes but not build the lib?
+      echo -e "\ninclude(../../Common/3dParty/icu/icu.pri)" >> test.pro
+    '';
+    postBuild = ''
+      patchelf --add-rpath ${icu}/lib $(find ./core_build -name test)
+    '';
+    installPhase = ''
+      mkdir -p $out/bin
+      cp $(find ./core_build -name test) $out/bin
+      cp -r testfiles $out
+      # TODO: this produces files in $out/testfiles. It looks like this should
+      # test that the files are identical, which they are not - but it is not
+      # obvious the test is 'wrong' :/
+      $out/bin/test
+    '';
+  };
+  graphics = buildCoreComponent "DesktopEditor/graphics/pro" {
+    patches = [
+      ./cximage-types.patch
+    ];
+    buildInputs = [
+      unicodeConverter
+      kernel
+    ];
+    preConfigure = ''
+      ln -s ${katana-parser-src} $BUILDRT/Common/3dParty/html/katana-parser
+
+      # Common/3dParty/harfbuzz/make.py
+      cat >$BUILDRT/Common/3dParty/harfbuzz/harfbuzz.pri <<EOL
+        INCLUDEPATH += ${harfbuzz.dev}/include/harfbuzz
+        LIBS += -L${harfbuzz}/lib -lharfbuzz
+      EOL
+
+      ln -s ${hyphen-src} $BUILDRT/Common/3dParty/hyphen/hyphen
+    '';
+  };
+  network = buildCoreComponent "Common/Network" {
+    buildInputs = [
+      kernel
+    ];
+  };
+  docxformatlib = buildCoreComponent "OOXML/Projects/Linux/DocxFormatLib" {
+    patches = [
+      # Interestingly only seems to pop up when debug mode is enabled
+      ./xlsx-missing-import.patch
+    ];
+    buildInputs = [ boost ];
+  };
+  cryptopp = buildCoreComponent "Common/3dParty/cryptopp/project" {
+    buildInputs = [ boost ];
+  };
+  xlsbformatlib = buildCoreComponent "OOXML/Projects/Linux/XlsbFormatLib" {
+    buildInputs = [ boost ];
+  };
+  xlsformatlib = buildCoreComponent "MsBinaryFile/Projects/XlsFormatLib/Linux" {
+    patches = [
+      ./MsBinaryFile-pragma-regions.patch
+    ];
+    buildInputs = [ boost ];
+  };
+  docformatlib = buildCoreComponent "MsBinaryFile/Projects/DocFormatLib/Linux" {
+    buildInputs = [ boost ];
+  };
+  pptformatlib = buildCoreComponent "MsBinaryFile/Projects/PPTFormatLib/Linux" {
+    buildInputs = [ boost ];
+  };
+  rtfformatlib = buildCoreComponent "RtfFile/Projects/Linux" {
+    buildInputs = [ boost ];
+  };
+  txtxmlformatlib = buildCoreComponent "TxtFile/Projects/Linux" {
+    buildInputs = [ boost ];
+  };
+  bindocument = buildCoreComponent "OOXML/Projects/Linux/BinDocument" {
+    buildInputs = [ boost ];
+  };
+  pptxformatlib = buildCoreComponent "OOXML/Projects/Linux/PPTXFormatLib" {
+    buildInputs = [ boost ];
+  };
+  compoundfilelib = buildCoreComponent "Common/cfcpp" { };
+  iworkfile = buildCoreComponent "Apple" {
+    patches = [
+      ./zlib-cstd.patch
+    ];
+    # mdds uses bool_constant which needs a newer c++
+    qmakeFlags = qmakeFlags ++ [ "CONFIG+=c++1z" ];
+    buildInputs = [
+      kernel
+      unicodeConverter
+      boost
+    ];
+    preConfigure = ''
+      ln -s ${glm-src} $BUILDRT/Common/3dParty/apple/glm
+      ln -s ${mdds-src} $BUILDRT/Common/3dParty/apple/mdds
+      ln -s ${libodfgen-src} $BUILDRT/Common/3dParty/apple/libodfgen
+      ln -s ${librevenge-src} $BUILDRT/Common/3dParty/apple/librevenge
+      cp -r ${libetonyek-src} $BUILDRT/Common/3dParty/apple/libetonyek
+      substituteInPlace \
+        $BUILDRT/Common/3dParty/apple/libetonyek/src/lib/IWORKTable.cpp \
+        --replace-fail "is_tree_valid" "valid_tree"
+      chmod u+w $BUILDRT/Common/3dParty/apple/libetonyek/src/lib
+      cp $BUILDRT/Common/3dParty/apple/headers/* $BUILDRT/Common/3dParty/apple/libetonyek/src/lib
+    '';
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/lib
+      mv ../build/lib/*/* $out/lib
+      runHook postInstall
+    '';
+    doCheck = true;
+  };
+  vbaformatlib = buildCoreComponent "MsBinaryFile/Projects/VbaFormatLib/Linux" {
+    buildInputs = [ boost ];
+  };
+  odfformatlib = buildCoreComponent "OdfFile/Projects/Linux" {
+    buildInputs = [ boost ];
+  };
+  hwpfile = buildCoreComponent "HwpFile" {
+    buildInputs = [
+      cryptopp
+      kernel
+      unicodeConverter
+      graphics
+    ];
+  };
+  pdffile = buildCoreComponent "PdfFile" {
+    buildInputs = [
+      graphics
+      kernel
+      unicodeConverter
+      cryptopp
+      network
+    ];
+  };
+  djvufile = buildCoreComponent "DjVuFile" {
+    buildInputs = [
+      unicodeConverter
+      kernel
+      graphics
+      pdffile
+    ];
+  };
+  docxrenderer = buildCoreComponent "DocxRenderer" {
+    buildInputs = [
+      unicodeConverter
+      kernel
+      graphics
+    ];
+  };
+  xpsfile = buildCoreComponent "XpsFile" {
+    buildInputs = [
+      unicodeConverter
+      graphics
+      kernel
+      pdffile
+    ];
+  };
+  doctrenderer = buildCoreComponent "DesktopEditor/doctrenderer" {
+    buildInputs = [
+      graphics
+      boost
+      kernel
+      unicodeConverter
+      network
+      pdffile
+      djvufile
+      xpsfile
+      docxrenderer
+    ];
+    patches = [
+      # https://github.com/ONLYOFFICE/core/pull/1631
+      ./doctrenderer-format-security.patch
+      ./doctrenderer-config-dir.patch
+      ./fontengine-format-security.patch
+      ./v8_updates.patch
+      ./common-v8-no-compress-pointers.patch
+      # we can enable snapshots again once we
+      # compile sdkjs from source as well
+      ./common-v8-no-snapshots.patch
+      # needed for c++ 20 for nodejs_23
+      ./common-pole-c20.patch
+    ];
+    qmakeFlags = qmakeFlags ++ [
+      # c++1z for nodejs_22.libv8 (20 seems to produce errors around 'is_void_v' there)
+      # c++ 20 for nodejs_23.libv8
+      "CONFIG+=c++2a"
+      # v8_base.h will set nMaxVirtualMemory to 4000000000/5000000000
+      # which is not page-aligned, so disable memory limitation for now
+      "QMAKE_CXXFLAGS+=-DV8_VERSION_121_PLUS"
+      "QMAKE_CXXFLAGS+=-DDISABLE_MEMORY_LIMITATION"
+    ];
+    preConfigure = ''
+      cd $BUILDRT
+
+      substituteInPlace \
+        DesktopEditor/doctrenderer/nativecontrol.h \
+        --replace-fail "fprintf(f, strVal.c_str());" "fprintf(f, \"%s\", strVal.c_str());" \
+        --replace-fail "fprintf(_file, sParam.c_str());" "fprintf(_file, \"%s\", sParam.c_str());"
+
+      # (not as patch because of line endings)
+      sed -i '47 a #include <limits>' Common/OfficeFileFormatChecker2.cpp
+
+      echo "== openssl =="
+      mkdir -p Common/3dParty/openssl/build/linux_64/lib
+      echo "Including openssl from ${openssl.dev}"
+      ln -s ${openssl.dev}/include Common/3dParty/openssl/build/linux_64/include
+      for i in ${openssl.out}/lib/*; do
+        ln -s $i Common/3dParty/openssl/build/linux_64/lib/$(basename $i)
+      done
+
+      echo "== v8 =="
+      mkdir -p Common/3dParty/v8_89/v8/out.gn/linux_64
+      ln -s ${libv8}/lib Common/3dParty/v8_89/v8/out.gn/linux_64/obj
+      tar xf ${libv8.src} --one-top-level=/tmp/xxxxx
+      for i in /tmp/xxxxx/*/deps/v8/*; do
+        cp -r $i Common/3dParty/v8_89/v8/
+      done
+
+      cd $BUILDRT/DesktopEditor/doctrenderer
+    '';
+  };
+  htmlfile2 = buildCoreComponent "HtmlFile2" {
+    buildInputs = [
+      boost
+      kernel
+      network
+      graphics
+      unicodeConverter
+    ];
+    preConfigure = ''
+      ln -s ${katana-parser-src} $BUILDRT/Common/3dParty/html/katana-parser
+      ln -s ${gumbo-parser-src} $BUILDRT/Common/3dParty/html/gumbo-parser
+    '';
+  };
+  epubfile = buildCoreComponent "EpubFile" {
+    buildInputs = [
+      kernel
+      graphics
+      htmlfile2
+    ];
+  };
+  fb2file = buildCoreComponent "Fb2File" {
+    buildInputs = [
+      unicodeConverter
+      kernel
+      graphics
+      boost
+    ];
+    preConfigure = ''
+      ln -s ${gumbo-parser-src} $BUILDRT/Common/3dParty/html/gumbo-parser
+    '';
+    passthru.tests.run = buildCoreTests "Fb2File" {
+      buildInputs = [
+        fb2file
+        kernel
+      ];
+      preConfigure = ''
+        source ${fixIcu}
+      '';
+      postBuild = ''
+        patchelf --add-rpath ${icu}/lib build/*/*
+      '';
+      checkPhase = ''
+        for i in ../examples/*.fb2; do
+          cp $i build/linux_64/res.fb2
+          ./build/linux_64/test
+        done
+      '';
+    };
+  };
+  allfontsgen = buildCoreComponent "DesktopEditor/AllFontsGen" {
+    buildInputs = [
+      unicodeConverter
+      kernel
+      graphics
+    ];
+    preConfigure = ''
+      source ${fixIcu}
+    '';
+    dontStrip = true;
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      cp $BUILDRT/build/bin/*/* $BUILDRT/build/bin/*/*/* $out/bin
+
+      patchelf --add-rpath ${icu}/lib $out/bin/allfontsgen
+
+      runHook postInstall
+    '';
+  };
+  core-fonts = fetchFromGitHub {
+    owner = "ONLYOFFICE";
+    repo = "core-fonts";
+    rev = "d5d80e6ae15800ccf31e1c4dbb1ae3385992e0c2";
+    hash = "sha256-daJG/4tcdRVVmlMCUW4iuoUkEEfY7sx5icYWMva4o+c=";
+  };
+  allfonts = runCommand "allfonts" { } ''
+    mkdir -p $out/web
+    mkdir -p $out/converter
+    mkdir -p $out/images
+    mkdir -p $out/fonts
+    ${allfontsgen}/bin/allfontsgen \
+      --input=${core-fonts} \
+      --allfonts-web=$out/web/AllFonts.js \
+      --allfonts=$out/converter/AllFonts.js \
+      --images=$out/images \
+      --selection=$out/converter/font_selection.bin \
+      --output-web=$out/fonts
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "x2t";
+  # x2t is not 'directly' versioned, so we version it after the version
+  # of documentserver it's pulled into as a submodule
+  version = "8.3.2";
+
+  src = core;
+
+  nativeBuildInputs = [
+    pkg-config
+    qt5.full
+  ];
+  buildInputs = [
+    unicodeConverter
+    kernel
+    graphics
+    network
+    boost
+    docformatlib
+    pptformatlib
+    rtfformatlib
+    txtxmlformatlib
+    bindocument
+    pptxformatlib
+    docxformatlib
+    xlsbformatlib
+    xlsformatlib
+    compoundfilelib
+    cryptopp
+    fb2file
+    pdffile
+    htmlfile2
+    epubfile
+    xpsfile
+    djvufile
+    doctrenderer
+    docxrenderer
+    iworkfile
+    hwpfile
+    vbaformatlib
+    odfformatlib
+  ];
+  dontStrip = true;
+  buildPhase = ''
+    runHook preBuild
+
+    BUILDRT=$(pwd)
+    source ${fixIcu}
+
+    # (not as patch because of line endings)
+    sed -i '47 a #include <limits>' Common/OfficeFileFormatChecker2.cpp
+
+    substituteInPlace \
+      ./Test/Applications/TestDownloader/mainwindow.h \
+      --replace-fail "../core" ""
+
+    echo "== X2tConverter =="
+    cd X2tConverter/build/Qt
+    qmake "CONFIG+=debug" -o Makefile X2tConverter.pro
+    make -j$NIX_BUILD_CORES
+    cd ../../..
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ./build/bin/linux_64/*/x2t $out/bin
+
+    mkdir -p $out/etc
+    cat >$out/etc/DoctRenderer.config <<EOF
+          <Settings>
+            <file>${onlyoffice-documentserver}/var/www/onlyoffice/documentserver/sdkjs/common/Native/native.js</file>
+            <file>${onlyoffice-documentserver}/var/www/onlyoffice/documentserver/sdkjs/common/Native/jquery_native.js</file>
+            <allfonts>${allfonts}/converter/AllFonts.js</allfonts>
+            <file>${onlyoffice-documentserver}/var/www/onlyoffice/documentserver/web-apps/vendor/xregexp/xregexp-all-min.js</file>
+            <sdkjs>${onlyoffice-documentserver}/var/www/onlyoffice/documentserver/sdkjs</sdkjs>
+            <dictionaries>${onlyoffice-documentserver}/var/www/onlyoffice/documentserver/dictionaries</dictionaries>
+          </Settings>
+    EOF
+
+    patchelf --add-rpath ${icu}/lib $out/bin/x2t
+
+    runHook postInstall
+  '';
+  passthru.tests = {
+    unicodeConverter = unicodeConverterTests;
+    fb2file = fb2file.tests.run;
+    x2t = runCommand "x2t-test" { } ''
+      (${x2t}/bin/x2t || true) | grep "OOX/binary file converter." && mkdir -p $out
+    '';
+  };
+  passthru.components = {
+    inherit
+      allfontsgen
+      allfonts
+      unicodeConverter
+      kernel
+      unicodeConverterTests
+      graphics
+      network
+      docxformatlib
+      cryptopp
+      xlsbformatlib
+      xlsformatlib
+      doctrenderer
+      htmlfile2
+      epubfile
+      fb2file
+      iworkfile
+      ;
+  };
+  meta = {
+    description = "Convert files from one format to another";
+    homepage = "https://github.com/ONLYOFFICE/core/tree/master/X2tConverter";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ raboof ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/x2/x2t/v8_updates.patch
+++ b/pkgs/by-name/x2/x2t/v8_updates.patch
@@ -1,0 +1,28 @@
+diff --git a/Common/3dParty/v8/v8.pri b/Common/3dParty/v8/v8.pri
+index 11c7c72d1b..eef42d3fc5 100644
+--- a/Common/3dParty/v8/v8.pri
++++ b/Common/3dParty/v8/v8.pri
+@@ -57,7 +57,7 @@ core_windows {
+ 
+ core_linux {
+     use_v8_monolith {
+-        LIBS += -L$$CORE_V8_PATH_LIBS -lv8_monolith
++        LIBS += -L$$CORE_V8_PATH_LIBS -lv8
+     } else {
+         SNAPSHOT_LIB=v8_snapshot
+         !exists($$CORE_V8_PATH_LIBS/libv8_snapshot.a) {
+diff --git a/DesktopEditor/doctrenderer/js_internal/v8/inspector/v8_inspector_client.cpp b/DesktopEditor/doctrenderer/js_internal/v8/inspector/v8_inspector_client.cpp
+index dbfda9807c..78af9a4e3a 100644
+--- a/DesktopEditor/doctrenderer/js_internal/v8/inspector/v8_inspector_client.cpp
++++ b/DesktopEditor/doctrenderer/js_internal/v8/inspector/v8_inspector_client.cpp
+@@ -22,7 +22,9 @@ namespace NSJSBase
+ 		// initialize all V8 inspector stuff
+ 		m_pChannel.reset(new CV8InspectorChannelImpl(m_pIsolate, fOnResponse));
+ 		m_pInspector = v8_inspector::V8Inspector::create(m_pIsolate, this);
+-		m_pSession = m_pInspector->connect(m_nContextGroupId, m_pChannel.get(), v8_inspector::StringView());
++		m_pSession = m_pInspector->connect(m_nContextGroupId, m_pChannel.get(), v8_inspector::StringView(),
++		    v8_inspector::V8Inspector::kFullyTrusted,
++		    v8_inspector::V8Inspector::kNotWaitingForDebugger);
+ 		context->SetAlignedPointerInEmbedderData(1, this);
+ 
+ 		v8_inspector::StringView oContextName = convertToStringView("inspector" + std::to_string(nContextGroupId));

--- a/pkgs/by-name/x2/x2t/xlsx-missing-import.patch
+++ b/pkgs/by-name/x2/x2t/xlsx-missing-import.patch
@@ -1,0 +1,12 @@
+diff --git a/OOXML/XlsxFormat/Worksheets/SheetData.cpp b/OOXML/XlsxFormat/Worksheets/SheetData.cpp
+index b808b46cb7..c90eb4e254 100644
+--- a/OOXML/XlsxFormat/Worksheets/SheetData.cpp
++++ b/OOXML/XlsxFormat/Worksheets/SheetData.cpp
+@@ -71,6 +71,7 @@
+ #include <boost/regex.hpp>
+ #include <boost/date_time/gregorian/gregorian.hpp>
+ #include <boost/date_time/posix_time/posix_time.hpp>
++#include <cfloat>
+ 
+ #ifndef MININT32
+ #define MAXUINT32   ((uint32_t)~((uint32_t)0))

--- a/pkgs/by-name/x2/x2t/zlib-cstd.patch
+++ b/pkgs/by-name/x2/x2t/zlib-cstd.patch
@@ -1,0 +1,23 @@
+diff --git a/OfficeUtils/OfficeUtils.pri b/OfficeUtils/OfficeUtils.pri
+index b4e1f497a8..6d99014ddd 100644
+--- a/OfficeUtils/OfficeUtils.pri
++++ b/OfficeUtils/OfficeUtils.pri
+@@ -1,5 +1,6 @@
+ core_linux {
+     QMAKE_CXXFLAGS += -Wall -Wno-ignored-qualifiers
++    QMAKE_CFLAGS += -DSTDC
+ }
+ core_mac {
+     QMAKE_CXXFLAGS += -Wall -Wno-ignored-qualifiers
+diff --git a/OfficeUtils/src/zlib-1.2.11/gzguts.h b/OfficeUtils/src/zlib-1.2.11/gzguts.h
+index 990a4d2514..aefbbd8879 100644
+--- a/OfficeUtils/src/zlib-1.2.11/gzguts.h
++++ b/OfficeUtils/src/zlib-1.2.11/gzguts.h
+@@ -24,6 +24,7 @@
+ #  include <string.h>
+ #  include <stdlib.h>
+ #  include <limits.h>
++#  include <unistd.h>
+ #endif
+ 
+ #ifndef _POSIX_SOURCE

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1244,6 +1244,13 @@ with pkgs;
     wine = wineWowPackages.stable;
   };
 
+  x2t = callPackage ../by-name/x2/x2t/package.nix {
+    openssl = openssl.override {
+      enableMD2 = true;
+      static = true;
+    };
+  };
+
   yabridge = callPackage ../tools/audio/yabridge {
     wine = wineWowPackages.staging;
   };


### PR DESCRIPTION
## Description of changes

This builds x2t, a utility that is part of the OnlyOffice DocumentServer, from source instead of taking it from the binary release. This has a couple of advantages, notably:
* avoiding assumptions made in the binary package that seem to have led to crashes
* build against a recent and supported version of v8 and other libraries
* easier patching
* easier building with debugging symbols
* etc, etc

the onlyoffice in main currently does not work at all for me (e.g. I'm seeing the same problems as described in https://github.com/ONLYOFFICE/onlyoffice-nextcloud/issues/931). This makes these problems go away, and seems like the right direction anyway.

I haven't checked if it fixes #385236, but at the very least it should make it much easier to debug.

There are of course further improvements to be made to reduce our reliance on the binary release of the documentserver package, but this seems like a nicely-contained first step that provides real value already.

## Things done

Deployed nextcloud+onlyoffice in qemu and loaded/saved docx and xlsx files.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
