### PR TITLE
postprocessd: init at 0.3.0

### DIFF
--- a/pkgs/by-name/me/megapixels/package.nix
+++ b/pkgs/by-name/me/megapixels/package.nix
@@ -54,6 +54,12 @@ stdenv.mkDerivation (finalAttrs: {
     zbar
   ];
 
+  patches = [
+    # In the settings menu of Megapixels the user can select a different postprocessing script. The path to the script is then stored in a dconf setting. If the path changes, for example because it is in the Nix store and a dependency of the postprocessor changes, Megapixels will try to use this now non-existing old path. This will cause Megapixels to not save any images that were taken until the user opens the settings again and selects a postprocessor again. Using a global path allows the setting to keep working.
+    # Note that this patch only fixes the issue for external postprocessors like postprocessd but the postprocessor script that comes with Megapixels is still refered to by the Nix store path.
+    ./search-for-postprocessors-in-NixOS-specific-global-location.patch
+  ];
+
   postInstall = ''
     glib-compile-schemas $out/share/glib-2.0/schemas
   '';

--- a/pkgs/by-name/me/megapixels/search-for-postprocessors-in-NixOS-specific-global-location.patch
+++ b/pkgs/by-name/me/megapixels/search-for-postprocessors-in-NixOS-specific-global-location.patch
@@ -1,0 +1,27 @@
+--- a/src/process_pipeline.c
++++ b/src/process_pipeline.c
+@@ -179,10 +179,10 @@ mp_process_find_all_processors(GtkListStore *store)
+                         store, &iter, 0, buffer, 1, "(built-in) postprocess.sh", -1);
+         }
+ 
+-        // Find extra packaged postprocessor scripts
+-        // These should be packaged in
+-        // /usr/share/megapixels/postprocessor.d/executable
+-        sprintf(buffer, "%s/megapixels/postprocessor.d", DATADIR);
++        // Find extra system postprocessor scripts
++        // These should be accessible in
++        // /run/current-system/sw/share/megapixels/postprocessor.d/executable
++        sprintf(buffer, "/run/current-system/sw/share/megapixels/postprocessor.d");
+         DIR *d;
+         struct dirent *dir;
+         d = opendir(buffer);
+@@ -192,8 +192,7 @@ mp_process_find_all_processors(GtkListStore *store)
+                                 continue;
+                         }
+                         sprintf(buffer,
+-                                "%s/megapixels/postprocessor.d/%s",
+-                                DATADIR,
++                                "/run/current-system/sw/share/megapixels/postprocessor.d/%s",
+                                 dir->d_name);
+                         gtk_list_store_insert(store, &iter, -1);
+                         gtk_list_store_set(

--- a/pkgs/by-name/po/postprocessd/package.nix
+++ b/pkgs/by-name/po/postprocessd/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  fetchFromSourcehut,
+  libexif,
+  libraw,
+  meson,
+  ninja,
+  opencv4,
+  pkg-config,
+  scdoc,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "postprocessd";
+  version = "0.3.0";
+
+  src = fetchFromSourcehut {
+    owner = "~martijnbraam";
+    repo = "postprocessd";
+    rev = finalAttrs.version;
+    hash = "sha256-xqEjjAv27TUrEU/5j8Um7fTFjmIYZovyJCccbtHPuGo=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+  ];
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libexif
+    libraw
+    opencv4
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "Queueing megapixels post-processor";
+    homepage = "https://git.sr.ht/~martijnbraam/postprocessd";
+    changelog = "https://git.sr.ht/~martijnbraam/postprocessd/refs/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ Luflosi ];
+    platforms = lib.platforms.linux;
+    mainProgram = "postprocess-single";
+  };
+})


### PR DESCRIPTION
## Description of changes
Add postprocessd, a queueing Megapixels post-processor.
Also patch Megapixels to be able to use the new postprocessor if it is installed globally. See the long comment in the code for a more detailed description and a discussion of tradeoffs.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
