### PR TITLE
dep-scan: 5.3.4 -> 5.4.3

### DIFF
--- a/pkgs/by-name/de/dep-scan/package.nix
+++ b/pkgs/by-name/de/dep-scan/package.nix
@@ -4,16 +4,28 @@
   python3,
 }:
 
+let
+  appthreat-vulnerability-db = (
+    python3.pkgs.appthreat-vulnerability-db.overrideAttrs (oldAttrs: rec {
+      version = "5.7.3";
+      src = oldAttrs.src.override {
+        rev = "refs/tags/v${version}";
+        hash = "sha256-MrlgBUx3T2G46Pnah3obe5b4yKDzsAFVC/B7AHM0kZY=";
+      };
+    })
+  );
+
+in
 python3.pkgs.buildPythonApplication rec {
   pname = "dep-scan";
-  version = "5.3.4";
+  version = "5.4.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "owasp-dep-scan";
     repo = "dep-scan";
     rev = "refs/tags/v${version}";
-    hash = "sha256-5iMhl3Wcxwgq4Wr0TUcAuRnb2+y8DHBugnnkpcZfSAM=";
+    hash = "sha256-m0vDsCetOSfScu1eprrGaDJ1VuXxuNFBitK8N5GtfSQ=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];


### PR DESCRIPTION
## Description of changes

Since dep-scan locks appthreat-vulnerability-db to a specific version (and is not compatible with nixpkgs' version), this adds an override to match dep-scan's version specified in the pyproject.toml.

note: The current package seems to be broken due to version mismatch with appthreat-vulnerability-db, this should fix that.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/owasp-dep-scan/dep-scan/releases/tag/v5.3.5
https://github.com/owasp-dep-scan/dep-scan/releases/tag/v5.4.0
https://github.com/owasp-dep-scan/dep-scan/releases/tag/v5.4.1
https://github.com/owasp-dep-scan/dep-scan/releases/tag/v5.4.2
https://github.com/owasp-dep-scan/dep-scan/releases/tag/v5.4.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
