### PR TITLE
hedgedoc: 1.9.9 -> 1.10.0

### DIFF
--- a/pkgs/servers/web-apps/hedgedoc/default.nix
+++ b/pkgs/servers/web-apps/hedgedoc/default.nix
@@ -11,13 +11,13 @@
 }:
 
 let
-  version = "1.9.9";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "hedgedoc";
     repo = "hedgedoc";
     rev = version;
-    hash = "sha256-6eKTgEZ+YLoSmPQWBS95fJ+ioIxeTVlT+moqslByPPw=";
+    hash = "sha256-cRIpcoD9WzLYxKYpkvhRxUmeyJR5z2QyqApzWvQND+s=";
   };
 
   # we cannot use fetchYarnDeps because that doesn't support yarn 2/berry lockfiles
@@ -42,12 +42,14 @@ let
     '';
 
     outputHashMode = "recursive";
-    outputHash = "sha256-Ga+tl4oZlum43tdfez1oWGMHZAfyePGl47S+9NRRvW8=";
+    outputHash = "sha256-RV9xzNVE4//tPVWVaET78ML3ah+hkZ8x6mTAxe5/pdE=";
   };
 
 in stdenv.mkDerivation {
   pname = "hedgedoc";
   inherit version src;
+
+  patches = [ ./fix-lock.patch ];
 
   nativeBuildInputs = [
     makeBinaryWrapper

--- a/pkgs/servers/web-apps/hedgedoc/fix-lock.patch
+++ b/pkgs/servers/web-apps/hedgedoc/fix-lock.patch
@@ -1,0 +1,26 @@
+diff --git a/yarn.lock b/yarn.lock
+index ace3967..d32e3a2 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -1264,7 +1264,7 @@ __metadata:
+     eslint: "npm:8.57.0"
+     eslint-config-standard: "npm:17.1.0"
+     eslint-plugin-import: "npm:2.29.1"
+-    eslint-plugin-n: "npm:14.0.0"
++    eslint-plugin-n: "npm:15.0.0"
+     eslint-plugin-promise: "npm:6.6.0"
+     eslint-plugin-standard: "npm:4.1.0"
+     exports-loader: "npm:1.1.1"
+@@ -6076,9 +6076,9 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"eslint-plugin-n@npm:14.0.0":
+-  version: 14.0.0
+-  resolution: "eslint-plugin-n@npm:14.0.0"
++"eslint-plugin-n@npm:15.0.0":
++  version: 15.0.0
++  resolution: "eslint-plugin-n@npm:15.0.0"
+   dependencies:
+     eslint-plugin-es: "npm:^4.1.0"
+     eslint-utils: "npm:^3.0.0"


### PR DESCRIPTION
## Description of changes

Release notes: https://github.com/hedgedoc/hedgedoc/releases/tag/1.10.0

This update contains security fixes for
https://github.com/hedgedoc/hedgedoc/security/advisories/GHSA-pjf2-269h-cx7p,
a 6.5 (moderate) severity network exploit.

Signed-off-by: Christina Sørensen <christina@cafkafk.com>


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
