### PR TITLE
magicard-cups-driver: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -95,6 +95,11 @@
     github = "0x120581f";
     githubId = 130835755;
   };
+  _0x3f = {
+    name = "0x3f";
+    github = "0x3fiona";
+    githubId = 178507884;
+  };
   _0x4A6F = {
     email = "mail-maintainer@0x4A6F.dev";
     matrix = "@0x4a6f:matrix.org";

--- a/pkgs/by-name/ma/magicard-cups-driver/CMakeLists.patch
+++ b/pkgs/by-name/ma/magicard-cups-driver/CMakeLists.patch
@@ -1,0 +1,52 @@
+--- a/CMakeLists.txt  2022-10-20 17:03:52.000000000 +0200
++++ b/CMakeLists.txt  2024-09-05 21:39:27.172090291 +0200
+@@ -98,7 +98,9 @@
+    src/magencd.c
+    src/rp2mag.c
+    src/utils.c
+-   src/rp2mag_encode.c)
++   src/rp2mag_encode.c
++   src/commandmb1.c
++   src/command_helper.c)
+ 
+ target_compile_options(rastertoultra PRIVATE ${CUPS_CFLAGS})
+ target_link_libraries(rastertoultra ${CUPS_LIBS})
+@@ -164,38 +166,3 @@
+    )
+ set(CPACK_VERBATIM_VARIABLES YES)
+ include(CPack)
+-
+-## TESTS
+-
+-add_subdirectory(test/unity EXCLUDE_FROM_ALL)
+-add_executable(test_rp2_mag EXCLUDE_FROM_ALL test/test_rp2_mag.c
+-   src/rp2mag.c
+-   src/rp2mag_encode.c
+-   src/utils.c)
+-target_compile_definitions(test_rp2_mag PRIVATE TEST)
+-target_include_directories(test_rp2_mag PRIVATE src)
+-target_link_libraries(test_rp2_mag unity)
+-
+-add_executable(test_dpi EXCLUDE_FROM_ALL test/test_dpi.c
+-   src/rastertoultra.c
+-   src/utils.c
+-   src/crc32.c
+-   src/rp2mag.c
+-   src/colrmtch.c
+-   src/rp2mag_encode.c
+-   src/magencd.c
+-   src/colour-profiles/magir2x.c
+-   src/colour-profiles/magiox.c
+-   src/colour-profiles/magiry.c)
+-target_include_directories(test_dpi PRIVATE src)
+-target_compile_definitions(test_dpi PRIVATE TEST)
+-target_compile_options(test_dpi PRIVATE -Wno-unused-function)
+-target_link_libraries(test_dpi unity m ${CUPS_LIBS})
+-
+-enable_testing()
+-add_test(test_rp2_mag test_rp2_mag)
+-add_test(test_dpi test_dpi)
+-
+-# Autotools-style "make check" command
+-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+-add_dependencies(check test_rp2_mag test_dpi)

--- a/pkgs/by-name/ma/magicard-cups-driver/package.nix
+++ b/pkgs/by-name/ma/magicard-cups-driver/package.nix
@@ -1,0 +1,78 @@
+{
+  stdenv,
+  lib,
+  fetchzip,
+  cmake,
+  cups,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "magicard-cups-driver";
+  version = "1.4.0";
+
+  src = fetchzip {
+    # https://support.magicard.com/solution/linux-driver/
+    url = "https://f08ddbe93aa02eaf9a6c-f08cd513e3a8c914f4f8f62af1786149.ssl.cf3.rackcdn.com/magicard_ltd-linux_driver-${version}.tar.gz";
+    hash = "sha256-1k2Twn1JBizw/tzQ0xF1uJIecblRd6VurB7FAUop5F0=";
+  };
+
+  src_v1_3_4 = fetchzip {
+    url = "https://techs.magicard.com/linux/v1.3.4/magicard_ltd-linux_driver-1.3.4.tar.gz";
+    hash = "sha256-6UIL2wyFOjOJeyGjYScfjbpURycN469raye6DnP19jg=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ cups ];
+
+  # Replace the supplied cmake generated makefile (which is useless on a different machine)
+  # with the CMakeLists.txt taken from v1.3.4 of the driver and patch it to make it compatible with v1.4.0
+  prePatch = ''
+    cp ${src_v1_3_4}/CMakeLists.txt CMakeLists.txt
+    rm makefile
+  '';
+
+  patches = [ ./CMakeLists.patch ];
+
+  cmakeFlags = [
+    "-DCUPS_SERVER_BIN=lib/cups"
+    "-DCUPS_DATA_DIR=share/cups"
+  ];
+
+  meta = {
+    description = "CUPS driver for Magicard Printers";
+    longDescription = ''
+      This driver supports Magicard printers and rebrands sold at least under the following brands:
+
+      - Aisino
+      - AlphaCard
+      - BOOD
+      - Brady
+      - Cardmaker
+      - Centena
+      - DTP
+      - Digital ID
+      - DoH
+      - Elliaden
+      - Fagoo
+      - Goodcard
+      - Gudecard
+      - IDentilam
+      - IDville
+      - ilinkcard
+      - Intersider
+      - Magicard
+      - Orphicard
+      - PPC ID
+      - Polaroid
+      - PriceCardPro
+      - Pridento
+      - ScreenCheck
+      - Titan
+      - Ying
+    '';
+    homepage = "https://support.magicard.com/solution/linux-driver/";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ _0x3f ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This commit adds a cups driver for card printers from Magicard and rebrands.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
