### PR TITLE
writers: add writeNim and writeNimBin

### DIFF
--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -31,6 +31,8 @@ let
     writeJSBin
     writeJSON
     writeLua
+    writeNim
+    writeNimBin
     writeNu
     writePerl
     writePerlBin
@@ -107,6 +109,10 @@ recurseIntoAttrs {
       main = case int of
         18871 -> putStrLn $ id "success"
         _ -> print "fail"
+    '');
+
+    nim = expectSuccessBin (writeNimBin "test-writers-nim-bin" { } ''
+      echo "success"
     '');
 
     js = expectSuccessBin (writeJSBin "test-writers-js-bin" { libraries = [ nodePackages.semver ]; } ''
@@ -189,6 +195,10 @@ recurseIntoAttrs {
       if test "test" = "test"
         echo "success"
       end
+    '');
+
+    nim = expectSuccess (writeNim "test-writers-nim" { } ''
+      echo "success"
     '');
 
     nu = expectSuccess (writeNu "test-writers-nushell" ''
@@ -408,6 +418,23 @@ recurseIntoAttrs {
         ''
           (when (= (System/getenv "ThaigerSprint") "Thailand")
             (println "success"))
+        ''
+    );
+
+    nim = expectSuccess (
+      writeNim "test-writers-wrapping-nim"
+        {
+          makeWrapperArgs = [
+            "--set"
+            "ThaigerSprint"
+            "Thailand"
+          ];
+        }
+        ''
+          import os
+
+          if getEnv("ThaigerSprint") == "Thailand":
+            echo "success"
         ''
     );
 


### PR DESCRIPTION
## Description of changes

This adds convenience writers for self-contained Nim programs.
Those are compiled into very small binaries.

Test with:
    nix build .#pkgs.tests.writers.{bin,simple,wrapping}.nim


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
