### PR TITLE
Revert "python312Packages.numba: use a single numpy version; don't propagate it"

### DIFF
--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -7,6 +7,7 @@
   python,
   buildPythonPackage,
   setuptools,
+  numpy,
   numpy_2,
   llvmlite,
   libcxx,
@@ -81,6 +82,7 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
+    numpy_2
   ];
 
   nativeBuildInputs = lib.optionals cudaSupport [
@@ -88,12 +90,10 @@ buildPythonPackage rec {
     cudaPackages.cuda_nvcc
   ];
 
-  buildInputs = [
-    # Not propagating it, because it numba can work with either numpy_2 or numpy_1
-    numpy_2
-  ] ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ];
+  buildInputs = lib.optionals cudaSupport [ cudaPackages.cuda_cudart ];
 
   dependencies = [
+    numpy
     llvmlite
     setuptools
   ] ++ lib.optionals (pythonOlder "3.9") [ importlib-metadata ];

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -82,7 +82,7 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
-    numpy_2
+    numpy
   ];
 
   nativeBuildInputs = lib.optionals cudaSupport [
@@ -160,6 +160,9 @@ buildPythonPackage rec {
       cudaSupport = false;
       doFullCheck = true;
       testsWithoutSandbox = false;
+    };
+    numpy_2 = numba.override {
+      numpy = numpy_2;
     };
   };
 


### PR DESCRIPTION
## Description of changes
This reverts commit https://github.com/NixOS/nixpkgs/commit/3bad18825ec132da9f34a41f37cc28e26084862e.
Numba doesn't work without NumPy and it's in upstream's setup_requires as well as install_requires.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
