### PR TITLE
nixos/services.bees: fix eval

### DIFF
--- a/nixos/modules/services/misc/bees.nix
+++ b/nixos/modules/services/misc/bees.nix
@@ -1,9 +1,23 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
 
   cfg = config.services.beesd;
 
-  logLevels = { emerg = 0; alert = 1; crit = 2; err = 3; warning = 4; notice = 5; info = 6; debug = 7; };
+  logLevels = {
+    emerg = 0;
+    alert = 1;
+    crit = 2;
+    err = 3;
+    warning = 4;
+    notice = 5;
+    info = 6;
+    debug = 7;
+  };
 
   fsOptions = with lib.types; {
     options.spec = lib.mkOption {
@@ -23,7 +37,7 @@ let
       example = "LABEL=MyBulkDataDrive";
     };
     options.hashTableSizeMB = lib.mkOption {
-      type = lib.types.addCheck lib.types.int (n: mod n 16 == 0);
+      type = lib.types.addCheck lib.types.int (n: lib.mod n 16 == 0);
       default = 1024; # 1GB; default from upstream beesd script
       description = ''
         Hash table size in MB; must be a multiple of 16.
@@ -84,8 +98,9 @@ in
     };
   };
   config = {
-    systemd.services = lib.mapAttrs'
-      (name: fs: lib.nameValuePair "beesd@${name}" {
+    systemd.services = lib.mapAttrs' (
+      name: fs:
+      lib.nameValuePair "beesd@${name}" {
         description = "Block-level BTRFS deduplication for %i";
         after = [ "sysinit.target" ];
 
@@ -120,7 +135,7 @@ in
           };
         unitConfig.RequiresMountsFor = lib.mkIf (lib.hasPrefix "/" fs.spec) fs.spec;
         wantedBy = [ "multi-user.target" ];
-      })
-      cfg.filesystems;
+      }
+    ) cfg.filesystems;
   };
 }


### PR DESCRIPTION
## Description of changes

- removal of "with lib;" left in a naked use of `mod`, so prefixed it with `lib.`
- on-save hook put the whole file through `nixfmt`, let's see what the CI machinery thinks about that...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [v ] x86_64-linux

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
