### PR TITLE
python312Packages.pydantic_1: 1.10.16 -> 1.10.18

### DIFF
--- a/pkgs/development/python-modules/pydantic/1.nix
+++ b/pkgs/development/python-modules/pydantic/1.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   cython_0,
+  distutils,
   email-validator,
   fetchFromGitHub,
   pytest-mock,
@@ -16,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "pydantic";
-  version = "1.10.16";
+  version = "1.10.18";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -25,46 +26,32 @@ buildPythonPackage rec {
     owner = "pydantic";
     repo = "pydantic";
     rev = "refs/tags/v${version}";
-    hash = "sha256-dn/ZsxbkyK2sJxpo6IsoMBRjq1STdu+xuqHXoNG+Kzk=";
+    hash = "sha256-IFctgyZAURVlUAYppwWjGU1k7Alo9w28CQfhdSjxZJ8=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     cython_0
   ];
 
   buildInputs = lib.optionals (pythonOlder "3.9") [ libxcrypt ];
 
-  propagatedBuildInputs = [ typing-extensions ];
+  dependencies = [ typing-extensions ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     dotenv = [ python-dotenv ];
     email = [ email-validator ];
   };
 
   nativeCheckInputs = [
+    distutils
     pytest-mock
     pytest7CheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
-
-  pytestFlagsArray = [
-    # https://github.com/pydantic/pydantic/issues/4817
-    "-W"
-    "ignore::pytest.PytestReturnNotNoneWarning"
-  ];
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
-
-  disabledTests = lib.optionals (pythonAtLeast "3.12") [
-    # depends on distuils
-    "test_cython_function_untouched"
-    # AssertionError on exact types and wording
-    "test_model_subclassing_abstract_base_classes_without_implementation_raises_exception"
-    "test_partial_specification_name"
-    "test_secretfield"
-  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/pydantic/pydantic/compare/refs/tags/v1.10.16...v1.10.18

Changelog: https://github.com/pydantic/pydantic/blob/v1.10.18/HISTORY.md



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
