### PR TITLE
cdxgen: 10.8.1 -> 10.9.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17011,6 +17011,12 @@
     githubId = 1332289;
     name = "Quentin Machu";
   };
+  quincepie = {
+    email = "flaky@quincepie.dev";
+    github = "Quince-Pie";
+    githubId = 127546159;
+    name = "QuincePie";
+  };
   quinn-dougherty = {
     email = "quinnd@riseup.net";
     github = "quinn-dougherty";

--- a/pkgs/tools/security/cdxgen/default.nix
+++ b/pkgs/tools/security/cdxgen/default.nix
@@ -62,6 +62,9 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "cdxgen";
     homepage = "https://github.com/CycloneDX/cdxgen";
     license = licenses.asl20;
-    maintainers = with maintainers; [ dit7ya ];
+    maintainers = with maintainers; [
+      dit7ya
+      quincepie
+    ];
   };
 })

--- a/pkgs/tools/security/cdxgen/default.nix
+++ b/pkgs/tools/security/cdxgen/default.nix
@@ -1,23 +1,24 @@
-{ fetchFromGitHub
-, lib
-, makeWrapper
-, nodejs
-, node-gyp
-, pnpm_9
-, python3
-, stdenv
-, xcbuild
+{
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  nodejs,
+  node-gyp,
+  pnpm_9,
+  python3,
+  stdenv,
+  xcbuild,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cdxgen";
-  version = "10.8.1";
+  version = "10.9.6";
 
   src = fetchFromGitHub {
     owner = "CycloneDX";
     repo = "cdxgen";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-PFvSHuIaHaGfKI5s7DOW1adSKpnURaQtk5lAO9lr1OM=";
+    hash = "sha256-WgY0soHwedYbQNDvDIqtaxMSzVcaOVV2/22wOXU2nbA=";
   };
 
   nativeBuildInputs = [
@@ -30,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-IO7hn5xHdlQ+uyH8RWc7ZnnthXydCnMSde22YYMWOoc=";
+    hash = "sha256-IgmTYmCmZ65Da5zL6Tx7P4bt2o+YhX0UvU0DEONmr7w=";
   };
 
   buildPhase = ''
@@ -55,7 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
-
 
   meta = with lib; {
     description = "Creates CycloneDX Software Bill-of-Materials (SBOM) for your projects from source and container images";


### PR DESCRIPTION
## Description of changes

https://github.com/CycloneDX/cdxgen/releases/tag/v10.8.2
https://github.com/CycloneDX/cdxgen/releases/tag/v10.8.3
https://github.com/CycloneDX/cdxgen/releases/tag/v10.8.4
https://github.com/CycloneDX/cdxgen/releases/tag/v10.8.5
https://github.com/CycloneDX/cdxgen/releases/tag/v10.8.6
https://github.com/CycloneDX/cdxgen/releases/tag/v10.8.7
https://github.com/CycloneDX/cdxgen/releases/tag/v10.8.8
https://github.com/CycloneDX/cdxgen/releases/tag/v10.8.9
https://github.com/CycloneDX/cdxgen/releases/tag/v10.9.0
https://github.com/CycloneDX/cdxgen/releases/tag/v10.9.1
https://github.com/CycloneDX/cdxgen/releases/tag/v10.9.2
https://github.com/CycloneDX/cdxgen/releases/tag/v10.9.3
https://github.com/CycloneDX/cdxgen/releases/tag/v10.9.4
https://github.com/CycloneDX/cdxgen/releases/tag/v10.9.5
https://github.com/CycloneDX/cdxgen/releases/tag/v10.9.6

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
