### PR TITLE
mongodb: fix building with python312

### DIFF
--- a/pkgs/servers/nosql/mongodb/5.0.nix
+++ b/pkgs/servers/nosql/mongodb/5.0.nix
@@ -29,6 +29,8 @@ buildMongoDB {
     ./forget-build-dependencies-4-4.patch
     ./asio-no-experimental-string-view-4-4.patch
     ./fix-gcc-Wno-exceptions-5.0.patch
+    # Fix building with python 3.12 since the imp module was removed
+    ./mongodb-python312.patch
   ] ++ variants.patches;
   passthru.tests = { inherit (nixosTests) mongodb; };
 }

--- a/pkgs/servers/nosql/mongodb/6.0.nix
+++ b/pkgs/servers/nosql/mongodb/6.0.nix
@@ -21,6 +21,9 @@ buildMongoDB {
       url = "https://github.com/mongodb/mongo/commit/5435f9585f857f6145beaf6d31daf336453ba86f.patch";
       sha256 = "sha256-gWlE2b/NyGe2243iNCXzjcERIY8/4ZWI4Gjh5SF0tYA=";
     })
+
+    # Fix building with python 3.12 since the imp module was removed
+    ./mongodb-python312.patch
   ];
   # passthru.tests = { inherit (nixosTests) mongodb; }; # currently tests mongodb-5_0
 }

--- a/pkgs/servers/nosql/mongodb/mongodb-python312.patch
+++ b/pkgs/servers/nosql/mongodb/mongodb-python312.patch
@@ -1,0 +1,22 @@
+diff --git a/buildscripts/moduleconfig.py b/buildscripts/moduleconfig.py
+index b4d0bba0490..f59ddd7bc5c 100644
+--- a/buildscripts/moduleconfig.py
++++ b/buildscripts/moduleconfig.py
+@@ -27,7 +27,7 @@ MongoDB SConscript files do.
+ __all__ = ('discover_modules', 'discover_module_directories', 'configure_modules',
+            'register_module_test')  # pylint: disable=undefined-all-variable
+ 
+-import imp
++import importlib
+ import inspect
+ import os
+ 
+@@ -71,7 +71,7 @@ def discover_modules(module_root, allowed_modules):
+             print("adding module: %s" % (name))
+             fp = open(build_py, "r")
+             try:
+-                module = imp.load_module("module_" + name, fp, build_py,
++                module = importlib.load_module("module_" + name, fp, build_py,
+                                          (".py", "r", imp.PY_SOURCE))
+                 if getattr(module, "name", None) is None:
+                     module.name = name

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -13,7 +13,6 @@
 , openldap
 , openssl
 , libpcap
-, python311Packages
 , curl
 , Security
 , CoreFoundation
@@ -32,12 +31,13 @@
 }:
 
 let
-  scons = buildPackages.scons.override{ python3Packages = python311Packages; };
+  scons = buildPackages.scons;
   python = scons.python.withPackages (ps: with ps; [
     pyyaml
     cheetah3
     psutil
     setuptools
+    distutils
   ] ++ lib.optionals (lib.versionAtLeast version "6.0") [
     packaging
     pymongo


### PR DESCRIPTION
## Description of changes

```
mongodb> ModuleNotFoundError: No module named 'imp':
mongodb>   File "/build/source/SConstruct", line 46:
mongodb>     from buildscripts import moduleconfig
mongodb>   File "/build/source/buildscripts/moduleconfig.py", line 30:
mongodb>     import imp
```

`imp` was removed in python 3.12

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
