### PR TITLE
mkosi: 22 -> 24.3-unstable-2024-08-28

### DIFF
--- a/pkgs/tools/virtualization/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
+++ b/pkgs/tools/virtualization/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
@@ -1,0 +1,116 @@
+From eb36791f873dd645b1cbfa693b9c246943647190 Mon Sep 17 00:00:00 2001
+From: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+Date: Tue, 3 Sep 2024 08:57:26 +0200
+Subject: [PATCH 1/3] Use wrapped binaries instead of Python interpreter
+
+Rather than calling ukify and mkosi with sys.executable, which doesn't use the Python wrappers for PATH and PYTHONPATH, we call the wrapped binaries directly.
+
+Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+---
+ mkosi/__init__.py | 19 ++++---------------
+ mkosi/run.py      |  8 ++++----
+ 2 files changed, 8 insertions(+), 19 deletions(-)
+
+diff --git a/mkosi/__init__.py b/mkosi/__init__.py
+index cc8482c4..ba44ad31 100644
+--- a/mkosi/__init__.py
++++ b/mkosi/__init__.py
+@@ -2059,16 +2059,7 @@ def join_initrds(initrds: Sequence[Path], output: Path) -> Path:
+
+
+ def python_binary(config: Config, *, binary: Optional[PathString]) -> PathString:
+-    tools = (
+-        not binary or
+-        not (path := config.find_binary(binary)) or
+-        not any(path.is_relative_to(d) for d in config.extra_search_paths)
+-    )
+-
+-    # If there's no tools tree, prefer the interpreter from MKOSI_INTERPRETER. If there is a tools
+-    # tree, just use the default python3 interpreter.
+-    exe = Path(sys.executable)
+-    return "python3" if (tools and config.tools_tree) or not exe.is_relative_to("/usr") else exe
++    return "@PYTHON_PEFILE@"
+
+
+ def extract_pe_section(context: Context, binary: Path, section: str, output: Path) -> Path:
+@@ -2135,11 +2126,10 @@ def build_uki(
+     if not (arch := context.config.architecture.to_efi()):
+         die(f"Architecture {context.config.architecture} does not support UEFI")
+
+-    if not (ukify := context.config.find_binary("ukify", "/usr/lib/systemd/ukify")):
++    if not (ukify := context.config.find_binary("ukify", "@UKIFY@")):
+         die("Could not find ukify")
+
+     cmd: list[PathString] = [
+-        python_binary(context.config, binary=ukify),
+         ukify,
+         *(["--cmdline", f"@{context.workspace / 'cmdline'}"] if cmdline else []),
+         "--os-release", f"@{context.root / 'usr/lib/os-release'}",
+@@ -2213,7 +2203,6 @@ def build_uki(
+         # new .ucode section support?
+         if (
+             systemd_tool_version(
+-                python_binary(context.config, binary=ukify),
+                 ukify,
+                 sandbox=context.sandbox,
+             ) >= "256" and
+@@ -2303,7 +2292,7 @@ def want_uki(context: Context) -> bool:
+             context.config.unified_kernel_images == ConfigFeature.enabled or (
+                 context.config.unified_kernel_images == ConfigFeature.auto and
+                 systemd_stub_binary(context).exists() and
+-                context.config.find_binary("ukify", "/usr/lib/systemd/ukify") is not None
++                context.config.find_binary("ukify", "@UKIFY@") is not None
+             )
+     )
+
+@@ -2914,7 +2903,7 @@ def check_ukify(
+     reason: str,
+     hint: Optional[str] = None,
+ ) -> None:
+-    ukify = check_tool(config, "ukify", "/usr/lib/systemd/ukify", reason=reason, hint=hint)
++    ukify = check_tool(config, "ukify", "@UKIFY@", reason=reason, hint=hint)
+
+     v = systemd_tool_version(python_binary(config, binary=ukify), ukify, sandbox=config.sandbox)
+     if v < version:
+diff --git a/mkosi/run.py b/mkosi/run.py
+index fd3bc98e..de47349a 100644
+--- a/mkosi/run.py
++++ b/mkosi/run.py
+@@ -450,7 +450,7 @@ def sandbox_cmd(
+ ) -> Iterator[list[PathString]]:
+     cmdline: list[PathString] = [
+         *setup,
+-        sys.executable, "-SI", mkosi.sandbox.__file__,
++        @MKOSI_SANDBOX@,
+         "--proc", "/proc",
+         # We mounted a subdirectory of TMPDIR to /var/tmp so we unset TMPDIR so that /tmp or /var/tmp are used instead.
+         "--unsetenv", "TMPDIR",
+@@ -563,7 +563,7 @@ def apivfs_options(*, root: Path = Path("/buildroot")) -> list[PathString]:
+ def apivfs_script_cmd(*, tools: bool, options: Sequence[PathString] = ()) -> list[PathString]:
+     exe = Path(sys.executable)
+     return [
+-        "python3" if tools or not exe.is_relative_to("/usr") else exe, "-SI", "/sandbox.py",
++        @MKOSI_SANDBOX@,
+         "--bind", "/", "/",
+         "--same-dir",
+         "--bind", "/var/tmp", "/buildroot/var/tmp",
+@@ -597,7 +597,7 @@ def chroot_cmd(
+     options: Sequence[PathString] = (),
+ ) -> Iterator[list[PathString]]:
+     cmdline: list[PathString] = [
+-        sys.executable, "-SI", mkosi.sandbox.__file__,
++        @MKOSI_SANDBOX@,
+         "--bind", root, "/",
+         # We mounted a subdirectory of TMPDIR to /var/tmp so we unset TMPDIR so that /tmp or /var/tmp are used instead.
+         "--unsetenv", "TMPDIR",
+@@ -619,7 +619,7 @@ def chroot_cmd(
+ def chroot_script_cmd(*, tools: bool, network: bool = False, work: bool = False) -> list[PathString]:
+     exe = Path(sys.executable)
+     return [
+-        "python3" if tools or not exe.is_relative_to("/usr") else exe, "-SI", "/sandbox.py",
++        @MKOSI_SANDBOX@,
+         "--bind", "/buildroot", "/",
+         "--bind", "/var/tmp", "/var/tmp",
+         *apivfs_options(root=Path("/")),
+--
+2.45.2

--- a/pkgs/tools/virtualization/mkosi/0002-Fix-library-resolving.patch
+++ b/pkgs/tools/virtualization/mkosi/0002-Fix-library-resolving.patch
@@ -1,0 +1,36 @@
+From a1e6ccfeaf8ef10361280b9ecad958e9d556005b Mon Sep 17 00:00:00 2001
+From: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+Date: Tue, 3 Sep 2024 09:00:34 +0200
+Subject: [PATCH 2/3] Fix library resolving
+
+As ctypes doesn't do lookups in the Nix store for libraries, we supply the exact paths.
+
+Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+---
+ mkosi/sandbox/__init__.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mkosi/sandbox/__init__.py b/mkosi/sandbox/__init__.py
+index 7db340c5..3d0a0e56 100644
+--- a/mkosi/sandbox/__init__.py
++++ b/mkosi/sandbox/__init__.py
+@@ -78,7 +78,7 @@ class cap_user_data_t(ctypes.Structure):
+     ]
+
+
+-libc = ctypes.CDLL(None, use_errno=True)
++libc = ctypes.CDLL("@LIBC@", use_errno=True)
+
+ libc.syscall.restype = ctypes.c_long
+ libc.unshare.argtypes = (ctypes.c_int,)
+@@ -175,7 +175,7 @@ def seccomp_suppress_chown() -> None:
+     Unfortunately, non-root users can only create files owned by their own uid. To still allow non-root users to build
+     images, if requested we install a seccomp filter that makes calls to chown() and friends a noop.
+     """
+-    libseccomp = ctypes.CDLL("libseccomp.so.2")
++    libseccomp = ctypes.CDLL("@LIBSECCOMP@")
+     if libseccomp is None:
+         raise FileNotFoundError("libseccomp.so.2")
+
+--
+2.45.2

--- a/pkgs/tools/virtualization/mkosi/0003-Fix-QEMU-firmware-path.patch
+++ b/pkgs/tools/virtualization/mkosi/0003-Fix-QEMU-firmware-path.patch
@@ -1,0 +1,25 @@
+From e834d51aa2542b141ceafdd42285ded6a9997c90 Mon Sep 17 00:00:00 2001
+From: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+Date: Tue, 3 Sep 2024 09:09:19 +0200
+Subject: [PATCH 3/3] Fix QEMU firmware path
+
+Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+---
+ mkosi/qemu.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mkosi/qemu.py b/mkosi/qemu.py
+index b98bec65..886598aa 100644
+--- a/mkosi/qemu.py
++++ b/mkosi/qemu.py
+@@ -182,7 +182,7 @@ def find_ovmf_firmware(config: Config, qemu: Path, firmware: QemuFirmware) -> Op
+
+     tools = Path("/") if any(qemu.is_relative_to(d) for d in config.extra_search_paths) else config.tools()
+
+-    desc = list((tools / "usr/share/qemu/firmware").glob("*"))
++    desc = list((tools / "@QEMU_FIRMWARE@").glob("*"))
+     if tools == Path("/"):
+         desc += list((tools / "etc/qemu/firmware").glob("*"))
+
+--
+2.45.2

--- a/pkgs/tools/virtualization/mkosi/default.nix
+++ b/pkgs/tools/virtualization/mkosi/default.nix
@@ -128,7 +128,10 @@ buildPythonApplication rec {
     changelog = "https://github.com/systemd/mkosi/releases/tag/v${version}";
     license = licenses.lgpl21Only;
     mainProgram = "mkosi";
-    maintainers = with maintainers; [ malt3 ];
+    maintainers = with maintainers; [
+      malt3
+      msanft
+    ];
     platforms = platforms.linux;
     # `mkosi qemu` boot fails in the uefi shell, image isn't found.
     broken = withQemu;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update `mkosi` from `v22` to an unstable version based on `v24.3` that includes a sandboxing rewrite that doesn't rely on `uidmap` anymore. This means that a Nix-sourced `mkosi` can be used more hermetically, as no external `uidmap` suid binary is required anymore, which couldn't - without further modifications - be sourced from Nix on most non-NixOS systems. Even though the update is marked as unstable as of now, throughout my testing of building various images, it would prove to be very reliable.

Notes:
- `pythonImportsCheck` had to be removed, as mkosi now wants to be aware of the TTY it's in, which doesn't work in the Nix sandbox.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
