### PR TITLE
edk2: loongarch64 support

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -29,6 +29,7 @@
     x86_64 = "OvmfPkg/OvmfPkgX64.dsc";
     aarch64 = "ArmVirtPkg/ArmVirtQemu.dsc";
     riscv64 = "OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc";
+    loongarch64 = "OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc";
   }.${stdenv.hostPlatform.parsed.cpu.name}
   or (throw "Unsupported OVMF `projectDscPath` on ${stdenv.hostPlatform.parsed.cpu.name}")
 , fwPrefix ? {
@@ -36,6 +37,7 @@
     x86_64 = "OVMF";
     aarch64 = "AAVMF";
     riscv64 = "RISCV_VIRT";
+    loongarch64 = "LOONGARCH_VIRT";
   }.${stdenv.hostPlatform.parsed.cpu.name}
   or (throw "Unsupported OVMF `fwPrefix` on ${stdenv.hostPlatform.parsed.cpu.name}")
 , metaPlatforms ? edk2.meta.platforms
@@ -130,17 +132,17 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     export PYTHONPATH=$NIX_BUILD_TOP/debian/python:$PYTHONPATH
   '';
 
-  postBuild = lib.optionalString stdenv.hostPlatform.isAarch ''
+  postBuild = lib.optionalString (stdenv.hostPlatform.isAarch || stdenv.hostPlatform.isLoongArch64) ''
     (
     cd ${buildPrefix}/FV
     cp QEMU_EFI.fd ${fwPrefix}_CODE.fd
     cp QEMU_VARS.fd ${fwPrefix}_VARS.fd
-
+    )
+  '' + lib.optionalString stdenv.hostPlatform.isAarch ''
     # QEMU expects 64MiB CODE and VARS files on ARM/AARCH64 architectures
     # Truncate the firmware files to the expected size
-    truncate -s 64M ${fwPrefix}_CODE.fd
-    truncate -s 64M ${fwPrefix}_VARS.fd
-    )
+    truncate -s 64M ${buildPrefix}/FV/${fwPrefix}_CODE.fd
+    truncate -s 64M ${buildPrefix}/FV/${fwPrefix}_VARS.fd
   '' + lib.optionalString stdenv.hostPlatform.isRiscV ''
     truncate -s 32M ${buildPrefix}/FV/${fwPrefix}_CODE.fd
     truncate -s 32M ${buildPrefix}/FV/${fwPrefix}_VARS.fd
@@ -165,7 +167,7 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
   postInstall = ''
     mkdir -vp $fd/FV
   '' + lib.optionalString (builtins.elem fwPrefix [
-    "OVMF" "AAVMF" "RISCV_VIRT"
+    "OVMF" "AAVMF" "RISCV_VIRT" "LOONGARCH_VIRT"
   ]) ''
     mv -v $out/FV/${fwPrefix}_{CODE,VARS}.fd $fd/FV
   '' + lib.optionalString stdenv.hostPlatform.isx86 ''

--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -23,6 +23,8 @@ else if stdenv.isAarch64 then
   "AARCH64"
 else if stdenv.hostPlatform.isRiscV64 then
   "RISCV64"
+else if stdenv.hostPlatform.isLoongArch64 then
+  "LOONGARCH64"
 else
   throw "Unsupported architecture";
 
@@ -128,7 +130,7 @@ edk2 = stdenv.mkDerivation {
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II/";
     changelog = "https://github.com/tianocore/edk2/releases/tag/edk2-stable${edk2.version}";
     license = lib.licenses.bsd2;
-    platforms = with lib.platforms; aarch64 ++ arm ++ i686 ++ x86_64 ++ riscv64;
+    platforms = with lib.platforms; aarch64 ++ arm ++ i686 ++ x86_64 ++ loongarch64 ++ riscv64;
     maintainers = [ lib.maintainers.mjoerg ];
   };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upstream had this for some time, let's just enable building it.

## Things done

Tested building `edk2-uefi-shell`, building `OVMF` and running `OVMF` in QEMU. I did not test if `edk2-uefi-shell` runs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] loongarch64-linux (cross compiled)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
