### PR TITLE
nodejs/importNpmLock: init source overrides option

### DIFF
--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -72,6 +72,10 @@ lib.fix (self: {
     # Example: { "node_modules/axios" = { curlOptsList = [ "--verbose" ]; }; }
     # This will download the axios package with curl's verbose option.
     , fetcherOpts ?  {}
+    # A map from node_module path to an alternative package to use instead of fetching the source in package-lock.json.
+    # Example: { "node_modules/axios" = stdenv.mkDerivation { ... }; }
+    # This is usefull if you want to inject custom sources for a specific package.
+    , packageSourceOverrides ? {}
     }:
     let
       mapLockDependencies =
@@ -94,10 +98,10 @@ lib.fix (self: {
           mapAttrs
             (modulePath: module:
               let
-                src = fetchModule {
+                src = packageSourceOverrides.${modulePath} or (fetchModule {
                   inherit module npmRoot;
                   fetcherOpts = fetcherOpts.${modulePath} or {};
-                };
+                });
               in
               cleanModule module
               // lib.optionalAttrs (src != null) {


### PR DESCRIPTION
## Description of changes

Allows the users to specify packageSourceOverrides for individual packages which can be used to:

- Apply patches to any dependency.
- Use nix-built nodejs dependencies.
- Fetch private dependencies e.g. with `builtins.fetchGit`  instead of `pkgs.fetchGit`.

The user of this interface is responsible to provide a correct node package which is specified:

https://docs.npmjs.com/about-packages-and-modules#about-package-formats

But Usually:

> A folder containing a program described by a package.json file.

## Usage example:

```nix
{ buildNpmPackage, importNpmLock, my-library,  stdenv, ... }:
  buildNpmPackage {
    pname = "hello";
    version = "0.1.0";
    src = ./.;

    npmDeps = importNpmLock {
      npmRoot = ./.;
      packageSourceOverrides = {
        "node_modules/A" = builtins.fetchGit {
              # my private repo
        };
       "node_modules/B" = stdenv.mkDerivation {
              # my custom dependency patch
        };
        "node_modules/@my/library" = my-library;
      };
    };

    npmConfigHook = pkgs.importNpmLock.npmConfigHook;
  };
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
