### PR TITLE
leftwm: fix build, add maintainer

### DIFF
--- a/pkgs/applications/window-managers/leftwm/default.nix
+++ b/pkgs/applications/window-managers/leftwm/default.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/leftwm/leftwm";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ yanganto ];
+    maintainers = with lib.maintainers; [ vuimuich yanganto ];
     changelog = "https://github.com/leftwm/leftwm/blob/${version}/CHANGELOG.md";
     mainProgram = "leftwm";
   };

--- a/pkgs/applications/window-managers/leftwm/default.nix
+++ b/pkgs/applications/window-managers/leftwm/default.nix
@@ -20,7 +20,16 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-wn5DurPWFwSUtc5naEL4lBSQpKWTJkugpN9mKx+Ed2Y=";
   };
 
-  cargoHash = "sha256-TylRxdpAVuGtZ3Lm8je6FZ0JUwetBi6mOGRoT2M3Jyk=";
+  cargoPatches = [
+    # This pacth can be removed with the next version bump, it just updates the `time` crate
+    ./update-time-crate.patch
+  ];
+
+  # To show the "correct" git-hash in `leftwm-check` we manually set the GIT_HASH env variable
+  # can be remove together with the above patch
+  GIT_HASH = "36609e0 patched";
+
+  cargoHash = "sha256-SNq76pTAPSUGVRp/+fwCjSMP/lKVzh6wU+WZW5n/yjg=";
 
   buildInputs = rpathLibs;
 

--- a/pkgs/applications/window-managers/leftwm/update-time-crate.patch
+++ b/pkgs/applications/window-managers/leftwm/update-time-crate.patch
@@ -1,0 +1,57 @@
+From 9358bebb11df19f46d0813723959518498d812b2 Mon Sep 17 00:00:00 2001
+From: VuiMuich <vuimuich@quantentunnel.de>
+Date: Mon, 2 Sep 2024 11:15:27 +0200
+Subject: [PATCH] fix rust 1.80.x for nixpkgs
+
+---
+ Cargo.lock | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index f8a82eecf..5728b55bf 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -777,6 +777,12 @@ dependencies = [
+  "winapi",
+ ]
+ 
++[[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
+ [[package]]
+ name = "num-traits"
+ version = "0.2.17"
+@@ -1218,13 +1224,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.30"
++version = "0.3.35"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
++checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
+ dependencies = [
+  "deranged",
+  "itoa",
+  "libc",
++ "num-conv",
+  "num_threads",
+  "powerfmt",
+  "serde",
+@@ -1240,10 +1247,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.15"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+ 


### PR DESCRIPTION
- **leftwm: add maintainer `vuimuich`**
- **leftwm: fix build**

## Description of changes

- fixes build failure with Rust 1.80.x by patching `cargo.lock` with updated `time` crate and deps (upstream version bump will take some time, as it might bring breaking changes for users)
- adds myself to maintainers, as I am also maintainer of the upstream repo

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
