### PR TITLE
audiobookshelf: 2.12.3 -> 2.13.2

### DIFF
--- a/pkgs/by-name/au/audiobookshelf/package.nix
+++ b/pkgs/by-name/au/audiobookshelf/package.nix
@@ -56,14 +56,6 @@ buildNpmPackage {
   inherit pname src;
   inherit (source) version;
 
-  postPatch = ''
-    # Always skip version checks of the binary manager.
-    # We provide our own binaries, and don't want to trigger downloads.
-    substituteInPlace server/managers/BinaryManager.js --replace-fail \
-      'if (!this.validVersions.length) return true' \
-      'return true'
-  '';
-
   buildInputs = [ util-linux ];
   nativeBuildInputs = [ python3 ];
 

--- a/pkgs/by-name/au/audiobookshelf/source.json
+++ b/pkgs/by-name/au/audiobookshelf/source.json
@@ -1,9 +1,9 @@
 {
   "owner": "advplyr",
   "repo": "audiobookshelf",
-  "rev": "52a3bc224ae7c79fbb543716a25b731c65a8f76a",
-  "hash": "sha256-SbpoCtd5PJ6fU9muy58J4VxlbKiJM0OfMALHC5DUqFc=",
-  "version": "2.12.3",
-  "depsHash": "sha256-8YUGM+MPYFLpLwWe3W+eObxH4ZklDVGj8bDYkSWTzQg=",
-  "clientDepsHash": "sha256-8xE1M7InH+Rxjpb2rsdvC3LcLV+k8a83BKWCis5P+tY="
+  "rev": "48f232790a5026ac886564ef57660a338a168187",
+  "hash": "sha256-2/lUByeWMZlxk7i+mvzBuxlxD97C+JEtmf/ajht5AOs=",
+  "version": "2.13.2",
+  "depsHash": "sha256-kU5Nrhy6AePwD2/kmvTXvrvGUH8uz3qm3ZvD3kC9EmE=",
+  "clientDepsHash": "sha256-1haujBoC9KyusE52HeepOcvmb6v7EG5XWD4dq1wPfe4="
 }

--- a/pkgs/by-name/au/audiobookshelf/wrapper.nix
+++ b/pkgs/by-name/au/audiobookshelf/wrapper.nix
@@ -52,6 +52,7 @@
 
     NODE_ENV=production \
       SOURCE=nixpkgs \
+      SKIP_BINARIES_CHECK=1 \
       FFMPEG_PATH=${ffmpeg-full}/bin/ffmpeg \
       FFPROBE_PATH=${ffmpeg-full}/bin/ffprobe \
       CONFIG_PATH="$config" \


### PR DESCRIPTION
## Description of changes

fixes CVE-2024-43797

https://github.com/advplyr/audiobookshelf/releases/tag/v2.13.0
https://github.com/advplyr/audiobookshelf/releases/tag/v2.13.1
https://github.com/advplyr/audiobookshelf/releases/tag/v2.13.2
https://github.com/advplyr/audiobookshelf/compare/v2.13.2..v2.12.3

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package built:</summary>
  <ul>
    <li>audiobookshelf</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc