### PR TITLE
gst_all_1.gstreamer: disable Rust if unavailable

### DIFF
--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -151,23 +151,10 @@ stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoUpdateHook" "carg
   strictDeps = true;
 
   meta = meta // {
-    badPlatforms = meta.badPlatforms or [] ++ [
-      # Rust is currently unable to target the n32 ABI
-      lib.systems.inspect.patterns.isMips64n32
-    ];
-  } // lib.optionalAttrs (rustc.meta ? platforms) {
+    badPlatforms = meta.badPlatforms or [] ++ rustc.badTargetPlatforms;
     # default to Rust's platforms
     platforms = lib.intersectLists
       meta.platforms or lib.platforms.all
-      (rustc.meta.platforms ++ [
-        # Platforms without host tools from
-        # https://doc.rust-lang.org/nightly/rustc/platform-support.html
-        "armv7a-darwin"
-        "armv5tel-linux" "armv7a-linux" "m68k-linux" "mips-linux"
-        "mips64-linux" "mipsel-linux" "mips64el-linux" "riscv32-linux"
-        "armv6l-netbsd" "mipsel-netbsd" "riscv64-netbsd"
-        "x86_64-redox"
-        "wasm32-wasi"
-      ]);
+      rustc.targetPlatforms;
   };
 })

--- a/pkgs/build-support/rust/rustc-wrapper/default.nix
+++ b/pkgs/build-support/rust/rustc-wrapper/default.nix
@@ -30,7 +30,9 @@ runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}" {
   };
 
   passthru = {
-    inherit (rustc-unwrapped) pname version src llvm llvmPackages;
+    inherit (rustc-unwrapped)
+      pname version src llvm llvmPackages
+      tier1TargetPlatforms targetPlatforms badTargetPlatforms;
     unwrapped = rustc-unwrapped;
   };
 

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -61,6 +61,37 @@ rec {
     dontStrip = true;
 
     setupHooks = ./setup-hook.sh;
+
+    passthru = rec {
+      tier1TargetPlatforms = [
+        # Platforms with host tools from
+        # https://doc.rust-lang.org/nightly/rustc/platform-support.html
+        "x86_64-darwin" "i686-darwin" "aarch64-darwin"
+        "i686-freebsd" "x86_64-freebsd"
+        "x86_64-solaris"
+        "aarch64-linux" "armv6l-linux" "armv7l-linux" "i686-linux"
+        "loongarch64-linux" "powerpc64-linux" "powerpc64le-linux"
+        "riscv64-linux" "s390x-linux" "x86_64-linux"
+        "aarch64-netbsd" "armv7l-netbsd" "i686-netbsd" "powerpc-netbsd"
+        "x86_64-netbsd"
+        "i686-openbsd" "x86_64-openbsd"
+        "i686-windows" "x86_64-windows"
+      ];
+      targetPlatforms = tier1TargetPlatforms ++ [
+        # Platforms without host tools from
+        # https://doc.rust-lang.org/nightly/rustc/platform-support.html
+        "armv7a-darwin"
+        "armv5tel-linux" "armv7a-linux" "m68k-linux" "mips-linux"
+        "mips64-linux" "mipsel-linux" "mips64el-linux" "riscv32-linux"
+        "armv6l-netbsd" "mipsel-netbsd" "riscv64-netbsd"
+        "x86_64-redox"
+        "wasm32-wasi"
+      ];
+      badTargetPlatforms = [
+        # Rust is currently unable to target the n32 ABI
+        lib.systems.inspect.patterns.isMips64n32
+      ];
+    };
   };
 
   rustc = wrapRustc rustc-unwrapped;

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -303,6 +303,7 @@ in stdenv.mkDerivation (finalAttrs: {
   passthru = {
     llvm = llvmShared;
     inherit llvmPackages;
+    inherit (rustc) tier1TargetPlatforms targetPlatforms badTargetPlatforms;
     tests = {
       inherit fd ripgrep wezterm;
     } // lib.optionalAttrs stdenv.hostPlatform.isLinux { inherit firefox thunderbird; };
@@ -313,19 +314,9 @@ in stdenv.mkDerivation (finalAttrs: {
     description = "Safe, concurrent, practical language";
     maintainers = with maintainers; [ havvy ] ++ teams.rust.members;
     license = [ licenses.mit licenses.asl20 ];
-    platforms = [
-      # Platforms with host tools from
-      # https://doc.rust-lang.org/nightly/rustc/platform-support.html
-      "x86_64-darwin" "i686-darwin" "aarch64-darwin"
-      "i686-freebsd" "x86_64-freebsd"
-      "x86_64-solaris"
-      "aarch64-linux" "armv6l-linux" "armv7l-linux" "i686-linux"
-      "loongarch64-linux" "powerpc64-linux" "powerpc64le-linux"
-      "riscv64-linux" "s390x-linux" "x86_64-linux"
-      "aarch64-netbsd" "armv7l-netbsd" "i686-netbsd" "powerpc-netbsd"
-      "x86_64-netbsd"
-      "i686-openbsd" "x86_64-openbsd"
-      "i686-windows" "x86_64-windows"
-    ];
+    platforms = rustc.tier1TargetPlatforms;
+    # If rustc can't target a platform, we also can't build rustc for
+    # that platform.
+    badPlatforms = rustc.badTargetPlatforms;
   };
 })

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -15,8 +15,11 @@
 , lib
 , Cocoa
 , CoreServices
-, rustc
 , testers
+, rustc
+, withRust ?
+    lib.any (lib.meta.platformMatch stdenv.hostPlatform) rustc.targetPlatforms &&
+    lib.all (p: !lib.meta.platformMatch stdenv.hostPlatform p) rustc.badTargetPlatforms
 , gobject-introspection
 , buildPackages
 , withIntrospection ? lib.meta.availableOn stdenv.hostPlatform gobject-introspection && stdenv.hostPlatform.emulatorAvailable buildPackages
@@ -62,11 +65,12 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     glib
     bash-completion
-    rustc
   ] ++ lib.optionals stdenv.isLinux [
     libcap # for setcap binary
   ] ++ lib.optionals withIntrospection [
     gobject-introspection
+  ] ++ lib.optionals withRust [
+    rustc
   ] ++ lib.optionals enableDocumentation [
     hotdoc
   ];
@@ -91,6 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Ddbghelp=disabled" # not needed as we already provide libunwind and libdw, and dbghelp is a fallback to those
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
+    (lib.mesonEnable "ptp-helper" withRust)
     (lib.mesonEnable "introspection" withIntrospection)
     (lib.mesonEnable "doc" enableDocumentation)
     (lib.mesonEnable "libunwind" withLibunwind)


### PR DESCRIPTION
## Description of changes

Previously, it wasn't possible to access the list of platforms we can build Rust programs for outside of buildRustPackage.  This was a problem for packages that have optional Rust components, like gstreamer or Meson, as there was no way to only build the Rust parts for supported platforms.  Now it's possible to get that information from rustc's passthru.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
