### PR TITLE
nixos/openvpn: add extraArgs option

### DIFF
--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -64,7 +64,7 @@ let
 
       path = [ pkgs.iptables pkgs.iproute2 pkgs.nettools ];
 
-      serviceConfig.ExecStart = "@${openvpn}/sbin/openvpn openvpn --suppress-timestamps --config ${configFile}";
+      serviceConfig.ExecStart = "@${openvpn}/sbin/openvpn openvpn --suppress-timestamps --config ${configFile} ${cfg.extraArgs}";
       serviceConfig.Restart = "always";
       serviceConfig.Type = "notify";
     };
@@ -179,6 +179,15 @@ in
               update resolv.conf with the DNS information provided by openvpn. The
               script will be run after the "up" commands and before the "down" commands.
             '';
+          };
+
+          extraArgs = mkOption {
+            default = null;
+            type = listOf str;
+            description = ''
+              Additional command line arguments to pass to this OpenVPN instance.
+            '';
+            apply = lib.escapeShellArgs;
           };
 
           authUserPass = mkOption {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

i would like to pass credentials to an `openvpn` instance but i ran into some limitations:

- `services.openvpn.<name>.authUserPass` option is insecure (and should probably be removed)
- specifying `auth-user-pass` in the `services.openvpn.<name>.config` option does not allow me to use environment variables which is required if you want to use [ImportCredential](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#ImportCredential=GLOB)

---

how i use this:

```
{ config, ... }:
{
  sops.secrets."openvpn/auth" = { };

  containers.nzbget = {
    enableTun = true;
    privateNetwork = true;
    ...
    extraFlags = [
      "--load-credential=auth-user-pass.txt:${config.sops.secrets."openvpn/auth".path}"
    ];
    config =
      { config, lib, ... }:
      {
        services.openvpn.servers.vpn.updateResolvConf = true;
        services.openvpn.servers.vpn.extraArgs = [ "--auth-user-pass" "\${CREDENTIALS_DIRECTORY}/auth-user-pass.txt" ];
        services.openvpn.servers.vpn.config = ...

        systemd.services.openvpn-vpn.serviceConfig.ImportCredential = [
          "auth-user-pass.txt"
        ];
      };
  };
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
