### PR TITLE
ani-cli: only add the player to the PATH as a fallback, format, add diniamo as a maintainer

### DIFF
--- a/pkgs/by-name/an/ani-cli/package.nix
+++ b/pkgs/by-name/an/ani-cli/package.nix
@@ -58,12 +58,15 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pystardust/ani-cli";
     description = "Cli tool to browse and play anime";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ skykanin diniamo ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      skykanin
+      diniamo
+    ];
+    platforms = lib.platforms.unix;
     mainProgram = "ani-cli";
   };
 }

--- a/pkgs/by-name/an/ani-cli/package.nix
+++ b/pkgs/by-name/an/ani-cli/package.nix
@@ -62,7 +62,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/pystardust/ani-cli";
     description = "Cli tool to browse and play anime";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ skykanin ];
+    maintainers = with maintainers; [ skykanin diniamo ];
     platforms = platforms.unix;
     mainProgram = "ani-cli";
   };

--- a/pkgs/by-name/an/ani-cli/package.nix
+++ b/pkgs/by-name/an/ani-cli/package.nix
@@ -25,19 +25,19 @@ let
   players = lib.optional withMpv mpv ++ lib.optional withVlc vlc ++ lib.optional withIina iina;
 in
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "ani-cli";
   version = "4.9";
 
   src = fetchFromGitHub {
     owner = "pystardust";
     repo = "ani-cli";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-7zuepWTtrFp9RW3zTSjPzyJ9e+09PdKgwcnV+DqPEUY=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  runtimeDependencies = [
+  runtimeInputs = [
     gnugrep
     gnused
     curl
@@ -52,7 +52,7 @@ stdenvNoCC.mkDerivation rec {
     install -Dm755 ani-cli $out/bin/ani-cli
 
     wrapProgram $out/bin/ani-cli \
-      --prefix PATH : ${lib.makeBinPath runtimeDependencies} \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeInputs} \
       ${lib.optionalString (builtins.length players > 0) "--suffix PATH : ${lib.makeBinPath players}"}
 
     runHook postInstall
@@ -69,4 +69,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "ani-cli";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

- Removes the assertation for choosing at least one player. This is questionable, because this should only be done if the user can assure that a player is installed separately, which doesn't sound pure/correct. Should I undo this?
- Adds the player as a suffix in PATH, so the user's configuration takes precedence. This important, because for example in mpv, scripts are added through wrapping.
- Format with nixfmt-rfc-style
- Avoid using `with lib;`
- Avoid using `rec`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
