### PR TITLE
vimPlugins.nvim-treesitter: handle duplicate grammars

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -31,27 +31,57 @@ let
   allGrammars = lib.attrValues generatedDerivations;
 
   # Usage:
-  # pkgs.vimPlugins.nvim-treesitter.withPlugins (p: [ p.c p.java ... ])
+  #   pkgs.vimPlugins.nvim-treesitter.withPlugins (p: [ p.c p.java ... ])
   # or for all grammars:
-  # pkgs.vimPlugins.nvim-treesitter.withAllGrammars
+  #   pkgs.vimPlugins.nvim-treesitter.withAllGrammars
+  # you can also filter out plugins (e.g. if there are duplicates):
+  #   pkgs.vimPlugins.nvim-treesitter.withAllGrammars.filterOutGrammars (e: e.meta.name == "c-grammar-0.0.0+rev=deca017")
+  # or use `e.name`, which contains `vimplugin-treesitter-grammar-c` (no version and rev)
+  # function provided to `filterOutGrammars` is passed to `lib.filter`
   withPlugins =
     f: self.nvim-treesitter.overrideAttrs {
-      passthru.dependencies =
-        let
-          grammars = map grammarToPlugin
-            (f (tree-sitter.builtGrammars // builtGrammars));
-          copyGrammar = grammar:
-            let name = lib.last (lib.splitString "-" grammar.name); in
-            "ln -sf ${grammar}/parser/${name}.so $out/parser/${name}.so";
-        in
-        [
-          (runCommand "vimplugin-treesitter-grammars"
-            { meta.platforms = lib.platforms.all; }
-            ''
-              mkdir -p $out/parser
-              ${lib.concatMapStringsSep "\n" copyGrammar grammars}
-            '')
-        ];
+      passthru = let
+        grammars = map grammarToPlugin
+          (f (tree-sitter.builtGrammars // builtGrammars));
+
+        filterDuplicateGrammars = lib.lists.foldl' (
+          res: new-el:
+            if lib.lists.any (old-el:
+              # `meta.name` contains something like `c-grammar-0.0.0+rev=be23d2c`
+              # while `name` contains `vimplugin-treesitter-grammar-c`
+              if new-el.meta.name == old-el.meta.name
+              then true
+              else if new-el.name == old-el.name
+                then builtins.trace ''
+                  error: found duplicate grammars (${new-el.meta.name} and ${old-el.meta.name}). use '.filterOutGrammars' to filter out duplicates
+                  example: 'vimPlugins.nvim-treesitter.withAllGrammars.filterOutGrammars (e: e.meta.name == "${new-el.meta.name}")'
+                '' false
+                else false
+            ) res
+            then res
+            else res ++ [ new-el ]
+        ) [ ];
+
+        copyGrammar = grammar:
+          let name = lib.last (lib.splitString "-" grammar.name); in
+          "ln -s ${grammar}/parser/${name}.so $out/parser/${name}.so";
+
+        collateGrammars = grammars:
+          [
+            (runCommand "vimplugin-treesitter-grammars"
+              { meta.platforms = lib.platforms.all; }
+              ''
+                mkdir -p $out/parser
+                ${lib.concatMapStringsSep "\n" copyGrammar (filterDuplicateGrammars grammars)}
+              '')
+          ];
+      in {
+        dependencies = collateGrammars grammars;
+
+        filterOutPlugins = filter: self.nvim-treesitter.overrideAttrs {
+          passthru.dependencies = collateGrammars (lib.filter filter grammars);
+        };
+      };
     };
 
   withAllGrammars = withPlugins (_: allGrammars);


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

In https://github.com/NixOS/nixpkgs/pull/319233, a new logic for colliding grammars didn't expect any duplicates, and if there were any, it raised a weird error: `ln: failed to create symbolic link '/nix/store/...-vimplugin-treesitter-grammars/parser/lua.so': File exists`. Previously, duplicates were silently ignored (though unsure, didn't investigate a lot).

In this PR I added a filter function, which should remove obvious duplicates (with the same commit). Though if two identical grammars with different revisions were added, it still raises `ln: failed to create symbolic link ...: File exists` (if you know how to improve the error, please let me know). The filtering logic itself was heavily inspired by [`lib.lists.unique`](https://github.com/NixOS/nixpkgs/blob/2349afa4740050369b2dc55df1c7571d659d6fdc/lib/lists.nix#L1793)

As this seems to be a common misunderstanding, **error on duplicate grammar but different revs is a feature, not a bug** (see https://github.com/NixOS/nixpkgs/pull/339076#issuecomment-2329585080).

See also https://github.com/NotAShelf/nvf/issues/368

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

CC @BirdeeHub, @stephen-huan, @FrothyMarrow (you provided nice feedback in https://github.com/NotAShelf/nvf/issues/368, so it would be good if you helped us reviewing this)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
