### PR TITLE
nixos/services.unpoller: remove `with lib;`

### DIFF
--- a/nixos/modules/services/monitoring/unpoller.nix
+++ b/nixos/modules/services/monitoring/unpoller.nix
@@ -1,11 +1,8 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.unpoller;
 
-  configFile = pkgs.writeText "unpoller.json" (generators.toJSON {} {
+  configFile = pkgs.writeText "unpoller.json" (lib.generators.toJSON {} {
     inherit (cfg) poller influxdb loki prometheus unifi;
   });
 
@@ -15,26 +12,26 @@ in {
   ];
 
   options.services.unpoller = {
-    enable = mkEnableOption "unpoller";
+    enable = lib.mkEnableOption "unpoller";
 
     poller = {
-      debug = mkOption {
-        type = types.bool;
+      debug = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Turns on line numbers, microsecond logging, and a per-device log.
           This may be noisy if you have a lot of devices. It adds one line per device.
         '';
       };
-      quiet = mkOption {
-        type = types.bool;
+      quiet = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Turns off per-interval logs. Only startup and error logs will be emitted.
         '';
       };
-      plugins = mkOption {
-        type = with types; listOf str;
+      plugins = lib.mkOption {
+        type = with lib.types; listOf str;
         default = [];
         description = ''
           Load additional plugins.
@@ -43,22 +40,22 @@ in {
     };
 
     prometheus = {
-      disable = mkOption {
-        type = types.bool;
+      disable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to disable the prometheus output plugin.
         '';
       };
-      http_listen = mkOption {
-        type = types.str;
+      http_listen = lib.mkOption {
+        type = lib.types.str;
         default = "[::]:9130";
         description = ''
           Bind the prometheus exporter to this IP or hostname.
         '';
       };
-      report_errors = mkOption {
-        type = types.bool;
+      report_errors = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to report errors.
@@ -67,53 +64,53 @@ in {
     };
 
     influxdb = {
-      disable = mkOption {
-        type = types.bool;
+      disable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to disable the influxdb output plugin.
         '';
       };
-      url = mkOption {
-        type = types.str;
+      url = lib.mkOption {
+        type = lib.types.str;
         default = "http://127.0.0.1:8086";
         description = ''
           URL of the influxdb host.
         '';
       };
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = "unifipoller";
         description = ''
           Username for the influxdb.
         '';
       };
-      pass = mkOption {
-        type = types.path;
+      pass = lib.mkOption {
+        type = lib.types.path;
         default = pkgs.writeText "unpoller-influxdb-default.password" "unifipoller";
-        defaultText = literalExpression "unpoller-influxdb-default.password";
+        defaultText = lib.literalExpression "unpoller-influxdb-default.password";
         description = ''
           Path of a file containing the password for influxdb.
           This file needs to be readable by the unifi-poller user.
         '';
         apply = v: "file://${v}";
       };
-      db = mkOption {
-        type = types.str;
+      db = lib.mkOption {
+        type = lib.types.str;
         default = "unifi";
         description = ''
           Database name. Database should exist.
         '';
       };
-      verify_ssl = mkOption {
-        type = types.bool;
+      verify_ssl = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Verify the influxdb's certificate.
         '';
       };
-      interval = mkOption {
-        type = types.str;
+      interval = lib.mkOption {
+        type = lib.types.str;
         default = "30s";
         description = ''
           Setting this lower than the Unifi controller's refresh
@@ -123,22 +120,22 @@ in {
     };
 
     loki = {
-      url = mkOption {
-        type = types.str;
+      url = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = ''
           URL of the Loki host.
         '';
       };
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = ''
           Username for Loki.
         '';
       };
-      pass = mkOption {
-        type = types.path;
+      pass = lib.mkOption {
+        type = lib.types.path;
         default = pkgs.writeText "unpoller-loki-default.password" "";
         defaultText = "unpoller-influxdb-default.password";
         description = ''
@@ -147,29 +144,29 @@ in {
         '';
         apply = v: "file://${v}";
       };
-      verify_ssl = mkOption {
-        type = types.bool;
+      verify_ssl = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Verify Loki's certificate.
         '';
       };
-      tenant_id = mkOption {
-        type = types.str;
+      tenant_id = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = ''
           Tenant ID to use in Loki.
         '';
       };
-      interval = mkOption {
-        type = types.str;
+      interval = lib.mkOption {
+        type = lib.types.str;
         default = "2m";
         description = ''
           How often the events are polled and pushed to Loki.
         '';
       };
-      timeout = mkOption {
-        type = types.str;
+      timeout = lib.mkOption {
+        type = lib.types.str;
         default = "10s";
         description = ''
           Should be increased in case of timeout errors.
@@ -179,92 +176,92 @@ in {
 
     unifi = let
       controllerOptions = {
-        user = mkOption {
-          type = types.str;
+        user = lib.mkOption {
+          type = lib.types.str;
           default = "unifi";
           description = ''
             Unifi service user name.
           '';
         };
-        pass = mkOption {
-          type = types.path;
+        pass = lib.mkOption {
+          type = lib.types.path;
           default = pkgs.writeText "unpoller-unifi-default.password" "unifi";
-          defaultText = literalExpression "unpoller-unifi-default.password";
+          defaultText = lib.literalExpression "unpoller-unifi-default.password";
           description = ''
             Path of a file containing the password for the unifi service user.
             This file needs to be readable by the unifi-poller user.
           '';
           apply = v: "file://${v}";
         };
-        url = mkOption {
-          type = types.str;
+        url = lib.mkOption {
+          type = lib.types.str;
           default = "https://unifi:8443";
           description = ''
             URL of the Unifi controller.
           '';
         };
-        sites = mkOption {
-          type = with types; either (enum [ "default" "all" ]) (listOf str);
+        sites = lib.mkOption {
+          type = with lib.types; either (enum [ "default" "all" ]) (listOf str);
           default = "all";
           description = ''
             List of site names for which statistics should be exported.
             Or the string "default" for the default site or the string "all" for all sites.
           '';
-          apply = toList;
+          apply = lib.toList;
         };
-        save_ids = mkOption {
-          type = types.bool;
+        save_ids = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Collect and save data from the intrusion detection system to influxdb and Loki.
           '';
         };
-        save_events = mkOption {
-          type = types.bool;
+        save_events = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Collect and save data from UniFi events to influxdb and Loki.
           '';
         };
-        save_alarms = mkOption {
-          type = types.bool;
+        save_alarms = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Collect and save data from UniFi alarms to influxdb and Loki.
           '';
         };
-        save_anomalies = mkOption {
-          type = types.bool;
+        save_anomalies = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Collect and save data from UniFi anomalies to influxdb and Loki.
           '';
         };
-        save_dpi = mkOption {
-          type = types.bool;
+        save_dpi = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Collect and save data from deep packet inspection.
             Adds around 150 data points and impacts performance.
           '';
         };
-        save_sites = mkOption {
-          type = types.bool;
+        save_sites = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Collect and save site data.
           '';
         };
-        hash_pii = mkOption {
-          type = types.bool;
+        hash_pii = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Hash, with md5, client names and MAC addresses. This attempts
             to protect personally identifiable information.
           '';
         };
-        verify_ssl = mkOption {
-          type = types.bool;
+        verify_ssl = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Verify the Unifi controller's certificate.
@@ -273,8 +270,8 @@ in {
       };
 
     in {
-      dynamic = mkOption {
-        type = types.bool;
+      dynamic = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Let prometheus select which controller to poll when scraping.
@@ -284,18 +281,18 @@ in {
 
       defaults = controllerOptions;
 
-      controllers = mkOption {
-        type = with types; listOf (submodule { options = controllerOptions; });
+      controllers = lib.mkOption {
+        type = with lib.types; listOf (submodule { options = controllerOptions; });
         default = [];
         description = ''
           List of Unifi controllers to poll. Use defaults if empty.
         '';
-        apply = map (flip removeAttrs [ "_module" ]);
+        apply = map (lib.flip removeAttrs [ "_module" ]);
       };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     users.groups.unifi-poller = { };
     users.users.unifi-poller = {
       description = "unifi-poller Service User";


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
