### PR TITLE
nixos/services.portunus: remove `with lib;`

### DIFF
--- a/nixos/modules/services/misc/portunus.nix
+++ b/nixos/modules/services/misc/portunus.nix
@@ -1,23 +1,20 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.portunus;
 
 in
 {
   options.services.portunus = {
-    enable = mkEnableOption "Portunus, a self-contained user/group management and authentication service for LDAP";
+    enable = lib.mkEnableOption "Portunus, a self-contained user/group management and authentication service for LDAP";
 
-    domain = mkOption {
-      type = types.str;
+    domain = lib.mkOption {
+      type = lib.types.str;
       example = "sso.example.com";
       description = "Subdomain which gets reverse proxied to Portunus webserver.";
     };
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 8080;
       description = ''
         Port where the Portunus webserver should listen on.
@@ -26,10 +23,10 @@ in
       '';
     };
 
-    package = mkPackageOption pkgs "portunus" { };
+    package = lib.mkPackageOption pkgs "portunus" { };
 
-    seedPath = mkOption {
-      type = types.nullOr types.path;
+    seedPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
         Path to a portunus seed file in json format.
@@ -46,26 +43,26 @@ in
       '';
     };
 
-    stateDir = mkOption {
-      type = types.path;
+    stateDir = lib.mkOption {
+      type = lib.types.path;
       default = "/var/lib/portunus";
       description = "Path where Portunus stores its state.";
     };
 
-    user = mkOption {
-      type = types.str;
+    user = lib.mkOption {
+      type = lib.types.str;
       default = "portunus";
       description = "User account under which Portunus runs its webserver.";
     };
 
-    group = mkOption {
-      type = types.str;
+    group = lib.mkOption {
+      type = lib.types.str;
       default = "portunus";
       description = "Group account under which Portunus runs its webserver.";
     };
 
     dex = {
-      enable = mkEnableOption ''
+      enable = lib.mkEnableOption ''
         Dex ldap connector.
 
         To activate dex, first a search user must be created in the Portunus web ui
@@ -73,15 +70,15 @@ in
         in the [](#opt-services.dex.environmentFile) setting
       '';
 
-      oidcClients = mkOption {
-        type = types.listOf (types.submodule {
+      oidcClients = lib.mkOption {
+        type = lib.types.listOf (lib.types.submodule {
           options = {
-            callbackURL = mkOption {
-              type = types.str;
+            callbackURL = lib.mkOption {
+              type = lib.types.str;
               description = "URL where the OIDC client should redirect";
             };
-            id = mkOption {
-              type = types.str;
+            id = lib.mkOption {
+              type = lib.types.str;
               description = "ID of the OIDC client";
             };
           };
@@ -105,23 +102,23 @@ in
         '';
       };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 5556;
         description = "Port where dex should listen on.";
       };
     };
 
     ldap = {
-      package = mkOption {
-        type = types.package;
+      package = lib.mkOption {
+        type = lib.types.package;
         default = pkgs.openldap;
         defaultText = lib.literalExpression "pkgs.openldap.override { libxcrypt = pkgs.libxcrypt-legacy; }";
         description = "The OpenLDAP package to use.";
       };
 
-      searchUserName = mkOption {
-        type = types.str;
+      searchUserName = lib.mkOption {
+        type = lib.types.str;
         default = "";
         example = "admin";
         description = ''
@@ -130,8 +127,8 @@ in
         '';
       };
 
-      suffix = mkOption {
-        type = types.str;
+      suffix = lib.mkOption {
+        type = lib.types.str;
         example = "dc=example,dc=org";
         description = ''
           The DN of the topmost entry in your LDAP directory.
@@ -139,8 +136,8 @@ in
         '';
       };
 
-      tls = mkOption {
-        type = types.bool;
+      tls = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable LDAPS protocol.
@@ -151,21 +148,21 @@ in
         '';
       };
 
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = "openldap";
         description = "User account under which Portunus runs its LDAP server.";
       };
 
-      group = mkOption {
-        type = types.str;
+      group = lib.mkOption {
+        type = lib.types.str;
         default = "openldap";
         description = "Group account under which Portunus runs its LDAP server.";
       };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.dex.enable -> cfg.ldap.searchUserName != "";
@@ -177,13 +174,13 @@ in
     environment.systemPackages = [ cfg.ldap.package ];
 
     # allow connecting via ldaps /w certificate without opening ports
-    networking.hosts = mkIf cfg.ldap.tls {
+    networking.hosts = lib.mkIf cfg.ldap.tls {
       "::1" = [ cfg.domain ];
       "127.0.0.1" = [ cfg.domain ];
     };
 
     services = {
-      dex = mkIf cfg.dex.enable {
+      dex = lib.mkIf cfg.dex.enable {
         enable = true;
         settings = {
           issuer = "https://${cfg.domain}/dex";
@@ -219,7 +216,7 @@ in
             };
           }];
 
-          staticClients = forEach cfg.dex.oidcClients (client: {
+          staticClients = lib.forEach cfg.dex.oidcClients (client: {
             inherit (client) id;
             redirectURIs = [ client.callbackURL ];
             name = "OIDC for ${client.id}";
@@ -232,7 +229,7 @@ in
     };
 
     systemd.services = {
-      dex = mkIf cfg.dex.enable {
+      dex = lib.mkIf cfg.dex.enable {
         serviceConfig = {
           # `dex.service` is super locked down out of the box, but we need some
           # place to write the SQLite database. This creates $STATE_DIRECTORY below
@@ -261,9 +258,9 @@ in
           PORTUNUS_SLAPD_GROUP = cfg.ldap.group;
           PORTUNUS_SLAPD_USER = cfg.ldap.user;
           PORTUNUS_SLAPD_SCHEMA_DIR = "${cfg.ldap.package}/etc/schema";
-        } // (optionalAttrs (cfg.seedPath != null) ({
+        } // (lib.optionalAttrs (cfg.seedPath != null) ({
           PORTUNUS_SEED_PATH = cfg.seedPath;
-        })) // (optionalAttrs cfg.ldap.tls (
+        })) // (lib.optionalAttrs cfg.ldap.tls (
           let
             acmeDirectory = config.security.acme.certs."${cfg.domain}".directory;
           in
@@ -277,14 +274,14 @@ in
       };
     };
 
-    users.users = mkMerge [
-      (mkIf (cfg.ldap.user == "openldap") {
+    users.users = lib.mkMerge [
+      (lib.mkIf (cfg.ldap.user == "openldap") {
         openldap = {
           group = cfg.ldap.group;
           isSystemUser = true;
         };
       })
-      (mkIf (cfg.user == "portunus") {
+      (lib.mkIf (cfg.user == "portunus") {
         portunus = {
           group = cfg.group;
           isSystemUser = true;
@@ -292,15 +289,15 @@ in
       })
     ];
 
-    users.groups = mkMerge [
-      (mkIf (cfg.ldap.user == "openldap") {
+    users.groups = lib.mkMerge [
+      (lib.mkIf (cfg.ldap.user == "openldap") {
         openldap = { };
       })
-      (mkIf (cfg.user == "portunus") {
+      (lib.mkIf (cfg.user == "portunus") {
         portunus = { };
       })
     ];
   };
 
-  meta.maintainers = [ maintainers.majewsky ] ++ teams.c3d2.members;
+  meta.maintainers = [ lib.maintainers.majewsky ] ++ lib.teams.c3d2.members;
 }


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
