### PR TITLE
nixos/services.snapserver: remove `with lib;`

### DIFF
--- a/nixos/modules/services/audio/snapserver.nix
+++ b/nixos/modules/services/audio/snapserver.nix
@@ -1,7 +1,4 @@
 { config, options, lib, pkgs, ... }:
-
-with lib;
-
 let
 
   name = "snapserver";
@@ -9,8 +6,8 @@ let
   cfg = config.services.snapserver;
 
   # Using types.nullOr to inherit upstream defaults.
-  sampleFormat = mkOption {
-    type = with types; nullOr str;
+  sampleFormat = lib.mkOption {
+    type = with lib.types; nullOr str;
     default = null;
     description = ''
       Default sample format.
@@ -18,8 +15,8 @@ let
     example = "48000:16:2";
   };
 
-  codec = mkOption {
-    type = with types; nullOr str;
+  codec = lib.mkOption {
+    type = with lib.types; nullOr str;
     default = null;
     description = ''
       Default audio compression method.
@@ -30,20 +27,20 @@ let
   streamToOption = name: opt:
     let
       os = val:
-        optionalString (val != null) "${val}";
+        lib.optionalString (val != null) "${val}";
       os' = prefix: val:
-        optionalString (val != null) (prefix + "${val}");
+        lib.optionalString (val != null) (prefix + "${val}");
       flatten = key: value:
         "&${key}=${value}";
     in
       "--stream.stream=\"${opt.type}://" + os opt.location + "?" + os' "name=" name
         + os' "&sampleformat=" opt.sampleFormat + os' "&codec=" opt.codec
-        + concatStrings (mapAttrsToList flatten opt.query) + "\"";
+        + lib.concatStrings (lib.mapAttrsToList lib.flatten opt.query) + "\"";
 
   optionalNull = val: ret:
-    optional (val != null) ret;
+    lib.optional (val != null) ret;
 
-  optionString = concatStringsSep " " (mapAttrsToList streamToOption cfg.streams
+  optionString = lib.concatStringsSep " " (lib.mapAttrsToList streamToOption cfg.streams
     # global options
     ++ [ "--stream.bind_to_address=${cfg.listenAddress}" ]
     ++ [ "--stream.port=${toString cfg.port}" ]
@@ -51,22 +48,22 @@ let
     ++ optionalNull cfg.codec "--stream.codec=${cfg.codec}"
     ++ optionalNull cfg.streamBuffer "--stream.stream_buffer=${toString cfg.streamBuffer}"
     ++ optionalNull cfg.buffer "--stream.buffer=${toString cfg.buffer}"
-    ++ optional cfg.sendToMuted "--stream.send_to_muted"
+    ++ lib.optional cfg.sendToMuted "--stream.send_to_muted"
     # tcp json rpc
     ++ [ "--tcp.enabled=${toString cfg.tcp.enable}" ]
-    ++ optionals cfg.tcp.enable [
+    ++ lib.optionals cfg.tcp.enable [
       "--tcp.bind_to_address=${cfg.tcp.listenAddress}"
       "--tcp.port=${toString cfg.tcp.port}" ]
      # http json rpc
     ++ [ "--http.enabled=${toString cfg.http.enable}" ]
-    ++ optionals cfg.http.enable [
+    ++ lib.optionals cfg.http.enable [
       "--http.bind_to_address=${cfg.http.listenAddress}"
       "--http.port=${toString cfg.http.port}"
-    ] ++ optional (cfg.http.docRoot != null) "--http.doc_root=\"${toString cfg.http.docRoot}\"");
+    ] ++ lib.optional (cfg.http.docRoot != null) "--http.doc_root=\"${toString cfg.http.docRoot}\"");
 
 in {
   imports = [
-    (mkRenamedOptionModule [ "services" "snapserver" "controlPort" ] [ "services" "snapserver" "tcp" "port" ])
+    (lib.mkRenamedOptionModule [ "services" "snapserver" "controlPort" ] [ "services" "snapserver" "tcp" "port" ])
   ];
 
   ###### interface
@@ -75,16 +72,16 @@ in {
 
     services.snapserver = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable snapserver.
         '';
       };
 
-      listenAddress = mkOption {
-        type = types.str;
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
         default = "::";
         example = "0.0.0.0";
         description = ''
@@ -92,16 +89,16 @@ in {
         '';
       };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 1704;
         description = ''
           The port that snapclients can connect to.
         '';
       };
 
-      openFirewall = mkOption {
-        type = types.bool;
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to automatically open the specified ports in the firewall.
@@ -111,8 +108,8 @@ in {
       inherit sampleFormat;
       inherit codec;
 
-      streamBuffer = mkOption {
-        type = with types; nullOr int;
+      streamBuffer = lib.mkOption {
+        type = with lib.types; nullOr int;
         default = null;
         description = ''
           Stream read (input) buffer in ms.
@@ -120,8 +117,8 @@ in {
         example = 20;
       };
 
-      buffer = mkOption {
-        type = with types; nullOr int;
+      buffer = lib.mkOption {
+        type = with lib.types; nullOr int;
         default = null;
         description = ''
           Network buffer in ms.
@@ -129,24 +126,24 @@ in {
         example = 1000;
       };
 
-      sendToMuted = mkOption {
-        type = types.bool;
+      sendToMuted = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Send audio to muted clients.
         '';
       };
 
-      tcp.enable = mkOption {
-        type = types.bool;
+      tcp.enable = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Whether to enable the JSON-RPC via TCP.
         '';
       };
 
-      tcp.listenAddress = mkOption {
-        type = types.str;
+      tcp.listenAddress = lib.mkOption {
+        type = lib.types.str;
         default = "::";
         example = "0.0.0.0";
         description = ''
@@ -154,24 +151,24 @@ in {
         '';
       };
 
-      tcp.port = mkOption {
-        type = types.port;
+      tcp.port = lib.mkOption {
+        type = lib.types.port;
         default = 1705;
         description = ''
           The port where the TCP JSON-RPC listens on.
         '';
       };
 
-      http.enable = mkOption {
-        type = types.bool;
+      http.enable = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Whether to enable the JSON-RPC via HTTP.
         '';
       };
 
-      http.listenAddress = mkOption {
-        type = types.str;
+      http.listenAddress = lib.mkOption {
+        type = lib.types.str;
         default = "::";
         example = "0.0.0.0";
         description = ''
@@ -179,27 +176,27 @@ in {
         '';
       };
 
-      http.port = mkOption {
-        type = types.port;
+      http.port = lib.mkOption {
+        type = lib.types.port;
         default = 1780;
         description = ''
           The port where the HTTP JSON-RPC listens on.
         '';
       };
 
-      http.docRoot = mkOption {
-        type = with types; nullOr path;
+      http.docRoot = lib.mkOption {
+        type = with lib.types; nullOr path;
         default = null;
         description = ''
           Path to serve from the HTTP servers root.
         '';
       };
 
-      streams = mkOption {
-        type = with types; attrsOf (submodule {
+      streams = lib.mkOption {
+        type = with lib.types; attrsOf (submodule {
           options = {
-            location = mkOption {
-              type = types.oneOf [ types.path types.str ];
+            location = lib.mkOption {
+              type = lib.types.oneOf [ lib.types.path lib.types.str ];
               description = ''
                 For type `pipe` or `file`, the path to the pipe or file.
                 For type `librespot`, `airplay` or `process`, the path to the corresponding binary.
@@ -207,27 +204,27 @@ in {
                 For type `meta`, a list of stream names in the form `/one/two/...`. Don't forget the leading slash.
                 For type `alsa`, use an empty string.
               '';
-              example = literalExpression ''
+              example = lib.literalExpression ''
                 "/path/to/pipe"
                 "/path/to/librespot"
                 "192.168.1.2:4444"
                 "/MyTCP/Spotify/MyPipe"
               '';
             };
-            type = mkOption {
-              type = types.enum [ "pipe" "librespot" "airplay" "file" "process" "tcp" "alsa" "spotify" "meta" ];
+            type = lib.mkOption {
+              type = lib.types.enum [ "pipe" "librespot" "airplay" "file" "process" "tcp" "alsa" "spotify" "meta" ];
               default = "pipe";
               description = ''
                 The type of input stream.
               '';
             };
-            query = mkOption {
+            query = lib.mkOption {
               type = attrsOf str;
               default = {};
               description = ''
                 Key-value pairs that convey additional parameters about a stream.
               '';
-              example = literalExpression ''
+              example = lib.literalExpression ''
                 # for type == "pipe":
                 {
                   mode = "create";
@@ -255,7 +252,7 @@ in {
         description = ''
           The definition for an input source.
         '';
-        example = literalExpression ''
+        example = lib.literalExpression ''
           {
             mpd = {
               type = "pipe";
@@ -272,11 +269,11 @@ in {
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     warnings =
       # https://github.com/badaix/snapcast/blob/98ac8b2fb7305084376607b59173ce4097c620d8/server/streamreader/stream_manager.cpp#L85
-      filter (w: w != "") (mapAttrsToList (k: v: optionalString (v.type == "spotify") ''
+      lib.filter (w: w != "") (lib.mapAttrsToList (k: v: lib.optionalString (v.type == "spotify") ''
         services.snapserver.streams.${k}.type = "spotify" is deprecated, use services.snapserver.streams.${k}.type = "librespot" instead.
       '') cfg.streams);
 
@@ -305,13 +302,13 @@ in {
     };
 
     networking.firewall.allowedTCPPorts =
-      optionals cfg.openFirewall [ cfg.port ]
-      ++ optional (cfg.openFirewall && cfg.tcp.enable) cfg.tcp.port
-      ++ optional (cfg.openFirewall && cfg.http.enable) cfg.http.port;
+      lib.optionals cfg.openFirewall [ cfg.port ]
+      ++ lib.optional (cfg.openFirewall && cfg.tcp.enable) cfg.tcp.port
+      ++ lib.optional (cfg.openFirewall && cfg.http.enable) cfg.http.port;
   };
 
   meta = {
-    maintainers = with maintainers; [ tobim ];
+    maintainers = with lib.maintainers; [ tobim ];
   };
 
 }


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
