### PR TITLE
nixos/iso-image: remove `with lib;`

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -1,11 +1,7 @@
 # This module creates a bootable ISO image containing the given NixOS
 # configuration.  The derivation for the ISO image will be placed in
 # config.system.build.isoImage.
-
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   /**
    * Given a list of `options`, concats the result of mapping each options
@@ -22,8 +18,8 @@ let
       (option: ''
         menuentry '${defaults.name} ${
         # Name appended to menuentry defaults to params if no specific name given.
-        option.name or (optionalString (option ? params) "(${option.params})")
-        }' ${optionalString (option ? class) " --class ${option.class}"} {
+        option.name or (lib.optionalString (option ? params) "(${option.params})")
+        }' ${lib.optionalString (option ? class) " --class ${option.class}"} {
           # Fallback to UEFI console for boot, efifb sometimes has difficulties.
           terminal_output console
 
@@ -153,8 +149,8 @@ let
     APPEND ${toString config.boot.loader.grub.memtest86.params}
   '';
 
-  isolinuxCfg = concatStringsSep "\n"
-    ([ baseIsolinuxCfg ] ++ optional config.boot.loader.grub.memtest86.enable isolinuxMemtest86Entry);
+  isolinuxCfg = lib.concatStringsSep "\n"
+    ([ baseIsolinuxCfg ] ++ lib.optional config.boot.loader.grub.memtest86.enable isolinuxMemtest86Entry);
 
   refindBinary = if targetArch == "x64" || targetArch == "aa64" then "refind_${targetArch}.efi" else null;
 
@@ -182,7 +178,7 @@ let
     insmod gfxterm
     insmod png
     set gfxpayload=keep
-    set gfxmode=${concatStringsSep "," [
+    set gfxmode=${lib.concatStringsSep "," [
       # GRUB will use the first valid mode listed here.
       # `auto` will sometimes choose the smallest valid mode it detects.
       # So instead we'll list a lot of possibly valid modes :/
@@ -321,7 +317,7 @@ let
 
     cat <<EOF > $out/EFI/boot/grub.cfg
 
-    set textmode=${boolToString (config.isoImage.forceTextMode)}
+    set textmode=${lib.boolToString (config.isoImage.forceTextMode)}
     set timeout=${toString grubEfiTimeout}
 
     clear
@@ -480,7 +476,7 @@ in
 {
   options = {
 
-    isoImage.isoName = mkOption {
+    isoImage.isoName = lib.mkOption {
       default = "${config.isoImage.isoBaseName}.iso";
       type = lib.types.str;
       description = ''
@@ -488,7 +484,7 @@ in
       '';
     };
 
-    isoImage.isoBaseName = mkOption {
+    isoImage.isoBaseName = lib.mkOption {
       default = config.system.nixos.distroId;
       type = lib.types.str;
       description = ''
@@ -496,7 +492,7 @@ in
       '';
     };
 
-    isoImage.compressImage = mkOption {
+    isoImage.compressImage = lib.mkOption {
       default = false;
       type = lib.types.bool;
       description = ''
@@ -505,7 +501,7 @@ in
       '';
     };
 
-    isoImage.squashfsCompression = mkOption {
+    isoImage.squashfsCompression = lib.mkOption {
       default = "zstd -Xcompression-level 19";
       type = lib.types.nullOr lib.types.str;
       description = ''
@@ -515,7 +511,7 @@ in
       example = "zstd -Xcompression-level 6";
     };
 
-    isoImage.edition = mkOption {
+    isoImage.edition = lib.mkOption {
       default = "";
       type = lib.types.str;
       description = ''
@@ -524,9 +520,9 @@ in
       '';
     };
 
-    isoImage.volumeID = mkOption {
+    isoImage.volumeID = lib.mkOption {
       # nixos-$EDITION-$RELEASE-$ARCH
-      default = "nixos${optionalString (config.isoImage.edition != "") "-${config.isoImage.edition}"}-${config.system.nixos.release}-${pkgs.stdenv.hostPlatform.uname.processor}";
+      default = "nixos${lib.optionalString (config.isoImage.edition != "") "-${config.isoImage.edition}"}-${config.system.nixos.release}-${pkgs.stdenv.hostPlatform.uname.processor}";
       type = lib.types.str;
       description = ''
         Specifies the label or volume ID of the generated ISO image.
@@ -535,8 +531,8 @@ in
       '';
     };
 
-    isoImage.contents = mkOption {
-      example = literalExpression ''
+    isoImage.contents = lib.mkOption {
+      example = lib.literalExpression ''
         [ { source = pkgs.memtest86 + "/memtest.bin";
             target = "boot/memtest.bin";
           }
@@ -548,15 +544,15 @@ in
       '';
     };
 
-    isoImage.storeContents = mkOption {
-      example = literalExpression "[ pkgs.stdenv ]";
+    isoImage.storeContents = lib.mkOption {
+      example = lib.literalExpression "[ pkgs.stdenv ]";
       description = ''
         This option lists additional derivations to be included in the
         Nix store in the generated ISO image.
       '';
     };
 
-    isoImage.includeSystemBuildDependencies = mkOption {
+    isoImage.includeSystemBuildDependencies = lib.mkOption {
       default = false;
       type = lib.types.bool;
       description = ''
@@ -568,7 +564,7 @@ in
       '';
     };
 
-    isoImage.makeBiosBootable = mkOption {
+    isoImage.makeBiosBootable = lib.mkOption {
       # Before this option was introduced, images were BIOS-bootable if the
       # hostPlatform was x86-based. This option is enabled by default for
       # backwards compatibility.
@@ -586,7 +582,7 @@ in
       '';
     };
 
-    isoImage.makeEfiBootable = mkOption {
+    isoImage.makeEfiBootable = lib.mkOption {
       default = false;
       type = lib.types.bool;
       description = ''
@@ -594,7 +590,7 @@ in
       '';
     };
 
-    isoImage.makeUsbBootable = mkOption {
+    isoImage.makeUsbBootable = lib.mkOption {
       default = false;
       type = lib.types.bool;
       description = ''
@@ -602,7 +598,7 @@ in
       '';
     };
 
-    isoImage.efiSplashImage = mkOption {
+    isoImage.efiSplashImage = lib.mkOption {
       default = pkgs.fetchurl {
           url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/a9e05d7deb38a8e005a2b52575a3f59a63a4dba0/bootloader/efi-background.png";
           sha256 = "18lfwmp8yq923322nlb9gxrh5qikj1wsk6g5qvdh31c4h5b1538x";
@@ -612,7 +608,7 @@ in
       '';
     };
 
-    isoImage.splashImage = mkOption {
+    isoImage.splashImage = lib.mkOption {
       default = pkgs.fetchurl {
           url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/a9e05d7deb38a8e005a2b52575a3f59a63a4dba0/bootloader/isolinux/bios-boot.png";
           sha256 = "1wp822zrhbg4fgfbwkr7cbkr4labx477209agzc0hr6k62fr6rxd";
@@ -622,15 +618,15 @@ in
       '';
     };
 
-    isoImage.grubTheme = mkOption {
+    isoImage.grubTheme = lib.mkOption {
       default = pkgs.nixos-grub2-theme;
-      type = types.nullOr (types.either types.path types.package);
+      type = lib.types.nullOr (lib.types.either lib.types.path lib.types.package);
       description = ''
         The grub2 theme used for UEFI boot.
       '';
     };
 
-    isoImage.syslinuxTheme = mkOption {
+    isoImage.syslinuxTheme = lib.mkOption {
       default = ''
         MENU TITLE ${config.system.nixos.distroName}
         MENU RESOLUTION 800 600
@@ -655,15 +651,15 @@ in
         MENU COLOR UNSEL        37;44      #FF000000    #00000000   none
         MENU COLOR SEL          7;37;40    #FFFFFFFF    #FF5277C3   std
       '';
-      type = types.str;
+      type = lib.types.str;
       description = ''
         The syslinux theme used for BIOS boot.
       '';
     };
 
-    isoImage.prependToMenuLabel = mkOption {
+    isoImage.prependToMenuLabel = lib.mkOption {
       default = "";
-      type = types.str;
+      type = lib.types.str;
       example = "Install ";
       description = ''
         The string to prepend before the menu label for the NixOS system.
@@ -674,9 +670,9 @@ in
       '';
     };
 
-    isoImage.appendToMenuLabel = mkOption {
+    isoImage.appendToMenuLabel = lib.mkOption {
       default = " Installer";
-      type = types.str;
+      type = lib.types.str;
       example = " Live System";
       description = ''
         The string to append after the menu label for the NixOS system.
@@ -687,9 +683,9 @@ in
       '';
     };
 
-    isoImage.forceTextMode = mkOption {
+    isoImage.forceTextMode = lib.mkOption {
       default = false;
-      type = types.bool;
+      type = lib.types.bool;
       example = true;
       description = ''
         Whether to use text mode instead of graphical grub.
@@ -706,7 +702,7 @@ in
   # store them in lib so we can mkImageMediaOverride the
   # entire file system layout in installation media (only)
   config.lib.isoFileSystems = {
-    "/" = mkImageMediaOverride
+    "/" = lib.mkImageMediaOverride
       {
         fsType = "tmpfs";
         options = [ "mode=0755" ];
@@ -715,7 +711,7 @@ in
     # Note that /dev/root is a symlink to the actual root device
     # specified on the kernel command line, created in the stage 1
     # init script.
-    "/iso" = mkImageMediaOverride
+    "/iso" = lib.mkImageMediaOverride
       { device = "/dev/root";
         neededForBoot = true;
         noCheck = true;
@@ -723,20 +719,20 @@ in
 
     # In stage 1, mount a tmpfs on top of /nix/store (the squashfs
     # image) to make this a live CD.
-    "/nix/.ro-store" = mkImageMediaOverride
+    "/nix/.ro-store" = lib.mkImageMediaOverride
       { fsType = "squashfs";
         device = "/iso/nix-store.squashfs";
         options = [ "loop" ];
         neededForBoot = true;
       };
 
-    "/nix/.rw-store" = mkImageMediaOverride
+    "/nix/.rw-store" = lib.mkImageMediaOverride
       { fsType = "tmpfs";
         options = [ "mode=0755" ];
         neededForBoot = true;
       };
 
-    "/nix/store" = mkImageMediaOverride
+    "/nix/store" = lib.mkImageMediaOverride
       { fsType = "overlay";
         device = "overlay";
         options = [
@@ -760,11 +756,11 @@ in
         message = "BIOS boot is only supported on x86-based architectures.";
       }
       {
-        assertion = !(stringLength config.isoImage.volumeID > 32);
+        assertion = !(lib.stringLength config.isoImage.volumeID > 32);
         # https://wiki.osdev.org/ISO_9660#The_Primary_Volume_Descriptor
         # Volume Identifier can only be 32 bytes
         message = let
-          length = stringLength config.isoImage.volumeID;
+          length = lib.stringLength config.isoImage.volumeID;
           howmany = toString length;
           toomany = toString (length - 32);
         in
@@ -777,7 +773,7 @@ in
     boot.loader.grub.enable = false;
 
     environment.systemPackages =  [ grubPkgs.grub2 grubPkgs.grub2_efi ]
-      ++ optional (config.isoImage.makeBiosBootable) pkgs.syslinux
+      ++ lib.optional (config.isoImage.makeBiosBootable) pkgs.syslinux
     ;
 
     # In stage 1 of the boot, mount the CD as the root FS by label so
@@ -803,7 +799,7 @@ in
     # script and the top-level system configuration directory.
     isoImage.storeContents =
       [ config.system.build.toplevel ] ++
-      optional config.isoImage.includeSystemBuildDependencies
+      lib.optional config.isoImage.includeSystemBuildDependencies
         config.system.build.toplevel.drvPath;
 
     # Individual files to be included on the CD, outside of the Nix
@@ -819,7 +815,7 @@ in
         { source = pkgs.writeText "version" config.system.nixos.label;
           target = "/version.txt";
         }
-      ] ++ optionals (config.isoImage.makeBiosBootable) [
+      ] ++ lib.optionals (config.isoImage.makeBiosBootable) [
         { source = config.isoImage.splashImage;
           target = "/isolinux/background.png";
         }
@@ -833,7 +829,7 @@ in
         { source = "${pkgs.syslinux}/share/syslinux";
           target = "/isolinux";
         }
-      ] ++ optionals config.isoImage.makeEfiBootable [
+      ] ++ lib.optionals config.isoImage.makeEfiBootable [
         { source = efiImg;
           target = "/boot/efi.img";
         }
@@ -846,11 +842,11 @@ in
         { source = config.isoImage.efiSplashImage;
           target = "/EFI/boot/efi-background.png";
         }
-      ] ++ optionals (config.boot.loader.grub.memtest86.enable && config.isoImage.makeBiosBootable) [
+      ] ++ lib.optionals (config.boot.loader.grub.memtest86.enable && config.isoImage.makeBiosBootable) [
         { source = "${pkgs.memtest86plus}/memtest.bin";
           target = "/boot/memtest.bin";
         }
-      ] ++ optionals (config.isoImage.grubTheme != null) [
+      ] ++ lib.optionals (config.isoImage.grubTheme != null) [
         { source = config.isoImage.grubTheme;
           target = "/EFI/boot/grub-theme";
         }
@@ -866,10 +862,10 @@ in
       syslinux = if config.isoImage.makeBiosBootable then pkgs.syslinux else null;
       squashfsContents = config.isoImage.storeContents;
       squashfsCompression = config.isoImage.squashfsCompression;
-    } // optionalAttrs (config.isoImage.makeUsbBootable && config.isoImage.makeBiosBootable) {
+    } // lib.optionalAttrs (config.isoImage.makeUsbBootable && config.isoImage.makeBiosBootable) {
       usbBootable = true;
       isohybridMbrImage = "${pkgs.syslinux}/share/syslinux/isohdpfx.bin";
-    } // optionalAttrs config.isoImage.makeEfiBootable {
+    } // lib.optionalAttrs config.isoImage.makeEfiBootable {
       efiBootable = true;
       efiBootImage = "boot/efi.img";
     });


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
