### PR TITLE
nixos/services.taskserver: remove `with lib;`

### DIFF
--- a/nixos/modules/services/misc/taskserver/default.nix
+++ b/nixos/modules/services/misc/taskserver/default.nix
@@ -1,14 +1,11 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.taskserver;
 
   taskd = "${pkgs.taskserver}/bin/taskd";
 
-  mkManualPkiOption = desc: mkOption {
-    type = types.nullOr types.path;
+  mkManualPkiOption = desc: lib.mkOption {
+    type = lib.types.nullOr lib.types.path;
     default = null;
     description = ''
       ${desc}
@@ -46,8 +43,8 @@ let
     :::
   '';
 
-  mkExpireOption = desc: mkOption {
-    type = types.nullOr types.int;
+  mkExpireOption = desc: lib.mkOption {
+    type = lib.types.nullOr lib.types.int;
     default = null;
     example = 365;
     apply = val: if val == null then -1 else val;
@@ -58,8 +55,8 @@ let
   };
 
   autoPkiOptions = {
-    bits = mkOption {
-      type = types.int;
+    bits = lib.mkOption {
+      type = lib.types.int;
       default = 4096;
       example = 2048;
       description = mkAutoDesc "The bit size for generated keys.";
@@ -75,20 +72,20 @@ let
 
   needToCreateCA = let
     notFound = path: let
-      dotted = concatStringsSep "." path;
+      dotted = lib.concatStringsSep "." path;
     in throw "Can't find option definitions for path `${dotted}'.";
     findPkiDefinitions = path: attrs: let
       mkSublist = key: val: let
-        newPath = path ++ singleton key;
-      in if isOption val
-         then attrByPath newPath (notFound newPath) cfg.pki.manual
+        newPath = path ++ lib.singleton key;
+      in if lib.isOption val
+         then lib.attrByPath newPath (notFound newPath) cfg.pki.manual
          else findPkiDefinitions newPath val;
-    in flatten (mapAttrsToList mkSublist attrs);
-  in all (x: x == null) (findPkiDefinitions [] manualPkiOptions);
+    in lib.flatten (lib.mapAttrsToList mkSublist attrs);
+  in lib.all (x: x == null) (findPkiDefinitions [] manualPkiOptions);
 
   orgOptions = { ... }: {
-    options.users = mkOption {
-      type = types.uniq (types.listOf types.str);
+    options.users = lib.mkOption {
+      type = lib.types.uniq (lib.types.listOf lib.types.str);
       default = [];
       example = [ "alice" "bob" ];
       description = ''
@@ -96,8 +93,8 @@ let
       '';
     };
 
-    options.groups = mkOption {
-      type = types.listOf types.str;
+    options.groups = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [];
       example = [ "workers" "slackers" ];
       description = ''
@@ -137,8 +134,8 @@ let
 in {
   options = {
     services.taskserver = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = let
           url = "https://nixos.org/manual/nixos/stable/index.html#module-services-taskserver";
@@ -150,26 +147,26 @@ in {
         '';
       };
 
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = "taskd";
         description = "User for Taskserver.";
       };
 
-      group = mkOption {
-        type = types.str;
+      group = lib.mkOption {
+        type = lib.types.str;
         default = "taskd";
         description = "Group for Taskserver.";
       };
 
-      dataDir = mkOption {
-        type = types.path;
+      dataDir = lib.mkOption {
+        type = lib.types.path;
         default = "/var/lib/taskserver";
         description = "Data directory for Taskserver.";
       };
 
-      ciphers = mkOption {
-        type = types.nullOr (types.separatedString ":");
+      ciphers = lib.mkOption {
+        type = lib.types.nullOr (lib.types.separatedString ":");
         default = null;
         example = "NORMAL:-VERS-SSL3.0";
         description = let
@@ -180,8 +177,8 @@ in {
         '';
       };
 
-      organisations = mkOption {
-        type = types.attrsOf (types.submodule orgOptions);
+      organisations = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.submodule orgOptions);
         default = {};
         example.myShinyOrganisation.users = [ "alice" "bob" ];
         example.myShinyOrganisation.groups = [ "staff" "outsiders" ];
@@ -193,24 +190,24 @@ in {
         '';
       };
 
-      confirmation = mkOption {
-        type = types.bool;
+      confirmation = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Determines whether certain commands are confirmed.
         '';
       };
 
-      debug = mkOption {
-        type = types.bool;
+      debug = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Logs debugging information.
         '';
       };
 
-      extensions = mkOption {
-        type = types.nullOr types.path;
+      extensions = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = null;
         description = ''
           Fully qualified path of the Taskserver extension scripts.
@@ -218,32 +215,32 @@ in {
         '';
       };
 
-      ipLog = mkOption {
-        type = types.bool;
+      ipLog = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Logs the IP addresses of incoming requests.
         '';
       };
 
-      queueSize = mkOption {
-        type = types.int;
+      queueSize = lib.mkOption {
+        type = lib.types.int;
         default = 10;
         description = ''
           Size of the connection backlog, see {manpage}`listen(2)`.
         '';
       };
 
-      requestLimit = mkOption {
-        type = types.int;
+      requestLimit = lib.mkOption {
+        type = lib.types.int;
         default = 1048576;
         description = ''
           Size limit of incoming requests, in bytes.
         '';
       };
 
-      allowedClientIDs = mkOption {
-        type = with types; either str (listOf str);
+      allowedClientIDs = lib.mkOption {
+        type = with lib.types; either str (listOf str);
         default = [];
         example = [ "[Tt]ask [2-9]+" ];
         description = ''
@@ -256,8 +253,8 @@ in {
         '';
       };
 
-      disallowedClientIDs = mkOption {
-        type = with types; either str (listOf str);
+      disallowedClientIDs = lib.mkOption {
+        type = with lib.types; either str (listOf str);
         default = [];
         example = [ "[Tt]ask [2-9]+" ];
         description = ''
@@ -270,8 +267,8 @@ in {
         '';
       };
 
-      listenHost = mkOption {
-        type = types.str;
+      listenHost = lib.mkOption {
+        type = lib.types.str;
         default = "localhost";
         example = "::";
         description = ''
@@ -279,24 +276,24 @@ in {
         '';
       };
 
-      listenPort = mkOption {
-        type = types.int;
+      listenPort = lib.mkOption {
+        type = lib.types.int;
         default = 53589;
         description = ''
           Port number of the Taskserver.
         '';
       };
 
-      openFirewall = mkOption {
-        type = types.bool;
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to open the firewall for the specified Taskserver port.
         '';
       };
 
-      fqdn = mkOption {
-        type = types.str;
+      fqdn = lib.mkOption {
+        type = lib.types.str;
         default = "localhost";
         description = ''
           The fully qualified domain name of this server, which is also used
@@ -304,8 +301,8 @@ in {
         '';
       };
 
-      trust = mkOption {
-        type = types.enum [ "allow all" "strict" ];
+      trust = lib.mkOption {
+        type = lib.types.enum [ "allow all" "strict" ];
         default = "strict";
         description = ''
           Determines how client certificates are validated.
@@ -320,8 +317,8 @@ in {
       pki.manual = manualPkiOptions;
       pki.auto = autoPkiOptions;
 
-      config = mkOption {
-        type = types.attrs;
+      config = lib.mkOption {
+        type = lib.types.attrs;
         example.client.cert = "/tmp/debugging.cert";
         description = ''
           Configuration options to pass to Taskserver.
@@ -340,23 +337,23 @@ in {
         '';
         apply = let
           mkKey = path: if path == ["server" "listen"] then "server"
-                        else concatStringsSep "." path;
+                        else lib.concatStringsSep "." path;
           recurse = path: attrs: let
             mapper = name: val: let
               newPath = path ++ [ name ];
               scalar = if val == true then "true"
                        else if val == false then "false"
                        else toString val;
-            in if isAttrs val then recurse newPath val
+            in if lib.isAttrs val then recurse newPath val
                else [ "${mkKey newPath}=${scalar}" ];
-          in concatLists (mapAttrsToList mapper attrs);
+          in lib.concatLists (lib.mapAttrsToList mapper attrs);
         in recurse [];
       };
     };
   };
 
   imports = [
-    (mkRemovedOptionModule ["services" "taskserver" "extraConfig"] ''
+    (lib.mkRemovedOptionModule ["services" "taskserver" "extraConfig"] ''
       This option was removed in favor of `services.taskserver.config` with
       different semantics (it's now a list of attributes instead of lines).
 
@@ -366,11 +363,11 @@ in {
     '')
   ];
 
-  config = mkMerge [
-    (mkIf cfg.enable {
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
       environment.systemPackages = [ nixos-taskserver ];
 
-      users.users = optionalAttrs (cfg.user == "taskd") {
+      users.users = lib.optionalAttrs (cfg.user == "taskd") {
         taskd = {
           uid = config.ids.uids.taskd;
           description = "Taskserver user";
@@ -378,7 +375,7 @@ in {
         };
       };
 
-      users.groups = optionalAttrs (cfg.group == "taskd") {
+      users.groups = lib.optionalAttrs (cfg.group == "taskd") {
         taskd.gid = config.ids.gids.taskd;
       };
 
@@ -413,7 +410,7 @@ in {
         } else {
           cert = "${cfg.pki.manual.server.cert}";
           key = "${cfg.pki.manual.server.key}";
-          ${mapNullable (_: "crl") cfg.pki.manual.server.crl} = "${cfg.pki.manual.server.crl}";
+          ${lib.mapNullable (_: "crl") cfg.pki.manual.server.crl} = "${cfg.pki.manual.server.crl}";
         });
 
         ca.cert = if needToCreateCA then "${cfg.dataDir}/keys/ca.cert"
@@ -464,8 +461,8 @@ in {
 
         serviceConfig = {
           ExecStart = let
-            mkCfgFlag = flag: escapeShellArg "--${flag}";
-            cfgFlags = concatMapStringsSep " " mkCfgFlag cfg.config;
+            mkCfgFlag = flag: lib.escapeShellArg "--${flag}";
+            cfgFlags = lib.concatMapStringsSep " " mkCfgFlag cfg.config;
           in "@${taskd} taskd server ${cfgFlags}";
           ExecReload = "${pkgs.coreutils}/bin/kill -USR1 $MAINPID";
           Restart = "on-failure";
@@ -477,7 +474,7 @@ in {
         };
       };
     })
-    (mkIf (cfg.enable && needToCreateCA) {
+    (lib.mkIf (cfg.enable && needToCreateCA) {
       systemd.services.taskserver-ca = {
         wantedBy = [ "taskserver.service" ];
         after = [ "taskserver-init.service" ];
@@ -561,7 +558,7 @@ in {
         '';
       };
     })
-    (mkIf (cfg.enable && cfg.openFirewall) {
+    (lib.mkIf (cfg.enable && cfg.openFirewall) {
       networking.firewall.allowedTCPPorts = [ cfg.listenPort ];
     })
   ];


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
