### PR TITLE
armcord: 3.2.8 -> 3.3.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/armcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/armcord/default.nix
@@ -3,27 +3,27 @@
 , fetchFromGitHub
 , pnpm
 , nodejs
-, electron_30
+, electron_31
 , makeWrapper
 , copyDesktopItems
 , makeDesktopItem
 }:
 stdenv.mkDerivation rec {
   pname = "armcord";
-  version = "3.2.8";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "ArmCord";
     repo = "ArmCord";
     rev = "v${version}";
-    hash = "sha256-H/Y3xA7gE24UsUkrxmrRFSvs16qZCVxli9vdnt7ihi8=";
+    hash = "sha256-nVirmGgR5yssMRXFUialMjTTSEa5nVNtue207eYUJCg=";
   };
 
   nativeBuildInputs = [ pnpm.configHook nodejs makeWrapper copyDesktopItems ];
 
   pnpmDeps = pnpm.fetchDeps {
     inherit pname version src;
-    hash = "sha256-hYp1XbWQL5NbIzzUSnZ7y7V+vYQmymRNo+EiSjn5d9E=";
+    hash = "sha256-ETnTWErdOIdcyK/v42bx+dFPPt+Lc0Lxyzo+RpxvEjU=";
   };
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
@@ -35,8 +35,8 @@ stdenv.mkDerivation rec {
 
     npm exec electron-builder -- \
       --dir \
-      -c.electronDist="${electron_30.dist}" \
-      -c.electronVersion="${electron_30.version}"
+      -c.electronDist="${electron_31.dist}" \
+      -c.electronVersion="${electron_31.version}"
 
     runHook postBuild
   '';
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
 
     install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/armcord.png"
 
-    makeShellWrapper "${lib.getExe electron_30}" "$out/bin/armcord" \
+    makeShellWrapper "${lib.getExe electron_31}" "$out/bin/armcord" \
       --add-flags "$out/share/lib/armcord/resources/app.asar" \
       "''${gappsWrapperArgs[@]}" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \


### PR DESCRIPTION
## Description of changes

This updates ArmCord from 3.2.8 -> 3.3.0.

Changelog: https://github.com/ArmCord/ArmCord/releases/tag/v3.3.0

ArmCord updated their own Electron to v32, but I don't believe it relies on anything Electron 32-specific, so I updated this package to use to Electron 31 in the meantime and did some rudimentary testing to make sure that it didn't screw anything up. Once Electron 32 is packaged, I'll update this package to use it.

Closes #337234.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
