### PR TITLE
fatrop: 0.0.1 -> 0.0.4, casadi: 3.6.6 -> 3.6.7

### DIFF
--- a/pkgs/by-name/ca/casadi/package.nix
+++ b/pkgs/by-name/ca/casadi/package.nix
@@ -47,29 +47,32 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # Fix build with system spral
+    # This was merged upstream and can be removed on next release
     (fetchpatch {
       name = "add-FindSPRAL.cmake.patch";
       url = "https://github.com/casadi/casadi/pull/3792/commits/28bc1b03e67ae06dea0c8557057020f5651be7ad.patch";
       hash = "sha256-t0+RnXoFakmoX93MhN08RWAbCg6Nerh42LicBBgAkRQ=";
     })
+    # Fix build with fatrop
+    # This was merged upstream and can be removed on next release
+    (fetchpatch {
+      url = "https://github.com/casadi/casadi/pull/3832/commits/4d4edb21521817fc980da5e570a607ad2f15aaa2.patch";
+      hash = "sha256-ui8pMaBz848Yv5xNlruPp9IFUhc97ZgvXGXqpxJG1Es=";
+    })
   ];
 
   postPatch =
     ''
-      # fix case of fatropConfig.cmake & hpipmConfig.cmake
+      # fix case of hpipmConfig.cmake
       substituteInPlace CMakeLists.txt --replace-fail \
         "FATROP HPIPM" \
-        "fatrop hpipm"
+        "FATROP hpipm"
 
       # nix provide lib/clang headers in libclang, not in llvm.
       substituteInPlace casadi/interfaces/clang/CMakeLists.txt --replace-fail \
         '$'{CLANG_LLVM_LIB_DIR} \
         ${llvmPackages_17.libclang.lib}/lib
-
-      # fix fatrop includes
-      substituteInPlace casadi/interfaces/fatrop/fatrop_conic_interface.hpp --replace-fail \
-        "<ocp/" \
-        "<fatrop/ocp/"
 
       # fix mumps lib name. No idea where this comes from.
       substituteInPlace cmake/FindMUMPS.cmake --replace-fail \
@@ -173,7 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WITH_CSPARSE" true)
     (lib.cmakeBool "WITH_BLASFEO" true)
     (lib.cmakeBool "WITH_HPIPM" true)
-    (lib.cmakeBool "WITH_FATROP" false) # invalid new-expression of abstract class type 'casadi::CasadiStructuredQP'
+    (lib.cmakeBool "WITH_FATROP" true)
     (lib.cmakeBool "WITH_BUILD_FATROP" false)
     (lib.cmakeBool "WITH_SUPERSCS" false) # packaging too chaotic
     (lib.cmakeBool "WITH_BUILD_OSQP" false)

--- a/pkgs/by-name/ca/casadi/package.nix
+++ b/pkgs/by-name/ca/casadi/package.nix
@@ -10,7 +10,6 @@
   cplex,
   fatrop,
   fetchFromGitHub,
-  fetchpatch,
   gurobi,
   highs,
   hpipm,
@@ -37,30 +36,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "casadi";
-  version = "3.6.6";
+  version = "3.6.7";
 
   src = fetchFromGitHub {
     owner = "casadi";
     repo = "casadi";
     rev = finalAttrs.version;
-    hash = "sha256-T4aaBS918NbUEwWkSx0URi0W9uhCB8IFmzRcOR7T8Og=";
+    hash = "sha256-Mft0qhjdAbU82RgjYuKue5p7EqbTbt3ii5yXSsCFHrQ=";
   };
-
-  patches = [
-    # Fix build with system spral
-    # This was merged upstream and can be removed on next release
-    (fetchpatch {
-      name = "add-FindSPRAL.cmake.patch";
-      url = "https://github.com/casadi/casadi/pull/3792/commits/28bc1b03e67ae06dea0c8557057020f5651be7ad.patch";
-      hash = "sha256-t0+RnXoFakmoX93MhN08RWAbCg6Nerh42LicBBgAkRQ=";
-    })
-    # Fix build with fatrop
-    # This was merged upstream and can be removed on next release
-    (fetchpatch {
-      url = "https://github.com/casadi/casadi/pull/3832/commits/4d4edb21521817fc980da5e570a607ad2f15aaa2.patch";
-      hash = "sha256-ui8pMaBz848Yv5xNlruPp9IFUhc97ZgvXGXqpxJG1Es=";
-    })
-  ];
 
   postPatch =
     ''

--- a/pkgs/by-name/fa/fatrop/package.nix
+++ b/pkgs/by-name/fa/fatrop/package.nix
@@ -2,7 +2,6 @@
   blasfeo,
   cmake,
   fetchFromGitHub,
-  fetchpatch,
   lib,
   llvmPackages,
   python3Packages,
@@ -12,28 +11,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fatrop";
-  version = "0.0.3";
+  version = "0.0.4";
 
   src = fetchFromGitHub {
     owner = "meco-group";
     repo = "fatrop";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-vCGix3qYQR9bY9GoIyBMrTNvsMgt0h7TZUye6wlH9H8=";
+    hash = "sha256-XVOS9L2vQeFkPXZieX1ZJiVagR0f2BtiRmSDPB9LQeI=";
   };
-
-  patches = lib.optionals pythonSupport [
-    # fix python packaging
-    # ref. https://github.com/meco-group/fatrop/pull/17
-    # this was merged upstream and can be removed on next release
-    (fetchpatch {
-      url = "https://github.com/meco-group/fatrop/pull/17/commits/22e33c216e47df90dc060686d7d1806233642249.patch";
-      hash = "sha256-0/uSHAXVzXVyR+kklQGvraLA6sJbHzUcAp3eEHQK068=";
-    })
-    (fetchpatch {
-      url = "https://github.com/meco-group/fatrop/pull/17/commits/0c03fd9fec95de42976fed1770a15081d0874ee2.patch";
-      hash = "sha256-FenQ05rqn9EbU0wDVQQ1OFxSXj1fL/rOFKOcP8t1NwY=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs =

--- a/pkgs/by-name/fa/fatrop/package.nix
+++ b/pkgs/by-name/fa/fatrop/package.nix
@@ -2,6 +2,7 @@
   blasfeo,
   cmake,
   fetchFromGitHub,
+  fetchpatch,
   lib,
   llvmPackages,
   python3Packages,
@@ -11,25 +12,28 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fatrop";
-  version = "0.0.1";
+  version = "0.0.3";
 
   src = fetchFromGitHub {
     owner = "meco-group";
     repo = "fatrop";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-c4qYh8RutRsMIx3m0oxXy73fnLTBGVZ1QjFcLEJ413Y=";
+    hash = "sha256-vCGix3qYQR9bY9GoIyBMrTNvsMgt0h7TZUye6wlH9H8=";
   };
 
-  postPatch = lib.optionalString pythonSupport ''
-    # avoid submodule
-    rmdir external/pybind11
-    ln -s ${python3Packages.pybind11.src} external/pybind11
-
-    # install python module
-    echo ""  >> fatropy/CMakeLists.txt
-    echo "install(DIRECTORY fatropy DESTINATION ${python3Packages.python.sitePackages})" >> fatropy/CMakeLists.txt
-    echo "install(TARGETS _fatropy DESTINATION ${python3Packages.python.sitePackages}/fatropy)" >> fatropy/CMakeLists.txt
-  '';
+  patches = lib.optionals pythonSupport [
+    # fix python packaging
+    # ref. https://github.com/meco-group/fatrop/pull/17
+    # this was merged upstream and can be removed on next release
+    (fetchpatch {
+      url = "https://github.com/meco-group/fatrop/pull/17/commits/22e33c216e47df90dc060686d7d1806233642249.patch";
+      hash = "sha256-0/uSHAXVzXVyR+kklQGvraLA6sJbHzUcAp3eEHQK068=";
+    })
+    (fetchpatch {
+      url = "https://github.com/meco-group/fatrop/pull/17/commits/0c03fd9fec95de42976fed1770a15081d0874ee2.patch";
+      hash = "sha256-FenQ05rqn9EbU0wDVQQ1OFxSXj1fL/rOFKOcP8t1NwY=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs =


### PR DESCRIPTION
## Description of changes

Changes: https://github.com/meco-group/fatrop/compare/v0.0.1...v0.0.3

And build casadi with it, thanks to https://github.com/casadi/casadi/pull/3832

And also update casadi, ref. https://github.com/casadi/casadi/releases/tag/3.6.7

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
