### PR TITLE
treewide: handle `*Phases` variables `__structuredAttrs`-agnostically

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -518,8 +518,10 @@ There are a number of variables that control what phases are executed and in wha
 
 Specifies the phases. You can change the order in which phases are executed, or add new phases, by setting this variable. If it’s not set, the default value is used, which is `$prePhases unpackPhase patchPhase $preConfigurePhases configurePhase $preBuildPhases buildPhase checkPhase $preInstallPhases installPhase fixupPhase installCheckPhase $preDistPhases distPhase $postPhases`.
 
+The elements of `phases` must not contain spaces. If `phases` is specified as a Nix Language attribute, it should be specified as lists instead of strings. The same rules apply to the `*Phases` variables.
+
 It is discouraged to set this variable, as it is easy to miss some important functionality hidden in some of the less obviously needed phases (like `fixupPhase` which patches the shebang of scripts).
-Usually, if you just want to add a few phases, it’s more convenient to set one of the variables below (such as `preInstallPhases`).
+Usually, if you just want to add a few phases, it’s more convenient to set one of the `*Phases` variables below.
 
 ##### `prePhases` {#var-stdenv-prePhases}
 

--- a/pkgs/applications/editors/vim/plugins/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/neovim-require-check-hook.sh
@@ -16,6 +16,6 @@ neovimRequireCheckHook () {
 }
 
 echo "Using neovimRequireCheckHook"
-preDistPhases+=" neovimRequireCheckHook"
+appendToVar preDistPhases neovimRequireCheckHook
 
 

--- a/pkgs/applications/editors/vim/plugins/vim-command-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/vim-command-check-hook.sh
@@ -21,5 +21,5 @@ vimCommandCheckHook () {
 }
 
 echo "Using vimCommandCheckHook"
-preDistPhases+=" vimCommandCheckHook"
+appendToVar preDistPhases vimCommandCheckHook
 

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -17,7 +17,7 @@ let
   pluginDerivation = attrs: let
     name = attrs.name or "${attrs.pname}-${attrs.version}";
   in stdenv.mkDerivation ({
-    prePhases = "extraLib";
+    prePhases = [ "extraLib" ];
     extraLib = ''
       installScripts(){
         mkdir -p $out/${gimp.targetScriptDir}/${name};
@@ -54,7 +54,7 @@ let
   });
 
   scriptDerivation = {src, ...}@attrs : pluginDerivation ({
-    prePhases = "extraLib";
+    prePhases = [ "extraLib" ];
     dontUnpack = true;
     installPhase = ''
       runHook preInstall

--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -146,7 +146,7 @@ stdenv.mkDerivation (removeAttrs ({
 })
 // (optionalAttrs (args?useMelquiondRemake) rec {
   COQUSERCONTRIB = "$out/lib/coq/${coq.coq-version}/user-contrib";
-  preConfigurePhases = "autoconf";
+  preConfigurePhases = [ "autoconf" ];
   configureFlags = [ "--libdir=${COQUSERCONTRIB}/${useMelquiondRemake.logpath or ""}" ];
   buildPhase = "./remake -j$NIX_BUILD_CORES";
   installPhase = "./remake install";

--- a/pkgs/build-support/make-darwin-bundle/default.nix
+++ b/pkgs/build-support/make-darwin-bundle/default.nix
@@ -22,5 +22,5 @@ writeShellScript "make-darwin-bundle-${name}" (''
     ${writeDarwinBundle}/bin/write-darwin-bundle "''${!outputBin}" "${name}" "${exec}"
   }
 
-  preDistPhases+=" makeDarwinBundlePhase"
+  appendToVar preDistPhases makeDarwinBundlePhase
 '')

--- a/pkgs/build-support/release/binary-tarball.nix
+++ b/pkgs/build-support/release/binary-tarball.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (
 
     prefix = "/usr/local";
 
-    postPhases = "finalPhase";
+    postPhases = [ "finalPhase" ];
   }
 
   // args //

--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -18,7 +18,7 @@ vmTools.runInLinuxImage (stdenv.mkDerivation (
 
     prefix = "/usr";
 
-    prePhases = "installExtraDebsPhase sysInfoPhase";
+    prePhases = [ "installExtraDebsPhase" "sysInfoPhase" ];
   }
 
   // removeAttrs args ["vmTools" "lib"] //

--- a/pkgs/build-support/release/source-tarball.nix
+++ b/pkgs/build-support/release/source-tarball.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (
 
     showBuildStats = true;
 
-    preConfigurePhases = "autoconfPhase";
+    preConfigurePhases = [ "autoconfPhase" ];
     postPhases = "finalPhase";
 
     # Autoconfiscate the sources.

--- a/pkgs/build-support/release/source-tarball.nix
+++ b/pkgs/build-support/release/source-tarball.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (
     showBuildStats = true;
 
     preConfigurePhases = [ "autoconfPhase" ];
-    postPhases = "finalPhase";
+    postPhases = [ "finalPhase" ];
 
     # Autoconfiscate the sources.
     autoconfPhase = ''

--- a/pkgs/build-support/setup-hooks/autoreconf.sh
+++ b/pkgs/build-support/setup-hooks/autoreconf.sh
@@ -1,4 +1,4 @@
-preConfigurePhases="${preConfigurePhases:-} autoreconfPhase"
+appendToVar preConfigurePhases autoreconfPhase
 
 autoreconfPhase() {
     runHook preAutoreconf

--- a/pkgs/build-support/setup-hooks/enable-coverage-instrumentation.sh
+++ b/pkgs/build-support/setup-hooks/enable-coverage-instrumentation.sh
@@ -1,4 +1,4 @@
-postPhases+=" cleanupBuildDir"
+appendToVar postPhases cleanupBuildDir
 
 # Force GCC to build with coverage instrumentation.  Also disable
 # optimisation, since it may confuse things.

--- a/pkgs/build-support/setup-hooks/keep-build-tree.sh
+++ b/pkgs/build-support/setup-hooks/keep-build-tree.sh
@@ -1,4 +1,4 @@
-prePhases+=" moveBuildDir"
+appendToVar prePhases moveBuildDir
 
 moveBuildDir() {
     mkdir -p $out/.build

--- a/pkgs/build-support/setup-hooks/make-coverage-analysis-report.sh
+++ b/pkgs/build-support/setup-hooks/make-coverage-analysis-report.sh
@@ -1,4 +1,4 @@
-postPhases+=" coverageReportPhase"
+appendToVar postPhases coverageReportPhase
 
 coverageReportPhase() {
     lcov --directory . --capture --output-file app.info

--- a/pkgs/build-support/setup-hooks/move-build-tree.sh
+++ b/pkgs/build-support/setup-hooks/move-build-tree.sh
@@ -1,4 +1,4 @@
-prePhases+=" moveBuildDir"
+appendToVar prePhases moveBuildDir
 
 moveBuildDir() {
     mkdir -p $out/.build

--- a/pkgs/build-support/setup-hooks/move-build-tree.sh
+++ b/pkgs/build-support/setup-hooks/move-build-tree.sh
@@ -5,7 +5,7 @@ moveBuildDir() {
     cd $out/.build
 }
 
-postPhases+=" removeBuildDir"
+appendToVar postPhases removeBuildDir
 
 removeBuildDir() {
     rm -rf $out/.build

--- a/pkgs/build-support/setup-hooks/update-autotools-gnu-config-scripts.sh
+++ b/pkgs/build-support/setup-hooks/update-autotools-gnu-config-scripts.sh
@@ -1,4 +1,4 @@
-preConfigurePhases+=" updateAutotoolsGnuConfigScriptsPhase"
+appendToVar preConfigurePhases updateAutotoolsGnuConfigScriptsPhase
 
 updateAutotoolsGnuConfigScriptsPhase() {
     if [ -n "${dontUpdateAutotoolsGnuConfigScripts-}" ]; then return; fi

--- a/pkgs/by-name/ha/hare/setup-hook.sh
+++ b/pkgs/by-name/ha/hare/setup-hook.sh
@@ -18,7 +18,7 @@ echoCmd "HAREPATH" "$HAREPATH"
 echoCmd "hare" "$(command -v hare)"
 echoCmd "hare-native" "$(command -v hare-native)"
 '
-prePhases+=("hareSetStdlibPhase" "hareInfoPhase")
+appendToVar prePhases hareSetStdlibPhase hareInfoPhase
 
 readonly hare_unconditional_flags="@hare_unconditional_flags@"
 case "${hareBuildType:-"release"}" in

--- a/pkgs/desktops/gnustep/make/setup-hook.sh
+++ b/pkgs/desktops/gnustep/make/setup-hook.sh
@@ -18,7 +18,7 @@ addGnustepInstallFlags() {
     )
 }
 
-preInstallPhases+=" addGnustepInstallFlags"
+appendToVar preInstallPhases addGnustepInstallFlags
 
 addGNUstepEnvVars() {
     local filename

--- a/pkgs/desktops/xfce/core/xfce4-dev-tools/setup-hook.sh
+++ b/pkgs/desktops/xfce/core/xfce4-dev-tools/setup-hook.sh
@@ -10,5 +10,5 @@ xdtAutogenPhase() {
 }
 
 if [ -z "${dontUseXdtAutogenPhase-}" ]; then
-    preConfigurePhases+=(xdtAutogenPhase)
+    appendToVar preConfigurePhases xdtAutogenPhase
 fi

--- a/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
+++ b/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
@@ -73,6 +73,6 @@ configureNuget() {
 }
 
 if [[ -z ${dontConfigureNuget-} ]]; then
-    prePhases+=(createNugetDirs)
+    appendToVar prePhases createNugetDirs
     preConfigurePhases+=(configureNuget)
 fi

--- a/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
+++ b/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
@@ -74,5 +74,5 @@ configureNuget() {
 
 if [[ -z ${dontConfigureNuget-} ]]; then
     appendToVar prePhases createNugetDirs
-    preConfigurePhases+=(configureNuget)
+    appendToVar preConfigurePhases configureNuget
 fi

--- a/pkgs/development/interpreters/octave/hooks/octave-write-required-octave-packages-hook.sh
+++ b/pkgs/development/interpreters/octave/hooks/octave-write-required-octave-packages-hook.sh
@@ -13,5 +13,5 @@ octaveWriteRequiredOctavePackagesPhase() {
 # Yes its a bit long...
 if [ -z "${dontWriteRequiredOctavePackagesPhase-}" ]; then
     echo "Using octaveWriteRequiredOctavePackagesPhase"
-    preDistPhases+=" octaveWriteRequiredOctavePackagesPhase"
+    appendToVar preDistPhases octaveWriteRequiredOctavePackagesPhase
 fi

--- a/pkgs/development/interpreters/octave/hooks/write-required-octave-packages-hook.sh
+++ b/pkgs/development/interpreters/octave/hooks/write-required-octave-packages-hook.sh
@@ -13,5 +13,5 @@ writeRequiredOctavePackagesPhase() {
 # Yes its a bit long...
 if [ -z "${dontWriteRequiredOctavePackagesPhase-}" ]; then
     echo "Using writeRequiredOctavePackagesPhase"
-    preDistPhases+=" writeRequiredOctavePackagesPhase"
+    appendToVar preDistPhases writeRequiredOctavePackagesPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -58,5 +58,5 @@ function pytestCheckPhase() {
 
 if [ -z "${dontUsePytestCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
     echo "Using pytestCheckPhase"
-    preDistPhases+=" pytestCheckPhase"
+    appendToVar preDistPhases pytestCheckPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook.sh
@@ -6,5 +6,5 @@ pythonCatchConflictsPhase() {
 }
 
 if [ -z "${dontUsePythonCatchConflicts-}" ]; then
-    preDistPhases+=" pythonCatchConflictsPhase"
+    appendToVar preDistPhases pythonCatchConflictsPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
@@ -18,5 +18,5 @@ pythonImportsCheckPhase () {
 
 if [ -z "${dontUsePythonImportsCheck-}" ]; then
     echo "Using pythonImportsCheckPhase"
-    preDistPhases+=" pythonImportsCheckPhase"
+    appendToVar preDistPhases pythonImportsCheckPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/python-recompile-bytecode-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-recompile-bytecode-hook.sh
@@ -20,5 +20,5 @@ pythonRecompileBytecodePhase () {
 }
 
 if [ -z "${dontUsePythonRecompileBytecode-}" ]; then
-    postPhases+=" pythonRecompileBytecodePhase"
+    appendToVar postPhases pythonRecompileBytecodePhase
 fi

--- a/pkgs/development/interpreters/python/hooks/python-remove-bin-bytecode-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-remove-bin-bytecode-hook.sh
@@ -13,5 +13,5 @@ pythonRemoveBinBytecodePhase () {
 }
 
 if [ -z "${dontUsePythonRemoveBinBytecode-}" ]; then
-    preDistPhases+=" pythonRemoveBinBytecodePhase"
+    appendToVar preDistPhases pythonRemoveBinBytecodePhase
 fi

--- a/pkgs/development/interpreters/python/hooks/python-runtime-deps-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-runtime-deps-check-hook.sh
@@ -16,5 +16,5 @@ pythonRuntimeDepsCheckHook() {
 
 if [ -z "${dontCheckRuntimeDeps-}" ]; then
     echo "Using pythonRuntimeDepsCheckHook"
-    preInstallPhases+=" pythonRuntimeDepsCheckHook"
+    appendToVar preInstallPhases pythonRuntimeDepsCheckHook
 fi

--- a/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
@@ -69,4 +69,4 @@ installSphinxPhase() {
     runHook postInstallSphinx
 }
 
-preDistPhases+=" buildSphinxPhase installSphinxPhase"
+appendToVar preDistPhases buildSphinxPhase installSphinxPhase

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -13,5 +13,5 @@ unittestCheckPhase() {
 
 if [ -z "${dontUseUnittestCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
     echo "Using unittestCheckPhase"
-    preDistPhases+=" unittestCheckPhase"
+    appendToVar preDistPhases unittestCheckPhase
 fi

--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -12,7 +12,7 @@ addEnvHooks "$targetOffset" make_glib_find_gsettings_schemas
 glibPreInstallPhase() {
   makeFlagsArray+=("gsettingsschemadir=${!outputLib}/share/gsettings-schemas/$name/glib-2.0/schemas/")
 }
-preInstallPhases+=" glibPreInstallPhase"
+appendToVar preInstallPhases glibPreInstallPhase
 
 glibPreFixupPhase() {
     # Move gschemas in case the install flag didn't help

--- a/pkgs/development/libraries/liquidfun/default.nix
+++ b/pkgs/development/libraries/liquidfun/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "liquidfun/Box2D";
 
-  preConfigurePhases = "preConfigure";
+  preConfigurePhases = [ "preConfigure" ];
 
   preConfigure = ''
     sed -i Box2D/Common/b2Settings.h -e 's@b2_maxPolygonVertices .*@b2_maxPolygonVertices 15@'

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -20,7 +20,7 @@ qmakePrePhase() {
     # do the stripping ourselves (needed for separateDebugInfo)
     prependToVar qmakeFlags "CONFIG+=nostrip"
 }
-prePhases+=" qmakePrePhase"
+appendToVar prePhases qmakePrePhase
 
 qmakeConfigurePhase() {
     runHook preConfigure

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -97,7 +97,7 @@ postPatchMkspecs() {
     fi
 }
 if [ -z "${dontPatchMkspecs-}" ]; then
-    postPhases="${postPhases-}${postPhases:+ }postPatchMkspecs"
+    appendToVar postPhases postPatchMkspecs
 fi
 
 qtPreHook() {

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -107,6 +107,6 @@ qtPreHook() {
         exit 1
     fi
 }
-prePhases+=" qtPreHook"
+appendToVar prePhases qtPreHook
 
 fi

--- a/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
@@ -13,7 +13,7 @@ qmakePrePhase() {
       "NIX_OUTPUT_QML=${!outputBin}/${qtQmlPrefix:?}" \
       "NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?}"
 }
-prePhases+=" qmakePrePhase"
+appendToVar prePhases qmakePrePhase
 
 qmakeConfigurePhase() {
     runHook preConfigure

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -71,7 +71,7 @@ else # Only set up Qt once.
         fi
     }
     if [ -z "${dontPatchMkspecs-}" ]; then
-        postPhases="${postPhases-}${postPhases:+ }postPatchMkspecs"
+        appendToVar postPhases postPatchMkspecs
     fi
 
     qtPreHook() {

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -81,7 +81,7 @@ else # Only set up Qt once.
             exit 1
         fi
     }
-    prePhases+=" qtPreHook"
+    appendToVar prePhases qtPreHook
 
     addQtModulePrefix() {
         addToSearchPath QT_ADDITIONAL_PACKAGES_PREFIX_PATH $1

--- a/pkgs/development/python-modules/pytest-forked/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-forked/setup-hook.sh
@@ -16,10 +16,17 @@ pytestForkedHook() {
 # until we have dependency mechanism in generic builder, we need to use this ugly hack.
 
 if [ -z "${dontUsePytestForked-}" ] && [ -z "${dontUsePytestCheck-}" ]; then
-    if [[ " ${preDistPhases:-} " =~ " pytestCheckPhase " ]]; then
-        preDistPhases+=" "
-        preDistPhases="${preDistPhases/ pytestCheckPhase / pytestForkedHook pytestCheckPhase }"
+    if [[ " ${preDistPhases[*]:-} " =~ " pytestCheckPhase " ]]; then
+        _preDistPhases="${preDistPhases[*]} "
+        _preDistPhases="${_preDistPhases/ pytestCheckPhase / pytestForkedHook pytestCheckPhase }"
+        if [[ -n "${__structuredAttrs-}" ]]; then
+            preDistPhases=()
+        else
+            preDistPhases=""
+        fi
+        appendToVar preDistPhases $_preDistPhases
+        unset _preDistPhases
     else
-        preDistPhases+=" pytestForkedHook"
+        appendToVar preDistPhases pytestForkedHook
     fi
 fi

--- a/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
@@ -8,10 +8,17 @@ pytestXdistHook() {
 # until we have dependency mechanism in generic builder, we need to use this ugly hack.
 
 if [ -z "${dontUsePytestXdist-}" ] && [ -z "${dontUsePytestCheck-}" ]; then
-    if [[ " ${preDistPhases:-} " =~ " pytestCheckPhase " ]]; then
-        preDistPhases+=" "
-        preDistPhases="${preDistPhases/ pytestCheckPhase / pytestXdistHook pytestCheckPhase }"
+    if [[ " ${preDistPhases[*]:-} " =~ " pytestCheckPhase " ]]; then
+        _preDistPhases="${preDistPhases[*]} "
+        _preDistPhases="${_preDistPhases/ pytestCheckPhase / pytestXdistHook pytestCheckPhase }"
+        if [[ -n "${__structuredAttrs-}" ]]; then
+            preDistPhases=()
+        else
+            preDistPhases=""
+        fi
+        appendToVar preDistPhases $_preDistPhases
+        unset _preDistPhases
     else
-        preDistPhases+=" pytestXdistHook"
+        appendToVar preDistPhases pytestXdistHook
     fi
 fi

--- a/pkgs/development/python-modules/pytest/7.nix
+++ b/pkgs/development/python-modules/pytest/7.nix
@@ -87,7 +87,7 @@ let
       pytestcachePhase() {
           find $out -name .pytest_cache -type d -exec rm -rf {} +
       }
-      preDistPhases+=" pytestcachePhase"
+      appendToVar preDistPhases pytestcachePhase
 
       # pytest generates it's own bytecode files to improve assertion messages.
       # These files similar to cpython's bytecode files but are never laoded
@@ -100,7 +100,7 @@ let
           #    https://github.com/pytest-dev/pytest/blob/7.2.1/src/_pytest/assertion/rewrite.py#L51-L53
           find $out -name "*-pytest-*.py[co]" -delete
       }
-      preDistPhases+=" pytestRemoveBytecodePhase"
+      appendToVar preDistPhases pytestRemoveBytecodePhase
     '';
 
     pythonImportsCheck = [ "pytest" ];

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -84,7 +84,7 @@ buildPythonPackage rec {
     pytestcachePhase() {
         find $out -name .pytest_cache -type d -exec rm -rf {} +
     }
-    preDistPhases+=" pytestcachePhase"
+    appendToVar preDistPhases pytestcachePhase
 
     # pytest generates it's own bytecode files to improve assertion messages.
     # These files similar to cpython's bytecode files but are never laoded
@@ -97,7 +97,7 @@ buildPythonPackage rec {
         #    https://github.com/pytest-dev/pytest/blob/7.2.1/src/_pytest/assertion/rewrite.py#L51-L53
         find $out -name "*-pytest-*.py[co]" -delete
     }
-    preDistPhases+=" pytestRemoveBytecodePhase"
+    appendToVar preDistPhases pytestRemoveBytecodePhase
   '';
 
   pythonImportsCheck = [ "pytest" ];

--- a/pkgs/development/python2-modules/pytest/default.nix
+++ b/pkgs/development/python2-modules/pytest/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
         find $out -name .pytest_cache -type d -exec rm -rf {} +
     }
 
-    preDistPhases+=" pytestcachePhase"
+    appendToVar preDistPhases pytestcachePhase
 
     # pytest generates it's own bytecode files to improve assertion messages.
     # These files similar to cpython's bytecode files but are never laoded
@@ -55,7 +55,7 @@ buildPythonPackage rec {
         #    https://github.com/pytest-dev/pytest/blob/4.6.11/src/_pytest/assertion/rewrite.py#L32-L47
         find $out -name "*-PYTEST.py[co]" -delete
     }
-    preDistPhases+=" pytestRemoveBytecodePhase"
+    appendToVar preDistPhases pytestRemoveBytecodePhase
   '';
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/build-custom-component/manifest-requirements-check-hook.sh
+++ b/pkgs/servers/home-assistant/build-custom-component/manifest-requirements-check-hook.sh
@@ -21,5 +21,5 @@ function manifestCheckPhase() {
 
 if [ -z "${dontCheckManifest-}" ] && [ -z "${installCheckPhase-}" ]; then
     echo "Using manifestCheckPhase"
-    preDistPhases+=" manifestCheckPhase"
+    appendToVar preDistPhases manifestCheckPhase
 fi


### PR DESCRIPTION
## Description of changes

Always specify the preDistPhases attribute as a list instead of a string.

Append elements to the preDistPhases Bash variable using appendToVar instead of string or Bash array concatenation.

Handle element insertion before a specific element using string substitution as before, but handle both structured and unstructured attributes.

State explicitly in the Nixpkgs Manual, "*Phases attributes are lists" and "elements of *Phases variables contain no spaces."

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
