### PR TITLE
{gst_all_1.*,python3Packages.gst-python}: 1.24.3 -> 1.24.7

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/darwin-old-sdk-fix.patch
+++ b/pkgs/development/libraries/gstreamer/bad/darwin-old-sdk-fix.patch
@@ -1,0 +1,49 @@
+From 816f2ccad16413a4961a0001fc02d8874d4fde47 Mon Sep 17 00:00:00 2001
+From: Alessandro Bono <alessandro.bono369@gmail.com>
+Date: Wed, 10 Jul 2024 15:33:34 +0200
+Subject: [PATCH] vtdec: Use kVTVideoDecoderReferenceMissingErr only when
+ defined
+
+The enum value is declared present since macOS 10.8+[1]. Howerver,
+the compilation now fails with the 10.15 SDK:
+```
+../sys/applemedia/vtdec.c:1219:12: error: use of undeclared identifier 'kVTVideoDecoderReferenceMissingErr'; did you mean 'kVTVideoDecoderMalfunctionErr'?
+      case kVTVideoDecoderReferenceMissingErr:
+           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+           kVTVideoDecoderMalfunctionErr
+/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/VideoToolbox.framework/Headers/VTErrors.h:40:2: note: 'kVTVideoDecoderMalfunctionErr' declared here
+        kVTVideoDecoderMalfunctionErr                   = -12911, // c.f. -8960
+        ^
+1 error generated.
+```
+
+Put the enum usage under #ifdef. When missing, the behavior will be
+the same as before commit a5c437c6430cdce603e46e09400beb4c5b9f5374.
+
+[1] https://developer.apple.com/documentation/videotoolbox/kvtvideodecoderreferencemissingerr?language=objc
+---
+ sys/applemedia/vtdec.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sys/applemedia/vtdec.c b/sys/applemedia/vtdec.c
+index 57fcbf9928a5..517c15365b52 100644
+--- a/sys/applemedia/vtdec.c
++++ b/sys/applemedia/vtdec.c
+@@ -1216,12 +1216,14 @@ gst_vtdec_session_output_callback (void *decompression_output_ref_con,
+ 
+   if (status != noErr) {
+     switch (status) {
++#ifdef kVTVideoDecoderReferenceMissingErr
+       case kVTVideoDecoderReferenceMissingErr:
+         /* ReferenceMissingErr is not critical, when it occurs the frame
+          * usually has the kVTDecodeInfo_FrameDropped flag set. Log only for debugging purposes. */
+         GST_DEBUG_OBJECT (vtdec, "ReferenceMissingErr when decoding frame %d",
+             frame->decode_frame_number);
+         break;
++#endif
+ #ifndef HAVE_IOS
+       case codecBadDataErr:    /* SW decoder on macOS uses a different code from the hardware one... */
+ #endif
+-- 
+GitLab
+

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -114,13 +114,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-plugins-bad";
-  version = "1.24.3";
+  version = "1.24.7";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-6Q8mx9ycdvSqWZt1jP1tjBDWoLnLJluiw8m984iFWPg=";
+    hash = "sha256-ddUT/AumNfsfOXhtiQtz+6xfS8iP858qn/YvS49CjyI=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -129,6 +129,11 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       inherit (addDriverRunpath) driverLink;
     })
+
+    # vtdec: Use kVTVideoDecoderReferenceMissingErr only when defined
+    # <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7157>
+    # TODO: Remove this when the build with the newer SDK works.
+    ./darwin-old-sdk-fix.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -49,7 +49,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-base";
-  version = "1.24.3";
+  version = "1.24.7";
 
   outputs = [ "out" "dev" ];
 
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version;
   in fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-8QlDl+qnky8G5X67sHWqM6osduS3VjChawLI1K9Ggy4=";
+    hash = "sha256-FSjRdGo5Mpn1rBfr8ToypmAgLx4p0KhSoiUPagWaL9o=";
   };
 
   strictDeps = true;

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -29,7 +29,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstreamer";
-  version = "1.24.3";
+  version = "1.24.7";
 
   outputs = [
     "bin"
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version;
   in fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-EiXvSjKfrhytxexyfaskmtVn6AcoeUk1Yc65HtNKpBQ=";
+    hash = "sha256-wOdbEkxSu3oMPc23NLKtJg6nKGqHRc8upinUyEnmqVg=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gstreamer/devtools/default.nix
+++ b/pkgs/development/libraries/gstreamer/devtools/default.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-devtools";
-  version = "1.24.3";
+  version = "1.24.7";
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-uREUov2Vj0Ks9EEYbofivsk1OO81qfgkgREZc2D/sjc=";
+    hash = "sha256-56p6I/pYfVjcWnu1Hvta159vKkxZh1ZMZvYztbvTixc=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-editing-services";
-  version = "1.24.3";
+  version = "1.24.7";
 
   outputs = [
     "out"
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-z3QyFWiLATkFzSyff+3aIeLTTIRDQJkMbqJdEKA3KT8=";
+    hash = "sha256-sjzDEqI/q3F+S2A/ByvkIJhPucndIHfiBraqmxHfKdg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -58,13 +58,13 @@ assert raspiCameraSupport -> (stdenv.isLinux && stdenv.isAarch32);
 
 stdenv.mkDerivation rec {
   pname = "gst-plugins-good";
-  version = "1.24.3";
+  version = "1.24.7";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-FQ+RTmHcBWALaLiMoQPHzCJxMBWOOJ6p6hWfQFCi67A=";
+    hash = "sha256-dZrLEebeg3P/jLteerjrmjhjG+gc8kIgJnsAHrVVk8E=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-libav";
-  version = "1.24.3";
+  version = "1.24.7";
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-2cWxUkaKRcH6g1FBBCIJCnGScHrXTS4aQ2f1JU4YjZE=";
+    hash = "sha256-w+QXm6GDwtMQHt+H/3DdB+cox2al/uNObs3tdspYAt8=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-rtsp-server";
-  version = "1.24.3";
+  version = "1.24.7";
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-YmKOzKeLj1tRxZpNYCxl6SBf/FDDyDzWH6sfY0i2NWU=";
+    hash = "sha256-2ceOXNC+rTC/XnSvgOQefVAGGUYX/b9EuIvibla76Pk=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gst-plugins-ugly";
-  version = "1.24.3";
+  version = "1.24.7";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-TJUTQcTGSGMLb+EjTsET2B3S0khSm/K1R44K0HfIDtM=";
+    hash = "sha256-PclU/FP+GIg2cDIqHCFePGUpA24KabMPZHgc1AwmhZM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -25,11 +25,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gstreamer-vaapi";
-  version = "1.24.3";
+  version = "1.24.7";
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-hF8u/g3KjasjTd6PsJHaLNBqnSpoNCK1bctoiVT5Bw4=";
+    hash = "sha256-OqXtnX9LWny2DYsDcNmD1ZOV3lRu52cEQBGA/Q/V7oY=";
   };
 
   outputs = [

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "gst-python";
-  version = "1.24.3";
+  version = "1.24.7";
 
   format = "other";
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-python/${pname}-${version}.tar.xz";
-    hash = "sha256-7Ns+K6lOosgrk6jHFdWn4E+XJqiDjAprF2lJKP0ehZU=";
+    hash = "sha256-bD7gKyDICobiQkWwYQLa4A4BdobydAdib0TcA6w8pTo=";
   };
 
   # Python 2.x is not supported.


### PR DESCRIPTION
## Description of changes

Upstream bug‐fix release; see [the changelog](https://gstreamer.freedesktop.org/releases/1.24/#1.24.7).

Includes fixes for FFmpeg 7.

I have successfully built `{gst_all_1.{gstreamer,gst-plugins-{base,good,bad,ugly},gst-libav,gst-vaapi,gst-rtsp-server,gst-devtools,gst-editing-services},python3Packages.gst-python}` for the platforms indicated (minus `gst_all_1.gst-vaapi` on macOS).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
