### PR TITLE
freebsd: make pkgsStatic work

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/patches/14.1/bsd-lib-mk-force-static.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.1/bsd-lib-mk-force-static.patch
@@ -1,0 +1,66 @@
+diff --git a/share/mk/bsd.lib.mk b/share/mk/bsd.lib.mk
+index 5f328d5378ca..89d16dc6fa41 100644
+--- a/share/mk/bsd.lib.mk
++++ b/share/mk/bsd.lib.mk
+@@ -242,7 +242,7 @@ PO_FLAG=-pg
+ _LIBDIR:=${LIBDIR}
+ _SHLIBDIR:=${SHLIBDIR}
+ 
+-.if defined(SHLIB_NAME)
++.if defined(SHLIB_NAME) && !empty(SHLIB_NAME)
+ .if ${MK_DEBUG_FILES} != "no"
+ SHLIB_NAME_FULL=${SHLIB_NAME}.full
+ # Use ${DEBUGDIR} for base system debug files, else .debug subdirectory
+@@ -277,7 +277,7 @@ LDFLAGS+=	-Wl,--undefined-version
+ .endif
+ .endif
+ 
+-.if defined(LIB) && !empty(LIB) || defined(SHLIB_NAME)
++.if defined(LIB) && !empty(LIB) || (defined(SHLIB_NAME) && !empty(SHLIB_NAME))
+ OBJS+=		${SRCS:N*.h:${OBJS_SRCS_FILTER:ts:}:S/$/.o/}
+ BCOBJS+=	${SRCS:N*.[hsS]:N*.asm:${OBJS_SRCS_FILTER:ts:}:S/$/.bco/g}
+ LLOBJS+=	${SRCS:N*.[hsS]:N*.asm:${OBJS_SRCS_FILTER:ts:}:S/$/.llo/g}
+@@ -320,14 +320,14 @@ lib${LIB_PRIVATE}${LIB}.ll: ${LLOBJS}
+ CLEANFILES+=	lib${LIB_PRIVATE}${LIB}.bc lib${LIB_PRIVATE}${LIB}.ll
+ .endif
+ 
+-.if defined(SHLIB_NAME) || \
++.if (defined(SHLIB_NAME) && !empty(SHLIB_NAME)) || \
+     defined(INSTALL_PIC_ARCHIVE) && defined(LIB) && !empty(LIB)
+ SOBJS+=		${OBJS:.o=.pico}
+ DEPENDOBJS+=	${SOBJS}
+ CLEANFILES+=	${SOBJS}
+ .endif
+ 
+-.if defined(SHLIB_NAME)
++.if defined(SHLIB_NAME) && !empty(SHLIB_NAME)
+ _LIBS+=		${SHLIB_NAME}
+ 
+ SOLINKOPTS+=	-shared -Wl,-x
+@@ -435,7 +435,7 @@ all: all-man
+ CLEANFILES+=	${_LIBS}
+ 
+ _EXTRADEPEND:
+-.if !defined(NO_EXTRADEPEND) && defined(SHLIB_NAME)
++.if !defined(NO_EXTRADEPEND) && defined(SHLIB_NAME) && !empty(SHLIB_NAME)
+ .if defined(DPADD) && !empty(DPADD)
+ 	echo ${SHLIB_NAME_FULL}: ${DPADD} >> ${DEPENDFILE}
+ .endif
+@@ -501,7 +501,7 @@ _libinstall:
+ 	    ${_INSTALLFLAGS} lib${LIB_PRIVATE}${LIB}_p.a ${DESTDIR}${_LIBDIR}/
+ .endif
+ .endif
+-.if defined(SHLIB_NAME)
++.if defined(SHLIB_NAME) && !empty(SHLIB_NAME)
+ 	${INSTALL} ${TAG_ARGS} ${STRIP} -o ${LIBOWN} -g ${LIBGRP} -m ${LIBMODE} \
+ 	    ${_INSTALLFLAGS} ${_SHLINSTALLFLAGS} \
+ 	    ${SHLIB_NAME} ${DESTDIR}${_SHLIBDIR}/
+@@ -588,7 +588,7 @@ OBJS_DEPEND_GUESS+= ${SRCS:M*.h}
+ OBJS_DEPEND_GUESS.${_S:${OBJS_SRCS_FILTER:ts:}}.po+=	${_S}
+ .endfor
+ .endif
+-.if defined(SHLIB_NAME) || \
++.if (defined(SHLIB_NAME) && !empty(SHLIB_NAME)) || \
+     defined(INSTALL_PIC_ARCHIVE) && defined(LIB) && !empty(LIB)
+ .for _S in ${SRCS:N*.[hly]}
+ OBJS_DEPEND_GUESS.${_S:${OBJS_SRCS_FILTER:ts:}}.pico+=	${_S}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/init.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/init.nix
@@ -1,7 +1,9 @@
-{ mkDerivation }:
+{ mkDerivation, stdenv }:
 mkDerivation {
   path = "sbin/init";
   extraPaths = [ "sbin/mount" ];
   NO_FSCHG = "yes";
   MK_TESTS = "no";
+
+  meta.broken = !stdenv.hostPlatform.isStatic;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libc/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libc/package.nix
@@ -116,6 +116,11 @@ mkDerivation {
         --replace '/usr/share/i18n' '${builtins.placeholder "out"}/share/i18n'
   '';
 
+  # here is the seed from which all static programs come, therefore we must remove the adapter's special logic for forcing builds with -static.
+  postConfigure = ''
+    export NIX_CFLAGS_LINK=
+  '';
+
   nativeBuildInputs = [
     bsdSetupHook
     freebsdSetupHook
@@ -194,7 +199,7 @@ mkDerivation {
       make -C $BSDSRCDIR/lib/libgcc_eh $makeFlags
       make -C $BSDSRCDIR/lib/libgcc_eh $makeFlags install
 
-      ln -s $BSDSRCDIR/lib/libc/libc.so.7 $BSDSRCDIR/lib/libc/libc.so  # not sure
+      ln -s $BSDSRCDIR/lib/libc/libc.so.7 $BSDSRCDIR/lib/libc/libc.so  # otherwise these dynamic libraries try to link with libc.a
       mkdir $BSDSRCDIR/lib/libgcc_s/i386 $BSDSRCDIR/lib/libgcc_s/cpu_model
       make -C $BSDSRCDIR/lib/libgcc_s $makeFlags
       make -C $BSDSRCDIR/lib/libgcc_s $makeFlags install
@@ -266,6 +271,13 @@ mkDerivation {
       make -C $BSDSRCDIR/libexec/rtld-elf $makeFlags install
       rm -f $out/libexec/ld-elf.so.1
       mv $out/bin/ld-elf.so.1 $out/libexec
+    ''
+    + lib.optionalString (!stdenv.hostPlatform.isStatic) ''
+      mkdir $out/lib/keep_static
+      mv $out/lib/*_nonshared.a $out/lib/libgcc*.a $out/lib/libcompiler_rt.a $out/lib/keep_static
+      rm $out/lib/*.a
+      mv $out/lib/keep_static/* $out/lib
+      rmdir $out/lib/keep_static
     '';
 
   # libc should not be allowed to refer to anything other than itself

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libcxxrt.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libcxxrt.nix
@@ -1,4 +1,8 @@
-{ mkDerivation }:
+{
+  mkDerivation,
+  stdenv,
+  lib,
+}:
 # this package is quite different from stock libcxxrt.
 # as of FreeBSD 14.0, it is vendored from APPROXIMATELY libcxxrt
 # 5d8a15823a103bbc27f1bfdcf2b5aa008fab57dd, though the vendoring mechanism is
@@ -8,11 +12,14 @@ mkDerivation {
   pname = "libcxxrt";
   path = "lib/libcxxrt";
   extraPaths = [ "contrib/libcxxrt" ];
-  outputs = [
-    "out"
-    "dev"
-    "debug"
-  ];
+  outputs =
+    [
+      "out"
+      "dev"
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
+      "debug"
+    ];
   noLibcxx = true;
   libName = "cxxrt";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -58,9 +58,16 @@ lib.makeOverridable (
 
       HOST_SH = stdenv'.shell;
 
-      makeFlags = [
-        "STRIP=-s" # flag to install, not command
-      ] ++ lib.optional (!stdenv'.hostPlatform.isFreeBSD) "MK_WERROR=no";
+      makeFlags =
+        [
+          "STRIP=-s" # flag to install, not command
+        ]
+        ++ lib.optionals (!stdenv'.hostPlatform.isFreeBSD) [
+          "MK_WERROR=no"
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isStatic [
+          "SHLIB_NAME="
+        ];
 
       # amd64 not x86_64 for this on unlike NetBSD
       MACHINE_ARCH = freebsd-lib.mkBsdArch stdenv';

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -79,8 +79,8 @@ stdenv.mkDerivation rec {
     "bash_cv_getcwd_malloc=yes"
     # This check cannot be performed when cross compiling. The "yes"
     # default is fine for static linking on Linux (weak symbols?) but
-    # not with OpenBSD, when it does clash with the regular `getenv`.
-    "bash_cv_getenv_redef=${if !(with stdenv.hostPlatform; isStatic && isOpenBSD) then "yes" else "no"}"
+    # not with BSDs, when it does clash with the regular `getenv`.
+    "bash_cv_getenv_redef=${if !(with stdenv.hostPlatform; isStatic && (isOpenBSD || isFreeBSD)) then "yes" else "no"}"
   ] ++ lib.optionals stdenv.hostPlatform.isCygwin [
     "--without-libintl-prefix"
     "--without-libiconv-prefix"


### PR DESCRIPTION
## Description of changes

See commit messages. This makes it work cross, though native has some issues which look to my untrained eye like "splicing isn't working correctly". I tested this by building bash, which needed a small patch.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
