### PR TITLE
python312Packages.orange-canvas-core: 0.2.1 -> 0.2.2; skip failing tests

### DIFF
--- a/pkgs/development/python-modules/orange-canvas-core/default.nix
+++ b/pkgs/development/python-modules/orange-canvas-core/default.nix
@@ -1,7 +1,12 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   anyqt,
   cachecontrol,
   commonmark,
@@ -10,24 +15,32 @@
   filelock,
   lockfile,
   numpy,
+  pip,
+  qasync,
+  requests-cache,
+  typing-extensions,
+
+  # tests
+  qt5,
   pytest-qt,
   pytestCheckHook,
-  qasync,
-  qt5,
-  requests-cache,
 }:
 
 buildPythonPackage rec {
   pname = "orange-canvas-core";
-  version = "0.2.1";
-  format = "setuptools";
+  version = "0.2.2";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-f0E/7jnzoIrV4V1KSbec0MZB/BLz0UVbBCsc3v4dp0o=";
+  src = fetchFromGitHub {
+    owner = "biolab";
+    repo = "orange-canvas-core";
+    rev = "refs/tags/${version}";
+    hash = "sha256-Jp3vCQmRdkFADStVkbCFPiCBqpbI0a4JiJ8qs60rpqw=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     anyqt
     cachecontrol
     commonmark
@@ -36,8 +49,10 @@ buildPythonPackage rec {
     filelock
     lockfile
     numpy
+    pip
     qasync
     requests-cache
+    typing-extensions
   ];
 
   pythonImportsCheck = [ "orangecanvas" ];
@@ -54,11 +69,26 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # Failed: CALL ERROR: Exceptions caught in Qt event loop
+    "test_create_new_window"
+    "test_dont_load_swp_on_new_window"
+    "test_editlinksnode"
+    "test_flattened"
+    "test_links_edit"
+    "test_links_edit_widget"
+    "test_new_window"
+    "test_toolbox"
+    "test_tooltree_registry"
+    "test_widgettoolgrid"
+  ];
+
   disabledTestPaths = [ "orangecanvas/canvas/items/tests/test_graphicstextitem.py" ];
 
   meta = {
     description = "Orange framework for building graphical user interfaces for editing workflows";
     homepage = "https://github.com/biolab/orange-canvas-core";
+    changelog = "https://github.com/biolab/orange-canvas-core/releases/tag/${version}";
     license = [ lib.licenses.gpl3 ];
     maintainers = [ lib.maintainers.lucasew ];
   };

--- a/pkgs/development/python-modules/orange-canvas-core/default.nix
+++ b/pkgs/development/python-modules/orange-canvas-core/default.nix
@@ -24,6 +24,8 @@
   qt5,
   pytest-qt,
   pytestCheckHook,
+
+  stdenv,
 }:
 
 buildPythonPackage rec {
@@ -91,5 +93,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/biolab/orange-canvas-core/releases/tag/${version}";
     license = [ lib.licenses.gpl3 ];
     maintainers = [ lib.maintainers.lucasew ];
+    # Segmentation fault during tests
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/biolab/orange-canvas-core/releases/tag/0.2.2

cc @lucasew

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
