### PR TITLE
nextflow: 22.10.6 -> 24.08.0-edge + remove buildFHSEnv + compile from source + add tests

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -658,6 +658,7 @@ in {
   # TODO: put in networking.nix after the test becomes more complete
   networkingProxy = handleTest ./networking-proxy.nix {};
   nextcloud = handleTest ./nextcloud {};
+  nextflow = handleTest ./nextflow.nix {};
   nextjs-ollama-llm-ui = runTest ./web-apps/nextjs-ollama-llm-ui.nix;
   nexus = handleTest ./nexus.nix {};
   # TODO: Test nfsv3 + Kerberos

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -658,7 +658,7 @@ in {
   # TODO: put in networking.nix after the test becomes more complete
   networkingProxy = handleTest ./networking-proxy.nix {};
   nextcloud = handleTest ./nextcloud {};
-  nextflow = handleTest ./nextflow.nix {};
+  nextflow = handleTestOn ["x86_64-linux"] ./nextflow.nix {};
   nextjs-ollama-llm-ui = runTest ./web-apps/nextjs-ollama-llm-ui.nix;
   nexus = handleTest ./nexus.nix {};
   # TODO: Test nfsv3 + Kerberos

--- a/nixos/tests/nextflow.nix
+++ b/nixos/tests/nextflow.nix
@@ -1,0 +1,60 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  let
+    bash = pkgs.dockerTools.pullImage {
+      imageName = "quay.io/nextflow/bash";
+      imageDigest = "sha256:bea0e244b7c5367b2b0de687e7d28f692013aa18970941c7dd184450125163ac";
+      sha256 = "161s9f24njjx87qrwq0c9nmnwvyc6iblcxka7hirw78lm7i9x4w5";
+      finalImageName = "quay.io/nextflow/bash";
+    };
+
+    hello = pkgs.stdenv.mkDerivation {
+      name = "nextflow-hello";
+      src = pkgs.fetchFromGitHub {
+        owner = "nextflow-io";
+        repo = "hello";
+        rev = "afff16a9b45c8e8a4f5a3743780ac13a541762f8";
+        hash = "sha256-c8FirHc+J5Y439g0BdHxRtXVrOAzIrGEKA0m1mp9b/U=";
+      };
+      installPhase = ''
+        cp -r $src $out
+      '';
+    };
+    run-nextflow-pipeline = pkgs.writeShellApplication {
+      name = "run-nextflow-pipeline";
+      runtimeInputs = [ pkgs.nextflow ];
+      text = ''
+        export NXF_OFFLINE=true
+        for b in false true; do
+          echo "docker.enabled = $b" > nextflow.config
+          cat nextflow.config
+          nextflow run -ansi-log false ${hello}
+        done
+      '';
+    };
+  in
+  {
+    name = "nextflow";
+
+    nodes.machine =
+      { ... }:
+      {
+        environment.systemPackages = [
+          run-nextflow-pipeline
+          pkgs.nextflow
+        ];
+        virtualisation = {
+          docker.enable = true;
+        };
+      };
+
+    testScript =
+      { nodes, ... }:
+      ''
+        start_all()
+        machine.wait_for_unit("docker.service")
+        machine.succeed("docker load < ${bash}")
+        machine.succeed("run-nextflow-pipeline >&2")
+      '';
+  }
+)

--- a/pkgs/development/interpreters/nextflow/default.nix
+++ b/pkgs/development/interpreters/nextflow/default.nix
@@ -12,6 +12,7 @@
   coreutils,
   bash,
   testers,
+  nixosTests,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "nextflow";
@@ -83,6 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
       --set JAVA_HOME ${openjdk.home}
   '';
 
+  passthru.tests.default = nixosTests.nextflow;
   # versionCheckHook doesn't work as of 2024-09-23.
   # See https://github.com/NixOS/nixpkgs/pull/339197#issuecomment-2363495060
   passthru.tests.version = testers.testVersion {

--- a/pkgs/development/interpreters/nextflow/default.nix
+++ b/pkgs/development/interpreters/nextflow/default.nix
@@ -11,6 +11,7 @@
   gawk,
   coreutils,
   bash,
+  testers,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "nextflow";
@@ -81,6 +82,13 @@ stdenv.mkDerivation (finalAttrs: {
       } \
       --set JAVA_HOME ${openjdk.home}
   '';
+
+  # versionCheckHook doesn't work as of 2024-09-23.
+  # See https://github.com/NixOS/nixpkgs/pull/339197#issuecomment-2363495060
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "env HOME=$TMPDIR nextflow -version";
+  };
 
   meta = with lib; {
     description = "DSL for data-driven computational pipelines";

--- a/pkgs/development/interpreters/nextflow/default.nix
+++ b/pkgs/development/interpreters/nextflow/default.nix
@@ -1,52 +1,85 @@
-{ lib
-, stdenv
-, fetchurl
-, makeWrapper
-, openjdk17
-, wget
-, which
-, gnused
-, gawk
-, coreutils
-, buildFHSEnv
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  openjdk,
+  gradle,
+  wget,
+  which,
+  gnused,
+  gawk,
+  coreutils,
+  bash,
 }:
-
-let
-  nextflow =
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nextflow";
-  version = "22.10.6";
+  # 24.08.0-edge is compatible with Java 21. The current (as of 2024-09-19)
+  # nextflow release (24.04.4) does not yet support java21, but java19. The
+  # latter is not in nixpkgs(-unstable) anymore.
+  version = "24.08.0-edge";
 
-  src = fetchurl {
-    url = "https://github.com/nextflow-io/nextflow/releases/download/v${version}/nextflow-${version}-all";
-    hash = "sha256-zeYsKxWRnzr0W6CD+yjoAXwCN/AbN5P4HhH1oftnrjY=";
+  src = fetchFromGitHub {
+    owner = "nextflow-io";
+    repo = "nextflow";
+    rev = "6e866ae81ff3bf8a9729e9dbaa9dd89afcb81a4b";
+    hash = "sha256-SA27cuP3iO5kD6u0uTeEaydyqbyJzOkVtPrb++m3Tv0=";
   };
 
   nativeBuildInputs = [
     makeWrapper
-    openjdk17
-    wget
-    which
-    gnused
-    gawk
-    coreutils
+    gradle
   ];
 
-  dontUnpack = true;
+  postPatch = ''
+    # Nextflow invokes the constant "/bin/bash" (not as a shebang) at
+    # several locations so we fix that globally. However, when running inside
+    # a container, we actually *want* "/bin/bash". Thus the global fix needs
+    # to be reverted for this specific use case.
+    substituteInPlace modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy \
+      --replace-fail "['/bin/bash'," "['${bash}/bin/bash'," \
+      --replace-fail "if( containerBuilder ) {" "if( containerBuilder ) {
+                launcher = launcher.replaceFirst(\"/nix/store/.*/bin/bash\", \"/bin/bash\")"
+  '';
+
+  mitmCache = gradle.fetchDeps {
+    inherit (finalAttrs) pname;
+    data = ./deps.json;
+  };
+  __darwinAllowLocalNetworking = true;
+
+  # During the build, some additional dependencies are downloaded ("detached
+  # configuration"). We thus need to run a full build on instead of the default
+  # one.
+  # See https://github.com/NixOS/nixpkgs/pull/339197#discussion_r1747749061
+  gradleUpdateTask = "pack";
+  # See Makefile (`make pack`)
+  preBuild = ''
+    export BUILD_PACK=1
+  '';
+  gradleBuildTask = "pack";
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
-    install -Dm755 $src $out/bin/nextflow
+    install -Dm755 build/releases/nextflow-${finalAttrs.version}-dist $out/bin/nextflow
 
     runHook postInstall
   '';
 
   postFixup = ''
     wrapProgram $out/bin/nextflow \
-      --prefix PATH : ${lib.makeBinPath nativeBuildInputs} \
-      --set JAVA_HOME ${openjdk17.home}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gawk
+          gnused
+          wget
+          which
+        ]
+      } \
+      --set JAVA_HOME ${openjdk.home}
   '';
 
   meta = with lib; {
@@ -61,17 +94,11 @@ stdenv.mkDerivation rec {
     homepage = "https://www.nextflow.io/";
     changelog = "https://github.com/nextflow-io/nextflow/releases";
     license = licenses.asl20;
-    maintainers = with maintainers; [ Etjean edmundmiller ];
+    maintainers = with maintainers; [
+      Etjean
+      edmundmiller
+    ];
     mainProgram = "nextflow";
     platforms = platforms.unix;
   };
-};
-in
-if stdenv.hostPlatform.isLinux then
-  buildFHSEnv
-  {
-    name = "nextflow";
-    targetPkgs = pkgs: [ nextflow ];
-    runScript = "nextflow";
-  }
-else nextflow
+})

--- a/pkgs/development/interpreters/nextflow/default.nix
+++ b/pkgs/development/interpreters/nextflow/default.nix
@@ -55,8 +55,10 @@ stdenv.mkDerivation (finalAttrs: {
   # one.
   # See https://github.com/NixOS/nixpkgs/pull/339197#discussion_r1747749061
   gradleUpdateTask = "pack";
-  # See Makefile (`make pack`)
+  # The installer attempts to copy a final JAR to $HOME/.nextflow/...
+  gradleFlags = ["-Duser.home=\$TMPDIR"];
   preBuild = ''
+    # See Makefile (`make pack`)
     export BUILD_PACK=1
   '';
   gradleBuildTask = "pack";

--- a/pkgs/development/interpreters/nextflow/deps.json
+++ b/pkgs/development/interpreters/nextflow/deps.json
@@ -1,0 +1,2026 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://plugins.gradle.org/m2": {
+  "com/fasterxml#oss-parent/48": {
+   "pom": "sha256-EbuiLYYxgW4JtiOiAHR0U9ZJGmbqyPXAicc9ordJAU8="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.14.1": {
+   "pom": "sha256-eP35nlBQ/EhfQRfauMzL+2+mxoOF6184oJtlU3HUpsw="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.14": {
+   "pom": "sha256-CQat2FWuOfkjV9Y/SFiJsI/KTEOl/kM1ItdTROB1exk="
+  },
+  "com/github/johnrengelman#shadow/8.1.1": {
+   "jar": "sha256-CEGXVVWQpTuyG1lQijMwVZ9TbdtEjq/R7GdfVGIDb88=",
+   "module": "sha256-nQ87SqpniYcj6vbF6c0nOHj5V03azWSqNwJDYgzgLko=",
+   "pom": "sha256-Mu55f8hDI3xM5cSeX0FSxYoIlK/OCg6SY25qLU/JjDU="
+  },
+  "com/github/johnrengelman/shadow#com.github.johnrengelman.shadow.gradle.plugin/8.1.1": {
+   "pom": "sha256-PLOIa5ffbgZvEIwxayGfJiyXw8st9tp4kn5kXetkPLA="
+  },
+  "com/google/code/gson#gson-parent/2.9.1": {
+   "pom": "sha256-fKCEXnNoVhjePka9NDTQOko3PVIPq5OmgDGK1sjLKnk="
+  },
+  "com/google/code/gson#gson/2.9.1": {
+   "jar": "sha256-N4U04znm5tULFzb7Ort28cFdG+P0wTzsbVNkEuI9pgM=",
+   "pom": "sha256-5ZZjI9cUJXCzekvpeeIbwtroSBB+TcQW2PRNmqPwKQM="
+  },
+  "com/gradle/plugin-publish#com.gradle.plugin-publish.gradle.plugin/1.2.1": {
+   "pom": "sha256-60lBRA8TGZbmT6SCDc264js95UhBi6ke9MY0pqcfVMs="
+  },
+  "com/gradle/publish#plugin-publish-plugin/1.2.1": {
+   "jar": "sha256-KY8MLpeVMhcaBaQWAyY3M7ZfiRE9ToCczQ4mmQFJ3hg=",
+   "module": "sha256-w98uuag1ZdO2MVDYa0344o9mG1XOzdRJJ+RpMxA2yxk=",
+   "pom": "sha256-E6X+iu2+Rs/b6hLp/NcJemKygqpqtMkIZWuWzpoqX6M="
+  },
+  "commons-beanutils#commons-beanutils/1.8.0": {
+   "jar": "sha256-E1Q5ObhuO7gzkBnWrMCOywTksJWoK6+YTlBbOvtUdCo=",
+   "pom": "sha256-RcBZb/rd9e7HOaIIBH3OId+bsawhwa/owNoMsOj/yO4="
+  },
+  "commons-codec#commons-codec/1.6": {
+   "jar": "sha256-VLNOlBuOFBS9PkDXNu/TSBdy3CbbMpb2qkXOyfYgPYY=",
+   "pom": "sha256-oG410//zprgT2UiU6/PkmPlUDIZMWzmueDkH46bHKIk="
+  },
+  "commons-collections#commons-collections/3.2.1": {
+   "jar": "sha256-hzY6TJTqq+79i5MMsFn2a2TJ99Yyhi8j3jAS2nZgBHs=",
+   "pom": "sha256-H5Ymy6pYTtXYYCGGbk42fib+Xvwkg4JlK+aL7rQ+dBY="
+  },
+  "commons-io#commons-io/2.11.0": {
+   "jar": "sha256-lhsvbYfbrMXVSr9Fq3puJJX4m3VZiWLYxyPOqbwhCQg=",
+   "pom": "sha256-LgFv1+MkS18sIKytg02TqkeQSG7h5FZGQTYaPoMe71k="
+  },
+  "commons-lang#commons-lang/2.4": {
+   "jar": "sha256-LHO5QMkSULyYNGkmJw8TpqELtuKdLJMWpw0TTjgshz4=",
+   "pom": "sha256-kDBieNOe1aUNr6Rore5NJytjXVTE9yleKT5Cu9uK1mY="
+  },
+  "commons-logging#commons-logging/1.1.1": {
+   "jar": "sha256-zm+RPK0fDbOq1wGG1lxbx//Mmpnj/o4LE3MSgZ98Ni8=",
+   "pom": "sha256-0PLhbQVOi7l63ZyiZSXrI0b2koCfzSooeH2ozrPDXug="
+  },
+  "io/codearte/gradle/nexus#gradle-nexus-staging-plugin/0.21.2": {
+   "jar": "sha256-IoBojVIvesDzggf1zqHeX4qQB+pwdkQCOkli7dcrdoM=",
+   "pom": "sha256-EbptdouvS6ax6Y+X+rPMJOEFJILBjDhxj2XRFjqfvd8="
+  },
+  "io/codearte/nexus-staging#io.codearte.nexus-staging.gradle.plugin/0.21.2": {
+   "pom": "sha256-U6ZiLniyF6D3uVuYuAb03ExyYhrb/vAeMqjQOU34CMk="
+  },
+  "io/fabric8#kubernetes-client-bom/5.12.2": {
+   "pom": "sha256-6qA8FpVlaNVKa6Q31J1Ay/DdjpOXf5hDGCQldrZQvDs="
+  },
+  "io/netty#netty-bom/4.1.86.Final": {
+   "pom": "sha256-EnFsH+ZM9b2qcETTfROq46iIIbkdR5hCDEanR2kXiv0="
+  },
+  "jakarta/platform#jakarta.jakartaee-bom/9.0.0": {
+   "pom": "sha256-kZA9Ddh23sZ/i5I/EzK6cr8pWwa9OX0Y868ZMHzhos4="
+  },
+  "jakarta/platform#jakartaee-api-parent/9.0.0": {
+   "pom": "sha256-9l3PFLbh2RSOGYo5D6/hVfrKCTJT3ekAMH8+DqgsrTs="
+  },
+  "net/sf/ezmorph#ezmorph/1.0.6": {
+   "jar": "sha256-K+BqI4D4ZWQmtcYQ22lLvXUxTK8+kZGv/NeUJyE5jtc=",
+   "pom": "sha256-+UPkVMTG00n/AKH9bH6vORUB0g3jdw0fjSLL4RrAgN0="
+  },
+  "net/sf/json-lib#json-lib/2.3": {
+   "pom": "sha256-4RmEasU+ymvP8FzE/VFRYXZjiVx+fKgr2M6R+fno6oM="
+  },
+  "net/sf/json-lib#json-lib/2.3/jdk15": {
+   "jar": "sha256-HljMSaAvKuIgScc95p0DpqpE8ZdTPEIQajAuA8lcQMo="
+  },
+  "net/sourceforge/nekohtml#nekohtml/1.9.16": {
+   "jar": "sha256-nYFgvdRdXznN3uO0DhQ/Pu8SlRA//hmxIHfuW/RsmA8=",
+   "pom": "sha256-0wDz8mGFya7uiIbu16CUHPffuf1JTP67coWvzKoQvIk="
+  },
+  "org/apache#apache/21": {
+   "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache#apache/27": {
+   "pom": "sha256-srD8aeIqZQw4kvHDZtdwdvKVdcZzjfTHpwpEhESEzfk="
+  },
+  "org/apache#apache/3": {
+   "pom": "sha256-OTxQr7S3qm61flN3pVoaBhCxn3W1Ls4BMI2wShGHog4="
+  },
+  "org/apache#apache/4": {
+   "pom": "sha256-npMjomuo6yOU7+8MltMbcN9XCAhjDcFHyrHnNUHMUZQ="
+  },
+  "org/apache#apache/9": {
+   "pom": "sha256-SUbmClR8jtpp87wjxbbw2tz4Rp6kmx0dp940rs/PGN0="
+  },
+  "org/apache/ant#ant-launcher/1.10.13": {
+   "jar": "sha256-zXaVs7+2lkq3G2oLMdrWAAWud/5QITI2Rnmqzwj3eXA=",
+   "pom": "sha256-ApkvvDgFU1bzyU0B6qJJmcsCoJuqnB/fXqx2t8MVY8o="
+  },
+  "org/apache/ant#ant-parent/1.10.13": {
+   "pom": "sha256-blv8hwgiFD8f+7LG8I7EiHctsxSlKDMC9IFLEms0aTk="
+  },
+  "org/apache/ant#ant/1.10.13": {
+   "jar": "sha256-vvv8eedE6Yks+n25bfO26C3BfSVxr0KqQnl2/CIpmDg=",
+   "pom": "sha256-J5NR7tkLj3QbtIyVvmHD7CRU48ipr7Q7zB0LrB3aE3o="
+  },
+  "org/apache/commons#commons-parent/11": {
+   "pom": "sha256-ueAwbzk0YBBbij+lEFJQxSkbHvqpmVSs4OwceDEJoCo="
+  },
+  "org/apache/commons#commons-parent/22": {
+   "pom": "sha256-+4xeVeMKet20/yEIWKDo0klO1nV7vhkBLamdUVhsPLs="
+  },
+  "org/apache/commons#commons-parent/5": {
+   "pom": "sha256-i9YywAvfgKfeNsIrYPEkUsFH2Oyi8A151maZ6+faoCo="
+  },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
+  "org/apache/commons#commons-parent/9": {
+   "pom": "sha256-UzG30+Cu1ZcoyA8RGOTb94Vl1BCegdFmAsnK29sjoSg="
+  },
+  "org/apache/httpcomponents#httpclient/4.2.1": {
+   "jar": "sha256-iIXYJLyCcE+oX2WKozCCD3l7LF95ygrOFbAKFLgRazI=",
+   "pom": "sha256-ukEy6mrvjTaI36vPhEkxsbDSuRuPe/4j/GIyJZRAtRo="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.2.1": {
+   "pom": "sha256-isgOv0pRag0bYCiTM8vtDqMreP+woAkVIgrWZq4RHcQ="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.2.1": {
+   "pom": "sha256-aEfHnY0ZIIx/eCWELDGhrdkGw6z61my1tcgw5iGWgXk="
+  },
+  "org/apache/httpcomponents#httpcore/4.2.1": {
+   "jar": "sha256-gIaCbdI0nYPkkz/eOYllzf6HHrknjNthrFvIFB15fYQ=",
+   "pom": "sha256-U6IZ7//SN64tgJPSqcfY264QoxFoo1L08LE6IEJeKzg="
+  },
+  "org/apache/httpcomponents#project/6": {
+   "pom": "sha256-tdkiWtuGg8HXxVFFRDgq3QBFR8k2lKu1vVK4c0aIb0I="
+  },
+  "org/apache/logging#logging-parent/7": {
+   "pom": "sha256-5YkR3J/GsXOhDlqp7bk8eZStBmAnBd0Gftz8bh6eFys="
+  },
+  "org/apache/logging/log4j#log4j-api/2.20.0": {
+   "jar": "sha256-L0PupnnqZvFMoPE/7CqGAKwST1pSMdy034OT7dy5dVA=",
+   "pom": "sha256-zUWDKj1s0hlENcDWPKAV8ZSWjy++pPKRVTv3r7hOFjc="
+  },
+  "org/apache/logging/log4j#log4j-bom/2.20.0": {
+   "pom": "sha256-+LtpLpWmt72mAehxAJWOg9AGG38SMlC2gSiUOhlenaE="
+  },
+  "org/apache/logging/log4j#log4j-core/2.20.0": {
+   "jar": "sha256-YTffhIza7Z9NUHb3VRPGyF2oC5U/TnrMo4CYt3B2P1U=",
+   "pom": "sha256-3nGsEAVR9KB3rsrQd70VPnHfeqacMELXZRbMXM4Ice4="
+  },
+  "org/apache/logging/log4j#log4j/2.20.0": {
+   "pom": "sha256-mje0qPZ+jUG8JHNxejAhYz1qPD8xBXnbmtC+PyRlnGk="
+  },
+  "org/apache/maven#maven-model/3.6.3": {
+   "jar": "sha256-F87x9Y4UbvDX2elrO5LZih1v19KzKIulOOj/Hg2RYM8=",
+   "pom": "sha256-fHIOjLA9KFxxzW4zTZyeWWBivdMQ7grRX1xHmpkxVPA="
+  },
+  "org/apache/maven#maven-parent/33": {
+   "pom": "sha256-OFbj/NFpUC1fEv4kUmBOv2x8Al8VZWv6VY6pntKdc+o="
+  },
+  "org/apache/maven#maven/3.6.3": {
+   "pom": "sha256-0thiRepmFJvBTS3XK7uWH5ZN1li4CaBXMlLAZTHu7BY="
+  },
+  "org/codehaus/groovy#groovy-bom/3.0.14": {
+   "pom": "sha256-JODptzjecRjennNWD/0GA0u1zwfKE6fgNFnoi6nRric="
+  },
+  "org/codehaus/groovy/modules/http-builder#http-builder/0.7.1": {
+   "jar": "sha256-F655HdDwm1S3xUlqw+DQKOlxMMZQOTLLB3+dPuOVpEg=",
+   "pom": "sha256-MPA6uhfjkl0XGsRPB26L0lTuw0IhgW0EESO3K+l6Lkk="
+  },
+  "org/codehaus/plexus#plexus-utils/3.5.1": {
+   "jar": "sha256-huAlXUyHnGG0gz7X8TEk6LtnnfR967EnMm59t91JoHs=",
+   "pom": "sha256-lP9o7etIIE0SyZGJx2cWTTqfd4oTctHc4RpBRi5iNvI="
+  },
+  "org/codehaus/plexus#plexus/10": {
+   "pom": "sha256-u6nFIQZLnKEyzpfMHMfrSvwtvjK8iMuHLIjpn2FiMB8="
+  },
+  "org/eclipse/ee4j#project/1.0.6": {
+   "pom": "sha256-Tn2DKdjafc8wd52CQkG+FF8nEIky9aWiTrkHZ3vI1y0="
+  },
+  "org/eclipse/jetty#jetty-bom/9.4.50.v20221201": {
+   "pom": "sha256-TN5uUz1gHq+LZazulWt3BsGBkvJ1XQI9fo0Zu31bOUM="
+  },
+  "org/gradle/toolchains#foojay-resolver/0.7.0": {
+   "jar": "sha256-k2crR0Cg/b+7W68INT24rpqbsl9rEKk8B4EmxxfbOsA=",
+   "module": "sha256-7WdGoJ8yv63bkLApECrmIybiSBKaaLdGYqSkM9VTFLg=",
+   "pom": "sha256-iCa8+5Iq8MIR5BPTmwgWWRPAgwZkE+BzDNgrLgsKie4="
+  },
+  "org/gradle/toolchains/foojay-resolver-convention#org.gradle.toolchains.foojay-resolver-convention.gradle.plugin/0.7.0": {
+   "pom": "sha256-yKRD4vrvh28zijkSM8IKka1bg/acHGuiDTmns5EGJAo="
+  },
+  "org/jdom#jdom2/2.0.6.1": {
+   "jar": "sha256-CyD0XjoP2PDRLNxTFrBndukCsTZdsAEYh2+RdcYPMCw=",
+   "pom": "sha256-VXleEBi4rmR7k3lnz4EKmbCFgsI3TnhzwShzTIyRS/M="
+  },
+  "org/junit#junit-bom/5.7.2": {
+   "module": "sha256-87zrHFndT2mT9DBN/6WAFyuN9lp2zTb6T9ksBXjSitg=",
+   "pom": "sha256-zRSqqGmZH4ICHFhdVw0x/zQry6WLtEIztwGTdxuWSHs="
+  },
+  "org/junit#junit-bom/5.9.1": {
+   "module": "sha256-kCbBZWaQ+hRa117Og2dCEaoSrYkwqRsQfC9c3s4vGxw=",
+   "pom": "sha256-sWPBz8j8H9WLRXoA1YbATEbphtdZBOnKVMA6l9ZbSWw="
+  },
+  "org/ow2#ow2/1.5.1": {
+   "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
+  },
+  "org/ow2/asm#asm-commons/9.4": {
+   "jar": "sha256-DBKKnsPzPJiVknL20WzxQke1CPWJUVdLzb0rVtYyY2Q=",
+   "pom": "sha256-tCyiq8+IEXdqXdwCkPIQbX8xP4LHiw3czVzOTGOjUXk="
+  },
+  "org/ow2/asm#asm-tree/9.4": {
+   "jar": "sha256-xC1HnPJFZqIesgr37q7vToa9tKiGMGz3L0g7ZedbKs8=",
+   "pom": "sha256-x+nvk73YqzYwMs5TgvzGTQAtbFicF1IzI2zSmOUaPBY="
+  },
+  "org/ow2/asm#asm/9.4": {
+   "jar": "sha256-OdDis9xFr2Wgmwl5RXUKlKEm4FLhJPk0aEQ6HQ4V84E=",
+   "pom": "sha256-SDdR5I+y0fQ8Ya06sA/6Rm7cAzPY/C/bWibpXTKYI5Q="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/springframework#spring-framework-bom/5.3.24": {
+   "module": "sha256-GZbh9hfLA/p26hGFD+Kh4gsOMKEEa6bV2zvbv0QRP84=",
+   "pom": "sha256-U1ITVmu77+Jjag1OjdGnOt5hLiQwyP/TENzCo7O5ukE="
+  },
+  "org/vafer#jdependency/2.8.0": {
+   "jar": "sha256-v9LMfhv8eKqDtEwKVL8s3jikOC7CRyivaD2Y3GvngZI=",
+   "pom": "sha256-EBhn8/npJlei74mjELYE1D0JDJuQqj4LBS3NFqO78y0="
+  },
+  "xerces#xercesImpl/2.9.1": {
+   "jar": "sha256-auVAp8hcgUrGS+pIAWs6b0XJXUdl9Uf8wAU9w2yU7Vw=",
+   "pom": "sha256-JGkAdY2p2Jst2FdWn8OceDGDBIFmgdyoK4S54m9Azkc="
+  },
+  "xml-apis#xml-apis/1.3.04": {
+   "jar": "sha256-1ASqiB65xfek+1RuhOoRUGzUF6crWXLojv8X9D+fimQ=",
+   "pom": "sha256-NaH9SdRLQcYW1IypkJejLvorZOGzc5+6xvvzbjw7V7E="
+  },
+  "xml-resolver#xml-resolver/1.2": {
+   "jar": "sha256-R9zeiYYBkxTveK5ygKlJc6IdLtlQdaQKAAtC2pVkKeE=",
+   "pom": "sha256-WB1eF4Pd17XaE2W3eNwS95ZxpDCddCIcT72TWYiYeps="
+  }
+ },
+ "https://repo.maven.apache.org/maven2": {
+  "ch/artecat/grengine#grengine/3.0.2": {
+   "jar": "sha256-vwYoa7L8DR9sh0S4+Dz85Y13U2jMHoeathgL55v2fYE=",
+   "pom": "sha256-Um5mRoK4WHXHqiRhXGVf7oEhLp8g0gyj3FafXhDTBvU="
+  },
+  "ch/qos/logback#logback-classic/1.4.14": {
+   "jar": "sha256-joMvcmPKYGrjbauy2LJML0PYLPY06B2tnRZA+m7jxZY=",
+   "pom": "sha256-r4qrpgYnomL9NllNmgMvUAGnB/BOhL3Jx7IxfR/hPL0="
+  },
+  "ch/qos/logback#logback-core/1.4.14": {
+   "jar": "sha256-+MLwX0JTCxhSc5UHwXkvAIAWeFDtjzlkRMaRPWYXopM=",
+   "pom": "sha256-XFBVktFPZqp/F3xpuTPkcE/R1pS2L5ST6peCbvVQAj0="
+  },
+  "ch/qos/logback#logback-parent/1.4.14": {
+   "pom": "sha256-5bddPe8EJ1dkUEoXp8GqHj7jcKWxpUiIS74Vfr3eXv0="
+  },
+  "ch/randelshofer#fastdoubleparser/0.8.0": {
+   "jar": "sha256-EP4oj9eiza9RdTMrc1Kfmr+P1U3P/zF9aWfAw1/7Ezs=",
+   "pom": "sha256-VWPl3UuwVHWfD4OFFgbZnSQm11wnNygUAnAF6S0cKqo="
+  },
+  "com/amazonaws#aws-java-sdk-batch/1.12.766": {
+   "jar": "sha256-F78YVNCV4Ijg2nQdL0cdl+wTetdLENGIZte7Mj40YKw=",
+   "pom": "sha256-xS6pzV5gFPcfVmn6SMpPiFzCsX2o2tO+lyOru/Bs/SU="
+  },
+  "com/amazonaws#aws-java-sdk-codecommit/1.12.766": {
+   "jar": "sha256-F2twu555Ujshdq73XYEAQbl5ZmORLrnpnyDmoFI7KEk=",
+   "pom": "sha256-4HU/47TiBcCd842OB1VomCi7Ra862ZraEahnSwxwbb0="
+  },
+  "com/amazonaws#aws-java-sdk-core/1.12.129": {
+   "jar": "sha256-gChkMWl8d7H1N5mLBP0kNcDPAJCjyXb+DCvD7cmV2wI=",
+   "pom": "sha256-PMW9SDO/u87EXdoeiD6BhM/4UmPujTt2aufU5igQc1w="
+  },
+  "com/amazonaws#aws-java-sdk-core/1.12.766": {
+   "jar": "sha256-rSOLnwug2Mvyx+xJdnB1LIksEU8fM1upKljjS9AmTMk=",
+   "pom": "sha256-j7FYgg8C9wI668Z2IRWV78acYCGx3FaEHCsvZCSKn/Y="
+  },
+  "com/amazonaws#aws-java-sdk-ec2/1.12.766": {
+   "jar": "sha256-ZBFv+empx4YHb3TkG4c2geIRMssLcTf9xhi086G17xM=",
+   "pom": "sha256-qrFIeGp9TUgi//cube8dCFKiTWO1Gde7Rlo7uB8p7b8="
+  },
+  "com/amazonaws#aws-java-sdk-ecs/1.12.766": {
+   "jar": "sha256-lja6aIkIyjbNA1o7dKwHOn1Ilc6j+SSWxzauHb2oruU=",
+   "pom": "sha256-9uRpdIPzwDd3aACWm0wKLVebhJXr2TMKJkCUCgXSt6I="
+  },
+  "com/amazonaws#aws-java-sdk-iam/1.12.766": {
+   "jar": "sha256-bJJpzEqIf6uEvYEsWmwDspO/PXY7b/fTEmYYtjRo94s=",
+   "pom": "sha256-uQcrkVP9kypjBLUBlPMVrPqNSvzMP5TvFpNPHa4ona8="
+  },
+  "com/amazonaws#aws-java-sdk-kms/1.12.129": {
+   "jar": "sha256-z+r7YwhGLaTr4m6IdKdLlzIaRBsmWoQq0WH3m3qA65o=",
+   "pom": "sha256-bb0LNTZq2L13T+ry0ep977p6ncLi9+I4a4Qs1EZKwX4="
+  },
+  "com/amazonaws#aws-java-sdk-kms/1.12.766": {
+   "jar": "sha256-igmYlAcAWnrjwwQKNZqLkjiT1ptRz/t2VrqFMSe70pY=",
+   "pom": "sha256-4SKxHYfOtJUtv6XMLNbU7QYNtYyT2Z9h99VYH5k+1eo="
+  },
+  "com/amazonaws#aws-java-sdk-logs/1.12.766": {
+   "jar": "sha256-uyXQqG9KZmDRHef1W7ulCHI9LsVNt1uMyobGo0EM0ek=",
+   "pom": "sha256-N6sw/Dg78zKMN4Ay6DW9bpUuJ82b8aRh+SV/zwL+DEs="
+  },
+  "com/amazonaws#aws-java-sdk-pom/1.12.129": {
+   "pom": "sha256-3d6dGQS42rlRwbSD3kIQGSHSj8oXLh46JH7IIi6SI/k="
+  },
+  "com/amazonaws#aws-java-sdk-pom/1.12.766": {
+   "pom": "sha256-wvk+tgX8XHJhG3dcuRf5cx2XaV/DX/r58MIFsnXKNa0="
+  },
+  "com/amazonaws#aws-java-sdk-s3/1.12.129": {
+   "jar": "sha256-RhIFflCWTBkn1vgsC+oBnoQz0ioCDAh0/qLQ/PAEy/E=",
+   "pom": "sha256-LMBKvouM0YvJ957HDYRUf3nZKV2MURyrcvYnRQWLum0="
+  },
+  "com/amazonaws#aws-java-sdk-s3/1.12.766": {
+   "jar": "sha256-PkL46g8NEEwwR10/MURrTCzK5VoHKu2p7eJfHqOw3xE=",
+   "pom": "sha256-aK/gwadp+KEYcF+NNqMEd16iGDoO80693AtOqjevy7A="
+  },
+  "com/amazonaws#aws-java-sdk-ses/1.12.766": {
+   "jar": "sha256-PSrkiYZ3habMCBpJzbYrUT3Xbjtpto7gxBDeGaGsZck=",
+   "pom": "sha256-1iHw8iFdRZYS4GIqtcY5KbBTLV8PPMQv97QJYxCBOEc="
+  },
+  "com/amazonaws#aws-java-sdk-sts/1.12.766": {
+   "jar": "sha256-oO7KbW8o5cft/r0oFobYcVUIQNQEnZVXGw6rEQlykPI=",
+   "pom": "sha256-sQSM4ZY/xmz4oSX/GMGgibjp0fPs5pPkRBVeJ4xeRPk="
+  },
+  "com/amazonaws#jmespath-java/1.12.129": {
+   "jar": "sha256-3g9Jjsdmj49Vs7W0BLCl66n3rVAx1u+IUlhXcaUfwI8=",
+   "pom": "sha256-Xnm4EyIb4wuEQ/lzIJDC4lhIGbSeVqhFXalgRMVTuOU="
+  },
+  "com/amazonaws#jmespath-java/1.12.766": {
+   "jar": "sha256-0A2gbcxfOCaHkbggSjs+1kz9j7UN7rvJPO2WKliIbMs=",
+   "pom": "sha256-ubu2Z/dwerV2rPSkqr0LbRjyfz9z0OJ2k31t5GCfHxE="
+  },
+  "com/azure#azure-client-sdk-parent/1.7.0": {
+   "pom": "sha256-wefnVlRCMD/1TD6GNXTreh9pIR2EX6Q1/thCgxNL0Uo="
+  },
+  "com/azure#azure-compute-batch/1.0.0-beta.2": {
+   "jar": "sha256-CQZNwcpPaclferr2YMEZokFibqaxF7rXMJYWF/8XH1g=",
+   "pom": "sha256-r6eMiunlnpEsamWFkshKzcydbGJnnE4apvr6XlKSFXE="
+  },
+  "com/azure#azure-core-http-netty/1.15.1": {
+   "jar": "sha256-4HACg1NkxnqSZ/0BnuEBncnqhlSRtrHU+bjIgJ/Buuc=",
+   "pom": "sha256-TgEbfCTrrciGEuyWa/DymFEE0OZKKlMnDl68OXKg4P4="
+  },
+  "com/azure#azure-core/1.49.1": {
+   "jar": "sha256-QgHYKyJ4IdENQG01PuHZdmTman9pJH1FTkyLcNp1OsY=",
+   "pom": "sha256-vEBXQbRgrabKwjC9DEPOH6L+jRjiUgAJHn/m+BkZiC4="
+  },
+  "com/azure#azure-identity/1.11.3": {
+   "jar": "sha256-NAhaWYJi6IqmJY13jTuEy+iTTrL4nrQILW9GFLSHdys=",
+   "pom": "sha256-uIRH+CM3ObxvOpCmW/K0iT0vu4glN2Ih9SR08F0uero="
+  },
+  "com/azure#azure-json/1.1.0": {
+   "jar": "sha256-EUr5sUWcnJMZCyqC9CfA6T+7soiW/FfyWFqbghJ1ylY=",
+   "pom": "sha256-r0x8HbDY0wxNUMlc04fLhD0aFl8Rw5a+vQlks5MjhAA="
+  },
+  "com/azure#azure-sdk-parent/1.6.0": {
+   "pom": "sha256-mDP57zl7whd1s4m+gWtWpomRiCIKJa0qQ4mwk2UDnJY="
+  },
+  "com/azure#azure-storage-blob/12.26.1": {
+   "jar": "sha256-k0W8riyacns7zitxX6pITKoPMZWqy8lXej3QVawc3h4=",
+   "pom": "sha256-Wr8eREEdeJoxt30wn8Ydssrv2DDuwBqQoAfwwgj9lhM="
+  },
+  "com/azure#azure-storage-common/12.25.1": {
+   "jar": "sha256-6XvwhWFyZEStcVkXeSkylcjV2L2dXPJxj2zpSRMRfkI=",
+   "pom": "sha256-7RARpdl8nsjhK+GUQ9wfvupMs0GQS4ujWjsLfDnvplY="
+  },
+  "com/azure#azure-storage-internal-avro/12.11.1": {
+   "jar": "sha256-9mhikjq89fZS08LKBp67zvuyRMp054v3NLlriTMIdjE=",
+   "pom": "sha256-yk7+M3vfdHVChlu3P1canMBEdZC4gug8I173nOPTOmQ="
+  },
+  "com/azure#azure-xml/1.0.0": {
+   "jar": "sha256-Q4uQ62+O+njgbv2hMuzXWStvtFHMcRC98gKqF9FqPac=",
+   "pom": "sha256-gbHQs1PRMgnSgAFqyiw90RjFZB9I6QtBZ4rC3dmL5DQ="
+  },
+  "com/beust#jcommander/1.35": {
+   "jar": "sha256-AZwS/sHOXALLq7FQ9qyKhtkqDsyciaVJ5VNyg+hjAAw=",
+   "pom": "sha256-PO4bOtiorcEiTl3UO/XdpjzdBUA/8zlTDSal/cj2djc="
+  },
+  "com/esotericsoftware/kryo#kryo/2.24.0": {
+   "jar": "sha256-flazLGNQWPmqKCD4iRmrcC0CnLzRUoXamZLjbMCuUvI=",
+   "pom": "sha256-H3LlOjNreSBg0D/fl9vK4POWOn0PgsFQe6uLOc+HsBk="
+  },
+  "com/fasterxml#oss-parent/38": {
+   "pom": "sha256-yD+PRd/cqNC2s2YcYLP4R4D2cbEuBvka1dHBodH5Zug="
+  },
+  "com/fasterxml#oss-parent/41": {
+   "pom": "sha256-r2UPpN1AC8V2kyC87wjtk4E/NJyr6CE9RprK+72UXYo="
+  },
+  "com/fasterxml#oss-parent/43": {
+   "pom": "sha256-5VhcwcNwebLjgXqJl5RXNvFYgxhE1Z0OTTpFsnYR+SY="
+  },
+  "com/fasterxml#oss-parent/45": {
+   "pom": "sha256-8AXsCuN62UoNBg2Lo7eeZllRD7tepeRkw1jZHDPDwXs="
+  },
+  "com/fasterxml#oss-parent/50": {
+   "pom": "sha256-9dpV3XuI+xcMRoAdF3dKZS+y9FgftbHQpfyGqhgrhXc="
+  },
+  "com/fasterxml#oss-parent/58": {
+   "pom": "sha256-VnDmrBxN3MnUE8+HmXpdou+qTSq+Q5Njr57xAqCgnkA="
+  },
+  "com/fasterxml/jackson#jackson-base/2.12.3": {
+   "pom": "sha256-akozb3kyLR9Q5XDa48U1QaOAc57Ypq1Ww+YJsyGSu1c="
+  },
+  "com/fasterxml/jackson#jackson-base/2.12.6": {
+   "pom": "sha256-cZmfWXUi5fUOtBR07iy+K5mRZRki7ooJDgC4dC3oyaY="
+  },
+  "com/fasterxml/jackson#jackson-base/2.12.7": {
+   "pom": "sha256-F55U/ibI1N/pJf7jHUqH0cwl+LfgCUik5laxIp4rdq4="
+  },
+  "com/fasterxml/jackson#jackson-base/2.13.3": {
+   "pom": "sha256-ctZykYdsY+GJa8fY/3mQM9OkuQKQIBEEiK+clzFe2Tk="
+  },
+  "com/fasterxml/jackson#jackson-base/2.13.5": {
+   "pom": "sha256-8uQSGN1QuSzkmDxdLAQgndYc0eAPwSXjYAqp6vRQHeo="
+  },
+  "com/fasterxml/jackson#jackson-base/2.15.0": {
+   "pom": "sha256-UkKWvt4yGFrBEBLwfZJG44wZJTwrUT8c8oeZEho053A="
+  },
+  "com/fasterxml/jackson#jackson-base/2.17.1": {
+   "pom": "sha256-4K78YdOPzd2VX/7sAbt1EE8bv/+jpuy1jb50r7cV4yI="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.12.3": {
+   "pom": "sha256-UFExBQ2LXUqBTyfzK8Q5GHsauGPWWH1JbrpMuozA4Co="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.12.6": {
+   "pom": "sha256-E2EHjtiug+qn6GDRZDiSSf83Qszf7yXKMySN/WLlU0I="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.12.7": {
+   "pom": "sha256-GVVDL22K8ygG2C2CGP7f5L47s+I9WadNgUSf/HS/e9E="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.13.3": {
+   "pom": "sha256-32dbg7bKunYC+0fXXUu1E8KvTAphVdfjl8DsDzQRLHU="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.13.5": {
+   "pom": "sha256-Cia280q5P5z6gBeYiMa/Ql8cF9zZwR22VhOTkw/bdGo="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.15.0": {
+   "pom": "sha256-4AwuhiKc2Wh5RpGukO7hWwjE1PV0jJs0u0ItcTRG3ZU="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.17.1": {
+   "pom": "sha256-n0RhIo4SkQPu16MC3BABqy5Mgt086pFcKn27jMYe/SU="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.12": {
+   "pom": "sha256-YqocFnmt4J8XPb8bbDLTXFXnWAAjj9XkjxOqQzfAh1s="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.13": {
+   "pom": "sha256-K7qJl4Fyrx7/y00UPQmSGj8wgspNzxIrHe2Yv1WyrVc="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.15": {
+   "pom": "sha256-bN+XvGbzifY+NoUNL1UtEhZoj45aWHJ9P2qY7fhnXN4="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.17": {
+   "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.12.3": {
+   "jar": "sha256-BdoKJbtEoheICimaGh4KMB0ZS1ZWqaB3drd6iPMm5+k=",
+   "module": "sha256-adbNxIKRVdrTyRUAq8rO/+97F+HiuxdeOmkBqMpQicc=",
+   "pom": "sha256-i4EAksOztjfQTbb53LnEQNymAfwoLSWGzTdR6PkYjuI="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.12.7": {
+   "jar": "sha256-PKzvcUqJ89aLafoRJjr6VaaqL97x//k97SLKoWtUaHw=",
+   "module": "sha256-udQUijW0OBPvz4AbJj7+jpyvHXWfbT6c/xIXrUs0uRQ=",
+   "pom": "sha256-u7b3aEXxQjrbJwnPw2M4OlKR/Blf407OEoYn/j9Z/dA="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.13.5": {
+   "jar": "sha256-gK6o7XIy21BAztSz+YLynalbs9gCND2/b9gszZjCHE8=",
+   "module": "sha256-V1RHbNv+Hc5wH/QUQ7FHQSL+5TEHgMnRbEoK/vlzvZQ=",
+   "pom": "sha256-RtVrd+RUf6R9Iq5EvJXgww76KFW56qsZ9TSfv+TAZMo="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.15.0": {
+   "jar": "sha256-ka3NPc9f2aFkmZNOdTaiPUVmkqAJPj1P1S8TjDk2NIw=",
+   "module": "sha256-vxVVouS7PyPbOR/EyN/GFX7GTow3ZYgUSiYPVBst4a4=",
+   "pom": "sha256-L4FZtEIZb6qg4TdOLSI0tX/uwysnYX+h1/XZqOC+Nyg="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.17.1": {
+   "jar": "sha256-/MrYLhMXLA5DhNtxV3IZybhjHAgg9LGNqqVwFvtmHHY=",
+   "module": "sha256-VNTVHaATppa+CeH0gDH39At3cYB4qpNuZMAjpP2blZM=",
+   "pom": "sha256-c1XzdEX12vUPUMdfLrzXG6LE+86ktiVBSAWexjVkTnc="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.12.3": {
+   "jar": "sha256-uu80+84EHVTzrz/0/JF+2LQ+0qb6MOCmq/2aKyw/ceA=",
+   "module": "sha256-pPykmRpxVhYcCjR3J0Y15QweIcwIo4WtTAimr2wrM4Q=",
+   "pom": "sha256-9DB/oy7KXJLxvk6lNWvLWxlxGNrzUyUBQpL7YmHeNs4="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.12.6": {
+   "module": "sha256-shNzadZQAawxsaxCO2KZrJ+EqTpNaAU9XABZfNezyTU=",
+   "pom": "sha256-PYtkMW44Q53m4PFBMebX1Y106STwPTE7PNgpKpZqoBA="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.12.7": {
+   "jar": "sha256-OYemozUEbiJuVrgdaWaPtakbFV6n/ZawhRrbt9SsHKY=",
+   "module": "sha256-B0jdOm9PbdgkSwkZ8RQPWw9oQm8LCkq2n7z1au+XnKw=",
+   "pom": "sha256-hmQUWI/gqPtzQbqph/b+4FZxuYWeKMMstjvFKfQqY6k="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.13.3": {
+   "jar": "sha256-qxGajqPMaUcuvA6HC4Sb+75TatV9YT3DhFPM1ZLKaj0=",
+   "module": "sha256-7KKsTR1nron0PmOQ/Ly/FjP9jDoaSWjZMhTr5YJfYeM=",
+   "pom": "sha256-PTyORDm/LbQ3YKYSB9/JV62ZpZt1LMhHaZC0neAM3vw="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.13.5": {
+   "jar": "sha256-SPNqAlMR0EZK2N2kUSogx54nmpVQ9j8xedcx2USCR0s=",
+   "module": "sha256-YmbmBIr3l7vrRuWx8bmjgyONWSjUD/ExgZkEUgGsMtk=",
+   "pom": "sha256-rZGrYCXrSK4yYigMQu/rtXtw0lwAqwppxaPHyjqAeO4="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.15.0": {
+   "jar": "sha256-W0g/aPqd1qo32jfR953VxLlGQjj08GYKJCy2tccklQw=",
+   "module": "sha256-7h0Go46NRNgaLmpvVLfYZK5LL/cQ3fWKK9+4kfJxc4E=",
+   "pom": "sha256-Cjr13zbx8n4XZEgXpiQJuqJYZKNJOj0ogK1wCbDnA64="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.17.1": {
+   "jar": "sha256-3bJsih8ahFNeghPEizWyUzcENOMoezzxV3eFb8TljOY=",
+   "module": "sha256-iowJZP38Js7bso2CXfRiGBf7jNIrnnpZ2cdKOl8b3R0=",
+   "pom": "sha256-2UiDEgmgTAE5G5Oq7nrTShyelIY/nnaFwvW2FJoqs50="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.12.3": {
+   "jar": "sha256-lNlzBiwv2j3/LJqF6vzlcgSCHM6QhamTd2k9vJ+42iM=",
+   "module": "sha256-XUGfgFCnfmlIcaUGX118rIqG3mNIIvlZGMU+usrVn20=",
+   "pom": "sha256-2v+kjFvS56C/fjUrsBzGbbrp8zEfQr+i2TJM+3VYt24="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.12.7.1": {
+   "module": "sha256-00wrIwGY2LLTmirRRxDWySJxwHhIxDKkDh1HFZSiKaY=",
+   "pom": "sha256-BXeRSYclRKUn7oo4VYqRcJeVMvSAb0/jz4k6EHaKj7I="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.12.7.2": {
+   "jar": "sha256-17Kqko+i4nWUYJzS6MMjBAtzgS6IRK+fgqYwvEdI0UE=",
+   "module": "sha256-X4qn4nRIcMkFvc3zuELR2Eigbf8WVpfDTZkgU6wW/KA=",
+   "pom": "sha256-rp52wD2JPdYCziKQsyxiGq2N7fuohLXUN2gN0dTYw5Y="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.13.5": {
+   "jar": "sha256-X+2ySyNWSRgV0YJn9l2poh3WdBM0Wtd5XyIa+iXHiYQ=",
+   "module": "sha256-HQzgnWo05MaImApbbjp/xKrhFFid9Eqa7Jf2ERrYXfI=",
+   "pom": "sha256-rhoE1XeQ6usGKh+iIGOraM7JCgMLc94tiasFIfJGVr4="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.15.0": {
+   "jar": "sha256-AMWl1a5xrI6NW42mBoQeIlHIBjVZOctdUcTNxrZEoNw=",
+   "module": "sha256-oahCNG/envxI3bk4tE8e7r1EaGj1zXAxMmZToTLAb4M=",
+   "pom": "sha256-jDgNP+PcwpjQKHmKH5Lfwxgk/aBBFEryNi8fzzDueI8="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.17.1": {
+   "jar": "sha256-tsovfVsaskXOxUlewzl3PS2QVUxIWSWQZz+xj0QAqUg=",
+   "module": "sha256-C6vGRqBi8NnTWEQCpQJxiE7cPhekGULB4x4OENcdvuY=",
+   "pom": "sha256-YKCKmGrDE60+MmiKTjJ6YSg6ioAa1vphV5+MS+bcj2w="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-cbor/2.12.3": {
+   "jar": "sha256-MUjUrO0/SLAovcMvtjs4RRpqdxaRjHYof5wOUi/AXc0=",
+   "module": "sha256-ALNtzmtZv62AjCeEo4fSsaaCV+94mBdYdCGxvpeSgFw=",
+   "pom": "sha256-Ub5jSLkUMCP1YMbygzzYJmNhfnw8k1J1JPOmkhyLafE="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-cbor/2.12.6": {
+   "module": "sha256-SpqXn3cK9t1UvLPABXJAFXERtfp+L7J99tfYBWBW0Go=",
+   "pom": "sha256-ha9YnMuV1fQ1t/O5iVv07lyi6ZXfsyq/R2encs0cmrI="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-cbor/2.12.7": {
+   "jar": "sha256-FNFmKcc6wVMJ2ylhU5SKxQgrJzW4H4XNv/vXGKOLucw=",
+   "module": "sha256-O6o3lB9Cm7QTtyIFRtqD+1kNoYQCLuH6b2INukBSogo=",
+   "pom": "sha256-CtKwpN8bXVY3UrcncYNb/YAOV3tiQ9xPKtEEuZgpR0Y="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-xml/2.13.5": {
+   "jar": "sha256-V2ap1UOpsuFjcR3lC6ewgxJe4k7ZIJR9L+G1+hdgj00=",
+   "module": "sha256-jc9kVq6Dx0S8m11j3+oxOtJEKHyoXhtQ99q+/WKhrbU=",
+   "pom": "sha256-wTNipB0iiQycW+DOahGguBFP8uqd9UXtfCmgnUyytBA="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.15.0": {
+   "jar": "sha256-aRoKYF3hXqYQGAMXMxlX/m9+kfRUce5Fy/mDLXQpHDE=",
+   "module": "sha256-z4AcQvZmQMI/nrPlAwQ+EmW4zSzprJfQx8eKRqYd4rI=",
+   "pom": "sha256-OZFsgO7zTEIpeuLynhsBGVxtLr3Ycy+5H1u8vMZEReI="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.17.1": {
+   "jar": "sha256-g/OEWVk7wQyusfomU2FoE7F0O2vtZxY8iujlpNMqVFY=",
+   "module": "sha256-ZqzfpBLUKx6hSKK2aMxot11oT53nmfQ2ucsDNKCVgUw=",
+   "pom": "sha256-rao4VC33yRqfUlmdv2CLM3GHn5V0f6Ytn8+E6p4Qz5o="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-binary/2.12.3": {
+   "pom": "sha256-7upA7Zns28Zx4VP8Q7O+lRi6A6TwFCHNKiZir5fyhFE="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-binary/2.12.6": {
+   "pom": "sha256-uAAxuMuWG3O1yzWnxyD19gRMLsUn/fw0HnE8/KGZfAg="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-binary/2.12.7": {
+   "pom": "sha256-JJvc26/70Soi2Om1Ms/J46zJtyYDJbHDw+WY5n02gCA="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.15.0": {
+   "pom": "sha256-gSCm1xgjiInHQlDqUjfpdFKrv7YDRzluM4+ReZVKxyY="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.17.1": {
+   "pom": "sha256-BIg/YsynqSsV2XvXb8zePjCCwY7LBJSUOyILrioLhys="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.13.5": {
+   "jar": "sha256-7xXO3d3FjfvWhra3/QhT7TKP8Ixii9SjlXNL7CDKhXs=",
+   "module": "sha256-xO6k314TZO0p8BDUoDffcWWydfDAIdkfb1q9isD5IKc=",
+   "pom": "sha256-niBiIkjdUnZ/9vd4Z5BdfmVSNEPm4ALmuAvDmoVHE54="
+  },
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.13.5": {
+   "pom": "sha256-hg2LWRRPDSDOqtPIBztQbEKkrkjrpPu7El6fc+dj4fs="
+  },
+  "com/fasterxml/woodstox#woodstox-core/6.4.0": {
+   "jar": "sha256-1uufL0AEmnqAi68R/7oHN2SOYv9S/eknHYCOXVeicnk=",
+   "pom": "sha256-YoFIIdsM2+xEwe1ZF+b2ZFLRzI3YmVYYeCdf19UiDnk="
+  },
+  "com/github/javaparser#javaparser-core/3.25.8": {
+   "jar": "sha256-OsLEKiNMHuQ6VbwikRk03dU3u6eJMSZdBy7TTCKwbZY=",
+   "pom": "sha256-ZRsNqsBbjKdFWa1Clt3OTV2Bs7PVZUdGRHkQshn98VM="
+  },
+  "com/github/javaparser#javaparser-core/3.26.1": {
+   "jar": "sha256-Z4Gv6Ce1H24dK0sBcXd/5vFNxWveFdfLti2IF2xLeV8=",
+   "pom": "sha256-zX+Uc0Bz/Ds1IOwRFsqS/jooHsfMGHUAJcTu7iu+OLA="
+  },
+  "com/github/javaparser#javaparser-parent/3.25.8": {
+   "pom": "sha256-GCe9gajuRIAfZInUHzUEuzXA70ZdsYysmVZ+A40eYes="
+  },
+  "com/github/javaparser#javaparser-parent/3.26.1": {
+   "pom": "sha256-9cwLLUUycDokUwpeSvfFS07/ohpqbLO773F6M6pioVo="
+  },
+  "com/github/stephenc/jcip#jcip-annotations/1.0-1": {
+   "jar": "sha256-T8z/g4Kq/FiZYsTtsmL2qlleNPHhHmEFfRxqluj8cyM=",
+   "pom": "sha256-aMKlqm6PNFdDCT5StbngGQuk1aUhXApZtNfTNkcgjLs="
+  },
+  "com/github/zafarkhaja#java-semver/0.10.2": {
+   "jar": "sha256-qOMuF1ddAYjB8+Lle7ldsJeTiDyIU/3oKLY+yx+Zpjo=",
+   "pom": "sha256-fwBf8/kA6GlV9aU0tamqjqVLtdYLtgrCN1lVCjZnaDU="
+  },
+  "com/google/android#annotations/4.1.1.4": {
+   "jar": "sha256-unNOHoTAnWFa9qCdMwNLTwRC+Hct7BIO+zdthqVlrhU=",
+   "pom": "sha256-5LtUdTw2onoOXXAVSlA0/t2P6sQoIpUDS/1IPWx6rng="
+  },
+  "com/google/api#api-common/2.19.0": {
+   "jar": "sha256-41xEttmwW84SRrvCqd8f60z7lqvWhDWro9E6YrJt0+0=",
+   "pom": "sha256-ODqOaljR+o6A47FvGFnikApXJe/L7udSrz+f+gyRPPQ="
+  },
+  "com/google/api#gapic-generator-java-pom-parent/2.28.0": {
+   "pom": "sha256-h5ZzCFWQ3Jkr3b55K1H/Uh+IpdcFM9/0kmwRZhfndB8="
+  },
+  "com/google/api#gax-bom/2.16.0": {
+   "pom": "sha256-ZB7oExWRLww+CFR+uoidNclsxQMNTB4NY8+E3roTAvU="
+  },
+  "com/google/api#gax-bom/2.18.2": {
+   "pom": "sha256-r2AyOcudIAnDrhXGF7T+44zl2TOi4ms4pCnJWwaoxis="
+  },
+  "com/google/api#gax-grpc/2.36.0": {
+   "jar": "sha256-MIk+PHzR5yWvlUHKgeTXdcUOjJM1uKEwT+m7TKBtaow=",
+   "pom": "sha256-GpgNJUUdYpXn1bfMAyYUCZpqoKBW5ZMzqtzXYD035dc="
+  },
+  "com/google/api#gax-httpjson/2.36.0": {
+   "jar": "sha256-WDOX3+1kiM+XzqirclKHoYDdZxNif76BGUrRK4I37a4=",
+   "pom": "sha256-sAOCCcAYvB1IJG74nd48MxpLNZOic6sF08UgWr1wiNg="
+  },
+  "com/google/api#gax-parent/2.36.0": {
+   "pom": "sha256-aatj69gK0uP+pA0zjLZLG6xIV20HOnkaPtPCThtNqf4="
+  },
+  "com/google/api#gax/2.36.0": {
+   "jar": "sha256-Qggv2wWbZWcY3L/NUK+YB+OAyM/cp7G2WQcP76S2hp0=",
+   "pom": "sha256-TsCcg3Vh0UD7RUAqDOk63ewydTT45CvCvDZ/UgiCRT4="
+  },
+  "com/google/api-client#google-api-client-bom/1.34.0": {
+   "pom": "sha256-gNGNvJ+qZmPEow0Du5brxNOpOcEVzLK8YZBP5oRtnTc="
+  },
+  "com/google/api-client#google-api-client-bom/1.35.1": {
+   "pom": "sha256-DKmnRNffswL62MCX/JA86xochDPsj/s/rbv5jHBku8o="
+  },
+  "com/google/api-client#google-api-client-parent/1.31.5": {
+   "pom": "sha256-P4Vy+wW2Z6eIaP/ezo3FBwPyxNeq2/vcPWRPL52SuhE="
+  },
+  "com/google/api-client#google-api-client-parent/1.35.1": {
+   "pom": "sha256-vet2hSU6vrByAiil5wI/EWgB2Q6pe+rmuO1luHT1FOc="
+  },
+  "com/google/api-client#google-api-client/1.31.5": {
+   "pom": "sha256-ohJXbClVH+/hccZNKTUuziHSuo3wwjelqtcMJ6lvDPo="
+  },
+  "com/google/api-client#google-api-client/1.35.1": {
+   "jar": "sha256-JHFK3QwCSHMKDnBUSLvJGlxo28Dcn3+gyXNmvHsnXiM=",
+   "pom": "sha256-tAXEfdfjXC9whUD/0v3jV3MuKqwsRgAQmDSK+WJRHtQ="
+  },
+  "com/google/api/grpc#grpc-google-common-protos/2.27.0": {
+   "jar": "sha256-q55IuMXaJg2lk5/V1H+UZ/t7vBqu1kmbaHsouFhkxW4=",
+   "pom": "sha256-O49slfJdD84wux4Mq0Ze2BlMwZW9nEWT59rPbsSsF5E="
+  },
+  "com/google/api/grpc#grpc-google-iam-v1/1.22.0": {
+   "jar": "sha256-FxAzS2VdIlWLJOY8lSt4n6mq67YXOIoIIflwdYChxq0=",
+   "pom": "sha256-ROalgBy39MxifjUuiyy+QTODJujqllkQXfSdy9turMA="
+  },
+  "com/google/api/grpc#proto-google-cloud-batch-v1/0.29.0": {
+   "jar": "sha256-ebNU1wYqlTrCePDSRUauntgR2HtZttGo+DgjuajByGs=",
+   "pom": "sha256-2I6/vji0IjPLcYJ3BEjWhLfJ411haCtNQQ/MDdyky0M="
+  },
+  "com/google/api/grpc#proto-google-cloud-batch-v1alpha/0.29.0": {
+   "jar": "sha256-8QxjZ0oGT82z3pfo7eUdxNWQqQHtW5kOUhD7T/gtXV4=",
+   "pom": "sha256-t4rrn68elvTjIEgYo0XqQjXwYS2D2opc0BMB/RcdQl4="
+  },
+  "com/google/api/grpc#proto-google-cloud-logging-v2/0.97.0": {
+   "jar": "sha256-txPG6Eq4tlt+r4NaF9C5g2MpRORrSpUBhRlYOKmFYAI=",
+   "pom": "sha256-tBGry/UY49mkQnDTncyoSmJVaeuCAjWkxO3v3WZJkDo="
+  },
+  "com/google/api/grpc#proto-google-common-protos/2.27.0": {
+   "jar": "sha256-S4y6+sn8nJDky5QN6GdspsgppoCCae4NLIWflDWSleg=",
+   "pom": "sha256-xknM8ar9+wc7ie5U7OIFdhWz4t+hyC7Ew/F5WcLIHIY="
+  },
+  "com/google/api/grpc#proto-google-iam-v1/1.22.0": {
+   "jar": "sha256-cG9Ypt/CBXJt0X//4cWBpEASUwEBUsCcn/+kll2/9gs=",
+   "pom": "sha256-5rSJv1KgMtmn6IhTmjvRoQjveCb7inViRnCG00IQrp0="
+  },
+  "com/google/apis#google-api-services-lifesciences/v2beta-rev20210527-1.31.5": {
+   "jar": "sha256-07JM/uqlousFv0zdzoVBHykptAgJZPtAY0tZQT+2inM=",
+   "pom": "sha256-zmT15UQnpPTDP1VC0g6LtTvDJ94r59HAjNQXMNgYPaE="
+  },
+  "com/google/apis#google-api-services-storage/v1-rev20220705-1.32.1": {
+   "jar": "sha256-UURs8Dc/Ga/BsHud118lTfypF6SDPfs7rGGyytVMNAA=",
+   "pom": "sha256-hRinzzDnHywiidPr1imxKWgA0GO80h1d6On506BO2vA="
+  },
+  "com/google/auth#google-auth-library-bom/1.20.0": {
+   "pom": "sha256-Un6FdQkASvKKQrOJk4h5DVyc0GnYo9h/RDrosMidUMo="
+  },
+  "com/google/auth#google-auth-library-bom/1.6.0": {
+   "pom": "sha256-3/SPlJaUr5S1iR6ZwtJQFrvPmNnMLp9a5k2FRNt8Agw="
+  },
+  "com/google/auth#google-auth-library-bom/1.7.0": {
+   "pom": "sha256-mGXnVfY6Furi9ZifhaC4CPtJ0mrY14l3y5MJ5+01C2M="
+  },
+  "com/google/auth#google-auth-library-credentials/0.18.0": {
+   "pom": "sha256-1uOsTj5a239g0iiwxBPH0ROJOL2uLJ8Ny+63qwWFRtw="
+  },
+  "com/google/auth#google-auth-library-credentials/1.20.0": {
+   "jar": "sha256-swVNh1eAf4r4AVtTX7KI7WdFZESSIhHw+Sn0wE5psLc=",
+   "pom": "sha256-IxVpUaNPq0mdBfG11MxaH1jfQIQsipGSQTl067L6rjI="
+  },
+  "com/google/auth#google-auth-library-oauth2-http/0.18.0": {
+   "pom": "sha256-aA5St0/ipZqbzIrKBgVJwnARHyjgQ/5NcmOf2ZEJsSk="
+  },
+  "com/google/auth#google-auth-library-oauth2-http/1.20.0": {
+   "jar": "sha256-qz7nTuzLEvykD0REr01F354pDyw/R1HoVWl97fUvenM=",
+   "pom": "sha256-BTiQjFiJ8NQDkiQDc36KQRO/8Gqry92uF756QaZQpAo="
+  },
+  "com/google/auth#google-auth-library-parent/0.18.0": {
+   "pom": "sha256-k27cyiHscyCtyJ4MWLxP6hIvapxUo9Ks8zBOuxY0c6M="
+  },
+  "com/google/auth#google-auth-library-parent/1.20.0": {
+   "pom": "sha256-UAY9yTe0V6AVHd2d6VWN6LmSmMkJ4b7PIJpj7vynDac="
+  },
+  "com/google/auto/value#auto-value-annotations/1.10.4": {
+   "jar": "sha256-4cRea+ra75eXyw2a/VpFYhrQYc2GMgEvhVgoU6OIeCU=",
+   "pom": "sha256-c6W4UV+F+IxAiff/SkPNF5Wkgf2rk/qQULE8+hqNJfc="
+  },
+  "com/google/auto/value#auto-value-annotations/1.6.6": {
+   "pom": "sha256-fFq7v2pJx8Qme+A2RAowcdCqNwrxQIJ1yB42FEyP/AM="
+  },
+  "com/google/auto/value#auto-value-parent/1.10.4": {
+   "pom": "sha256-vsOhnk3ci2QGZyMzzFBbngy2s1WLskIxSGm7bh1ojTA="
+  },
+  "com/google/auto/value#auto-value-parent/1.6.6": {
+   "pom": "sha256-6CnzniFqfhjpocYftjqO2KanIpvEqgwEKhClMCSQlD4="
+  },
+  "com/google/cloud#first-party-dependencies/2.13.0": {
+   "pom": "sha256-nB52x1eaPypjdPz0vlEpbyGzt1BwMwmv+294tE2gxeE="
+  },
+  "com/google/cloud#google-cloud-batch/0.29.0": {
+   "jar": "sha256-9WOhEhZgH7kdddK8OxAI23xrgzyjbZV8Cdjkk3XV9dg=",
+   "pom": "sha256-6gM7H2dln6VW51GDlItsGSgm/iTDCUIAqNJpHigiSLk="
+  },
+  "com/google/cloud#google-cloud-core-bom/2.8.0": {
+   "pom": "sha256-0pSClODskgLMKPg0EJI4NfjkO9aQbiaId2ucfDFS1aE="
+  },
+  "com/google/cloud#google-cloud-core-grpc/2.6.0": {
+   "jar": "sha256-k9ks7mEwpSgzFCra+TCjCf7xmEvydORL3qDHl3/i6Cw=",
+   "pom": "sha256-CccR+kIkEDDI6QYj2s4/qFGxV0H6COyw0MuXKH+ABRs="
+  },
+  "com/google/cloud#google-cloud-core-http/2.8.0": {
+   "jar": "sha256-4ILfXafvo2Dgw4nqPx1+Kdu1B3ydEnnBhK0FrOcTT7o=",
+   "pom": "sha256-hho0yWWEsocdqxd9jB6FAME0fSbJ2OGYsLxcFCe6LDM="
+  },
+  "com/google/cloud#google-cloud-core-parent/2.6.0": {
+   "pom": "sha256-WgWI1WVv8sgFtjAVGbQXq6DiCwO1vZYpK78xtBa2sCM="
+  },
+  "com/google/cloud#google-cloud-core-parent/2.8.0": {
+   "pom": "sha256-rM3e/8uuRwQE7Kw/7HVF3UombVsCi96gXXILpIPB4Gs="
+  },
+  "com/google/cloud#google-cloud-core/2.6.0": {
+   "pom": "sha256-+4ThumRLM54AH97ml+TQX0Ag06LAMK2ZsH3q0o+bwHA="
+  },
+  "com/google/cloud#google-cloud-core/2.8.0": {
+   "jar": "sha256-OYayK0nZFiEC5/Lk8pnfEIv28o6hzgY+NfM6tghjzbQ=",
+   "pom": "sha256-NPQso7VDVBY1xcDnR5gr7TTRsJgb7zkk4gxDDs7vkJU="
+  },
+  "com/google/cloud#google-cloud-logging/3.8.0": {
+   "jar": "sha256-eauSWxuKzTl9uGQPHoE8CNRTj8lTKTREQWVY7yO+sts=",
+   "pom": "sha256-Lsw/jIzS1dDVTep2PkIMQ/FmiwumEEiu4US+kNQSObM="
+  },
+  "com/google/cloud#google-cloud-nio-parent/0.124.8": {
+   "pom": "sha256-rC/p26d3pZK1UhbnTOouDUgiTlEsRMFHnhdyyZdtHzo="
+  },
+  "com/google/cloud#google-cloud-nio/0.124.8": {
+   "jar": "sha256-uxtshcFif5fUSGHZR8NRIfA8Y9SQ9PwMLOG68K9QDHY=",
+   "pom": "sha256-9SHkEQR3vfTyLiUn4rycAWEWFdtnmNpt69ojbn0JQ18="
+  },
+  "com/google/cloud#google-cloud-shared-config/1.3.2": {
+   "pom": "sha256-d062OMvm8NbWQNau3dE8WcZROHIhSre6gEgzrxxY0I8="
+  },
+  "com/google/cloud#google-cloud-shared-config/1.5.0": {
+   "pom": "sha256-M7okd43AbDxH3XPYFS/B2nv8ClXHgXw3j566X/y7OTI="
+  },
+  "com/google/cloud#google-cloud-shared-config/1.5.1": {
+   "pom": "sha256-ZGKcKLfQLRBlutTKZ3UiP6rFpuVXbSuAZeWyvZ7daI8="
+  },
+  "com/google/cloud#google-cloud-shared-config/1.6.0": {
+   "pom": "sha256-P+482RNWJC5ggjxaVVReUrjmV5YPQuxgGhQfURtZPcM="
+  },
+  "com/google/cloud#google-cloud-shared-dependencies/2.13.0": {
+   "pom": "sha256-YiBBDWubno4HyicrTLm1t146tl+Ra/SezQxduC6sLIE="
+  },
+  "com/google/cloud#google-cloud-storage/2.9.3": {
+   "jar": "sha256-1EtTaLH1mvO2AtLXDD4gmQW0dovErTEGdlLzPxk2hAM=",
+   "pom": "sha256-o9UYW6GHjGzZM2g6JEZ6PSSz8W9CkemjEtMX1HZdeL4="
+  },
+  "com/google/cloud#third-party-dependencies/2.13.0": {
+   "pom": "sha256-uPtfVA8hAIRcsngkgMy7FR+h4D8BO0fY0yEDzyftLuI="
+  },
+  "com/google/code/findbugs#jsr305/3.0.2": {
+   "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
+   "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
+  },
+  "com/google/code/gson#gson-parent/2.10.1": {
+   "pom": "sha256-QkjgiCQmxhUYI4XWCGw+8yYudplXGJ4pMGKAuFSCuDM="
+  },
+  "com/google/code/gson#gson/2.10.1": {
+   "jar": "sha256-QkHBSncnw0/uplB+yAExij1KkPBw5FJWgQefuU7kxZM=",
+   "pom": "sha256-0rEVY09cCF20ucn/wmWOieIx/b++IkISGhzZXU2Ujdc="
+  },
+  "com/google/errorprone#error_prone_annotations/2.22.0": {
+   "jar": "sha256-gqAnuGVB9Y0fnuAgzfa+voKsx6Jn08U6LqXNYzWTK70=",
+   "pom": "sha256-tyXFIVFBaOnCDTcZp2qgG1DlpygoWfTqhMJRz5+EIIA="
+  },
+  "com/google/errorprone#error_prone_annotations/2.23.0": {
+   "jar": "sha256-7G858Gi2/5rDI8aOKLkpn4wKgMpRLcyx1KcPQKw+wFQ=",
+   "pom": "sha256-1auxfyMbY78Ak1j6ZAKBt0SBDLlYflmUl3g0lZwH29g="
+  },
+  "com/google/errorprone#error_prone_parent/2.22.0": {
+   "pom": "sha256-XSUivqg99aWBzNayJ2Nco04NOXt2ct50ispBVwgFc8c="
+  },
+  "com/google/errorprone#error_prone_parent/2.23.0": {
+   "pom": "sha256-9UcKSzEE/jCfvpSoDRbDxU0g90j0xd5PaKQoaI8wy9Q="
+  },
+  "com/google/guava#failureaccess/1.0.1": {
+   "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
+   "pom": "sha256-6WBCznj+y6DaK+lkUilHyHtAopG1/TzWcqQ0kkEDxLk="
+  },
+  "com/google/guava#failureaccess/1.0.2": {
+   "jar": "sha256-io+Bz5s1nj9t+mkaHndphcBh7y8iPJssgHU+G0WOgGQ=",
+   "pom": "sha256-GevG9L207bs9B7bumU+Ea1TvKVWCqbVjRxn/qfMdA7I="
+  },
+  "com/google/guava#guava-bom/31.1-jre": {
+   "pom": "sha256-oRnYiA5WquiLFvM8gFLk1uZJoi4Xjzkd7zsvsfShKeY="
+  },
+  "com/google/guava#guava-parent/26.0-android": {
+   "pom": "sha256-+GmKtGypls6InBr8jKTyXrisawNNyJjUWDdCNgAWzAQ="
+  },
+  "com/google/guava#guava-parent/28.1-android": {
+   "pom": "sha256-+K/LQ/0kw7YibkCL25zsVpFzcVpMLIAXPMrt2E4VGJE="
+  },
+  "com/google/guava#guava-parent/32.1.2-jre": {
+   "pom": "sha256-iOnLAHM1q1/bMUpuPJh3NOwjCMmgY/90fHRpGJ0Kkr8="
+  },
+  "com/google/guava#guava-parent/33.0.0-jre": {
+   "pom": "sha256-BAzIjGgLQT1wup/INxs2CTAhsQmWqjWYYh3nZ9QYIpo="
+  },
+  "com/google/guava#guava/28.1-android": {
+   "pom": "sha256-AZa+urqiZWDxCO6xBNYph62L6mB9mxPto/Aoa3ZdbqY="
+  },
+  "com/google/guava#guava/32.1.2-jre": {
+   "jar": "sha256-vGXep8/Z5NrPhBnYrw50FlWFfSeIW7NdlD1xh/w6j84=",
+   "module": "sha256-5Azwhc7QWrGPnJTnx7wZfhzbaVvJOa/DRKskwUFNbH4=",
+   "pom": "sha256-PyCFltceCDmyU6SQr0mjbvf9tFG+kKQqsd+els/TFmA="
+  },
+  "com/google/guava#guava/33.0.0-jre": {
+   "jar": "sha256-9NhcPk1BFpQzfLhzq+oJskK2ZLsBMyC+YQUyfEWZFTc=",
+   "module": "sha256-WaLb0FXRuqdi548aW6Orlz7dE/wn3MGHEQXi95f2gtM=",
+   "pom": "sha256-/XCxTEQZhsIubSLO0ldnh3Vr5JGLFFqKvSI+OoC24y0="
+  },
+  "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+   "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
+   "pom": "sha256-GNSx2yYVPU5VB5zh92ux/gXNuGLvmVSojLzE/zi4Z5s="
+  },
+  "com/google/http-client#google-http-client-apache-v2/1.42.0": {
+   "jar": "sha256-H8SWQja2fPPFZR16wd/2aPc7eBDH8dwIYqDlvAFgh4U=",
+   "pom": "sha256-3v1ITpfzPeHmMvSDRDYnQHbUKyvSbb6D5Ep4X+3pO9c="
+  },
+  "com/google/http-client#google-http-client-appengine/1.42.0": {
+   "jar": "sha256-dlkcCMLrAkQy3Kv4HTP0QPv1yLC25aE3Z8cDTQtcios=",
+   "pom": "sha256-ZP7RbImFSRGvQWiYTyHtpU1LBskNMkLWxtBJtfBYee4="
+  },
+  "com/google/http-client#google-http-client-bom/1.32.1": {
+   "pom": "sha256-1XrIp95S0zwXNLvcveJrOkjVHmLCyTJsTVTLmxR+H0M="
+  },
+  "com/google/http-client#google-http-client-bom/1.39.2": {
+   "pom": "sha256-l/nYCnyC3uSbVE5IiJAzbgz2oZ3EU/EcG9aFm8qVags="
+  },
+  "com/google/http-client#google-http-client-bom/1.41.7": {
+   "pom": "sha256-oWdHl+UGkrxuzMF7MYQ/QNSWfYVGqwDUr+LAGOHm/hY="
+  },
+  "com/google/http-client#google-http-client-bom/1.42.0": {
+   "pom": "sha256-mP9hZSXmP9BhMiFZAVOOI/9nrtuJNM0l3FkkjwzAU4w="
+  },
+  "com/google/http-client#google-http-client-bom/1.43.3": {
+   "pom": "sha256-K9C6F9zatcBDtHXQR3XKphHUINxWEIsY402T0nmwJrk="
+  },
+  "com/google/http-client#google-http-client-gson/1.43.3": {
+   "jar": "sha256-4xpO3LnIOVSiWH4U+i8/j0qtVhUjgbMyGjvQvK4D+iY=",
+   "pom": "sha256-KyAU+fZJiplSKUvW9zyLUfd5ZqXs7RICm/09tnarcPk="
+  },
+  "com/google/http-client#google-http-client-jackson2/1.32.1": {
+   "pom": "sha256-f+FwIDjrVANkfdf3UrmMU+RF+laF5l7CzNc+0dQpf7s="
+  },
+  "com/google/http-client#google-http-client-jackson2/1.42.0": {
+   "jar": "sha256-MG0sVsR1ATU05k7TutAyAToHggrqHyP+3oaFUr2xgHE=",
+   "pom": "sha256-kEXZ+CMJtcalvNgoLv70vkZzWlzPv/LDkEbjnc9txaI="
+  },
+  "com/google/http-client#google-http-client-parent/1.32.1": {
+   "pom": "sha256-bkiHJ8hJaA5YUwJ9GfWbt1wi3iNLvawX2BVd8MdrQDE="
+  },
+  "com/google/http-client#google-http-client-parent/1.42.0": {
+   "pom": "sha256-MHiW91y5Uj6NSrEEz9C2KnJPZrnH5+7rHCq5mmTcnrE="
+  },
+  "com/google/http-client#google-http-client-parent/1.43.3": {
+   "pom": "sha256-G0vu3GfcwIIWSwAe7KbFEpgHs4GYav1Gcv5tnRaMZRs="
+  },
+  "com/google/http-client#google-http-client/1.32.1": {
+   "pom": "sha256-/jwHLLG0NCqLzFipZXM9gEN+g1HY6CnFnb7xl/dUaWM="
+  },
+  "com/google/http-client#google-http-client/1.43.3": {
+   "jar": "sha256-YKynQoxaH/NlW3BUGpj/PXDd7UisEyTa4a858bYZFK8=",
+   "pom": "sha256-VPdTPbvnaReXxiMmHufiYVmoLyTMIFCRdWsiafK1Les="
+  },
+  "com/google/j2objc#j2objc-annotations/2.8": {
+   "jar": "sha256-8CqV+hpele2z7YWf0Pt99wnRIaNSkO/4t03OKrf01u0=",
+   "pom": "sha256-N/h3mLGDhRE8kYv6nhJ2/lBzXvj6hJtYAMUZ1U2/Efg="
+  },
+  "com/google/oauth-client#google-oauth-client-bom/1.31.5": {
+   "pom": "sha256-i6oAEB5PZY0BZHd1mET6uGERMg+HP8BOVPKGQSb7ir8="
+  },
+  "com/google/oauth-client#google-oauth-client-bom/1.34.1": {
+   "pom": "sha256-6WOBq0Zz9W3gDWxbRwwnsjFuZ4wr/8IK6ozfMqcuIT4="
+  },
+  "com/google/oauth-client#google-oauth-client-parent/1.34.1": {
+   "pom": "sha256-N4sHWGVenWD93gjaiF0Vg4BAvL34ivrXrtEK8Ve0QD8="
+  },
+  "com/google/oauth-client#google-oauth-client/1.34.1": {
+   "jar": "sha256-GT7fl676KLk8WJK9xZi6w0+kw5ZYgDAITykLFEDouYo=",
+   "pom": "sha256-yF9HUepssOHsTxEwM89Odhw6vabX9BDJ1qQmpUWrgps="
+  },
+  "com/google/protobuf#protobuf-bom/3.19.4": {
+   "pom": "sha256-boApzAR0/BegHP6eIRZ6CjPLlYB96JNEfTZ9nkKYxNs="
+  },
+  "com/google/protobuf#protobuf-bom/3.21.1": {
+   "pom": "sha256-30nEvQKDTGO3FFDtP6srw7o91wSopML0Iele5GN/vhs="
+  },
+  "com/google/protobuf#protobuf-bom/3.24.4": {
+   "pom": "sha256-BOz9UsUN8Hp1VR+bCeDvMGMO5CN9CRyg7KceW/t4zOU="
+  },
+  "com/google/protobuf#protobuf-java-util/3.24.4": {
+   "jar": "sha256-EzySniz+OZChBdGOrMxJEistL7SStCDvAtXZ+Tfq67g=",
+   "pom": "sha256-nwzsJ21NnVpD1uKcwrAk5GgEyThqlvpSfu/Xv3SI5/A="
+  },
+  "com/google/protobuf#protobuf-java/3.24.4": {
+   "jar": "sha256-5WVVIr4apcwfLwkqoDawRFFX8pSSju3xMyrJOMe2loY=",
+   "pom": "sha256-OUEiHKZXgZ3evZX+i3QPRwr3q/MEYLE+ocmrefEPq5E="
+  },
+  "com/google/protobuf#protobuf-parent/3.24.4": {
+   "pom": "sha256-+37AUFh2/bnseVEKztLR6wTDuM/GkLWJBJdXypgcrbM="
+  },
+  "com/google/re2j#re2j/1.7": {
+   "jar": "sha256-T2V69Rq4uwkJvMPrQIYtJhJa+MvPkqqrpZX+13+Ue8A=",
+   "pom": "sha256-i7C3rpQfVyzEnH0DFdpHf89wHFkZPJalqP4tWcCVepo="
+  },
+  "com/googlecode/javaewah#JavaEWAH/1.2.3": {
+   "jar": "sha256-1lImlJcTxMYaeE9BxRFn57Axb5N2Q5jrup5DNrPZVMI=",
+   "pom": "sha256-5O1sZpYgNm+ZOSBln+CsfLyD11PbwNwOseUplzr5byM="
+  },
+  "com/microsoft/azure#msal4j-persistence-extension/1.2.0": {
+   "jar": "sha256-aNg3QZ702HCO07jIgdb8Isnt+BZ/TnAYtiG8od/XUyo=",
+   "pom": "sha256-gvbJWI44ai2Iq3QatIydFTlAVvgAkDyLdS3KLhmXkSU="
+  },
+  "com/microsoft/azure#msal4j/1.14.0": {
+   "jar": "sha256-cFz2SozIymo1knx885sYRMMJc1Zz295kkQbdYpX6vJo=",
+   "pom": "sha256-a3yVLlVmJtvTU1QveVElq0JRhgu7fi0i/MGx7c+EJA4="
+  },
+  "com/nimbusds#content-type/2.2": {
+   "jar": "sha256-cw8YFhlhReiCdQk8FH8ubaPD5UEges01A6GwYSm5vqk=",
+   "pom": "sha256-iznCFjD7tvBIqAflfjy/c17zDaPxHnAZ5muqa5fa8Gs="
+  },
+  "com/nimbusds#lang-tag/1.7": {
+   "jar": "sha256-6MHFlOJCW9vqLYYN5Vxptp/F1ZRURSRJoPCRPCpbijE=",
+   "pom": "sha256-gksNfeeCer/GpH5u+UsP+qE4/vOK8IxWon9dOhUiEZ4="
+  },
+  "com/nimbusds#nimbus-jose-jwt/9.30.2": {
+   "jar": "sha256-HF89lM09d9YXb4VPHHjrZYz7g++APw2lT7R59WFJce8=",
+   "pom": "sha256-wI/3srHtdUZS3KQqwWyaPGqG8bj2gKY92nDx636/2fQ="
+  },
+  "com/nimbusds#oauth2-oidc-sdk/10.7.1": {
+   "jar": "sha256-8DsrqKUBzIfhuQcQbbsuU7wrfP+DUtC6gmi2NvhVXdo=",
+   "pom": "sha256-uUig3Af6U7rd3OrxtihjiWzIpihNLBAh/AJ8/3mmMI8="
+  },
+  "com/squareup/moshi#moshi-adapters/1.14.0": {
+   "jar": "sha256-EjBlt/85bpGrB2BdO1Y5bNefn8353GG+bGCh3THxOJE=",
+   "module": "sha256-/Rerzmxk6sa84O0Pewz73c70vgoCVDTMzXEkGp1rrKk=",
+   "pom": "sha256-nPIpkpEiYaOKN42V6aQjzgpwGQ4zXeNDG+4zMckgU3M="
+  },
+  "com/squareup/moshi#moshi/1.14.0": {
+   "jar": "sha256-NDmywhrErNJQNAMIVKa9B9igN/Lgn5jLE3CJCMhOmxU=",
+   "module": "sha256-EDSH3k437tkI0WFzGltAIxtmJlszFED1EXdiNzO2mKk=",
+   "pom": "sha256-ne0k5l4oIEH/pbMYK/5kqEtzUcS5s3gLzDwpALRNaiA="
+  },
+  "com/squareup/okio#okio/2.10.0": {
+   "jar": "sha256-on8JHTSqRS43In4s+oWAnykBKo7yUBqbWhJal45Py8E=",
+   "module": "sha256-EcvqvDp2XJqAMkL6ICShGFPrCGXaU2xLBa/c27I0Y3A=",
+   "pom": "sha256-S5YGC20aK5bpDkKtcVitvjRpMWuA/qCBfGwzmT7hzHI="
+  },
+  "com/sun/activation#all/1.2.0": {
+   "pom": "sha256-HYUY46x1MqEE5Pe+d97zfJguUwcjxr2z1ncIzOKwwsQ="
+  },
+  "com/sun/mail#all/1.4.7": {
+   "pom": "sha256-WWVyZBVPF2+UWc9Fwk0H9Olm8sXpxRCtoS1lTHxbxU4="
+  },
+  "com/thoughtworks/qdox#qdox/1.12.1": {
+   "jar": "sha256-IfuiL4MOkmjwfPSrLZnoGBq73LDLke4CKOs8uRjc3R0=",
+   "pom": "sha256-xSpmFtBO+zDJ7eq57oKwWR5NBNOOAwv4HiUHdlUtIV0="
+  },
+  "commons-codec#commons-codec/1.10": {
+   "jar": "sha256-QkHfqU5xHUNfKaRgSj4t5cSqPBZeI70Ga+b8H8QwlWk=",
+   "pom": "sha256-vbjbcBLREqbj6o/bfFELMA2Z7/CBnSfd26nEM5fqTPs="
+  },
+  "commons-codec#commons-codec/1.15": {
+   "jar": "sha256-s+n21jp5AQm/DQVmEfvtHPaQVYJt7+uYlKcTadJG7WM=",
+   "pom": "sha256-yG7hmKNaNxVIeGD0Gcv2Qufk2ehxR3eUfb5qTjogq1g="
+  },
+  "commons-codec#commons-codec/1.16.0": {
+   "jar": "sha256-VllfsgsLhbyR0NUD2tULt/G5r8Du1d/6bLslkpAASE0=",
+   "pom": "sha256-bLWVeBnfOTlW/TEaOgw/XuwevEm6Wy0J8/ROYWf6PnQ="
+  },
+  "commons-codec#commons-codec/1.16.1": {
+   "jar": "sha256-7Ie/tV8iy9GyHiGQ7toosrMS7SpDHuSfvcwBgS0EpeQ=",
+   "pom": "sha256-uCbd2S+dfMZDcaAvoIMMFU1nyYNw6lSi0ZbnLrWQrSg="
+  },
+  "commons-codec#commons-codec/1.17.0": {
+   "jar": "sha256-9wDegKwnDQNE/ep0aCAdi5yAXlxkgzHDYZ8u4GfM/Fk=",
+   "pom": "sha256-wBxM2l5Aj0HtHYPkoKFwz1OAG2M4q6SfD5BHhrwSFPw="
+  },
+  "commons-codec#commons-codec/1.17.1": {
+   "jar": "sha256-+fbLED8t3DyZqdgK2irnvwaFER/Wv/zLcgM9HaTm/yM=",
+   "pom": "sha256-f6DbTYFQ2vkylYuK6onuJKu00Y4jFqXeU1J4/BMVEqA="
+  },
+  "commons-io#commons-io/2.11.0": {
+   "jar": "sha256-lhsvbYfbrMXVSr9Fq3puJJX4m3VZiWLYxyPOqbwhCQg=",
+   "pom": "sha256-LgFv1+MkS18sIKytg02TqkeQSG7h5FZGQTYaPoMe71k="
+  },
+  "commons-io#commons-io/2.15.1": {
+   "jar": "sha256-pYrxLuG2jP0uuwwnyu8WTwhDgaAOyBpIzCdf1+pU4VQ=",
+   "pom": "sha256-Fxoa+CtnWetXQLO4gJrKgBE96vEVMDby9ERZAd/T+R0="
+  },
+  "commons-lang#commons-lang/2.6": {
+   "jar": "sha256-UPEbCfh3wpTVbyRGP0fSj5Kc9QRPZIZhwPDPuumi9Jw=",
+   "pom": "sha256-7Xa4iRwwtWYonHQ2Vvik1DWYaYJDjUDFZ8YmIzJH5xE="
+  },
+  "commons-logging#commons-logging/1.1.3": {
+   "pom": "sha256-MlCsOsa9YO0GMfXNAzUDKymT1j5AWmrgVV0np+SGWEk="
+  },
+  "commons-logging#commons-logging/1.2": {
+   "jar": "sha256-2t3qHqC+D1aXirMAa4rJKDSv7vvZt+TmMW/KV98PpjY=",
+   "pom": "sha256-yRq1qlcNhvb9B8wVjsa8LFAIBAKXLukXn+JBAHOfuyA="
+  },
+  "dev/failsafe#failsafe/3.1.0": {
+   "jar": "sha256-/mJlpoO4Zux1Buq2lMZ1nW0jomQXJiEmLHTvWj0rIWA=",
+   "pom": "sha256-OxdELqAXFh31AS2sAMFjHpMMm96kU30EbvBgx/uJpOE="
+  },
+  "io/airlift#airbase/77": {
+   "pom": "sha256-ZXcwMrJ5toeFOqstKYhS2A+hoMdZu1A+ZpDFBWRJR0k="
+  },
+  "io/grpc#grpc-alts/1.58.0": {
+   "jar": "sha256-0QiRK2RmwWoVvLYuNBikXtPJuqjTSo5Yc4SvhMUtCUg=",
+   "pom": "sha256-KgRI+cA86RY02uja1fnJc6JmJXMDGjmhTKwZCTyqghI="
+  },
+  "io/grpc#grpc-api/1.58.0": {
+   "jar": "sha256-1ojSX09TOXnfL80IgeHjDCko5bZU/wm/FECSMoKw2UU=",
+   "pom": "sha256-YqRSk7jq7MGOHIVsza8Ep/dzTFWVOyVaRV3hlFyuaHA="
+  },
+  "io/grpc#grpc-auth/1.58.0": {
+   "jar": "sha256-XfsDgny2Hd3m3eF5kYjmYHF2TSYVlDKfGcm2jocPxjo=",
+   "pom": "sha256-6WP6fWudGBhBtjx9KfeMivTX+2ylAwYpb68+mq0yTWI="
+  },
+  "io/grpc#grpc-bom/1.45.1": {
+   "pom": "sha256-fIkCauO5HRCtbPBVAu7W58lIW7SusiqpLi1MKJe9HEI="
+  },
+  "io/grpc#grpc-bom/1.47.0": {
+   "pom": "sha256-R0Qp79u61ToB1rcWq4loAn3N5wV6+3Yzp8q/oFHc02k="
+  },
+  "io/grpc#grpc-bom/1.58.0": {
+   "pom": "sha256-n17rMjZvLueDNdmVVfbeQbDBAMAPI5p4bO5quTS9tg8="
+  },
+  "io/grpc#grpc-context/1.58.0": {
+   "jar": "sha256-OnYm0TCElYvN6rWUEuTshz8HyDFf8lENNjhW+sf63FE=",
+   "pom": "sha256-isDIMAqJciEYV0LvXcQ5PZv7ZD3tr63B3vCt9NebHiE="
+  },
+  "io/grpc#grpc-core/1.58.0": {
+   "jar": "sha256-k8iICCTuEkuRwx8PEFL4Y3JxnW7ObkvhxZG31txjn18=",
+   "pom": "sha256-Sck1NqvqLYdBnF3zrWYWsW8tJe8jCOTrQCmkpmr+aSk="
+  },
+  "io/grpc#grpc-googleapis/1.58.0": {
+   "jar": "sha256-12ysnK/8WRrUyMUmN32IEFe1OOvTjNFfS+bfqVhc64g=",
+   "pom": "sha256-g12F75i8szY6ipIq8nC6kk+on0f2hY1e6mzt1b+wFJs="
+  },
+  "io/grpc#grpc-grpclb/1.58.0": {
+   "jar": "sha256-orxFVUUcWMH7DTrUnpuXlju3Maq3pxDvqn1bySwirlM=",
+   "pom": "sha256-Qj+2HRr9CpaVJ3mA1i0/3AAl1PbgmCeJbdxuuPqSAJo="
+  },
+  "io/grpc#grpc-inprocess/1.58.0": {
+   "jar": "sha256-V0hkuEshLyEaRfZ8PKPd+t5lVlT6dqF6tqbyc7iABCU=",
+   "pom": "sha256-z6mcK/VSori/C4uZMMm2IspIL3gTuAxijKaSNt0qaQE="
+  },
+  "io/grpc#grpc-netty-shaded/1.58.0": {
+   "jar": "sha256-EvyEebikPvYpVcRSpP2mPEfCDW14/ZkPmzpqfAn8CXc=",
+   "pom": "sha256-evbM2J0elTac/88M2r+AFeEkNNZmbQi+myso/3jeovA="
+  },
+  "io/grpc#grpc-protobuf-lite/1.58.0": {
+   "jar": "sha256-9dKj9gFiDbA29y1RveShn5Oax2GAWOV0P7NZnneJkuc=",
+   "pom": "sha256-OpP0sfjgizXM30vFEKk9P6jwvk64VeefNP2d1jJcSnI="
+  },
+  "io/grpc#grpc-protobuf/1.58.0": {
+   "jar": "sha256-d/FndJktWALP7vep0As6P5qC0yTOHKt/hMbxoN9aOcM=",
+   "pom": "sha256-A4i2LJCVZuG1J/J+bToO5+v8aCw3nAlmnK8nO6xu+S4="
+  },
+  "io/grpc#grpc-services/1.58.0": {
+   "jar": "sha256-XYxV+ib5F1wOrInCr6n1DdM9j2CIUf7ZQ+QdR6YnsjE=",
+   "pom": "sha256-F773fOlrisZLKUUs116Ns32+2rFqe4ZbpIH/YMo8azU="
+  },
+  "io/grpc#grpc-stub/1.58.0": {
+   "jar": "sha256-Gve7xWvnsRMcEyK6GDEm3QUDBvkRKBk/S5vV6nGsjIg=",
+   "pom": "sha256-mVBfRvn0NFDion1VCARh0gJnCJ12OUhTcI54tdbDAGk="
+  },
+  "io/grpc#grpc-util/1.58.0": {
+   "jar": "sha256-nomZ2YUj+5dcejFr1SRnFXbBxjixsf01c0C7kL4Utds=",
+   "pom": "sha256-vAboS0gQjpEfdI0crO2Xti3g2YRPkdbfEpEjgtCUlyE="
+  },
+  "io/grpc#grpc-xds/1.58.0": {
+   "jar": "sha256-5Z4rTetvrOydNgg9D1+fvvOISdSOCw6sa8Idb/6C2J4=",
+   "pom": "sha256-iXMqZzQn9O9up+fE0tvgZNnx5MiL8NWvIqaV14qUhbo="
+  },
+  "io/netty#netty-buffer/4.1.110.Final": {
+   "jar": "sha256-RtdOeRJarMBVwx8YFS/cXUpWmqjWAJEgPQuqgzlzrDw=",
+   "pom": "sha256-cQrBnMAc2A32vpo/qtPCIrShoy9LVRN74HtgmdXaNWI="
+  },
+  "io/netty#netty-buffer/4.1.111.Final": {
+   "jar": "sha256-fZS2Cfs2r9iDBMc5IkEdCPOD95RaqIK1mhUhm17L+3Y=",
+   "pom": "sha256-avx+dR4KkNLLEWj2pIVNgL87qIgQSvqzAyM80xaE9LQ="
+  },
+  "io/netty#netty-codec-dns/4.1.109.Final": {
+   "jar": "sha256-pnqEwKRglIFeIESsExTY2BCJ0hnsjoxzL5oSukzUUb0=",
+   "pom": "sha256-pKx7ZGqBAZfmiBT3MAuFGoqinCV0RyHMpeQ1gMn1qmE="
+  },
+  "io/netty#netty-codec-http/4.1.110.Final": {
+   "jar": "sha256-3A1q9QVGMKcP8O81TyCqem5Gc4yfxWNu09T+d+OL1I0=",
+   "pom": "sha256-Ua6ZCvFKMh2209aIS5F7fUNj62Dd3A8Uk7GAIaFC560="
+  },
+  "io/netty#netty-codec-http/4.1.111.Final": {
+   "jar": "sha256-v1DCEsrsh2u2+6hbdPGEgtoteCTdB2bxgpyp+TqgGlI=",
+   "pom": "sha256-gDcuPm5huos6vmI5ZMmGN2VotrvscFrbKdKpWc17n4w="
+  },
+  "io/netty#netty-codec-http2/4.1.110.Final": {
+   "jar": "sha256-tUbHVEWkh7t7zVqUd5yuzOM1gs974xuLOfwOZbHuJvw=",
+   "pom": "sha256-KdL2wmw8yp/oOTZxcH/o75w+MQIKLf4GuCxCZJnCWDc="
+  },
+  "io/netty#netty-codec-http2/4.1.111.Final": {
+   "jar": "sha256-qeubBicEH0iR3pKqiWSZrjNM32B9ug3N+v01FqfQ7Mo=",
+   "pom": "sha256-x/AyWqTHXJ6uHjiDBtx9EEJsaipsj3Evh29YpLwVft4="
+  },
+  "io/netty#netty-codec-socks/4.1.110.Final": {
+   "jar": "sha256-l2BSo8m7KAvG2Z86KeZARnfPlYw94FsgUJPTjABriAw=",
+   "pom": "sha256-/+V7MWGR3U+WvuZsVwnBPL207KsIXAEMjbDGqoCav2w="
+  },
+  "io/netty#netty-codec/4.1.110.Final": {
+   "jar": "sha256-nszOmo2Ce7jOhPnDGD/sWL0clqUQEM9xEpd0YDSvNwE=",
+   "pom": "sha256-qAa7U2uzI2Zbr/fNEiPysnKi1HF6tPmxI2EIbarl3z4="
+  },
+  "io/netty#netty-codec/4.1.111.Final": {
+   "jar": "sha256-pjrHE/YOwLjiu4GCZl0hZmLR9HSHLsXDaNJfFfVE9Lw=",
+   "pom": "sha256-bHMiRpMuE1Z6M8Liuf1KpR1zKvuqdxN8UmCoR+PQo38="
+  },
+  "io/netty#netty-common/4.1.110.Final": {
+   "jar": "sha256-mFHsZlSLng1BFkzpiUPN1LvjBfaN29JOrlLkUBoNexo=",
+   "pom": "sha256-fUF/UzUwTa4eoIoGWGA4yD/orYTB01uqFe0RkhzveSA="
+  },
+  "io/netty#netty-common/4.1.111.Final": {
+   "jar": "sha256-muEumon1nOJPsjOFH92T48Lfrrn6AsYGJ81n+nVhhx0=",
+   "pom": "sha256-uceDN2Fr+NVNVRW6tsuh3y20b9sBtBJDTMf7r+eDRcU="
+  },
+  "io/netty#netty-handler-proxy/4.1.110.Final": {
+   "jar": "sha256-rVSrT+nEfvPnI9cSURJttT6NtUOHGtuer8lERlOe/1I=",
+   "pom": "sha256-xhPLTn4G9C76MduNiyoznti/QfAMRtONCQmkwGxlbc8="
+  },
+  "io/netty#netty-handler/4.1.110.Final": {
+   "jar": "sha256-1aCNfeNkkS5ChZaN5NTM4/AdpLsEjVxpN+Xyrx+OFIo=",
+   "pom": "sha256-TUPBPRT1Y1oviw1QlNejHFCe4PUsck66DvMM/+PqFVU="
+  },
+  "io/netty#netty-handler/4.1.111.Final": {
+   "jar": "sha256-GgNGcsomyL5iRcjoZBspeF7SwBhhe7Ldfge+Offqcfw=",
+   "pom": "sha256-9XXURvpc1Ua+T84LvzTBRAQXYbidp3lx4wv4PUKQXRs="
+  },
+  "io/netty#netty-parent/4.1.109.Final": {
+   "pom": "sha256-yzNkxyqg7R/zy6mLRI4ozQ7xFh7adk0QBpO2h5Y652Q="
+  },
+  "io/netty#netty-parent/4.1.110.Final": {
+   "pom": "sha256-aFra83Nmb8FUJ8gQ+K/zpP4ZSpfH7XS2nQfFSPDULxw="
+  },
+  "io/netty#netty-parent/4.1.111.Final": {
+   "pom": "sha256-lrBVrnr38eMts9cmGRjZAPuhXh5YnM1oL5z9V0QkmlE="
+  },
+  "io/netty#netty-resolver-dns-classes-macos/4.1.109.Final": {
+   "jar": "sha256-yisxxot4hCiOgGV3xtoR01i2vYivGGq9koyASPsXs2k=",
+   "pom": "sha256-yWBaR/ZGSRURVFmy+GuYlnksjyec6o8saQKYQeKjv6g="
+  },
+  "io/netty#netty-resolver-dns-native-macos/4.1.109.Final": {
+   "pom": "sha256-T6RpDUwC4/uf7QyGcu3qIxNWLeelrBetdMLymdrOsis="
+  },
+  "io/netty#netty-resolver-dns-native-macos/4.1.109.Final/osx-x86_64": {
+   "jar": "sha256-ozFCDSrfVodMW5DLrKjXs5cGzSR7fioUjfNlYUTrJpM="
+  },
+  "io/netty#netty-resolver-dns/4.1.109.Final": {
+   "jar": "sha256-fjVKhfgUd0SuudPh5krOGPZDKiXAn4veVzg5WahCyWc=",
+   "pom": "sha256-I6CzSuEZbi+FsWMW9Qy4qPPCMdpH7ocRpmKzg5Nvb0E="
+  },
+  "io/netty#netty-resolver/4.1.110.Final": {
+   "jar": "sha256-oum0rnyqkvxb10fhHR3sINgbGPwAlZVUMCJErFxWznA=",
+   "pom": "sha256-ZV80GS6MdhizxaeeSI5NqjXe9BsNFtRfo2Ujw7TJ9kE="
+  },
+  "io/netty#netty-resolver/4.1.111.Final": {
+   "jar": "sha256-eOc1dG0fmMqJeTF2NZyXrVu2OT7GPNKWLzDbQ74JDhs=",
+   "pom": "sha256-11JAU0WdQlycu7+T8Hk1BMTQFIx1+0naqz4U1OTTjvA="
+  },
+  "io/netty#netty-tcnative-boringssl-static/2.0.65.Final": {
+   "jar": "sha256-u4NJvaO6BDwJ9ccyxbLUfxisTa/OJIy4UM+9BZnlugE=",
+   "pom": "sha256-uonxFajDC9vLbbo2hJoEfagDtJbz6FbkNl1T3xQDky0="
+  },
+  "io/netty#netty-tcnative-classes/2.0.65.Final": {
+   "jar": "sha256-hO8CQa2htO2SeF4QwW7b6wYzSJWaOw73QHErrdCfoSg=",
+   "pom": "sha256-Vckic4c3c+lUvHjpJnvPGIr5Mz9Idi2GKMm9mawVy2Q="
+  },
+  "io/netty#netty-tcnative-parent/2.0.65.Final": {
+   "pom": "sha256-KqThVEhalgFdM81wRayS86Znkbt3uQVAMLoupdmufeY="
+  },
+  "io/netty#netty-transport-classes-epoll/4.1.110.Final": {
+   "jar": "sha256-jlnOxn3jufiv5OzOwR7YzkQjlI7q9MpRK/aTJAUu1RA=",
+   "pom": "sha256-4tQXVD7zF/+pGTigAf5e481xyTwBT70zcDdNAPHnAZU="
+  },
+  "io/netty#netty-transport-classes-epoll/4.1.111.Final": {
+   "jar": "sha256-0jDRaA0VF8fXsuJe9qmofCLrvPJkoNqOgHc08Vt8fK4=",
+   "pom": "sha256-S2Dz1R7m1+WtWC5bAbSLfemiOu1SHjiHmoWGJVlk5E8="
+  },
+  "io/netty#netty-transport-classes-kqueue/4.1.110.Final": {
+   "jar": "sha256-uOt/4coCxgS4mE3HvDGFdgQ915V1hGqkvyLgPblTywI=",
+   "pom": "sha256-AMiktbOP9sYE441c3VqEEu9XI3EBZKRpHtHlXsgPuE0="
+  },
+  "io/netty#netty-transport-native-epoll/4.1.110.Final": {
+   "pom": "sha256-4AycaYcLeTT0hsptCXc3YR/acQjnj36i8HiMeCfRHR8="
+  },
+  "io/netty#netty-transport-native-epoll/4.1.110.Final/linux-x86_64": {
+   "jar": "sha256-3NYMazB2rzB6uHcgGhNuHxBmyb6Amq7YJzkaI5CfkTU="
+  },
+  "io/netty#netty-transport-native-kqueue/4.1.110.Final": {
+   "pom": "sha256-cVl3ZunJCOUKwXKhlO5bt3Kiziau3howy5n6UcC0qYc="
+  },
+  "io/netty#netty-transport-native-kqueue/4.1.110.Final/osx-x86_64": {
+   "jar": "sha256-pRcvVXMO47dnAAy5vwih7Gco/PwX6KSgV/6YNzcJkNA="
+  },
+  "io/netty#netty-transport-native-unix-common/4.1.110.Final": {
+   "jar": "sha256-UXF7t0cRQZUDkMZxOkSf2xBU0H5gc37n3acIN5bN7kg=",
+   "pom": "sha256-6hjOBMmpesDFH045exhSKf2VmX6QsRM5rc98UZRtU9g="
+  },
+  "io/netty#netty-transport-native-unix-common/4.1.111.Final": {
+   "jar": "sha256-7EvUV07h7HdqGxQTn7aZgt339QOagDCCB0qB9mBOytI=",
+   "pom": "sha256-LqcKGGSrOPzsK9woxp7pdW261YpGJsZkVU08hg1UCYE="
+  },
+  "io/netty#netty-transport/4.1.110.Final": {
+   "jar": "sha256-pC3Wg5DKFLT/LUBiiglsdkhbStt8GWAtUokyGgZp5wQ=",
+   "pom": "sha256-MPXaDnZG8YQNYy+IYVyLnYIFSZ1oVZucRUezsEoGg80="
+  },
+  "io/netty#netty-transport/4.1.111.Final": {
+   "jar": "sha256-SaPMC200I0DwmA8EcCbbdBYcGeoqB3U6FLTSLuBlOqU=",
+   "pom": "sha256-hmK9XX9i03JUj0CtiWuH6lXCsdF5Ap75hYN9zkOlImk="
+  },
+  "io/opencensus#opencensus-api/0.31.1": {
+   "jar": "sha256-8UdNR/S2sAFVitJ7lS417aXMcUZ4iHf8UpOMbroks4I=",
+   "pom": "sha256-VW9CfhIJDvs2pgh/dBCr/kXeEBByktlvpj5BdRdOy3Y="
+  },
+  "io/opencensus#opencensus-contrib-http-util/0.31.1": {
+   "jar": "sha256-PqmVtVpAaL4imJtwzCmk14jC0yjR1QYTp6mv0T/dLQo=",
+   "pom": "sha256-6+IsQiIX1mLHzumUdvC1LIBXftRFeGrCmSUb76pMB1s="
+  },
+  "io/opencensus#opencensus-proto/0.2.0": {
+   "jar": "sha256-DBktRR6d106Ychsn0C8OK2vKRLUVY7Xavy4hH3o+vxM=",
+   "pom": "sha256-twh5B5IPyKgVNGhrLxorMxEnr5fwFau9s3hqUfP6HlI="
+  },
+  "io/perfmark#perfmark-api/0.26.0": {
+   "jar": "sha256-t9I+k6NFN84zJwgmmg0UBHiKW14ZSegvVTX85Rs+qVs=",
+   "module": "sha256-MdgyMyR0zkgVD1uuADNDMZE28zav0QdqKJApMZ4+qXo=",
+   "pom": "sha256-ft7khhbhe2Epfq46gutIOoXlbSVnkpN4qkbzCpUDIto="
+  },
+  "io/projectreactor#reactor-core/3.4.38": {
+   "jar": "sha256-qSVfYNkuj8WMPIcyDMQ5k24IIn22W9iOuX6ESvhT5gg=",
+   "module": "sha256-s881PZK60hi9mRC0xb0neVd0L+e+U5GrgAJtm6nRYBU=",
+   "pom": "sha256-DqFXvFKNTUZhK6Vzyha639GvJYaS01eQdQLSreA+1Nc="
+  },
+  "io/projectreactor/netty#reactor-netty-core/1.0.45": {
+   "jar": "sha256-s4/bwGGLwZM1m7MoB7wXtpH+1CJZ3SeqArGN288rCEQ=",
+   "pom": "sha256-TDBu7MeIo/sfmzB3vFmyfaRIz0C2T/iB9NovCk9G6Ww="
+  },
+  "io/projectreactor/netty#reactor-netty-http/1.0.45": {
+   "jar": "sha256-9lfr/PgRUAj6jFXnUgDaiGpF8ixIjYLdqvAT/8y2UgU=",
+   "pom": "sha256-fXLOos9Oo8CAUjPMcfezfVmOCPdu5lnCB6sEH3ZtXAc="
+  },
+  "javax/activation#activation/1.1.1": {
+   "jar": "sha256-rkdRIOn82ZtLALODKb1hzcXrdU7uA/5mwB9Q4TdyT5k=",
+   "pom": "sha256-I4FJ4En7vEM06sjt1ZzKVlp1COKDmEHn02zSaBFY//A="
+  },
+  "javax/activation#javax.activation-api/1.2.0": {
+   "jar": "sha256-Q/3vC1ts6zGwQksgi5MMdKtY+sLO63s/b9OuuLXKQ5M=",
+   "pom": "sha256-2ikm88i+iYZDzBCs3sbeCwNRpX+yc1dw+gF3sGrecbk="
+  },
+  "javax/annotation#javax.annotation-api/1.3.2": {
+   "jar": "sha256-4EulGVvNVV3JVlD3zGFNFR5LzVLSmhC4qiGX86uJq5s=",
+   "pom": "sha256-RqSiUcpAbnjkhT16K66DKChEpJkoUUOe6aHyNxbwa5c="
+  },
+  "javax/inject#javax.inject/1": {
+   "jar": "sha256-kcdwRKUMSBY2wy2Rb9ickRinIZU5BFLIEGUID5V95/8=",
+   "pom": "sha256-lD4SsQBieARjj6KFgFoKt4imgCZlMeZQkh6/5GIai/o="
+  },
+  "javax/mail#mail/1.4.7": {
+   "jar": "sha256-eMM7T3x7YPS2gPLSQFsfBj1xkpzxpPvDKIiDefNl/Ps=",
+   "pom": "sha256-lhCZpCD2wx3rczQQwKJGLAZpJzI1+ljFcNYay9udjYo="
+  },
+  "javax/xml/bind#jaxb-api-parent/2.4.0-b180830.0359": {
+   "pom": "sha256-ctEy4shY0iMPFdBI8ek6J5xAxOnshLxW+fLz61r0tLg="
+  },
+  "javax/xml/bind#jaxb-api/2.4.0-b180830.0359": {
+   "jar": "sha256-VrnpcCdTdjAHQ1Fi6niAVe/P78hquSDwMsBBHcVHuDY=",
+   "pom": "sha256-sck/wwHX9f5M3hPRlTKZJR2jfv/8kfUjg1UEw/+HNwc="
+  },
+  "jline#jline/2.9": {
+   "jar": "sha256-GUPYSuoegm2nJOofMGNj4CaR2xzwQWXTOdl7/I/dENs=",
+   "pom": "sha256-sSn5BHWQUlcnTVgojGe7hlxCmbRIng0S3aehOWSexl0="
+  },
+  "joda-time#joda-time/2.12.7": {
+   "jar": "sha256-OFKCsAWBjPrM2+i9JCmBHn5kF4LyuIkyprj/UdZo9hY=",
+   "pom": "sha256-hf3b+kfCmf2OzhyT//1H2cLTyQNaM7XbAXswTGd+hCg="
+  },
+  "joda-time#joda-time/2.8.1": {
+   "jar": "sha256-tGcLlfdZV8l0KExfOtqWYEC+JXj2Q8XGCD0mIWIGH6I=",
+   "pom": "sha256-GLpc/f+WCR4AGYlTYURgedkSNe5WbLHUl2OcGs5inXg="
+  },
+  "junit#junit/4.13.2": {
+   "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
+   "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
+  },
+  "net/java#jvnet-parent/1": {
+   "pom": "sha256-KBRAgRJo5l2eJms8yJgpfiFOBPCXQNA4bO60qJI9Y78="
+  },
+  "net/java#jvnet-parent/3": {
+   "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
+  },
+  "net/java#jvnet-parent/5": {
+   "pom": "sha256-GvaZ+Nndq2f5oNIC+9eRXrA2Klpt/V/8VMr6NGXJywo="
+  },
+  "net/java/dev/jna#jna-platform/5.13.0": {
+   "jar": "sha256-R017iPbpcAm27B2YwwJN2VwjGHxl2r+8NTMbysPRc90=",
+   "pom": "sha256-Y7IMivBXyYGW+HieGiGm3d8Cqo84XmsEtLT58N8lcGY="
+  },
+  "net/java/dev/jna#jna-platform/5.6.0": {
+   "pom": "sha256-G+s1y0GE5skGp+Murr2FLdPaCiY5YumRNKuUWDI5Tig="
+  },
+  "net/java/dev/jna#jna/5.13.0": {
+   "jar": "sha256-ZtT4GaBipRodVie//CP6xV0Wd/Dgof66FEqr3WcKZLs=",
+   "pom": "sha256-9RXCV4F49FJH7Mp6nh2xCVMbHELyQk4lPO6w9rjUI3Q="
+  },
+  "net/minidev#accessors-smart/2.4.9": {
+   "jar": "sha256-rM3Vx6xMSbFViQquof/KKpzNWCa1Yt2VqZ/BiHAD4DE=",
+   "pom": "sha256-/sBelw8jmtqEcfTqPwYRwDb7zHxD886qnl575vMhe7E="
+  },
+  "net/minidev#json-smart/2.4.10": {
+   "jar": "sha256-cMq16UiGMNxjGx/G5/pVDZXN3Rm6FNs5zsp8q/vU5a4=",
+   "pom": "sha256-qVnWK1dC8NmRu3zF15fvmHgT6U3pORcAzw2N9v0hOSs="
+  },
+  "org/abego/treelayout#org.abego.treelayout.core/1.0.3": {
+   "jar": "sha256-+l4xOVw5wufUasoPgfcgYJMWB7L6Qb02A46yy2+5MyY=",
+   "pom": "sha256-o7KyI3lDcDVeeSQzrwEvyZNmfAMxviusrYTbwJrOSgw="
+  },
+  "org/apache#apache/13": {
+   "pom": "sha256-/1E9sDYf1BI3vvR4SWi8FarkeNTsCpSW+BEHLMrzhB0="
+  },
+  "org/apache#apache/15": {
+   "pom": "sha256-NsLy+XmsZ7RQwMtIDk6br2tA86aB8iupaSKH0ROa1JQ="
+  },
+  "org/apache#apache/21": {
+   "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache#apache/29": {
+   "pom": "sha256-PkkDcXSCC70N9jQgqXclWIY5iVTCoGKR+mH3J6w1s3c="
+  },
+  "org/apache#apache/30": {
+   "pom": "sha256-Y91KOTqcDfyzFO/oOHGkHSQ7yNIAy8fy0ZfzDaeCOdg="
+  },
+  "org/apache#apache/31": {
+   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
+  },
+  "org/apache#apache/32": {
+   "pom": "sha256-z9hywOwn9Trmj0PbwP7N7YrddzB5pTr705DkB7Qs5y8="
+  },
+  "org/apache#apache/7": {
+   "pom": "sha256-E5fOHbQzrcnyI9vwdJbRM2gUSHUfSuKeWPaOePtLbCU="
+  },
+  "org/apache/ant#ant-antlr/1.10.14": {
+   "jar": "sha256-1zfetbCZL2kb/+lAdmlad1I+HjtdUktGX5DZPi2O16I=",
+   "pom": "sha256-W9EwNnEP7b03cFBS+57G7RNI3lchm6ulyVNXWERrgQM="
+  },
+  "org/apache/ant#ant-junit/1.10.14": {
+   "jar": "sha256-o7U109VJ8YUKiRenwr/fNk//t51ScmfbMKEpR1yi+vg=",
+   "pom": "sha256-ZFiOW9XE89jIh5NFpsNQoxzIp5qovBJjGNytBL4/Pno="
+  },
+  "org/apache/ant#ant-launcher/1.10.14": {
+   "jar": "sha256-8JCXJaeiTjk4iPP7tVg0er9QbOL368WB/yYzG5TZUaU=",
+   "pom": "sha256-nJ2qQSPp63BzVnk2UsOIo1UQqqWm0UW0T4VdCN1LK7w="
+  },
+  "org/apache/ant#ant-parent/1.10.14": {
+   "pom": "sha256-CBYQamBniMJw767yFWLPy9j0uvfafBG85RSetWYbMx8="
+  },
+  "org/apache/ant#ant/1.10.14": {
+   "jar": "sha256-TLvZJD3kwQQtYdmhXbTEPJD/k7FteLOUgdoclWyOlnE=",
+   "pom": "sha256-L6QmnmscRXI6iojmnZhKdm27IEzQ/pgUlMzfP+469lw="
+  },
+  "org/apache/commons#commons-compress/1.26.1": {
+   "jar": "sha256-J7tdQPN8O7cgW0oFQCR98FdxXp9su9l9Ymq4tQMYuwQ=",
+   "pom": "sha256-X0SKAh2IyW84QN/mGRKNYuXPticSzW5m3KincElFsG4="
+  },
+  "org/apache/commons#commons-lang3/3.12.0": {
+   "pom": "sha256-gtMfHcxFg+/9dE6XkWWxbaZL+GvKYj/F0bA+2U9FyFo="
+  },
+  "org/apache/commons#commons-lang3/3.14.0": {
+   "jar": "sha256-e5a/PuaJSau1vEZVWawnDgVRWW+jRSP934kOxBjd4Tw=",
+   "pom": "sha256-EQQ4hjutN8KPkGv4cBbjjHqMdYujIeCdEdxaI2Oo554="
+  },
+  "org/apache/commons#commons-parent/17": {
+   "pom": "sha256-lucYuvU0h07mLOTULeJl8t2s2IORpUDgMNWdmPp8RAg="
+  },
+  "org/apache/commons#commons-parent/28": {
+   "pom": "sha256-FHM6aOixILad5gzZbSIhRtzzLwPBxsxqdQsSabr+hsc="
+  },
+  "org/apache/commons#commons-parent/34": {
+   "pom": "sha256-Oi5p0G1kHR87KTEm3J4uTqZWO/jDbIfgq2+kKS0Et5w="
+  },
+  "org/apache/commons#commons-parent/35": {
+   "pom": "sha256-cJihq4M27NTJ3CHLvKyGn4LGb2S4rE95iNQbT8tE5Jo="
+  },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
+  "org/apache/commons#commons-parent/58": {
+   "pom": "sha256-LUsS4YiZBjq9fHUni1+pejcp2Ah4zuy2pA2UbpwNVZA="
+  },
+  "org/apache/commons#commons-parent/64": {
+   "pom": "sha256-bxljiZToNXtO1zRpb5kgV++q+hI1ZzmYEzKZeY4szds="
+  },
+  "org/apache/commons#commons-parent/65": {
+   "pom": "sha256-bPNJX8LmrJE6K38uA/tZCPs/Ip+wbTNY3EVnjVrz424="
+  },
+  "org/apache/commons#commons-parent/66": {
+   "pom": "sha256-SP1tyEblax9AhmDRY+dTAPnjhLtjvkgqgIKiHXKo25w="
+  },
+  "org/apache/commons#commons-parent/69": {
+   "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
+  },
+  "org/apache/commons#commons-parent/71": {
+   "pom": "sha256-lbe+cPMWrkyiL2+90I3iGC6HzYdKZQ3nw9M4anR6gqM="
+  },
+  "org/apache/groovy#groovy-ant/4.0.22": {
+   "jar": "sha256-O1qAR9OpcR+sIhCDZPuM3xX6O23s/Ru6Fa4Y1IjihsU=",
+   "module": "sha256-L71eCyR+7FLhAogO4p+nS6b5imF2B4xm27jHiPAQyfU=",
+   "pom": "sha256-ae94A40xqz+7umZ/Tlc6yrOKhxSDYPAfA95TRJRGarE="
+  },
+  "org/apache/groovy#groovy-astbuilder/4.0.22": {
+   "jar": "sha256-XOLXHmOmYESDERx8Z6eImGnLUI/wv++mY32ULmtWWGw=",
+   "module": "sha256-DgSx19T1SHJxjgl1v28HCRBxNfjwoRLzok5oujVTLAM=",
+   "pom": "sha256-4pe/0Gv1qKatL/V49cUuYH3jyZaA9FtMU2oQkbAm+uE="
+  },
+  "org/apache/groovy#groovy-bom/4.0.22": {
+   "module": "sha256-Ul0/SGvArfFvN+YAL9RlqygCpb2l9MZWf778copo5mY=",
+   "pom": "sha256-Hh9rQiKue/1jMgA+33AgGDWZDb1GEGsWzduopT4832U="
+  },
+  "org/apache/groovy#groovy-console/4.0.22": {
+   "jar": "sha256-NbjJmqNHz9eHeigsqFBl+tyWIs/dJezjYRGuHOWG3/k=",
+   "module": "sha256-hth/+n825//cjTGt5nXarPP3GpEEMz07Px4gPGN8U6Q=",
+   "pom": "sha256-fX68X2L4u/Fand9PVCIaUMEdT0VOx2uky847NFkWSzo="
+  },
+  "org/apache/groovy#groovy-datetime/4.0.22": {
+   "jar": "sha256-tE9+5dmw1oQxC3nESjVpMH4YrjWdBE1sF+9f1D/KK8g=",
+   "module": "sha256-s6OAY7hhtVBTVg1rlJLdff/0B/0LkJT10YmgV6UnJgQ=",
+   "pom": "sha256-Yq7rWVbIbovf26l9BZ/dR//ExnPp25JO3u77tjNEOBY="
+  },
+  "org/apache/groovy#groovy-dateutil/4.0.22": {
+   "jar": "sha256-p5HDt8gOdUTjWhHAJlyj9y8PaAqysuFUa2xeP+ahexg=",
+   "module": "sha256-35srMbE0B9wFLtllXmu2uUzPO9t7jzfaGXHRu2LHw0s=",
+   "pom": "sha256-BTW1Zs/Eav7KtOnXgdIps22Gh0ZUssD/7llVJUZiFkA="
+  },
+  "org/apache/groovy#groovy-docgenerator/4.0.22": {
+   "jar": "sha256-sHU0ihy22HZYJumzlv09rxQg6hEUrrLn1RlzjJgik7k=",
+   "module": "sha256-olhJZ2qL+FGIDMDRm4cmqViXH6d7m6naGxbsbSLXVFc=",
+   "pom": "sha256-q06iRmwnr3tP61TAQujBorugC3z9rpLHh9c06EdbckU="
+  },
+  "org/apache/groovy#groovy-groovydoc/4.0.22": {
+   "jar": "sha256-pfz5r+u5ep3tut3P186Q3f+F0IuiS2P5thauK59Pmb8=",
+   "module": "sha256-czTLKp9ILUoXAsmR3ipvY+2BjwkuQBDlDDamLNugEyA=",
+   "pom": "sha256-yHMhp8DNMgYfujQB/zLpHISOn0wcyEXH6/UjAr5XngM="
+  },
+  "org/apache/groovy#groovy-json/4.0.22": {
+   "jar": "sha256-q6kyVNkpOIEoK9Y5t7Pbi9y1v2zKTKwN96C9GTdD9lI=",
+   "module": "sha256-zNCqhZfYpL50KU9/8umAgffndwkK1i2BkVr5pgMT/MY=",
+   "pom": "sha256-b5SbBK4/HGwPKdR7xCiNDkRAZpGUYuPtlyzwuUtWjAo="
+  },
+  "org/apache/groovy#groovy-nio/4.0.22": {
+   "jar": "sha256-wGvLEry6gtM9bEl2MhDGnrjhWysjr48seaLckLe/TSU=",
+   "module": "sha256-AaEkGSIUH9pPzoWnBdF6WK8mFZjBFEHDM6PrMqrgwS8=",
+   "pom": "sha256-JnQ0TFl8348bePSnaAa71TwGc1ZUUB1zvZYbswFJMVQ="
+  },
+  "org/apache/groovy#groovy-sql/4.0.22": {
+   "jar": "sha256-HBsfsFbuHvu3QyN8aMo1Z9qvg6i62kWYNtm6ezukVqs=",
+   "module": "sha256-6GHVtR+HvuG2+mtWZc64EIbMCZQf/w9VOCFhY5eXLLs=",
+   "pom": "sha256-RhXCg//EtB5XPXwAgJ/S7Ja45JGeFzIe6uQGbP1/CwY="
+  },
+  "org/apache/groovy#groovy-swing/4.0.22": {
+   "jar": "sha256-RMwmmirUQoUMuQrCuOu1YEEqfeAEic9LzabUPW4D72o=",
+   "module": "sha256-dh8BpcQprVZXgq/HdJgCd0ReI6jaRjZoDDSzUHXDzzw=",
+   "pom": "sha256-H1JhJeQvpHGzb1B2bQMdnqaI0HaWcOnUVtN6eY2EI+g="
+  },
+  "org/apache/groovy#groovy-templates/4.0.22": {
+   "jar": "sha256-dA4rUYsVAJVuh6ix/TJuCywhrcZ3qj/sVWXQF7aQzTU=",
+   "module": "sha256-NfWvWkE2jYp8bMLPL7Vtg3ZbLJGETfi4uRyJ2ne2IEU=",
+   "pom": "sha256-h9Ls2H3VPKYPGT7SOM6gfCaThtzAw/xUkhdrXVlbUIE="
+  },
+  "org/apache/groovy#groovy-test/4.0.22": {
+   "jar": "sha256-+vfSOY3ELHvakh7jZSK1UTJlglzW1za0KPJzHnl0q0o=",
+   "module": "sha256-nAjbyztGaX9Dsi99c2Hmr0ZhZV7ywrnqVIG6MhIjtxQ=",
+   "pom": "sha256-M43f8+RSWL736IxDALYpH3Dq7A9mKP1uCxzRYY+5vkw="
+  },
+  "org/apache/groovy#groovy-xml/4.0.22": {
+   "jar": "sha256-qMbIRe0i/qrtjw/Xl5i4q+o+CQr9Wpraq5bb2hUhacs=",
+   "module": "sha256-CCKmJjoD/xQevfvoytpZ1cbES1k4cHdk2Vm29dEYtx8=",
+   "pom": "sha256-OP4UoARgVl/aznkr8Z31VCEuQGvnnWZvqP6KZ6SnYfk="
+  },
+  "org/apache/groovy#groovy-yaml/4.0.22": {
+   "jar": "sha256-y/Y1CEcIYQxClw8aA1QM7Qm2OH+sdQn2pxb+O81GmzU=",
+   "module": "sha256-X+tDbJ4KoO2LYzMXYBFmcH9gPW+j3cgj5Rh/fYHiu1A=",
+   "pom": "sha256-X0xaX+IEQ18yiHup+G37IbIDdxxXEilqb7f7LuVzHZY="
+  },
+  "org/apache/groovy#groovy/4.0.22": {
+   "jar": "sha256-+di9TWWFLBgZTjU8d/PSwj4AE4VpUcVDC6VpctL2eh4=",
+   "module": "sha256-Jor7Vc8AXY4Pd1qtSNNFdjykD+PkMP+5CG85iztJBTQ=",
+   "pom": "sha256-Vuw4/yqflfFX6tIc7fMwWsMB+3kmQBSyzvPoX7JrNK0="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.13": {
+   "jar": "sha256-b+kCalZsalABYIzz/DIZZkH2weXhmG0QN8zb1fMe90M=",
+   "pom": "sha256-eOua2nSSn81j0HrcT0kjaEGkXMKdX4F79FgB9RP9fmw="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.14": {
+   "jar": "sha256-yLx+HFGm1M5y9A0uu6vxxLaL/nbnMhBLBDgbSTR46dY=",
+   "pom": "sha256-8YNVr0z4CopO8E69dCpH6Qp+rwgMclsgldvE/F2977c="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.13": {
+   "pom": "sha256-nLpZTAjbcnHQwg6YRdYiuznmlYORC0Xn1d+C9gWNTdk="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.14": {
+   "pom": "sha256-W60d5PEBRHZZ+J0ImGjMutZKaMxQPS1lQQtR9pBKoGE="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.13": {
+   "pom": "sha256-xVTnAI5FF8fvVOAFzIt09Mh6VKDqLG9Xvl0Fad9Rk2s="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.16": {
+   "pom": "sha256-8tdaLC1COtGFOb8hZW1W+IpAkZRKZi/K8VnVrig9t/c="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/11": {
+   "pom": "sha256-qQH4exFcVQcMfuQ+//Y+IOewLTCvJEOuKSvx9OUy06o="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.13": {
+   "jar": "sha256-4G6J1AlDJF/Po57FN82/zjdirs3o+cWXeA0rAMK0NCQ=",
+   "pom": "sha256-j4Etn6e3Kj1Kp/glJ4kypd80S0Km2DmJBYeUMaG/mpc="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.16": {
+   "jar": "sha256-bJs90UKgncRo4jrTmq1vdaDyuFElEERp8CblKkdORk8=",
+   "pom": "sha256-PLrYSbNdrP5s7DGtraLGI8AmwyYRQbDSbux+OZxs1/o="
+  },
+  "org/apache/ivy#ivy/2.5.2": {
+   "jar": "sha256-mEKNVF6mPNmgqvJVyvQsuMtk/kMNu15wmu1TbU2u7QQ=",
+   "pom": "sha256-SrIWH63j2EHp2H8iVfdgfLiHCcbISPf7JdBmkd2VbkQ="
+  },
+  "org/bouncycastle#bcpkix-jdk15on/1.67": {
+   "jar": "sha256-77ynVIgM45IspHpDwfC3LEVzFFCg7xk7nbM79Ls4zl8=",
+   "pom": "sha256-qbswvZh9wwWwXuU+nyfm6QL8EM48bplhjP8DYteWsE0="
+  },
+  "org/bouncycastle#bcpkix-jdk15on/1.70": {
+   "jar": "sha256-5bnLgh31f3CwWTNY6JwOjXJmUV2p0IivbGRvY9QzwHw=",
+   "pom": "sha256-bqVQK37r7HAYJxu4qCy4Gb9MHytlQ1ScXP2E1qE5lr8="
+  },
+  "org/bouncycastle#bcprov-ext-jdk15on/1.70": {
+   "jar": "sha256-XYGfO4hZfsaAyUFRoLoKOv/wwMHJmbWwZaZ8mYo+Phs=",
+   "pom": "sha256-349vD7+aZoBvsV+M/E40S1fEdgoiYpAIbKuLkb4X4m8="
+  },
+  "org/bouncycastle#bcprov-jdk15on/1.67": {
+   "jar": "sha256-+gBBo2+fIK88a42/brSalp4snMApBJ1hrMUmujJHs+8=",
+   "pom": "sha256-pHOndHbdYxYw67OjezSBL5TmpyRcOXZaFNcjG5DgZFs="
+  },
+  "org/bouncycastle#bcprov-jdk15on/1.70": {
+   "jar": "sha256-jzwg4+LVZdJvM+jUhXo30Nf4rDm2KnAmSW/Ksb2sMNQ=",
+   "pom": "sha256-bfS1t22QYgF2ZK0MooXlcVSugDYHy4nJcLOcwOAWq7A="
+  },
+  "org/bouncycastle#bcutil-jdk15on/1.70": {
+   "jar": "sha256-UtxVUbAldmZSbFCVQkVn/tfcewDSsbp71SKYQRESsdA=",
+   "pom": "sha256-nrrnHCXgyfLNdWADwB8a0Pw5jKBvvNoNF15xysWECq0="
+  },
+  "org/checkerframework#checker-qual/3.39.0": {
+   "jar": "sha256-PpAHA5btiI7jlBZbIIOmejTDfhEaw6/XuZaop4KcQd0=",
+   "module": "sha256-56P+D0lZ4m6ZCH6KwOzHhK4AtmcGGdBWA/ZATim8fRc=",
+   "pom": "sha256-SIsYMPs9WeqTtYulPhrZGLuTWnzL00uDXbT6QCZmXjI="
+  },
+  "org/checkerframework#checker-qual/3.41.0": {
+   "jar": "sha256-L58kW/aOQlnWEIlPJAbcH2Nj3GOTAr1WboJy5PRUEXI=",
+   "module": "sha256-s4ZywX9FUnayEO00Av+S3OZmdwsajGEMfMNK1UxTLSA=",
+   "pom": "sha256-XHOwdwVAhCzwagHSZLu4muXiSGadydqA6GHoIz3UZ1s="
+  },
+  "org/codehaus#codehaus-parent/4": {
+   "pom": "sha256-a4cjfejC4XQM+AYnx/POPhXeGTC7JQxVoeypT6PgFN8="
+  },
+  "org/codehaus/gpars#gpars/1.2.1": {
+   "jar": "sha256-+eCL+WTzTRKTREBMAWZiduxDxnBN106NTKMtzR0vtKg=",
+   "pom": "sha256-QoGa4DFjcSPJS8c9bvANBfh29tSixUiztj722uw4gw4="
+  },
+  "org/codehaus/jsr166-mirror#jsr166y/1.7.0": {
+   "jar": "sha256-TU50Uy6BvGpU5MvahlmZ9KspiF6FDwuDXqN0gAuE0LI=",
+   "pom": "sha256-tmtSb0df2k3Oi5X/8P7ukkqPBZKYwzrgyTS3fYkJBkM="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.23": {
+   "jar": "sha256-n/5Sa/Q6Y0jp2LM7nNb1gKf17tDPBVkTAH7aJj3pdNA=",
+   "pom": "sha256-VhDbBrczZBrLx6DEioDEAGnbYnutBD+MfI16+09qPSc="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.23": {
+   "pom": "sha256-a38FSrhqh/jiWZ81gIsJiZIuhrbKsTmIAhzRJkCktAQ="
+  },
+  "org/codehaus/mojo#mojo-parent/74": {
+   "pom": "sha256-FHIyWhbwsb2r7SH6SDk3KWSURhApTOJoGyBZ7cZU8rM="
+  },
+  "org/codehaus/woodstox#stax2-api/4.2.1": {
+   "jar": "sha256-Z4Vn5ItRpCxlxpnyZlOa09Z21LGlsK19iezoudV3JXk=",
+   "pom": "sha256-edpBDIwPRqP46K2zDWwkzNYGW272v96HvZfpiB6gouc="
+  },
+  "org/conscrypt#conscrypt-openjdk-uber/2.5.2": {
+   "jar": "sha256-6vU32Y4DPQ8EUc0bjMdOAte1XsiC2mPIgGDYBrqJw0g=",
+   "pom": "sha256-tf1UhzL5MlRdd3iQ65lSIr/oZiMjUb6QgTfjnDxnLYs="
+  },
+  "org/eclipse/jgit#org.eclipse.jgit-parent/6.10.0.202406032230-r": {
+   "pom": "sha256-8tNTmgp5Iv15RwgsGQHSCQ2uB0mGsi2r2XO0OYzR6i4="
+  },
+  "org/eclipse/jgit#org.eclipse.jgit/6.10.0.202406032230-r": {
+   "jar": "sha256-Q/kvOttoGl8wBrl56NNBwSqM/YAp8ofEK88KgDd1Za4=",
+   "pom": "sha256-BVlUQr62ogYQi2c6qcZpLIPkHfGDF33GcROxzD9Sgd0="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  },
+  "org/iq80/leveldb#leveldb-api/0.12": {
+   "jar": "sha256-OvfzUKuBy6mjXL+HTmTJCG/bxUZGQ/2sAKkIu/b1v+0=",
+   "pom": "sha256-u3YgQdQp1fGrIo2Vdueo9KMJOXPYlp9J9Z60Pt4nEnw="
+  },
+  "org/iq80/leveldb#leveldb-project/0.12": {
+   "pom": "sha256-TC30AYOjb6TRMRQAa2se+DwABq6w7TQJOKc7Hu5FKP8="
+  },
+  "org/iq80/leveldb#leveldb/0.12": {
+   "jar": "sha256-PBLq+4v/NZ+XrsTXV0SAz8Bug/RHBN4CChwGJ2UbpLY=",
+   "pom": "sha256-BLLnbGq+AuopCM5vdltp80j3+lq86j5sO0DXWgRuMFM="
+  },
+  "org/jetbrains#annotations/13.0": {
+   "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
+   "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.4.20": {
+   "pom": "sha256-fFcG67pX1ETCyQJCiTE6SThr6gmWwDKUwrVwmnUP9Ck="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.7.0": {
+   "jar": "sha256-Wcb/ZP6aZgSvzgPoqqdfg1hsYDCscfsLNO583v7TYY8=",
+   "pom": "sha256-JhqZ5S596dKySKuJmKUEbOZB/h4oI39p3xUOxL6aMBo="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.7.0": {
+   "jar": "sha256-B+kb6bLKIGctK9t+GBt2bnNFOi2hNJK13a7o+keuojk=",
+   "pom": "sha256-riOkxqK9/AzVp7uuh9mYoR4DVr5J/voKmvbD/22ioCs="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.7.0": {
+   "jar": "sha256-zwWOEdsd/JlEaAyMYblaxomqqoo+swvO0CgQDwOPAws=",
+   "pom": "sha256-l+G1Or5F8Ti1h5U/UEPjmcOA9VWmIz1VeV567gPQpzE="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.4.20": {
+   "pom": "sha256-OYXvH5KCjVgqQ87JztsmJnQuD+FQXTE268KYzJi8I0o="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.7.0": {
+   "jar": "sha256-qojpYlV3lX8ySaRstuFm7gmzaeYA96EdFI0WsKbYfwU=",
+   "pom": "sha256-CsWfu0zZGIqggUYASiUpXDdSCe+rkxJad/UDfpVldk4="
+  },
+  "org/jsoup#jsoup/1.15.4": {
+   "jar": "sha256-AGgw0Hl3EECN5VicGNhkNDwO8aOgxgPJyxOMlDtn2aQ=",
+   "pom": "sha256-chKJC3LAuGDgIlhWvnQT5469Ps0+y4Vn3eaqxic9+4k="
+  },
+  "org/junit#junit-bom/5.10.0": {
+   "module": "sha256-6z7mEnYIAQaUqJgFbnQH0RcpYAOrpfXbgB30MLmIf88=",
+   "pom": "sha256-4AbdiJT5/Ht1/DK7Ev5e2L5lZn1bRU+Z4uC4xbuNMLM="
+  },
+  "org/junit#junit-bom/5.10.1": {
+   "module": "sha256-IbCvz//i7LN3D16wCuehn+rulOdx+jkYFzhQ2ueAZ7c=",
+   "pom": "sha256-IcSwKG9LIAaVd/9LIJeKhcEArIpGtvHIZy+6qzN7w/I="
+  },
+  "org/junit#junit-bom/5.10.2": {
+   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
+   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
+  "org/junit#junit-bom/5.11.0-M2": {
+   "module": "sha256-hkd6vPSQ1soFmqmXPLEI0ipQb0nRpVabsyzGy/Q8LM4=",
+   "pom": "sha256-Sj/8Sk7c/sLLXWGZInBqlAcWF5hXGTn4VN/ac+ThfMg="
+  },
+  "org/junit#junit-bom/5.7.1": {
+   "module": "sha256-mFTjiU1kskhSB+AEa8oHs9QtFp54L0+oyc4imnj67gQ=",
+   "pom": "sha256-C5sUo9YhBvr+jGinF7h7h60YaFiZRRt1PAT6QbaFd4Q="
+  },
+  "org/junit#junit-bom/5.7.2": {
+   "module": "sha256-87zrHFndT2mT9DBN/6WAFyuN9lp2zTb6T9ksBXjSitg=",
+   "pom": "sha256-zRSqqGmZH4ICHFhdVw0x/zQry6WLtEIztwGTdxuWSHs="
+  },
+  "org/junit#junit-bom/5.9.2": {
+   "module": "sha256-qxN7pajjLJsGa/kSahx23VYUtyS6XAsCVJdyten0zx8=",
+   "pom": "sha256-LtB9ZYRRMfUzaoZHbJpAVrWdC1i5gVqzZ5uw82819wU="
+  },
+  "org/junit#junit-bom/5.9.3": {
+   "module": "sha256-tAH9JZAeWCpSSqU0PEs54ovFbiSWHBBpvytLv87ka5M=",
+   "pom": "sha256-TQMpzZ5y8kIOXKFXJMv+b/puX9KIg2FRYnEZD9w0Ltc="
+  },
+  "org/multiverse#multiverse-core/0.7.0": {
+   "jar": "sha256-xUOY8CKAVLf65lInQzrp2oflsqluuoJOZqkkkS0Q/FA=",
+   "pom": "sha256-p7gugArForuaPFPIf328LPcE45XMMnNRC6OAd9PrURQ="
+  },
+  "org/multiverse#multiverse/0.7.0": {
+   "pom": "sha256-7eh88cQ59oa9lF8cRiz8//VQg6HnKxjCjmP050MEohg="
+  },
+  "org/objenesis#objenesis-parent/2.1": {
+   "pom": "sha256-NDsaMJNBDj+ybGaZhCOrOJw6dEHNGohZvTJ90VtHmqQ="
+  },
+  "org/objenesis#objenesis/2.1": {
+   "jar": "sha256-x0MwzGuAbIBP0350SHtP5dfCdQxeFfvG76E73uG974A=",
+   "pom": "sha256-QFTxhhN+O4SafCPJ6EbNV9ii/jLBfUxivUIFEtdMPT8="
+  },
+  "org/ow2#ow2/1.5": {
+   "pom": "sha256-D4obEW52C4/mOJxRuE5LB6cPwRCC1Pk25FO1g91QtDs="
+  },
+  "org/ow2#ow2/1.5.1": {
+   "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
+  },
+  "org/ow2/asm#asm-analysis/9.7": {
+   "jar": "sha256-e8a8vCE3mUigyMRn+w+GQgbluBj2vAtUaHL1yflBVW8=",
+   "pom": "sha256-nDMIDry2Ma5Pd+ti7We/xAy4cujP0Fishj5EXB3Zc98="
+  },
+  "org/ow2/asm#asm-tree/9.7": {
+   "jar": "sha256-YvSzvENgRcGstcO6LY7FVuwzaQk9f10Gx0frBLVtUrE=",
+   "pom": "sha256-o06h4+QSjAEDjbQ8aXbojHec9a+EsFBdombf5pZWaOw="
+  },
+  "org/ow2/asm#asm-util/9.7": {
+   "jar": "sha256-N6ZBTTZkGXPxrxBJN8ldbZIbLdtNYSxmxanysT/BQhE=",
+   "pom": "sha256-XQFNjIcNSHGCW9LdtVZ7Ie9trI7Ei7uNu0ZbCzor9FI="
+  },
+  "org/ow2/asm#asm/9.3": {
+   "jar": "sha256-EmM2m1ninJQ5GN4R1tYVLi7GCFzmPlcQUW+MZ9No5Lw=",
+   "pom": "sha256-jqwH4p+K6oOoFW17Kfo2j26/O+z7IJyaGsNqvZBhI+A="
+  },
+  "org/ow2/asm#asm/9.7": {
+   "jar": "sha256-rfRtXjSUC98Ujs3Sap7o7qlElqcgNP9xQQZrPupcTp0=",
+   "pom": "sha256-3gARXx2E86Cy7jpLb2GS0Gb4bRhdZ7nRUi8sgP6sXwA="
+  },
+  "org/pf4j#pf4j-parent/3.12.0": {
+   "pom": "sha256-CJafObKJ1C3l4L6je+jADJoykGvd2Vhga6YqkP/om/g="
+  },
+  "org/pf4j#pf4j-update/2.3.0": {
+   "jar": "sha256-ecnWJAzagsPTHuelcitjWj03rVjBJKTbDd6kAUXDD0U=",
+   "pom": "sha256-UYnVbbrkEiTpD2l3vGFFOBOlLgvE4ITO6eaa8GUsZFU="
+  },
+  "org/pf4j#pf4j/3.12.0": {
+   "jar": "sha256-5K9fDpqbEewYfAhO2BnO3t5/Jwdqxc9qojM+zq21chU=",
+   "pom": "sha256-+2hRCZ61BSoRaSLHRpvmngj7w5ksF2thr9/gZGOvaYs="
+  },
+  "org/reactivestreams#reactive-streams/1.0.4": {
+   "jar": "sha256-91yll3ibPaxY9hhXuawuEDSmj6Zy2zUFWo+0UJ4yXyg=",
+   "pom": "sha256-VLoj2HotQ4VAyZ74eUoIVvxXOiVrSYZ4KDw8Z+8Yrag="
+  },
+  "org/slf4j#jcl-over-slf4j/2.0.7": {
+   "jar": "sha256-QYBnV+HSba5dbbLKfUpRdu7S1ucJzYZWTUoR2rBgF0I=",
+   "pom": "sha256-QzT/rbuOhgtdjjm7HHDDHO8BEGQ1EGZkQQsK9+vi8uc="
+  },
+  "org/slf4j#jul-to-slf4j/2.0.7": {
+   "jar": "sha256-6rplSDuzjJPmjVV6GeVziWIyLeGUZUXb9A5eMvYpMAg=",
+   "pom": "sha256-bceobwo6J1dfgBavGvR/hhHToDhvmhoaK1EMDWDBTNA="
+  },
+  "org/slf4j#log4j-over-slf4j/2.0.7": {
+   "jar": "sha256-/FdxTuix5Ks5uUiMFX8IQ95xumcIJSy+BsmUrZ1y0e4=",
+   "pom": "sha256-ZtCdHNU3gbrEkQ94x0zKL9M6z6KqXK24qP1bxEAM6mI="
+  },
+  "org/slf4j#slf4j-api/2.0.7": {
+   "jar": "sha256-XWKYuToZBcMs2mR4gIrBTC1KR+kVNeU8Qff+64XZRvQ=",
+   "pom": "sha256-LUA8zw4KAtXBqGZ7DiozyN/GA4qyh7lnHdaBwgUmeYE="
+  },
+  "org/slf4j#slf4j-parent/2.0.7": {
+   "pom": "sha256-wYK7Ns068ck8FgPN/v54iRV9swuotYT0pEU1/NIuRec="
+  },
+  "org/sonatype/oss#oss-parent/3": {
+   "pom": "sha256-DCeIkmfAlGJEYRaZcJPGcVzMAMKzqVTmZDRDDY9Nrt4="
+  },
+  "org/sonatype/oss#oss-parent/5": {
+   "pom": "sha256-FnjUEgpYXYpjATGu7ExSTZKDmFg7fqthbufVqH9SDT0="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/threeten#threetenbp/1.6.8": {
+   "jar": "sha256-5LHrPZDDilTH8zhP2pV+C1vwtBtAZypErosDy2yHzgY=",
+   "pom": "sha256-ztMznYANG7wB7mct+A5NqHUgrgKXuarI+MS33aI+SwI="
+  },
+  "org/yaml#snakeyaml/2.0": {
+   "jar": "sha256-iAydiW5LdKBsVJwVyklkUBZdaQn6FdfmYr7o9qZtevo=",
+   "pom": "sha256-Q8dh+StUnIsI+5kggCU+SfCpg+VE7wZjwfT51o61JhY="
+  },
+  "org/yaml#snakeyaml/2.2": {
+   "jar": "sha256-FGeTFEiggXaWrigFt7iyC/sIJlK/nE767VKJMNxJOJs=",
+   "pom": "sha256-6YLq3HiMac8uTeUKn2MrGCwx26UGEoMNNI/EtLqN19Y="
+  },
+  "software/amazon/awssdk#annotations/2.26.26": {
+   "jar": "sha256-aUAhId1u6bXYLVWn/R3HUvzahdd9WnRMDp6/0wm2FSs=",
+   "pom": "sha256-IvMaqFQAXCp7vRRVLIoVVwG0tnMIzP3FQTLeXHgdcgw="
+  },
+  "software/amazon/awssdk#apache-client/2.26.26": {
+   "jar": "sha256-nznXLKoWQTaATuW4IyLFrB/i1wOuCrNvgcMFGq+Zn0o=",
+   "pom": "sha256-aMQ1YXRPnMIYQkDwuAOI8GDtEICH7GGTms9eXlw1+W8="
+  },
+  "software/amazon/awssdk#auth/2.26.26": {
+   "jar": "sha256-rkmVeQTycJvMwIFxP8lJEpDq72n9mQo+IKuuCIV93S0=",
+   "pom": "sha256-DVvm6KQ4ysNOafB2iQzFKAEo+3jcSZeieCOGYhX6oDo="
+  },
+  "software/amazon/awssdk#aws-core/2.26.26": {
+   "jar": "sha256-A0+oms7HtbQOjaXVuRissdqjm54xbVfV9uU56fqyr68=",
+   "pom": "sha256-TsMPuyNwzQgblM8sv8Xae64Pn2Qyvmcb1UWI/uSp6+g="
+  },
+  "software/amazon/awssdk#aws-json-protocol/2.26.26": {
+   "jar": "sha256-xlfKtDtRnf2zcqhZQS8gbs+0mD4yr8Mz3Xju9wfYcNs=",
+   "pom": "sha256-c8xGFgRSrk9LFXjQa8drKpnowsYrOtWt0pxUv7Y99wI="
+  },
+  "software/amazon/awssdk#aws-sdk-java-pom/2.26.26": {
+   "pom": "sha256-lixU0LOpTDywFJRwHr6x9su3fK+zDLKAFRy7pj4/0nQ="
+  },
+  "software/amazon/awssdk#bom-internal/2.26.26": {
+   "pom": "sha256-coi03Ywm/076O6TCx7ysOVWmZjEs6fHIytuSsQmbDGo="
+  },
+  "software/amazon/awssdk#checksums-spi/2.26.26": {
+   "jar": "sha256-aJYOIepQDm3zVfzfYfTN22aNLA94S++rnASHrKTRvjg=",
+   "pom": "sha256-tYAqjgEhp81DP7ERSXVmBHkJbqf0NbQma5e6jwLFacU="
+  },
+  "software/amazon/awssdk#checksums/2.26.26": {
+   "jar": "sha256-9ZrOEkJJRC7lSR4pvaQzPkCtRnaIp2759mjY4CoxNqQ=",
+   "pom": "sha256-rc1ErSAB439wqC/X0rx7ypN/8IskPWRkIV/+vmql7uU="
+  },
+  "software/amazon/awssdk#core/2.26.26": {
+   "pom": "sha256-K5+nldQU0Q+Hamh3C2DRdrBA4rdz3IzLBjPE9zDeM1w="
+  },
+  "software/amazon/awssdk#endpoints-spi/2.26.26": {
+   "jar": "sha256-kGvBRZF0TSj6Ne4thJxBCVpBB2EEdWMAemDpbkodhuo=",
+   "pom": "sha256-bvg/+OvJbbxp0+TX72v1U6pJrI2yZM3AdZ2S23dVlH0="
+  },
+  "software/amazon/awssdk#http-auth-aws-eventstream/2.26.26": {
+   "jar": "sha256-YpmuIwZQhO9z5Ub3reRbvfTg8+QMe5S42OrGgp3tp6g=",
+   "pom": "sha256-4Np6b+83VkyjsXp6Oo2ugmGV3SwuG2cWmwuVpa0AQlQ="
+  },
+  "software/amazon/awssdk#http-auth-aws/2.26.26": {
+   "jar": "sha256-dZz9f5mzEr6lmd+OJVzxWOlV/GDg59Hgs48pZQjpfh8=",
+   "pom": "sha256-Ctmn3ZG3h3E2k+FTvuUO/24B3JTOc0n4JI0Ul4fNrSQ="
+  },
+  "software/amazon/awssdk#http-auth-spi/2.26.26": {
+   "jar": "sha256-3WW9KrsL6aqeJGYZz0/XfjHlmTcSpm/4mydpsGxYoOc=",
+   "pom": "sha256-DAKFhZzgbxwl0aFiUXZIQvT9K7kXbLRD2QfM2xvDwes="
+  },
+  "software/amazon/awssdk#http-auth/2.26.26": {
+   "jar": "sha256-rIzrcDLQintVc2y2f0H4qyVoYCJkoMDChJPPdH6VzH8=",
+   "pom": "sha256-LBuR3WNojggJp8UleJx8SRKX35xGucTbY24sCXPKm3A="
+  },
+  "software/amazon/awssdk#http-client-spi/2.26.26": {
+   "jar": "sha256-RL26bCp5eBhrNpftYIB9n6m2jAnE1dBNAyGdgu6vNj0=",
+   "pom": "sha256-ujMvgWsw2Hw+ocevP5Zu413YRAnlM+b32cAY5vVsuns="
+  },
+  "software/amazon/awssdk#http-clients/2.26.26": {
+   "pom": "sha256-mXs8qIVYTm0HNJRYVxN+ltcdYXsgasjvUm6LM7boXCo="
+  },
+  "software/amazon/awssdk#identity-spi/2.26.26": {
+   "jar": "sha256-CJGE2jC757V3a6H65X5TorVVzce+Tcd55UFLvuPOUu8=",
+   "pom": "sha256-GK1UqC+Q5WGKJ6YKTcm1Vo+lHut2riwXdPmEOm8w1CU="
+  },
+  "software/amazon/awssdk#json-utils/2.26.26": {
+   "jar": "sha256-8txWzIzoKqIaU5qPDyNx0+XzEuQJAUoHIDQlgDy09Nc=",
+   "pom": "sha256-fEMwRPC06iQzEEYfgMxP0uzB+5f2jXA6qim2y5zTeCI="
+  },
+  "software/amazon/awssdk#metrics-spi/2.26.26": {
+   "jar": "sha256-tlVae3mgb3SJeHkRVWm/nooBzZfWs7KxvVa/yoIfF10=",
+   "pom": "sha256-h36orVjr2+CvJEG2TIJ0tCmtr6lgXfKcqXO0NNtg6k8="
+  },
+  "software/amazon/awssdk#netty-nio-client/2.26.26": {
+   "jar": "sha256-EpKX9C0+0xmIPb8Xk2WVc7fP2HLr1gjBtN5YCX+MAb4=",
+   "pom": "sha256-QlXAVSwZB26ozmBLrmGr2oqZ7z6RXlncHHc2RAQwbJI="
+  },
+  "software/amazon/awssdk#profiles/2.26.26": {
+   "jar": "sha256-R6SXYs4vkuuQfTMZcEA8LmFOTSHl3ir+1wthTsSRu8c=",
+   "pom": "sha256-YpOKDV6FJ5YxpD9CJGwv/IE3WVWNuQqvh2Q16vVjOnI="
+  },
+  "software/amazon/awssdk#protocol-core/2.26.26": {
+   "jar": "sha256-E7I1lBn/+0pwg6RnZCY15VRA+ZqxB4bVd8LXsUhY0F4=",
+   "pom": "sha256-hC5LiggNaBlTtyaXT0dp8XPzD+Jvu17FijtCx1j6k7o="
+  },
+  "software/amazon/awssdk#protocols/2.26.26": {
+   "pom": "sha256-HFmySfp7T2YH9X4WrQCGN7qOkeo0wmio3yyhf6FW85M="
+  },
+  "software/amazon/awssdk#regions/2.26.26": {
+   "jar": "sha256-f92SCgVh8caZIYK4h3IZpx1SzJdeZTcobgsxvhFO5VM=",
+   "pom": "sha256-zrhmZK7lUMI6EktCfRlc1UxFw/5k0vJjyT8p6QMJ2m4="
+  },
+  "software/amazon/awssdk#retries-spi/2.26.26": {
+   "jar": "sha256-nt0ORlM7MGz3zXBzXb+y1GARg8TLzCeG5ii+Tqv3PJk=",
+   "pom": "sha256-od61yIhPnnlNVHoQUZGVMHV9IbeqZavOT0J8V4AyQtY="
+  },
+  "software/amazon/awssdk#retries/2.26.26": {
+   "jar": "sha256-1BR62e+CDBJlBU0w291/deQSF8qXGrXe86JIdKyWQUk=",
+   "pom": "sha256-ynF08Ykay4BO+ulxOA8VTeocU3UTzgbB3j+MwcvuBho="
+  },
+  "software/amazon/awssdk#sdk-core/2.26.26": {
+   "jar": "sha256-FOkMdT7cv/dxtUWPDRKyxwVXeJT8vBwPbJKiCQVg3P4=",
+   "pom": "sha256-sWuvZSiIsMQ01+XaiTIQiDR+AYfXaRx08ttDAsllU7c="
+  },
+  "software/amazon/awssdk#services/2.26.26": {
+   "pom": "sha256-+QGkOvR1z2Rx57NCCJ1OAp7yX6+NmVkExdkb5XxxXwk="
+  },
+  "software/amazon/awssdk#sso/2.26.26": {
+   "jar": "sha256-z/eJpT+DJIrUCrgETxT30+dHbZ55Cy1cQPKKAA5MK3A=",
+   "pom": "sha256-AGZB90pSiaUq9HOOK17aedvvf0ArYyZFGDQLRT/t6cs="
+  },
+  "software/amazon/awssdk#ssooidc/2.26.26": {
+   "jar": "sha256-2cJarRdNv9WjxdsvIdO6g91XjFD6ddk97Xlv7cDUAMQ=",
+   "pom": "sha256-X9oyf/3E5Dm9sW3ISOFViyHqSxiBUa7hUY8SwGPw6u0="
+  },
+  "software/amazon/awssdk#third-party-jackson-core/2.26.26": {
+   "jar": "sha256-hIIh41sn4Lu15Kh+bG8tDGqs60aTKEMF2jigJTfvzHY=",
+   "pom": "sha256-f9Y88xZ2Eta7OZ/CdgeURegvEkRrrRD94c5aBzvCjis="
+  },
+  "software/amazon/awssdk#third-party/2.26.26": {
+   "pom": "sha256-RdgCMKrfXWkjyNh20ouKjovZ5H4hdKJ4SKgOSMtN+E0="
+  },
+  "software/amazon/awssdk#utils/2.26.26": {
+   "jar": "sha256-Y2z08uIYzqoovxoTUZHJcQQ5mv9U7Sl6MGjGnPffASs=",
+   "pom": "sha256-NnbH7ytCITB3Zgt4EU+twT/r1CWCQPvz6C4HNIfiUt0="
+  },
+  "software/amazon/eventstream#eventstream/1.0.1": {
+   "jar": "sha256-DDfY5pYRfwLDAhkbgRCw0Osg+kEvzjTDomnsc8Fs6CI=",
+   "pom": "sha256-+UYMt5Sgp69oJ377V2lWno5mUVJQJ2w35ip+i9SyV8w="
+  },
+  "software/amazon/ion#ion-java/1.0.2": {
+   "jar": "sha256-DRJ7IFofzgq8KjdXoEF0hlG8ZsFc9MBZusWDOyfUcaU=",
+   "pom": "sha256-IKZDxG3mvDDMgfo7njuxaXr6NxaMwYN0VJe3BJabu5I="
+  }
+ },
+ "https://s3-eu-west-1.amazonaws.com/maven.seqera.io/releases": {
+  "io/seqera#wave-api/0.11.1": {
+   "jar": "sha256-nK04/nLgc9JnhcG0aErn0p+Ryvyzda7XgjZdcasxv/c=",
+   "module": "sha256-sg+2H0LtPSLg5RgufvApayx6NWLMjv2SKUm8UdNGWsM=",
+   "pom": "sha256-LjtN7MZPXCoqoG6E2VFOiksp+0ycX6Zh/p0rMtqmBEQ="
+  },
+  "io/seqera#wave-utils/0.12.1": {
+   "jar": "sha256-9X38gNB1Pdv8DZvmstNxHQj/I+kIuI9Bpa3x/2rvoO0=",
+   "module": "sha256-Ukgc/tr5Tu5LwCKmOOHy7cD8KpXkVr6ILyyIRK6gwIQ=",
+   "pom": "sha256-Fr4n54p6eWDDLO/FJ3O+0fpT7Td0xmhR735eH462g8E="
+  },
+  "org/apache/groovy#groovy-bom/4.0.21-patch.2": {
+   "module": "sha256-A38EDWOFyVE2tpRetXMsRbObHavHanSG0Z+Ea6iUErk=",
+   "pom": "sha256-DbAn/Ue8d61Hro5LY/gnyZwbDF0bcPTxtdeuSnPDXKk="
+  },
+  "org/apache/groovy#groovy-console/4.0.21-patch.2": {
+   "jar": "sha256-5u2tAQZfe46pmvWkePVNScU3uw5u8uFCNdaVeELM5Aw=",
+   "module": "sha256-Xj/ZsAfVMWDtV72+R3RRdrVKmffOH/1ynAlwj2NwMzU=",
+   "pom": "sha256-C/44K5FvC04qagEWksqaa2QSKoDucSJGeI7b9O8dal8="
+  }
+ }
+}


### PR DESCRIPTION
~~There is no need to use buildFHSEnv (anymore) on Linux. I removed it here because a) it makes the code cleaner, b) improves access (e.g. the `version` will be shown on https://search.nixos.org/packages?query=nextflow) and c) allows to add & run tests.~~

**Update 2024-09-06**

This PR is a complete rewrite of the `nextflow` derivation:
* Do not use `buildFSHEnv` anymore but rather patch the original source (so that `/bin/bash` is not referenced anymore)
* The above is only possible when compiling from source (instead of downloading a release), this is done using `gradle`
* Update nextflow version
* Use the latest Java version
* Add tests

This PR supersedes [a previous one](https://github.com/NixOS/nixpkgs/pull/286701) prepared by @edmundmiller. I have incorporated his `openjdk` change.


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
