### PR TITLE
Flarum: fix installation and client interface issues

### DIFF
--- a/nixos/modules/services/web-apps/flarum.nix
+++ b/nixos/modules/services/web-apps/flarum.nix
@@ -116,6 +116,7 @@ in {
       isSystemUser = true;
       home = cfg.stateDir;
       createHome = true;
+      homeMode = "755";
       group = cfg.group;
     };
     users.groups.${cfg.group} = {};
@@ -194,8 +195,6 @@ in {
         cp -f ${cfg.package}/share/php/flarum/{extend.php,site.php,flarum} .
         ln -sf ${cfg.package}/share/php/flarum/vendor .
         ln -sf ${cfg.package}/share/php/flarum/public/index.php public/
-        chmod a+x . public
-        chmod +x site.php extend.php flarum
       '' + optionalString (cfg.createDatabaseLocally && cfg.database.driver == "mysql") ''
         if [ ! -f config.php ]; then
             php flarum install --file=${flarumInstallConfig}

--- a/nixos/modules/services/web-apps/flarum.nix
+++ b/nixos/modules/services/web-apps/flarum.nix
@@ -106,8 +106,14 @@ in {
 
     createDatabaseLocally = mkOption {
       type = types.bool;
-      default = true;
-      description = "Create the database and database user locally, and run installation.";
+      default = false;
+      description = ''
+        Create the database and database user locally, and run installation.
+
+        WARNING: Due to https://github.com/flarum/framework/issues/4018, this option is set
+        to false by default. The 'flarum install' command may delete existing database tables.
+        Only set this to true if you are certain you are working with a fresh, empty database.
+      '';
     };
   };
 


### PR DESCRIPTION
## Description of changes
Fix common issues in flarum, mainly:

1. Client interface is not loading well and can have this warning:
```
Something went wrong while trying to load the full version of this site...
```
2. As mentioned on issue: https://github.com/flarum/framework/issues/4018, `flarum install` currently drops entire database tables, such as the user tables, if they exist.

Closes:  #338577

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
