### PR TITLE
sqlitebrowser: Fix build for macOS

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/macos.patch
+++ b/pkgs/development/tools/database/sqlitebrowser/macos.patch
@@ -1,0 +1,86 @@
+diff -ru source/CMakeLists.txt source-patched/CMakeLists.txt
+--- source/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
++++ source-patched/CMakeLists.txt	2024-09-03 11:09:48.289053141 +0200
+@@ -39,9 +39,7 @@
+ set(CMAKE_AUTOMOC ON)
+ set(CMAKE_INCLUDE_CURRENT_DIR ON)
+ 
+-if(APPLE)
+-    add_executable(${PROJECT_NAME} MACOSX_BUNDLE)
+-elseif(WIN32)
++if(WIN32)
+     add_executable(${PROJECT_NAME} WIN32)
+ else()
+     add_executable(${PROJECT_NAME})
+@@ -106,33 +104,6 @@
+     list(PREPEND CMAKE_PREFIX_PATH ${QT5_PATH} ${SQLITE3_PATH})
+ endif()
+ 
+-
+-if(APPLE)
+-    # For Intel Mac's
+-    if(EXISTS /usr/local/opt/qt5)
+-        list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
+-    endif()
+-
+-    # For Apple Silicon Mac's
+-    if(EXISTS /opt/homebrew/opt/qt5)
+-        list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/qt5")
+-    endif()
+-    if(EXISTS /opt/homebrew/opt/sqlitefts5)
+-        list(PREPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/sqlitefts5")
+-    endif()
+-
+-    # For Apple Silicon Mac's and install dependencies via our Homebrew tap(sqlitebrowser/homebrew-tap)
+-    if(customTap AND EXISTS /opt/homebrew/opt/)
+-        list(PREPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/sqlb-qt@5")
+-        list(PREPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/sqlb-sqlite")
+-
+-        if(sqlcipher)
+-            list(APPEND SQLCIPHER_INCLUDE_DIR "/opt/homebrew/include")
+-            list(APPEND SQLCIPHER_LIBRARY "/opt/homebrew/opt/sqlb-sqlcipher/lib/libsqlcipher.0.dylib")
+-        endif()
+-    endif()
+-endif()
+-
+ find_package(Qt5 REQUIRED COMPONENTS Concurrent Gui LinguistTools Network PrintSupport Test Widgets Xml)
+ 
+ if(NOT FORCE_INTERNAL_QSCINTILLA)
+@@ -439,13 +410,6 @@
+     set(LIBSQLITE_NAME SQLite3)
+ endif()
+ 
+-# add extra library path for MacOS and FreeBSD
+-set(EXTRAPATH APPLE OR ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+-if(EXTRAPATH)
+-    list(PREPEND CMAKE_PREFIX_PATH /usr/local/opt/sqlite/lib)
+-    list(PREPEND CMAKE_PREFIX_PATH /usr/local/opt/sqlitefts5/lib)
+-endif()
+-
+ find_package(${LIBSQLITE_NAME})
+ if (sqlcipher)
+     target_link_libraries(${PROJECT_NAME} SQLCipher::SQLCipher)
+@@ -510,7 +474,7 @@
+     endif()
+ endif()
+ 
+-if((NOT WIN32 AND NOT APPLE) OR MINGW)
++if(NOT WIN32 OR MINGW)
+     install(TARGETS ${PROJECT_NAME}
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+@@ -630,14 +594,6 @@
+     )
+ endif()
+ 
+-if(APPLE)
+-    set_target_properties(${PROJECT_NAME} PROPERTIES
+-        BUNDLE True
+-        OUTPUT_NAME "DB Browser for SQLite"
+-        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/src/app.plist
+-    )
+-endif()
+-
+ # CPack configuration
+ set(CPACK_STRIP_FILES ON)
+ set(CPACK_DEBIAN_PACKAGE_PRIORITY optional)


### PR DESCRIPTION
## Description of changes

On macOS, the package does not produce the output `$out/bin/sqlitebrowser`. There is only a `share` folder.

The reason for this is that the build system creates a typical macOS `.app` bundle, but it is not even installed in `$out`. Also, such bundles can't be run from the command line of a nix shell and similar.

This PR patches out macOS-app-bundle specific instructions so that it works like a normal command line package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc @peterhoeg 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
