### PR TITLE
saml2aws: install shell completion

### DIFF
--- a/pkgs/tools/security/saml2aws/default.nix
+++ b/pkgs/tools/security/saml2aws/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildGoModule, fetchFromGitHub, AppKit }:
+{ lib, stdenv, buildGoModule, fetchFromGitHub, installShellFiles, AppKit }:
 
 buildGoModule rec {
   pname = "saml2aws";
@@ -13,6 +13,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-gtl8T8wXnpLgDZc6qSgFKpA+XbcLNHf20ieBkyNdE+s=";
 
+  nativeBuildInputs = [ installShellFiles ];
   buildInputs = lib.optionals stdenv.isDarwin [ AppKit ];
 
   subPackages = [ "." "cmd/saml2aws" ];
@@ -20,6 +21,12 @@ buildGoModule rec {
   ldflags = [
     "-X main.Version=${version}"
   ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd saml2aws \
+      --bash <($out/bin/saml2aws --completion-script-bash) \
+      --zsh <($out/bin/saml2aws --completion-script-zsh)
+  '';
 
   meta = with lib; {
     description = "CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP";

--- a/pkgs/tools/security/saml2aws/default.nix
+++ b/pkgs/tools/security/saml2aws/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, buildGoModule, fetchFromGitHub, installShellFiles, AppKit }:
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  AppKit,
+}:
 
 buildGoModule rec {
   pname = "saml2aws";
@@ -16,7 +23,10 @@ buildGoModule rec {
   nativeBuildInputs = [ installShellFiles ];
   buildInputs = lib.optionals stdenv.isDarwin [ AppKit ];
 
-  subPackages = [ "." "cmd/saml2aws" ];
+  subPackages = [
+    "."
+    "cmd/saml2aws"
+  ];
 
   ldflags = [
     "-X main.Version=${version}"
@@ -31,8 +41,8 @@ buildGoModule rec {
   meta = with lib; {
     description = "CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP";
     mainProgram = "saml2aws";
-    homepage    = "https://github.com/Versent/saml2aws";
-    license     = licenses.mit;
+    homepage = "https://github.com/Versent/saml2aws";
+    license = licenses.mit;
     maintainers = [ lib.maintainers.pmyjavec ];
   };
 }


### PR DESCRIPTION
## Description of changes

- Install shell completion for `bash` and `zsh`, as described in [README](https://github.com/Versent/saml2aws/blob/64255ff/README.md#autocomplete)
- Reformat file using `nixfmt-rfc-style`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
