### PR TITLE
python3Packages.mkPythonEditablePackage: init

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -374,6 +374,50 @@ mkPythonMetaPackage {
 }
 ```
 
+#### `mkPythonEditablePackage` function {#mkpythoneditablepackage-function}
+
+When developing Python packages it's common to install packages in [editable mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html).
+Like `mkPythonMetaPackage` this function exists to create an otherwise empty package, but also containing a pointer to an impure location outside the Nix store that can be changed without rebuilding.
+
+The editable root is passed as a string. Normally `.pth` files contains absolute paths to the mutable location. This isn't always ergonomic with Nix, so environment variables are expanded at runtime.
+This means that a shell hook setting up something like a `$REPO_ROOT` variable can be used as the relative package root.
+
+As an implementation detail, the [PEP-518](https://peps.python.org/pep-0518/) `build-system` specified won't be used, but instead the editable package will be built using [hatchling](https://pypi.org/project/hatchling/).
+The `build-system`'s provided will instead become runtime dependencies of the editable package.
+
+Note that overriding packages deeper in the dependency graph _can_ work, but it's not the primary use case and overriding existing packages can make others break in unexpected ways.
+
+``` nix
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  pyproject = pkgs.lib.importTOML ./pyproject.toml;
+
+  myPython = pkgs.python.override {
+    self = myPython;
+    packageOverrides = pyfinal: pyprev: {
+      # An editable package with a script that loads our mutable location
+      my-editable = pyfinal.mkPythonEditablePackage {
+        # Inherit project metadata from pyproject.toml
+        pname = pyproject.project.name;
+        inherit (pyproject.project) version;
+
+        # The editable root passed as a string
+        root = "$REPO_ROOT/src"; # Use environment variable expansion at runtime
+
+        # Inject a script (other PEP-621 entrypoints are also accepted)
+        inherit (pyproject.project) scripts;
+      };
+    };
+  };
+
+  pythonEnv =  testPython.withPackages (ps: [ ps.my-editable ]);
+
+in pkgs.mkShell {
+  packages = [ pythonEnv ];
+}
+```
+
 #### `python.buildEnv` function {#python.buildenv-function}
 
 Python environments can be created using the low-level `pkgs.buildEnv` function.

--- a/pkgs/development/interpreters/python/editable.nix
+++ b/pkgs/development/interpreters/python/editable.nix
@@ -1,0 +1,99 @@
+{
+  buildPythonPackage,
+  lib,
+  hatchling,
+  tomli-w,
+}:
+{
+  pname,
+  version,
+
+  # Editable root as string.
+  # Environment variables will be expanded at runtime using os.path.expandvars.
+  root,
+
+  # Arguments passed on verbatim to buildPythonPackage
+  derivationArgs ? { },
+
+  # Python dependencies
+  dependencies ? [ ],
+  optional-dependencies ? { },
+
+  # PEP-518 build-system https://peps.python.org/pep-518
+  build-system ? [ ],
+
+  # PEP-621 entry points https://peps.python.org/pep-0621/#entry-points
+  scripts ? { },
+  gui-scripts ? { },
+  entry-points ? { },
+
+  passthru ? { },
+  meta ? { },
+}:
+
+# Create a PEP-660 (https://peps.python.org/pep-0660/) editable package pointing to an impure location outside the Nix store.
+# The primary use case of this function is to enable local development workflows where the local package is installed into a virtualenv-like environment using withPackages.
+
+assert lib.isString root;
+let
+  # In editable mode build-system's are considered to be runtime dependencies.
+  dependencies' = dependencies ++ build-system;
+
+  pyproject = {
+    # PEP-621 project table
+    project = {
+      name = pname;
+      inherit
+        version
+        scripts
+        gui-scripts
+        entry-points
+        ;
+      dependencies = map lib.getName dependencies';
+      optional-dependencies = lib.mapAttrs (_: lib.getName) optional-dependencies;
+    };
+
+    # Allow empty package
+    tool.hatch.build.targets.wheel.bypass-selection = true;
+
+    # Include our editable pointer file in build
+    tool.hatch.build.targets.wheel.force-include."_${pname}.pth" = "_${pname}.pth";
+
+    # Build editable package using hatchling
+    build-system = {
+      requires = [ "hatchling" ];
+      build-backend = "hatchling.build";
+    };
+  };
+
+in
+buildPythonPackage (
+  {
+    inherit
+      pname
+      version
+      optional-dependencies
+      passthru
+      meta
+      ;
+    dependencies = dependencies';
+
+    pyproject = true;
+
+    unpackPhase = ''
+      python -c "import json, tomli_w; print(tomli_w.dumps(json.load(open('$pyprojectContentsPath'))))" > pyproject.toml
+      echo 'import os.path, sys; sys.path.insert(0, os.path.expandvars("${root}"))' > _${pname}.pth
+    '';
+
+    build-system = [ hatchling ];
+  }
+  // derivationArgs
+  // {
+    # Note: Using formats.toml generates another intermediary derivation that needs to be built.
+    # We inline the same functionality for better UX.
+    nativeBuildInputs = (derivationArgs.nativeBuildInputs or [ ]) ++ [ tomli-w ];
+    pyprojectContents = builtins.toJSON pyproject;
+    passAsFile = [ "pyprojectContents" ];
+    preferLocalBuild = true;
+  }
+)

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -61,6 +61,8 @@ let
 
   removePythonPrefix = lib.removePrefix namePrefix;
 
+  mkPythonEditablePackage = callPackage ./editable.nix { };
+
   mkPythonMetaPackage = callPackage ./meta-package.nix { };
 
   # Convert derivation to a Python module.
@@ -99,7 +101,7 @@ in {
   inherit buildPythonPackage buildPythonApplication;
   inherit hasPythonModule requiredPythonModules makePythonPath disabled disabledIf;
   inherit toPythonModule toPythonApplication;
-  inherit mkPythonMetaPackage;
+  inherit mkPythonMetaPackage mkPythonEditablePackage;
 
   python = toPythonModule python;
 


### PR DESCRIPTION
## Description of changes

When developing Python packages it's common to install packages in [editable mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html).
Like `mkPythonMetaPackage` this function exists to create an otherwise empty package, but also containing a pointer to an impure location outside the Nix store that can be changed without rebuilding.

The editable root is passed as a string. Normally `.pth` files contains _absolute_ paths to the mutable location. This isn't always ergonomic with Nix, so I have decided to expand environment variables at runtime.
This means that a shell hook setting up something like a `$REPO_ROOT` variable can be used as the relative package root.

Note that overriding packages deeper in the dependency graph _can_ work, but it's not the primary usecase and overriding existing packages can make others break in unexpected ways.

``` nix
{ pkgs ? import <nixpkgs> { } }:

let
  myPython = pkgs.python.override {
    self = myPython;
    packageOverrides = pyfinal: pyprev: {
      # An editable package with a script that loads our mutable location
      my-editable = pyfinal.mkPythonEditablePackage {
        pname = "my-editable";
        version = "0.1.0";
        root = "$REPO_ROOT/src"; # Use environment variable expansion at runtime
        # Inject a script (other PEP-621 entrypoints are also accepted)
        scripts = {
          my-script = "my_editable.main:main";
        };
      };
    };
  };

  pythonEnv =  testPython.withPackages (ps: [ ps.my-editable ]);

in pkgs.mkShell {
  packages = [ pythonEnv ];
}
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
