### PR TITLE
pkgs/build-support/rust: fix warning "`build/.cargo/config` is  deprecated"

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
+++ b/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
@@ -73,7 +73,7 @@ in stdenv.mkDerivation ({
 
     ${cargoUpdateHook}
 
-    # Override the `http.cainfo` option usually specified in `.cargo/config`.
+    # Override the `http.cainfo` option usually specified in `.cargo/config.toml`.
     export CARGO_HTTP_CAINFO=${cacert}/etc/ssl/certs/ca-bundle.crt
 
     if grep '^source = "git' Cargo.lock; then
@@ -96,7 +96,8 @@ in stdenv.mkDerivation ({
 
     # Packages with git dependencies generate non-default cargo configs, so
     # always install it rather than trying to write a standard default template.
-    install -D $CARGO_CONFIG $name/.cargo/config;
+    install -D $CARGO_CONFIG $name/.cargo/config.toml;
+    ln -s .cargo/config.toml .cargo/config
 
     runHook postBuild
   '';

--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -22,7 +22,7 @@ cargoSetupPostUnpackHook() {
         mkdir .cargo
     fi
 
-    config="$cargoDepsCopy/.cargo/config";
+    config="$cargoDepsCopy/.cargo/config.toml";
     if [[ ! -e $config ]]; then
       config=@defaultConfig@
     fi;
@@ -30,11 +30,12 @@ cargoSetupPostUnpackHook() {
     tmp_config=$(mktemp)
     substitute $config $tmp_config \
       --subst-var-by vendor "$cargoDepsCopy"
-    cat ${tmp_config} >> .cargo/config
+    cat ${tmp_config} >> .cargo/config.toml
 
-    cat >> .cargo/config <<'EOF'
+    cat >> .cargo/config.toml <<'EOF'
     @cargoConfig@
 EOF
+    ln -s .cargo/config.toml .cargo/config
 
     echo "Finished cargoSetupPostUnpackHook"
 }

--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -229,7 +229,7 @@ let
       else "cp $lockFileContentsPath $out/Cargo.lock"
     }
 
-    cat > $out/.cargo/config <<EOF
+    cat > $out/.cargo/config.toml <<EOF
 [source.crates-io]
 replace-with = "vendored-sources"
 
@@ -240,7 +240,8 @@ EOF
     declare -A keysSeen
 
     for registry in ${toString (builtins.attrNames extraRegistries)}; do
-      cat >> $out/.cargo/config <<EOF
+      cat >> $out/.cargo/config.toml <<EOF
+      ln -s .cargo/config.toml .cargo/config
 
 [source."$registry"]
 registry = "$registry"
@@ -256,7 +257,8 @@ EOF
         key=$(sed 's/\[source\."\(.*\)"\]/\1/; t; d' < "$crate/.cargo-config")
         if [[ -z ''${keysSeen[$key]} ]]; then
           keysSeen[$key]=1
-          cat "$crate/.cargo-config" >> $out/.cargo/config
+          cat "$crate/.cargo-config" >> $out/.cargo/config.toml
+          ln -s .cargo/config.toml .cargo/config
         fi
       fi
     done


### PR DESCRIPTION
## Description of changes

With a recent `cargo` version update the deprecation warning (see below) became more vocal.

```
warning: `/build/.cargo/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
```

To verify this works I built the `bk` package, as it is very small and has very little deps.

Edit: it creates the symlink to the old `/build/.cargo/confgi` in case some packge enforces an old `cargo` version of `1.38` or older

closes #334857

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
