### PR TITLE
[DRAFT] libcosmicAppHook: init

### DIFF
--- a/pkgs/build-support/setup-hooks/libcosmicAppHook/default.nix
+++ b/pkgs/build-support/setup-hooks/libcosmicAppHook/default.nix
@@ -1,0 +1,74 @@
+{
+  stdenv,
+  lib,
+  makeSetupHook,
+  makeBinaryWrapper,
+  pkg-config,
+  libGL,
+  libxkbcommon,
+  xorg,
+  wayland,
+  vulkan-loader,
+  targetPackages,
+  includeSettings ? true,
+}:
+
+makeSetupHook {
+  name = "libcosmic-app-hook";
+
+  propagatedBuildInputs = [
+    makeBinaryWrapper
+    pkg-config
+  ];
+
+  # TODO: Xorg libs can be removed once tiny-xlib is bumped above 0.2.2 in libcosmic/iced
+  depsTargetTargetPropagated =
+    assert (lib.assertMsg (!targetPackages ? raw) "libcosmicAppHook must be in nativeBuildInputs");
+    [
+      libGL
+      libxkbcommon
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXi
+      xorg.libXrandr
+    ]
+    ++ lib.optionals (!stdenv.isDarwin) [
+      wayland
+      vulkan-loader
+    ];
+
+  substitutions = {
+    fallbackXdgDirs = "${lib.optionalString includeSettings "${targetPackages.cosmic-settings}/share:"}${targetPackages.cosmic-icons}/share";
+
+    cargoLinkerVar = stdenv.hostPlatform.rust.cargoEnvVarTarget;
+    cargoLinkLibs = lib.escapeShellArgs (
+      [
+        # propagated from libGL
+        "EGL"
+        # propagated from libxkbcommon
+        "xkbcommon"
+        # propagated from xorg.libX11
+        "X11"
+        # propagated from xorg.libXcursor
+        "Xcursor"
+        # propagated from xorg.libXi
+        "Xi"
+        # propagated from xorg.libXrandr
+        "Xrandr"
+      ]
+      ++ lib.optionals (!stdenv.isDarwin) [
+        # propagated from wayland
+        "wayland-client"
+        # propagated from vulkan-loader
+        "vulkan"
+      ]
+    );
+  };
+
+  meta = {
+    description = "Setup hook for configuring and wrapping applications based on libcosmic";
+    maintainers = [
+      lib.maintainers.nyanbinary
+    ];
+  };
+} ./libcosmic-app-hook.sh

--- a/pkgs/build-support/setup-hooks/libcosmicAppHook/libcosmic-app-hook.sh
+++ b/pkgs/build-support/setup-hooks/libcosmicAppHook/libcosmic-app-hook.sh
@@ -1,0 +1,83 @@
+# shellcheck shell=bash
+libcosmicAppWrapperArgs=()
+
+libcosmicAppVergenHook() {
+  export VERGEN_GIT_COMMIT_DATE="$SOURCE_DATE_EPOCH"
+}
+
+libcosmicAppLinkerArgsHook() {
+  # Force linking to certain libraries like libEGL, which are always dlopen()ed
+  local flags="CARGO_TARGET_@cargoLinkerVar@_RUSTFLAGS"
+
+  export "$flags"="${!flags-} -C link-arg=-Wl,--push-state,--no-as-needed"
+  # shellcheck disable=SC2043
+  for lib in @cargoLinkLibs@; do
+      export "$flags"="${!flags} -C link-arg=-l${lib}"
+  done
+  export "$flags"="${!flags} -C link-arg=-Wl,--pop-state"
+}
+
+preConfigurePhases+=" libcosmicAppVergenHook libcosmicAppLinkerArgsHook"
+
+libcosmicAppWrapperArgsHook() {
+    if [ -d "${prefix:?}/share" ]; then
+        libcosmicAppWrapperArgs+=(--suffix XDG_DATA_DIRS : "$prefix/share")
+    fi
+
+    # add fallback schemas, icons, and settings paths
+    libcosmicAppWrapperArgs+=(--suffix XDG_DATA_DIRS : "@fallbackXdgDirs@")
+}
+
+preFixupPhases+=" libcosmicAppWrapperArgsHook"
+
+wrapLibcosmicApp() {
+    local program="$1"
+    shift 1
+    wrapProgram "$program" "${libcosmicAppWrapperArgs[@]}" "$@"
+}
+
+# Note: $libcosmicAppWrapperArgs still gets defined even if ${dontWrapLibcosmicApp-} is set
+libcosmicAppWrapHook() {
+    # guard against running multiple times (e.g. due to propagation)
+    [ -z "$libcosmicAppWrapHookHasRun" ] || return 0
+    libcosmicAppWrapHookHasRun=1
+
+    if [[ -z "${dontWrapLibcosmicApp:-}" ]]; then
+        targetDirsThatExist=()
+        targetDirsRealPath=()
+
+        # wrap binaries
+        targetDirs=("${prefix}/bin" "${prefix}/libexec")
+        for targetDir in "${targetDirs[@]}"; do
+            if [[ -d "${targetDir}" ]]; then
+                targetDirsThatExist+=("${targetDir}")
+                targetDirsRealPath+=("$(realpath "${targetDir}")/")
+                find "${targetDir}" -type f -executable -print0 |
+                    while IFS= read -r -d '' file; do
+                        echo "Wrapping program '${file}'"
+                        wrapLibcosmicApp "${file}"
+                    done
+            fi
+        done
+
+        # wrap links to binaries that point outside targetDirs
+        # Note: links to binaries within targetDirs do not need
+        #       to be wrapped as the binaries have already been wrapped
+        if [[ ${#targetDirsThatExist[@]} -ne 0 ]]; then
+            find "${targetDirsThatExist[@]}" -type l -xtype f -executable -print0 |
+                while IFS= read -r -d '' linkPath; do
+                    linkPathReal=$(realpath "${linkPath}")
+                    for targetPath in "${targetDirsRealPath[@]}"; do
+                        if [[ "$linkPathReal" == "$targetPath"* ]]; then
+                            echo "Not wrapping link: '$linkPath' (already wrapped)"
+                            continue 2
+                        fi
+                    done
+                    echo "Wrapping link: '$linkPath'"
+                    wrapLibcosmicApp "${linkPath}"
+                done
+        fi
+    fi
+}
+
+fixupOutputHooks+=(libcosmicAppWrapHook)


### PR DESCRIPTION
## Description of changes
Adds libcosmicAppHook for libcosmic apps.
Upstreamed from [nixos-cosmic](https://github.com/lilyinstarlight/nixos-cosmic) by @lilyinstarlight 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
