### PR TITLE
nix-direnv: Use nix from $PATH

### DIFF
--- a/pkgs/by-name/ni/nix-direnv/package.nix
+++ b/pkgs/by-name/ni/nix-direnv/package.nix
@@ -1,4 +1,4 @@
-{ resholve, lib, coreutils, direnv, nix, fetchFromGitHub }:
+{ resholve, lib, coreutils, direnv, fetchFromGitHub }:
 
 # resholve does not yet support `finalAttrs` call pattern hence `rec`
 # https://github.com/abathur/resholve/issues/107
@@ -28,7 +28,7 @@ resholve.mkDerivation rec {
     default = {
       scripts = [ "share/nix-direnv/direnvrc" ];
       interpreter = "none";
-      inputs = [ coreutils nix ];
+      inputs = [ coreutils ];
       fake = {
         builtin = [
           "PATH_add"
@@ -42,6 +42,10 @@ resholve.mkDerivation rec {
           # not really a function - this is in an else branch for macOS/homebrew that
           # cannot be reached when built with nix
           "shasum"
+          # Use the `nix` executable from the user's environment; the user
+          # might not have stable Nix installed and might be depending on
+          # features, settings etc. that stable Nix doesn't support.
+          "nix"
         ];
       };
       keep = {
@@ -50,7 +54,6 @@ resholve.mkDerivation rec {
       };
       execer = [
         "cannot:${direnv}/bin/direnv"
-        "cannot:${nix}/bin/nix"
       ];
     };
   };


### PR DESCRIPTION
## Description of changes

`nix-direnv` always uses the stable `nix` from the nixpkgs it's built with, which is not always the `nix` that the user has installed. Instead of baking the absolute path to the nixpkgs' default `nix` into the outputs, let's use the `nix` on the user's `$PATH`.

This is the approach used by [`nix-output-monitor`](https://github.com/NixOS/nixpkgs/blob/f511a20bc062ec34c91a9964eeb39710423a6e19/pkgs/tools/nix/nix-output-monitor/default.nix) and similar. Compare to packages like [`git-absorb`](https://github.com/NixOS/nixpkgs/blob/f511a20bc062ec34c91a9964eeb39710423a6e19/pkgs/applications/version-management/git-absorb/default.nix) or [`git-revise`](https://github.com/NixOS/nixpkgs/blob/f511a20bc062ec34c91a9964eeb39710423a6e19/pkgs/development/python-modules/git-revise/default.nix), which don't include `git` in their `runtimeInputs`.

Before (stable `nix` doesn't recognize [the `repl-overlays` setting](https://docs.lix.systems/manual/lix/stable/command-ref/conf-file.html#conf-repl-overlays)):

```
$ direnv reload
direnv: loading ~/cabal/.envrc
direnv: using flake github:9999years/cabal.nix
warning: unknown setting 'repl-overlays'
warning: unknown setting 'repl-overlays'
warning: unknown setting 'repl-overlays'
warning: unknown setting 'repl-overlays'
warning: unknown setting 'repl-overlays'
warning: unknown setting 'repl-overlays'
warning: unknown setting 'repl-overlays'
direnv: nix-direnv: Renewed cache
direnv: export +AR +AS +CC +CONFIG_SHELL ...
```

After (the `nix` binary on my `$PATH` does know about the `repl-overlays` setting, so no warnings are emitted):

```
$ direnv reload
direnv: loading ~/cabal/.envrc
direnv: using flake github:9999years/cabal.nix/52eb322ece8a0bb34153d682eed994c5dbd634d3
direnv: nix-direnv: Renewed cache
direnv: export +AR +AS +CC +CONFIG_SHELL ...
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
