### PR TITLE
replaceVars.withoutCheck: init

### DIFF
--- a/pkgs/build-support/replace-vars/default.nix
+++ b/pkgs/build-support/replace-vars/default.nix
@@ -1,18 +1,24 @@
-{ lib, stdenvNoCC }:
+{
+  lib,
+  stdenvNoCC,
+  doCheck ? true,
+}:
 
 /**
-  `replaceVars` is a wrapper around the [bash function `substitute`](https://nixos.org/manual/nixpkgs/stable/#fun-substitute)
+  `replaceVars` is a wrapper around the [bash function `substitute`](https://nixos.org/manual/nixpkgs/unstable/#fun-substitute)
   in the stdenv. It allows for terse replacement of names in the specified path, while checking
   for common mistakes such as naming a replacement that does nothing or forgetting a variable which
   needs to be replaced.
 
-  As with the [`--subst-var-by`](https://nixos.org/manual/nixpkgs/stable/#fun-substitute-subst-var-by)
+  As with the [`--subst-var-by`](https://nixos.org/manual/nixpkgs/unstable/#fun-substitute-subst-var-by)
   flag, names are encoded as `@name@` in the provided file at the provided path.
 
   Any unmatched variable names in the file at the provided path will cause a build failure.
 
   Any remaining text that matches `@[A-Za-z_][0-9A-Za-z_'-]@` in the output after replacement
-  has occurred will cause a build failure.
+  has occurred will cause a build failure. In the case this step is not desired, use
+  `replaceVars.withoutCheck`, which has the same semantics but doesn't have a check phase making
+  the assertion about remaining unreplaced variables.
 
   # Inputs
 
@@ -20,15 +26,65 @@
   : The file in which to replace variables.
 
   `attrs` (AttrsOf String)
-  : Each entry in this set corresponds to a `--subst-var-by` entry in [`substitute`](https://nixos.org/manual/nixpkgs/stable/#fun-substitute).
+  : Each entry in this set corresponds to a `--subst-var-by` entry in [`substitute`](https://nixos.org/manual/nixpkgs/unstable/#fun-substitute).
 
-  # Example
+  # Examples
+
+  ## `replaceVars`
+
+  Given a file `greeting.txt` that contains the following contents:
+
+  ```
+  @greeting@! Have you heard about the way of the Jedi?
+  ```
+
+  And a derivation that looks like this:
 
   ```nix
   { replaceVars }:
 
-  replaceVars ./greeting.txt { world = "hello"; }
+  replaceVars ./greeting.txt { greeting = "Hello there"; }
   ```
+
+  The resulting file in `$out` contains this text:
+
+  ```
+  Hello there! Have you heard about the way of the Jedi?
+  ```
+
+  ## `replaceVars.withoutCheck`
+
+  Given a file named `template.json` that contains the following contents:
+
+  ```
+  {
+    "key": "@key@",
+    "value": @value@
+  }
+  ```
+
+  And a derivation that looks like this:
+
+  ```nix
+  { replaceVars }:
+
+  replaceVars.withoutCheck ./template.json { key = "master"; }
+  ```
+
+  The resulting file in `$out` contains this text:
+
+  ```
+  {
+    "key": "master",
+    "value": @value@
+  }
+  ```
+
+  This allows chaining together `replaceVars` calls in subsequent derivations or the use of the
+  `substituteInPlace` stdenv function to complete the replacements, at the cost of potentially
+  leaving unreplaced material in the output.
+
+  # Tests
 
   See `../../test/replace-vars/default.nix` for tests of this function.
 */
@@ -48,7 +104,7 @@ in
 stdenvNoCC.mkDerivation {
   name = baseNameOf (toString path);
   src = path;
-  doCheck = true;
+  inherit doCheck;
   dontUnpack = true;
   preferLocalBuild = true;
   allowSubstitutes = false;

--- a/pkgs/test/replace-vars/default.nix
+++ b/pkgs/test/replace-vars/default.nix
@@ -27,6 +27,23 @@ in
     '';
   };
 
+  # Success case for `replaceVars.withoutCheck`.
+  replaceVars-without-check = testEqualContents {
+    assertion = "replaceVars-without-check";
+    actual = replaceVars.withoutCheck ./source.txt {
+      "equal in" = "are the same in";
+      brotherhood = "shared humanity";
+    };
+
+    expected = builtins.toFile "expected" ''
+      All human beings are born @free@ and are the same in dignity and rights.
+      They are endowed with reason and conscience and should act towards
+      one another in a spirit of shared humanity.
+
+        -- eroosevelt@humanrights.un.org
+    '';
+  };
+
   # There might eventually be a usecase for this, but it's not supported at the moment.
   replaceVars-fails-on-directory =
     runCommand "replaceVars-fails" { failed = testBuildFailure (replaceVars emptyDirectory { }); }
@@ -38,6 +55,14 @@ in
   replaceVars-fails-in-build-phase =
     runCommand "replaceVars-fails"
       { failed = testBuildFailure (replaceVars emptyFile { not-found = "boo~"; }); }
+      ''
+        grep -e "ERROR: pattern @not-found@ doesn't match anything in file.*empty-file" $failed/testBuildFailure.log
+        touch $out
+      '';
+
+  replaceVars-without-check-fails-in-build-phase =
+    runCommand "replaceVars-fails"
+      { failed = testBuildFailure (replaceVars.withoutCheck emptyFile { not-found = "boo~"; }); }
       ''
         grep -e "ERROR: pattern @not-found@ doesn't match anything in file.*empty-file" $failed/testBuildFailure.log
         touch $out

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1329,7 +1329,9 @@ with pkgs;
 
   replaceDependency = callPackage ../build-support/replace-dependency.nix { };
 
-  replaceVars = callPackage ../build-support/replace-vars { };
+  replaceVars = callPackage ../build-support/replace-vars { } // {
+    withoutCheck = callPackage ../build-support/replace-vars { doCheck = false; };
+  };
 
   nukeReferences = callPackage ../build-support/nuke-references {
     inherit (darwin) signingUtils;


### PR DESCRIPTION
## Motivation for change

[`replaceVars`](https://github.com/NixOS/nixpkgs/pull/301350) is a wrapper around the [bash function `substitute`](https://nixos.org/manual/nixpkgs/unstable/#fun-substitute) in the stdenv.

It has a checkPhase which causes the derivation to fail to build if any remaining text that matches `@[A-Za-z_][0-9A-Za-z_'-]@` is in the output after replacement has occurred.

As can be seen in https://github.com/NixOS/nixpkgs/pull/338962#discussion_r1742238053, sometimes this check phase is too strict, and there needs to be two phases of substitution.

So this PR introduces `replaceVars.withoutCheck`, which has the same semantics but doesn't have a check phase making the assertion about remaining unreplaced variables.

## Description of changes

- [x] Add `replaceVars.withoutCheck`
- [x] Document it
- [x] Test it
- [ ] Use it

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).