### PR TITLE
treewide: Fix or remove some markdown links

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,7 +1,7 @@
 # CI support files
 
 This directory contains files to support CI, such as [GitHub Actions](https://github.com/NixOS/nixpkgs/tree/master/.github/workflows) and [Ofborg](https://github.com/nixos/ofborg).
-This is in contrast with [`maintainers/scripts`](`../maintainers/scripts`) which is for human use instead.
+This is in contrast with [`maintainers/scripts`](../maintainers/scripts) which is for human use instead.
 
 ## Pinned Nixpkgs
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -285,7 +285,7 @@ You, as the writer of documentation, are still in charge of its content.
   - _optional_ attributes have a _`Default:`_ if it's easily described as a value.
   - _optional_ attributes have a _`Default behavior:`_ if it's not easily described using a value.
   - Nix types aren't in code spans, because they are not code
-  - Nix types are capitalized, to distinguish them from the camelCase [Module System](#module-system) types, which _are_ code and behave like functions.
+  - Nix types are capitalized, to distinguish them from the camelCase Module System types, which _are_ code and behave like functions.
 
 #### Examples
 

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -689,7 +689,7 @@ Here are examples of package tests:
 - [Lobster compile test](development/compilers/lobster/test-can-run-hello-world.nix)
 - [Spacy annotation test](development/python-modules/spacy/annotation-test/default.nix)
 - [Libtorch test](development/libraries/science/math/libtorch/test/default.nix)
-- [Multiple tests for nanopb](development/libraries/nanopb/default.nix)
+- [Multiple tests for nanopb](./by-name/na/nanopb/package.nix)
 
 ### Linking NixOS module tests to a package
 

--- a/pkgs/applications/science/math/sage/README.md
+++ b/pkgs/applications/science/math/sage/README.md
@@ -12,7 +12,7 @@ If the build broke as a result of a package update, try those solutions in order
 
 - search the [sage GitHub repo](https://github.com/sagemath/sage) for keywords like "Upgrade <package>". Maybe somebody has already proposed a patch that fixes the issue. You can then add a `fetchpatch` to `sage-src.nix`.
 
-- check if [gentoo](https://github.com/cschwan/sage-on-gentoo/tree/master/sci-mathematics/sage), [debian](https://salsa.debian.org/science-team/sagemath/tree/master/debian) or [arch linux](https://git.archlinux.org/svntogit/community.git/tree/trunk?h=packages/sagemath) already solved the problem. You can then again add a `fetchpatch` to `sage-src.nix`. If applicable you should also [propose the patch upstream](#proposing-a-sage-patch).
+- check if [gentoo](https://github.com/cschwan/sage-on-gentoo/tree/master/sci-mathematics/sage), [debian](https://salsa.debian.org/science-team/sagemath/tree/master/debian) or [arch linux](https://git.archlinux.org/svntogit/community.git/tree/trunk?h=packages/sagemath) already solved the problem. You can then again add a `fetchpatch` to `sage-src.nix`. If applicable you should also propose the patch upstream.
 
 - fix the problem yourself. First clone the sagemath source and then check out the sage version you want to patch:
 

--- a/pkgs/development/compilers/elm/packages/README.md
+++ b/pkgs/development/compilers/elm/packages/README.md
@@ -9,15 +9,15 @@ Please refer to [nix documentation](https://nixos.org/nixpkgs/manual/#how-to-cre
 and [cabal2nix readme](https://github.com/NixOS/cabal2nix#readme) for more information. Elm-format [update scripts](https://github.com/avh4/elm-format/tree/master/package/nix)
 is part of its repository.
 
-Node dependencies are defined in [node-packages.json](node-packages.json).
+Node dependencies are defined in [node-packages.json](node/node-packages.json).
 [Node2nix](https://github.com/svanderburg/node2nix) is used for generating nix expression
-from this file. Use [generate-node-packages.sh](generate-node-packages.sh) for updates of nix expressions.
+from this file. Use [generate-node-packages.sh](node/generate-node-packages.sh) for updates of nix expressions.
 
 ## Binwrap Patch
 
 Some node packages might use [binwrap](https://github.com/avh4/binwrap) typically for installing
 [elmi-to-json](https://github.com/stoeffel/elmi-to-json). Binwrap is not compatible with nix.
-To overcome issues with those packages apply [patch-binwrap.nix](patch-binwrap.nix) which essentially does 2 things.
+To overcome issues with those packages apply [patch-binwrap.nix](../lib/default.nix) which essentially does 2 things.
 
 1. It replaces binwrap scripts with noop shell scripts
 2. It uses nix for installing the binaries to expected location in `node_modules`

--- a/pkgs/development/cuda-modules/modules/README.md
+++ b/pkgs/development/cuda-modules/modules/README.md
@@ -25,11 +25,11 @@ aliases the generic module for manifests.
 
 Alternatively, additional fields or values may need to be configured to account
 for the particulars of a package. For example, while the release expressions for
-[CUDNN](./cudnn/releases.nix) and [TensorRT](./tensorrt/releases.nix) are very
+[CUDNN](../cudnn/releases.nix) and [TensorRT](../tensorrt/releases.nix) are very
 close, they differ slightly in the fields they have. The [module for
-CUDNN](./modules/cudnn/default.nix) is able to use the generic module for
+CUDNN](./cudnn/default.nix) is able to use the generic module for
 release expressions, while the [module for
-TensorRT](./modules/tensorrt/default.nix) must add additional fields to the
+TensorRT](./tensorrt/default.nix) must add additional fields to the
 generic module.
 
 ### `manifests`


### PR DESCRIPTION
## Description of changes

Found using https://github.com/serokell/xrefcheck, which unfortunately can't trivially be enforced in CI because we also have the manual markdown files that need post-processing to be valid

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
