### PR TITLE
`nix-direnv`: 3.0.5 -> 3.0.6

### DIFF
--- a/pkgs/by-name/ni/nix-direnv/package.nix
+++ b/pkgs/by-name/ni/nix-direnv/package.nix
@@ -1,4 +1,11 @@
-{ resholve, lib, coreutils, direnv, nix, fetchFromGitHub }:
+{
+  resholve,
+  lib,
+  coreutils,
+  nix,
+  fetchFromGitHub,
+  writeText,
+}:
 
 # resholve does not yet support `finalAttrs` call pattern hence `rec`
 # https://github.com/abathur/resholve/issues/107
@@ -13,11 +20,6 @@ resholve.mkDerivation rec {
     hash = "sha256-oNqhPqgQT92yxbKmcgX4F3e2yTUPyXYG7b2xQm3TvQw=";
   };
 
-  # skip min version checks which are redundant when built with nix
-  postPatch = ''
-    sed -i 1iNIX_DIRENV_SKIP_VERSION_CHECK=1 direnvrc
-  '';
-
   installPhase = ''
     runHook preInstall
     install -m400 -D direnvrc $out/share/nix-direnv/direnvrc
@@ -28,7 +30,7 @@ resholve.mkDerivation rec {
     default = {
       scripts = [ "share/nix-direnv/direnvrc" ];
       interpreter = "none";
-      inputs = [ coreutils nix ];
+      inputs = [ coreutils ];
       fake = {
         builtin = [
           "PATH_add"
@@ -43,23 +45,36 @@ resholve.mkDerivation rec {
           # cannot be reached when built with nix
           "shasum"
         ];
+        external = [
+          # We want to reference the ambient Nix when possible, and have custom logic
+          # for the fallback
+          "nix"
+        ];
       };
       keep = {
         "$cmd" = true;
         "$direnv" = true;
+
+        # Nix fallback implementation
+        "$_nix_direnv_nix" = true;
+        "$ambient_nix" = true;
+        "$NIX_DIRENV_FALLBACK_NIX" = true;
       };
-      execer = [
-        "cannot:${direnv}/bin/direnv"
-        "cannot:${nix}/bin/nix"
-      ];
+      prologue =
+        (writeText "prologue.sh" ''
+          NIX_DIRENV_FALLBACK_NIX=''${NIX_DIRENV_FALLBACK_NIX:-${lib.getExe nix}}
+        '').outPath;
     };
   };
 
   meta = {
     description = "Fast, persistent use_nix implementation for direnv";
-    homepage    = "https://github.com/nix-community/nix-direnv";
-    license     = lib.licenses.mit;
-    platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ mic92 bbenne10 ];
+    homepage = "https://github.com/nix-community/nix-direnv";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      mic92
+      bbenne10
+    ];
   };
 }

--- a/pkgs/by-name/ni/nix-direnv/package.nix
+++ b/pkgs/by-name/ni/nix-direnv/package.nix
@@ -4,13 +4,13 @@
 # https://github.com/abathur/resholve/issues/107
 resholve.mkDerivation rec {
   pname = "nix-direnv";
-  version = "3.0.5";
+  version = "3.0.6";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nix-direnv";
     rev = version;
-    hash = "sha256-imUlc5v/Ow7dgjCjTyEeet+4lNHLeEwfqGQcB4dKcao=";
+    hash = "sha256-oNqhPqgQT92yxbKmcgX4F3e2yTUPyXYG7b2xQm3TvQw=";
   };
 
   # skip min version checks which are redundant when built with nix


### PR DESCRIPTION
## Description of changes

Integrates https://github.com/nix-community/nix-direnv/pull/513 to use the ambient `nix` on the user's `$PATH`, if one is available.

Tested locally (aarch64-darwin).

See: https://github.com/nix-community/nix-direnv/releases/tag/3.0.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
