### PR TITLE
{micro-full,micro-with-wl-clipboard,micro-with-xclip}: "init"

### DIFF
--- a/pkgs/by-name/mi/micro/package.nix
+++ b/pkgs/by-name/mi/micro/package.nix
@@ -63,6 +63,7 @@ let
         inherit callPackage;
         directory = ./tests;
       };
+      wrapper = callPackage ./wrapper.nix { micro = self; };
     };
 
     meta = {

--- a/pkgs/by-name/mi/micro/package.nix
+++ b/pkgs/by-name/mi/micro/package.nix
@@ -1,26 +1,14 @@
 {
   lib,
-  stdenv,
   buildGoModule,
+  callPackage,
   fetchFromGitHub,
   installShellFiles,
-  callPackage,
-  wl-clipboard,
-  xclip,
-  makeWrapper,
-  # Boolean flags
-  withXclip ? stdenv.isLinux,
-  withWlClipboard ?
-    if withWlclip != null then
-      lib.warn ''
-        withWlclip is deprecated and will be removed;
-        use withWlClipboard instead.
-      '' withWlclip
-    else
-      stdenv.isLinux,
+  stdenv,
   # Deprecated options
-  # Remove them before or right after next version update from Nixpkgs or this
-  # package itself
+  # Remove them as soon as possible
+  withXclip ? null,
+  withWlClipboard ? null,
   withWlclip ? null,
 }:
 
@@ -38,10 +26,7 @@ let
 
     vendorHash = "sha256-ePhObvm3m/nT+7IyT0W6K+y+9UNkfd2kYjle2ffAd9Y=";
 
-    nativeBuildInputs = [
-      installShellFiles
-      makeWrapper
-    ];
+    nativeBuildInputs = [ installShellFiles ];
 
     outputs = [
       "out"
@@ -73,17 +58,6 @@ let
       install -Dm644 assets/micro-logo-mark.svg $out/share/icons/hicolor/scalable/apps/micro.svg
     '';
 
-    postFixup =
-      let
-        clipboardPackages =
-          lib.optionals withXclip [ xclip ]
-          ++ lib.optionals withWlClipboard [ wl-clipboard ];
-      in
-      lib.optionalString (withXclip || withWlClipboard) ''
-        wrapProgram "$out/bin/micro" \
-                  --prefix PATH : "${lib.makeBinPath clipboardPackages}"
-      '';
-
     passthru = {
       tests = lib.packagesFromDirectoryRecursive {
         inherit callPackage;
@@ -114,4 +88,11 @@ let
     };
   };
 in
-self
+lib.warnIf (withXclip != null || withWlClipboard != null || withWlclip != null) ''
+  The options `withXclip`, `withWlClipboard`, `withWlclip` were removed. If
+  you are seeking for clipboard support, please consider the following
+  packages:
+  - `micro-with-wl-clipboard`
+  - `micro-with-xclip`
+  - `micro-full`
+'' self

--- a/pkgs/by-name/mi/micro/wrapper.nix
+++ b/pkgs/by-name/mi/micro/wrapper.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  micro,
+  makeWrapper,
+  symlinkJoin,
+  # configurable options
+  extraPackages ? [ ],
+}:
+
+symlinkJoin {
+  name = "micro-wrapped-${micro.version}";
+  inherit (micro) pname version outputs;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  paths = [ micro ];
+
+  postBuild = ''
+    ${lib.concatMapStringsSep "\n" (
+      output: "ln --verbose --symbolic --no-target-directory ${micro.${output}} \$${output}"
+    ) (lib.remove "out" micro.outputs)}
+
+    pushd $out/bin
+    for f in *; do
+      rm $f
+      makeWrapper ${micro}/bin/$f $f \
+        --prefix PATH ":" "${lib.makeBinPath extraPackages}"
+    done
+    popd
+  '';
+
+  meta = micro.meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25113,6 +25113,25 @@ with pkgs;
 
   meteor = callPackage ../servers/meteor { };
 
+  micro-full = micro.wrapper.override {
+    extraPackages = [
+      wl-clipboard
+      xclip
+    ];
+  };
+
+  micro-with-wl-clipboard = micro.wrapper.override {
+    extraPackages = [
+      wl-clipboard
+    ];
+  };
+
+  micro-with-xclip = micro.wrapper.override {
+    extraPackages = [
+      xclip
+    ];
+  };
+
   micronaut = callPackage ../development/tools/micronaut { };
 
   minio = callPackage ../servers/minio { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/338934

Inspired in https://github.com/NixOS/nixpkgs/issues/338934 and in parallel.

pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/339075

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
