### PR TITLE
duckstation: Fix build on aarch64-linux

### DIFF
--- a/pkgs/by-name/du/duckstation/package.nix
+++ b/pkgs/by-name/du/duckstation/package.nix
@@ -76,6 +76,9 @@ stdenv.mkDerivation (finalAttrs: {
       substituteAllInPlace src/scmversion/gen_scmversion.sh
   '';
 
+  # error: cannot convert 'int16x8_t' to '__Int32x4_t'
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isAarch64 "-flax-vector-conversions";
+
   installCheckPhase = ''
     runHook preCheck
 


### PR DESCRIPTION
## Description of changes

Build was broken with the bump in #322093:

```
FAILED: src/util/CMakeFiles/util.dir/audio_stream.cpp.o 
/nix/store/j4ficcv5bf7cc2pw4d1wwf7j506jav6q-gcc-wrapper-13.3.0/bin/g++ -DENABLE_EGL=1 -DENABLE_OPENGL=1 -DENABLE_VULKAN=1 -DENABLE_WAYLAND=1 -DENABLE_X11=1 -DOVERRIDE_HOST_PAGE_SIZE=4096 -DSHADERC_SHAREDLIB -DSOUNDTOUCH_FLOAT_SAMPLES -DST_NO_EXCEPTION_HANDLING=1 -DXXH_STATIC_LINKING_ONLY -I/build/source/src/util/.. -I/nix/store/pgs4dzfbjnawyz9mk9cjcqwdr0y47lfj-dbus-1.14.10-dev/include/dbus-1.0 -I/nix/store/nl94vjysl23jcv6hm1xvn2fkgzdgh21n-dbus-1.14.10-lib/lib/dbus-1.0/include -I/build/source/src/common/.. -I/build/source/dep/fmt/include -I/build/source/dep/fast_float/include -I/build/source/dep/simpleini/include -I/build/source/dep/imgui/include -I/build/source/dep/libchdr/include -I/build/source/dep/soundtouch/include -I/build/source/dep/xxhash/include -I/build/source/dep/reshadefx/include -I/build/source/dep/glad/include -I/build/source/dep/vulkan/include -I/build/source/dep/cubeb/include -I/build/source/dep/freesurround/include -I/build/source/dep/kissfft/include -isystem /nix/store/icpk2xrnm3fzmb3gnmkqib9scqw669dy-SDL2-2.30.6-dev/include/SDL2 -Wall -Wno-class-memaccess -Wno-invalid-offsetof -Wno-switch -fno-exceptions -fno-rtti -DFMT_EXCEPTIONS=0 -O3 -DNDEBUG -std=gnu++20 -Winvalid-pch -include /build/source/build/src/util/CMakeFiles/util.dir/cmake_pch.hxx -MD -MT src/util/CMakeFiles/util.dir/audio_stream.cpp.o -MF src/util/CMakeFiles/util.dir/audio_stream.cpp.o.d -o src/util/CMakeFiles/util.dir/audio_stream.cpp.o -c /build/source/src/util/audio_stream.cpp
/build/source/src/util/audio_stream.cpp: In function 'void S16ChunkToFloat(const s16*, float*, u32)':
/build/source/src/util/audio_stream.cpp:575:47: note: use '-flax-vector-conversions' to permit conversions between vectors with differing element types or numbers of subparts
  575 |     const int16x8_t sv = vreinterpretq_s16_s32(vld1q_s16(src));
      |                          ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
/build/source/src/util/audio_stream.cpp:575:57: error: cannot convert 'int16x8_t' to '__Int32x4_t'
  575 |     const int16x8_t sv = vreinterpretq_s16_s32(vld1q_s16(src));
      |                                                ~~~~~~~~~^~~~~
      |                                                         |
      |                                                         int16x8_t
In file included from /build/source/src/util/../common/intrin.h:21,
                 from /build/source/src/util/audio_stream.cpp:10:
/nix/store/96qghviz2f47hd0z2zsjj0lpp9hlfm91-gcc-13.3.0/lib/gcc/aarch64-unknown-linux-gnu/13.3.0/include/arm_neon.h:33:21: note:   initializing argument 1 of '__Int16x8_t vreinterpretq_s16_s32(__Int32x4_t)'
   33 | #pragma GCC aarch64 "arm_neon.h"
      |                     ^~~~~~~~~~~~
```

Applying the suggested compiler option works, and the sound doesn't seem to immediately explode on me. Though maybe we should instead just use an upstream-supported configuration?

```
-- Building for Linux.
-- Building with GNU GCC.
-- Building ARM64 binaries.
[...]
CMake Warning at CMakeModules/DuckStationBuildSummary.cmake:28 (message):
  

  *************** UNSUPPORTED CONFIGURATION ***************

  You are not compiling DuckStation with a supported compiler.

  It may not even build successfully.

  DuckStation only supports the Clang and MSVC compilers.

  No support will be provided, continue at your own risk.

  *********************************************************
Call Stack (most recent call first):
  CMakeLists.txt:109 (include)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
