### PR TITLE
simple-dlna-browser: remove loveisgrief from maintainers

### DIFF
--- a/pkgs/tools/networking/simple-dlna-browser/default.nix
+++ b/pkgs/tools/networking/simple-dlna-browser/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
     '';
     homepage = "https://github.com/javier-lopez/learn/blob/master/sh/tools/simple-dlna-browser";
     license = lib.licenses.fair;
-    maintainers = with lib.maintainers; [ loveisgrief ];
+    maintainers = with lib.maintainers; [ ];
   };
 }
 


### PR DESCRIPTION
## Description of changes

LoveIsGrief (now a `ghost` user) has requested to be removed from Nixpkgs. This trivial PR only drops them from the only package they were maintaining, and does not remove their maintainer entry in `maintainer-list.nix`. (It's possible that a tree-wide or staging change is still listing them as a maintainer, so keeping the entry prevents spurious build failures. Let me know if we should remove it anyway)

Fixes #339089.

## Things done

- No rebuilds.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
