### PR TITLE
bitwarden-desktop: fix system authentication

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/dont-auto-setup-biometrics.patch
+++ b/pkgs/by-name/bi/bitwarden-desktop/dont-auto-setup-biometrics.patch
@@ -1,0 +1,13 @@
+diff --git a/apps/desktop/src/platform/main/biometric/biometric.unix.main.ts b/apps/desktop/src/platform/main/biometric/biometric.unix.main.ts
+index e2428d9d12..de4e9e1e62 100644
+--- a/apps/desktop/src/platform/main/biometric/biometric.unix.main.ts
++++ b/apps/desktop/src/platform/main/biometric/biometric.unix.main.ts
+@@ -109,7 +109,7 @@ export default class BiometricUnixMain implements OsBiometricService {
+     // The user needs to manually set up the polkit policy outside of the sandbox
+     // since we allow access to polkit via dbus for the sandboxed clients, the authentication works from
+     // the sandbox, once the policy is set up outside of the sandbox.
+-    return isLinux() && !isSnapStore() && !isFlatpak();
++    return false;
+   }
+ 
+   async osBiometricsSetup(): Promise<void> {

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -40,11 +40,15 @@ in buildNpmPackage rec {
 
   patches = [
     ./electron-builder-package-lock.patch
+    ./dont-auto-setup-biometrics.patch
+    ./set-exe-path.patch # ensures `app.getPath("exe")` returns our wrapper, not ${electron}/bin/electron
   ];
 
   postPatch = ''
     # remove code under unfree license
     rm -r bitwarden_license
+
+    substituteInPlace apps/desktop/src/main.ts --replace-fail '%%exePath%%' "$out/bin/bitwarden"
   '';
 
   nodejs = nodejs_20;
@@ -173,6 +177,13 @@ in buildNpmPackage rec {
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0
+
+    # Extract the polkit policy file from the multiline string in the source code.
+    # This may break in the future but its better than copy-pasting it manually.
+    mkdir -p $out/share/polkit-1/actions/
+    pushd apps/desktop/src/platform/main/biometric
+    awk '/const polkitPolicy = `/{gsub(/^.*`/, ""); print; str=1; next} str{if (/`;/) str=0; gsub(/`;/, ""); print}' biometric.unix.main.ts > $out/share/polkit-1/actions/com.bitwarden.Bitwarden.policy
+    popd
 
     pushd apps/desktop/resources/icons
     for icon in *.png; do

--- a/pkgs/by-name/bi/bitwarden-desktop/set-exe-path.patch
+++ b/pkgs/by-name/bi/bitwarden-desktop/set-exe-path.patch
@@ -1,0 +1,13 @@
+diff --git a/apps/desktop/src/main.ts b/apps/desktop/src/main.ts
+index 86d07440a7..be9fa6b4ab 100644
+--- a/apps/desktop/src/main.ts
++++ b/apps/desktop/src/main.ts
+@@ -80,6 +80,8 @@ export class Main {
+       appDataPath = path.join(process.env.SNAP_USER_DATA, "appdata");
+     }
+ 
++    app.setPath("exe", "%%exePath%%");
++
+     app.on("ready", () => {
+       // on ready stuff...
+     });


### PR DESCRIPTION
## Description of changes

This does 3 things:

- installs the `com.bitwarden.Bitwarden.policy` polkit action file (required for system authentication)
- patches bitwarden to not try to install it manually into `/usr/share/polkit-1/actions/`
- patches bitwarden to return the path to our wrapper script when it looks for its executable instead of returning the path to electron (see [this comment](https://github.com/Bvngee/nixpkgs/blob/adca5a7480c2e21bb085efa58aa3a9a370588a9c/pkgs/by-name/bi/bitwarden-desktop/package.nix#L49-L52)). This is required for Native Messaging to work (part of system auth)

now we can use bitwarden-desktop to authenticate with biometrics in the web extension via polkit and native messaging :)

Relevant: 
- [Archlinux issue](https://gitlab.archlinux.org/archlinux/packaging/packages/bitwarden/-/issues/2), [AUR fix](https://gitlab.archlinux.org/archlinux/packaging/packages/bitwarden/-/commit/bb7b0551349319f1439e08e778bc1819d31af80b)
- [GitHub comment](https://github.com/bitwarden/clients/pull/4586#issuecomment-2308934096) explaining the exe path problem (on the biometrics PR)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
