### PR TITLE
nixos-rebuild: add --no-ssh-tty flag

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
+++ b/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
@@ -36,6 +36,7 @@ _nixos-rebuild() {
     --rollback
     --specialisation -c # name
     --use-remote-sudo
+    --no-ssh-tty
     --build-host # host
     --target-host # host
     # Used with list-generations

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -37,6 +37,7 @@
 .Op Fl -build-host Va host
 .Op Fl -target-host Va host
 .Op Fl -use-remote-sudo
+.Op Fl -no-ssh-tty
 .br
 .Op Fl -verbose | v
 .Op Fl -quiet
@@ -391,6 +392,16 @@ When set, nixos-rebuild prefixes activation commands that run on the
 system with
 .Ic sudo Ns
 \&. Setting this option allows deploying as a non-root user.
+.
+.It Fl -no-ssh-tty
+When set, nixos-rebuild will not request a tty when executing commands on the
+.Fl -target-host
+system with
+.Ic ssh Ns
+\&. This may help avoid corrupted terminal output when running multiple
+nixos-rebuild commands in parallel, but may also prevent the remote
+.Ic sudo
+from working properly.
 .
 .It Fl -file Ar path , Fl f Ar path
 Enable and build the NixOS system from the specified file. The file must

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -32,6 +32,7 @@ specialisation=
 buildHost=
 targetHost=
 remoteSudo=
+noSSHTTY=
 verboseScript=
 noFlake=
 attr=
@@ -152,6 +153,9 @@ while [ "$#" -gt 0 ]; do
       --use-remote-sudo)
         remoteSudo=1
         ;;
+      --no-ssh-tty)
+        noSSHTTY=1
+        ;;
       --flake)
         flake="$1"
         shift 1
@@ -227,12 +231,18 @@ targetHostCmd() {
 }
 
 targetHostSudoCmd() {
+    local t=
+    if [[ ! "${noSSHTTY:-x}" = 1 ]]; then
+        t="-t"
+    fi
+
     if [ -n "$remoteSudo" ]; then
-        useSudo=1 SSHOPTS="$SSHOPTS -t" targetHostCmd "$@"
+        useSudo=1 SSHOPTS="$SSHOPTS $t" targetHostCmd "$@"
     else
         # While a tty might not be necessary, we apply it to be consistent with
         # sudo usage, and an experience that is more consistent with local deployment.
-        SSHOPTS="$SSHOPTS -t" targetHostCmd "$@"
+        # But if the user really doesn't want it, don't do it.
+        SSHOPTS="$SSHOPTS $t" targetHostCmd "$@"
     fi
 }
 


### PR DESCRIPTION
## Description of changes

This closes #336967 by adding a `--no-ssh-tty` flag to nixos-rebuild.sh.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
