### PR TITLE
Revert "nixos/firewall: fix reverse path check failures with IPsec"

### DIFF
--- a/nixos/modules/services/networking/firewall-iptables.nix
+++ b/nixos/modules/services/networking/firewall-iptables.nix
@@ -123,9 +123,6 @@ let
       # Allows this host to act as a DHCP4 client without first having to use APIPA
       iptables -t mangle -A nixos-fw-rpfilter -p udp --sport 67 --dport 68 -j RETURN
 
-      # Allows decrypted packets from an IPsec VPN
-      ip46tables -t mangle -A nixos-fw-rpfilter -m policy --dir in --pol ipsec -j RETURN
-
       # Allows this host to act as a DHCPv4 server
       iptables -t mangle -A nixos-fw-rpfilter -s 0.0.0.0 -d 255.255.255.255 -p udp --sport 68 --dport 67 -j RETURN
 

--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -82,11 +82,6 @@ in
       }
     ];
 
-    networking.nftables.preCheckRuleset = ''
-      # can't validate IPsec rules
-      sed '/meta ipsec/d' -i ruleset.conf
-    '';
-
     networking.nftables.tables."nixos-fw".family = "inet";
     networking.nftables.tables."nixos-fw".content = ''
         ${optionalString (cfg.checkReversePath != false) ''
@@ -94,7 +89,6 @@ in
             type filter hook prerouting priority mangle + 10; policy drop;
 
             meta nfproto ipv4 udp sport . udp dport { 67 . 68, 68 . 67 } accept comment "DHCPv4 client/server"
-            meta ipsec exists accept comment "decrypted packets from an IPsec VPN"
             fib saddr . mark ${optionalString (cfg.checkReversePath != "loose") ". iif"} oif exists accept
 
             jump rpfilter-allow


### PR DESCRIPTION
The inclusion of the "meta ipsec" rule in the default reverse path filtering breaks systems not built with specific XFRM kernel config options.  Specifically CONFIG_XFRM must be set, which gets selected by CONFIG_NFT_XFRM, which is hidden behind CONFIG_XFRM_USER.

These options are not selected by default in most defconfig's provided by the kernel with the exception of some device-specific defconfigs.

These options are not set by the nix kernel common_config, and I would argue that IPSec support does not belong in a minimal kernel as that elevates its support status above other in-kernel VPN interfaces.

The contributor of this feature does not seem interested in working towards a solution that does not break systems running kernels built with "autoModules = false" while supporting this feature, and as this silently breaks firewalls into an insecure state and poses an immediate security issue I propose this be reverted until a solution that does not break such systems is proposed.
https://github.com/NixOS/nixpkgs/pull/310857#discussion_r1742834970

Devices used as firewalls, if they do not have the required kernel config, will fail to load the new firewall rules and will upon boot pass traffic without any filtering into the internal network.

Devices exposed directly to the internet, after reboot, will boot without filtering potentially exposing services not intended to be exposed to the internet, such as databases.

The following platforms in nixpkgs appear to be impacted:
 - pc_simplekernel
 - pogoplug4
 - sheevaplug
 - zero-gravitas
 - zero-sugar
 - utilite
 - guruplug
 - beaglebone
 - fuloong2f_n32

References to hardware without autoModules can be found in nixos-hardware, as well as in active third-party repos on github.

I suspect there are other users impacted that do not have their configurations public, as autoModules = true leads to long compile times when targeting kernels to less standard hardware or hardware with quirks that require patches that cannot be upstreamed.

This reverts commit 3c12ef3f219c1a0f458d72e7b460782287974bbd.