### PR TITLE
python312Packages.httpie: 3.2.2 -> 3.2.3

### DIFF
--- a/pkgs/development/python-modules/httpie/default.nix
+++ b/pkgs/development/python-modules/httpie/default.nix
@@ -2,45 +2,51 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchFromGitHub,
-  installShellFiles,
-  pandoc,
-  # BuildInputs
   charset-normalizer,
   defusedxml,
+  fetchFromGitHub,
+  installShellFiles,
   multidict,
-  pygments,
-  requests,
-  requests-toolbelt,
-  setuptools,
-  rich,
+  pandoc,
   pip,
+  pygments,
   pytest-httpbin,
   pytest-lazy-fixture,
   pytest-mock,
   pytestCheckHook,
+  requests-toolbelt,
+  requests,
   responses,
+  rich,
+  setuptools,
   werkzeug,
 }:
 
 buildPythonPackage rec {
   pname = "httpie";
-  version = "3.2.2";
-  format = "setuptools";
+  version = "3.2.3";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "httpie";
     repo = "httpie";
-    rev = version;
-    hash = "sha256-hPsjEpvT6tnPm68AUB2Tv3Gon4DfSzO2VYCGqP8ozSI=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-ogUqhMVY1fm+hKCMFYqfYsqHX+Gj6y8CMOUsxA3q29g=";
   };
+
+  pythonRelaxDeps = [
+    "defusedxml"
+    "requests"
+  ];
+
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [
     installShellFiles
     pandoc
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     charset-normalizer
     defusedxml
     multidict
@@ -81,28 +87,15 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "httpie" ];
 
-  disabledTestPaths = lib.optionals stdenv.isDarwin [
-    # flaky
+  disabledTestPaths = [
+    # Tests are flaky
     "tests/test_plugins_cli.py"
   ];
 
   disabledTests =
     [
-      # flaky
+      # Test is flaky
       "test_stdin_read_warning"
-      # Re-evaluate those tests with the next release
-      "test_duplicate_keys_support_from_response"
-      "test_invalid_xml"
-      "test_json_formatter_with_body_preceded_by_non_json_data"
-      "test_pretty_options_with_and_without_stream_with_converter"
-      "test_response_mime_overwrite"
-      "test_terminal_output_response_charset_detection"
-      "test_terminal_output_response_charset_override"
-      "test_terminal_output_response_content_type_charset_with_stream"
-      "test_terminal_output_response_content_type_charset"
-      "test_valid_xml"
-      "test_xml_format_options"
-      "test_xml_xhtm"
       # httpbin compatibility issues
       "test_compress_form"
       "test_binary_suppresses_when_terminal"
@@ -110,7 +103,7 @@ buildPythonPackage rec {
       "test_binary_included_and_correct_when_suitable"
     ]
     ++ lib.optionals stdenv.isDarwin [
-      # flaky
+      # Test is flaky
       "test_daemon_runner"
     ];
 


### PR DESCRIPTION
Diff: https://github.com/httpie/httpie/compare/refs/tags/3.2.2...3.2.3

Changelog: https://github.com/httpie/httpie/blob/3.2.3/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
