### PR TITLE
python3Packages.ydata-profiling: 4.8.3 -> 4.9.0

### DIFF
--- a/pkgs/development/python-modules/ydata-profiling/default.nix
+++ b/pkgs/development/python-modules/ydata-profiling/default.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "ydata-profiling";
-  version = "4.8.3";
+  version = "4.9.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -36,13 +36,17 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ydataai";
     repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-tMwhoVnn65EvZK5NBvh/G36W8tH7I9qaL+NTK3IZVdI=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-OZCgtnsLXLJ0m1t/mWqQTbFL8DPKaR9Tr7QCGT2HpvE=";
   };
 
   preBuild = ''
     echo ${version} > VERSION
   '';
+
+  pythonRelaxDeps = [
+    "scipy"
+  ];
 
   propagatedBuildInputs = [
     dacite


### PR DESCRIPTION
## Description of changes

[ydata-profiling release change log](https://github.com/ydataai/ydata-profiling/releases)

Relax `scipy` version requirement `scipy>=1.4.1, <1.14` in `requirements.txt` as `1.14.0` is in `nixpkgs-unstable`  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python311Packages.ydata-profiling</li>
    <li>python311Packages.ydata-profiling.dist</li>
    <li>python312Packages.ydata-profiling</li>
    <li>python312Packages.ydata-profiling.dist</li>
  </ul>
</details>
