### PR TITLE
cato-client: init at 5.2.1.1, nixos/cato-client: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22773,6 +22773,12 @@
     githubId = 15948162;
     name = "Yanni Papandreou";
   };
+  yarekt = {
+    name = "Yarek T";
+    email = "yarekt+nixpkgs@gmail.com";
+    github = "yarektyshchenko";
+    githubId = 185304;
+  };
   yarny = {
     github = "Yarny0";
     githubId = 41838844;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -988,6 +988,7 @@
   ./services/networking/bitlbee.nix
   ./services/networking/blockbook-frontend.nix
   ./services/networking/blocky.nix
+  ./services/networking/cato-client.nix
   ./services/networking/centrifugo.nix
   ./services/networking/cgit.nix
   ./services/networking/charybdis.nix

--- a/nixos/modules/services/networking/cato-client.nix
+++ b/nixos/modules/services/networking/cato-client.nix
@@ -1,0 +1,75 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (lib) mkIf mkEnableOption mkPackageOption;
+
+  cfg = config.services.cato-client;
+in
+{
+  options.services.cato-client = {
+    enable = mkEnableOption "cato-client service";
+    package = mkPackageOption pkgs "cato-client" { };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      groups.cato-client = { };
+    };
+
+    environment.systemPackages = [
+      cfg.package
+    ];
+
+    systemd.services.cato-client = {
+      enable = true;
+      description = "Cato Networks Linux client - connects tunnel to Cato cloud";
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = "root"; # Note: daemon runs as root, tools sticky to group
+        Group = "cato-client";
+        ExecStart = "${cfg.package}/bin/cato-clientd systemd";
+        WorkingDirectory = "${cfg.package}";
+        Restart = "always";
+
+        # Cato client seems to do the following:
+        # - Look in each user's ~/.cato/ for configuration and keys
+        # - Write to /var/log/cato-client.log
+        # - Create and use sockets /var/run/cato-sdp.i, /var/run/cato-sdp.o
+        # - Read and Write to /opt/cato/ for runtime settings
+        # - Read /etc/systemd/resolved.conf (but fine if fails)
+        # - Restart systemd-resolved (also fine if doesn't exist)
+
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        ProtectSystem = true;
+      };
+
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    # set up Security wrapper Same as inteded in deb post install
+    security.wrappers.cato-clientd = {
+      source = "${cfg.package}/bin/cato-clientd";
+      owner = "root";
+      group = "cato-client";
+      permissions = "u+rwx,g+rwx"; # 770
+      setgid = true;
+    };
+
+    security.wrappers.cato-sdp = {
+      source = "${cfg.package}/bin/cato-sdp";
+      owner = "root";
+      group = "cato-client";
+      permissions = "u+rwx,g+rx,a+rx"; # 755
+      setgid = true;
+    };
+  };
+}

--- a/pkgs/by-name/ca/cato-client/package.nix
+++ b/pkgs/by-name/ca/cato-client/package.nix
@@ -1,0 +1,69 @@
+{
+  stdenv,
+  fetchurl,
+  writeScript,
+  autoPatchelfHook,
+  dpkg,
+  libz,
+  lib,
+}:
+stdenv.mkDerivation rec {
+  pname = "cato-client";
+  version = "5.2.1.1";
+
+  src = fetchurl {
+    url = "https://clients.catonetworks.com/linux/${version}/cato-client-install.deb";
+    sha256 = "sha256-0hUchaxaiKJth2ByQMFfjsCLi/4kl+SrNSQ33Y6r3WA=";
+  };
+
+  passthru.updateScript = writeScript "update-cato-client" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl pcre2 common-updater-scripts
+
+    set -eu -o pipefail
+
+    version="$(curl -sI https://clientdownload.catonetworks.com/public/clients/cato-client-install.deb | grep -Fi 'Location:' | pcre2grep -o1 '/(([0-9]\.?)+)/')"
+    update-source-version cato-client "$version"
+  '';
+
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    libz
+    stdenv.cc.cc
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg -x $src source
+    cd source
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir $out
+
+    mv usr/lib $out/lib
+
+    mkdir -p $out/bin
+    mv usr/sbin/* $out/bin
+    mv usr/bin/* $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Lightweight agent that provides secure zero-trust access to resources everywhere";
+    homepage = "https://www.catonetworks.com/platform/cato-client/";
+    mainProgram = "cato-sdp";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ yarekt ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add Cato VPN client
https://www.catonetworks.com/platform/cato-client/

From their webpage:
> The Cato Client is a lightweight agent that provides secure zero-trust access to resources everywhere – on the Internet, SaaS, and Cloud or in your private data center. The Cato Client delivers endpoint protection capabilities for the enterprise with comprehensive malware prevention. With support for Windows, MacOS, Linux, Android, and iOS, the client brings the full capabilities of the Cato SASE Cloud Platform to any user device without compromising on security or network performance.

closes #338964

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
