### PR TITLE
onedrivegui: 1.0.3 -> 1.1.0rc3

### DIFF
--- a/pkgs/by-name/on/onedrivegui/package.nix
+++ b/pkgs/by-name/on/onedrivegui/package.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "1.0.3";
+  version = "1.1.0rc3";
 
   setupPy = writeText "setup.py" ''
     from setuptools import setup
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication rec {
     owner = "bpozdena";
     repo = "OneDriveGUI";
     rev = "v${version}";
-    hash = "sha256-HutziAzhIDYP8upNPieL2GNrxPBHUCVs09FFxdSqeBs=";
+    hash = "sha256-d5NAcT3x9R/2DVQKZsw4GH63nTlVFsvkWwMrb42s18s=";
   };
 
   nativeBuildInputs = [ copyDesktopItems makeWrapper ];

--- a/pkgs/by-name/on/onedrivegui/package.nix
+++ b/pkgs/by-name/on/onedrivegui/package.nix
@@ -1,11 +1,12 @@
-{ lib
-, python3Packages
-, fetchFromGitHub
-, writeText
-, copyDesktopItems
-, makeDesktopItem
-, makeWrapper
-, onedrive
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  writeText,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+  onedrive,
 }:
 
 let
@@ -34,9 +35,15 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-d5NAcT3x9R/2DVQKZsw4GH63nTlVFsvkWwMrb42s18s=";
   };
 
-  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
-  propagatedBuildInputs = with python3Packages; [ pyside6 requests ];
+  propagatedBuildInputs = with python3Packages; [
+    pyside6
+    requests
+  ];
 
   # wrap manually to avoid having a bash script in $out/bin with a .py extension
   dontWrapPythonPrograms = true;
@@ -73,7 +80,9 @@ python3Packages.buildPythonApplication rec {
 
     makeWrapper ${python3Packages.python.interpreter} $out/bin/onedrivegui \
       --prefix PATH : ${lib.makeBinPath [ onedrive ]} \
-      --prefix PYTHONPATH : ${python3Packages.makePythonPath (propagatedBuildInputs ++ [(placeholder "out")])} \
+      --prefix PYTHONPATH : ${
+        python3Packages.makePythonPath (propagatedBuildInputs ++ [ (placeholder "out") ])
+      } \
       --add-flags $out/${python3Packages.python.sitePackages}/OneDriveGUI.py
   '';
 


### PR DESCRIPTION
## Description of changes
https://github.com/bpozdena/OneDriveGUI/releases/tag/v1.1.0rc3

Closes https://github.com/NixOS/nixpkgs/issues/339480

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
