### PR TITLE
nixos/espanso: add required capabilities for wayland

### DIFF
--- a/nixos/modules/services/desktops/espanso.nix
+++ b/nixos/modules/services/desktops/espanso.nix
@@ -15,16 +15,36 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    systemd.user.services.espanso = {
-      description = "Espanso daemon";
-      serviceConfig = {
-        ExecStart = "${lib.getExe cfg.package} daemon";
-        Restart = "on-failure";
-      };
-      wantedBy = [ "default.target" ];
-    };
+  config =
+    let
+      wayland = cfg.package == pkgs.espanso-wayland;
+    in
+    mkMerge [
+      (mkIf cfg.enable {
+        systemd.user.services.espanso = {
+          description = "Espanso daemon";
+          serviceConfig = {
+            ExecStart =
+              # Espanso responsibly tries to drop capabilities as soon as possible
+              # but forks *after* dropping, leaving the `worker` process without the
+              # capabilities required for the EVDEV backend for wayland. Running
+              # `worker` directly from the wrapper works around this issue.
+              # https://github.com/NixOS/nixpkgs/issues/249364#issuecomment-2322837290
+              if wayland then "/run/wrappers/bin/espanso worker" else "${lib.getExe cfg.package} daemon";
+            Restart = "on-failure";
+          };
+          wantedBy = [ "default.target" ];
+        };
 
-    environment.systemPackages = [ cfg.package ];
-  };
+        environment.systemPackages = [ cfg.package ];
+      })
+      (mkIf wayland {
+        security.wrappers.espanso = {
+          source = "${lib.getExe cfg.package}";
+          capabilities = "cap_dac_override+p";
+          owner = "root";
+          group = "root";
+        };
+      })
+    ];
 }


### PR DESCRIPTION
On Wayland, Espanso depends on `cap_dac_override+p` for the EVDEV
backend. Specifically, this capability is required by the `worker`
thread, which is forked from the main espanso process when run by the
usual means (`espanso start` or `espanso daemon`).

Espanso (responsibly) drops capabilities as soon as possible, prior
to forking the worker process. Unfortunately, `security.wrappers` sets
the capabilities in such a way that the forked process does not pick
up these capabilities (due to `/proc/self/exe` pointing to the original
espanso binary, which does *not* have these capabilities).

By running `worker` directly from the capability-enabled wrapper,
the worker thread is able to run without issue, and Espanso runs as
expected on wayland.

- https://github.com/NixOS/nixpkgs/issues/249364
- https://github.com/NixOS/nixpkgs/pull/328890
- https://espanso.org/docs/install/linux

- fixes https://github.com/NixOS/nixpkgs/issues/249364

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
