### PR TITLE
treewide: remove use of python3(Packages) in python package set

### DIFF
--- a/pkgs/development/python-modules/ansible-builder/default.nix
+++ b/pkgs/development/python-modules/ansible-builder/default.nix
@@ -1,11 +1,16 @@
 {
   lib,
-  python3Packages,
+  setuptools,
+  setuptools-scm,
+  jsonschema,
+  requirements-parser,
+  pyyaml,
   podman,
   fetchPypi,
   bindep,
+  buildPythonPackage,
 }:
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "ansible-builder";
   version = "3.0.1";
   format = "pyproject";
@@ -15,14 +20,14 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-rxyhgj9Cad751tPAptCTLCtXQLUXaRYv39bkoFzzjOk=";
   };
 
-  nativeBuildInputs = with python3Packages; [
+  nativeBuildInputs = [
     setuptools
     setuptools-scm
   ];
 
   buildInputs = [ bindep ];
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     podman
     jsonschema
     requirements-parser

--- a/pkgs/development/python-modules/bindep/default.nix
+++ b/pkgs/development/python-modules/bindep/default.nix
@@ -1,9 +1,14 @@
 {
   lib,
-  python3Packages,
   fetchPypi,
+  buildPythonPackage,
+  distro,
+  pbr,
+  setuptools,
+  packaging,
+  parsley,
 }:
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "bindep";
   version = "2.11.0";
   format = "pyproject";
@@ -13,13 +18,13 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-rLLyWbzh/RUIhzR5YJu95bmq5Qg3hHamjWtqGQAufi8=";
   };
 
-  buildInputs = with python3Packages; [
+  buildInputs = [
     distro
     pbr
     setuptools
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     parsley
     pbr
     packaging

--- a/pkgs/development/python-modules/chainstream/default.nix
+++ b/pkgs/development/python-modules/chainstream/default.nix
@@ -1,16 +1,17 @@
 {
   lib,
   fetchPypi,
-  python3Packages,
+  buildPythonPackage,
+  setuptools,
 }:
 
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "chainstream";
   version = "1.0.1";
 
   pyproject = true;
 
-  nativeBuildInputs = [ python3Packages.setuptools ];
+  nativeBuildInputs = [ setuptools ];
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/cli-ui/default.nix
+++ b/pkgs/development/python-modules/cli-ui/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  python3Packages,
   fetchPypi,
   pytestCheckHook,
   pythonOlder,
@@ -8,8 +7,9 @@
   colorama,
   tabulate,
   unidecode,
+  buildPythonPackage,
 }:
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "cli-ui";
   version = "0.17.2";
   pyproject = true;

--- a/pkgs/development/python-modules/controku/default.nix
+++ b/pkgs/development/python-modules/controku/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  python3Packages,
   fetchFromGitHub,
   setuptools,
   requests,
@@ -10,10 +9,11 @@
   gobject-introspection,
   gtk3,
   wrapGAppsHook3,
+  buildPythonPackage,
   buildApplication ? false,
 }:
 
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "controku";
   version = "1.1.0";
   format = "pyproject";

--- a/pkgs/development/python-modules/dbt-core/default.nix
+++ b/pkgs/development/python-modules/dbt-core/default.nix
@@ -17,7 +17,7 @@
   packaging,
   pathspec,
   protobuf,
-  python,
+  callPackage,
   pythonOlder,
   pytz,
   pyyaml,
@@ -85,7 +85,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   passthru = {
-    withAdapters = python.pkgs.callPackage ./with-adapters.nix { };
+    withAdapters = callPackage ./with-adapters.nix { };
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/dnf4/wrapper.nix
+++ b/pkgs/development/python-modules/dnf4/wrapper.nix
@@ -1,15 +1,16 @@
 {
   lib,
   wrapPython,
-  python3,
+  python,
   stdenv,
+  dnf4,
   dnf-plugins-core,
   plugins ? [ dnf-plugins-core ],
 }:
 let
-  pluginPaths = map (p: "${p}/${python3.sitePackages}/dnf-plugins") plugins;
+  pluginPaths = map (p: "${p}/${python.sitePackages}/dnf-plugins") plugins;
 
-  dnf4-unwrapped = python3.pkgs.dnf4;
+  dnf4-unwrapped = dnf4;
 in
 
 stdenv.mkDerivation {

--- a/pkgs/development/python-modules/exiv2/default.nix
+++ b/pkgs/development/python-modules/exiv2/default.nix
@@ -3,11 +3,14 @@
   pkg-config,
   exiv2,
   gettext,
-  python3Packages,
   fetchFromGitHub,
   gitUpdater,
+  buildPythonPackage,
+  setuptools,
+  toml,
+  unittestCheckHook,
 }:
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "exiv2";
   version = "0.17.0";
   pyproject = true;
@@ -30,7 +33,7 @@ python3Packages.buildPythonPackage rec {
         def test_localisation(self):"
   '';
 
-  build-system = with python3Packages; [
+  build-system = [
     setuptools
     toml
   ];
@@ -42,7 +45,7 @@ python3Packages.buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "exiv2" ];
-  nativeCheckInputs = with python3Packages; [ unittestCheckHook ];
+  nativeCheckInputs = [ unittestCheckHook ];
   unittestFlagsArray = [
     "-s"
     "tests"

--- a/pkgs/development/python-modules/invisible-watermark/tests/cli.nix
+++ b/pkgs/development/python-modules/invisible-watermark/tests/cli.nix
@@ -1,7 +1,7 @@
 {
   image,
   method,
-  python3Packages,
+  invisible-watermark,
   runCommand,
   testName,
   withOnnx,
@@ -25,7 +25,7 @@ let
     else
       "fnörd1";
   length = (builtins.stringLength message) * 8;
-  invisible-watermark' = python3Packages.invisible-watermark.override { inherit withOnnx; };
+  invisible-watermark' = invisible-watermark.override { inherit withOnnx; };
   expected-exit-code = if method == "rivaGan" && !withOnnx then "1" else "0";
 in
 runCommand "invisible-watermark-test-${testName}" { nativeBuildInputs = [ invisible-watermark' ]; }

--- a/pkgs/development/python-modules/invisible-watermark/tests/python/default.nix
+++ b/pkgs/development/python-modules/invisible-watermark/tests/python/default.nix
@@ -2,7 +2,7 @@
   image,
   invisible-watermark,
   opencv4,
-  python3,
+  python,
   runCommand,
   stdenvNoCC,
 }:
@@ -13,12 +13,10 @@ let
   message = "fnörd1";
   method = "dwtDct";
 
-  pythonWithPackages = python3.withPackages (
-    pp: with pp; [
-      invisible-watermark
-      opencv4
-    ]
-  );
+  pythonWithPackages = python.withPackages (_: [
+    invisible-watermark
+    opencv4
+  ]);
   pythonInterpreter = pythonWithPackages.interpreter;
 
   encode = stdenvNoCC.mkDerivation {

--- a/pkgs/development/python-modules/manuf/default.nix
+++ b/pkgs/development/python-modules/manuf/default.nix
@@ -3,9 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
   runCommand,
-  python3,
   wireshark-cli,
   pytestCheckHook,
+  manuf, # remove when buildPythonPackage supports finalAttrs
 }:
 
 buildPythonPackage rec {
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   passthru.tests = {
     testMacAddress = runCommand "${pname}-test" { } ''
-      ${python3.pkgs.manuf}/bin/manuf BC:EE:7B:00:00:00 > $out
+      ${lib.getExe manuf} BC:EE:7B:00:00:00 > $out
       [ "$(cat $out | tr -d '\n')" = "Vendor(manuf='ASUSTekC', manuf_long='ASUSTek COMPUTER INC.', comment=None)" ]
     '';
   };

--- a/pkgs/development/python-modules/mlx/default.nix
+++ b/pkgs/development/python-modules/mlx/default.nix
@@ -2,13 +2,13 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  python3Packages,
   pybind11,
   cmake,
   xcbuild,
   zsh,
   blas,
   lapack,
+  setuptools,
 }:
 
 let
@@ -69,7 +69,8 @@ buildPythonPackage rec {
     zsh
     gguf-tools
     nlohmann_json
-  ] ++ (with python3Packages; [ setuptools ]);
+    setuptools
+  ];
 
   buildInputs = [
     blas

--- a/pkgs/development/python-modules/onigurumacffi/default.nix
+++ b/pkgs/development/python-modules/onigurumacffi/default.nix
@@ -1,10 +1,12 @@
 {
   lib,
-  python3Packages,
+  buildPythonPackage,
   fetchPypi,
   oniguruma,
+  setuptools,
+  cffi,
 }:
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "onigurumacffi";
   version = "1.3.0";
   format = "pyproject";
@@ -14,7 +16,7 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-d0XNxWCWrOyIofOwhmCiKwnGWe040/WdtsHK12qXa+8=";
   };
 
-  buildInputs = with python3Packages; [
+  buildInputs = [
     oniguruma
     setuptools
     cffi

--- a/pkgs/development/python-modules/orgparse/default.nix
+++ b/pkgs/development/python-modules/orgparse/default.nix
@@ -1,10 +1,11 @@
 {
   lib,
-  python3Packages,
+  setuptools-scm,
   fetchPypi,
+  buildPythonPackage,
 }:
 
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "orgparse";
   version = "0.4.20231004";
 
@@ -13,7 +14,7 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-pOOK6tq/mYiw9npmrNCCedGCILy8QioSkGDCiQu6kaA=";
   };
 
-  nativeBuildInputs = [ python3Packages.setuptools-scm ];
+  nativeBuildInputs = [ setuptools-scm ];
 
   pyproject = true;
 


### PR DESCRIPTION
## Description of changes

successor to #325963 to pick up the remaining usages

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>python311Packages.ansible-builder</li>
    <li>python311Packages.ansible-builder.dist</li>
    <li>python311Packages.bindep</li>
    <li>python311Packages.bindep.dist</li>
    <li>python311Packages.chainstream</li>
    <li>python311Packages.chainstream.dist</li>
    <li>python311Packages.cli-ui</li>
    <li>python311Packages.cli-ui.dist</li>
    <li>python311Packages.controku</li>
    <li>python311Packages.controku.dist</li>
    <li>python311Packages.exiv2</li>
    <li>python311Packages.exiv2.dist</li>
    <li>python311Packages.onigurumacffi</li>
    <li>python311Packages.onigurumacffi.dist</li>
    <li>python311Packages.orgparse</li>
    <li>python311Packages.orgparse.dist</li>
  </ul>
</details>
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
