### PR TITLE
Revert "nixos/version: validate system.stateVersion"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -335,10 +335,6 @@
 - `zx` was updated to v8, which introduces several breaking changes.
   See the [v8 changelog](https://github.com/google/zx/releases/tag/8.0.0) for more information.
 
-- `system.stateVersion` is now validated. If you never changed this yourself, you don't need to do anything. If your `stateVersion` is not a valid NixOS release version (e.g. "24.11" is valid),
-  your system was already at risk of experiencing silent incompatible state updates. If your previous value is a well-formed version but not a valid release (e.g. "23.12"),
-  round down to the nearest actual release. If it wasn't a well-formed version (e.g. "nixos-unstable"), set it to the version of NixOS that you originally installed.
-
 - The `portunus` package and service do not support weak password hashes anymore.
   If you installed Portunus on NixOS 23.11 or earlier, upgrade to NixOS 24.05 first to get support for strong password hashing.
   Then, follow the instructions on the [upstream release notes](https://github.com/majewsky/portunus/releases/tag/v2.0.0) to upgrade all existing user accounts to strong password hashes.

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -44,49 +44,6 @@ let
   };
   initrdRelease = pkgs.writeText "initrd-release" (attrsToText initrdReleaseContents);
 
-  checkRelease = version:
-    let
-      parts = lib.versions.splitVersion version;
-      isVersion = lib.length parts == 2 && lib.all (p: lib.stringLength p == 2) parts;
-      majorVersion = lib.toIntBase10 (lib.elemAt parts 0);
-      minorVersion = lib.elemAt parts 1;
-
-      versionPatterns = [
-        # only 13.10
-        { fromMajor = 13; minor = [ "10" ]; }
-        # 14.04 and 14.12
-        { fromMajor = 14; minor = [ "04" "12" ]; }
-        # only 15.09
-        { fromMajor = 15; minor = [ "09" ]; }
-        # 16.03 to 20.09
-        { fromMajor = 16; minor = [ "03" "09" ]; }
-        # from 21.05
-        { fromMajor = 21; minor = [ "05" "11" ]; }
-      ];
-
-      # find the versioning pattern that applies by looking for the first
-      # major version newer than `majorVersion`, and picking the previous pattern
-      patternIndex = lib.lists.findFirstIndex
-        ({ fromMajor, ... }: fromMajor > majorVersion)
-        (lib.length versionPatterns)
-        versionPatterns;
-
-      validMinorVersions =
-        if patternIndex == 0
-        then []
-        else (lib.elemAt versionPatterns (patternIndex - 1)).minor;
-
-      correctMinorVersion = lib.elem minorVersion validMinorVersions;
-      notNewerThanNixpkgs = lib.versionAtLeast trivial.release version;
-    in isVersion && correctMinorVersion && notNewerThanNixpkgs;
-
-  releaseType = types.addCheck
-    (types.strMatching "[[:digit:]]{2}\\.[[:digit:]]{2}")
-    checkRelease // {
-      name = "nixosRelease";
-      description = "NixOS release version, e.g. \"${trivial.release}\"";
-      descriptionClass = "nonRestrictiveClause";
-    };
 in
 {
   imports = [
@@ -113,7 +70,7 @@ in
 
       release = mkOption {
         readOnly = true;
-        type = releaseType;
+        type = types.str;
         default = trivial.release;
         description = "The NixOS release (e.g. `16.03`).";
       };
@@ -194,7 +151,7 @@ in
     };
 
     stateVersion = mkOption {
-      type = releaseType;
+      type = types.str;
       # TODO Remove this and drop the default of the option so people are forced to set it.
       # Doing this also means fixing the comment in nixos/modules/testing/test-instrumentation.nix
       apply = v:


### PR DESCRIPTION
Reverts NixOS/nixpkgs#317858

```
{UNKNOWN}: aggregate job ‘tested’ failed with the error: nixos.iso_minimal.x86_64-linux: error:
       … while calling the 'deepSeq' builtin

         at /nix/store/q6clqkg4j8bij5ff0q8hdwnc0cmbacbv-source/lib/customisation.nix:415:7:

          414|     in if drv == null then null else
          415|       deepSeq drv' drv';
             |       ^
          416|

       … while evaluating the attribute 'outPath'

         at /nix/store/q6clqkg4j8bij5ff0q8hdwnc0cmbacbv-source/lib/customisation.nix:404:13:

          403|           value = commonAttrs // {
          404|             outPath = output.outPath;
             |             ^
          405|             drvPath = output.drvPath;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: A definition for option `system.stateVersion' is not of type `NixOS release version, e.g. "24.11"'. Definition values:
       - In `/nix/store/q6clqkg4j8bij5ff0q8hdwnc0cmbacbv-source/nixos/release.nix': "24.11pre676716.6f16e67b4921"
nixos.iso_minimal.aarch64-linux: error:
       … while calling the 'deepSeq' builtin

         at /nix/store/q6clqkg4j8bij5ff0q8hdwnc0cmbacbv-source/lib/customisation.nix:415:7:

          414|     in if drv == null then null else
          415|       deepSeq drv' drv';
             |       ^
          416|

       … while evaluating the attribute 'outPath'

         at /nix/store/q6clqkg4j8bij5ff0q8hdwnc0cmbacbv-source/lib/customisation.nix:404:13:

          403|           value = commonAttrs // {
          404|             outPath = output.outPath;
             |             ^
          405|             drvPath = output.drvPath;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: A definition for option `system.stateVersion' is not of type `NixOS release version, e.g. "24.11"'. Definition values:
       - In `/nix/store/q6clqkg4j8bij5ff0q8hdwnc0cmbacbv-source/nixos/release.nix': "24.11pre676716.6f16e67b4921"
 at /nix/store/v4m018s4j4ijqj9bmy4vp39pbj27aacz-hydra-perl-deps/lib/perl5/site_perl/5.38.2/Catalyst/Model/DBIC/Schema.pm line 526
```