### PR TITLE
glamoroustoolkit: 1.0.11 -> 1.0.42

### DIFF
--- a/pkgs/development/tools/glamoroustoolkit/default.nix
+++ b/pkgs/development/tools/glamoroustoolkit/default.nix
@@ -1,6 +1,9 @@
 { lib
+, pkgs
 , stdenv
 , fetchzip
+, fetchurl
+, patchelf
 , wrapGAppsHook3
 , cairo
 , dbus
@@ -18,25 +21,38 @@
 , libglvnd
 , libuuid
 , libxcb
+, harfbuzz        # libWebView.so
+, libsoup_3       # libWebView.so
+, webkitgtk_4_1   # libWebView.so
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glamoroustoolkit";
-  version = "1.0.11";
+  version = "1.0.42";
 
   src = fetchzip {
     url = "https://github.com/feenkcom/gtoolkit-vm/releases/download/v${finalAttrs.version}/GlamorousToolkit-x86_64-unknown-linux-gnu.zip";
     stripRoot = false;
-    hash = "sha256-GQeYR232zoHLIt1AzznD7rp6u4zMiAdj1+0OfXfT6AQ=";
+    hash = "sha256-CwWJ5hntnfE9/xBNlV5yCp/Ndd0xj7rQHVopwKLAgSU=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook3 ];
+  nativeBuildInputs = [
+    wrapGAppsHook3
+    (patchelf.overrideAttrs (old: {
+      version = "0.11";
+      src = fetchurl {
+        url = "https://nixos.org/releases/patchelf/patchelf-0.11/patchelf-0.11.tar.bz2";
+        sha256 = "16ms3ijcihb88j3x6cl8cbvhia72afmfcphczb9cfwr0gbc22chx";
+      };
+    }))
+  ];
 
   sourceRoot = ".";
 
   dontConfigure = true;
   dontBuild = true;
   dontPatchELF = true;
+  dontStrip = true;
 
   installPhase = ''
     runHook preInstall
@@ -65,7 +81,13 @@ preFixup = let
       libglvnd
       libuuid
       libxcb
+      harfbuzz
+      libsoup_3
+      webkitgtk_4_1
       stdenv.cc.cc.lib
+    ];
+    binPath = lib.makeBinPath [
+      pkgs.gnome.zenity   # File selection dialog
     ];
   in ''
     chmod +x $out/lib/*.so
@@ -94,6 +116,10 @@ preFixup = let
     ln -s $out/lib/libcairo.so $out/lib/libcairo.so.2
     rm $out/lib/libgit2.so
     ln -s "${libgit2}/lib/libgit2.so" $out/lib/libgit2.so.1.1
+
+    gappsWrapperArgs+=(
+      --prefix PATH : ${binPath}
+    )
   '';
 
   meta = {

--- a/pkgs/development/tools/glamoroustoolkit/default.nix
+++ b/pkgs/development/tools/glamoroustoolkit/default.nix
@@ -1,5 +1,5 @@
 { lib
-, pkgs
+, zenity
 , stdenv
 , fetchzip
 , fetchurl
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-preFixup = let
+  preFixup = let
     libPath = lib.makeLibraryPath [
       cairo
       dbus
@@ -87,7 +87,7 @@ preFixup = let
       stdenv.cc.cc.lib
     ];
     binPath = lib.makeBinPath [
-      pkgs.gnome.zenity   # File selection dialog
+      zenity   # File selection dialog
     ];
   in ''
     chmod +x $out/lib/*.so


### PR DESCRIPTION
Changes:

- Work around an issue with patchelf 0.12 and later by using patchelf 0.11 (see https://github.com/NixOS/patchelf/issues/546)
- Set "dontStrip = true" as patchelf 0.11 corrupts libWinit.so
- Add dependencies for new library libWebView
- Add zenity to $PATH (used for GlamorousToolkit file open dialog)

## Description of changes

See https://github.com/feenkcom/gtoolkit-vm/releases/tag/v1.0.42

## Things done

This is a resubmission of https://github.com/NixOS/nixpkgs/pull/339546 (where I accidentally did a mass ping, sorry!).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
