### PR TITLE
nixos: switch to `switch-to-configuration-ng` by default

### DIFF
--- a/nixos/doc/manual/configuration/profiles/perlless.section.md
+++ b/nixos/doc/manual/configuration/profiles/perlless.section.md
@@ -1,11 +1,5 @@
 # Perlless {#sec-perlless}
 
-::: {.warning}
-If you enable this profile, you will NOT be able to switch to a new
-configuration and thus you will not be able to rebuild your system with
-nixos-rebuild!
-:::
-
 Render your system completely perlless (i.e. without the perl interpreter). This
 includes a mechanism so that your build fails if it contains a Nix store path
 that references the string "perl".

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -34,6 +34,10 @@
   Users that want to keep PulseAudio will want to set `services.pipewire.enable = false;` and `hardware.pulseaudio.enable = true;`.
   There is currently no plan to fully deprecate and remove PulseAudio, however, PipeWire should generally be preferred for new installs.
 
+- The Rust rewrite of the `switch-to-configuration` program is now used for system activation by default.
+  If you experience any issues, please report them.
+  The original Perl script can still be used for now by setting `system.switch.enableNg` to `false`.
+
 ## New Modules {#sec-release-24.11-new-modules}
 
 - [TaskChampion Sync-Server](https://github.com/GothenburgBitFactory/taskchampion-sync-server), a [Taskwariror 3](https://taskwarrior.org/docs/upgrade-3/) sync server, replacing Taskwarrior 2's sync server named [`taskserver`](https://github.com/GothenburgBitFactory/taskserver).

--- a/nixos/modules/profiles/perlless.nix
+++ b/nixos/modules/profiles/perlless.nix
@@ -2,13 +2,6 @@
 
 {
 
-  # switch-to-configuration-ng reimplements switch-to-configuration, but
-  # without perl.
-  system.switch = lib.mkDefault {
-    enable = false;
-    enableNg = true;
-  };
-
   # Remove perl from activation
   boot.initrd.systemd.enable = lib.mkDefault true;
   system.etc.overlay.enable = lib.mkDefault true;

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -48,10 +48,7 @@ in {
 
   nodes = {
     machine = { pkgs, lib, ... }: {
-      system.switch = {
-        enable = !ng;
-        enableNg = ng;
-      };
+      system.switch.enableNg = ng;
 
       environment.systemPackages = [ pkgs.socat ]; # for the socket activation stuff
       users.mutableUsers = false;


### PR DESCRIPTION
## Description of changes

The Rust `switch-to-configuration-ng` rewrite was carefully written to be compatible with the original Perl script, has been checked against NixOS VM tests, and has been available on an opt‐in basis for testing for the 24.05 release cycle.

The next step towards replacing the Perl script entirely is to switch it on by default so that we can get real‐world testing from a much greater number of users. Maintaining two implementations in parallel is becoming a burden; we are having to adjust the systemd service activation behaviour slightly to fix a long‐standing bug, and backporting the changes to the Perl script is an unpleasant process. We will do it anyway to ensure that the Rust and Perl implementations keep parity with each other throughout the 24.11 release cycle, but we think the time has come to flip the switch.

Taking this step now will give us two to three months to test this in the wild before the 24.11 release and gain confidence that there are no regressions. If any non‐trivial problems arise before the final release, we will revert to the Perl implementation by default. Doing this switch ASAP will help to disentangle any problems that might arise from the Rust implementation from problems that arise from the systemd service activation changes, or the upcoming switch to using systemd in stage 1 by default.

The main concern that was raised about replacing the Perl script in the PR that added `switch-to-configuration-ng` was that it is currently possible to run NixOS on systems that cannot natively host a Rust compiler. This does not apply to any platforms that have official support from NixOS, and as far as I know we do not know of any such systems with users that are not cross‐compiling anyway.

My understanding is that these systems are already broken by default anyway, as `systemd.shutdownRamfs.enable` is on by default and uses `make-initrd-ng`, which is also written in Rust. Switching the default while keeping the Perl implementation around will give us at least an entire release cycle to find out if there are any users that will be affected by this and decide what to do about it if so.

There is currently one known inconsistency between the Perl and Rust implementations, as documented in <https://github.com/NixOS/nixpkgs/issues/312297>; the Rust implementation has more accurate handling of failed systemd units.

We slightly adjust the semantics of `system.switch.enable{,Ng}` to not conflict with each other, so that `system.switch.enableNg` is on by default, but turning off `system.switch.enable` still results in no `switch-to-configuration` implementation being used. This won’t break the configuration of anyone who already opted in to `system.switch.enableNg` and is probably how the option should have worked to begin with.

---

I have tested a pretty random smattering of NixOS tests on both `aarch64-linux` and `x86_64-linux`, as listed below, to confirm that what I did here hopefully doesn’t itself break anything.

See: https://github.com/NixOS/nixpkgs/pull/308801

cc @jmbaur @ElvishJerricco @nikstur @alyssais @flokli @dasJ @RossComputerGuy

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    * `acme`
    * `activation-etc-overlay-immutable`
    * `activation-etc-overlay-mutable`
    * `activation-nix-channel`
    * `activation-perlless`
    * `activation-var`
    * `containers-reloadable`
    * `mutableUsers`
    * `nginx`
    * `switchTestNg`
    * `switchTest`
    * `user-activation-scripts`
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
