### PR TITLE
zed-editor: fix license menu and `--version`

### DIFF
--- a/pkgs/by-name/ze/zed-editor/0001-generate-licenses.patch
+++ b/pkgs/by-name/ze/zed-editor/0001-generate-licenses.patch
@@ -1,0 +1,17 @@
+diff --git a/script/generate-licenses b/script/generate-licenses
+index 43b2f5c458..c740a3afa2 100755
+--- a/script/generate-licenses
++++ b/script/generate-licenses
+@@ -15,12 +15,6 @@ cat assets/icons/LICENSES >> $OUTPUT_FILE
+ 
+ echo -e "# ###### CODE LICENSES ######\n" >> $OUTPUT_FILE
+ 
+-if ! cargo install --list | grep "cargo-about v$CARGO_ABOUT_VERSION" > /dev/null; then
+-  echo "Installing cargo-about@$CARGO_ABOUT_VERSION..."
+-  cargo install "cargo-about@$CARGO_ABOUT_VERSION"
+-else
+-  echo "cargo-about@$CARGO_ABOUT_VERSION is already installed."
+-fi
+ 
+ echo "Generating cargo licenses"
+ cargo about generate --fail -c script/licenses/zed-licenses.toml script/licenses/template.hbs.md >> $OUTPUT_FILE

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -27,6 +27,7 @@
   vulkan-loader,
   envsubst,
   nix-update-script,
+  cargo-about,
 
   withGLES ? false,
 }:
@@ -44,6 +45,12 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-9xvCElW1J3LMiNPUeVxaNIexx7a2rVEoAh4Ntrh1N6E=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # Zed uses cargo-install to install cargo-about during the script execution.
+    # We provide cargo-about ourselves and can skip this step.
+    ./0001-generate-licenses.patch
+  ];
 
   cargoLock = {
     lockFile = ./Cargo.lock;
@@ -73,6 +80,7 @@ rustPlatform.buildRustPackage rec {
     pkg-config
     protobuf
     rustPlatform.bindgenHook
+    cargo-about
   ] ++ lib.optionals stdenv.isDarwin [ xcbuild.xcrun ];
 
   buildInputs =
@@ -132,6 +140,10 @@ rustPlatform.buildRustPackage rec {
 
   RUSTFLAGS = if withGLES then "--cfg gles" else "";
   gpu-lib = if withGLES then libglvnd else vulkan-loader;
+
+  preBuild = ''
+    bash script/generate-licenses
+  '';
 
   postFixup = lib.optionalString stdenv.isLinux ''
     patchelf --add-rpath ${gpu-lib}/lib $out/libexec/*

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -28,6 +28,8 @@
   envsubst,
   nix-update-script,
   cargo-about,
+  testers,
+  zed-editor,
 
   withGLES ? false,
 }:
@@ -136,6 +138,8 @@ rustPlatform.buildRustPackage rec {
     # Setting this environment variable allows to disable auto-updates
     # https://zed.dev/docs/development/linux#notes-for-packaging-zed
     ZED_UPDATE_EXPLANATION = "zed has been installed using nix. Auto-updates have thus been disabled.";
+    # Used by `zed --version`
+    RELEASE_VERSION = version;
   };
 
   RUSTFLAGS = if withGLES then "--cfg gles" else "";
@@ -187,11 +191,17 @@ rustPlatform.buildRustPackage rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "v(.*)"
-    ];
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "v(.*)"
+      ];
+    };
+    tests.version = testers.testVersion {
+      inherit version;
+      package = zed-editor;
+    };
   };
 
   meta = {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1. Pushing the `View Dependency Licenses` menu button currently leads to a crash as the license information is missing. With this fix, the license file is generated and the menu button works correctly.
2. `zed --version` currently prints `Zed  – /nix/store/aaw34y95dcz8n94rlpm11widq2k3bbbs-zed-0.150.4/libexec/zed-editor`. With this fix, the version is included: `Zed 0.151.1 – /nix/store/2y1gawvwckby74ky7ja3gs57dzwqq838-zed-0.151.1/libexec/zed-editor`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
