### PR TITLE
bruno: 1.25.0 -> 1.28.0

### DIFF
--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -26,20 +26,20 @@ let
 in
 buildNpmPackage' rec {
   pname = "bruno";
-  version = "1.25.0";
+  version = "1.28.0";
 
   src = fetchFromGitHub {
     owner = "usebruno";
     repo = "bruno";
     rev = "v${version}";
-    hash = "sha256-TXEe0ICrkljxfnvW1wv/e1BB7J6p/KW3JklCvYyjqSs=";
+    hash = "sha256-SLND+eEEMFVHE5XPt2EKkJ+BjENqvUSrWkqnC6ghUBI=";
 
     postFetch = ''
       ${lib.getExe npm-lockfile-fix} $out/package-lock.json
     '';
   };
 
-  npmDepsHash = "sha256-/1/QPKjSgJJDtmUipgbiVR+Buea9cXO+HvICfKVX/2g=";
+  npmDepsHash = "sha256-RFn7Bbx1xMm4gt++lhPflXjEfTIgmls2TkrJ8Ta2qpI=";
   npmFlags = [ "--legacy-peer-deps" ];
 
   nativeBuildInputs =
@@ -79,15 +79,12 @@ buildNpmPackage' rec {
       --replace-fail 'if [ "$1" == "snap" ]; then' 'exit 0; if [ "$1" == "snap" ]; then'
   '';
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
-
-  # remove giflib dependency
-  npmRebuildFlags = [ "--ignore-scripts" ];
-  preBuild = ''
-    substituteInPlace node_modules/canvas/binding.gyp \
-      --replace-fail "'with_gif%': '<!(node ./util/has_lib.js gif)'" "'with_gif%': 'false'"
-    npm rebuild
+  postConfigure = ''
+    # sh: line 1: /build/source/packages/bruno-common/node_modules/.bin/rollup: cannot execute: required file not found
+    patchShebangs packages/*/node_modules
   '';
+
+  ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
   dontNpmBuild = true;
   postBuild = ''
@@ -95,6 +92,8 @@ buildNpmPackage' rec {
     npm run build --workspace=packages/bruno-graphql-docs
     npm run build --workspace=packages/bruno-app
     npm run build --workspace=packages/bruno-query
+
+    npm run sandbox:bundle-libraries --workspace=packages/bruno-js
 
     bash scripts/build-electron.sh
 


### PR DESCRIPTION
## Description of changes

### Remove giflib patch
Context: canvas was an unused optional dependency in bruno, that checked for giflib dependency in interesting ways, see https://github.com/NixOS/nixpkgs/pull/319759.
In https://github.com/usebruno/bruno/commit/cef6f8584564881a7745938cde606e4eff475e58 (between v1.26.1 and v1.26.2) an npm install removed canvas, so our patch can be removed.

### Build js sandbox libraries
Without this the app crashes on startup:
```
Error: Cannot find module '../bundle-browser-rollup'
```
Adding this extra build step fixes it as it is documented in contributing.md: https://github.com/usebruno/bruno/pull/2848/files#diff-0b82d9a8fc9c94f7729e7685fca44dd89a479746f7cb14171e6dcdc7beb94387.

### Downgrade to rollup 3.2.5
With https://github.com/usebruno/bruno/commit/71ffe1f8d474833a7f9ad2cefcd7f76f522a8b4b rollup was upgraded from 3.2.5 to 3.29.4. Trying to build with this new version results in this build error:
```
sh: line 1: /build/source/packages/bruno-common/node_modules/.bin/rollup: cannot execute: required file not found
```
In fact upgrading to any newer rollup version, eg. 3.3.0 also causes this issue. When any of these upgrades happen, new entries get added to `package-lock.json`, eg `"packages/bruno-graphql-docs/node_modules/rollup"`.
The weird thing is building bruno with new rollup in a shell works (eg 1.28.0 without the rollup downgrade patch):
```bash
cd $(mktemp -d)
nix-shell -E "with import (fetchTarball https://github.com/NixOS/nixpkgs/archive/12228ff1752d.tar.gz) {}; callPackage /PATH/TO/NIXPKGS/pkgs/by-name/br/bruno/package.nix {}"
genericBuild
```
I couldn't find related issues and I'm not sure how to continue debugging other than making a smaller reproducible environment for this bug. Any help would be appreciated!
I added a fragile patch to package-lock.json as a workaround. It was made by checking out bruno v1.28.0, running `npm-lockfile-fix` (the diff produced by this is not part of the patch), then downgrading rollup by hand and removing the `"packages/bruno-*/node_modules/rollup"` entries.

### Releases
- https://github.com/usebruno/bruno/releases/tag/v1.26.0
- https://github.com/usebruno/bruno/releases/tag/v1.26.1
- https://github.com/usebruno/bruno/releases/tag/v1.26.2
- https://github.com/usebruno/bruno/releases/tag/v1.27.0
- https://github.com/usebruno/bruno/releases/tag/v1.28.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
