### PR TITLE
edencommon: patch to increase test discovery timeout

### DIFF
--- a/pkgs/development/libraries/edencommon/default.nix
+++ b/pkgs/development/libraries/edencommon/default.nix
@@ -20,6 +20,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-1z4QicS98juv4bUEbHBkCjVJHEhnoJyLYp4zMHmDbMg=";
   };
 
+  patches = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    # Test discovery timeout is bizarrely flaky on `x86_64-darwin`
+    ./increase-test-discovery-timeout.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = lib.optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/edencommon/increase-test-discovery-timeout.patch
+++ b/pkgs/development/libraries/edencommon/increase-test-discovery-timeout.patch
@@ -1,0 +1,20 @@
+diff --git a/eden/common/os/test/CMakeLists.txt b/eden/common/os/test/CMakeLists.txt
+index a9f71443f8..be1423c455 100644
+--- a/eden/common/os/test/CMakeLists.txt
++++ b/eden/common/os/test/CMakeLists.txt
+@@ -18,4 +18,4 @@
+     ${LIBGMOCK_LIBRARIES}
+ )
+ 
+-gtest_discover_tests(os_test)
++gtest_discover_tests(os_test DISCOVERY_TIMEOUT 25)
+diff --git a/eden/common/utils/test/CMakeLists.txt b/eden/common/utils/test/CMakeLists.txt
+index 0cac73e569..ff08ecccb8 100644
+--- a/eden/common/utils/test/CMakeLists.txt
++++ b/eden/common/utils/test/CMakeLists.txt
+@@ -34,4 +34,4 @@
+     ${LIBGMOCK_LIBRARIES}
+ )
+ 
+-gtest_discover_tests(utils_test)
++gtest_discover_tests(utils_test DISCOVERY_TIMEOUT 25)


### PR DESCRIPTION
## Description of changes

For some reason, this build is incredibly flaky on `x86_64-darwin`, possibly after the recent `staging-next` merge, failing with a test discovery timeout error both on Hydra and locally. The default discovery timeout is apparently 5 seconds, so let’s try giving it 5 times as long and see if that helps.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
