### PR TITLE
nixos/unl0kr: add settings to the unl0kr module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8617,6 +8617,13 @@
     name = "Luna Perego";
     keys = [ { fingerprint = "09E4 B981 9B93 5B0C 0B91  1274 0578 7332 9217 08FF"; } ];
   };
+  hustlerone = {
+    email = "nine-ball@tutanota.com";
+    matrix = "@hustlerone:matrix.org";
+    github = "hustlerone";
+    name = "Hustler One";
+    githubId = 167621692;
+  };
   huyngo = {
     email = "huyngo@disroot.org";
     github = "Huy-Ngo";

--- a/nixos/modules/system/boot/unl0kr.nix
+++ b/nixos/modules/system/boot/unl0kr.nix
@@ -1,27 +1,85 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.boot.initrd.unl0kr;
+  settingsFormat = pkgs.formats.ini { };
 in
 {
   options.boot.initrd.unl0kr = {
     enable = lib.mkEnableOption "unl0kr in initrd" // {
+      description = ''Whether to enable the unl0kr on-screen keyboard in initrd to unlock LUKS.'';
+    };
+
+    allowVendorDrivers = lib.mkEnableOption "load optional drivers" // {
+      description = ''Whether to load additional drivers for certain vendors (I.E: Wacom, Intel, etc.)'';
+    };
+
+    settings = lib.mkOption {
       description = ''
-        Whether to enable the unl0kr on-screen keyboard in initrd to unlock LUKS.
+        Configuration for `unl0kr`.
+
+        See `unl0kr.conf(5)` for supported values.
+
+        Alternatively, visit `https://gitlab.com/postmarketOS/buffybox/-/blob/unl0kr-2.0.0/unl0kr.conf`
       '';
+
+      example = lib.literalExpression ''
+        {
+            general.animations = true;
+            theme = {
+                  default = "pmos-dark";
+                  alternate = "pmos-light";
+            };
+        }
+      '';
+      default = { };
+      type = lib.types.submodule { freeformType = settingsFormat.type; };
     };
   };
 
   config = lib.mkIf cfg.enable {
-    meta.maintainers = [];
+    meta.maintainers = with lib.maintainers; [ hustlerone ];
     assertions = [
       {
         assertion = cfg.enable -> config.boot.initrd.systemd.enable;
         message = "boot.initrd.unl0kr is only supported with boot.initrd.systemd.";
       }
+      {
+        assertion = !config.boot.plymouth.enable;
+        message = "unl0kr will not work if plymouth is enabled.";
+      }
+      {
+        assertion = !config.hardware.amdgpu.initrd.enable;
+        message = "unl0kr has issues with video drivers that are loaded on stage 1.";
+      }
     ];
 
+    boot.initrd.availableKernelModules =
+      lib.optionals cfg.enable [
+        "hid-multitouch"
+        "hid-generic"
+        "usbhid"
+
+        "i2c-designware-core"
+        "i2c-designware-platform"
+        "i2c-hid-acpi"
+
+        "usbtouchscreen"
+        "evdev"
+      ]
+      ++ lib.optionals cfg.allowVendorDrivers [
+        "intel_lpss_pci"
+        "elo"
+        "wacom"
+      ];
+
     boot.initrd.systemd = {
+      contents."/etc/unl0kr.conf".source = settingsFormat.generate "unl0kr.conf" cfg.settings;
       storePaths = with pkgs; [
         "${pkgs.gnugrep}/bin/grep"
         libinput
@@ -42,9 +100,7 @@ in
             "systemd-vconsole-setup.service"
             "udev.service"
           ];
-          before = [
-            "shutdown.target"
-          ];
+          before = [ "shutdown.target" ];
           script = ''
             # This script acts as a Password Agent: https://systemd.io/PASSWORD_AGENTS/
 
@@ -56,7 +112,7 @@ in
             do
               for file in `ls $DIR/ask.*`; do
                 socket="$(cat "$file" | ${pkgs.gnugrep}/bin/grep "Socket=" | cut -d= -f2)"
-                ${pkgs.unl0kr}/bin/unl0kr | ${config.boot.initrd.systemd.package}/lib/systemd/systemd-reply-password 1 "$socket"
+                ${pkgs.unl0kr}/bin/unl0kr -v -C "/etc/unl0kr.conf" | ${config.boot.initrd.systemd.package}/lib/systemd/systemd-reply-password 1 "$socket"
               done
             done
           '';

--- a/pkgs/by-name/un/unl0kr/package.nix
+++ b/pkgs/by-name/un/unl0kr/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "unl0kr";
     homepage = "https://gitlab.com/cherrypicker/unl0kr";
     license = licenses.gpl3Plus;
-    maintainers = [];
+    maintainers = with maintainers; [ hustlerone ];
     platforms = platforms.linux;
   };
 })


### PR DESCRIPTION
## Description of changes

This PR centers around the service aspect of unl0kr in NixOS (despite the branch name suggesting otherwise). While it would've also been great to also [bump the version](https://github.com/NixOS/nixpkgs/pull/319126#issuecomment-2331351623) I feel like this is a much easier and important contribution, since the most notable changes in between v2.0.0 and v3.2.0 are slight changes in configuration attributes, a new theme and a (presumably hacky but operational) bugfix

Credit to https://github.com/Electrostasy for most of the heavy lifting.


This PR also removes tomfitzhenry as the maintainer of unl0kr at his request.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
