### PR TITLE
python312Packages.google-resumable-media: 2.7.1 -> 2.7.2, python312Packages.google-cloud-storage: 2.17.0 -> 2.18.2

### DIFF
--- a/pkgs/development/python-modules/google-cloud-storage/default.nix
+++ b/pkgs/development/python-modules/google-cloud-storage/default.nix
@@ -18,30 +18,29 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-storage";
-  version = "2.17.0";
+  version = "2.18.2";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-STeKv/VO9la1Lcpe8PLrqaqD3CsscseHFLA6GpX+k4g=";
+    pname = "google_cloud_storage";
+    inherit version;
+    hash = "sha256-qves1wza2fJ00pMyZz/KuYcI0OH03OtaU1aq7wavTZk=";
   };
-
-  nativeBuildInputs = [
-    setuptools
-  ];
 
   pythonRelaxDeps = [ "google-auth" ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     google-auth
     google-cloud-core
     google-resumable-media
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     protobuf = [ protobuf ];
   };
 
@@ -59,15 +58,16 @@ buildPythonPackage rec {
     "download"
     "get"
     "post"
-    "upload"
+    "test_anonymous_client_access_to_public_bucket"
     "test_build_api_url"
     "test_ctor_mtls"
+    "test_ctor_w_api_endpoint_override"
+    "test_ctor_w_custom_endpoint_use_auth"
     "test_hmac_key_crud"
     "test_list_buckets"
     "test_open"
-    "test_anonymous_client_access_to_public_bucket"
-    "test_ctor_w_custom_endpoint_use_auth"
-    "test_ctor_w_api_endpoint_override"
+    "test_set_api_request_attr"
+    "upload"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/google-resumable-media/default.nix
+++ b/pkgs/development/python-modules/google-resumable-media/default.nix
@@ -11,26 +11,30 @@
   pytestCheckHook,
   pythonOlder,
   requests,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "google-resumable-media";
-  version = "2.7.1";
-  format = "setuptools";
+  version = "2.7.2";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-6uRRp7LizbqqD9LrAMyKHuXpXha1VZc1nLw9J9fZDjM=";
+    pname = "google_resumable_media";
+    inherit version;
+    hash = "sha256-UoCu1GKfK2C4R7DUL5hX/Uk1wRryZnRN8z2AdMrpL+A=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     google-auth
     google-crc32c
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     requests = [ requests ];
     aiohttp = [ aiohttp ];
   };
@@ -40,7 +44,7 @@ buildPythonPackage rec {
     mock
     pytest-asyncio
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.requests;
+  ] ++ optional-dependencies.requests;
 
   preCheck = ''
     # prevent shadowing imports


### PR DESCRIPTION
Changelog:

- https://github.com/googleapis/google-resumable-media-python/blob/v2.7.2/CHANGELOG.md
- https://github.com/googleapis/python-storage/blob/v2.18.2/CHANGELOG.md
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
