### PR TITLE
matrix: migrated links to new element-hq org

### DIFF
--- a/nixos/modules/services/matrix/synapse.md
+++ b/nixos/modules/services/matrix/synapse.md
@@ -188,7 +188,7 @@ or [OpenID](https://element-hq.github.io/synapse/latest/openid.html).
 
 ## Element (formerly known as Riot) Web Client {#module-services-matrix-element-web}
 
-[Element Web](https://github.com/vector-im/riot-web/) is
+[Element Web](https://github.com/element-hq/element-web) is
 the reference web client for Matrix and developed by the core team at
 matrix.org. Element was formerly known as Riot.im, see the
 [Element introductory blog post](https://element.io/blog/welcome-to-element/)
@@ -228,6 +228,6 @@ the example, this means that you should not reuse the
 `myhostname.example.org` virtualHost to also serve Element,
 but instead serve it on a different subdomain, like
 `element.example.org` in the example. See the
-[Element Important Security Notes](https://github.com/vector-im/element-web/tree/v1.10.0#important-security-notes)
+[Element Important Security Notes](https://github.com/element-hq/element-web/tree/v1.10.0#important-security-notes)
 for more information on this subject.
 :::

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
   pname = "element-desktop";
   name = "${finalAttrs.pname}-${finalAttrs.version}";
   src = fetchFromGitHub {
-    owner = "vector-im";
+    owner = "element-hq";
     repo = "element-desktop";
     rev = "v${finalAttrs.version}";
     hash = desktopSrcHash;
@@ -112,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
   '';
 
   # The desktop item properties should be kept in sync with data from upstream:
-  # https://github.com/vector-im/element-desktop/blob/develop/package.json
+  # https://github.com/element-hq/element-desktop/blob/develop/package.json
   desktopItem = makeDesktopItem {
     name = "element-desktop";
     exec = "${executableName} %u";
@@ -147,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
   meta = with lib; {
     description = "A feature-rich client for Matrix.org";
     homepage = "https://element.io/";
-    changelog = "https://github.com/vector-im/element-desktop/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/element-hq/element-desktop/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = teams.matrix.members;
     inherit (electron.meta) platforms;

--- a/pkgs/applications/networking/instant-messengers/element/element-web.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-web.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
   pname = "element-web";
 
   src = fetchFromGitHub {
-    owner = "vector-im";
+    owner = "element-hq";
     repo = "element-web";
     rev = "v${finalAttrs.version}";
     hash = webSrcHash;
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
     # with the update of openssl3, some key ciphers are not supported anymore
     # this flag will allow those codecs again as a workaround
     # see https://medium.com/the-node-js-collection/node-js-17-is-here-8dba1e14e382#5f07
-    # and https://github.com/vector-im/element-web/issues/21043
+    # and https://github.com/element-hq/element-web/issues/21043
     export NODE_OPTIONS=--openssl-legacy-provider
     mkdir -p $HOME
 
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
   meta = {
     description = "Glossy Matrix collaboration client for the web";
     homepage = "https://element.io/";
-    changelog = "https://github.com/vector-im/element-web/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/element-hq/element-web/blob/v${finalAttrs.version}/CHANGELOG.md";
     maintainers = lib.teams.matrix.members;
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;

--- a/pkgs/applications/networking/instant-messengers/element/update.sh
+++ b/pkgs/applications/networking/instant-messengers/element/update.sh
@@ -12,15 +12,15 @@ version="$1"
 set -euo pipefail
 
 if [ -z "$version" ]; then
-  version="$(wget -q -O- "https://api.github.com/repos/vector-im/element-desktop/releases?per_page=1" | jq -r '.[0].tag_name')"
+  version="$(wget -q -O- "https://api.github.com/repos/element-hq/element-desktop/releases?per_page=1" | jq -r '.[0].tag_name')"
 fi
 
 # strip leading "v"
 version="${version#v}"
 
 # Element Web
-web_src="https://raw.githubusercontent.com/vector-im/element-web/v$version"
-web_src_hash=$(nix-prefetch-github vector-im element-web --rev v${version} | jq -r .hash)
+web_src="https://raw.githubusercontent.com/element-hq/element-web/v$version"
+web_src_hash=$(nix-prefetch-github element-hq element-web --rev v${version} | jq -r .hash)
 
 web_tmpdir=$(mktemp -d)
 trap 'rm -rf "$web_tmpdir"' EXIT
@@ -31,8 +31,8 @@ web_yarn_hash=$(prefetch-yarn-deps yarn.lock)
 popd
 
 # Element Desktop
-desktop_src="https://raw.githubusercontent.com/vector-im/element-desktop/v$version"
-desktop_src_hash=$(nix-prefetch-github vector-im element-desktop --rev v${version} | jq -r .hash)
+desktop_src="https://raw.githubusercontent.com/element-hq/element-desktop/v$version"
+desktop_src_hash=$(nix-prefetch-github element-hq element-desktop --rev v${version} | jq -r .hash)
 
 desktop_tmpdir=$(mktemp -d)
 trap 'rm -rf "$desktop_tmpdir"' EXIT

--- a/pkgs/applications/networking/instant-messengers/hydrogen-web/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/hydrogen-web/unwrapped.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "vector-im";
+    owner = "element-hq";
     repo = "hydrogen-web";
     rev = "v${finalAttrs.version}";
     hash = "sha256-u8Yex3r7EZH+JztQHJbfncYeyyl6hgb1ZNFIg//wcb0=";
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Lightweight matrix client with legacy and mobile browser support";
-    homepage = "https://github.com/vector-im/hydrogen-web";
+    homepage = "https://github.com/element-hq/hydrogen-web";
     maintainers = lib.teams.matrix.members;
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;


### PR DESCRIPTION
The vector-im GitHub organisation has been renamed to element-hq: 
https://github.com/vector-im/.github/blob/1d586281f08885acaa0284598d3a5dfc32402767/profile/README.md

- I verified that all links work as expected.
- I created only one PR since all packages are maintained by: lib.teams.matrix.members

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
