### PR TITLE
nixos/installation-device: getty.helpLine as optional blocks

### DIFF
--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -52,21 +52,30 @@ with lib;
     services.getty.autologinUser = "nixos";
 
     # Some more help text.
-    services.getty.helpLine = ''
-      The "nixos" and "root" accounts have empty passwords.
-
-      To log in over ssh you must set a password for either "nixos" or "root"
-      with `passwd` (prefix with `sudo` for "root"), or add your public key to
-      /home/nixos/.ssh/authorized_keys or /root/.ssh/authorized_keys.
-
-      If you need a wireless connection, type
-      `sudo systemctl start wpa_supplicant` and configure a
-      network using `wpa_cli`. See the NixOS manual for details.
-    '' + optionalString config.services.xserver.enable ''
-
-      Type `sudo systemctl start display-manager' to
-      start the graphical user interface.
-    '';
+    services.getty.helpLine =
+      let
+        concatBlocks = blocks: concatStringsSep "\n" (filter (x: x != "") blocks);
+      in
+      concatBlocks [
+        # each block must have a trailing newline
+        ''
+          The "nixos" and "root" accounts have empty passwords.
+        ''
+        (optionalString config.services.openssh.enable ''
+          To log in over ssh you must set a password for either "nixos" or "root"
+          with `passwd` (prefix with `sudo` for "root"), or add your public key to
+          /home/nixos/.ssh/authorized_keys or /root/.ssh/authorized_keys.
+        '')
+        (optionalString config.networking.wireless.enable ''
+          If you need a wireless connection, type
+          `sudo systemctl start wpa_supplicant` and configure a
+          network using `wpa_cli`. See the NixOS manual for details.
+        '')
+        (optionalString config.services.xserver.enable ''
+          Type `sudo systemctl start display-manager' to
+          start the graphical user interface.
+        '')
+      ];
 
     # We run sshd by default. Login is only possible after adding a
     # password via "passwd" or by adding a ssh key to ~/.ssh/authorized_keys.


### PR DESCRIPTION
## Description of changes

As an addition to #339786 (just technically separated), I rewrote the compositioning of `services.getty.helpLine` for NixOS installers. These are logically separated into blocks, making it easier to add blocks based on conditions. Together with this, I made the blocks for wireless connectivity & for SSH authentication configuration optional, depending on if their corresponding services are indeed enabled (similar to the GUI block depending on xserver being enabled).

Visually, for the `simple` installer test, the output changed as follows (first before the PR):

![Screenshot_20240905_152236](https://github.com/user-attachments/assets/f949bf17-8c67-453d-89a5-19d861b5d2d7)

And now after this PR:

![Screenshot_20240905_152752](https://github.com/user-attachments/assets/819abea6-5cd1-40a5-b4cd-a0b38e7fa23b)

The help message for wireless networking is now missing here, because it is not enabled on the `simple` installer test.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I ran following NixOS tests myself from `nixosTests.installer` on x86_64-linux to make sure, that the installer continuous to work as expected:
- `simple`
- `simpleSpecialised`
- `simpleUefiSystemdBoot`
- `clevisLuks`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
