### PR TITLE
gcalcli: 4.3.0 → 4.4.0

### DIFF
--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -8,43 +8,52 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gcalcli";
-  version = "4.3.0";
+  version = "4.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "insanum";
     repo = "gcalcli";
     rev = "refs/tags/v${version}";
-    hash = "sha256-roHMWUwklLMNhLJANsAeBKcSX1Qk47kH5A3Y8SuDrmg=";
+    hash = "sha256-X9sgnujHMbmrt7cpcBOvTycIKFz3G2QzNDt3me5GUrQ=";
   };
 
-  postPatch = lib.optionalString stdenv.isLinux ''
-    substituteInPlace gcalcli/argparsers.py \
-      --replace-fail "'notify-send" "'${lib.getExe libnotify}"
-  '';
+  postPatch =
+    ''
+      # dev dependencies
+      substituteInPlace pyproject.toml \
+        --replace-fail "\"google-api-python-client-stubs\"," "" \
+        --replace-fail "\"types-python-dateutil\"," "" \
+        --replace-fail "\"types-requests\"," "" \
+        --replace-fail "\"types-vobject\"," ""
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      substituteInPlace gcalcli/argparsers.py \
+        --replace-fail "'notify-send" "'${lib.getExe libnotify}"
+    '';
 
   build-system = with python3Packages; [ setuptools ];
 
   dependencies = with python3Packages; [
+    argcomplete
     python-dateutil
     gflags
     httplib2
     parsedatetime
-    six
     vobject
     google-api-python-client
-    oauth2client
+    google-auth-oauthlib
     uritemplate
     libnotify
   ];
 
   nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
-  meta = with lib; {
+  meta = {
     description = "CLI for Google Calendar";
     mainProgram = "gcalcli";
     homepage = "https://github.com/insanum/gcalcli";
-    license = licenses.mit;
-    maintainers = with maintainers; [ nocoolnametom ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nocoolnametom ];
   };
 }


### PR DESCRIPTION
## Description of changes
https://github.com/insanum/gcalcli/releases/tag/v4.4.0

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
