### PR TITLE
wayland support dolphin

### DIFF
--- a/pkgs/kde/gear/dolphin/default.nix
+++ b/pkgs/kde/gear/dolphin/default.nix
@@ -1,4 +1,9 @@
-{mkKdeDerivation}:
+{
+  mkKdeDerivation,
+  qtwayland
+}:
 mkKdeDerivation {
   pname = "dolphin";
+
+  extraBuildInputs = [qtwayland];
 }


### PR DESCRIPTION
qtwayland client side is the wayland platform plugin, provides a way to run Qt applications as Wayland clients without this, Qt applications only work on x11/xwayland