### PR TITLE
protoc-gen-es: fix missing node_modules directories

### DIFF
--- a/pkgs/by-name/pr/protoc-gen-es/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-es/package.nix
@@ -29,6 +29,13 @@ buildNpmPackage rec {
     npm run --workspace=packages/protoplugin build
   '';
 
+  # copy npm workspace modules while properly resolving symlinks
+  # TODO: workaround can be removed once this is merged: https://github.com/NixOS/nixpkgs/pull/333759
+  postInstall = ''
+    rm -rf $out/lib/node_modules/protobuf-es/node_modules/@bufbuild
+    cp -rL node_modules/@bufbuild $out/lib/node_modules/protobuf-es/node_modules/
+  '';
+
   passthru.updateScript = ./update.sh;
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Fixes runtime error where some dependencies cannot be found in `node_modules` due to broken symlinks: https://github.com/NixOS/nixpkgs/pull/243432#issuecomment-2186894801

It's possible to fix this in npm-install-hooks itself: https://github.com/NixOS/nixpkgs/pull/333759.
However I haven't gotten a response yet, so I created this workaround to get the package fixed without any risk of breaking other packages.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
