### PR TITLE
alot: v0.10 -> v0.11

### DIFF
--- a/pkgs/applications/networking/mailreaders/alot/default.nix
+++ b/pkgs/applications/networking/mailreaders/alot/default.nix
@@ -31,7 +31,7 @@ with python311.pkgs; buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace alot/settings/manager.py \
-      --replace /usr/share "$out/share"
+      --replace-fail /usr/share "$out/share"
   '';
 
   nativeBuildInputs = [
@@ -85,7 +85,7 @@ with python311.pkgs; buildPythonApplication rec {
       cp -r extra/themes $out/share/alot
 
       substituteInPlace extra/completion/alot-completion.zsh \
-        --replace "python3" "${completionPython.interpreter}"
+        --replace-fail "python3" "${completionPython.interpreter}"
       install -D extra/completion/alot-completion.zsh $out/share/zsh/site-functions/_alot
 
       sed "s,/usr/bin,$out/bin,g" extra/alot.desktop > $out/share/applications/alot.desktop

--- a/pkgs/applications/networking/mailreaders/alot/default.nix
+++ b/pkgs/applications/networking/mailreaders/alot/default.nix
@@ -5,12 +5,14 @@
 , gnupg
 , gawk
 , procps
+, notmuch
 , withManpage ? false
 }:
 
 with python311.pkgs; buildPythonApplication rec {
   pname = "alot";
-  version = "0.10";
+  version = "0.11";
+  pyproject = true;
 
   outputs = [
     "out"
@@ -23,8 +25,8 @@ with python311.pkgs; buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "pazz";
     repo = "alot";
-    rev = version;
-    sha256 = "sha256-1reAq8X9VwaaZDY5UfvcFzHDKd71J88CqJgH3+ANjis=";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-mXaRzl7260uxio/BQ36BCBxgKhl1r0Rc6PwFZA8qNqc=";
   };
 
   postPatch = ''
@@ -32,7 +34,9 @@ with python311.pkgs; buildPythonApplication rec {
       --replace /usr/share "$out/share"
   '';
 
-  nativeBuildInputs = lib.optional withManpage sphinx;
+  nativeBuildInputs = [
+    setuptools-scm
+  ] ++ lib.optional withManpage sphinx;
 
   propagatedBuildInputs = [
     configobj
@@ -53,6 +57,7 @@ with python311.pkgs; buildPythonApplication rec {
     mock
     procps
     pytestCheckHook
+    notmuch
   ];
 
   postBuild = lib.optionalString withManpage [


### PR DESCRIPTION
notable changes:
- the project moved from `setup.py` to `pyproject`
- `setuptools-scm` was introduced as a build dependency
- `notmuch` is now used in the unittests

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
