### PR TITLE
akku: 1.1.0 -> 1.1.0-unstable-2024-03-03

### DIFF
--- a/pkgs/tools/package-management/akku/akku.nix
+++ b/pkgs/tools/package-management/akku/akku.nix
@@ -1,26 +1,20 @@
-{ lib, stdenv, fetchFromGitLab, autoreconfHook, pkg-config, guile, curl, substituteAll }:
+{ lib, stdenv, fetchFromGitLab, autoreconfHook, pkg-config, git, guile, curl }:
 stdenv.mkDerivation rec {
   pname = "akku";
-  version = "1.1.0";
+  version = "1.1.0-unstable-2024-03-03";
 
   src = fetchFromGitLab {
     owner = "akkuscm";
     repo = "akku";
-    rev = "v${version}";
-    sha256 = "1pi18aamg1fd6f9ynfl7zx92052xzf0zwmhi2pwcwjs1kbah19f5";
+    rev = "cb996572fe0dbe74a42d2abeafadffaea2bf8ae3";
+    sha256 = "sha256-6xqASnFxzz0yE5oJnh15SOB74PVrVkMVwS3PwKAmgks=";
   };
 
-  patches = [
-    # substitute libcurl path
-    (substituteAll {
-      src = ./hardcode-libcurl.patch;
-      libcurl = "${curl.out}/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary}";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
-  buildInputs = [ guile ];
+  # akku calls curl commands
+  buildInputs = [ guile curl git ];
 
   # Use a dummy package index to boostrap Akku
   preBuild = ''

--- a/pkgs/tools/package-management/akku/akkuDerivation.nix
+++ b/pkgs/tools/package-management/akku/akkuDerivation.nix
@@ -18,8 +18,7 @@ stdenv.mkDerivation ({
     # only install the project
     rm -f Akku.lock Akku.manifest
 
-    # build, filter out guile warnings
-    akku install 2>&1 | grep -v "\(guile-user\)" - | cat
+    akku install
 
     # make sure akku metadata is present during testing and onwards
     echo $PWD $CHEZSCHEMELIBDIRS \

--- a/pkgs/tools/package-management/akku/overrides.nix
+++ b/pkgs/tools/package-management/akku/overrides.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, akku, curl, git, substituteAll }:
+{ stdenv, lib, akku, curl, git }:
 let
   joinOverrides =
     overrides: pkg: old:
@@ -39,11 +39,14 @@ in
   };
 
   akku = joinOverrides [
+    # uses chez
     (addToBuildInputs [ curl git ])
     (pkg: old: {
-      # hardcode-libcurl
-      patches = akku.patches;
+      # bump akku to 1.1.0-unstable-2024-03-03
+      src = akku.src;
     })
+    # not a tar archive
+    (pkg: old: removeAttrs old [ "unpackPhase" ])
   ];
 
   # circular dependency on wak-trc-testing !?


### PR DESCRIPTION
## Description of changes
closes #339501

cc @nagy @rc-zb

Running akku prints guile warnings in this format:
`WARNING: (guile-user): imported module (rnrs) overrides core binding `<something>'`

There was a PR to address this in the main repo: https://gitlab.com/akkuscm/akku/-/merge_requests/7, merged Feb 8, 2021, which was after the version we're currently using (v1.1.0, released on Feb 6). I bumped akku to 1.1.0-unstable-2024-03-03, and that removed the guile-user warnings.

However, one thing to consider: akkuPackages.akku is still on v1.1.0. Should I override the akkuDerivation's src to bump it as well?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
I built all the akkuPackages on x86_64-linux.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
