### PR TITLE
musescore: 4.4.0 -> 4.4.1

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -49,27 +49,15 @@ let
   } else portaudio;
 in stdenv'.mkDerivation (finalAttrs: {
   pname = "musescore";
-  version = "4.4.0";
+  version = "4.4.1";
 
   src = fetchFromGitHub {
     owner = "musescore";
     repo = "MuseScore";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-oDbOaLFmSpZ7D8E7LBxUwFwiaPcucIUj3eEp6sXR5o8=";
+    sha256 = "sha256-eLtpLgXSc8L5y1Mg3s1wrxr09+/vBxNqJEtl9IoKYSM=";
   };
   patches = [
-    # https://github.com/musescore/MuseScore/pull/24247
-    (fetchpatch {
-      name = "skip-downloading-harfbuzz.patch";
-      url = "https://github.com/musescore/MuseScore/commit/686ea243d58b43eb3dff7ebdabb2e09de4d212e4.patch";
-      hash = "sha256-fsb1hKFKXwBdMPh+Ek0UT3XtI8qg3ieWUQW1/XDvhmg=";
-    })
-    # https://github.com/musescore/MuseScore/pull/24261
-    (fetchpatch {
-      name = "allow-using-system-harfbuzz.patch";
-      url = "https://github.com/musescore/MuseScore/commit/696279e362afe72db5e92f8a47aa64b3a0e86a86.patch";
-      hash = "sha256-z1W2SmzUUlVL7mRR2frzUZjMEnwqkVfRVz4TufR1tDU=";
-    })
     # https://github.com/musescore/MuseScore/pull/24326
     (fetchpatch {
       name = "fix-menubar-with-qt6.5+.patch";

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -120,12 +120,12 @@ in stdenv'.mkDerivation (finalAttrs: {
     qtbase
     qtdeclarative
     qt5compat
-    qtwayland
     qtsvg
     qtscxml
     qtnetworkauth
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
+    qtwayland
   ];
 
   postInstall = ''

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -126,6 +126,8 @@ in stdenv'.mkDerivation (finalAttrs: {
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
     qtwayland
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk_11_0.frameworks.Cocoa
   ];
 
   postInstall = ''


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
