### PR TITLE
emilua: bump + plugin support

### DIFF
--- a/pkgs/development/emilua-plugins/beast/default.nix
+++ b/pkgs/development/emilua-plugins/beast/default.nix
@@ -1,12 +1,13 @@
-{ stdenv
-, emilua
-, meson
-, gperf
-, ninja
-, asciidoctor
-, pkg-config
-, fetchFromGitLab
-, gitUpdater
+{
+  stdenv,
+  emilua,
+  meson,
+  gperf,
+  ninja,
+  asciidoctor,
+  pkg-config,
+  fetchFromGitLab,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation (self: {
@@ -20,9 +21,17 @@ stdenv.mkDerivation (self: {
     hash = "sha256-HvfEigHJTZelPvHFk22PWxkTFEajHJXfiCndxXHVgq8=";
   };
 
-  buildInputs = [ emilua asciidoctor gperf ];
+  buildInputs = [
+    emilua
+    asciidoctor
+    gperf
+  ];
 
-  nativeBuildInputs = [ meson pkg-config ninja ];
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+  ];
 
-  passthru.updateScript = gitUpdater {rev-prefix="v";};
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 })

--- a/pkgs/development/emilua-plugins/beast/default.nix
+++ b/pkgs/development/emilua-plugins/beast/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, emilua
+, meson
+, gperf
+, ninja
+, asciidoctor
+, pkg-config
+, fetchFromGitLab
+, gitUpdater
+}:
+
+stdenv.mkDerivation (self: {
+  pname = "emilua_beast";
+  version = "1.1.0";
+
+  src = fetchFromGitLab {
+    owner = "emilua";
+    repo = "beast";
+    rev = "v${self.version}";
+    hash = "sha256-HvfEigHJTZelPvHFk22PWxkTFEajHJXfiCndxXHVgq8=";
+  };
+
+  buildInputs = [ emilua asciidoctor gperf ];
+
+  nativeBuildInputs = [ meson pkg-config ninja ];
+
+  passthru.updateScript = gitUpdater {rev-prefix="v";};
+})

--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -110,6 +110,13 @@ stdenv.mkDerivation (self: {
     "--no-suite" "libpsx"
   ];
 
+  postInstall = ''
+    mkdir -p $out/nix-support
+    cp ${./setup-hook.sh} $out/nix-support/setup-hook
+    substituteInPlace $out/nix-support/setup-hook \
+      --replace @sitePackages@ "${self.passthru.sitePackages}"
+  '';
+
   passthru = {
     updateScript = gitUpdater {rev-prefix = "v";};
     inherit boost;

--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -50,13 +50,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "emilua";
-  version = "0.7.3";
+  version = "0.10.1";
 
   src = fetchFromGitLab {
     owner = "emilua";
     repo = "emilua";
     rev = "v${version}";
-    hash = "sha256-j8ohhqHjSBgc4Xk9PcQNrbADmsz4VH2zCv+UNqiCv4I=";
+    hash = "sha256-D6XKXik9nWQ6t6EF6dLbRGB60iFbPUM8/H8iFAz1QlE=";
   };
 
   buildInputs = [

--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation (self: {
     mainProgram = "emilua";
     homepage = "https://emilua.org/";
     license = licenses.boost;
-    maintainers = with maintainers; [ manipuladordedados ];
+    maintainers = with maintainers; [ manipuladordedados lucasew ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -47,7 +47,10 @@ let
       EOF
     '';
   };
+
+  boost = boost182;
 in
+
 stdenv.mkDerivation (self: {
   pname = "emilua";
   version = "0.10.1";
@@ -59,9 +62,9 @@ stdenv.mkDerivation (self: {
     hash = "sha256-D6XKXik9nWQ6t6EF6dLbRGB60iFbPUM8/H8iFAz1QlE=";
   };
 
-  buildInputs = [
+  propagatedBuildInputs = [
     luajit_openresty
-    boost182
+    boost
     fmt
     ncurses
     serd
@@ -109,6 +112,7 @@ stdenv.mkDerivation (self: {
 
   passthru = {
     updateScript = gitUpdater {rev-prefix = "v";};
+    inherit boost;
     sitePackages = "lib/emilua-${(lib.concatStringsSep "." (lib.take 2 (lib.splitVersion self.version)))}";
   };
 

--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -22,6 +22,7 @@
   cmake,
   asciidoctor,
   makeWrapper,
+  gitUpdater
 }:
 
 let
@@ -105,6 +106,8 @@ stdenv.mkDerivation rec {
     # Known issue with no-new-privs disabled in the Nix build environment.
     "--no-suite" "libpsx"
   ];
+
+  passthru.updateScript = gitUpdater {rev-prefix = "v";};
 
   meta = with lib; {
     description = "Lua execution engine";

--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -29,8 +29,22 @@ let
     owner = "breese";
     repo = "trial.protocol";
     rev = "79149f604a49b8dfec57857ca28aaf508069b669";
-    name = "trial-protocol";
-    hash = "sha256-Xd8bX3z9PZWU17N9R95HXdj6qo9at5FBL/+PTVaJgkw=";
+    sparseCheckout = [
+      "include"
+    ];
+    hash = "sha256-QpQ70KDcJyR67PtOowAF6w48GitMJ700B8HiEwDA5sU=";
+    postFetch = ''
+      rm $out/*.*
+      mkdir -p $out/lib/pkgconfig
+      cat > $out/lib/pkgconfig/trial-protocol.pc << EOF
+        Name: trial.protocol
+        Version: 0-unstable-2023-02-10
+        Description:  C++ header-only library with parsers and generators for network wire protocols
+        Requires:
+        Libs:
+        Cflags:
+      EOF
+    '';
   };
 in
 stdenv.mkDerivation rec {
@@ -55,6 +69,7 @@ stdenv.mkDerivation rec {
     liburing
     openssl
     cereal
+    trial-protocol-wrap
   ];
 
   nativeBuildInputs = [
@@ -80,12 +95,6 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    pushd subprojects
-    cp -r ${trial-protocol-wrap} trial-protocol
-    chmod +w trial-protocol
-    cp "packagefiles/trial.protocol/meson.build" "trial-protocol/"
-    popd
-
     patchShebangs src/emilua_gperf.awk --interpreter '${lib.getExe gawk} -f'
   '';
 

--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -48,14 +48,14 @@ let
     '';
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (self: {
   pname = "emilua";
   version = "0.10.1";
 
   src = fetchFromGitLab {
     owner = "emilua";
     repo = "emilua";
-    rev = "v${version}";
+    rev = "v${self.version}";
     hash = "sha256-D6XKXik9nWQ6t6EF6dLbRGB60iFbPUM8/H8iFAz1QlE=";
   };
 
@@ -107,7 +107,10 @@ stdenv.mkDerivation rec {
     "--no-suite" "libpsx"
   ];
 
-  passthru.updateScript = gitUpdater {rev-prefix = "v";};
+  passthru = {
+    updateScript = gitUpdater {rev-prefix = "v";};
+    sitePackages = "lib/emilua-${(lib.concatStringsSep "." (lib.take 2 (lib.splitVersion self.version)))}";
+  };
 
   meta = with lib; {
     description = "Lua execution engine";
@@ -117,4 +120,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ manipuladordedados ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/development/interpreters/emilua/setup-hook.sh
+++ b/pkgs/development/interpreters/emilua/setup-hook.sh
@@ -1,0 +1,17 @@
+addEmiluaPath() {
+  addToSearchPathWithCustomDelimiter : EMILUA_PATH $1/@sitePackages@
+}
+
+toEmiluaPath() {
+    local paths="$1"
+    local result=
+    for i in $paths; do
+        p="$i/@sitePackages@"
+        result="${result}${result:+:}$p"
+    done
+    echo $result
+}
+
+if [ -z "${dontAddEmiluaPath:-}" ]; then
+    addEnvHooks "$hostOffset" addEmiluaPath
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16630,7 +16630,10 @@ with pkgs;
   zuo = callPackage ../development/interpreters/zuo { };
 
   ### LUA interpreters
-  emilua = callPackage ../development/interpreters/emilua { };
+  emiluaPlugins = callPackage ./emilua-plugins.nix {}
+    (callPackage ../development/interpreters/emilua { });
+
+  inherit (emiluaPlugins) emilua;
 
   luaInterpreters = callPackage ./../development/interpreters/lua-5 { };
   inherit (luaInterpreters) lua5_1 lua5_2 lua5_2_compat lua5_3 lua5_3_compat lua5_4 lua5_4_compat luajit_2_1 luajit_2_0 luajit_openresty;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16630,8 +16630,9 @@ with pkgs;
   zuo = callPackage ../development/interpreters/zuo { };
 
   ### LUA interpreters
-  emiluaPlugins = callPackage ./emilua-plugins.nix {}
-    (callPackage ../development/interpreters/emilua { });
+  emiluaPlugins = recurseIntoAttrs
+    (callPackage ./emilua-plugins.nix {}
+      (callPackage ../development/interpreters/emilua { }));
 
   inherit (emiluaPlugins) emilua;
 

--- a/pkgs/top-level/emilua-plugins.nix
+++ b/pkgs/top-level/emilua-plugins.nix
@@ -1,7 +1,12 @@
-{lib, newScope, pkgs, config }:
+{
+  lib,
+  newScope,
+  pkgs,
+  config,
+}:
 
 emilua:
-  (lib.makeScope newScope (self: {
-    inherit emilua;
-    beast = self.callPackage ../development/emilua-plugins/beast {};
-  }))
+(lib.makeScope newScope (self: {
+  inherit emilua;
+  beast = self.callPackage ../development/emilua-plugins/beast { };
+}))

--- a/pkgs/top-level/emilua-plugins.nix
+++ b/pkgs/top-level/emilua-plugins.nix
@@ -1,0 +1,6 @@
+{lib, newScope, pkgs, config }:
+
+emilua:
+  (lib.makeScope newScope (self: {
+    inherit emilua;
+  }))

--- a/pkgs/top-level/emilua-plugins.nix
+++ b/pkgs/top-level/emilua-plugins.nix
@@ -3,4 +3,5 @@
 emilua:
   (lib.makeScope newScope (self: {
     inherit emilua;
+    beast = self.callPackage ../development/emilua-plugins/beast {};
   }))


### PR DESCRIPTION
## Description of changes
- trial-protocol: move it to it's own package (used by emilua)
- emilua: 0.7.3 -> 0.10.1
- emiluaPlugins: init scope
- emiluaPlugins.beast: init at 1.1.0 (had to introduce a plugin to test the abstractions)
- emilua: add setup hook that automatically populates EMILUA_PATH
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Test script to test if it imports the module properly:

```lua
print("import beast")                                                                                                                              
local beast = require'beast'
print("import ok") 
```

```bash
NIX_PATH=nixpkgs=/path/to/this/pr nix-shell -p  -p emiluaPlugins.{beast,emilua}
emilua /path/to/the/script/above.lua
```

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
