### PR TITLE
rustc: Fix cross build for FreeBSD

### DIFF
--- a/pkgs/development/compilers/rust/1_82.nix
+++ b/pkgs/development/compilers/rust/1_82.nix
@@ -20,6 +20,7 @@
   pkgsBuildTarget,
   pkgsBuildBuild,
   pkgsBuildHost,
+  pkgsHostTarget,
   pkgsTargetTarget,
   makeRustPlatform,
   wrapRustcWith,
@@ -40,7 +41,7 @@ let
         # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
         stdenv = pkgSet.stdenv.override {
           allowedRequisites = null;
-          cc = pkgSet.llvmPackages_18.clangUseLLVM;
+          cc = pkgSet.pkgsBuildHost.llvmPackages_18.clangUseLLVM;
         };
       }
     );
@@ -55,7 +56,7 @@ import ./default.nix
     llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
 
     # For use at runtime
-    llvmShared = llvmSharedFor { inherit llvmPackages_18 stdenv; };
+    llvmShared = llvmSharedFor pkgsHostTarget;
 
     # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
     llvmPackages =
@@ -74,7 +75,7 @@ import ./default.nix
               pkg.override {
                 stdenv = stdenv.override {
                   allowedRequisites = null;
-                  cc = llvmPackages.clangUseLLVM;
+                  cc = pkgsBuildHost.llvmPackages_18.clangUseLLVM;
                 };
               };
           in
@@ -87,7 +88,7 @@ import ./default.nix
             libcxx = llvmPackages.libcxx.override {
               stdenv = stdenv.override {
                 allowedRequisites = null;
-                cc = llvmPackages.clangNoLibcxx;
+                cc = pkgsBuildHost.llvmPackages_18.clangNoLibcxx;
                 hostPlatform = stdenv.hostPlatform // {
                   useLLVM = !stdenv.hostPlatform.isDarwin;
                 };
@@ -142,5 +143,6 @@ import ./default.nix
       "wrapCCWith"
       "overrideCC"
       "fetchpatch"
+      "pkgsHostTarget"
     ]
   )

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -172,7 +172,7 @@ in stdenv.mkDerivation (finalAttrs: {
   ] ++ optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # https://github.com/rust-lang/rust/issues/92173
     "--set rust.jemalloc"
-  ] ++ optionals useLLVM [
+  ] ++ optionals (useLLVM && !stdenv.targetPlatform.isFreeBSD) [
     # https://github.com/NixOS/nixpkgs/issues/311930
     "--llvm-libunwind=${if withBundledLLVM then "in-tree" else "system"}"
     "--enable-use-libcxx"
@@ -262,7 +262,7 @@ in stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ openssl ]
     ++ optionals stdenv.hostPlatform.isDarwin [ libiconv Security zlib ]
     ++ optional (!withBundledLLVM) llvmShared.lib
-    ++ optional (useLLVM && !withBundledLLVM) [
+    ++ optional (useLLVM && !withBundledLLVM && !stdenv.targetPlatform.isFreeBSD) [
       llvmPackages.libunwind
       # Hack which is used upstream https://github.com/gentoo/gentoo/blob/master/dev-lang/rust/rust-1.78.0.ebuild#L284
       (runCommandLocal "libunwind-libgcc" {} ''


### PR DESCRIPTION
## Description of changes

I ran into two errors trying to build rust packages cross for FreeBSD on staging.

The first was that llvm wouldn't compile, since it was using a guest compiler as the host compiler and it was segfaulting trying to execute min-llvm-tblgen. The fix for this is the second commit.

The second was that rustc wouldn't compile, citing errors about libunwind. As per https://github.com/NixOS/nixpkgs/pull/320472, FreeBSD shouldn't use libunwind.

I believe both of these are simple errors from https://github.com/NixOS/nixpkgs/pull/320432. The day we get FreeBSD CI is the day I will be happy waterfowl.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
