### PR TITLE
freebsd: improve overridability of entire package set

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/package-set.nix
+++ b/pkgs/os-specific/bsd/freebsd/package-set.nix
@@ -18,7 +18,6 @@ lib.packagesFromDirectoryRecursive {
 }
 // {
   inherit sourceData patchesRoot versionData;
-  patches = ./patches + "/${self.versionData.revision}";
 
   # Keep the crawled portion of Nixpkgs finite.
   buildFreebsd = lib.dontRecurseIntoAttrs buildFreebsd // {

--- a/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
@@ -41,7 +41,7 @@ mkDerivation {
 
       "sys/rpc/types.h"
     ]
-    ++ lib.optionals (versionData.major == 14) [
+    ++ lib.optionals (versionData.major >= 14) [
       "sys/sys/bitcount.h"
       "sys/sys/linker_set.h"
       "sys/sys/module.h"
@@ -60,7 +60,7 @@ mkDerivation {
       "include/elf.h"
       "sys/sys/ctf.h"
     ]
-    ++ lib.optionals (versionData.major == 14) [
+    ++ lib.optionals (versionData.major >= 14) [
       "include/bitstring.h"
       "sys/sys/bitstring.h"
       "sys/sys/nv_namespace.h"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/csu.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/csu.nix
@@ -18,7 +18,7 @@ mkDerivation {
   extraPaths = [
     "lib/Makefile.inc"
     "lib/libc/include/libc_private.h"
-  ] ++ lib.optionals (versionData.major == 14) [ "sys/sys/param.h" ];
+  ] ++ lib.optionals (versionData.major >= 14) [ "sys/sys/param.h" ];
   nativeBuildInputs = [
     bsdSetupHook
     freebsdSetupHook

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libc/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libc/package.nix
@@ -44,7 +44,7 @@ mkDerivation {
       "contrib/libc-vis"
     ]
     ++ lib.optionals (versionData.major == 13) [ "contrib/tzcode/stdtime" ]
-    ++ lib.optionals (versionData.major == 14) [ "contrib/tzcode" ]
+    ++ lib.optionals (versionData.major >= 14) [ "contrib/tzcode" ]
     ++ [
 
       # libthr

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libncurses.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libncurses.nix
@@ -13,10 +13,10 @@ mkDerivation {
     "lib/Makefile.inc"
   ];
   MK_TESTS = "no";
-  preBuild = lib.optionalString (versionData.major == 14) ''
+  preBuild = lib.optionalString (versionData.major >= 14) ''
     make -C ../tinfo $makeFlags curses.h ncurses_dll.h ncurses_def.h
   '';
-  buildInputs = lib.optionals (versionData.major == 14) [ libncurses-tinfo ];
+  buildInputs = lib.optionals (versionData.major >= 14) [ libncurses-tinfo ];
 
   # some packages depend on libncursesw.so.8
   postInstall = ''

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -7,7 +7,7 @@
   buildPackages,
   stdenvNoLibcxx ? overrideCC stdenv buildPackages.llvmPackages.clangNoLibcxx,
   versionData,
-  patches,
+  patchesRoot,
   compatIfNeeded,
   freebsd-lib,
   filterSource,
@@ -118,7 +118,7 @@ lib.makeOverridable (
     // {
       patches =
         (lib.optionals (attrs.autoPickPatches or true) (
-          freebsd-lib.filterPatches patches (
+          freebsd-lib.filterPatches patchesRoot (
             attrs.extraPaths or [ ] ++ (lib.optional (attrs ? path) attrs.path)
           )
         ))

--- a/pkgs/os-specific/bsd/freebsd/pkgs/rc.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/rc.nix
@@ -74,6 +74,7 @@ mkDerivation {
       + lib.concatMapStringsSep "\n" (fname: ''
         sed -E -i -e "s|${fname}|${lib.last (lib.splitString "/" fname)}|g" \
           ${scriptPaths}'') bins
+      + "\n"
     );
 
   skipIncludesPhase = true;

--- a/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
@@ -1,13 +1,15 @@
 {
   lib,
   mkDerivation,
+  writeText,
   stdenv,
   buildPackages,
   freebsd-lib,
-  patches,
+  patchesRoot,
   filterSource,
   applyPatches,
   baseConfig ? "GENERIC",
+  extraConfig ? null,
   extraFlags ? { },
   bsdSetupHook,
   mandoc,
@@ -24,6 +26,13 @@
   kldxref,
 }:
 let
+  baseConfigFile =
+    if (extraConfig == null) then
+      null
+    else if (lib.isDerivation extraConfig) || (lib.isPath extraConfig) then
+      extraConfig
+    else
+      writeText "extraConfig" extraConfig;
   hostArchBsd = freebsd-lib.mkBsdArch stdenv;
   filteredSource = filterSource {
     pname = "sys";
@@ -32,23 +41,27 @@ let
   };
   patchedSource = applyPatches {
     src = filteredSource;
-    patches = freebsd-lib.filterPatches patches [
+    patches = freebsd-lib.filterPatches patchesRoot [
       "sys"
       "include"
     ];
-    postPatch = ''
-      for f in sys/conf/kmod.mk sys/contrib/dev/acpica/acpica_prep.sh; do
-        substituteInPlace "$f" --replace-warn 'xargs -J' 'xargs-j '
-      done
+    postPatch =
+      ''
+        for f in sys/conf/kmod.mk sys/contrib/dev/acpica/acpica_prep.sh; do
+          substituteInPlace "$f" --replace-warn 'xargs -J' 'xargs-j '
+        done
 
-      for f in sys/conf/*.mk; do
-        substituteInPlace "$f" --replace-quiet 'KERN_DEBUGDIR}''${' 'KERN_DEBUGDIR_'
-      done
+        for f in sys/conf/*.mk; do
+          substituteInPlace "$f" --replace-quiet 'KERN_DEBUGDIR}''${' 'KERN_DEBUGDIR_'
+        done
 
-      sed -i sys/${hostArchBsd}/conf/${baseConfig} \
-        -e 's/WITH_CTF=1/WITH_CTF=0/' \
-        -e '/KDTRACE/d'
-    '';
+        sed -i sys/${hostArchBsd}/conf/${baseConfig} \
+          -e 's/WITH_CTF=1/WITH_CTF=0/' \
+          -e '/KDTRACE/d'
+      ''
+      + lib.optionalString (baseConfigFile != null) ''
+        cat ${baseConfigFile} >>sys/${hostArchBsd}/conf/${baseConfig}
+      '';
   };
 
   # Kernel modules need this for kern.opts.mk


### PR DESCRIPTION
## Description of changes

See commit. Basically, this lets us use [a simple overlay](https://github.com/nixos-bsd/nixbsd/blob/e715563da325d08f7e319a8d7a7ab4fd7216206e/overlays/freebsd-main.nix) in order to build FreeBSD 15.0-CURRENT!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
