### PR TITLE
WIP Cpp2IL: init at 2022.1.0-pre-release.17

### DIFF
--- a/pkgs/by-name/cp/cpp2il/deps.nix
+++ b/pkgs/by-name/cp/cpp2il/deps.nix
@@ -1,0 +1,159 @@
+{ fetchNuGet }:
+[
+  (fetchNuGet {
+    pname = "AsmResolver";
+    version = "6.0.0-beta.1";
+    hash = "sha256-ZW61z6Qmztdy2NaiqxvNcP5RWBIiIO6CWNnqYq0MwoA=";
+  })
+  (fetchNuGet {
+    pname = "AsmResolver.DotNet";
+    version = "6.0.0-beta.1";
+    hash = "sha256-VoTiIr2/r2my6sg2AOEeiqz9vZhWtq5mGaW2Hx90Uo4=";
+  })
+  (fetchNuGet {
+    pname = "AsmResolver.PE";
+    version = "6.0.0-beta.1";
+    hash = "sha256-tTU/flTxRJaC4gkmI/gctqIriGIMntkgTs51TqzcQlg=";
+  })
+  (fetchNuGet {
+    pname = "AsmResolver.PE.File";
+    version = "6.0.0-beta.1";
+    hash = "sha256-hPuFrpcm2VMiYEirsL4kYmAhOzjwjNXUklIfYJEonLo=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.CIL";
+    version = "1.1.0";
+    hash = "sha256-cmB+Z9/HddmJPWwUsQFwSdfQiN+PDopa4R/N3aaAAeE=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Gee.External.Capstone";
+    version = "2.3.2";
+    hash = "sha256-IrcwjWUR0hAO2dmDVIFCd82pJYnpnrRrUMd8Z0dcVjk=";
+  })
+  (fetchNuGet {
+    pname = "AssetRipper.Primitives";
+    version = "3.1.2";
+    hash = "sha256-8+ColCmLU5JM3S14ylyGRZE/syuds0+XLO0QHHfNfEM=";
+  })
+  (fetchNuGet {
+    pname = "CommandLineParser";
+    version = "2.9.1";
+    hash = "sha256-ApU9y1yX60daSjPk3KYDBeJ7XZByKW8hse9NRZGcjeo=";
+  })
+  (fetchNuGet {
+    pname = "Disarm";
+    version = "2022.1.0-master.34";
+    hash = "sha256-wSaOu4BCh1IznKQZqTE1KPhQKLzkDYA3EKWrC9No5Kw=";
+    url = "https://nuget.samboy.dev/v3/package/disarm/2022.1.0-master.34/disarm.2022.1.0-master.34.nupkg";
+  })
+  (fetchNuGet {
+    pname = "Iced";
+    version = "1.21.0";
+    hash = "sha256-0xYTYX4935Ejm7yUqMWHhJtCNuj4oqK6Weojl6FIfHo=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Bcl.HashCode";
+    version = "1.1.1";
+    hash = "sha256-gP6ZhEsjjbmw6a477sm7UuOvGFFTxZYfRE2kKxK8jnc=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Build.Tasks.Git";
+    version = "8.0.0";
+    hash = "sha256-vX6/kPij8vNAu8f7rrvHHhPrNph20IcufmrBgZNxpQA=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NET.ILLink.Analyzers";
+    version = "7.0.100-1.23401.1";
+    hash = "sha256-jGyhmj7DZxTv9Hir6YonkpL+SDsRore8Ph4RNN+2q94=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NET.ILLink.Tasks";
+    version = "7.0.100-1.23401.1";
+    hash = "sha256-n95rHugj0BOtCBvv5209zJ5ttPX0A2+RWLjEwwtxgRA=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.Platforms";
+    version = "1.1.0";
+    hash = "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETFramework.ReferenceAssemblies";
+    version = "1.0.3";
+    hash = "sha256-FBoJP5DHZF0QHM0xLm9yd4HJZVQOuSpSKA+VQRpphEE=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETFramework.ReferenceAssemblies.net472";
+    version = "1.0.3";
+    hash = "sha256-/6ClVwo5+RE5kWTQWB/93vmbXj37ql8iDlziKWm89Xw=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.SourceLink.Common";
+    version = "8.0.0";
+    hash = "sha256-AfUqleVEqWuHE7z2hNiwOLnquBJ3tuYtbkdGMppHOXc=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.SourceLink.GitHub";
+    version = "8.0.0";
+    hash = "sha256-hNTkpKdCLY5kIuOmznD1mY+pRdJ0PKu2HypyXog9vb0=";
+  })
+  (fetchNuGet {
+    pname = "MonoMod.Backports";
+    version = "1.1.0";
+    hash = "sha256-ruRX10/u+lRfMKr0UMbCVYS/nUK5fzV4+8ujJXBnles=";
+  })
+  (fetchNuGet {
+    pname = "MonoMod.ILHelpers";
+    version = "1.0.1";
+    hash = "sha256-0yOtx1f9V5k+IZx4vu8RQ/Ctw3ICyYAU8XSOefQnVp4=";
+  })
+  (fetchNuGet {
+    pname = "NETStandard.Library";
+    version = "2.0.3";
+    hash = "sha256-Prh2RPebz/s8AzHb2sPHg3Jl8s31inv9k+Qxd293ybo=";
+  })
+  (fetchNuGet {
+    pname = "Pastel";
+    version = "4.2.0";
+    hash = "sha256-gpVgKkbof6Q5azCbyyVXK1fBU2VzMooYt7/OKrml7Cw=";
+  })
+  (fetchNuGet {
+    pname = "PolySharp";
+    version = "1.14.1";
+    hash = "sha256-l6hz+SG+cEO817xTMq4DbJSJVnRe6Ffr+uJGVj/t170=";
+  })
+  (fetchNuGet {
+    pname = "System.Buffers";
+    version = "4.5.1";
+    hash = "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI=";
+  })
+  (fetchNuGet {
+    pname = "System.Memory";
+    version = "4.5.5";
+    hash = "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI=";
+  })
+  (fetchNuGet {
+    pname = "System.Numerics.Vectors";
+    version = "4.4.0";
+    hash = "sha256-auXQK2flL/JpnB/rEcAcUm4vYMCYMEMiWOCAlIaqu2U=";
+  })
+  (fetchNuGet {
+    pname = "System.Numerics.Vectors";
+    version = "4.5.0";
+    hash = "sha256-qdSTIFgf2htPS+YhLGjAGiLN8igCYJnCCo6r78+Q+c8=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.5.3";
+    hash = "sha256-lnZMUqRO4RYRUeSO8HSJ9yBHqFHLVbmenwHWkIU20ak=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.3.0";
+    hash = "sha256-MYpl6/ZyC6hjmzWRIe+iDoldOMW1mfbwXsduAnXIKGA=";
+  })
+  (fetchNuGet {
+    pname = "System.ValueTuple";
+    version = "4.5.0";
+    hash = "sha256-niH6l2fU52vAzuBlwdQMw0OEoRS/7E1w5smBFoqSaAI=";
+  })
+]

--- a/pkgs/by-name/cp/cpp2il/package.nix
+++ b/pkgs/by-name/cp/cpp2il/package.nix
@@ -1,0 +1,45 @@
+{
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  lib,
+}:
+
+buildDotnetModule (finalAttrs: {
+  pname = "Cpp2IL";
+  version = "2022.1.0-pre-release.17";
+
+  src = fetchFromGitHub {
+    owner = "SamboyCoding";
+    repo = "Cpp2IL";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-1rh62mkphwNVgeNDGaukem/M58gGv7DFvyAMI/QpStI=";
+  };
+
+  nugetDeps = ./deps.nix;
+
+  projectFile = "Cpp2IL/Cpp2IL.csproj";
+
+  dotnet-sdk =
+    with dotnetCorePackages;
+    combinePackages [
+      sdk_6_0
+      sdk_7_0
+      sdk_8_0
+    ];
+
+  dotnet-runtime = dotnetCorePackages.runtime_7_0;
+
+  dotnetInstallFlags = [ "-p:TargetFramework=net7.0" ];
+
+  executables = [ "Cpp2IL" ];
+
+  meta = {
+    description = "Tool to reverse Unity's IL2CPP toolchain";
+    homepage = "https://github.com/SamboyCoding/Cpp2IL";
+    license = lib.licenses.mit;
+    mainProgram = "Cpp2IL";
+    maintainers = with lib.maintainers; [ diadatp ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

This pull request introduces [CPP2IL](https://github.com/SamboyCoding/Cpp2IL), a powerful tool for reverse engineering Unity IL2CPP binaries.

I'm opening this (draft) PR early to work on the packaging publicly. Currently, this PR only packages the main CPP2IL program and does not build or include the plugins. Are there any nixpkgs conventions for handling plugin architectures? I am leaning towards a `withPlugins` type solution.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
