### PR TITLE
exificient: init at 1.0.7

### DIFF
--- a/pkgs/by-name/ex/exificient/package.nix
+++ b/pkgs/by-name/ex/exificient/package.nix
@@ -1,0 +1,44 @@
+{
+  maven,
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  jre,
+}:
+
+maven.buildMavenPackage rec {
+  pname = "exificient";
+  version = "1.0.7";
+
+  src = fetchFromGitHub {
+    owner = "EXIficient";
+    repo = "exificient";
+    rev = "exificient-${version}";
+    hash = "sha256-XrlZQf2BamYw8u1S2qQ6jV9mgyCEjBxKqPZCXMJzXmc=";
+  };
+
+  mvnHash = "sha256-/72Pi8WbKhPXu7Zb9r30znY1FHJc7FM42f7uQJqJnWo=";
+
+  mvnParameters = "package assembly:single -Dmaven.test.skip=true";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    ls -al target/classes/com/siemens/
+    mkdir -p $out/bin $out/share/exificient
+    install -Dm644 target/exificient-jar-with-dependencies.jar $out/share/exificient
+
+    makeWrapper ${jre}/bin/java $out/bin/exificient \
+    --add-flags "-classpath $out/share/exificient/exificient-jar-with-dependencies.jar com.siemens.ct.exi.main.cmd.EXIficientCMD"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Java implementation of the W3C Efficient Extensible Interchange (EXI) format specification";
+    homepage = "http://exificient.github.io/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ samw ];
+    mainProgram = "exificient";
+  };
+}


### PR DESCRIPTION
## Description of changes

A java implementation of EXI, specifically the command line tool included with it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
