### PR TITLE
Feature: [matrix-synapse] postgresql init

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -171,23 +171,6 @@ in
                 The keys are the options and the values are the values to pass.
 
                 See: https://www.postgresql.org/docs/current/sql-createdatabase.html
-
-                [ WITH ] [ OWNER [=] user_name ]
-                      [ TEMPLATE [=] template ]
-                      [ ENCODING [=] encoding ]
-                      [ STRATEGY [=] strategy ]
-                      [ LOCALE [=] locale ]
-                      [ LC_COLLATE [=] lc_collate ]
-                      [ LC_CTYPE [=] lc_ctype ]
-                      [ ICU_LOCALE [=] icu_locale ]
-                      [ ICU_RULES [=] icu_rules ]
-                      [ LOCALE_PROVIDER [=] locale_provider ]
-                      [ COLLATION_VERSION = collation_version ]
-                      [ TABLESPACE [=] tablespace_name ]
-                      [ ALLOW_CONNECTIONS [=] allowconn ]
-                      [ CONNECTION LIMIT [=] connlimit ]
-                      [ IS_TEMPLATE [=] istemplate ]
-                      [ OID [=] oid ]
               '';
               example = {
                 template = "template0";

--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -1303,6 +1303,23 @@ in {
       user = "matrix-synapse";
     };
 
+    services.postgresql = lib.mkIf hasLocalPostgresDB {
+      ensureUsers = [{
+        name = cfg.settings.database.args.user;
+      }];
+      ensureDatabases = [
+        {
+          name = cfg.settings.database.args.database;
+          withOptions = {
+            owner = cfg.settings.database.args.user;
+            template = "template0";
+            encoding = "UTF8";
+            locale = "C";
+          };
+        }
+      ];
+    };
+
     environment.systemPackages = lib.optionals cfg.enableRegistrationScript [
       registerNewMatrixUser
     ];


### PR DESCRIPTION
## Description of changes

Automatic init postgresql database and user for local pg instance.

This depends on
- [ ] https://github.com/NixOS/nixpkgs/pull/339195

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
