### PR TITLE
silx: init at 2.1.1, fabio: init at 24.4.0

### DIFF
--- a/pkgs/by-name/si/silx/package.nix
+++ b/pkgs/by-name/si/silx/package.nix
@@ -1,0 +1,42 @@
+{
+  python3Packages,
+  fetchPypi,
+  lib,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "silx";
+  version = "2.1.1";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-LfCRWkUrqQb7zxiFTPhy/g9FWhNMXTRbhEgek4tZb5I=";
+  };
+
+  build-system = with python3Packages; [
+    cython
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    h5py
+    numpy
+    matplotlib
+    pyopengl
+    python-dateutil
+    pyside6
+    fabio
+  ];
+
+  meta = {
+    changelog = "https://github.com/silx-kit/silx/blob/main/CHANGELOG.rst";
+    description = "Software to support data assessment, reduction and analysis at synchrotron radiation facilities";
+    homepage = "https://github.com/silx-kit/silx";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.pmiddend ];
+    mainProgram = "silx";
+  };
+
+}

--- a/pkgs/development/python-modules/fabio/default.nix
+++ b/pkgs/development/python-modules/fabio/default.nix
@@ -1,0 +1,58 @@
+{
+  buildPythonPackage,
+  ninja,
+  fetchPypi,
+  meson,
+  lib,
+  cython,
+  meson-python,
+  numpy,
+  lxml,
+  h5py,
+  hdf5plugin,
+  pillow,
+  tomli,
+}:
+
+buildPythonPackage rec {
+  pname = "fabio";
+  version = "2024.4.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-NPVxu4sZ7hIvrHrh1iRakraa5fj1cUnH259tTDByRNc=";
+  };
+
+  pythonImportsCheck = [ "fabio" ];
+
+  nativeBuildInputs = [
+    meson
+    cython
+    meson-python
+    ninja
+  ];
+
+  # While building, it tries to run version.py, which has a #!/usr/bin/env python3 shebang
+  postPatch = ''
+    patchShebangs --build version.py
+  '';
+
+  dependencies = [
+    numpy
+    lxml
+    h5py
+    hdf5plugin
+    pillow
+    tomli
+  ];
+
+  meta = {
+    changelog = "https://github.com/silx-kit/fabio/blob/main/doc/source/Changelog.rst";
+    description = "I/O library for images produced by 2D X-ray detector";
+    homepage = "https://github.com/silx-kit/fabio";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.pmiddend ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4345,6 +4345,8 @@ self: super: with self; {
 
   f90nml = callPackage ../development/python-modules/f90nml { };
 
+  fabio = callPackage ../development/python-modules/fabio { };
+
   fabric = callPackage ../development/python-modules/fabric { };
 
   faadelays = callPackage ../development/python-modules/faadelays { };


### PR DESCRIPTION
## Description of changes

Both fabio and silx are used at so-called synchroton radiation facilities all around the globe (particle accelerators that produce nice X-ray radiation). See [the fabio/silx website](http://www.silx.org/).

Originally, I wanted to package just silx, a viewer for experimental data in different formats, most notably HDF5, but it needed the fabio library, which is used by other tools as well.

I asked around and having this as one PR with two commits seems agreeable to people.

If you actually want to try running silx, download [a sample h5 file](https://zenodo.org/records/6497438/files/xrr_dataset.h5?download=1) and then after building silx, run `silx view xrr_dataset.h5`. It should show a tree of attributes on the left and actual data on the right.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
