### PR TITLE
ocamlPackages.mrmime: 0.5.0 → 0.6.1

### DIFF
--- a/pkgs/development/ocaml-modules/mrmime/default.nix
+++ b/pkgs/development/ocaml-modules/mrmime/default.nix
@@ -2,14 +2,12 @@
 , alcotest
 , angstrom
 , base64
-, bigarray-compat
 , bigarray-overlap
 , bigstringaf
 , buildDunePackage
 , cmdliner
 , emile
-, fetchzip
-, fmt
+, fetchurl
 , fpath
 , hxd
 , ipaddr
@@ -17,56 +15,49 @@
 , ke
 , lib
 , mirage-crypto-rng
-, ocaml
 , pecu
 , prettym
 , ptime
 , rosetta
-, rresult
 , unstrctrd
 , uutf
 }:
 
 buildDunePackage rec {
   pname = "mrmime";
-  version = "0.5.0";
+  version = "0.6.1";
 
-  src = fetchzip {
-    url = "https://github.com/mirage/mrmime/releases/download/v${version}/mrmime-v${version}.tbz";
-    sha256 = "14k67v0b39b8jq3ny2ymi8g8sqx2gd81mlzsjphdzdqnlx6fk716";
+  src = fetchurl {
+    url = "https://github.com/mirage/mrmime/releases/download/v${version}/mrmime-${version}.tbz";
+    hash = "sha256-Dzsr7xPzu5RIzIdubF4OAAjHJY7CdBVnHRZxQbcCsBY=";
   };
-
-  duneVersion = "3";
-
-  buildInputs = [ cmdliner hxd ];
 
   propagatedBuildInputs = [
     angstrom
     base64
     emile
-    fmt
     ipaddr
     ke
     pecu
     prettym
     ptime
     rosetta
-    rresult
     unstrctrd
     uutf
-    afl-persistent
-    bigarray-compat
     bigarray-overlap
     bigstringaf
-    fpath
-    mirage-crypto-rng
   ];
 
   checkInputs = [
+    afl-persistent
     alcotest
+    cmdliner
+    fpath
+    hxd
     jsonm
+    mirage-crypto-rng
   ];
-  doCheck = lib.versionOlder ocaml.version "5.0";
+  doCheck = true;
 
   meta = {
     description = "Parser and generator of mail in OCaml";

--- a/pkgs/development/ocaml-modules/piaf/default.nix
+++ b/pkgs/development/ocaml-modules/piaf/default.nix
@@ -1,6 +1,7 @@
 { alcotest-lwt
 , buildDunePackage
 , ocaml
+, bigarray-compat
 , dune-site
 , fetchurl
 , gluten-lwt-unix
@@ -9,6 +10,7 @@
 , magic-mime
 , mrmime
 , psq
+, rresult
 , uri
 }:
 
@@ -18,8 +20,6 @@ lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
 buildDunePackage rec {
   pname = "piaf";
   version = "0.1.0";
-
-  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/anmonteiro/piaf/releases/download/${version}/piaf-${version}.tbz";
@@ -31,10 +31,12 @@ buildDunePackage rec {
   '';
 
   propagatedBuildInputs = [
+    bigarray-compat
     logs
     magic-mime
     mrmime
     psq
+    rresult
     uri
     gluten-lwt-unix
   ];


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/mirage/mrmime/v0.6.1/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
