### PR TITLE
dmarc-metrics-exporter: disable flaky tests

### DIFF
--- a/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
@@ -1,6 +1,7 @@
-{ lib
-, python3
-, fetchFromGitHub
+{
+  lib,
+  python3,
+  fetchFromGitHub,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -24,15 +25,17 @@ python3.pkgs.buildPythonApplication rec {
     poetry-core
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
-    bite-parser
-    dataclasses-serialization
-    prometheus-client
-    structlog
-    uvicorn
-    xsdata
-  ]
-  ++ uvicorn.optional-dependencies.standard;
+  propagatedBuildInputs =
+    with python3.pkgs;
+    [
+      bite-parser
+      dataclasses-serialization
+      prometheus-client
+      structlog
+      uvicorn
+      xsdata
+    ]
+    ++ uvicorn.optional-dependencies.standard;
 
   nativeCheckInputs = with python3.pkgs; [
     aiohttp

--- a/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
@@ -8,8 +8,6 @@ python3.pkgs.buildPythonApplication rec {
   pname = "dmarc-metrics-exporter";
   version = "1.1.0";
 
-  disabled = python3.pythonOlder "3.8";
-
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -21,11 +19,11 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonRelaxDeps = true;
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [
     poetry-core
   ];
 
-  propagatedBuildInputs =
+  dependencies =
     with python3.pkgs;
     [
       bite-parser

--- a/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3,
   fetchFromGitHub,
 }:
@@ -40,6 +41,12 @@ python3.pkgs.buildPythonApplication rec {
     pytest-asyncio
     pytestCheckHook
     requests
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # flaky tests
+    "test_build_info"
+    "test_prometheus_exporter"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
## Description of changes

This package is currently not broken on `master`. However, as soon as I try to build them on the darwin builders, they fail:
```
=========================== short test summary info ============================
FAILED dmarc_metrics_exporter/tests/test_prometheus_exporter.py::test_prometheus_exporter - SystemExit: 1
FAILED dmarc_metrics_exporter/tests/test_prometheus_exporter.py::test_build_info - ValueError: Duplicated timeseries in CollectorRegistry: {'dmarc_compliant_c...
========================= 2 failed, 78 passed in 1.78s =========================
```

I have then disabled those tests on darwin.

- **dmarc-metrics-exporter: format with nixfmt**
- **dmarc-metrics-exporter: clean**
- **dmarc-metrics-exporter: disable flaky tests on darwin**

cc @Ma27 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
