### PR TITLE
shadcn: init at 2.0.3

### DIFF
--- a/pkgs/by-name/sh/shadcn/package.nix
+++ b/pkgs/by-name/sh/shadcn/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nodejs,
+  pnpm_9,
+  testers,
+  shadcn,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "shadcn";
+  version = "2.0.3";
+
+  src = fetchFromGitHub {
+    owner = "shadcn-ui";
+    repo = "ui";
+    rev = "shadcn@${finalAttrs.version}";
+    hash = "sha256-OBLKCj+v5KgYslJGuwLgJHjgcrxLPiiyO5/ucrJ14Ws=";
+  };
+
+  pnpmWorkspace = "shadcn";
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspace
+      ;
+    hash = "sha256-OcoZfbB04CFHpAM/fW3IhIMXtas6x8H3+lvk7nTN8Tg=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    nodejs
+    pnpm_9.configHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run shadcn:build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+    cp -r {packages,node_modules} $out/lib
+
+    # cleanup
+    rm -r $out/lib/packages/{cli,shadcn/src}
+    find $out/lib/packages/shadcn -name '*.ts' -delete
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/shadcn \
+      --inherit-argv0 \
+      --add-flags $out/lib/packages/shadcn/dist/index.js
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = shadcn;
+    command = "shadcn --version";
+    version = finalAttrs.version;
+  };
+
+  meta = {
+    changelog = "https://github.com/shadcn-ui/ui/blob/${finalAttrs.src.rev}/packages/shadcn/CHANGELOG.md#${
+      builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version
+    }";
+    description = "Beautifully designed components that you can copy and paste into your apps";
+    homepage = "https://ui.shadcn.com/docs/cli";
+    license = lib.licenses.mit;
+    mainProgram = "shadcn";
+    maintainers = with lib.maintainers; [ getpsyched ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds the newly released ShadCN CLI.
Docs: https://ui.shadcn.com/docs/cli

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
