### PR TITLE
langchain{-community,core,text-splitters}: update

### DIFF
--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -2,44 +2,49 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   poetry-core,
-  pythonOlder,
+
+  # dependencies
   aiohttp,
   dataclasses-json,
-  langchain,
   langchain-core,
-  langchain-standard-tests,
+  langchain,
   langsmith,
-  httpx,
-  lark,
+  pyyaml,
+  requests,
+  sqlalchemy,
+  tenacity,
+
+  # optional-dependencies
+  typer,
   numpy,
+
+  # tests
+  httpx,
+  langchain-standard-tests,
+  lark,
   pandas,
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
-  pyyaml,
-  requests,
   requests-mock,
   responses,
-  sqlalchemy,
   syrupy,
-  tenacity,
   toml,
-  typer,
 }:
 
 buildPythonPackage rec {
   pname = "langchain-community";
-  version = "0.2.15";
+  version = "0.2.16";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     rev = "refs/tags/langchain-community==${version}";
-    hash = "sha256-R1C+tEXCLqYHzQ2zrYaYa6cqJn/UWZEHBMC+WjbdQaQ=";
+    hash = "sha256-0FKbx/ZPX7sioof5pMdqpnVWc46+eOiTIseyxwYK49E=";
   };
 
   sourceRoot = "${src.name}/libs/community";

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -3,38 +3,45 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  jsonpatch,
+  langsmith,
+  packaging,
+  pyyaml,
+  tenacity,
+
+  # optional-dependencies
+  pydantic,
+
+  # tests
   freezegun,
   grandalf,
   httpx,
-  jsonpatch,
-  langsmith,
   numpy,
-  packaging,
-  poetry-core,
-  pydantic,
   pytest-asyncio,
   pytest-mock,
   pytest-xdist,
   pytestCheckHook,
-  pythonOlder,
-  pyyaml,
   syrupy,
-  tenacity,
+
+  # passthru
   writeScript,
 }:
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "0.2.37";
+  version = "0.2.38";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     rev = "refs/tags/langchain-core==${version}";
-    hash = "sha256-An2ApN0pgCrQjqu9XPFfPyPvWx0+6JnUkGPrcD0/3kg=";
+    hash = "sha256-3nRirzQe5KCVoeJ29fYelYuOD6r4adJof4NXreyfrzY=";
   };
 
   sourceRoot = "${src.name}/libs/core";

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -2,25 +2,28 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   poetry-core,
+
+  # dependencies
   langchain-core,
+
+  # tests
   pytest-asyncio,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "langchain-text-splitters";
-  version = "0.2.2";
+  version = "0.2.4";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     rev = "refs/tags/langchain-text-splitters==${version}";
-    hash = "sha256-SixF3ZkN+gjQ4KYLhGoezdQAOQ1AlGEC6IBzHePF6/o=";
+    hash = "sha256-8n5eImRXOG/3tN/59Gd2/GpoGpt7P2ABj0T4pJi6xrk=";
   };
 
   sourceRoot = "${src.name}/libs/text-splitters";

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -1,46 +1,54 @@
 {
   lib,
-  aiohttp,
-  async-timeout,
-  bash,
   buildPythonPackage,
   fetchFromGitHub,
-  freezegun,
+  pythonOlder,
+
+  # build-system
+  poetry-core,
+
+  # buildInputs
+  bash,
+
+  # dependencies
+  aiohttp,
   langchain-core,
   langchain-text-splitters,
   langsmith,
-  lark,
-  numpy,
-  pandas,
-  poetry-core,
   pydantic,
+  pyyaml,
+  requests,
+  sqlalchemy,
+  tenacity,
+  async-timeout,
+
+  # optional-dependencies
+  numpy,
+
+  # tests
+  freezegun,
+  lark,
+  pandas,
   pytest-asyncio,
   pytest-mock,
   pytest-socket,
   pytestCheckHook,
-  pythonOlder,
-  pyyaml,
   requests-mock,
-  requests,
   responses,
-  sqlalchemy,
   syrupy,
-  tenacity,
   toml,
 }:
 
 buildPythonPackage rec {
   pname = "langchain";
-  version = "0.2.15";
+  version = "0.2.16";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     rev = "refs/tags/langchain==${version}";
-    hash = "sha256-8F6ntFstCTQjQNbE9oiYbpZ7kZ1grcnV3FHAfhFnAzA=";
+    hash = "sha256-8n5eImRXOG/3tN/59Gd2/GpoGpt7P2ABj0T4pJi6xrk=";
   };
 
   sourceRoot = "${src.name}/libs/langchain";

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -2,26 +2,29 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
   httpx,
   httpx-sse,
   orjson,
-  poetry-core,
-  pythonOlder,
+
+  # passthru
   writeScript,
 }:
 
 buildPythonPackage rec {
   pname = "langgraph-sdk";
-  version = "0.1.26";
+  version = "0.1.30";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/sdk==${version}";
-    hash = "sha256-o7JrB2WSWfPm927tDRMcjzx+6Io6Q+Yjp4XPVs2+F4o=";
+    hash = "sha256-gI12XuxFplqIKVlVjeO60YxT7WG/SSsZ0aWfjg5bHIs=";
   };
 
   sourceRoot = "${src.name}/libs/sdk-py";

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -1,43 +1,48 @@
 {
   lib,
   buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  langchain-core,
+  langgraph-checkpoint,
+
+  # tests
   aiosqlite,
   dataclasses-json,
-  fetchFromGitHub,
   grandalf,
   httpx,
-  langchain-core,
-  langgraph-sdk,
-  langgraph-checkpoint,
   langgraph-checkpoint-postgres,
   langgraph-checkpoint-sqlite,
-  psycopg,
   langsmith,
-  poetry-core,
+  psycopg,
   pydantic,
   pytest-asyncio,
   pytest-mock,
   pytest-repeat,
   pytest-xdist,
   pytestCheckHook,
-  pythonOlder,
   syrupy,
   postgresql,
   postgresqlTestHook,
+
+  # passthru
+  langgraph-sdk,
 }:
 
 buildPythonPackage rec {
   pname = "langgraph";
-  version = "0.2.4";
+  version = "0.2.19";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/${version}";
-    hash = "sha256-jUBaWXrHCXAph8EGEJnH7lbKIyjQ8oPt4eDMyIkbURo=";
+    hash = "sha256-qJIZAHftIKyWK0A/MjilalmmB8b8E7JtLnFn156hE08=";
   };
 
   postgresqlTestSetupPost = ''
@@ -65,6 +70,7 @@ buildPythonPackage rec {
     langgraph-checkpoint-sqlite
     langsmith
     psycopg
+    psycopg.pool
     pydantic
     pytest-asyncio
     pytest-mock
@@ -91,6 +97,12 @@ buildPythonPackage rec {
     "test_no_modifier"
     "test_pending_writes_resume"
     "test_remove_message_via_state_update"
+  ];
+
+  disabledTestPaths = [
+    # psycopg.errors.InsufficientPrivilege: permission denied to create database
+    "tests/test_pregel_async.py"
+    "tests/test_pregel.py"
   ];
 
   passthru = {


### PR DESCRIPTION
## Description of changes

- **python3Packages.langchain-core: 0.2.37 -> 0.2.38**
    https://github.com/langchain-ai/langchain/releases/tag/v0.2.38
- **python312Packages.langchain-text-splitters: 0.2.2 -> 0.2.4**
    https://github.com/langchain-ai/langchain/releases/tag/langchain-text-splitters==0.2.4
- **python312Packages.langchain: 0.2.15 -> 0.2.16**
    https://github.com/langchain-ai/langchain/releases/tag/v0.2.16
- **python312Packages.langchain-community: 0.2.15 -> 0.2.16**
    https://github.com/langchain-ai/langchain/releases/tag/langchain-community==0.2.16

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
