### PR TITLE
nixos/netdata: fix permissions for some collectors

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -48,6 +48,7 @@
   withSsl ? true,
   withSystemdJournal ? (stdenv.hostPlatform.isLinux),
   zlib,
+  withNdsudo ? false,
 }:
 let
   stdenv' = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;
@@ -181,6 +182,12 @@ stdenv'.mkDerivation (finalAttrs: {
         rm -rf $out/share/netdata/web/index.html
         cp $out/share/netdata/web/v1/index.html $out/share/netdata/web/index.html
       ''}
+      ${lib.optionalString withNdsudo ''
+        mv $out/libexec/netdata/plugins.d/ndsudo \
+          $out/libexec/netdata/plugins.d/ndsudo.org
+
+        ln -s /var/lib/netdata/ndsudo/ndsudo $out/libexec/netdata/plugins.d/ndsudo
+      ''}
     '';
 
   preConfigure = ''
@@ -269,7 +276,7 @@ stdenv'.mkDerivation (finalAttrs: {
           license = lib.licenses.gpl3Only;
         };
       }).goModules;
-    inherit withIpmi withNetworkViewer;
+    inherit withIpmi withNetworkViewer withNdsudo;
     tests.netdata = nixosTests.netdata;
   };
 

--- a/pkgs/tools/system/netdata/ndsudo-fix-path.patch
+++ b/pkgs/tools/system/netdata/ndsudo-fix-path.patch
@@ -5,13 +5,14 @@ diff --git a/src/collectors/plugins.d/ndsudo.c b/src/collectors/plugins.d/ndsudo
 index d53ca9f28..b42a121bf 100644
 --- a/src/collectors/plugins.d/ndsudo.c
 +++ b/src/collectors/plugins.d/ndsudo.c
-@@ -357,9 +357,6 @@ int main(int argc, char *argv[]) {
+@@ -357,9 +357,9 @@ int main(int argc, char *argv[]) {
          return 3;
      }
 
 -    char new_path[] = "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin";
--    putenv(new_path);
--
++    char new_path[] = "PATH=/var/lib/netdata/ndsudo/runtime-dependencies";
+     putenv(new_path);
+
      setuid(0);
      setgid(0);
      setegid(0);


### PR DESCRIPTION
## Description of changes

With this change netdata's `ndsudo` will be able to run commands with root privileges. This allows collectors like `nvme` and `smartctl` to work properly.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
