### PR TITLE
check-meta: add allowBrokenPredicate

### DIFF
--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -33,7 +33,7 @@ Most unfree licenses prohibit either executing or distributing the software.
 
 ## Installing broken packages {#sec-allow-broken}
 
-There are two ways to try compiling a package which has been marked as broken.
+There are several ways to try compiling a package which has been marked as broken.
 
 -   For allowing the build of a broken package once, you can use an environment variable for a single invocation of the nix tools:
 
@@ -41,7 +41,15 @@ There are two ways to try compiling a package which has been marked as broken.
     $ export NIXPKGS_ALLOW_BROKEN=1
     ```
 
--   For permanently allowing broken packages to be built, you may add `allowBroken = true;` to your user's configuration file, like this:
+-   For permanently allowing broken packages that match some condition to be built, you may add `allowBrokenPredicate` to your user's configuration file with the desired condition, for example:
+
+    ```nix
+    {
+      allowBrokenPredicate = pkg: builtins.elem (pkgs.lib.getName pkg) [ "hello" ];
+    }
+    ```
+
+-   For permanently allowing all broken packages to be built, you may add `allowBroken = true;` to your user's configuration file, like this:
 
     ```nix
     {

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -116,6 +116,18 @@ let
 
   isMarkedBroken = attrs: attrs.meta.broken or false;
 
+  # Allow granular checks to allow only some broken packages
+  # Example:
+  # { pkgs, ... }:
+  # {
+  #   allowBroken = false;
+  #   allowBrokenPredicate = pkg: builtins.elem (pkgs.lib.getName pkg) [ "hello" ];
+  # }
+  allowBrokenPredicate = config.allowBrokenPredicate or (x: false);
+
+  hasDeniedBroken =
+    attrs: (attrs.meta.broken or false) && !allowBroken && !allowBrokenPredicate attrs;
+
   hasUnsupportedPlatform = pkg: !(availableOn hostPlatform pkg);
 
   isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or [ ]) != [ ];
@@ -507,7 +519,7 @@ let
         reason = "non-source";
         errormsg = "contains elements not built from source (‘${showSourceType attrs.meta.sourceProvenance}’)";
       }
-    else if !allowBroken && attrs.meta.broken or false then
+    else if hasDeniedBroken attrs then
       {
         valid = "no";
         reason = "broken";


### PR DESCRIPTION
Similar to allowUnfreePredicate, sometimes users may want to only allow specific broken packages to avoid unexpectedly building others.

Some packages may be marked broken for policy reasons (lack of upstream support) or due to broken or unsupported functionality that the user may not care about. An example might be forcing ZFS to build on a newer, unsupported Kernel where compilation succeeds and the user is willing to take the risk of being unsupported.

I think the larger topic for discussion would be: should `broken` be used in this way? I.e., should `broken` only be used for packages that actually fail to build or fundamentally work at all, or is it okay to use it for things that *might* work but are explicitly unsupported? [The manual for `broken`](https://github.com/NixOS/nixpkgs/blob/aa3169dbfb0fc386658839f2db17d05bc4b399f0/doc/stdenv/meta.chapter.md#broken-var-meta-broken) doesn’t say much about when to use it.

If the answer is that `broken` should only be used for things that fail to build or fundamentally work, then perhaps this PR doesn’t make sense as there’s little use-case for bypassing broken on a per-package basis in one’s config. It does bring up the question, though: how should we then mark packages whose config is unsupported? Back to the ZFS example, running a filesystem on Kernels not explicitly tested and supported by upstream seems like a bad idea *by default*, and users should have to opt-in to that risk in some way.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested with

```
$ nix-build -A linuxKernel.packages.linux_testing.zfs_unstable
…error: Package ‘zfs-kernel-2.2.5-6.11-rc6’ … is marked as broken, refusing to evaluate.…

$ < config.nix echo '{ pkgs }: { allowBrokenPredicate = pkg: pkgs.lib.hasInfix "zfs" pkg.pname; }'
$ NIXPKGS_CONFIG=$(pwd)/config.nix nix-build -A linuxKernel.packages.linux_testing.zfs_unstable
…building…
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
