### PR TITLE
nixos: add virtio_iommu module for vIOMMU support

### DIFF
--- a/nixos/modules/hardware/all-hardware.nix
+++ b/nixos/modules/hardware/all-hardware.nix
@@ -99,6 +99,7 @@ in
       "virtio_scsi"
       "virtio_balloon"
       "virtio_console"
+      "virtio_iommu"
 
       # VMware support.
       "mptspi"

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -187,9 +187,16 @@ sub pciCheck {
         push @imports, "(modulesPath + \"/hardware/network/broadcom-43xx.nix\")";
     }
 
-    # In case this is a virtio scsi device, we need to explicitly make this available.
+    # detect (QEMU) virtio devices possibly required for booting, IDs taken from:
+    # - https://github.com/qemu/qemu/blob/fa19879df1658f96ac07365fca8835b7decd6995/docs/specs/pci-ids.rst
+    # - https://github.com/qemu/qemu/blob/fa19879df1658f96ac07365fca8835b7decd6995/include/standard-headers/linux/virtio_ids.h
+    # virtio scsi devices (legacy ID & virtio Specification ID)
     if ($vendor eq "0x1af4" && ($device eq "0x1004" || $device eq "0x1048") ) {
         push @initrdAvailableKernelModules, "virtio_scsi";
+    }
+    # virtio IOMMU device (needed for pci boot devices behind it)
+    if ($vendor eq "0x1af4" && $device eq "0x1057") {
+        push @initrdAvailableKernelModules, "virtio_iommu";
     }
 
     # Can't rely on $module here, since the module may not be loaded

--- a/nixos/modules/profiles/qemu-guest.nix
+++ b/nixos/modules/profiles/qemu-guest.nix
@@ -10,6 +10,7 @@
     "virtio_mmio"
     "virtio_blk"
     "virtio_scsi"
+    "virtio_iommu"
     "9p"
     "9pnet_virtio"
     "virtiofs"


### PR DESCRIPTION
## Description of changes

This module is required for booting in QEMU setups with vIOMMU enabled.
Fixes #340086.

Coming back to this old PR, I now looked into the nixos-generate-config script & decided to now add this kernel module at 3 locations for 3 differing reasons (reasonings also on each commit):
- under the `hardware.enableAllHardware` option:
	- supporting vIOMMU setups should be considered in all hardware IMO
	- fixes the nixos-installer
- as special case in `nixos-generate-config`:
	- `virtio-scsi` has a similar special case for making sure that when such a device detected, the kernel module is declared as needed
	- I assume the special case was added there in #91316 as a special case because the system can otherwise not continue booting.
- in the `qemu-guest` profile:
	- supporting vIOMMU setups should be considered in that as well IMO
	- improves usability of that profile for users which are using that instead of relying on `nixos-generate-config`

Technically, the special case should be redundant because `nixos-generate-config` is already expected to also include the `virtio-iommu` module indirectly when detecting to be running in a QEMU guest.
But the same principle applies to the `virtio-scsi` as well, where the issues #76980 & #91300 happened despite that the `qemu-guest` profile already had that module on the immediate parent commit of their fixing PR #91300.
(Maybe this happened because the hypervisor was supporting virtio while not being (detectable as) a QEMU hypervisor?)
So I decided to add it to both locations as explained above.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

