### PR TITLE
beam-packages: add nodocs target for building ex_doc on 27+

### DIFF
--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -19,11 +19,11 @@
 , libGLU ? null
 , wxGTK ? null
 , xorg ? null
-, exdoc ? null
+, ex_doc ? null
 , parallelBuild ? false
 , systemd
 , wxSupport ? true
-, exdocSupport ? false
+, ex_docSupport ? false
 , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd # systemd support in epmd
   # updateScript deps
 , writeScript
@@ -64,7 +64,7 @@
 , installPhase ? ""
 , preInstall ? ""
 , postInstall ? ""
-, installTargets ? [ "install" "install-docs" ]
+, installTargets ? if ((lib.versionOlder version "27.0") || ex_docSupport) then [ "install" "install-docs" ] else [ "install" ]
 , checkPhase ? ""
 , preCheck ? ""
 , postCheck ? ""
@@ -80,7 +80,7 @@ else libGL != null && libGLU != null && wxGTK != null && xorg != null);
 
 assert odbcSupport -> unixODBC != null;
 assert javacSupport -> openjdk11 != null;
-assert exdocSupport -> exdoc != null;
+assert ex_docSupport -> ex_doc != null;
 
 let
   inherit (lib) optional optionals optionalAttrs optionalString;
@@ -122,15 +122,15 @@ stdenv.mkDerivation ({
   '';
 
   # For OTP 27+ we need ex_doc to build the documentation
-  # When exdocSupport is enabled, grab the raw ex_doc executable from the exdoc
+  # When ex_docSupport is enabled, grab the raw ex_doc executable from the ex_doc
   # derivation. Next, patch the first line to use the escript that will be
   # built during the build phase of this derivation. Finally, building the
   # documentation requires the erlang-logo.png asset.
   preConfigure = ''
     ./otp_build autoconf
-  '' + optionalString exdocSupport ''
+  '' + optionalString ex_docSupport ''
     mkdir -p $out/bin
-    cp ${exdoc}/bin/.ex_doc-wrapped $out/bin/ex_doc
+    cp ${ex_doc}/bin/.ex_doc-wrapped $out/bin/ex_doc
     sed -i "1 s:^.*$:#!$out/bin/escript:" $out/bin/ex_doc
     export EX_DOC=$out/bin/ex_doc
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16529,6 +16529,12 @@ with pkgs;
     wxSupport = false;
     systemdSupport = false;
   };
+  beam_nodocs = callPackage ./beam-packages.nix {
+    beam = beam_nodocs;
+    wxSupport = false;
+    systemdSupport = false;
+    ex_docSupport = false;
+  };
 
   inherit (beam.interpreters)
     erlang erlang_27 erlang_26 erlang_25 erlang_24

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,9 +1,11 @@
 { lib
 , beam
+, beam_nodocs
 , callPackage
 , wxGTK32
 , buildPackages
 , stdenv
+, ex_docSupport ? true
 , wxSupport ? true
 , systemd
 , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
@@ -30,9 +32,8 @@ in
       wxGTK = wxGTK32;
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
-      exdocSupport = true;
-      exdoc = self.packages.erlang_26.ex_doc;
-      inherit wxSupport systemdSupport;
+      inherit (beam_nodocs.packages.erlang_27) ex_doc;
+      inherit ex_docSupport wxSupport systemdSupport;
     };
 
     erlang_26 = self.beamLib.callErlang ../development/interpreters/erlang/26.nix {


### PR DESCRIPTION
## Description of changes

Create beam_nodocs and expose it to beam-packages so we can build ex_doc using the same release we want to ship.
Renamed exdoc -> ex_doc everywhere for consistency in naming and inheritance.
Fix build on 27+ when exdocSupport is disabled.
Switch 27 to use a nodocs version of 27.

This will of course require two builds of erlang to get a final release, but there is likely no way around this. This was already the case, but we were building two separate versions previously.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
