### PR TITLE
pre-commit: add rustup and gcc to support nixpkgs-fmt pre-commit-hook support

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -3,6 +3,8 @@
 , python3Packages
 , libiconv
 , cargo
+, rustup
+, gcc
 , coursier
 , dotnet-sdk
 , git
@@ -43,6 +45,8 @@ buildPythonApplication rec {
     pyyaml
     toml
     virtualenv
+    rustup
+    gcc
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description of changes

Rustup and gcc are needed in the PATH to use the [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt) pre-commit hook. Otherwise, pre-commit tries to install the dependencies in the pre-commit toolchain and fails:

```
$ pre-commit run
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Initializing environment for https://github.com/pycqa/isort.
[INFO] Initializing environment for https://github.com/PyCQA/autoflake.
[INFO] Initializing environment for https://github.com/nix-community/nixpkgs-fmt.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pycqa/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/autoflake.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/nix-community/nixpkgs-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/bin/sh', '/tmp/tmpukmvn9aq/rustup-init', '-y', '--quiet', '--no-modify-path', '--default-toolchain', 'none')
return code: 1
stdout: (none)
stderr:
    info: downloading installer
    Could not start dynamically linked executable: /tmp/tmp.QF1anEeoYg/rustup-init
    NixOS cannot run dynamically linked executables intended for generic
    linux environments out of the box. For more information, see:
    https://nix.dev/permalink/stub-ld
Check the log at /home/user/.cache/pre-commit/pre-commit.log
```

Without gcc (only rustup):
```
$ pre-commit run
[INFO] Installing environment for https://github.com/nix-community/nixpkgs-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/nix/store/691v6lwgyz0jhwv754c64lkk372yy1v8-rustup-1.26.0/bin/cargo', 'install', '--bins', '--root', '/home/max/.cache/pre-commit/repopsn8ksx5/rustenv-default', '--path', '.')
return code: 101
stdout: (none)
stderr:
    info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
    info: latest update on 2024-09-05, rust version 1.81.0 (eeb90cda1 2024-09-04)
    info: downloading component 'cargo'
    info: downloading component 'clippy'
    info: downloading component 'rust-docs'
    info: downloading component 'rust-std'
    info: downloading component 'rustc'
    info: downloading component 'rustfmt'
    info: installing component 'cargo'
    info: installing component 'clippy'
    info: installing component 'rust-docs'
    info: installing component 'rust-std'
    info: installing component 'rustc'
    info: installing component 'rustfmt'
      Installing nixpkgs-fmt v1.3.0 (/home/max/.cache/pre-commit/repopsn8ksx5)
        Updating crates.io index
         Locking 63 packages to latest compatible versions
          Adding bitflags v1.3.2 (latest: v2.6.0)
          Adding cfg-if v0.1.10 (latest: v1.0.0)
          Adding clap v2.34.0 (latest: v4.5.17)
          Adding countme v2.0.4 (latest: v3.0.1)
          Adding crossbeam-channel v0.4.4 (latest: v0.5.13)
          Adding crossbeam-utils v0.7.2 (latest: v0.8.20)
          Adding hashbrown v0.9.1 (latest: v0.14.5)
          Adding hermit-abi v0.1.19 (latest: v0.4.0)
          Adding memoffset v0.6.5 (latest: v0.9.1)
          Adding rnix v0.10.2 (latest: v0.11.0)
          Adding rowan v0.12.6 (latest: v0.15.16)
          Adding rustc-hash v1.1.0 (latest: v2.0.0)
          Adding smol_str v0.1.24 (latest: v0.3.1)
          Adding strsim v0.8.0 (latest: v0.11.1)
          Adding textwrap v0.11.0 (latest: v0.16.1)
     Downloading crates ...
      Downloaded serde v1.0.209
      Downloaded serde_json v1.0.128
      Downloaded libc v0.2.158
       Compiling autocfg v1.3.0
       Compiling serde v1.0.209
       Compiling memchr v2.7.4
       Compiling crossbeam-utils v0.8.20
       Compiling libc v0.2.158
       Compiling maybe-uninit v2.0.0
       Compiling regex-syntax v0.8.4
       Compiling log v0.4.22
       Compiling hashbrown v0.9.1
       Compiling serde_json v1.0.128
       Compiling countme v2.0.4
       Compiling unicode-width v0.1.13
    error: linker `cc` not found
      |
      = note: No such file or directory (os error 2)
    
    error: could not compile `serde_json` (build script) due to 1 previous error
    warning: build failed, waiting for other jobs to finish...
    error: could not compile `serde` (build script) due to 1 previous error
    error: could not compile `maybe-uninit` (build script) due to 1 previous error
    error: could not compile `crossbeam-utils` (build script) due to 1 previous error
    error: could not compile `libc` (build script) due to 1 previous error
    error: failed to compile `nixpkgs-fmt v1.3.0 (/home/user/.cache/pre-commit/repopsn8ksx5)`, intermediate artifacts can be found at `/home/user/.cache/pre-commit/repopsn8ksx5/target`.
    To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
Check the log at /home/user/.cache/pre-commit/pre-commit.log
```


While nixpkgs-fmt is deprecated, the replacement [nixfmt](https://github.com/NixOS/nixfmt) does not contain pre-commit hooks in the [0.6.0](https://github.com/NixOS/nixfmt/releases/tag/v0.6.0) release and was just merged NixOS/nixfmt#238 on the master branch. Thus, this PR adds toolchain support for nixpkgs-fmt until nixfmt is stable.

I am not completely sure if adding the dependencies to nixpkgs is the best place, however it makes the installation of pre-commit for nix related projects much easier.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
