### PR TITLE
acme: add TLS ALPN challenge

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -419,13 +419,14 @@ let
         redirectListen = filter (x: !x.ssl) defaultListen;
 
         # The acme-challenge location doesn't need to be added if we are not using any automated
-        # certificate provisioning and can also be omitted when we use a certificate obtained via a DNS-01 challenge
+        # certificate provisioning and can also be omitted when we use a certificate obtained via a DNS-01 or TLS-ALPN challenge
         acmeName = if vhost.useACMEHost != null then vhost.useACMEHost else vhost.serverName;
         acmeLocation =
           optionalString
             (
               (vhost.enableACME || vhost.useACMEHost != null)
               && config.security.acme.certs.${acmeName}.dnsProvider == null
+              && !config.security.acme.certs.${acmeName}.tlsMode
             )
             # Rule for legitimate ACME Challenge requests (like /.well-known/acme-challenge/xxxxxxxxx)
             # We use ^~ here, so that we don't check any regexes (which could
@@ -1637,7 +1638,11 @@ in
               # if acmeRoot is null inherit config.security.acme
               # Since config.security.acme.certs.<cert>.webroot's own default value
               # should take precedence set priority higher than mkOptionDefault
-              webroot = mkOverride (if hasRoot then 1000 else 2000) vhostConfig.acmeRoot;
+              webroot =
+                if certs.${vhostConfig.serverName}.tlsMode then
+                  null
+                else
+                  mkOverride (if hasRoot then 1000 else 2000) vhostConfig.acmeRoot;
               # Also nudge dnsProvider to null in case it is inherited
               dnsProvider = mkOverride (if hasRoot then 1000 else 2000) null;
               extraDomainNames = vhostConfig.serverAliases;


### PR DESCRIPTION
This commit adds the `tlsMode`, `tlsPort` and `conflictingServices` options to `security.acme.[...]` to allow using it even if port 80 is blocked and DNS access is impossible.

Initial work based on [this commit by @jeschmidt](https://github.com/jeschmidt/nixpkgs/commit/851e5aef4fa97c18f2f076ec39299be5062db5b4).

I tested these changes successfully ([backported to 24.05](https://github.com/nobodyinperson/nixpkgs/pull/2) though), config [here](https://gitlab.com/nobodyinperson/nixconfig/-/blob/733235a118f9053570b23c4964405c8727c5c9f4/forgejo.nix#L188-L207).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
     - there was [an error](https://github.com/NixOS/nixpkgs/pull/340136#issuecomment-2334459969), not sure if relevant
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
