### PR TITLE
incus: 6.4.0 -> 6.5.0

### DIFF
--- a/pkgs/by-name/in/incus/0c37b7e3ec65b4d0e166e2127d9f1835320165b8.patch
+++ b/pkgs/by-name/in/incus/0c37b7e3ec65b4d0e166e2127d9f1835320165b8.patch
@@ -1,0 +1,29 @@
+From 0c37b7e3ec65b4d0e166e2127d9f1835320165b8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?St=C3=A9phane=20Graber?= <stgraber@stgraber.org>
+Date: Fri, 6 Sep 2024 17:07:11 -0400
+Subject: [PATCH] incusd/instance/qemu: Make O_DIRECT conditional on
+ directCache
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Stéphane Graber <stgraber@stgraber.org>
+---
+ internal/server/instance/drivers/driver_qemu.go | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/internal/server/instance/drivers/driver_qemu.go b/internal/server/instance/drivers/driver_qemu.go
+index 5a94c9db43..9609b73c1b 100644
+--- a/internal/server/instance/drivers/driver_qemu.go
++++ b/internal/server/instance/drivers/driver_qemu.go
+@@ -4276,7 +4276,9 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
+ 				permissions = unix.O_RDONLY
+ 			}
+ 
+-			permissions |= unix.O_DIRECT
++			if directCache {
++				permissions |= unix.O_DIRECT
++			}
+ 
+ 			f, err := os.OpenFile(driveConf.DevPath, permissions, 0)
+ 			if err != nil {

--- a/pkgs/by-name/in/incus/572afb06f66f83ca95efa1b9386fceeaa1c9e11b.patch
+++ b/pkgs/by-name/in/incus/572afb06f66f83ca95efa1b9386fceeaa1c9e11b.patch
@@ -1,0 +1,28 @@
+From 572afb06f66f83ca95efa1b9386fceeaa1c9e11b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?St=C3=A9phane=20Graber?= <stgraber@stgraber.org>
+Date: Fri, 6 Sep 2024 15:51:35 -0400
+Subject: [PATCH] incusd/instance/qemu: Set O_DIRECT when passing in FDs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is required in most cases with QEMU 9.1.0.
+
+Signed-off-by: Stéphane Graber <stgraber@stgraber.org>
+---
+ internal/server/instance/drivers/driver_qemu.go | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/internal/server/instance/drivers/driver_qemu.go b/internal/server/instance/drivers/driver_qemu.go
+index 37da21f42f..e25aab0667 100644
+--- a/internal/server/instance/drivers/driver_qemu.go
++++ b/internal/server/instance/drivers/driver_qemu.go
+@@ -4277,6 +4277,8 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
+ 				permissions = unix.O_RDONLY
+ 			}
+ 
++			permissions |= unix.O_DIRECT
++
+ 			f, err := os.OpenFile(driveConf.DevPath, permissions, 0)
+ 			if err != nil {
+ 				return fmt.Errorf("Failed opening file descriptor for disk device %q: %w", driveConf.DevName, err)

--- a/pkgs/by-name/in/incus/58eeb4eeee8a9e7f9fa9c62443d00f0ec6797078.patch
+++ b/pkgs/by-name/in/incus/58eeb4eeee8a9e7f9fa9c62443d00f0ec6797078.patch
@@ -1,0 +1,33 @@
+From 58eeb4eeee8a9e7f9fa9c62443d00f0ec6797078 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?St=C3=A9phane=20Graber?= <stgraber@stgraber.org>
+Date: Fri, 6 Sep 2024 17:10:01 -0400
+Subject: [PATCH] incusd/instance/qemu: Force threads I/O mode for
+ unsafe/writeback
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The default "native" aioMode requires direct I/O which is incompatible
+with unsafe/writeback.
+
+Signed-off-by: Stéphane Graber <stgraber@stgraber.org>
+---
+ internal/server/instance/drivers/driver_qemu.go | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/internal/server/instance/drivers/driver_qemu.go b/internal/server/instance/drivers/driver_qemu.go
+index 9609b73c1b..a5a4944d40 100644
+--- a/internal/server/instance/drivers/driver_qemu.go
++++ b/internal/server/instance/drivers/driver_qemu.go
+@@ -4088,9 +4088,11 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
+ 	noFlushCache := false // Don't ignore any flush requests for the device.
+ 
+ 	if cacheMode == "unsafe" {
++		aioMode = "threads"
+ 		directCache = false
+ 		noFlushCache = true
+ 	} else if cacheMode == "writeback" {
++		aioMode = "threads"
+ 		directCache = false
+ 	}
+ 

--- a/pkgs/by-name/in/incus/package.nix
+++ b/pkgs/by-name/in/incus/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  hash = "sha256-fWc+qUAFlqMuiDhZzEY99rXHjKq40GPzplSN8ggId9g=";
-  version = "6.4.0";
-  vendorHash = "sha256-j+ywLnN+/6HvMKOEr1FuXTLxUMX7VtU4eG3GGx3yAOo=";
+  hash = "sha256-FdoJI0SUH8KS3Epyw/HejgyhISWGLePsIjYUS2YTBvc=";
+  version = "6.5.0";
+  vendorHash = "sha256-8e2X7HIy1IEx6p41SHJyq5dNUJ3rRC2maXC4uNaSlnk=";
   patches = [ ];
 }

--- a/pkgs/by-name/in/incus/package.nix
+++ b/pkgs/by-name/in/incus/package.nix
@@ -2,5 +2,10 @@ import ./generic.nix {
   hash = "sha256-FdoJI0SUH8KS3Epyw/HejgyhISWGLePsIjYUS2YTBvc=";
   version = "6.5.0";
   vendorHash = "sha256-8e2X7HIy1IEx6p41SHJyq5dNUJ3rRC2maXC4uNaSlnk=";
-  patches = [ ];
+  patches = [
+    # qemu 9.1 compat, remove in 6.6
+    ./572afb06f66f83ca95efa1b9386fceeaa1c9e11b.patch
+    ./58eeb4eeee8a9e7f9fa9c62443d00f0ec6797078.patch
+    ./0c37b7e3ec65b4d0e166e2127d9f1835320165b8.patch
+  ];
 }


### PR DESCRIPTION
## Description of changes

https://github.com/lxc/incus/releases/tag/v6.5.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

`nix-build -A incus.passthru.tests` seems to fail on my side. I'll test with 6.4.0.

```
machine # Error: Failed setting up device via monitor: Failed adding block device for disk device "root": Failed adding block device: Failed to find file descriptor with matching flags=0x4002
machine # Try `incus info --show-log instance1` for more info
```

EDIT: it also fails with 6.4.0 on my side.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
