### PR TITLE
fonts: Update gdouros fonts to use Web Archive (temporary fix)

### DIFF
--- a/pkgs/data/fonts/gdouros/default.nix
+++ b/pkgs/data/fonts/gdouros/default.nix
@@ -17,7 +17,7 @@ let
     inherit pname version;
 
     src = fetchzip {
-      url = "https://dn-works.com/wp-content/uploads/2020/UFAS-Fonts/${file}";
+      url = "https://web.archive.org/web/20240212172059/https://dn-works.com/wp-content/uploads/2020/UFAS-Fonts/${file}";
       stripRoot = false;
       inherit hash;
     };
@@ -34,12 +34,12 @@ let
 
     meta = {
       inherit description;
-      # see https://dn-works.com/wp-content/uploads/2020/UFAS-Docs/License.pdf
+      # see https://web.archive.org/web/20240212172059/https://dn-works.com/wp-content/uploads/2020/UFAS-Docs/License.pdf
       # quite draconian: non-commercial, no modifications,
       # no redistribution, "a single instantiation and no
       # network installation"
       license = lib.licenses.unfree;
-      homepage = "https://dn-works.com/ufas/";
+      homepage = "https://web.archive.org/web/20240212172059/https://dn-works.com/ufas/";
     };
   };
 in


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes issue #339757

The original website (https://dn-works.com) hosting the gdouros fonts is currently down. This PR updates the URLs to use Web Archive versions as a temporary solution.

Changes:
- Updated all URLs in `pkgs/data/fonts/gdouros/default.nix` to use Web Archive links
- Updated the `src` attribute in the `mkpkg` function to use the Web Archive URL
- Updated the `homepage` meta field to point to the Web Archive version of the original site

This is a temporary fix to ensure the fonts remain accessible while the original website is unavailable. We should revert these changes once the original site is back online.

Steps taken:
1. Replaced all download URLs with their Web Archive counterparts
2. Updated the `src` attribute to fetch from Web Archive
3. Verified that all fonts can be downloaded and built successfully
4. Updated the `homepage` in the `meta` attribute to reflect the Web Archive URL

Testing:
- Built several fonts individually using `nix-build -A <font-name>`
- Confirmed that the build process is working properly for the tested fonts
- Installed and tested some of the fonts to ensure they work correctly

Tested fonts:
- aegyptus
- akkadian
- symbola

All tested fonts built successfully and are functioning as expected.

Note: This is not an ideal long-term solution, as Web Archive links may not be as stable as the original source. We should monitor the situation and update the package once the original website is restored.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
