### PR TITLE
maputnik: init at 2.1.1

### DIFF
--- a/pkgs/by-name/ma/maputnik/no-cypress.patch
+++ b/pkgs/by-name/ma/maputnik/no-cypress.patch
@@ -1,0 +1,64 @@
+diff --git a/package.json b/package.json
+index c12e765..4cc2f53 100644
+--- a/package.json
++++ b/package.json
+@@ -36,7 +36,6 @@
+     "classnames": "^2.5.1",
+     "codemirror": "^5.65.2",
+     "color": "^4.2.3",
+-    "cypress-plugin-tab": "^1.0.5",
+     "detect-browser": "^5.3.0",
+     "events": "^3.3.0",
+     "file-saver": "^2.0.5",
+@@ -96,10 +95,8 @@
+     }
+   },
+   "devDependencies": {
+-    "@cypress/code-coverage": "^3.12.30",
+     "@istanbuljs/nyc-config-typescript": "^1.0.2",
+     "@rollup/plugin-replace": "^5.0.5",
+-    "@shellygo/cypress-test-utils": "^2.1.9",
+     "@types/codemirror": "^5.60.15",
+     "@types/color": "^3.0.6",
+     "@types/cors": "^2.8.17",
+@@ -127,7 +124,6 @@
+     "@types/uuid": "^9.0.8",
+     "@vitejs/plugin-react": "^4.2.1",
+     "cors": "^2.8.5",
+-    "cypress": "^13.13.0",
+     "eslint": "^8.57.0",
+     "eslint-plugin-react": "^7.34.1",
+     "eslint-plugin-react-hooks": "^4.6.0",
+diff --git a/tsconfig.json b/tsconfig.json
+index 24f3388..8b2ed4f 100644
+--- a/tsconfig.json
++++ b/tsconfig.json
+@@ -21,7 +21,7 @@
+       "noUnusedParameters": true,
+       "noFallthroughCasesInSwitch": true
+     },
+-    "include": ["src", "cypress/e2e"],
++    "include": ["src"],
+     "references": [{ "path": "./tsconfig.node.json" }],
+     // TODO: Remove when issue is resolved https://github.com/cypress-io/cypress/issues/27448
+     "ts-node": {
+@@ -30,4 +30,4 @@
+         "moduleResolution": "Node"
+       }
+     }
+-}
+\ No newline at end of file
++}
+diff --git a/vite.config.ts b/vite.config.ts
+index e1ca3e8..7fd6380 100644
+--- a/vite.config.ts
++++ b/vite.config.ts
+@@ -21,7 +21,7 @@ export default defineConfig({
+     }) as any,
+     react(),
+     istanbul({
+-      cypress: true,
++      cypress: false,
+       requireEnv: false,
+       nycrcPath: "./.nycrc.json",
+       forceBuildInstrument: true, //Instrument the source code for cypress runs

--- a/pkgs/by-name/ma/maputnik/package.nix
+++ b/pkgs/by-name/ma/maputnik/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkgs,
+}:
+
+buildGoModule rec {
+  pname = "maputnik";
+  version = "2.1.1";
+  maputnikSrc = fetchFromGitHub {
+    owner = "maplibre";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-rrrRX+W1OQ16ss11x1qFWBxoQBOiOUlL5lQfGUMkVU0=";
+  };
+  src = "${maputnikSrc}/desktop";
+  vendorHash = "sha256-UPYpYEY2fdez5o2uYdjWAfA8A4DyA88K7sIPEUFQzyw=";
+
+  maputnikNpm = buildNpmPackage rec {
+    inherit pname version;
+    src = maputnikSrc;
+
+    npmDepsHash = "sha256-I4rgk3RKCtEQvzwlzCrBdim9xlilciIuOqxhqlNyaFc=";
+    npmFlags = [ "--legacy-peer-deps" ];
+    dontNpmBuild = true;
+    makeCacheWritable = true;
+
+    patches = [ ./no-cypress.patch ];
+
+    buildPhase = "./node_modules/vite/bin/vite.js build --base=/ --outDir=editor";
+    installPhase = "mkdir -p $out/lib && cp -r editor $out/lib/";
+  };
+
+  nativeBuildInputs = [ pkgs.go-rice ];
+
+  # TODO: DesktopVersion removed in master
+  versionGo = pkgs.writeText "version.go" ''
+    package main
+
+    const DesktopVersion = "1.1.1"
+    const EditorVersion = "${version}"
+  '';
+
+  preConfigure = ''
+    cp ${versionGo} version.go
+    cp -r ${maputnikNpm}/lib/editor .
+    rice embed-go
+  '';
+
+  postInstall = "mv $out/bin/desktop $out/bin/maputnik";
+
+  meta = {
+    description = "An open source visual editor for the 'MapLibre Style Specification'";
+    homepage = "https://github.com/maplibre/maputnik/wiki";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ starsep ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
An open source visual editor for the 'MapLibre Style Specification'
https://github.com/maplibre/maputnik

Fixes #338663

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
