### PR TITLE
autoPatchelfHook: expose script as top level package

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -79,7 +79,7 @@ autoPatchelf() {
         fi
     done
 
-    @pythonInterpreter@ @autoPatchelfScript@                            \
+    auto-patchelf                                                       \
         ${norecurse:+--no-recurse}                                      \
         --ignore-missing "${ignoreMissingDepsArray[@]}"                 \
         --paths "$@"                                                    \

--- a/pkgs/by-name/au/auto-patchelf/auto-patchelf.py
+++ b/pkgs/by-name/au/auto-patchelf/auto-patchelf.py
@@ -425,7 +425,7 @@ interpreter_arch: str   = None # type: ignore
 libc_lib: Path          = None # type: ignore
 
 if __name__ == "__main__":
-    nix_support = Path(os.environ['NIX_BINTOOLS']) / 'nix-support'
+    nix_support = Path(os.environ.get('NIX_BINTOOLS', os.environ['DEFAULT_BINTOOLS'])) / 'nix-support'
     interpreter_path = Path((nix_support / 'dynamic-linker').read_text().strip())
     libc_lib = Path((nix_support / 'orig-libc').read_text().strip()) / 'lib'
 

--- a/pkgs/by-name/au/auto-patchelf/package.nix
+++ b/pkgs/by-name/au/auto-patchelf/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "auto-patchelf";
+  version = "0-unstable-2024-08-14";
+  pyproject = false;
+
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./auto-patchelf.py
+    ];
+  };
+
+  dependencies = with python3Packages; [
+    pyelftools
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 auto-patchelf.py $out/bin/auto-patchelf
+
+    runHook postInstall
+  '';
+
+  makeWrapperArgs = [
+    "--set DEFAULT_BINTOOLS $NIX_BINTOOLS"
+  ];
+
+  meta = {
+    description = "Automatically patch ELF binaries using patchelf";
+    mainProgram = "auto-patchelf";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Scrumplex ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -188,11 +188,7 @@ with pkgs;
 
   autoPatchelfHook = makeSetupHook {
     name = "auto-patchelf-hook";
-    propagatedBuildInputs = [ bintools ];
-    substitutions = {
-      pythonInterpreter = "${python3.withPackages (ps: [ ps.pyelftools ])}/bin/python";
-      autoPatchelfScript = ../build-support/setup-hooks/auto-patchelf.py;
-    };
+    propagatedBuildInputs = [ auto-patchelf bintools ];
   } ../build-support/setup-hooks/auto-patchelf.sh;
 
   tomato-c = callPackage ../applications/misc/tomato-c { };


### PR DESCRIPTION
## Description of changes

This allows PRs like #337340 to make use of auto-patchelf in downstream applications.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
