### PR TITLE
peering-manager: fix runtime with pyixapi 0.2.3

### DIFF
--- a/pkgs/servers/web-apps/peering-manager/default.nix
+++ b/pkgs/servers/web-apps/peering-manager/default.nix
@@ -19,6 +19,12 @@ python3.pkgs.buildPythonApplication rec {
 
   format = "other";
 
+  patches = [
+    # Fix compatibility with pyixapi 0.2.3
+    # https://github.com/peering-manager/peering-manager/commit/ee558ff66e467412942559a8a92252e3fc009920
+    ./fix-pyixapi-0.2.3-compatibility.patch
+  ];
+
   propagatedBuildInputs = with python3.pkgs; [
     django
     djangorestframework

--- a/pkgs/servers/web-apps/peering-manager/fix-pyixapi-0.2.3-compatibility.patch
+++ b/pkgs/servers/web-apps/peering-manager/fix-pyixapi-0.2.3-compatibility.patch
@@ -1,0 +1,30 @@
+From ee558ff66e467412942559a8a92252e3fc009920 Mon Sep 17 00:00:00 2001
+From: Guillaume Mazoyer <guillaume@mazoyer.eu>
+Date: Wed, 21 Feb 2024 23:32:32 +0100
+Subject: [PATCH] Use pyixapi 0.2.3
+
+---
+diff --git a/extras/models/ixapi.py b/extras/models/ixapi.py
+index 65572c971e065e3deed69465a71a54b4e1372851..637a004043e0a044c65a5e37fbb2b3bf82965436 100644
+--- a/extras/models/ixapi.py
++++ b/extras/models/ixapi.py
+@@ -7,7 +7,6 @@
+ from django.db import models
+ from django.db.models import Q
+ from django.urls import reverse
+-from django.utils.timezone import make_aware
+ 
+ from peering_manager.models import ChangeLoggedModel
+ 
+@@ -117,9 +116,9 @@ def dial(self):
+         if auth:
+             # Save tokens if they've changed
+             self.access_token = api.access_token.encoded
+-            self.access_token_expiration = make_aware(api.access_token.expires_at)
++            self.access_token_expiration = api.access_token.expires_at
+             self.refresh_token = api.refresh_token.encoded
+-            self.refresh_token_expiration = make_aware(api.refresh_token.expires_at)
++            self.refresh_token_expiration = api.refresh_token.expires_at
+             self.save()
+ 
+         return api


### PR DESCRIPTION
- add patch from merged upstream commit fixing pyixapi 0.2.3 compatibility:
https://github.com/peering-manager/peering-manager/commit/ee558ff66e467412942559a8a92252e3fc009920

## Description of changes

Since `pyixapi` 0.2.3 some api inside returns datetime with timezone:
https://github.com/peering-manager/pyixapi/commit/9ed71da8af2588b428884f6d1c6c633f7eadc302
making `peering-manager` fail on trying to add timezone again with `make_aware`

Upstream commit fixing compatibility with it:
https://github.com/peering-manager/peering-manager/commit/ee558ff66e467412942559a8a92252e3fc009920
Could not use `fetchpatch` as patch does not apply cleanly because of other files there (`requirements.txt` and `poetry.lock`), removed diff from them and put it into file.

Fixes `nixosTests.peering-manager` (fails since `2024-03-21`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.peering-manager.x86_64-linux
https://hydra.nixos.org/build/271509942

Error log:
```text
machine: must succeed: cd /nix/store/lkx78szb4cfglk5nrczvw1kjfzdj8ak8-peering-manager-1.8.3/opt/peering-manager ; peering-manager-manage test --no-input
...
machine # ======================================================================
machine # ERROR: test_dial (extras.tests.test_models.IXAPITest.test_dial)
machine # ----------------------------------------------------------------------
machine # Traceback (most recent call last):
machine #   File "/nix/store/pgb120fb7srbh418v4i2a70aq1w9dawd-python3-3.12.5/lib/python3.12/unittest/mock.py", line 1393, in patched
machine #     return func(*newargs, **newkeywargs)
machine #            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
machine #   File "/nix/store/lkx78szb4cfglk5nrczvw1kjfzdj8ak8-peering-manager-1.8.3/opt/peering-manager/extras/tests/test_models.py", line 72, in test_dial
machine #     a = self.ix_api.dial()
machine #         ^^^^^^^^^^^^^^^^^^
machine #   File "/nix/store/lkx78szb4cfglk5nrczvw1kjfzdj8ak8-peering-manager-1.8.3/opt/peering-manager/extras/models/ixapi.py", line 120, in dial
machine #     self.access_token_expiration = make_aware(api.access_token.expires_at)
machine #                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
machine #   File "/nix/store/0nvckmcabh7d4c1q762sjsmsywq79zl5-python3.12-django-4.2.15/lib/python3.12/site-packages/django/utils/timezone.py", line 291, in make_aware
machine #     raise ValueError("make_aware expects a naive datetime, got %s" % value)
machine # ValueError: make_aware expects a naive datetime, got 2100-01-28 11:05:14+00:00
...
machine # ----------------------------------------------------------------------
machine # Ran 821 tests in 32.311s
machine # 
machine # FAILED (errors=7, skipped=7)
```
test fails since `pyixapi` update to 0.2.3:
https://github.com/NixOS/nixpkgs/commit/555f832bd49318b1b571dc40b501dfdbf76f3dc4
(manual revert of update also fixes test)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
