### PR TITLE
zfs: Fix samba freeform settings and 2.1 build

### DIFF
--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -213,8 +213,8 @@ in {
     enableSystemdStage1 = true;
   };
 
-  installerBoot = (import ./installer.nix { }).separateBootZfs;
-  installer = (import ./installer.nix { }).zfsroot;
+  installerBoot = (import ./installer.nix { inherit system; }).separateBootZfs;
+  installer = (import ./installer.nix { inherit system; }).zfsroot;
 
   expand-partitions = makeTest {
     name = "multi-disk-zfs";

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -45,13 +45,13 @@ let
         specialisation.samba.configuration = {
           services.samba = {
             enable = true;
-            extraConfig = ''
-              registry shares = yes
-              usershare path = ${usersharePath}
-              usershare allow guests = yes
-              usershare max shares = 100
-              usershare owner only = no
-            '';
+            settings.global = {
+              "registry shares" = true;
+              "usershare path" = "${usersharePath}";
+              "usershare allow guests" = true;
+              "usershare max shares" = "100";
+              "usershare owner only" = false;
+            };
           };
           systemd.services.samba-smbd.serviceConfig.ExecStartPre =
             "${pkgs.coreutils}/bin/mkdir -m +t -p ${usersharePath}";

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -182,10 +182,11 @@ let
       # Remove tests because they add a runtime dependency on gcc
       rm -rf $out/share/zfs/zfs-tests
 
-      # Add Bash completions.
-      install -v -m444 -D -t $out/share/bash-completion/completions contrib/bash_completion.d/zfs
-    '' + optionalString (lib.versionOlder version "2.2.6") ''
-      (cd $out/share/bash-completion/completions; ln -s zfs zpool)
+      ${optionalString (lib.versionOlder version "2.2") ''
+        # Add Bash completions.
+        install -v -m444 -D -t $out/share/bash-completion/completions contrib/bash_completion.d/zfs
+        (cd $out/share/bash-completion/completions; ln -s zfs zpool)
+      ''}
     '';
 
     postFixup = let


### PR DESCRIPTION
## Description of changes

Fix zfs tests after #302681, and 2.1 after #339696

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
