### PR TITLE
[Backport release-24.05] gallery-dl: 1.26.9 -> 1.27.4

### DIFF
--- a/pkgs/applications/misc/gallery-dl/default.nix
+++ b/pkgs/applications/misc/gallery-dl/default.nix
@@ -1,4 +1,11 @@
-{ lib, buildPythonApplication, fetchPypi, requests, yt-dlp, pytestCheckHook }:
+{
+  lib,
+  buildPythonApplication,
+  fetchPypi,
+  requests,
+  yt-dlp,
+  pytestCheckHook,
+}:
 
 buildPythonApplication rec {
   pname = "gallery-dl";
@@ -16,9 +23,7 @@ buildPythonApplication rec {
     yt-dlp
   ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pytestFlagsArray = [
     # requires network access
@@ -29,9 +34,7 @@ buildPythonApplication rec {
     "--ignore=test/test_ytdl.py"
   ];
 
-  pythonImportsCheck = [
-    "gallery_dl"
-  ];
+  pythonImportsCheck = [ "gallery_dl" ];
 
   meta = with lib; {
     description = "Command-line program to download image-galleries and -collections from several image hosting sites";

--- a/pkgs/applications/misc/gallery-dl/default.nix
+++ b/pkgs/applications/misc/gallery-dl/default.nix
@@ -36,12 +36,12 @@ buildPythonApplication rec {
 
   pythonImportsCheck = [ "gallery_dl" ];
 
-  meta = with lib; {
+  meta = {
     description = "Command-line program to download image-galleries and -collections from several image hosting sites";
     homepage = "https://github.com/mikf/gallery-dl";
     changelog = "https://github.com/mikf/gallery-dl/blob/v${version}/CHANGELOG.md";
-    license = licenses.gpl2Only;
+    license = lib.licenses.gpl2Only;
     mainProgram = "gallery-dl";
-    maintainers = with maintainers; [ dawidsowa ];
+    maintainers = with lib.maintainers; [ dawidsowa ];
   };
 }

--- a/pkgs/applications/misc/gallery-dl/default.nix
+++ b/pkgs/applications/misc/gallery-dl/default.nix
@@ -1,23 +1,15 @@
-{ lib, buildPythonApplication, fetchPypi, fetchpatch, requests, yt-dlp, pytestCheckHook }:
+{ lib, buildPythonApplication, fetchPypi, requests, yt-dlp, pytestCheckHook }:
 
 buildPythonApplication rec {
   pname = "gallery-dl";
-  version = "1.26.9";
+  version = "1.27.0";
   format = "setuptools";
 
   src = fetchPypi {
     inherit version;
     pname = "gallery_dl";
-    sha256 = "sha256-PgbfppyJCpgFupBQng8MUPihbDmit4C+xWnSzCJyu5k=";
+    hash = "sha256-zMimHjaXgwOSt8HbSec4o0y3e9Xf6tFFiI4KzsrP850=";
   };
-
-  patches = [
-    # catch general Exceptions. Remove with the next release.
-    (fetchpatch {
-      url = "https://github.com/mikf/gallery-dl/commit/5227bb6b1d62ecef5b281592b0d001e7f9c101e3.patch";
-      hash = "sha256-rVsd764siP/07XBPVDnpxMm/4kLiH3fp9+NtpHHH23U=";
-    })
-  ];
 
   propagatedBuildInputs = [
     requests

--- a/pkgs/applications/misc/gallery-dl/default.nix
+++ b/pkgs/applications/misc/gallery-dl/default.nix
@@ -10,13 +10,13 @@
 
 buildPythonApplication rec {
   pname = "gallery-dl";
-  version = "1.27.3";
+  version = "1.27.4";
   format = "setuptools";
 
   src = fetchPypi {
     inherit version;
     pname = "gallery_dl";
-    hash = "sha256-ILnnbnQiJnBBOV87mWw1xHU8DtCXIVVwRwz/PfzVSSI=";
+    hash = "sha256-28y5sU9onPHIqlTIYzIQ+J2KElJocbuwKQN/E50JGI8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/applications/misc/gallery-dl/default.nix
+++ b/pkgs/applications/misc/gallery-dl/default.nix
@@ -5,17 +5,18 @@
   requests,
   yt-dlp,
   pytestCheckHook,
+  nix-update-script,
 }:
 
 buildPythonApplication rec {
   pname = "gallery-dl";
-  version = "1.27.2";
+  version = "1.27.3";
   format = "setuptools";
 
   src = fetchPypi {
     inherit version;
     pname = "gallery_dl";
-    hash = "sha256-CTc6CBAFIxOX5Bd/hy3e65MbWyI2wFn+a6hj4ktuBjo=";
+    hash = "sha256-ILnnbnQiJnBBOV87mWw1xHU8DtCXIVVwRwz/PfzVSSI=";
   };
 
   propagatedBuildInputs = [
@@ -35,6 +36,8 @@ buildPythonApplication rec {
   ];
 
   pythonImportsCheck = [ "gallery_dl" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Command-line program to download image-galleries and -collections from several image hosting sites";

--- a/pkgs/applications/misc/gallery-dl/default.nix
+++ b/pkgs/applications/misc/gallery-dl/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonApplication rec {
   pname = "gallery-dl";
-  version = "1.27.1";
+  version = "1.27.2";
   format = "setuptools";
 
   src = fetchPypi {
     inherit version;
     pname = "gallery_dl";
-    hash = "sha256-S1RF0FNJ/oKTwq9SXXIOnqBIViGIYBVuxPjV/6fbeV8=";
+    hash = "sha256-CTc6CBAFIxOX5Bd/hy3e65MbWyI2wFn+a6hj4ktuBjo=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/applications/misc/gallery-dl/default.nix
+++ b/pkgs/applications/misc/gallery-dl/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonApplication rec {
   pname = "gallery-dl";
-  version = "1.27.0";
+  version = "1.27.1";
   format = "setuptools";
 
   src = fetchPypi {
     inherit version;
     pname = "gallery_dl";
-    hash = "sha256-zMimHjaXgwOSt8HbSec4o0y3e9Xf6tFFiI4KzsrP850=";
+    hash = "sha256-S1RF0FNJ/oKTwq9SXXIOnqBIViGIYBVuxPjV/6fbeV8=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Things done

Backport of:
https://github.com/NixOS/nixpkgs/pull/316532
https://github.com/NixOS/nixpkgs/pull/322462
https://github.com/NixOS/nixpkgs/pull/332055
https://github.com/NixOS/nixpkgs/pull/333824
https://github.com/NixOS/nixpkgs/pull/340064

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc