### PR TITLE
nixos/pam: add serviceDefaults

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -25,6 +25,9 @@
 - `hardware.display` is a new module implementing workarounds for misbehaving monitors
   through setting up custom EDID files and forcing kernel/framebuffer modes.
 
+- `security.pam.serviceDefaults` is a new way to configure the default PAM modules for all services, providing a
+  simple way to only use a pam module for one specific service.
+
 - A new display-manager `services.displayManager.ly` was added.
   It is a tui based replacement of sddm and lightdm for window manager users.
   Users can use it by `services.displayManager.ly.enable` and config it by

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -98,13 +98,9 @@ let
   package = config.security.pam.package;
   parentConfig = config;
 
-  pamOpts = { config, name, ... }: let cfg = config; in let config = parentConfig; in {
-
-    imports = [
-      (lib.mkRenamedOptionModule [ "enableKwallet" ] [ "kwallet" "enable" ])
-    ];
-
-    options = {
+  pamOpts = default: {config, name, ...}: let cfg = config; in let
+    config = parentConfig;
+    configDefaults = {
 
       name = lib.mkOption {
         example = "sshd";
@@ -585,6 +581,24 @@ let
       };
 
     };
+  in {
+    imports = [
+      (lib.mkRenamedOptionModule [ "enableKwallet" ] [ "kwallet" "enable" ])
+    ];
+
+    options =
+      if default
+      then configDefaults
+      else lib.mapAttrsRecursiveCond
+        (as: !(lib.isOption as))
+        (path: value:
+          if lib.isOption value && builtins.hasAttr "default" value
+          then value // {
+            default = lib.attrByPath path (throw "Service default does not exist") config.security.pam.serviceDefaults;
+            defaultText = lib.literalExpression "config.security.pam.serviceDefaults.${lib.concatStringsSep "." path}";
+          }
+          else value)
+        configDefaults;
 
     # The resulting /etc/pam.d/* file contents are verified in
     # nixos/tests/pam/pam-file-contents.nix. Please update tests there when
@@ -1008,9 +1022,17 @@ in
      '';
     };
 
+    security.pam.serviceDefaults = lib.mkOption {
+      default = {};
+      type = lib.types.submodule (pamOpts true);
+      description = ''
+        This option defines the default PAM service configuration.
+      '';
+    };
+
     security.pam.services = lib.mkOption {
       default = {};
-      type = with lib.types; attrsOf (submodule pamOpts);
+      type = with lib.types; attrsOf (submodule (pamOpts false));
       description = ''
           This option defines the PAM services.  A service typically
           corresponds to a program that uses PAM,


### PR DESCRIPTION
## Description of changes

This change addresses a shortcoming of how the PAM module handles setting up service configurations. As it stands now, if you enable certain modules, then that will affect all the default service configurations for all services, with no way of overriding it. This change adds configuration options to set the default option for all services, taking priority over the defaults given by the system configuration. 

### Example (`fprintd`):
When you set `services.fprintd.enable = true` in your NixOS config, the `fprintAuth` option is set to `true` by default for *all services*, making fingerprint the preferred PAM method for all services by default. If the goal is simply to disable fingerprint for one service, this is easily accomplished by updating the configuration for that particular service (i.e. `security.pam.services.sudo.fprintAuth = false` for the `sudo` service). If, on the other hand, one only want's `fprintAuth` to be set to `true` for _one_ service, then short of manually setting it to `false` for all the enabled services (infinite recursion cuts short any attempts at making this automatic), there is no way to change the default settings for `fprintAuth` to `false`.

In other words, the only paradigm for setting PAM settings is _opt-out_, and _opt-in_ is not possible.

With the changes in place, one simply sets `security.pam.serviceDefaults.fprintAuth = false;`

### Motive for how it was implemented
The way the `security.pam.serviceDefaults` option is implemented should guarantee complete backwards compatibility with old configurations, with the opt-out paradigm still being the default.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
