### PR TITLE
lib.types.anything: remove custom logic for lists

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -426,8 +426,8 @@ checkConfigOutput '^null$' config.value.l1.l2.foo ./types-anything/nested-attrs.
 checkConfigOutput '^null$' config.value.l1.l2.l3.foo ./types-anything/nested-attrs.nix
 # Attribute sets that are coercible to strings shouldn't be recursed into
 checkConfigOutput '^"foo"$' config.value.outPath ./types-anything/attrs-coercible.nix
-# Multiple lists aren't concatenated together
-checkConfigError 'The option .* has conflicting definitions' config.value ./types-anything/lists.nix
+# Multiple lists aren't concatenated together if their definitions are not equal
+checkConfigError 'The option .* has conflicting definition values' config.value ./types-anything/lists.nix
 # Check that all equalizable atoms can be used as long as all definitions are equal
 checkConfigOutput '^0$' config.value.int ./types-anything/equal-atoms.nix
 checkConfigOutput '^false$' config.value.bool ./types-anything/equal-atoms.nix
@@ -435,6 +435,7 @@ checkConfigOutput '^""$' config.value.string ./types-anything/equal-atoms.nix
 checkConfigOutput '^"/[^"]+"$' config.value.path ./types-anything/equal-atoms.nix
 checkConfigOutput '^null$' config.value.null ./types-anything/equal-atoms.nix
 checkConfigOutput '^0.1$' config.value.float ./types-anything/equal-atoms.nix
+checkConfigOutput '^\[1,"a",{"x":null}\]$' config.value.list ./types-anything/equal-atoms.nix
 # Functions can't be merged together
 checkConfigError "The option .value.multiple-lambdas.<function body>. has conflicting option types" config.applied.multiple-lambdas ./types-anything/functions.nix
 checkConfigOutput '^true$' config.valueIsFunction.single-lambda ./types-anything/functions.nix

--- a/lib/tests/modules/types-anything/equal-atoms.nix
+++ b/lib/tests/modules/types-anything/equal-atoms.nix
@@ -12,6 +12,7 @@
       value.path = ./.;
       value.null = null;
       value.float = 0.1;
+      value.list = [1 "a" {x=null;}];
     }
     {
       value.int = 0;
@@ -20,6 +21,7 @@
       value.path = ./.;
       value.null = null;
       value.float = 0.1;
+      value.list = [1 "a" {x=null;}];
     }
   ];
 

--- a/lib/tests/modules/types-anything/lists.nix
+++ b/lib/tests/modules/types-anything/lists.nix
@@ -6,10 +6,10 @@
 
   config = lib.mkMerge [
     {
-      value = [ null ];
+      value = [ "a value" ];
     }
     {
-      value = [ null ];
+      value = [ "another value" ];
     }
   ];
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -253,12 +253,6 @@ rec {
           mergeFunction = {
             # Recursively merge attribute sets
             set = (attrsOf anything).merge;
-            # Safe and deterministic behavior for lists is to only accept one definition
-            # listOf only used to apply mkIf and co.
-            list =
-              if length defs > 1
-              then throw "The option `${showOption loc}' has conflicting definitions, in ${showFiles (getFiles defs)}."
-              else (listOf anything).merge;
             # This is the type of packages, only accept a single definition
             stringCoercibleSet = mergeOneOption;
             lambda = loc: defs: arg: anything.merge


### PR DESCRIPTION
## Description of changes

Previously, in the lib.types.anything option type, for values of type list, the merge function would only retain the value if the number of option definitions was less than or equal to 1, and would throw an error for conflicting definitions to avoid potentially unwanted list merges.

This change removes that logic, defaulting to the 'mergeEqualOption' function for values of type list. This approach maintains the same safeguard against merging different lists while allowing lists with identical values to be merged.

You can find some more context [here](https://discourse.nixos.org/t/lib-types-anythings-merge-function-behavior-regarding-lists/51708).

## Things done

Removed the special handling of lists in lib.types.anything.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
