### PR TITLE
shadps4: init at 0.3.0-unstable-2024-10-13

### DIFF
--- a/pkgs/by-name/sh/shadps4/0001-Disable-update-checking.patch
+++ b/pkgs/by-name/sh/shadps4/0001-Disable-update-checking.patch
@@ -1,0 +1,30 @@
+From 266a090882133e30df20899bbf8a5b66b28e02cd Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Mon, 14 Oct 2024 00:31:01 +0200
+Subject: [PATCH] Disable update checking
+
+Downloading an AppImage and trying to run it just won't work.
+---
+ src/qt_gui/check_update.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/qt_gui/check_update.cpp b/src/qt_gui/check_update.cpp
+index ca6009ca..e3b14d5d 100644
+--- a/src/qt_gui/check_update.cpp
++++ b/src/qt_gui/check_update.cpp
+@@ -201,6 +201,12 @@ void CheckUpdate::setupUI(const QString& downloadUrl, const QString& latestDate,
+     noButton->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
+     bottomLayout->addWidget(autoUpdateCheckBox);
+ 
++    yesButton->setVisible(false);
++    yesButton->setEnabled(false);
++    QString updateDisabledText = QStringLiteral("[Nix] Auto-updating has been disabled in this package.");
++    QLabel* updateDisabledLabel = new QLabel(updateDisabledText, this);
++    layout->addWidget(updateDisabledLabel);
++
+     QSpacerItem* spacer = new QSpacerItem(40, 20, QSizePolicy::Expanding, QSizePolicy::Minimum);
+     bottomLayout->addItem(spacer);
+ 
+-- 
+2.44.1
+

--- a/pkgs/by-name/sh/shadps4/bloodborne.patch
+++ b/pkgs/by-name/sh/shadps4/bloodborne.patch
@@ -1,0 +1,19 @@
+--- a/src/core/libraries/kernel/thread_management.cpp
++++ b/src/core/libraries/kernel/thread_management.cpp
+@@ -1065,7 +1065,16 @@ ScePthread PThreadPool::Create() {
+         }
+     }
+
++#ifdef _WIN64
+     auto* ret = new PthreadInternal{};
++#else
++    // TODO: Linux specific hack
++    static u8* hint_address = reinterpret_cast<u8*>(0x7FFFFC000ULL);
++    auto* ret = reinterpret_cast<PthreadInternal*>(
++        mmap(hint_address, sizeof(PthreadInternal), PROT_READ | PROT_WRITE,
++             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0));
++    hint_address += Common::AlignUp(sizeof(PthreadInternal), 4_KB);
++#endif
+     ret->is_free = false;
+     ret->is_detached = false;
+     ret->is_almost_done = false;

--- a/pkgs/by-name/sh/shadps4/laptop-controls.patch
+++ b/pkgs/by-name/sh/shadps4/laptop-controls.patch
@@ -1,0 +1,24 @@
+diff --git a/src/sdl_window.cpp b/src/sdl_window.cpp
+index bd2cc39d..13438149 100644
+--- a/src/sdl_window.cpp
++++ b/src/sdl_window.cpp
+@@ -127,19 +127,12 @@ void WindowSDL::onResize() {
+ void WindowSDL::onKeyPress(const SDL_Event* event) {
+     using Libraries::Pad::OrbisPadButtonDataOffset;
+ 
+-#ifdef __APPLE__
+     // Use keys that are more friendly for keyboards without a keypad.
+     // Once there are key binding options this won't be necessary.
+     constexpr SDL_Keycode CrossKey = SDLK_N;
+     constexpr SDL_Keycode CircleKey = SDLK_B;
+     constexpr SDL_Keycode SquareKey = SDLK_V;
+     constexpr SDL_Keycode TriangleKey = SDLK_C;
+-#else
+-    constexpr SDL_Keycode CrossKey = SDLK_KP_2;
+-    constexpr SDL_Keycode CircleKey = SDLK_KP_6;
+-    constexpr SDL_Keycode SquareKey = SDLK_KP_4;
+-    constexpr SDL_Keycode TriangleKey = SDLK_KP_8;
+-#endif
+ 
+     u32 button = 0;
+     Input::Axis axis = Input::Axis::AxisMax;

--- a/pkgs/by-name/sh/shadps4/package.nix
+++ b/pkgs/by-name/sh/shadps4/package.nix
@@ -1,0 +1,140 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  alsa-lib,
+  boost184,
+  cmake,
+  cryptopp,
+  glslang,
+  ffmpeg,
+  fmt,
+  jack2,
+  libdecor,
+  libpulseaudio,
+  libunwind,
+  libusb1,
+  magic-enum,
+  mesa,
+  pkg-config,
+  pugixml,
+  qt6,
+  rapidjson,
+  renderdoc,
+  sndio,
+  toml11,
+  vulkan-headers,
+  vulkan-loader,
+  vulkan-memory-allocator,
+  xorg,
+  xxHash,
+  zlib-ng,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation {
+  pname = "shadps4";
+  version = "0.3.0-unstable-2024-10-13";
+
+  src = fetchFromGitHub {
+    owner = "shadps4-emu";
+    repo = "shadPS4";
+    rev = "bd9f82df94847b4a5f3d2676ae938f064505c992";
+    hash = "sha256-Z4+hHq2VI4wA1D72dBI7Lt++Rm3q0svjF6AialXxM0k=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # https://github.com/shadps4-emu/shadPS4/issues/758
+    ./bloodborne.patch
+    # Fix controls without a numpad
+    ./laptop-controls.patch
+
+    # Disable auto-updating, as
+    # downloading an AppImage and trying to run it just won't work.
+    # https://github.com/shadps4-emu/shadPS4/issues/1368
+    ./0001-Disable-update-checking.patch
+  ];
+
+  buildInputs = [
+    alsa-lib
+    boost184
+    cryptopp
+    glslang
+    ffmpeg
+    fmt
+    jack2
+    libdecor
+    libpulseaudio
+    libunwind
+    libusb1
+    xorg.libX11
+    xorg.libXext
+    magic-enum
+    mesa
+    pugixml
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtmultimedia
+    qt6.qttools
+    qt6.qtwayland
+    rapidjson
+    renderdoc
+    sndio
+    toml11
+    vulkan-headers
+    vulkan-loader
+    vulkan-memory-allocator
+    xxHash
+    zlib-ng
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_QT_GUI" true)
+  ];
+
+  # Still in development, help with debugging
+  cmakeBuildType = "RelWithDebugInfo";
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -t $out/bin shadps4
+    install -Dm644 -t $out/share/icons/hicolor/512x512/apps $src/.github/shadps4.png
+    install -Dm644 -t $out/share/applications $src/.github/shadps4.desktop
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    patchelf --add-rpath ${
+      lib.makeLibraryPath [
+        vulkan-loader
+        xorg.libXi
+      ]
+    } \
+      $out/bin/shadps4
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    tagFormat = "v.*";
+    tagPrefix = "v.";
+  };
+
+  meta = {
+    description = "Early in development PS4 emulator";
+    homepage = "https://github.com/shadps4-emu/shadPS4";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ryand56 ];
+    mainProgram = "shadps4";
+    platforms = lib.intersectLists lib.platforms.linux lib.platforms.x86_64;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [shadPS4](https://github.com/shadps4-emu/shadPS4), an in-early development PS4 emulator.
Closes #339617

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
