### PR TITLE
python312Packages.langgraph-{sdk,checkpoint,checkpoint-postgres,checkpoint-sqlite} Sept. 6 2024 update 

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -5,6 +5,7 @@
   langgraph-checkpoint,
   orjson,
   psycopg,
+  psycopg-pool,
   langgraph-sdk,
   poetry-core,
   pythonOlder,
@@ -12,11 +13,12 @@
   postgresqlTestHook,
   pytestCheckHook,
   pytest-asyncio,
+  stdenvNoCC,
 }:
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-postgres";
-  version = "1.0.3";
+  version = "1.0.6";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -25,7 +27,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/checkpointpostgres==${version}";
-    hash = "sha256-U7Bymo+Nj82kwjxN33W2MT10jv+lioZUxIKUt8Yxh/s=";
+    hash = "sha256-F9sgZQQBFs5hDUsaR5BI9ERve9L8LTUvEKOgyz5ioqY=";
   };
 
   postgresqlTestSetupPost = ''
@@ -41,7 +43,12 @@ buildPythonPackage rec {
     langgraph-checkpoint
     orjson
     psycopg
+    psycopg-pool
   ];
+
+  pythonRelaxDeps = [ "psycopg-pool" ];
+
+  doCheck = !(stdenvNoCC.isDarwin);
 
   pythonImportsCheck = [ "langgraph.checkpoint.postgres" ];
 

--- a/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-sqlite";
-  version = "1.0.0";
+  version = "1.0.2";
   pyproject = true;
 
   disabled = pythonOlder "3.9";

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -4,6 +4,7 @@
   dataclasses-json,
   fetchFromGitHub,
   langchain-core,
+  langgraph-sdk,
   poetry-core,
   pytest-asyncio,
   pytestCheckHook,
@@ -12,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint";
-  version = "1.0.3";
+  version = "1.0.9";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -21,7 +22,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/checkpoint==${version}";
-    hash = "sha256-5JP9f2uHNo71btQ96sBPlS7JPqo35C3VEMeHN1cJSro=";
+    hash = "sha256-3gm+L67pPAKpY1kqnX1lPnca40KoBVZdRZ1Cy6D0dzU=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint";
@@ -37,6 +38,10 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ];
+
+  passthru = {
+    updateScript = langgraph-sdk.updateScript;
+  };
 
   meta = {
     changelog = "https://github.com/langchain-ai/langgraph/releases/tag/checkpoint==${version}";

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -48,6 +48,9 @@ buildPythonPackage rec {
       set -eu -o pipefail
       nix-update --commit --version-regex '(.*)' python3Packages.langgraph
       nix-update --commit --version-regex 'sdk==(.*)' python3Packages.langgraph-sdk
+      nix-update --commit --version-regex 'checkpoint==(.*)' python3Packages.langgraph-checkpoint
+      nix-update --commit --version-regex 'checkpointpostgres==(.*)' python3Packages.langgraph-checkpoint-postgres
+      nix-update --commit --version-regex 'checkpointsqlite==(.*)' python3Packages.langgraph-checkpoint-sqlite
     '';
   };
 


### PR DESCRIPTION
1. Version bumps:
- python3Packages.langgraph-checkpoint: 1.03 -> 1.0.9
- python3Packages.langgraph-checkpoint-postgres: 1.0.3 -> 1.0.7
- python3Packages.langgraph-checkpoint-sqlite: 1.01 -> 1.0.2
2. Integrate the above packages into the langgraph-sdk update script.
3. Disable database testing on Darwin where it fails in the sandbox.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
