### PR TITLE
nix-update-source: 0.6.3 -> 0.7.0

### DIFF
--- a/pkgs/tools/package-management/nix-update-source/default.nix
+++ b/pkgs/tools/package-management/nix-update-source/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "nix-update-source";
-  version = "0.6.3";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
+    hash = "sha256-+49Yb+rZ3CzFnwEpwj5xrcMUVBiYOJtCk9YeZ15IM/U=";
     owner = "timbertson";
     repo = "nix-update-source";
     rev = "version-${version}";
-    sha256 = "157wvv9vnaszzwbj68jpdc0imcm1hdab3z760bx2axbsgfpqqilz";
   };
 
   propagatedBuildInputs = [ nix-prefetch-scripts ];
@@ -34,20 +34,25 @@ python3Packages.buildPythonApplication rec {
         overrideSrc = drv: lib.overrideDerivation drv (orig: { inherit src; });
       };
 
-    updateScript = ''
-      #!${runtimeShell}
-      set -e
-      echo
-      cd ${toString ./.}
-      ${pkgs.nix-update-source}/bin/nix-update-source \
-        --prompt version \
-        --replace-attr version \
-        --set owner timbertson \
-        --set repo nix-update-source \
-        --set type fetchFromGitHub \
-        --set rev 'version-{version}' \
-        --modify-nix default.nix
-    '';
+
+    updateScript = [
+      runtimeShell
+      "-c"
+      ''
+        set -e
+        echo
+        cd ${toString ./.}
+        ${pkgs.nix-update-source}/bin/nix-update-source \
+          --prompt version \
+          --replace-attr version \
+          --set owner timbertson \
+          --set repo nix-update-source \
+          --set type fetchFromGitHub \
+          --set rev 'version-{version}' \
+          --nix-literal rev 'version-''${version}'\
+          --modify-nix default.nix
+      ''
+    ];
   };
 
   meta = {


### PR DESCRIPTION
## Description of changes

Adds support for SRI hashes and literal nix attributes. Updated the package's own update script as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
