### PR TITLE
pkgs/by-name: Update manual migration guidelines

### DIFF
--- a/pkgs/by-name/README.md
+++ b/pkgs/by-name/README.md
@@ -79,18 +79,21 @@ and override its value in [`pkgs/top-level/all-packages.nix`](../top-level/all-p
 ## Manual migration guidelines
 
 Most packages are still defined in `all-packages.nix` and the [category hierarchy](../README.md#category-hierarchy).
-Please hold off migrating your maintained packages to this directory.
+Since it would take a lot of contributor and reviewer time to migrate all packages manually,
+an [automated migration is planned](https://github.com/NixOS/nixpkgs/pull/211832),
+though it is expected to still take some time to get done.
+If you're interested in helping out with this effort,
+please see [this ticket](https://github.com/NixOS/nixpkgs-vet/issues/56).
 
-1. An automated migration for the majority of packages [is being worked on](https://github.com/NixOS/nixpkgs/pull/211832).
-   In order to save on contributor and reviewer time, packages should only be migrated manually afterwards if they couldn't be migrated automatically.
+Since [only PRs to packages in `pkgs/by-name` can be automatically merged](../../CONTRIBUTING.md#how-to-merge-pull-requests),
+if package maintainers would like to use this feature, they are welcome to migrate their packages to `pkgs/by-name`.
+To lessen PR traffic, they're encouraged to also perform some more general maintenance on the package in the same PR,
+though this is not required and must not be expected.
 
-1. Manual migrations should only be lightly encouraged if the relevant code is being worked on anyways.
-   For example with a package update or refactoring.
-
-1. Manual migrations should not remove definitions from `all-packages.nix` with custom arguments.
-   That is a backwards-incompatible change because it changes the `.override` interface.
-   Such packages may still be moved to `pkgs/by-name` however, while keeping the definition in `all-packages.nix`.
-   See also [changing implicit attribute defaults](#changing-implicit-attribute-defaults).
+Note that definitions in `all-packages.nix` with custom arguments should not be removed.
+That is a backwards-incompatible change because it changes the `.override` interface.
+Such packages may still be moved to `pkgs/by-name` however, while keeping the definition in `all-packages.nix`.
+See also [changing implicit attribute defaults](#changing-implicit-attribute-defaults).
 
 ## Limitations
 


### PR DESCRIPTION
## Description of changes

Since this original guideline has been written, the new nixpkgs-merge-bot has appeared, and depends on packages being in `pkgs/by-name`. It's totally fine to move packages for that purpose only.

Also update the guidelines to indicate that it might take some time still for the automated migration to be completed.

Ping @mweinelt @eclairevoyant @Atemu @felixsinger from https://github.com/NixOS/nixpkgs/pull/338675

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
