### PR TITLE
remmina: disable web browser plugin by default

### DIFF
--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -2,17 +2,18 @@
 , curl, fuse3, fetchpatch2
 , desktopToDarwinBundle
 , glib, gtk3, gettext, libxkbfile, libX11, python3
-, freerdp3, libssh, libgcrypt, gnutls, vte
+, freerdp3, libssh, libgcrypt, gnutls
 , pcre2, libdbusmenu-gtk3, libappindicator-gtk3
 , libvncserver, libpthreadstubs, libXdmcp, libxkbcommon
 , libsecret, libsoup_3, spice-protocol, spice-gtk, libepoxy, at-spi2-core
-, openssl, gsettings-desktop-schemas, json-glib, libsodium, webkitgtk_4_1, harfbuzz
+, openssl, gsettings-desktop-schemas, json-glib, libsodium, harfbuzz
 , wayland
 # The themes here are soft dependencies; only icons are missing without them.
 , adwaita-icon-theme
 , withKf5Wallet ? stdenv.isLinux, libsForQt5
 , withLibsecret ? stdenv.isLinux
-, withVte ? true
+, withWebkitGtk ? false, webkitgtk_4_1
+, withVte ? true, vte
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,9 +51,10 @@ stdenv.mkDerivation (finalAttrs: {
     openssl adwaita-icon-theme json-glib libsodium
     harfbuzz python3
     wayland
-  ] ++ lib.optionals stdenv.isLinux [ fuse3 libappindicator-gtk3 libdbusmenu-gtk3 webkitgtk_4_1 ]
+  ] ++ lib.optionals stdenv.isLinux [ fuse3 libappindicator-gtk3 libdbusmenu-gtk3 ]
     ++ lib.optionals withLibsecret [ libsecret ]
     ++ lib.optionals withKf5Wallet [ libsForQt5.kwallet ]
+    ++ lib.optionals withWebkitGtk [ webkitgtk_4_1 ]
     ++ lib.optionals withVte [ vte ];
 
   cmakeFlags = [
@@ -62,11 +64,11 @@ stdenv.mkDerivation (finalAttrs: {
     "-DWITH_AVAHI=OFF"
     "-DWITH_KF5WALLET=${if withKf5Wallet then "ON" else "OFF"}"
     "-DWITH_LIBSECRET=${if withLibsecret then "ON" else "OFF"}"
+    "-DWITH_WEBKIT2GTK=${if withWebkitGtk then "ON" else "OFF"}"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DHAVE_LIBAPPINDICATOR=OFF"
     "-DWITH_CUPS=OFF"
     "-DWITH_ICON_CACHE=OFF"
-    "-DWITH_WEBKIT2GTK=OFF"
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin (toString [


### PR DESCRIPTION


## Description of changes

This reduces the closure size from 1.8 GiB to 935.4 MiB.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
