### PR TITLE
qtscrcpy: init at 2.2.1

### DIFF
--- a/pkgs/by-name/qt/qtscrcpy/package.nix
+++ b/pkgs/by-name/qt/qtscrcpy/package.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  libsForQt5,
+  scrcpy,
+  android-tools,
+  ffmpeg_4,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qtscrcpy";
+  version = "2.2.1";
+
+  src =
+    (fetchFromGitHub {
+      owner = "barry-ran";
+      repo = "QtScrcpy";
+      rev = "refs/tags/v${version}";
+      hash = "sha256-PL/UvRNqvLaFuvSHbkJsaJ2nqRp5+ERM+rmlKVtbShk=";
+      fetchSubmodules = true;
+    }).overrideAttrs
+      (_: {
+        GIT_CONFIG_COUNT = 1;
+        GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+        GIT_CONFIG_VALUE_0 = "git@github.com:";
+      });
+
+  patches = [
+    # remove vendored ffmpeg, adb and scrcpy-server
+    ./remove_vendors.patch
+
+    # remove predefined adb and scrcpy-server path
+    # we later set them in wrapper
+    ./remove_predefined_paths.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace QtScrcpy/QtScrcpyCore/{include/QtScrcpyCoreDef.h,src/device/server/server.h} \
+      --replace-fail 'serverVersion = "2.1.1"' 'serverVersion = "${scrcpy.version}"'
+    substituteInPlace QtScrcpy/util/config.cpp \
+      --replace-fail 'COMMON_SERVER_VERSION_DEF "2.1.1"' 'COMMON_SERVER_VERSION_DEF "${scrcpy.version}"'
+    substituteInPlace QtScrcpy/audio/audiooutput.cpp \
+      --replace-fail 'sndcpy.sh' "$out/share/qtscrcpy/sndcpy.sh"
+    substituteInPlace QtScrcpy/sndcpy/sndcpy.sh \
+      --replace-fail 'ADB=./adb' "ADB=${lib.getExe' android-tools "adb"}" \
+      --replace-fail 'SNDCPY_APK=sndcpy.apk' "SNDCPY_APK=$out/share/qtscrcpy/sndcpy.apk"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    libsForQt5.wrapQtAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs =
+    [
+      scrcpy
+      ffmpeg_4
+    ]
+    ++ (with libsForQt5; [
+      qtbase
+      qtmultimedia
+      qtx11extras
+    ]);
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=sign-compare"
+  ];
+
+  # Doesn't contain rule to install
+  installPhase = ''
+    runHook preInstall
+
+    pushd ../output/x64/Release
+      install -Dm755 QtScrcpy -t $out/bin
+      install -Dm755 sndcpy.sh -t $out/share/qtscrcpy
+      install -Dm644 sndcpy.apk -t $out/share/qtscrcpy
+    popd
+
+    install -Dm644 ../QtScrcpy/res/image/tray/logo.png $out/share/pixmaps/qtscrcpy.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "QtScrcpy";
+      exec = "QtScrcpy %U";
+      icon = "qtscrcpy";
+      desktopName = "QtScrcpy";
+      genericName = "Android Display Control";
+      categories = [
+        "Utility"
+        "RemoteAccess"
+      ];
+    })
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --set QTSCRCPY_ADB_PATH ${lib.getExe' android-tools "adb"}
+      --set QTSCRCPY_SERVER_PATH ${scrcpy}/share/scrcpy/scrcpy-server
+    )
+  '';
+
+  meta = {
+    description = "Android real-time display control software";
+    homepage = "https://github.com/barry-ran/QtScrcpy";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      daru-san
+      aleksana
+    ];
+    mainProgram = "QtScrcpy";
+    platforms = with lib.platforms; linux ++ darwin ++ windows;
+    # needs some special handling on darwin as it generates .app bundle directly
+    badPlatforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      # Still includes sndcpy.apk vendored in the same repo
+      # which will run on controlled Android device
+      # https://github.com/barry-ran/QtScrcpy/blob/master/QtScrcpy/sndcpy/sndcpy.apk
+      binaryBytecode
+    ];
+  };
+}

--- a/pkgs/by-name/qt/qtscrcpy/remove_predefined_paths.patch
+++ b/pkgs/by-name/qt/qtscrcpy/remove_predefined_paths.patch
@@ -1,0 +1,27 @@
+diff --git a/QtScrcpy/main.cpp b/QtScrcpy/main.cpp
+index a24ba60..51e3d76 100644
+--- a/QtScrcpy/main.cpp
++++ b/QtScrcpy/main.cpp
+@@ -22,22 +22,16 @@ int main(int argc, char *argv[])
+ {
+     // set env
+ #ifdef Q_OS_WIN32
+-    qputenv("QTSCRCPY_ADB_PATH", "../../../QtScrcpy/QtScrcpyCore/src/third_party/adb/win/adb.exe");
+-    qputenv("QTSCRCPY_SERVER_PATH", "../../../QtScrcpy/QtScrcpyCore/src/third_party/scrcpy-server");
+     qputenv("QTSCRCPY_KEYMAP_PATH", "../../../keymap");
+     qputenv("QTSCRCPY_CONFIG_PATH", "../../../config");
+ #endif
+ 
+ #ifdef Q_OS_OSX
+-    qputenv("QTSCRCPY_ADB_PATH", "../../../../../../QtScrcpy/QtScrcpyCore/src/third_party/adb/mac/adb");
+-    qputenv("QTSCRCPY_SERVER_PATH", "../../../../../../QtScrcpy/QtScrcpyCore/src/third_party/scrcpy-server");
+     qputenv("QTSCRCPY_KEYMAP_PATH", "../../../../../../keymap");
+     qputenv("QTSCRCPY_CONFIG_PATH", "../../../../../../config");
+ #endif
+ 
+ #ifdef Q_OS_LINUX
+-    qputenv("QTSCRCPY_ADB_PATH", "../../../QtScrcpy/QtScrcpyCore/src/third_party/adb/linux/adb");
+-    qputenv("QTSCRCPY_SERVER_PATH", "../../../QtScrcpy/QtScrcpyCore/src/third_party/scrcpy-server");
+     qputenv("QTSCRCPY_KEYMAP_PATH", "../../../keymap");
+     qputenv("QTSCRCPY_CONFIG_PATH", "../../../config");
+ #endif

--- a/pkgs/by-name/qt/qtscrcpy/remove_vendors.patch
+++ b/pkgs/by-name/qt/qtscrcpy/remove_vendors.patch
@@ -1,0 +1,96 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 85c733e..02fea2c 100644
+--- a/QtScrcpy/QtScrcpyCore/CMakeLists.txt
++++ b/QtScrcpy/QtScrcpyCore/CMakeLists.txt
+@@ -139,87 +139,10 @@ target_include_directories(${QSC_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DI
+ target_include_directories(${QSC_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/device/recorder)
+ target_include_directories(${QSC_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/devicemanage)
+ 
+-#
+-# plantform deps
+-#
+ 
+-# windows
+-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+-    # ffmpeg
+-    # include
+-    target_include_directories(${QSC_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/include)
+-    # link
+-    set(FFMPEG_LIB_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/lib/${QSC_CPU_ARCH}")
+-    target_link_directories(${QSC_PROJECT_NAME} PUBLIC ${FFMPEG_LIB_PATH})
+-    target_link_libraries(${QSC_PROJECT_NAME} PRIVATE
+-        avformat
+-        avcodec
+-        avutil
+-        swscale
+-    )
+-    # copy
+-    set(THIRD_PARTY_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party")
+-    set(FFMPEG_BIN_PATH "${THIRD_PARTY_PATH}/ffmpeg/bin/${QSC_CPU_ARCH}")
+-    add_custom_command(TARGET ${QSC_PROJECT_NAME} POST_BUILD
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_BIN_PATH}/avcodec-58.dll" "${QSC_DEPLOY_PATH}"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_BIN_PATH}/avformat-58.dll" "${QSC_DEPLOY_PATH}"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_BIN_PATH}/avutil-56.dll" "${QSC_DEPLOY_PATH}"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_BIN_PATH}/swscale-5.dll" "${QSC_DEPLOY_PATH}"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_BIN_PATH}/swresample-3.dll" "${QSC_DEPLOY_PATH}"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${THIRD_PARTY_PATH}/adb/win/adb.exe" "${QSC_DEPLOY_PATH}"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${THIRD_PARTY_PATH}/adb/win/AdbWinApi.dll" "${QSC_DEPLOY_PATH}"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${THIRD_PARTY_PATH}/adb/win/AdbWinUsbApi.dll" "${QSC_DEPLOY_PATH}"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${THIRD_PARTY_PATH}/scrcpy-server" "${QSC_DEPLOY_PATH}"
+-    )
+-endif()
+ 
+-# MacOS
+-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+-    # ffmpeg
+-    # include
+-    target_include_directories(${QSC_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/include)
+-    # link
+-    set(FFMPEG_LIB_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/lib")
+-    target_link_directories(${QSC_PROJECT_NAME} PUBLIC ${FFMPEG_LIB_PATH})
+-    target_link_libraries(${QSC_PROJECT_NAME} PRIVATE
+-        avformat.58
+-        avcodec.58
+-        avutil.56
+-        swscale.5
+-    )
+-
+-    # copy bundle file
+-    add_custom_command(TARGET ${QSC_PROJECT_NAME} POST_BUILD
+-        # dylib,scrcpy-server,adb copy to Contents/MacOS
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/lib/libavcodec.58.dylib" "${QSC_DEPLOY_PATH}/MacOS"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/lib/libavformat.58.dylib" "${QSC_DEPLOY_PATH}/MacOS"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/lib/libavutil.56.dylib" "${QSC_DEPLOY_PATH}/MacOS"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/lib/libswscale.5.dylib" "${QSC_DEPLOY_PATH}/MacOS"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/lib/libswresample.3.dylib" "${QSC_DEPLOY_PATH}/MacOS"
+-
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/scrcpy-server" "${QSC_DEPLOY_PATH}/MacOS"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/adb/mac/adb" "${QSC_DEPLOY_PATH}/MacOS"
+-    )
+-endif()
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(FFMPEG REQUIRED libavcodec libavformat libavutil libswscale)
+ 
+-# Linux
+-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-    # include
+-    target_include_directories(${QSC_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/include)
+-    # link
+-    set(FFMPEG_LIB_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/lib")
+-    target_link_directories(${QSC_PROJECT_NAME} PUBLIC ${FFMPEG_LIB_PATH})
+-    target_link_libraries(${QSC_PROJECT_NAME} PRIVATE
+-        # ffmpeg
+-        avformat
+-        avcodec
+-        avutil
+-        swscale
+-        z
+-    )
+-
+-    add_custom_command(TARGET ${QSC_PROJECT_NAME} POST_BUILD
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/adb/linux/adb" "${QSC_DEPLOY_PATH}"
+-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/scrcpy-server" "${QSC_DEPLOY_PATH}"
+-    )
+-endif()
++target_link_libraries(${QSC_PROJECT_NAME} PRIVATE ${FFMPEG_LIBRARIES})
++target_include_directories(${QSC_PROJECT_NAME} PRIVATE ${FFMPEG_INCLUDE_DIRS})


### PR DESCRIPTION
## Description of changes

Adds qt-scrcpy, a qt frontend for scrcpy.
Homepage : https://github.com/barry-ran/QtScrcpy

Build unsuccessful at the moment, help would be great :smile: 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
