### PR TITLE
nixos/samba: fix conditional activation of samba services

### DIFF
--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -183,7 +183,7 @@ in
         networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall [ 137 138 ];
       })
 
-      (lib.mkIf cfg.nmbd.enable {
+      (lib.mkIf (cfg.enable && cfg.nmbd.enable) {
         systemd.services.samba-nmbd = {
           description = "Samba NMB Daemon";
           documentation = [ "man:nmbd(8)" "man:samba(7)" "man:smb.conf(5)" ];
@@ -214,7 +214,7 @@ in
         };
       })
 
-      (lib.mkIf cfg.smbd.enable {
+      (lib.mkIf (cfg.enable && cfg.smbd.enable) {
         systemd.services.samba-smbd = {
           description = "Samba SMB Daemon";
           documentation = [ "man:smbd(8)" "man:samba(7)" "man:smb.conf(5)" ];
@@ -250,7 +250,7 @@ in
         };
       })
 
-      (lib.mkIf cfg.winbindd.enable {
+      (lib.mkIf (cfg.enable && cfg.winbindd.enable) {
         systemd.services.samba-winbindd = {
           description = "Samba Winbind Daemon";
           documentation = [ "man:winbindd(8)" "man:samba(7)" "man:smb.conf(5)" ];


### PR DESCRIPTION
## Description of changes

Issue introduced with RFC0042 refactoring: https://github.com/NixOS/nixpkgs/pull/302681

Ensure `nmbd`, `smbd`, and `winbindd` services are only enabled, if both `cfg.enable` and the service-specific flag (eg. `cfg.nmbd.enable`) are set to true.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
