### PR TITLE
nixosTests.gnome-flashback, nixosTests.mate-wayland: Unbreak

### DIFF
--- a/nixos/tests/mate-wayland.nix
+++ b/nixos/tests/mate-wayland.nix
@@ -20,8 +20,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     };
     services.xserver.desktopManager.mate.enableWaylandSession = true;
 
-    hardware.pulseaudio.enable = true;
-
     # Need to switch to a different GPU driver than the default one (-vga std) so that wayfire can launch:
     virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };

--- a/nixos/tests/mate-wayland.nix
+++ b/nixos/tests/mate-wayland.nix
@@ -39,7 +39,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       with subtest("Check if MATE session components actually start"):
           for i in ["wayfire", "mate-panel", "mate-wayland.sh", "mate-wayland-components.sh"]:
               machine.wait_until_succeeds(f"pgrep -f {i}")
-          machine.wait_for_text('(Applications|Places|System)')
           # It is expected that this applet doesn't work in Wayland
           machine.wait_for_text('WorkspaceSwitcherApplet')
 

--- a/pkgs/by-name/gn/gnome-flashback/package.nix
+++ b/pkgs/by-name/gn/gnome-flashback/package.nix
@@ -202,7 +202,7 @@ stdenv.mkDerivation (finalAttrs: {
       }:
       runCommand "gnome-flashback-${wmName}.target" { } ''
         mkdir -p $out/lib/systemd/user
-        cp -r "${finalAttrs.gnome-flashback}/lib/systemd/user/gnome-session@gnome-flashback-metacity.target.d" \
+        cp -r "${finalAttrs.finalPackage}/lib/systemd/user/gnome-session@gnome-flashback-metacity.target.d" \
           "$out/lib/systemd/user/gnome-session@gnome-flashback-${wmName}.target.d"
       '';
 


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->


