### PR TITLE
docs: rust: Improve wording about adding Cargo.lock to src

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -162,9 +162,10 @@ rustPlatform.buildRustPackage {
 }
 ```
 
-Note that setting `cargoLock.lockFile` or `cargoLock.lockFileContents`
-doesn't add a `Cargo.lock` to your `src`, and a `Cargo.lock` is still
-required to build a rust package. A simple fix is to use:
+If the upstream source repository lacks a `Cargo.lock` file, you must add one
+to `src`, as it is essential for building a Rust package. Setting
+`cargoLock.lockFile` or `cargoLock.lockFileContents` will not automatically add
+a `Cargo.lock` file to `src`. A straightforward solution is to use:
 
 ```nix
 {


### PR DESCRIPTION
## Description of changes

Improved the wording about adding the Cargo.lock file to src. It was not clear when this operation was necessary.

## Things done

Only changed Rust docs.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
