### PR TITLE
warp-terminal: 0.2024.08.20.08.02.stable_00 -> 0.2024.09.03.08.02.stable_03

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-EDhj4Gb0ykFX8W2G8osusjggemcuHO7hkUKb151cQ6g=",
-    "version": "0.2024.08.20.08.02.stable_00"
+    "hash": "sha256-EDu3BwNvCsy11pycqwDasSdV1g50fFQCa2eaax3mGTg=",
+    "version": "0.2024.09.03.08.02.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-Uk5pSoAvEppjLnskLc5/ftcCaiJnXATJfCPDP2QpBo8=",
-    "version": "0.2024.08.20.08.02.stable_00"
+    "hash": "sha256-yG7Gr2B5VqDuZfB4RJZYZNt7SNOJ2HSwSCM+1iKhshc=",
+    "version": "0.2024.09.03.08.02.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-B0mUAwydIgi7Nhm/iUhEjkV3LL+qLfXZcOz6+7eDZGc=",
-    "version": "0.2024.08.20.08.02.stable_00"
+    "hash": "sha256-gg5ACoABFesDUhdVBOlv+bQtliQ3N/RZlmzDMuONef8=",
+    "version": "0.2024.09.03.08.02.stable_03"
   }
 }


### PR DESCRIPTION
## Description of changes

Closes: https://github.com/NixOS/nixpkgs/issues/340318

Changelog: https://docs.warp.dev/getting-started/changelog#id-2024.09.05-v0.2024.09.03.08.02

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc