### PR TITLE
darling: fix build

### DIFF
--- a/pkgs/applications/emulators/darling/default.nix
+++ b/pkgs/applications/emulators/darling/default.nix
@@ -3,6 +3,7 @@
 , runCommandWith
 , writeShellScript
 , fetchFromGitHub
+, fetchpatch
 , nixosTests
 
 , freetype
@@ -114,10 +115,26 @@ in stdenv.mkDerivation {
     repo = "darling";
     rev = "25afbc76428c39c3909e9efcf5caef1140425211";
     fetchSubmodules = true;
-    hash = "sha256-T0g38loUFv3jHvUu3R3QH9hwP8JVe2al4g4VhXnBDMc=";
+    hash = "sha256-z9IMgc5hH2Upn8wHl1OgP42q9HTSkeHnxB3N812A+Kc=";
+    # Remove 500MB of dependency test files to get under Hydra output limit
+    postFetch = ''
+      rm -r $out/src/external/openjdk/test
+      rm -r $out/src/external/libmalloc/tests
+      rm -r $out/src/external/libarchive/libarchive/tar/test
+    '';
   };
 
   outputs = [ "out" "sdk" ];
+
+  patches = [
+    # Fix 'clang: error: no such file or directory: .../signal/mach_excUser.c'
+    # https://github.com/darlinghq/darling/issues/1511
+    # https://github.com/darlinghq/darling/commit/f46eb721c11d32addd807f092f4b3a6ea515bb6d
+    (fetchpatch {
+      url = "https://github.com/darlinghq/darling/commit/f46eb721c11d32addd807f092f4b3a6ea515bb6d.patch?full_index=1";
+      hash = "sha256-FnLcHnK4cNto+E3OQSxE3iK+FHSU8y459FcpMvrzd6o=";
+    })
+  ];
 
   postPatch = ''
     # We have to be careful - Patching everything indiscriminately


### PR DESCRIPTION
- add patch from upstream commit fixing build error: https://github.com/darlinghq/darling/commit/f46eb721c11d32addd807f092f4b3a6ea515bb6d
- add postPatch removing 500MB of dependency test files to get under Hydra output limit

## Description of changes


Currently build fails with:
```text
[208/25908] Building C object src/external/xnu/darling/src/libsystem_kernel/emulation/linux/CMakeFiles/emulation.dir/signal/mach_excUser.c.o
FAILED: src/external/xnu/darling/src/libsystem_kernel/emulation/linux/CMakeFiles/emulation.dir/signal/mach_excUser.c.o
/nix/store/xn5ibpsl0g3gc99pdghdpwa527gnp72j-cc-wrapper-bypass/bin/clang -DBSDTHREAD_WRAP_LINUX_PTHREAD -DDARLING -DDARWIN -DEMULATED_OSPRODUCTVERSION=\
"11.7.4\" -DEMULATED_OSVERSION=\"20G1120\" -DEMULATED_RELEASE=\"20.6.0\" -DEMULATED_SYSNAME=\"Darwin\" -DEMULATED_VERSION="\"Darwin Kernel Version 20.6.0\"" -DPLATFORM_MacOSX -DTARGET_OS_MAC=1 -D_DARWIN_C_SOURCE -D_POSIX_C_SOURCE -D__APPLE__ -D__DYNAMIC__ -D__MACH__ -I/build/source/build/src/include -I/build/source/src/include -I/build/source/basic-headers -I/build/source/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -I/build/source/build/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -I/build/source/framework-include -I/build/source/framework-private-include -I/build/source/src/external/lkm/include -I/build/source/src/libDiagnosticMessagesClient/include -I/build/source/src/libMobileGestalt/include -I/build/source/src/lib/include -I/build/source/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libxml2 -I/build/source/build/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libxml2 -I/build/source/src/external/xnu/darling/src/libsystem_kernel -I/build/source/src/external/xnu/darling/src/libsystem_kernel/emulation/linux -I/build/source/build/src/startup -I/build/source/build/src/external/xnu/darling/src/libsystem_kernel/libsyscall -I/build/source/build/src/external/xnu/darling/src/libsystem_kernel/emulation/linux -I/build/source/build/src/external/darlingserver/include -I/build/source/src/external/darlingserver/include -I/build/source/src/libsimple/include -isystem /nix/store/jp7haqy22790sirigbjlfr10m170a7sy-clang-wrapper-18.1.8/resource-root/include -Wno-nullability-completeness -Wno-deprecated-declarations -Wno-availability -Wno-expansion-to-defined -Wno-elaborated-enum-base -Wno-undef-prefix -mmacosx-version-min=11.0 -std=gnu99 -fvisibility=hidden -fPIC -fno-builtin -ggdb -Wno-int-conversion -Wno-compare-distinct-pointer-types   -target x86_64-apple-darwin20  -B /build/source/build/src/external/cctools-port/cctools/misc/ -arch x86_64 -B /build/source/build/src/external/cctools-port/cctools/misc/ -arch x86_64 -MD -MT src/external/xnu/darling/src/libsystem_kernel/emulation/linux/CMakeFiles/emulation.dir/signal/mach_excUser.c.o -MF src/external/xnu/darling/src/libsystem_kernel/emulation/linux/CMakeFiles/emulation.dir/signal/mach_excUser.c.o.d -o src/external/xnu/darling/src/libsystem_kernel/emulation/linux/CMakeFiles/emulation.dir/signal/mach_excUser.c.o -c /build/source/build/src/external/xnu/darling/src/libsystem_kernel/emulation/linux/signal/mach_excUser.c
clang: error: no such file or directory: '/build/source/build/src/external/xnu/darling/src/libsystem_kernel/emulation/linux/signal/mach_excUser.c'
clang: error: no input files
```
Upstream issue:
https://github.com/darlinghq/darling/issues/1511
Commit fixing it:
https://github.com/darlinghq/darling/commit/f46eb721c11d32addd807f092f4b3a6ea515bb6d
(could not find more information upstream)

---

On Hydra package and test does not build because of "Output limit exceeded".
Fixes build of `darling` (fails since `2023-11-17`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.darling.x86_64-linux
https://hydra.nixos.org/build/271165242

Fixes build of `nixosTests.darling` (fails since `2023-11-16`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.darling.x86_64-linux
https://hydra.nixos.org/build/271653953

Size of `src` without postPatch (3512428168 ~3.3GB) exceeds output limit on Hydra (3421225472):
```text
nix path-info /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source --size
/nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source       3512428168
---
/nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source         3.3G
---
226M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/openjdk/test
151M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/libmalloc/tests
148M    /nix/store/rr9zmigbyykmbb9ym3h00dizhc2b72wy-source/src/external/libarchive/libarchive/tar/test
```

Size after (2952729928 ~2.7GB):
```text
nix path-info --size /nix/store/7kphcplf824css0nvbsahahgi1vp0g7l-source
/nix/store/7kphcplf824css0nvbsahahgi1vp0g7l-source       2952729928
---
/nix/store/7kphcplf824css0nvbsahahgi1vp0g7l-source         2.7G
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
