### PR TITLE
nixos/networkmanager: set up /etc/ipsec.secrets as required by the L2TP plugin

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -514,6 +514,12 @@ in
 
     environment.etc = {
       "NetworkManager/NetworkManager.conf".source = configFile;
+
+      # The networkmanager-l2tp plugin expects /etc/ipsec.secrets to include /etc/ipsec.d/ipsec.nm-l2tp.secrets;
+      # see https://github.com/NixOS/nixpkgs/issues/64965
+      "ipsec.secrets".text = ''
+        include ipsec.d/ipsec.nm-l2tp.secrets
+      '';
     }
     // builtins.listToAttrs (map
       (pkg: nameValuePair "NetworkManager/${pkg.networkManagerPlugin}" {


### PR DESCRIPTION
The networkmanager-l2tp plugin (which is always enabled) expects /etc/ipsec.secrets to include /etc/ipsec.d/ipsec.nm-l2tp.secrets; see https://github.com/NixOS/nixpkgs/issues/64965

In order for this to continue working if the strongswan module is enabled, we use `"ipsec.secrets".text` instead of `.source` so that the configurations of both modules are concatenated.

Fixes https://github.com/NixOS/nixpkgs/issues/64965, fixes https://github.com/NixOS/nixpkgs/issues/217628

:warning: **This change will wipe `/etc/ipsec.secrets`, so if you've made manual changes to that file be sure to back them up.**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests): `strongswan-swanctl`, `networking.networkmanager`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
