### PR TITLE
ocaml-ng: remove `__attrsFailEvaluation`

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15792,7 +15792,7 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;
   };
 
-  ocaml-ng = callPackage ./ocaml-packages.nix { } // { __attrsFailEvaluation = true; };
+  ocaml-ng = callPackage ./ocaml-packages.nix { };
   ocaml = ocamlPackages.ocaml;
 
   ocamlPackages = recurseIntoAttrs ocaml-ng.ocamlPackages;


### PR DESCRIPTION
## Motivation for changes

Remove an instance of [`__attrsFailEvaluation`](https://discourse.nixos.org/t/discourse-via-email/29/12).

Previously:

- https://github.com/NixOS/nixpkgs/pull/323854
- https://github.com/NixOS/nixpkgs/pull/323857
- https://github.com/NixOS/nixpkgs/pull/323860
- https://github.com/NixOS/nixpkgs/pull/323865
- https://github.com/NixOS/nixpkgs/pull/323867
- https://github.com/NixOS/nixpkgs/pull/323868
- https://github.com/NixOS/nixpkgs/pull/324622
- https://github.com/NixOS/nixpkgs/pull/324633
- https://github.com/NixOS/nixpkgs/pull/324675
- https://github.com/NixOS/nixpkgs/pull/324680
- https://github.com/NixOS/nixpkgs/pull/324682
- https://github.com/NixOS/nixpkgs/pull/324685
- https://github.com/NixOS/nixpkgs/pull/324688
- https://github.com/NixOS/nixpkgs/pull/324691

## Description of changes

https://gist.github.com/philiptaron/3a5bad8ac3d3c58485f907d4233066c0

The test (`nix-build pkgs/test/release/default.nix`) continues to pass on `x86_64-linux`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
