### PR TITLE
minc-tools: unstable-2020-07-25 -> 2.3.06-unstable-2023-08-12

### DIFF
--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "minc-tools";
-  version = "unstable-2020-07-25";
+  version = "2.3.06-unstable-2023-08-12";
 
   src = fetchFromGitHub {
     owner = "BIC-MNI";
     repo = pname;
-    rev = "fb0a68a07d281e4e099c5d54df29925240de14c1";
-    sha256 = "0zcv2sdj3k6k0xjqdq8j5bxq8smm48dzai90vwsmz8znmbbm6kvw";
+    rev = "c86a767dbb63aaa05ee981306fa09f6133bde427";
+    hash = "sha256-PLNcuDU0ht1PcjloDhrPzpOpE42gbhPP3rfHtP7WnM4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -1,24 +1,54 @@
-{ lib, stdenv, fetchFromGitHub, cmake, makeWrapper, flex, bison, perl, TextFormat,
-  libminc, libjpeg, nifticlib, zlib }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  makeWrapper,
+  flex,
+  bison,
+  perl,
+  TextFormat,
+  libminc,
+  libjpeg,
+  nifticlib,
+  zlib,
+}:
 
 stdenv.mkDerivation rec {
-  pname   = "minc-tools";
+  pname = "minc-tools";
   version = "unstable-2020-07-25";
 
   src = fetchFromGitHub {
-    owner  = "BIC-MNI";
-    repo   = pname;
-    rev    = "fb0a68a07d281e4e099c5d54df29925240de14c1";
+    owner = "BIC-MNI";
+    repo = pname;
+    rev = "fb0a68a07d281e4e099c5d54df29925240de14c1";
     sha256 = "0zcv2sdj3k6k0xjqdq8j5bxq8smm48dzai90vwsmz8znmbbm6kvw";
   };
 
-  nativeBuildInputs = [ cmake flex bison makeWrapper ];
-  buildInputs = [ libminc libjpeg nifticlib zlib ];
-  propagatedBuildInputs = [ perl TextFormat ];
+  nativeBuildInputs = [
+    cmake
+    flex
+    bison
+    makeWrapper
+  ];
 
-  cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/cmake"
-                 "-DZNZ_INCLUDE_DIR=${nifticlib}/include/nifti"
-                 "-DNIFTI_INCLUDE_DIR=${nifticlib}/include/nifti" ];
+  buildInputs = [
+    libminc
+    libjpeg
+    nifticlib
+    zlib
+  ];
+
+  propagatedBuildInputs = [
+    perl
+    TextFormat
+  ];
+
+  cmakeFlags = [
+    "-DLIBMINC_DIR=${libminc}/lib/cmake"
+    "-DZNZ_INCLUDE_DIR=${nifticlib}/include/nifti"
+    "-DNIFTI_INCLUDE_DIR=${nifticlib}/include/nifti"
+  ];
 
   postFixup = ''
     for prog in minccomplete minchistory mincpik; do
@@ -31,6 +61,6 @@ stdenv.mkDerivation rec {
     description = "Command-line utilities for working with MINC files";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;
-    license   = licenses.free;
+    license = licenses.free;
   };
 }


### PR DESCRIPTION
## Description of changes

Routine update and apply `nixfmt`.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
