### PR TITLE
so: fix build

### DIFF
--- a/pkgs/by-name/so/so/package.nix
+++ b/pkgs/by-name/so/so/package.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  inherit (darwin.apple_sdk.frameworks) Security;
+  inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
   self = rustPlatform.buildRustPackage {
     pname = "so";
     version = "0.4.10";
@@ -33,7 +33,9 @@ let
       [ openssl ]
       ++ lib.optionals stdenv.isDarwin [
         libiconv
+        CoreServices
         Security
+        SystemConfiguration
       ];
 
     strictDeps = true;
@@ -56,7 +58,10 @@ let
       changelog = "https://github.com/samtay/so/blob/main/CHANGELOG.md";
       mainProgram = "so";
       license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [ AndersonTorres ];
+      maintainers = with lib.maintainers; [
+        AndersonTorres
+        unsolvedcypher
+      ];
     };
   };
 in


### PR DESCRIPTION
## Description of changes

Building on Darwin aarch-64 fails with:
```
   Compiling so v0.4.10 (/private/tmp/nix-build-so-0.4.10.drv-0/so-source-0.4.10)
error: linking with `/nix/store/2hi8rl1w19i0v57jdcplyfnag9hyk9y3-clang-wrapper-16.0.6/bin/cc` failed: exit status: 1
  |
  = note: env -u IPHONEOS_DEPLOYMENT_TARGET -u TVOS_DEPLOYMENT_TARGET -u XROS_DEPLOYMENT_TARGET LC_ALL="C" PATH="/nix/store/xw16bz6bpzyrrwcwqz32i>
  = note: ld: framework not found CoreServices
          clang-16: error: linker command failed with exit code 1 (use -v to see invocation)


error: could not compile `so` (bin "so") due to 1 previous error
```

Failure seems similar to https://github.com/NixOS/nixpkgs/pull/340323 .

I added the missing build inputs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] Not a significant change for release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
