### PR TITLE
autogluon: init at version 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18039,6 +18039,12 @@
     keys = [ { fingerprint = "7DCA 5615 8AB2 621F 2F32  9FF4 1C7C E491 479F A273"; } ];
     name = "Rahul Butani";
   };
+  rrrodzilla = {
+    email = "roland@govcraft.ai";
+    github = "rrrodzilla";
+    githubId = 24578097;
+    name = "Roland Rodriguez";
+  };
   rski = {
     name = "rski";
     email = "rom.skiad+nix@gmail.com";

--- a/pkgs/by-name/au/autogluon/package.nix
+++ b/pkgs/by-name/au/autogluon/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  makeWrapper,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "autogluon";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "autogluon";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-vM1XSACXzhIEZPXB+QnvN1nBDqQwzNCsZXhSwsHWXuU=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    makeWrapper
+    setuptools
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    numpy
+    pandas
+    scipy
+    scikit-learn
+    tqdm
+    pytz
+    requests
+    boto3
+    pyyaml
+    psutil
+    matplotlib
+    pillow
+    networkx
+  ];
+
+  # Developer note: Tests are disabled because they're not used in the main full_install.sh file
+  # used by autogluon during normal installs which this package aims to replicate.
+  doCheck = false;
+
+  # Create a custom setup.py file before building
+  # Autogluon uses a script file to run the setup.py files in each subdir
+  # so this creates a setup.py file in the root to do the same thing
+  preBuild = ''
+        cat > setup.py << EOF
+    from setuptools import setup, find_namespace_packages
+    setup(
+        name="${pname}",
+        version="${version}",
+        packages=find_namespace_packages(include=['autogluon*']),
+        package_data={"": ["*.txt", "*.md", "*.rst", "*.yml", "*.yaml"]},
+        include_package_data=True,
+        install_requires=[
+            'numpy',
+            'pandas',
+            'scipy',
+            'scikit-learn',
+            'tqdm',
+            'pytz',
+            'requests',
+            'boto3',
+            'pyyaml',
+            'psutil<6,>=5.7.3',
+            'matplotlib',
+            'pillow',
+            'networkx',
+        ],
+    )
+    EOF
+  '';
+
+  postInstall = ''
+    for subpackage in core common features tabular multimodal timeseries eda; do
+      if [ -d "$subpackage" ]; then
+        pushd $subpackage
+        ${python3Packages.python.interpreter} setup.py install --prefix=$out --single-version-externally-managed --root=/
+        popd
+      fi
+    done
+  '';
+
+  # No postFixup needed as this is a Python library package with no executables in $out/bin
+
+  pythonImportsCheck = [ "autogluon" ];
+
+  meta = {
+    description = "AutoML toolkit for deep learning";
+    homepage = "https://github.com/autogluon/autogluon";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rrrodzilla ];
+  };
+}


### PR DESCRIPTION
Reopened after inadvertent closure of #340011
Continued review requested from @yunfachi 
Added AutoGluon 1.1.1 to Nixpkgs. AutoGluon is a machine learning toolkit that automates machine learning tasks. Tests are disabled because they are not used in the main `full_install.sh` file, which is used by AutoGluon during normal installations, and this package aims to replicate that behavior.

https://github.com/autogluon/autogluon/releases/tag/v1.1.1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
