### PR TITLE
[Backport release-24.05] zfs: 2.2.5 -> 2.2.6

### DIFF
--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -213,8 +213,8 @@ in {
     enableSystemdStage1 = true;
   };
 
-  installerBoot = (import ./installer.nix { }).separateBootZfs;
-  installer = (import ./installer.nix { }).zfsroot;
+  installerBoot = (import ./installer.nix { inherit system; }).separateBootZfs;
+  installer = (import ./installer.nix { inherit system; }).zfsroot;
 
   expand-partitions = makeTest {
     name = "multi-disk-zfs";

--- a/pkgs/os-specific/linux/zfs/2_1.nix
+++ b/pkgs/os-specific/linux/zfs/2_1.nix
@@ -1,7 +1,6 @@
 { callPackage
 , kernel ? null
 , stdenv
-, linuxKernel
 , lib
 , nixosTests
 , ...
@@ -15,9 +14,7 @@ callPackage ./generic.nix args {
   # this attribute is the correct one for this package.
   kernelModuleAttribute = "zfs_2_1";
   # check the release notes for compatible kernels
-  kernelCompatible = kernel.kernelOlder "6.8";
-
-  latestCompatibleLinuxPackages = linuxKernel.packages.linux_6_6;
+  kernelCompatible = kernel: kernel.kernelOlder "6.8";
 
   # This is a fixed version to the 2.1.x series, move only
   # if the 2.1.x series moves.

--- a/pkgs/os-specific/linux/zfs/2_2.nix
+++ b/pkgs/os-specific/linux/zfs/2_2.nix
@@ -2,7 +2,6 @@
 , kernel ? null
 , stdenv
 , lib
-, linuxKernel
 , nixosTests
 , ...
 } @ args:
@@ -15,9 +14,7 @@ callPackage ./generic.nix args {
   # this attribute is the correct one for this package.
   kernelModuleAttribute = "zfs_2_2";
   # check the release notes for compatible kernels
-  kernelCompatible = kernel.kernelOlder "6.10";
-
-  latestCompatibleLinuxPackages = linuxKernel.packages.linux_6_6;
+  kernelCompatible = kernel: kernel.kernelOlder "6.10";
 
   # this package should point to the latest release.
   version = "2.2.5";

--- a/pkgs/os-specific/linux/zfs/2_2.nix
+++ b/pkgs/os-specific/linux/zfs/2_2.nix
@@ -14,10 +14,10 @@ callPackage ./generic.nix args {
   # this attribute is the correct one for this package.
   kernelModuleAttribute = "zfs_2_2";
   # check the release notes for compatible kernels
-  kernelCompatible = kernel: kernel.kernelOlder "6.10";
+  kernelCompatible = kernel: kernel.kernelOlder "6.11";
 
   # this package should point to the latest release.
-  version = "2.2.5";
+  version = "2.2.6";
 
   tests = [
     nixosTests.zfs.installer
@@ -26,5 +26,5 @@ callPackage ./generic.nix args {
 
   maintainers = with lib.maintainers; [ adamcstephens amarshall ];
 
-  hash = "sha256-BkwcNPk+jX8CXp5xEVrg4THof7o/5j8RY2SY6+IPNTg=";
+  hash = "sha256-wkgoYg6uQOHVq8a9sJXzO/QXJ6q28l7JXWkC+BFvOb0=";
 }

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -27,7 +27,6 @@ let
   , kernelModuleAttribute
   , extraPatches ? []
   , rev ? "zfs-${version}"
-  , isUnstable ? false
   , latestCompatibleLinuxPackages
   , kernelCompatible ? null
   , maintainers ? (with lib.maintainers; [ amarshall ])

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -182,10 +182,11 @@ let
       # Remove tests because they add a runtime dependency on gcc
       rm -rf $out/share/zfs/zfs-tests
 
-      # Add Bash completions.
-      install -v -m444 -D -t $out/share/bash-completion/completions contrib/bash_completion.d/zfs
-    '' + optionalString (lib.versionOlder version "2.2.6") ''
-      (cd $out/share/bash-completion/completions; ln -s zfs zpool)
+      ${optionalString (lib.versionOlder version "2.2") ''
+        # Add Bash completions.
+        install -v -m444 -D -t $out/share/bash-completion/completions contrib/bash_completion.d/zfs
+        (cd $out/share/bash-completion/completions; ln -s zfs zpool)
+      ''}
     '';
 
     postFixup = let

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -184,6 +184,7 @@ let
 
       # Add Bash completions.
       install -v -m444 -D -t $out/share/bash-completion/completions contrib/bash_completion.d/zfs
+    '' + optionalString (lib.versionOlder version "2.2.6") ''
       (cd $out/share/bash-completion/completions; ln -s zfs zpool)
     '';
 

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -2,6 +2,7 @@ let
   genericBuild =
   { pkgs, lib, stdenv, fetchFromGitHub, fetchpatch
   , autoreconfHook269, util-linux, nukeReferences, coreutils
+  , linuxKernel
   , perl
   , configFile ? "all"
 
@@ -27,7 +28,6 @@ let
   , kernelModuleAttribute
   , extraPatches ? []
   , rev ? "zfs-${version}"
-  , latestCompatibleLinuxPackages
   , kernelCompatible ? null
   , maintainers ? (with lib.maintainers; [ amarshall ])
   , tests
@@ -198,7 +198,13 @@ let
     outputs = [ "out" ] ++ optionals buildUser [ "dev" ];
 
     passthru = {
-      inherit enableMail latestCompatibleLinuxPackages kernelModuleAttribute;
+      inherit enableMail kernelModuleAttribute;
+      latestCompatibleLinuxPackages = lib.pipe linuxKernel.packages [
+        builtins.attrValues
+        (builtins.filter (kPkgs: (builtins.tryEval kPkgs).success && kPkgs ? kernel && kPkgs.kernel.pname == "linux" && kernelCompatible kPkgs.kernel))
+        (builtins.sort (a: b: (lib.versionOlder a.kernel.version b.kernel.version)))
+        lib.last
+      ];
       # The corresponding userspace tools to this instantiation
       # of the ZFS package set.
       userspaceTools = genericBuild (outerArgs // {
@@ -235,7 +241,7 @@ let
       mainProgram = "zfs";
       # If your Linux kernel version is not yet supported by zfs, try zfs_unstable.
       # On NixOS set the option `boot.zfs.package = pkgs.zfs_unstable`.
-      broken = buildKernel && (kernelCompatible != null) && !kernelCompatible;
+      broken = buildKernel && (kernelCompatible != null) && !(kernelCompatible kernel);
     };
   };
 in

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -1,7 +1,6 @@
 { callPackage
 , kernel ? null
 , stdenv
-, linuxKernel
 , nixosTests
 , ...
 } @ args:
@@ -14,9 +13,7 @@ callPackage ./generic.nix args {
   # this attribute is the correct one for this package.
   kernelModuleAttribute = "zfs_unstable";
   # check the release notes for compatible kernels
-  kernelCompatible = kernel.kernelOlder "6.11";
-
-  latestCompatibleLinuxPackages = linuxKernel.packages.linux_6_10;
+  kernelCompatible = kernel: kernel.kernelOlder "6.11";
 
   # this package should point to a version / git revision compatible with the latest kernel release
   # IMPORTANT: Always use a tagged release candidate or commits from the

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -25,7 +25,6 @@ callPackage ./generic.nix args {
   version = "2.2.5";
   # rev = "";
 
-  isUnstable = true;
   tests = [
     nixosTests.zfs.unstable
   ];

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -19,12 +19,12 @@ callPackage ./generic.nix args {
   # IMPORTANT: Always use a tagged release candidate or commits from the
   # zfs-<version>-staging branch, because this is tested by the OpenZFS
   # maintainers.
-  version = "2.2.5";
+  version = "2.2.6";
   # rev = "";
 
   tests = [
     nixosTests.zfs.unstable
   ];
 
-  hash = "sha256-BkwcNPk+jX8CXp5xEVrg4THof7o/5j8RY2SY6+IPNTg=";
+  hash = "sha256-wkgoYg6uQOHVq8a9sJXzO/QXJ6q28l7JXWkC+BFvOb0=";
 }


### PR DESCRIPTION
## Description of changes

I’m on the fence about backporting the changes to `latestCompatibleLinuxPackages`—it does make backporting and maintenance a lot easier. It should also ease backports for Kernel updates and removals as it decouples the ZFS drv from them somewhat. My hesitation is simply that it is a more “substantial” change.

Leaving this draft for a bit for discussion re above and also to let 2.2.6 sit on unstable for a bit before backporting.

## Things done

```
$ nix-instantiate --eval -A zfs_2_1.passthru.latestCompatibleLinuxPackages.kernel.name
"linux-6.6.50"

$ nix-instantiate --eval -A zfs_2_2.passthru.latestCompatibleLinuxPackages.kernel.name
"linux-6.10.9"

$ nix-instantiate --eval -A zfs_unstable.passthru.latestCompatibleLinuxPackages.kernel.name
"linux-6.10.9"
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
