### PR TITLE
lomiri.lomiri*: Init online accounts manager & settings plugin

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -119,6 +119,7 @@ in
             lomiri-history-service
             lomiri-mediaplayer-app
             lomiri-music-app
+            lomiri-notes-app
             lomiri-online-accounts
             lomiri-polkit-agent
             lomiri-schemas # exposes some required dbus interfaces

--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -119,6 +119,7 @@ in
             lomiri-history-service
             lomiri-mediaplayer-app
             lomiri-music-app
+            lomiri-online-accounts
             lomiri-polkit-agent
             lomiri-schemas # exposes some required dbus interfaces
             lomiri-session # wrappers to properly launch the session
@@ -200,6 +201,8 @@ in
       };
 
       environment.pathsToLink = [
+        # Accounts SSO information, for online account management
+        "/share/accounts"
         # Configs for inter-app data exchange system
         "/share/lomiri-content-hub/peers"
         # Configs for inter-app URL requests

--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -97,6 +97,7 @@ in
           (with pkgs; [
             glib # XDG MIME-related tools identify it as GNOME, add gio for MIME identification to work
             libayatana-common
+            libsForQt5.signond # provides SSO-relevant services, for online accounts settings
             ubports-click
           ])
           # Qt5 qtwebengine is not secure: https://github.com/NixOS/nixpkgs/pull/435067

--- a/nixos/tests/lomiri-system-settings.nix
+++ b/nixos/tests/lomiri-system-settings.nix
@@ -37,7 +37,7 @@
   testScript =
     let
       settingsPages = [
-        # Base pages
+        # Order == how they're shown in LSS
         {
           name = "wifi";
           type = "internal";
@@ -48,10 +48,10 @@
           type = "internal";
           element = "discoverable|None detected";
         }
-        # only text we can really look for with VPN is on a button, OCR on CI struggles with it
         {
           name = "vpn";
           type = "internal";
+          # only text we can really look for with VPN is on a button, OCR on CI struggles with it
           element = "Add|Manual|Configuration";
           skipOCR = true;
         }
@@ -76,6 +76,29 @@
           element = "Display language|External keyboard";
         }
         {
+          name = "online-accounts";
+          type = "external";
+          element = "No accounts";
+          elementLocalised = "Keine Konten";
+          # Check that LOA within LSSOA is localised
+          #extraLocalised = ''
+          #  machine.succeed("xdotool mousemove 512 102 click 1")
+          #  machine.wait_for_text("Kennung")
+          #  machine.screenshot("lss_localised_page_online-accounts-plugin")
+          #
+          #  # Return focus
+          #  machine.send_key("shift-tab")
+          #  machine.send_key("shift-tab")
+          #  machine.send_key("shift-tab")
+          #  machine.send_key("shift-tab")
+          #  machine.send_key("shift-tab")
+          #  machine.send_key("shift-tab")
+          #  machine.send_key("shift-tab")
+          #  machine.send_key("shift-tab")
+          #  machine.send_key("shift-tab")
+          #'';
+        }
+        {
           name = "notification";
           type = "internal";
           element = "Apps that notify";
@@ -95,10 +118,9 @@
           type = "internal";
           element = "Time zone|Set the time and date";
         }
-
-        # External plugins
         {
           name = "security-privacy";
+          # No longer external, but elementLocalised check is currently bound to external plugins
           type = "external";
           element = "Locking|unlocking|permissions";
           elementLocalised = "Sperren|Entsperren|Berechtigungen";

--- a/pkgs/desktops/lomiri/applications/lomiri-notes-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-notes-app/default.nix
@@ -1,0 +1,150 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  unstableGitUpdater,
+  accounts-qml-module,
+  boost,
+  cmake,
+  gettext,
+  lomiri-content-hub,
+  lomiri-indicator-network,
+  lomiri-online-accounts-unwrapped,
+  lomiri-push-qml,
+  lomiri-ui-toolkit,
+  openssl,
+  pkg-config,
+  qqc2-suru-style,
+  qtbase,
+  qtdeclarative,
+  qtpim,
+  qtsvg,
+  qtwebsockets,
+  wrapQtAppsHook,
+  writableTmpDirAsHomeHook,
+  xvfb-run,
+}:
+
+let
+  listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-notes-app";
+  version = "1.0.1-unstable-2026-03-26";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/apps/lomiri-notes-app";
+    rev = "4b8a3825b1a1710e2ccebde06a63463977bda4e5";
+    hash = "sha256-w7Hy8IEHOaEwLi09/LzkvyjWWi39GY66a7GAyOrukF0=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'QT_IMPORTS_DIR "''${CMAKE_INSTALL_LIBDIR}/qt5/qml"' 'QT_IMPORTS_DIR "${qtbase.qtQmlPrefix}"'
+  ''
+  # Needs to be in a different place, and named differently
+  + ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'set(ACCOUNT_QML_PLUGIN_DIR ''${CMAKE_INSTALL_DATADIR}/accounts/qml-plugins)' \
+        'set(ACCOUNT_QML_PLUGIN_DIR ''${CMAKE_INSTALL_DATADIR}/lomiri-online-accounts/qml-plugins)'
+
+    substituteInPlace src/account-plugin/CMakeLists.txt \
+      --replace-fail \
+        'DESTINATION ''${ACCOUNT_QML_PLUGIN_DIR}/''${EVERNOTE_ACCOUNT_NAME}' \
+        'DESTINATION ''${ACCOUNT_QML_PLUGIN_DIR}/''${EVERNOTE_PROVIDER_ID}'
+  ''
+  + ''
+    substituteInPlace tests/qml/CMakeLists.txt \
+      --replace-fail 'NO_DEFAULT_PATH' ""
+
+    substituteInPlace tests/qml/tst_NotebooksDelegate.qml \
+      --replace-fail 'delegate: NotebooksDelegate' 'delegate: NotebookDelegate'
+  ''
+  + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'add_subdirectory(tests)' '#add_subdirectory(tests)'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    boost
+    openssl
+    qtbase
+    qtpim
+
+    # Plugin
+    qtsvg
+
+    # QML
+    accounts-qml-module
+    lomiri-content-hub
+    lomiri-indicator-network
+    lomiri-online-accounts-unwrapped
+    lomiri-push-qml
+    lomiri-ui-toolkit
+    qqc2-suru-style
+    qtwebsockets
+  ];
+
+  nativeCheckInputs = [
+    qtdeclarative # qmltestrunner
+    writableTmpDirAsHomeHook
+    xvfb-run
+  ];
+
+  cmakeFlags = [
+    (lib.strings.cmakeBool "CLICK_MODE" false)
+    (lib.strings.cmakeBool "INSTALL_TESTS" false)
+    (lib.strings.cmakeBool "USE_XVFB" true)
+  ];
+
+  # Tests seem broken, have been left disabled since 2022
+  doCheck = false;
+
+  # xvfb-run in parallel
+  enableParallelChecking = false;
+
+  preCheck = ''
+    export QT_PLUGIN_PATH=${
+      listToQtVar qtbase.qtPluginPrefix [
+        qtbase
+        qtsvg
+      ]
+    }
+    export QML2_IMPORT_PATH=${
+      listToQtVar qtbase.qtQmlPrefix [
+        accounts-qml-module
+        lomiri-content-hub
+        lomiri-indicator-network
+        lomiri-online-accounts-unwrapped
+        lomiri-push-qml
+        lomiri-ui-toolkit
+        qqc2-suru-style
+        qtwebsockets
+      ]
+    }
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
+
+  meta = {
+    description = "Advanced note taking application for Ubuntu Touch devices";
+    homepage = "https://gitlab.com/ubports/development/apps/lomiri-notes-app";
+    license = lib.licenses.gpl3Only;
+    teams = [ lib.teams.lomiri ];
+    platforms = lib.platforms.linux;
+    mainProgram = "lomiri-notes-app";
+  };
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/plugins/lomiri-system-settings-online-accounts.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/plugins/lomiri-system-settings-online-accounts.nix
@@ -1,0 +1,87 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  accounts-qt,
+  lomiri-online-accounts-unwrapped,
+  lomiri-online-accounts-plugins,
+  lomiri-system-settings-unwrapped,
+  pkg-config,
+  qmake,
+  qtdeclarative,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-system-settings-online-accounts";
+  version = "0.12";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-system-settings-online-accounts";
+    rev = finalAttrs.version;
+    hash = "sha256-HXu4xIiF1GAVNf7j0+3J9b8xKcQoZvTAZoDZ9BP7UX0=";
+  };
+
+  patches = [
+    # Remove when version > 0.12
+    (fetchpatch {
+      name = "0001-lomiri-system-settings-online-accounts-Fix-LOA-porting-mistake.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings-online-accounts/-/commit/0619fa9d81c244d69744aff3cd96eda16da8fe7d.patch";
+      hash = "sha256-/s9F+fnbGqlCKeFSIZtqeHjx3PN2XMbCLNnJIH2nSck=";
+    })
+  ];
+
+  postPatch =
+    # Get rid of harmless warning
+    ''
+      substituteInPlace po/po.pro \
+        --replace-fail 'message("")' 'message(" ")'
+    ''
+    + ''
+      substituteInPlace common-project-config.pri \
+        --replace-fail '--define-variable=prefix=''$''${INSTALL_PREFIX}' '--define-variable=prefix=''$''${INSTALL_PREFIX} --define-variable=libdir=''$''${INSTALL_PREFIX}/lib'
+    ''
+    # LOA expects "lomiri-system-settings"
+    + ''
+      substituteInPlace system-settings-plugin/ProviderPluginList.qml \
+        --replace-fail 'applicationId: "system-settings"' 'applicationId: "lomiri-system-settings"'
+    '';
+
+  nativeBuildInputs = [
+    pkg-config
+    qmake
+  ];
+
+  buildInputs = [
+    accounts-qt
+    lomiri-system-settings-unwrapped
+    qtdeclarative
+  ];
+
+  propagatedBuildInputs = [
+    lomiri-online-accounts-unwrapped
+  ];
+
+  dontWrapQtApps = true;
+
+  postConfigure = ''
+    make qmake_all
+  '';
+
+  passthru = {
+    # Is this the correct "spot" to propagate this? Needed because LOA usage calls accountsservice, which needs to find LOA-plugins in XDG_DATA_DIRS
+    extraSearchPrefixes = [ lomiri-online-accounts-plugins ];
+    updateScript = gitUpdater { };
+  };
+
+  meta = {
+    description = "Online accounts management plugin for Lomiri system settings";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-system-settings-online-accounts";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-system-settings-online-accounts/-/blob/${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
@@ -4,12 +4,18 @@
   nixosTests,
   glib,
   lndir,
+  lomiri-system-settings-online-accounts,
   lomiri-system-settings-unwrapped,
   wrapGAppsHook3,
   wrapQtAppsHook,
-  plugins ? [ ],
+  plugins ? [ lomiri-system-settings-online-accounts ],
 }:
 
+let
+  pluginsAndTheirExtraPrefixes = lib.lists.foldl (
+    prefixes: plugin: prefixes ++ [ plugin ] ++ (plugin.passthru.extraSearchPrefixes or [ ])
+  ) [ ] plugins;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "lomiri-system-settings";
   inherit (lomiri-system-settings-unwrapped) version;
@@ -30,7 +36,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     glib # schema hook
     lomiri-system-settings-unwrapped
   ]
-  ++ plugins;
+  ++ pluginsAndTheirExtraPrefixes;
 
   installPhase = ''
     runHook preInstall
@@ -43,10 +49,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       lndir ${lomiri-system-settings-unwrapped}/$inheritedPath $out/$inheritedPath
     done
 
-    for mergedPath in lib/lomiri-system-settings share/lomiri-system-settings share/locale; do
-      mkdir -p $out/$mergedPath
-      for lssPart in ${lomiri-system-settings-unwrapped} ${lib.strings.concatStringsSep " " plugins}; do
-        lndir $lssPart/$mergedPath $out/$mergedPath
+    for mergedPath in lib/lomiri-system-settings share/lomiri-system-settings share/accounts share/locale share/lomiri-online-accounts; do
+      for lssPart in ${lomiri-system-settings-unwrapped} ${lib.strings.concatStringsSep " " pluginsAndTheirExtraPrefixes}; do
+        if [ -d $lssPart/$mergedPath ]; then
+          mkdir -p $out/$mergedPath
+          lndir $lssPart/$mergedPath $out/$mergedPath
+        fi
       done
     done
 
@@ -59,6 +67,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     qtWrapperArgs+=(
       "''${gappsWrapperArgs[@]}"
       --set NIX_LSS_PREFIX "$out"
+      --set NIX_LOA_PLUGIN_DIR_PREFIX "$out/share"
+      --set NIX_LOA_PRIVATE_MODULE_DIR_PREFIX "$out/lib"
     )
   '';
 

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -69,6 +69,7 @@ let
       lomiri-gallery-app = callPackage ./applications/lomiri-gallery-app { };
       lomiri-mediaplayer-app = callPackage ./applications/lomiri-mediaplayer-app { };
       lomiri-music-app = callPackage ./applications/lomiri-music-app { };
+      lomiri-notes-app = callPackage ./applications/lomiri-notes-app { };
       lomiri-system-settings-online-accounts =
         callPackage ./applications/lomiri-system-settings/plugins/lomiri-system-settings-online-accounts.nix
           { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -81,6 +81,7 @@ let
       geonames = callPackage ./development/geonames { };
       gmenuharness = callPackage ./development/gmenuharness { };
       libusermetrics = callPackage ./development/libusermetrics { };
+      lomiri-online-accounts-unwrapped = callPackage ./development/lomiri-online-accounts { };
       qtmir = callPackage ./development/qtmir { };
       trust-store = callPackage ./development/trust-store { };
       u1db-qt = callPackage ./development/u1db-qt { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -69,6 +69,9 @@ let
       lomiri-gallery-app = callPackage ./applications/lomiri-gallery-app { };
       lomiri-mediaplayer-app = callPackage ./applications/lomiri-mediaplayer-app { };
       lomiri-music-app = callPackage ./applications/lomiri-music-app { };
+      lomiri-system-settings-online-accounts =
+        callPackage ./applications/lomiri-system-settings/plugins/lomiri-system-settings-online-accounts.nix
+          { };
       lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
       lomiri-system-settings = callPackage ./applications/lomiri-system-settings/wrapper.nix { };
       lomiri-terminal-app = callPackage ./applications/lomiri-terminal-app { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -88,6 +88,7 @@ let
 
       #### QML / QML-related
       lomiri-notifications = callPackage ./qml/lomiri-notifications { };
+      lomiri-online-accounts-plugins = callPackage ./qml/lomiri-online-accounts-plugins { };
       lomiri-push-qml = callPackage ./qml/lomiri-push-qml { };
       lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };
       qqc2-suru-style = callPackage ./qml/qqc2-suru-style { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -85,6 +85,7 @@ let
       gmenuharness = callPackage ./development/gmenuharness { };
       libusermetrics = callPackage ./development/libusermetrics { };
       lomiri-online-accounts-unwrapped = callPackage ./development/lomiri-online-accounts { };
+      lomiri-online-accounts = callPackage ./development/lomiri-online-accounts/wrapper.nix { };
       qtmir = callPackage ./development/qtmir { };
       trust-store = callPackage ./development/trust-store { };
       u1db-qt = callPackage ./development/u1db-qt { };

--- a/pkgs/desktops/lomiri/development/lomiri-online-accounts/2000-Support-wrapping-for-Nixpkgs.patch
+++ b/pkgs/desktops/lomiri/development/lomiri-online-accounts/2000-Support-wrapping-for-Nixpkgs.patch
@@ -1,0 +1,212 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d0cb6e0..51337e0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,14 +58,15 @@ endif()
+ 
+ pkg_check_modules(APPARMOR libapparmor REQUIRED)
+ 
+-set(ONLINE_ACCOUNTS_PLUGIN_DIR ${CMAKE_INSTALL_FULL_DATADIR}/lomiri-online-accounts/qml-plugins)
+-set(ONLINE_ACCOUNTS_PLUGIN_PRIVATE_MODULE_DIR ${CMAKE_INSTALL_FULL_LIBDIR}/lomiri-online-accounts/private)
++set(ONLINE_ACCOUNTS_PLUGIN_DIR_SUFFIX lomiri-online-accounts/qml-plugins)
++set(ONLINE_ACCOUNTS_PLUGIN_PRIVATE_MODULE_DIR_SUFFIX lomiri-online-accounts/private)
+ 
+ set(LOA_I18N_DOMAIN "${PROJECT_NAME}")
+ set(SIGNONUI_I18N_DOMAIN "signon-ui")
+ 
+ include(JoinPaths)
+ join_paths(PC_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
++join_paths(PC_DATADIR "\${prefix}" "${CMAKE_INSTALL_DATADIR}")
+ join_paths(PC_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+ 
+ add_subdirectory(click-hooks)
+diff --git a/online-accounts-plugins/lib/LomiriOnlineAccountsPlugin/CMakeLists.txt b/online-accounts-plugins/lib/LomiriOnlineAccountsPlugin/CMakeLists.txt
+index ffc4667..9333ea7 100644
+--- a/online-accounts-plugins/lib/LomiriOnlineAccountsPlugin/CMakeLists.txt
++++ b/online-accounts-plugins/lib/LomiriOnlineAccountsPlugin/CMakeLists.txt
+@@ -16,7 +16,7 @@ add_definitions(
+     ${SIGNONPLUGINSCOMMON_CFLAGS}
+ )
+ 
+-add_definitions(-DONLINE_ACCOUNTS_PLUGIN_DIR="${ONLINE_ACCOUNTS_PLUGIN_DIR}")
++add_definitions(-DONLINE_ACCOUNTS_PLUGIN_DIR_SUFFIX="${ONLINE_ACCOUNTS_PLUGIN_DIR_SUFFIX}")
+ add_definitions(-DBUILDING_ONLINE_ACCOUNTS_PLUGIN)
+ 
+ set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
+diff --git a/online-accounts-plugins/lib/LomiriOnlineAccountsPlugin/LomiriOnlineAccountsPlugin.pc.in b/online-accounts-plugins/lib/LomiriOnlineAccountsPlugin/LomiriOnlineAccountsPlugin.pc.in
+index 3cbeb1d..b8a9ec6 100644
+--- a/online-accounts-plugins/lib/LomiriOnlineAccountsPlugin/LomiriOnlineAccountsPlugin.pc.in
++++ b/online-accounts-plugins/lib/LomiriOnlineAccountsPlugin/LomiriOnlineAccountsPlugin.pc.in
+@@ -2,7 +2,8 @@ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+ libdir=@PC_LIBDIR@
+ includedir=@PC_INCLUDEDIR@
+-plugin_qml_dir=@ONLINE_ACCOUNTS_PLUGIN_DIR@
++datadir=@PC_DATADIR@
++plugin_qml_dir=${datadir}/@ONLINE_ACCOUNTS_PLUGIN_DIR_SUFFIX@
+ 
+ Name: @PLUGIN_LIB@
+ Description: Online Accounts plugin module for Lomiri
+diff --git a/online-accounts-ui/src/CMakeLists.txt b/online-accounts-ui/src/CMakeLists.txt
+index 17f6d90..ae3f215 100644
+--- a/online-accounts-ui/src/CMakeLists.txt
++++ b/online-accounts-ui/src/CMakeLists.txt
+@@ -25,8 +25,10 @@ add_definitions(
+ add_definitions(-DLOA_I18N_DOMAIN="${LOA_I18N_DOMAIN}")
+ add_definitions(-DSIGNONUI_I18N_DOMAIN="${SIGNONUI_I18N_DOMAIN}")
+ add_definitions(-DDEBUG_ENABLED)
+-add_definitions(-DOAU_PLUGIN_DIR="${ONLINE_ACCOUNTS_PLUGIN_DIR}")
+-add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR="${ONLINE_ACCOUNTS_PLUGIN_PRIVATE_MODULE_DIR}")
++add_definitions(-DOAU_PLUGIN_DIR_PREFIX_FALLBACK="${CMAKE_INSTALL_FULL_DATADIR}")
++add_definitions(-DOAU_PLUGIN_DIR_SUFFIX="${ONLINE_ACCOUNTS_PLUGIN_DIR_SUFFIX}")
++add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR_PREFIX_FALLBACK="${CMAKE_INSTALL_FULL_LIBDIR}")
++add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR_SUFFIX="${ONLINE_ACCOUNTS_PLUGIN_PRIVATE_MODULE_DIR_SUFFIX}")
+ 
+ set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
+ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+diff --git a/online-accounts-ui/src/browser-request.cpp b/online-accounts-ui/src/browser-request.cpp
+index 762e0b8..4c66ed1 100644
+--- a/online-accounts-ui/src/browser-request.cpp
++++ b/online-accounts-ui/src/browser-request.cpp
+@@ -163,7 +163,14 @@ void BrowserRequestPrivate::start()
+         QObject::connect(m_dialog, SIGNAL(finished(int)),
+                          this, SLOT(onFinished()));
+ 
+-        m_dialog->engine()->addImportPath(PLUGIN_PRIVATE_MODULE_DIR);
++        QByteArray nixWrapperPluginPrivateModuleDirPrefix = qgetenv("NIX_LOA_PRIVATE_MODULE_DIR_PREFIX");
++        QString pluginPrivateModuleDir = QDir(
++            !nixWrapperPluginPrivateModuleDirPrefix.isEmpty()
++            ? nixWrapperPluginPrivateModuleDirPrefix
++            : PLUGIN_PRIVATE_MODULE_DIR_PREFIX_FALLBACK
++        ).absoluteFilePath(PLUGIN_PRIVATE_MODULE_DIR_SUFFIX);
++
++        m_dialog->engine()->addImportPath(pluginPrivateModuleDir);
+         m_dialog->rootContext()->setContextProperty("request", this);
+         m_dialog->setSource(QUrl("qrc:/qml/SignOnUiPage.qml"));
+     } else {
+diff --git a/online-accounts-ui/src/dialog-request.cpp b/online-accounts-ui/src/dialog-request.cpp
+index 4eb6ace..063003c 100644
+--- a/online-accounts-ui/src/dialog-request.cpp
++++ b/online-accounts-ui/src/dialog-request.cpp
+@@ -180,8 +180,15 @@ void DialogRequestPrivate::start()
+         QObject::connect(m_dialog, SIGNAL(finished(int)),
+                          this, SLOT(onFinished()));
+ 
++        QByteArray nixWrapperPluginPrivateModuleDirPrefix = qgetenv("NIX_LOA_PRIVATE_MODULE_DIR_PREFIX");
++        QString pluginPrivateModuleDir = QDir(
++            !nixWrapperPluginPrivateModuleDirPrefix.isEmpty()
++            ? nixWrapperPluginPrivateModuleDirPrefix
++            : PLUGIN_PRIVATE_MODULE_DIR_PREFIX_FALLBACK
++        ).absoluteFilePath(PLUGIN_PRIVATE_MODULE_DIR_SUFFIX);
++
+         m_dialog->engine()->addImportPath(q->mountPoint() +
+-                                          PLUGIN_PRIVATE_MODULE_DIR);
++                                          pluginPrivateModuleDir);
+         m_dialog->rootContext()->setContextProperty("request", this);
+         m_dialog->setSource(QUrl("qrc:/qml/SignOnUiDialog.qml"));
+         q->setWindow(m_dialog);
+diff --git a/online-accounts-ui/src/external-browser-request.cpp b/online-accounts-ui/src/external-browser-request.cpp
+index 98cee6b..4c9adcd 100644
+--- a/online-accounts-ui/src/external-browser-request.cpp
++++ b/online-accounts-ui/src/external-browser-request.cpp
+@@ -26,6 +26,7 @@
+ #include <online-accounts-common/i18n.h>
+ 
+ #include <LomiriOnlineAccountsPlugin/request-handler.h>
++#include <QDir>
+ #include <QQmlContext>
+ #include <QQmlEngine>
+ #include <QVariant>
+@@ -104,7 +105,14 @@ void ExternalBrowserRequestPrivate::start()
+         QObject::connect(m_dialog, SIGNAL(finished(int)),
+                          this, SLOT(onFinished()));
+ 
+-        m_dialog->engine()->addImportPath(PLUGIN_PRIVATE_MODULE_DIR);
++        QByteArray nixWrapperPluginPrivateModuleDirPrefix = qgetenv("NIX_LOA_PRIVATE_MODULE_DIR_PREFIX");
++        QString pluginPrivateModuleDir = QDir(
++            !nixWrapperPluginPrivateModuleDirPrefix.isEmpty()
++            ? nixWrapperPluginPrivateModuleDirPrefix
++            : PLUGIN_PRIVATE_MODULE_DIR_PREFIX_FALLBACK
++        ).absoluteFilePath(PLUGIN_PRIVATE_MODULE_DIR_SUFFIX);
++
++        m_dialog->engine()->addImportPath(pluginPrivateModuleDir);
+         m_dialog->rootContext()->setContextProperty("request", this);
+         m_dialog->setSource(QUrl("qrc:/qml/SignOnUiPage.qml"));
+     } else {
+diff --git a/online-accounts-ui/src/provider-request.cpp b/online-accounts-ui/src/provider-request.cpp
+index b134ffa..6435d8c 100644
+--- a/online-accounts-ui/src/provider-request.cpp
++++ b/online-accounts-ui/src/provider-request.cpp
+@@ -25,6 +25,7 @@
+ 
+ #include <LomiriOnlineAccountsPlugin/account-manager.h>
+ #include <LomiriOnlineAccountsPlugin/application-manager.h>
++#include <QDir>
+ #include <QQmlContext>
+ #include <QQmlEngine>
+ #include <QQuickItem>
+@@ -123,8 +124,23 @@ void ProviderRequestPrivate::start()
+                      this, SLOT(onWindowVisibleChanged(bool)));
+     m_view->setResizeMode(QQuickView::SizeRootObjectToView);
+     QString mountPoint = q->mountPoint();
++
++    QByteArray nixWrapperPluginPrivateModuleDirPrefix = qgetenv("NIX_LOA_PRIVATE_MODULE_DIR_PREFIX");
++    QString pluginPrivateModuleDir = QDir(
++        !nixWrapperPluginPrivateModuleDirPrefix.isEmpty()
++        ? nixWrapperPluginPrivateModuleDirPrefix
++        : PLUGIN_PRIVATE_MODULE_DIR_PREFIX_FALLBACK
++    ).absoluteFilePath(PLUGIN_PRIVATE_MODULE_DIR_SUFFIX);
++
++    QByteArray nixWrapperPluginDirPrefix = qgetenv("NIX_LOA_PLUGIN_DIR_PREFIX");
++    QString pluginDir = QDir(
++        !nixWrapperPluginDirPrefix.isEmpty()
++        ? nixWrapperPluginDirPrefix
++        : OAU_PLUGIN_DIR_PREFIX_FALLBACK
++    ).absoluteFilePath(OAU_PLUGIN_DIR_SUFFIX);
++
+     QQmlEngine *engine = m_view->engine();
+-    engine->addImportPath(mountPoint + PLUGIN_PRIVATE_MODULE_DIR);
++    engine->addImportPath(mountPoint + pluginPrivateModuleDir);
+ 
+     /* If the plugin comes from a click package, also add
+      *   <package-dir>/lib
+@@ -142,7 +158,7 @@ void ProviderRequestPrivate::start()
+     QQmlContext *context = m_view->rootContext();
+ 
+     context->setContextProperty("systemQmlPluginPath",
+-                                QUrl::fromLocalFile(mountPoint + OAU_PLUGIN_DIR));
++                                QUrl::fromLocalFile(mountPoint + pluginDir));
+     context->setContextProperty("localQmlPluginPath",
+                                 QUrl::fromLocalFile(QStandardPaths::writableLocation(
+                                     QStandardPaths::GenericDataLocation) +
+diff --git a/tests/online-accounts-ui/tst_browser_request/CMakeLists.txt b/tests/online-accounts-ui/tst_browser_request/CMakeLists.txt
+index 11d31a9..a7cb4f0 100644
+--- a/tests/online-accounts-ui/tst_browser_request/CMakeLists.txt
++++ b/tests/online-accounts-ui/tst_browser_request/CMakeLists.txt
+@@ -37,7 +37,8 @@ set(SOURCES
+ )
+ 
+ add_definitions(-DNO_REQUEST_FACTORY)
+-add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR="/tmp")
++add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR_PREFIX_FALLBACK="/tmp")
++add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR_SUFFIX="")
+ add_definitions(-DSIGNONUI_FAIL_TIMEOUT=100)
+ add_definitions(-DSIGNONUI_I18N_DOMAIN="${SIGNONUI_I18N_DOMAIN}")
+ add_definitions(-DTEST_DATA_DIR="${CMAKE_CURRENT_BINARY_DIR}/data")
+diff --git a/tests/online-accounts-ui/tst_provider_request/CMakeLists.txt b/tests/online-accounts-ui/tst_provider_request/CMakeLists.txt
+index bf00c45..1d38e4d 100644
+--- a/tests/online-accounts-ui/tst_provider_request/CMakeLists.txt
++++ b/tests/online-accounts-ui/tst_provider_request/CMakeLists.txt
+@@ -33,8 +33,10 @@ set(SOURCES
+ 
+ add_definitions(-DNO_REQUEST_FACTORY)
+ add_definitions(-DTEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../data")
+-add_definitions(-DOAU_PLUGIN_DIR="/tmp")
+-add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR="/tmp")
++add_definitions(-DOAU_PLUGIN_DIR_PREFIX_FALLBACK="/tmp")
++add_definitions(-DOAU_PLUGIN_DIR_SUFFIX="")
++add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR_PREFIX_FALLBACK="/tmp")
++add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR_SUFFIX="")
+ 
+ qt_add_resources(UI_RESOURCES tst_provider_request.qrc)
+ 

--- a/pkgs/desktops/lomiri/development/lomiri-online-accounts/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-online-accounts/default.nix
@@ -1,0 +1,196 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  testers,
+  accounts-qml-module,
+  accounts-qt,
+  cmake,
+  ctestCheckHook,
+  dbus-test-runner,
+  gettext,
+  json-glib,
+  libapparmor,
+  libnotify,
+  libqtdbusmock,
+  libqtdbustest,
+  lomiri-ui-toolkit,
+  mesa,
+  pkg-config,
+  python3,
+  qtbase,
+  qtdeclarative,
+  qttools,
+  signond,
+  ubports-click,
+  wrapQtAppsHook,
+  xauth,
+  xmldiff,
+  xvfb-run,
+  withDocumentation ? true,
+}:
+
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-online-accounts-unwrapped";
+  version = "0.20";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-online-accounts";
+    rev = finalAttrs.version;
+    hash = "sha256-vllZ0M5bgVfMrnHgCBshzhDFgAMNNt9tDp8+unxXUL4=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ]
+  ++ lib.optionals withDocumentation [
+    "doc"
+  ];
+
+  patches = [
+    # Remove when version > 0.20
+    (fetchpatch {
+      name = "0001-lomiri-online-accounts-Fix-API-version-substitution-in-qmldir-file.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-online-accounts/-/commit/b0bdc1a982d89c9072907c4c3af305a0d6677fb7.patch";
+      hash = "sha256-1LDSxfZISzh7dtf7mA3V2BsuI9lMOjK2hOHJUtHJb94=";
+    })
+
+    ./2000-Support-wrapping-for-Nixpkgs.patch
+  ];
+
+  postPatch =
+    # QMake-returned value is from QMake's build environment
+    ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail \
+          'QT_INSTALL_QML ''${CMAKE_INSTALL_FULL_LIBDIR}/qt''${QT_VERSION}/qml' \
+          'QT_INSTALL_QML ''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}' \
+        --replace-fail \
+          'qmake -query QT_INSTALL_QML' \
+          'echo ''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}'
+    ''
+    # Don't assume confinement if AppArmor isn't running
+    + ''
+      substituteInPlace online-accounts-service/src/utils.cpp \
+        --replace-fail \
+          'aa_getcon(&label, &mode);' \
+          '
+            char labelUnconfined[] = "unconfined";
+            if (aa_getcon(&label, &mode) == -1) {
+              label = (char*)calloc (sizeof (labelUnconfined) + 2, sizeof (char));
+              strncpy (label, labelUnconfined, sizeof (label));
+            }
+          ' \
+        --replace-fail \
+          'QString appId;' \
+          'QString appId = "unconfined";'
+    '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+  ]
+  ++ lib.optionals withDocumentation [
+    qttools # qdoc
+  ];
+
+  # TODO: accounts-qml-module & lomiri-ui-toolkit? Or via plugin wrapper?
+  buildInputs = [
+    accounts-qt
+    json-glib # for ubports-click
+    libapparmor
+    libnotify
+    qtbase
+    qtdeclarative
+    signond
+    ubports-click
+  ];
+
+  nativeCheckInputs = [
+    ctestCheckHook
+    dbus-test-runner
+    # LUITK sometimes needs a valid OpenGL context
+    # https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/issues/35
+    mesa.llvmpipeHook
+    (python3.withPackages (ps: with ps; [ python-dbusmock ]))
+    xauth
+    xmldiff
+    xvfb-run
+  ];
+
+  checkInputs = [
+    accounts-qml-module
+    libqtdbusmock
+    libqtdbustest
+    lomiri-ui-toolkit
+  ];
+
+  # Done in separate wrapper
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_DOC" withDocumentation) # needs qdoc
+    (lib.cmakeBool "ENABLE_MIRCLIENT" false) # we use Mir 2.x
+    (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" false)
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Breaks test shutdown
+  enableParallelChecking = false;
+
+  preCheck =
+    let
+      listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
+    in
+    ''
+      export QT_PLUGIN_PATH=${listToQtVar qtbase.qtPluginPrefix [ qtbase ]}
+      export QML2_IMPORT_PATH=${
+        listToQtVar qtbase.qtQmlPrefix [
+          accounts-qml-module
+          lomiri-ui-toolkit
+        ]
+      }
+    '';
+
+  disabledTests = [
+    # Known-bad after recent refactor, other test was already disabled by upstream
+    # https://gitlab.com/ubports/development/core/lomiri-online-accounts/-/issues/5
+    "functional_tests"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+    updateScript = gitUpdater { };
+  };
+
+  meta = {
+    description = "Lomiri's simplified Online Accounts API";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-online-accounts";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-online-accounts/-/blob/${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "lomiri-online-accounts-service";
+    teams = [ lib.teams.lomiri ];
+    platforms = lib.platforms.linux;
+    pkgConfigModules = [
+      "LomiriOnlineAccountsClient"
+      "LomiriOnlineAccountsDaemon"
+      "LomiriOnlineAccountsPlugin"
+      "LomiriOnlineAccountsQt5"
+    ];
+  };
+})

--- a/pkgs/desktops/lomiri/development/lomiri-online-accounts/wrapper.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-online-accounts/wrapper.nix
@@ -1,0 +1,77 @@
+{
+  stdenvNoCC,
+  lib,
+  lndir,
+  lomiri-online-accounts-unwrapped,
+  lomiri-online-accounts-plugins,
+  wrapQtAppsHook,
+  accountsSsoPackages ? [
+    lomiri-online-accounts-plugins
+  ],
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lomiri-online-accounts";
+  inherit (lomiri-online-accounts-unwrapped) version;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    lndir
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    lomiri-online-accounts-unwrapped
+  ]
+  ++ accountsSsoPackages;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    lndir ${lomiri-online-accounts-unwrapped}/bin $out/bin
+
+    for inheritedPath in share/applications share/click share/dbus-1/interfaces share/locale; do
+      mkdir -p $out/$inheritedPath
+      lndir ${lomiri-online-accounts-unwrapped}/$inheritedPath $out/$inheritedPath
+    done
+
+    mkdir -p $out/share/dbus-1/services
+    for dbusService in ${lomiri-online-accounts-unwrapped}/share/dbus-1/services/*; do
+      outService=$out/share/dbus-1/services/"$(basename "$dbusService")"
+      cp -v $dbusService $outService
+      substituteInPlace $outService \
+        --replace-fail '${lomiri-online-accounts-unwrapped}' "$out"
+    done
+
+    for mergedPath in share/accounts share/icons share/locale share/lomiri-online-accounts; do
+      for lssPart in ${lomiri-online-accounts-unwrapped} ${lib.strings.concatStringsSep " " accountsSsoPackages}; do
+        if [ -d $lssPart/$mergedPath ]; then
+          mkdir -p $out/$mergedPath
+          lndir $lssPart/$mergedPath $out/$mergedPath
+        fi
+      done
+    done
+
+    runHook postInstall
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --set NIX_LOA_PLUGIN_DIR_PREFIX "$out/share"
+      --set NIX_LOA_PRIVATE_MODULE_DIR_PREFIX "$out/lib"
+    )
+  '';
+
+  meta = lomiri-online-accounts-unwrapped.meta // {
+    description = "${lomiri-online-accounts-unwrapped.meta.description} (wrapped)";
+    priority = (lomiri-online-accounts-unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
+  };
+})

--- a/pkgs/desktops/lomiri/development/lomiri-online-accounts/wrapper.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-online-accounts/wrapper.nix
@@ -2,10 +2,12 @@
   stdenvNoCC,
   lib,
   lndir,
+  lomiri-notes-app,
   lomiri-online-accounts-unwrapped,
   lomiri-online-accounts-plugins,
   wrapQtAppsHook,
   accountsSsoPackages ? [
+    lomiri-notes-app
     lomiri-online-accounts-plugins
   ],
 }:

--- a/pkgs/desktops/lomiri/qml/lomiri-online-accounts-plugins/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-online-accounts-plugins/default.nix
@@ -1,0 +1,84 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  autoreconfHook,
+  gobject-introspection,
+  libaccounts-glib,
+  libsignon-glib,
+  libxml2,
+  lomiri-online-accounts-unwrapped,
+  pkg-config,
+  python3,
+  wrapGAppsHook3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-online-accounts-plugins";
+  version = "0.21";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-online-accounts-plugins";
+    rev = finalAttrs.version;
+    hash = "sha256-9Ngwfy+GCxmtCv4eMdYLWjmbOSbKAtZ3WghX0MV2oIE=";
+  };
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace-fail \
+        '$PKG_CONFIG --variable plugin_qml_dir --define-variable=prefix=$real_prefix LomiriOnlineAccountsPlugin' \
+        '$PKG_CONFIG --variable plugin_qml_dir --define-variable=datadir=$real_prefix/share LomiriOnlineAccountsPlugin'
+
+    substituteInPlace tools/lomiri-account-console \
+      --replace-fail 'see /usr/share' "see $out/share"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gobject-introspection
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    libaccounts-glib
+    libsignon-glib
+    lomiri-online-accounts-unwrapped
+    (python3.withPackages (
+      ps: with ps; [
+        pygobject3
+        (toPythonModule libaccounts-glib.py)
+      ]
+    ))
+  ];
+
+  nativeCheckInputs = [
+    libxml2 # xmllint
+  ];
+
+  configureFlags = [
+    (lib.strings.enableFeature true "qml-plugins")
+    (lib.strings.enableFeature finalAttrs.finalPackage.doCheck "tests")
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    updateScript = gitUpdater { };
+  };
+
+  meta = {
+    description = "Account configuration plugins for the credentials configuration panel";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-online-accounts-plugins";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-online-accounts-plugins/-/blob/${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl2Plus;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards https://github.com/NixOS/nixpkgs/issues/99090.

This inits:

- [Lomiri Online Accounts](https://gitlab.com/ubports/development/core/lomiri-online-accounts), the API for Lomiri's simplified online accounts management
- [Lomiri Online Accounts Plugins](https://gitlab.com/ubports/development/core/lomiri-online-accounts-plugins), plugins to create & manage accounts for various online services
- [Lomiri System Settings Online Accounts](https://gitlab.com/ubports/development/core/lomiri-system-settings-online-accounts), a settings app plugin to allow managing one's online accounts

This also fixes an issue with the localisation in LSS, which I didn't spot in the latest OTA update.

The settings app page shows up, but without any services being listed by default. This behaviour is identical to what happens on Debian if I build the involved packages there, ~~so not sure what's wrong. Don't have a device to test it on UBtouch~~. Seems to be expected behaviour, see https://github.com/NixOS/nixpkgs/pull/340391#issuecomment-2362325473 for reason.

I don't think this is urgently needed, so I'll leave this as-is and see if there's any updates upstream on this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
