### PR TITLE
amber-lang: 0.3.3-alpha -> 0.3.5-alpha, `passthru.updateScript`

### DIFF
--- a/pkgs/by-name/am/amber-lang/package.nix
+++ b/pkgs/by-name/am/amber-lang/package.nix
@@ -7,6 +7,7 @@
   makeWrapper,
   runCommand,
   amber-lang,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -45,10 +46,13 @@ rustPlatform.buildRustPackage rec {
     wrapProgram "$out/bin/amber" --prefix PATH : "${lib.makeBinPath [ bc ]}"
   '';
 
-  passthru.tests.run = runCommand "amber-lang-eval-test" { nativeBuildInputs = [ amber-lang ]; } ''
-    diff -U3 --color=auto <(amber -e 'echo "Hello, World"') <(echo 'Hello, World')
-    touch $out
-  '';
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.run = runCommand "amber-lang-eval-test" { nativeBuildInputs = [ amber-lang ]; } ''
+      diff -U3 --color=auto <(amber -e 'echo "Hello, World"') <(echo 'Hello, World')
+      touch $out
+    '';
+  };
 
   meta = with lib; {
     description = "Programming language compiled to bash";

--- a/pkgs/by-name/am/amber-lang/package.nix
+++ b/pkgs/by-name/am/amber-lang/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "amber-lang";
-  version = "0.3.3-alpha";
+  version = "0.3.5-alpha";
 
   src = fetchFromGitHub {
-    owner = "Ph0enixKM";
-    repo = "Amber";
+    owner = "amber-lang";
+    repo = "amber";
     rev = version;
-    hash = "sha256-Al1zTwQufuVGSlttf02s5uI3cyCNDShhzMT3l9Ctv3Y=";
+    hash = "sha256-wf0JNWNliDGNvlbWoatPqDKmVaBzHeCKOvJWuE9PnpQ=";
   };
 
-  cargoHash = "sha256-HbkIkCVy2YI+nP5t01frXBhlp/rCsB6DwLL53AHJ4vE=";
+  cargoHash = "sha256-6T4WcQkCMR8W67w0uhhN8W0FlLsrTUMa3/xRXDtW4Es=";
 
   preConfigure = ''
     substituteInPlace src/compiler.rs \
@@ -34,6 +34,11 @@ rustPlatform.buildRustPackage rec {
     # 'rev' in generated bash script of test
     # tests::validity::variable_ref_function_invocation
     util-linux
+  ];
+
+  checkFlags = [
+    "--skip=tests::extra::download"
+    "--skip=tests::formatter::all_exist"
   ];
 
   postInstall = ''


### PR DESCRIPTION
## Description of changes
Updates to latest version, and adds update script so we don't have to do this
manually.

- **amber-lang: 0.3.3-alpha -> 0.3.5-alpha**
- **amber-lang: add `passthru.updateScript`**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
