### PR TITLE
nixos/minio: add TLS certificates option

### DIFF
--- a/nixos/modules/services/web-servers/minio.nix
+++ b/nixos/modules/services/web-servers/minio.nix
@@ -40,6 +40,12 @@ in
       description = "The config directory, for the access keys and other settings.";
     };
 
+    certificatesDir = mkOption {
+      default = "/var/lib/minio/certs";
+      type = types.path;
+      description = "The directory where TLS certificates are stored.";
+    };
+
     accessKey = mkOption {
       default = "";
       type = types.str;
@@ -102,7 +108,7 @@ in
         after = [ "network-online.target" ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
-          ExecStart = "${cfg.package}/bin/minio server --json --address ${cfg.listenAddress} --console-address ${cfg.consoleAddress} --config-dir=${cfg.configDir} ${toString cfg.dataDir}";
+          ExecStart = "${cfg.package}/bin/minio server --json --address ${cfg.listenAddress} --console-address ${cfg.consoleAddress} --config-dir=${cfg.configDir} --certs-dir=${cfg.certificatesDir} ${toString cfg.dataDir}";
           Type = "simple";
           User = "minio";
           Group = "minio";

--- a/nixos/tests/minio.nix
+++ b/nixos/tests/minio.nix
@@ -1,16 +1,35 @@
 import ./make-test-python.nix ({ pkgs, ... }:
   let
+    tls-cert =
+      pkgs.runCommand "selfSignedCerts" { buildInputs = [ pkgs.openssl ]; } ''
+        openssl req \
+          -x509 -newkey rsa:4096 -sha256 -days 365 \
+          -nodes -out cert.pem -keyout key.pem \
+          -subj '/CN=minio' -addext "subjectAltName=DNS:localhost"
+
+        mkdir -p $out
+        cp key.pem cert.pem $out
+      '';
+
     accessKey = "BKIKJAA5BMMU2RHO6IBB";
     secretKey = "V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12";
     minioPythonScript = pkgs.writeScript "minio-test.py" ''
       #! ${pkgs.python3.withPackages(ps: [ ps.minio ])}/bin/python
       import io
       import os
+      import sys
       from minio import Minio
+
+      if len(sys.argv) > 1 and sys.argv[1] == 'tls':
+        tls = True
+      else:
+        tls = False
+
       minioClient = Minio('localhost:9000',
                     access_key='${accessKey}',
                     secret_key='${secretKey}',
-                    secure=False)
+                    secure=tls,
+                    cert_check=False)
       sio = io.BytesIO()
       sio.write(b'Test from Python')
       sio.seek(0, os.SEEK_END)
@@ -56,6 +75,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
       machine.wait_for_unit("multi-user.target")
       machine.copy_from_host("${credsFull}", "${rootCredentialsFile}")
 
+      # Test non-TLS server
       machine.wait_for_unit("minio.service")
       machine.wait_for_open_port(9000)
 
@@ -67,6 +87,27 @@ import ./make-test-python.nix ({ pkgs, ... }:
       machine.succeed("${minioPythonScript}")
       assert "test-bucket" in machine.succeed("mc ls minio")
       assert "Test from Python" in machine.succeed("mc cat minio/test-bucket/test.txt")
+      machine.succeed("mc rb --force minio/test-bucket")
+      machine.systemctl("stop minio.service")
+
+      # Test TLS server
+      machine.copy_from_host("${tls-cert}/cert.pem", "/var/lib/minio/certs/public.crt")
+      machine.copy_from_host("${tls-cert}/key.pem", "/var/lib/minio/certs/private.key")
+
+      machine.systemctl("start minio.service")
+      machine.wait_for_unit("minio.service")
+      machine.wait_for_open_port(9000)
+
+      # Create a test bucket on the server
+      machine.succeed(
+          "mc config host add minio https://localhost:9000 ${accessKey} ${secretKey} --api s3v4"
+      )
+      machine.succeed("mc --insecure mb minio/test-bucket")
+      machine.succeed("${minioPythonScript} tls")
+      assert "test-bucket" in machine.succeed("mc --insecure ls minio")
+      assert "Test from Python" in machine.succeed("mc --insecure cat minio/test-bucket/test.txt")
+      machine.succeed("mc --insecure rb --force minio/test-bucket")
+
       machine.shutdown()
     '';
   })


### PR DESCRIPTION
## Description of changes

Added option to specify TLS certificates directory to MinIO service.
Added test to verify correct functioning of MinIO when set up with TLS certificates.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
