### PR TITLE
nixos/tests: don't include switch-to-configuration in DUT by default

### DIFF
--- a/nixos/lib/testing/nixos-test-base.nix
+++ b/nixos/lib/testing/nixos-test-base.nix
@@ -3,7 +3,7 @@
 # even in `inheritParentConfig = false` specialisations.
 { lib, ... }:
 let
-  inherit (lib) mkForce;
+  inherit (lib) mkDefault mkForce;
 in
 {
   imports = [
@@ -22,6 +22,11 @@ in
         label = mkForce "test";
       };
     }
-
+    ({ config, ... }: {
+      # Don't pull in switch-to-configuration by default, except when specialisations are involved.
+      # This is mostly a Hydra optimization, so we don't rebuild all the tests every time switch-to-configuration-ng changes.
+      key = "no-switch-to-configuration";
+      system.switch.enable = mkDefault (config.isSpecialisation || config.specialisation != {});
+    })
   ];
 }

--- a/nixos/modules/system/activation/no-clone.nix
+++ b/nixos/modules/system/activation/no-clone.nix
@@ -5,4 +5,5 @@ with lib;
 {
   boot.loader.grub.device = mkOverride 0 "nodev";
   specialisation = mkOverride 0 {};
+  isSpecialisation = mkOverride 0 true;
 }

--- a/nixos/modules/system/activation/specialisation.nix
+++ b/nixos/modules/system/activation/specialisation.nix
@@ -23,6 +23,12 @@ let
 in
 {
   options = {
+    isSpecialisation = mkOption {
+      type = lib.types.bool;
+      internal = true;
+      default = false;
+      description = "Whether this system is a specialisation of another.";
+    };
 
     specialisation = mkOption {
       default = { };

--- a/nixos/tests/chrony.nix
+++ b/nixos/tests/chrony.nix
@@ -23,7 +23,8 @@ import ./make-test-python.nix ({ lib, ... }:
     machine.start()
     machine.wait_for_unit('multi-user.target')
     machine.succeed('systemctl is-active chronyd.service')
-    machine.succeed('/run/current-system/specialisation/hardened/bin/switch-to-configuration test')
-    machine.succeed('systemctl is-active chronyd.service')
+    machine.succeed('/run/booted-system/specialisation/hardened/bin/switch-to-configuration test')
+    machine.succeed('systemctl restart chronyd.service')
+    machine.wait_for_unit('chronyd.service')
   '';
 })

--- a/nixos/tests/chrony.nix
+++ b/nixos/tests/chrony.nix
@@ -7,25 +7,23 @@ import ./make-test-python.nix ({ lib, ... }:
   };
 
   nodes = {
-    default = {
+    machine = {
       services.chrony.enable = true;
-    };
-    graphene-hardened = {
-      services.chrony.enable = true;
-      services.chrony.enableMemoryLocking = true;
-      environment.memoryAllocator.provider = "graphene-hardened";
-      # dhcpcd privsep is incompatible with graphene-hardened
-      networking.useNetworkd = true;
+
+      specialisation.hardened.configuration = {
+        services.chrony.enableMemoryLocking = true;
+        environment.memoryAllocator.provider = "graphene-hardened";
+        # dhcpcd privsep is incompatible with graphene-hardened
+        networking.useNetworkd = true;
+      };
     };
   };
 
-  testScript = {nodes, ...} : let
-    graphene-hardened = nodes.graphene-hardened.system.build.toplevel;
-  in ''
-    default.start()
-    default.wait_for_unit('multi-user.target')
-    default.succeed('systemctl is-active chronyd.service')
-    default.succeed('${graphene-hardened}/bin/switch-to-configuration test')
-    default.succeed('systemctl is-active chronyd.service')
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit('multi-user.target')
+    machine.succeed('systemctl is-active chronyd.service')
+    machine.succeed('/run/current-system/specialisation/hardened/bin/switch-to-configuration test')
+    machine.succeed('systemctl is-active chronyd.service')
   '';
 })

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -1,71 +1,57 @@
 import ./make-test-python.nix ({ pkgs, lib, ... }:
-let
-  client_base = {
-    containers.test1 = {
-      autoStart = true;
-      config = {
-        environment.etc.check.text = "client_base";
-      };
-    };
-
-    # prevent make-test-python.nix to change IP
-    networking.interfaces = {
-      eth1.ipv4.addresses = lib.mkOverride 0 [ ];
-    };
-  };
-in {
+{
   name = "containers-reloadable";
   meta = {
     maintainers = with lib.maintainers; [ danbst ];
   };
 
   nodes = {
-    client = { ... }: {
-      imports = [ client_base ];
-    };
-
-    client_c1 = { lib, ... }: {
-      imports = [ client_base ];
-
-      containers.test1.config = {
-        environment.etc.check.text = lib.mkForce "client_c1";
-        services.httpd.enable = true;
-        services.httpd.adminAddr = "nixos@example.com";
+    machine = { lib, ... }: {
+      containers.test1 = {
+        autoStart = true;
+        config.environment.etc.check.text = "client_base";
       };
-    };
-    client_c2 = { lib, ... }: {
-      imports = [ client_base ];
 
-      containers.test1.config = {
-        environment.etc.check.text = lib.mkForce "client_c2";
-        services.nginx.enable = true;
+      # prevent make-test-python.nix to change IP
+      networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [ ];
+
+      specialisation.c1.configuration = {
+        containers.test1.config = {
+          environment.etc.check.text = lib.mkForce "client_c1";
+          services.httpd.enable = true;
+          services.httpd.adminAddr = "nixos@example.com";
+        };
+      };
+
+      specialisation.c2.configuration = {
+        containers.test1.config = {
+          environment.etc.check.text = lib.mkForce "client_c2";
+          services.nginx.enable = true;
+        };
       };
     };
   };
 
-  testScript = {nodes, ...}: let
-    c1System = nodes.client_c1.config.system.build.toplevel;
-    c2System = nodes.client_c2.config.system.build.toplevel;
-  in ''
-    client.start()
-    client.wait_for_unit("default.target")
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("default.target")
 
-    assert "client_base" in client.succeed("nixos-container run test1 cat /etc/check")
+    assert "client_base" in machine.succeed("nixos-container run test1 cat /etc/check")
 
     with subtest("httpd is available after activating config1"):
-        client.succeed(
-            "${c1System}/bin/switch-to-configuration test >&2",
+        machine.succeed(
+            "/run/booted-system/specialisation/c1/bin/switch-to-configuration test >&2",
             "[[ $(nixos-container run test1 cat /etc/check) == client_c1 ]] >&2",
             "systemctl status httpd -M test1 >&2",
         )
 
     with subtest("httpd is not available any longer after switching to config2"):
-        client.succeed(
-            "${c2System}/bin/switch-to-configuration test >&2",
+        machine.succeed(
+            "/run/booted-system/specialisation/c2/bin/switch-to-configuration test >&2",
             "[[ $(nixos-container run test1 cat /etc/check) == client_c2 ]] >&2",
             "systemctl status nginx -M test1 >&2",
         )
-        client.fail("systemctl status httpd -M test1 >&2")
+        machine.fail("systemctl status httpd -M test1 >&2")
   '';
 
 })

--- a/nixos/tests/containers-restart_networking.nix
+++ b/nixos/tests/containers-restart_networking.nix
@@ -1,20 +1,4 @@
-let
-  client_base = {
-    networking.firewall.enable = false;
-
-    containers.webserver = {
-      autoStart = true;
-      privateNetwork = true;
-      hostBridge = "br0";
-      config = {
-        networking.firewall.enable = false;
-        networking.interfaces.eth0.ipv4.addresses = [
-          { address = "192.168.1.122"; prefixLength = 24; }
-        ];
-      };
-    };
-  };
-in import ./make-test-python.nix ({ pkgs, lib, ... }:
+import ./make-test-python.nix ({ pkgs, lib, ... }:
 {
   name = "containers-restart_networking";
   meta = {
@@ -22,46 +6,55 @@ in import ./make-test-python.nix ({ pkgs, lib, ... }:
   };
 
   nodes = {
-    client = { lib, ... }: client_base // {
+    client = {
       virtualisation.vlans = [ 1 ];
+
+      networking.firewall.enable = false;
+
+      containers.webserver = {
+        autoStart = true;
+        privateNetwork = true;
+        hostBridge = "br0";
+        config = {
+          networking.firewall.enable = false;
+          networking.interfaces.eth0.ipv4.addresses = [
+            { address = "192.168.1.122"; prefixLength = 24; }
+          ];
+        };
+      };
 
       networking.bridges.br0 = {
         interfaces = [];
         rstp = false;
       };
-      networking.interfaces = {
-        eth1.ipv4.addresses = lib.mkOverride 0 [ ];
-        br0.ipv4.addresses = [ { address = "192.168.1.1"; prefixLength = 24; } ];
+
+      networking.interfaces.br0.ipv4.addresses = [ { address = "192.168.1.1"; prefixLength = 24; } ];
+
+      specialisation.eth1.configuration = {
+        networking.bridges.br0.interfaces = [ "eth1" ];
+        networking.interfaces = {
+          eth1.ipv4.addresses = lib.mkForce [ ];
+          eth1.ipv6.addresses = lib.mkForce [ ];
+          br0.ipv4.addresses = [ { address = "192.168.1.2"; prefixLength = 24; } ];
+        };
       };
 
-    };
-    client_eth1 = { lib, ... }: client_base // {
-      networking.bridges.br0 = {
-        interfaces = [ "eth1" ];
-        rstp = false;
-      };
-      networking.interfaces = {
-        eth1.ipv4.addresses = lib.mkOverride 0 [ ];
-        br0.ipv4.addresses = [ { address = "192.168.1.2"; prefixLength = 24; } ];
-      };
-    };
-    client_eth1_rstp = { lib, ... }: client_base // {
-      networking.bridges.br0 = {
-        interfaces = [ "eth1" ];
-        rstp = true;
-      };
-      networking.interfaces = {
-        eth1.ipv4.addresses = lib.mkOverride 0 [ ];
-        br0.ipv4.addresses =  [ { address = "192.168.1.2"; prefixLength = 24; } ];
+      specialisation.eth1-rstp.configuration = {
+        networking.bridges.br0 = {
+          interfaces = [ "eth1" ];
+          rstp = lib.mkForce true;
+        };
+
+        networking.interfaces = {
+          eth1.ipv4.addresses = lib.mkForce [ ];
+          eth1.ipv6.addresses = lib.mkForce [ ];
+          br0.ipv4.addresses = [ { address = "192.168.1.2"; prefixLength = 24; } ];
+        };
       };
     };
   };
 
-  testScript = {nodes, ...}: let
-    originalSystem = nodes.client.config.system.build.toplevel;
-    eth1_bridged = nodes.client_eth1.config.system.build.toplevel;
-    eth1_rstp = nodes.client_eth1_rstp.config.system.build.toplevel;
-  in ''
+  testScript = ''
     client.start()
 
     client.wait_for_unit("default.target")
@@ -75,7 +68,7 @@ in import ./make-test-python.nix ({ pkgs, lib, ... }:
 
     with subtest("Bridged configuration without STP preserves connectivity"):
         client.succeed(
-            "${eth1_bridged}/bin/switch-to-configuration test >&2"
+            "/run/booted-system/specialisation/eth1/bin/switch-to-configuration test >&2"
         )
 
         client.succeed(
@@ -87,7 +80,7 @@ in import ./make-test-python.nix ({ pkgs, lib, ... }:
 
     #  activating rstp needs another service, therefore the bridge will restart and the container will lose its connectivity
     # with subtest("Bridged configuration with STP"):
-    #     client.succeed("${eth1_rstp}/bin/switch-to-configuration test >&2")
+    #     client.succeed("/run/booted-system/specialisation/eth1-rstp/bin/switch-to-configuration test >&2")
     #     client.execute("ip -4 a >&2")
     #     client.execute("ip l >&2")
     #
@@ -100,7 +93,7 @@ in import ./make-test-python.nix ({ pkgs, lib, ... }:
 
     with subtest("Reverting to initial configuration preserves connectivity"):
         client.succeed(
-            "${originalSystem}/bin/switch-to-configuration test >&2"
+            "/run/booted-system/bin/switch-to-configuration test >&2"
         )
 
         client.succeed("ping 192.168.1.122 -c 1 -n >&2")

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -635,6 +635,7 @@ let
             (python3.withPackages (p: [ p.mistune ]))
             shared-mime-info
             sudo
+            switch-to-configuration-ng
             texinfo
             unionfs-fuse
             xorg.lndir
@@ -648,6 +649,10 @@ let
           in [
             (pkgs.grub2.override { inherit zfsSupport; })
             (pkgs.grub2_efi.override { inherit zfsSupport; })
+            pkgs.nixos-artwork.wallpapers.simple-dark-gray-bootloader
+            pkgs.perlPackages.FileCopyRecursive
+            pkgs.perlPackages.XMLSAX
+            pkgs.perlPackages.XMLSAXBase
           ])
           ++ optionals (bootLoader == "systemd-boot") [
             pkgs.zstd.bin

--- a/nixos/tests/restart-by-activation-script.nix
+++ b/nixos/tests/restart-by-activation-script.nix
@@ -7,6 +7,8 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   nodes.machine = { pkgs, ... }: {
     imports = [ ../modules/profiles/minimal.nix ];
 
+    system.switch.enable = true;
+
     systemd.services.restart-me = {
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -591,6 +591,7 @@ in {
     };
 
     other = {
+      system.switch.enable = true;
       users.mutableUsers = true;
     };
   };

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -13,6 +13,7 @@ let
     boot.loader.systemd-boot.enable = true;
     boot.loader.efi.canTouchEfiVariables = true;
     environment.systemPackages = [ pkgs.efibootmgr ];
+    system.switch.enable = true;
   };
 
   commonXbootldr = { config, lib, pkgs, ... }:

--- a/nixos/tests/user-activation-scripts.nix
+++ b/nixos/tests/user-activation-scripts.nix
@@ -3,6 +3,7 @@ import ./make-test-python.nix ({ lib, ... }: {
   meta = with lib.maintainers; { maintainers = [ chkno ]; };
 
   nodes.machine = {
+    system.switch.enable = true;
     system.userActivationScripts.foo = "mktemp ~/user-activation-ran.XXXXXX";
     users.users.alice = {
       initialPassword = "pass1";


### PR DESCRIPTION
## Description of changes

Should save a bunch of rebuilds on Hydra.

Overall, there are three types of tests that use switch-to-configuration in Hydra:

1. Tests for switch-to-configuration itself
2. Tests that use specializations to set up different configurations of software under test faster
3. Tests that use separate NixOS configs activated on the same VM to do the same thing

Group 1 gets stc enabled explicitly; group 2 gets stc enabled by default in presence of specializations; group 3 is refactored and absorbed into group 2. All the affected tests still work, as does a random sample of unaffected ones.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
