### PR TITLE
box2d: 2.4.2 -> 3.1.0

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -10,7 +10,7 @@
   libxslt,
   perl,
   perlPackages,
-  box2d,
+  box2d_2,
   gettext,
   zlib,
   libjpeg,
@@ -397,7 +397,7 @@ stdenv.mkDerivation (finalAttrs: {
       ant
       bluez5
       boost
-      box2d
+      box2d_2
       cairo
       clucene_core_2
       cppunit

--- a/pkgs/by-name/bo/box2d/cmake_dont_fetch_enkits.patch
+++ b/pkgs/by-name/bo/box2d/cmake_dont_fetch_enkits.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8c1390e..791d3b7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -83,10 +83,7 @@ if(PROJECT_IS_TOP_LEVEL)
+ 		# Used in tests and samples
+ 		FetchContent_Declare(
+ 			enkits
+-			GIT_REPOSITORY https://github.com/dougbinks/enkiTS.git
+-			GIT_TAG master
+-			GIT_SHALLOW TRUE
+-			GIT_PROGRESS TRUE
++			URL @enkits_src@
+ 		)
+ 		FetchContent_MakeAvailable(enkits)
+ 	endif()

--- a/pkgs/by-name/bo/box2d/cmake_use_system_glfw_and_imgui.patch
+++ b/pkgs/by-name/bo/box2d/cmake_use_system_glfw_and_imgui.patch
@@ -1,0 +1,54 @@
+diff --git a/samples/CMakeLists.txt b/samples/CMakeLists.txt
+index 5020345..97af8c6 100644
+--- a/samples/CMakeLists.txt
++++ b/samples/CMakeLists.txt
+@@ -17,47 +17,12 @@ set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "GLFW Examples")
+ set(GLFW_BUILD_TESTS OFF CACHE BOOL "GLFW Tests")
+ set(GLFW_INSTALL OFF CACHE BOOL "GLFW Install")
+ 
+-FetchContent_Declare(
+-	glfw
+-	GIT_REPOSITORY https://github.com/glfw/glfw.git
+-	GIT_TAG 3.4
+-	GIT_SHALLOW TRUE
+-	GIT_PROGRESS TRUE
+-)
+-FetchContent_MakeAvailable(glfw)
++find_package(glfw)
+ 
+ # imgui and glfw backend for GUI
+ # https://gist.github.com/jeffamstutz/992723dfabac4e3ffff265eb71a24cd9
+ # Modified to pin to a specific imgui release
+-FetchContent_Populate(imgui
+-	URL https://github.com/ocornut/imgui/archive/refs/tags/v1.91.3.zip
+-	SOURCE_DIR ${CMAKE_SOURCE_DIR}/build/imgui
+-)
+-
+-set(IMGUI_DIR ${CMAKE_SOURCE_DIR}/build/imgui)
+-
+-add_library(imgui STATIC
+-	${IMGUI_DIR}/imconfig.h
+-	${IMGUI_DIR}/imgui.h
+-
+-	${IMGUI_DIR}/imgui.cpp
+-	${IMGUI_DIR}/imgui_draw.cpp
+-	${IMGUI_DIR}/imgui_demo.cpp
+-	${IMGUI_DIR}/imgui_tables.cpp
+-	${IMGUI_DIR}/imgui_widgets.cpp
+-
+-	${IMGUI_DIR}/backends/imgui_impl_glfw.cpp
+-	${IMGUI_DIR}/backends/imgui_impl_opengl3.cpp
+-)
+-
+-target_link_libraries(imgui PUBLIC glfw glad)
+-target_include_directories(imgui PUBLIC ${IMGUI_DIR} ${IMGUI_DIR}/backends)
+-target_compile_definitions(imgui PUBLIC IMGUI_DISABLE_OBSOLETE_FUNCTIONS)
+-set_target_properties(imgui PROPERTIES
+-	CXX_STANDARD 20
+-    CXX_STANDARD_REQUIRED YES
+-    CXX_EXTENSIONS NO
+-)
++find_package(imgui)
+ 
+ # jsmn for json
+ set(JSMN_DIR ${CMAKE_SOURCE_DIR}/extern/jsmn)

--- a/pkgs/by-name/bo/box2d/package.nix
+++ b/pkgs/by-name/bo/box2d/package.nix
@@ -13,10 +13,6 @@
   xorgproto,
   libXi,
   pkg-config,
-  Carbon,
-  Cocoa,
-  Kernel,
-  OpenGL,
   settingsFile ? "include/box2d/b2_settings.h",
 }:
 
@@ -40,24 +36,17 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs =
-    [
-      libGLU
-      libGL
-      libglut
-      libX11
-      libXcursor
-      libXinerama
-      libXrandr
-      xorgproto
-      libXi
-    ]
-    ++ optionals stdenv.hostPlatform.isDarwin [
-      Carbon
-      Cocoa
-      Kernel
-      OpenGL
-    ];
+  buildInputs = [
+    libGL
+    libGLU
+    libX11
+    libXcursor
+    libXi
+    libXinerama
+    libXrandr
+    libglut
+    xorgproto
+  ];
 
   cmakeFlags = [
     (cmakeBool "BOX2D_BUILD_UNIT_TESTS" finalAttrs.finalPackage.doCheck)

--- a/pkgs/by-name/bo/box2d_2/package.nix
+++ b/pkgs/by-name/bo/box2d_2/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  cmake,
+  pkg-config,
+
+  # buildInputs
+  glfw3,
+  libGLU,
+  libX11,
+  libXcursor,
+  libXi,
+  libXinerama,
+  libXrandr,
+  libglut,
+  xorgproto,
+
+  nix-update-script,
+}:
+
+let
+  inherit (lib) cmakeBool;
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "box2d";
+  version = "2.4.2";
+
+  src = fetchFromGitHub {
+    owner = "erincatto";
+    repo = "box2d";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yvhpgiZpjTPeSY7Ma1bh4LwIokUUKB10v2WHlamL9D8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    glfw3
+    libGLU
+    libX11
+    libXcursor
+    libXi
+    libXinerama
+    libXrandr
+    libglut
+    xorgproto
+  ];
+
+  cmakeFlags = [
+    (cmakeBool "BOX2D_BUILD_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  meta = {
+    description = "2D physics engine";
+    homepage = "https://box2d.org/";
+    changelog = "https://github.com/erincatto/box2d/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ raskin ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.zlib;
+  };
+})

--- a/pkgs/development/libraries/qmlbox2d/default.nix
+++ b/pkgs/development/libraries/qmlbox2d/default.nix
@@ -7,20 +7,23 @@
   cmake,
   pkg-config,
   box2d,
+  unstableGitUpdater,
 }:
 
 let
   inherit (lib) cmakeBool;
 
   # 2.3.1 is the only supported version
-  box2d' = (box2d.override { settingsFile = "Box2D/Common/b2Settings.h"; }).overrideAttrs (old: rec {
+  box2d' = box2d.overrideAttrs (old: rec {
     version = "2.3.1";
     src = fetchFromGitHub {
       owner = "erincatto";
       repo = "box2d";
-      rev = "v${version}";
+      tag = "v${version}";
       hash = "sha256-Z2J17YMzQNZqABIa5eyJDT7BWfXveymzs+DWsrklPIs=";
     };
+    patches = [ ];
+    postPatch = "";
     sourceRoot = "${src.name}/Box2D";
     cmakeFlags = old.cmakeFlags or [ ] ++ [
       (cmakeBool "BOX2D_INSTALL" true)
@@ -32,13 +35,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "qml-box2d";
-  version = "unstable-2022-08-25";
+  version = "0-unstable-2024-04-15";
 
   src = fetchFromGitHub {
     owner = "qml-box2d";
     repo = "qml-box2d";
-    rev = "0bb88a6f871eef72b3b9ded9329c15f1da1f4fd7";
-    hash = "sha256-sfSVetpHIAIujpgjvRScAkJRlQQYjQ/yQrkWvp7Yu0s=";
+    rev = "3a85439726d1ac4d082308feba45f23859ba71e0";
+    hash = "sha256-lTgzPJWSwNfPRj5Lc63C69o4ILuyhVRLvltTo5E7yq0=";
   };
 
   dontWrapQtApps = true;
@@ -58,11 +61,17 @@ stdenv.mkDerivation {
     (cmakeBool "USE_SYSTEM_BOX2D" true)
   ];
 
-  meta = with lib; {
+  passthru = {
+    updateScript = unstableGitUpdater {
+      hardcodeZeroVersion = true;
+    };
+  };
+
+  meta = {
     description = "QML plugin for Box2D engine";
     homepage = "https://github.com/qml-box2d/qml-box2d";
-    maintainers = with maintainers; [ guibou ];
-    platforms = platforms.linux;
-    license = licenses.zlib;
+    maintainers = with lib.maintainers; [ guibou ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.zlib;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9012,15 +9012,6 @@ with pkgs;
     botan3
     ;
 
-  box2d = callPackage ../development/libraries/box2d {
-    inherit (darwin.apple_sdk.frameworks)
-      Carbon
-      Cocoa
-      Kernel
-      OpenGL
-      ;
-  };
-
   c-ares = callPackage ../development/libraries/c-ares { };
 
   c-aresMinimal = callPackage ../development/libraries/c-ares {


### PR DESCRIPTION
## Description of changes

Changelogs:
- https://box2d.org/posts/2024/08/releasing-box2d-3.0/
- https://box2d.org/documentation/md_release__notes__v310.html

Diff: https://github.com/erincatto/box2d/compare/v2.4.2...v3.1.0

cc @raskin

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
