### PR TITLE
proxsuite-nlp: init at 0.7.1

### DIFF
--- a/pkgs/by-name/ei/eigenrand/package.nix
+++ b/pkgs/by-name/ei/eigenrand/package.nix
@@ -1,0 +1,48 @@
+{
+  cmake,
+  eigen,
+  fetchFromGitHub,
+  gtest,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "eigenrand";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "bab2min";
+    repo = "EigenRand";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-mrpkWIb6kfLvppmIfzhjF1/3m1zSd8XG1D07V6Zjlu0=";
+  };
+
+  # Avoid downloading googletest: we already have it.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "FetchContent_MakeAvailable(googletest)" \
+      "add_subdirectory(${gtest.src} googletest SYSTEM)"
+  '';
+
+  postInstall = ''
+    # Remove installed tests and googletest stuff
+    rm -rf $out/bin $out/include/gmock $out/include/gtest $out/lib
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ eigen ];
+  checkInputs = [ gtest ];
+
+  doCheck = true;
+
+  cmakeFlags = [ "-DCMAKE_CTEST_ARGUMENTS=--exclude-regex;EigenRand-test" ];
+
+  meta = {
+    description = "Fastest Random Distribution Generator for Eigen";
+    homepage = "https://github.com/bab2min/EigenRand";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/pr/proxsuite-nlp/package.nix
+++ b/pkgs/by-name/pr/proxsuite-nlp/package.nix
@@ -1,0 +1,95 @@
+{
+  cmake,
+  doxygen,
+  eigenrand,
+  example-robot-data,
+  fetchFromGitHub,
+  fetchpatch,
+  fmt,
+  fontconfig,
+  graphviz,
+  lib,
+  stdenv,
+  pinocchio,
+  pkg-config,
+  proxsuite,
+  python3Packages,
+  pythonSupport ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "proxsuite-nlp";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "Simple-Robotics";
+    repo = "proxsuite-nlp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-aMTEjAu1ltjorx5vhz7klB0cGgdm+7STAPhi+NA6mnI=";
+  };
+
+  outputs = [
+    "doc"
+    "out"
+  ];
+
+  patches = [
+    # Fix use of system jrl-cmakemodules
+    # This patch was merged upstream and can be removed on next release
+    (fetchpatch {
+      url = "https://github.com/Simple-Robotics/proxsuite-nlp/pull/106/commits/c653ab67860fdf7b53b1a919f0b8a7746eba016b.patch";
+      hash = "sha256-Kw2obJGOWms/Lr4cVkLFpaLTickCq5WQyDVbwi8Bd58=";
+    })
+    # Fix use of system EigenRand
+    # This patch was merged upstream and can be removed on next release
+    (fetchpatch {
+      url = "https://github.com/Simple-Robotics/proxsuite-nlp/pull/106/commits/25370417755f003708b5b2b81e253797e8d96928.patch";
+      hash = "sha256-PKijVmttt5JakF3X/GiVWptncxHJUbs/aikgwgB5NME=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    graphviz
+    pkg-config
+  ] ++ lib.optional pythonSupport python3Packages.pythonImportsCheckHook;
+  checkInputs = [ eigenrand ] ++ lib.optional pythonSupport python3Packages.pytest;
+  propagatedBuildInputs =
+    [
+      example-robot-data
+      fmt
+    ]
+    ++ lib.optionals pythonSupport [
+      python3Packages.pinocchio
+      python3Packages.proxsuite
+    ]
+    ++ lib.optionals (!pythonSupport) [
+      pinocchio
+      proxsuite
+    ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_PYTHON_INTERFACE" pythonSupport)
+    (lib.cmakeBool "BUILD_WITH_PINOCCHIO_SUPPORT" true)
+    (lib.cmakeBool "BUILD_WITH_PROXSUITE_SUPPORT" true)
+  ];
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  # Fontconfig error: No writable cache directories
+  preBuild = "export XDG_CACHE_HOME=$(mktemp -d)";
+
+  doCheck = true;
+  pythonImportsCheck = [ "proxsuite_nlp" ];
+
+  meta = {
+    description = "Primal-dual augmented Lagrangian solver for nonlinear programming on manifolds";
+    homepage = "https://github.com/Simple-Robotics/proxsuite-nlp";
+    changelog = "https://github.com/Simple-Robotics/proxsuite-nlp/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10017,6 +10017,8 @@ self: super: with self; {
 
   proxsuite = toPythonModule (pkgs.proxsuite.override { pythonSupport = true; python3Packages = self; });
 
+  proxsuite-nlp = toPythonModule (pkgs.proxsuite-nlp.override { pythonSupport = true; python3Packages = self; });
+
   proxy-tools = callPackage ../development/python-modules/proxy-tools { };
 
   proxy-db = callPackage ../development/python-modules/proxy-db { };


### PR DESCRIPTION
## Description of changes

This add proxsuite-nlp, "a primal-dual augmented Lagrangian solver for nonlinear programming on manifolds":
https://github.com/Simple-Robotics/proxsuite-nlp
This also add its check dependency, eigenrand, the  "Fastest Random Distribution Generator for Eigen":
https://github.com/bab2min/EigenRand

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
