### PR TITLE
nix-weather: init at 0.0.2

### DIFF
--- a/pkgs/by-name/ni/nix-weather/package.nix
+++ b/pkgs/by-name/ni/nix-weather/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nix-weather";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "cafkafk";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-4zcdQ28MejGgdyZgqQD2XHWj/PBDq4aW78jyeBDv2h8=";
+  };
+
+  cargoHash = "sha256-Hj9cB1CY6SEwwin85QnDy9+0dMhlKdnp2IE2yM5a9C8=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  meta = {
+    description = "Check Cache Availablility of NixOS Configurations";
+    longDescription = ''
+      fast rust tool to check availability of your entire system in caches. It so to speak "checks the weather" before going to update.
+
+      Heavily inspired by guix weather.
+    '';
+    homepage = "https://git.fem.gg/cafkafk/nix-weather";
+    changelog = "https://git.fem.gg/cafkafk/nix-weather/releases/tag/v${version}";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [
+      freyacodes
+      cafkafk
+    ];
+    mainProgram = "nix-weather";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

> A fast rust tool to check availability of your entire system in caches. It so to speak "checks the weather" before going to update. Heavily inspired by [guix weather](https://guix.gnu.org/manual/en/html_node/Invoking-guix-weather.html).

https://git.fem.gg/cafkafk/nix-weather/

This PR relies upon #339854 to build. I could consider patching the version in `Cargo.toml`, as Rust 1.80.1 can otherwise build this just fine. 

I have decided to use the GitHub mirror because @cafkafk expressed bandwidth and speed concerns with the upstream. I have added her as a maintainer per her request. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
