### PR TITLE
protobufc: fix compatibility with new protobuf

### DIFF
--- a/pkgs/development/libraries/protobufc/default.nix
+++ b/pkgs/development/libraries/protobufc/default.nix
@@ -19,6 +19,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-Dkpcc7ZfvAIVY91trRiHuiRFcUGUbQxbheYKTBcq80I=";
   };
 
+  patches = [
+    # https://github.com/protobuf-c/protobuf-c/issues/709
+    # https://github.com/protobuf-c/protobuf-c/pull/711
+    ./recent_protobuf_compat.patch
+  ];
+
   outputs = [ "out" "dev" "lib" ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];

--- a/pkgs/development/libraries/protobufc/recent_protobuf_compat.patch
+++ b/pkgs/development/libraries/protobufc/recent_protobuf_compat.patch
@@ -1,0 +1,80 @@
+diff --git a/protoc-c/c_file.cc b/protoc-c/c_file.cc
+index ca0ad34..c6d8a24 100644
+--- a/protoc-c/c_file.cc
++++ b/protoc-c/c_file.cc
+@@ -117,14 +117,7 @@ FileGenerator::~FileGenerator() {}
+ void FileGenerator::GenerateHeader(io::Printer* printer) {
+   std::string filename_identifier = FilenameIdentifier(file_->name());
+ 
+-  int min_header_version = 1000000;
+-#if GOOGLE_PROTOBUF_VERSION >= 4023000
+-  if (FileDescriptorLegacy(file_).syntax() == FileDescriptorLegacy::SYNTAX_PROTO3) {
+-#else
+-  if (file_->syntax() == FileDescriptor::SYNTAX_PROTO3) {
+-#endif
+-    min_header_version = 1003000;
+-  }
++  const int min_header_version = 1003000;
+ 
+   // Generate top of header.
+   printer->Print(
+diff --git a/protoc-c/c_generator.h b/protoc-c/c_generator.h
+index b8b44aa..4aeb579 100644
+--- a/protoc-c/c_generator.h
++++ b/protoc-c/c_generator.h
+@@ -93,6 +93,12 @@ class PROTOC_C_EXPORT CGenerator : public CodeGenerator {
+                 const std::string& parameter,
+                 OutputDirectory* output_directory,
+                 std::string* error) const;
++
++#if GOOGLE_PROTOBUF_VERSION >= 5026000
++  uint64_t GetSupportedFeatures() const { return CodeGenerator::FEATURE_SUPPORTS_EDITIONS; }
++  Edition GetMinimumEdition() const { return Edition::EDITION_PROTO2; }
++  Edition GetMaximumEdition() const { return Edition::EDITION_PROTO3; }
++#endif
+ };
+ 
+ }  // namespace c
+diff --git a/protoc-c/c_helpers.h b/protoc-c/c_helpers.h
+index 062d330..be28b60 100644
+--- a/protoc-c/c_helpers.h
++++ b/protoc-c/c_helpers.h
+@@ -70,10 +70,6 @@
+ #include <protobuf-c/protobuf-c.pb.h>
+ #include <google/protobuf/io/printer.h>
+ 
+-#if GOOGLE_PROTOBUF_VERSION >= 4023000
+-# include <google/protobuf/descriptor_legacy.h>
+-#endif
+-
+ namespace google {
+ namespace protobuf {
+ namespace compiler {
+@@ -173,13 +169,21 @@ struct NameIndex
+ int compare_name_indices_by_name(const void*, const void*);
+ 
+ // Return the syntax version of the file containing the field.
+-// This wrapper is needed to be able to compile against protobuf2.
+ inline int FieldSyntax(const FieldDescriptor* field) {
+-#if GOOGLE_PROTOBUF_VERSION >= 4023000
+-  return FileDescriptorLegacy(field->file()).syntax() == FileDescriptorLegacy::SYNTAX_PROTO3 ? 3 : 2;
+-#else
+-  return field->file()->syntax() == FileDescriptor::SYNTAX_PROTO3 ? 3 : 2;
+-#endif
++  auto proto = FileDescriptorProto();
++  field->file()->CopyTo(&proto);
++
++  if (proto.has_syntax()) {
++    auto syntax = proto.syntax();
++    assert(syntax == "proto2" || syntax == "proto3");
++    if (syntax == "proto2") {
++      return 2;
++    } else if (syntax == "proto3") {
++      return 3;
++    }
++  }
++
++  return 2;
+ }
+ 
+ // Work around changes in protobuf >= 22.x without breaking compilation against


### PR DESCRIPTION
## Description of changes

Fixes failure caused by bumping `protobuf`: https://github.com/NixOS/nixpkgs/pull/338885

https://github.com/protobuf-c/protobuf-c/issues/709
protobuf-c/protobuf-c#711

cc @trofi @NickCao 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
