### PR TITLE
linuxPackages.rtw8852cu: init at unstable-2024-04-28

### DIFF
--- a/pkgs/os-specific/linux/rtw8852cu/0001-add-platforms_ops-to-arm_rk-HCI_USB.patch
+++ b/pkgs/os-specific/linux/rtw8852cu/0001-add-platforms_ops-to-arm_rk-HCI_USB.patch
@@ -1,0 +1,22 @@
+From bfa5132f52526e8e63a8a88b9c91b47e98374838 Mon Sep 17 00:00:00 2001
+From: Matei Dibu <contact@mateidibu.dev>
+Date: Sun, 15 Sep 2024 17:08:42 +0300
+Subject: [PATCH] add platforms_ops to arm_rk HCI_USB
+
+---
+ platform/arm_rk.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/platform/arm_rk.mk b/platform/arm_rk.mk
+index a7a4f94..8db140e 100644
+--- a/platform/arm_rk.mk
++++ b/platform/arm_rk.mk
+@@ -33,4 +33,5 @@ endif
+ ifeq ($(CONFIG_SDIO_HCI), y)
+ _PLATFORM_FILES = platform/platform_ARM_RK_sdio.c
+ endif
++_PLATFORM_FILES = platform/platform_ops.o
+ endif
+-- 
+2.46.0
+

--- a/pkgs/os-specific/linux/rtw8852cu/default.nix
+++ b/pkgs/os-specific/linux/rtw8852cu/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  bc,
+  nukeReferences,
+}:
+stdenv.mkDerivation rec {
+  pname = "rtw8852cu";
+  version = "${kernel.version}-unstable-2024-04-28";
+
+  src = fetchFromGitHub {
+    owner = "lwfinger";
+    repo = pname;
+    rev = "d256c2ae282b70f03629e36900da54905ab4187c";
+    hash = "sha256-RHKoy/XMANF7Ma7ZxLhzpTJR3NEQUSQBH/hOLwnvvNg=";
+  };
+
+  nativeBuildInputs = [
+    bc
+    nukeReferences
+  ] ++ kernel.moduleBuildDependencies;
+
+  hardeningDisable = [
+    "pic"
+    "format"
+  ];
+
+  patches = [
+    ./txe70uh.patch
+    ./0001-add-platforms_ops-to-arm_rk-HCI_USB.patch
+  ];
+
+  KVER = kernel.version;
+
+  postPatch = ''
+    substituteInPlace ./Makefile \
+      --replace-fail /sbin/depmod \# \
+      --replace-fail '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+
+    substituteInPlace ./platform/i386_pc.mk \
+      --replace-fail /lib/modules "${kernel.dev}/lib/modules"
+
+    substituteInPlace ./platform/arm_rk.mk --replace-fail \
+      /home/android_sdk/Rockchip/Rk3188/kernel "${kernel.dev}/lib/modules/''${KVER}/build" \
+      --replace-fail \
+      /home/android_sdk/Rockchip/Rk3188/prebuilts/gcc/linux-x86/arm/arm-eabi-4.6/bin/arm-eabi- ""
+  '';
+
+  makeFlags =
+    [
+      "ARCH=${stdenv.hostPlatform.linuxArch}"
+      ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
+      ("CONFIG_PLATFORM_ARM_ROCKCHIP=" + (if stdenv.hostPlatform.isAarch then "y" else "n"))
+    ]
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    ];
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  postInstall = ''
+    nuke-refs $out/lib/modules/*/kernel/net/wireless/*.ko
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Driver for Realtek rtl8852cu and rtl8832cu chipsets, provides the 8852cu mod";
+    homepage = "https://github.com/lwfinger/rtl8852cu";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ matdibu ];
+  };
+}

--- a/pkgs/os-specific/linux/rtw8852cu/txe70uh.patch
+++ b/pkgs/os-specific/linux/rtw8852cu/txe70uh.patch
@@ -1,0 +1,14 @@
+diff --git a/os_dep/linux/usb_intf.c b/os_dep/linux/usb_intf.c
+index 760030b..64298f1 100755
+--- a/os_dep/linux/usb_intf.c
++++ b/os_dep/linux/usb_intf.c
+@@ -145,7 +145,9 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
+ 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xC85A, 0xff, 0xff, 0xff), .driver_info = RTL8852C},
+ 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xC832, 0xff, 0xff, 0xff), .driver_info = RTL8852C},
+ 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xC85D, 0xff, 0xff, 0xff), .driver_info = RTL8852C},
+-	{USB_DEVICE_AND_INTERFACE_INFO(0x35b2, 0x0502, 0xff, 0xff, 0xff), .driver_info = RTL8852C}, /* TP-Link AXE5400 */
++	{USB_DEVICE_AND_INTERFACE_INFO(0x35b2, 0x0502, 0xff, 0xff, 0xff), .driver_info = RTL8852C}, /* TP-Link AXE5400 (RTW8832CU) */
++	{USB_DEVICE_AND_INTERFACE_INFO(0x35bc, 0x0101, 0xff, 0xff, 0xff), .driver_info = RTL8852C}, /* TP-Link AXE5400 TX50UH (RTW8832CU) */
++	{USB_DEVICE_AND_INTERFACE_INFO(0x35bc, 0x0102, 0xff, 0xff, 0xff), .driver_info = RTL8852C}, /* TP-Link AXE5400 TXE70UH (RTW8852CU) */
+ 	{}	/* Terminating entry */
+ };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -474,6 +474,8 @@ in {
 
     rtw88 = callPackage ../os-specific/linux/rtw88 { };
 
+    rtw8852cu = callPackage ../os-specific/linux/rtw8852cu { };
+
     rtw89 = if lib.versionOlder kernel.version "5.16" then callPackage ../os-specific/linux/rtw89 { } else null;
 
     openafs_1_8 = callPackage ../servers/openafs/1.8/module.nix { };


### PR DESCRIPTION
## Description of changes

Add `rtw8852cu` together with a patch to add some device IDs

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
