### PR TITLE
dotnetCorePackages.fetchNupkg: override avalonia to include upstream fix

### DIFF
--- a/pkgs/build-support/dotnet/fetch-nupkg/overrides.nix
+++ b/pkgs/build-support/dotnet/fetch-nupkg/overrides.nix
@@ -17,6 +17,38 @@
   #     buildInputs = old.buildInputs or [ ] ++ [ hello ];
   #   });
 
+  "Avalonia" =
+    package:
+    package.overrideAttrs (
+      old:
+      let
+        # These versions have a runtime error when built with `dotnet publish --no-build`
+        # When attempting to draw a window, Avalonia will throw "No precompiled XAML found"
+        #
+        # Introduced in https://github.com/AvaloniaUI/Avalonia/pull/13840
+        # Fixed by https://github.com/AvaloniaUI/Avalonia/pull/16835
+        affectedVersions = [
+          "11.1.0-beta1"
+          "11.1.0-beta2"
+          "11.1.0-rc1"
+          "11.1.0-rc2"
+          "11.1.0"
+          "11.1.1"
+          "11.1.2-rc1"
+          "11.1.2"
+          "11.1.3"
+          "11.2.0-beta1"
+        ];
+      in
+      lib.optionalAttrs (builtins.elem old.version affectedVersions) {
+        postPatch = ''
+          substituteInPlace {build,buildTransitive}/AvaloniaBuildTasks.targets \
+            --replace-fail 'BeforeTargets="CopyFilesToOutputDirectory;BuiltProjectOutputGroup"' \
+                           'BeforeTargets="CopyFilesToOutputDirectory;BuiltProjectOutputGroup;ComputeResolvedFilesToPublishList"'
+        '';
+      }
+    );
+
   "Avalonia.X11" =
     package:
     package.overrideAttrs (


### PR DESCRIPTION
## Description of changes

Backport https://github.com/AvaloniaUI/Avalonia/pull/16835 to versions 11.1.0 through 11.2.0-beta1

These versions have a runtime error when built with `dotnet publish --no-build`. When attempting to draw a window, Avalonia will throw "No precompiled XAML found".

#### Upstream
- Introduced in https://github.com/AvaloniaUI/Avalonia/pull/13840
- Fixed by https://github.com/AvaloniaUI/Avalonia/pull/16835

#### Packages affected
- Affects `retrospy` since https://github.com/NixOS/nixpkgs/pull/338143
- Will affect `nexusmods-app`; has been blocking https://github.com/NixOS/nixpkgs/pull/331150

AFAICT these are the only affected packages in nixpkgs, but I included the list of affected release versions anyway to avoid regressions when updating other packages and to aid anyone using nixpkg's dotnet built-support functions outside of nixpkgs.

See https://github.com/NixOS/nixpkgs/pull/331150#discussion_r1749031290 where this was originally discussed.

cc @corngood @Naxdy @NickCao

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
