### PR TITLE
clever-tools: remove update notifications

### DIFF
--- a/pkgs/by-name/cl/clever-tools/package.nix
+++ b/pkgs/by-name/cl/clever-tools/package.nix
@@ -1,9 +1,10 @@
-{ lib
-, buildNpmPackage
-, fetchFromGitHub
-, nodejs_18
-, installShellFiles
-, stdenv
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs_18,
+  installShellFiles,
+  stdenv,
 }:
 
 buildNpmPackage rec {
@@ -26,14 +27,16 @@ buildNpmPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd clever \
-      --bash <($out/bin/clever --bash-autocomplete-script $out/bin/clever) \
-      --zsh <($out/bin/clever --zsh-autocomplete-script $out/bin/clever)
-  '' + ''
-    rm $out/bin/install-clever-completion
-    rm $out/bin/uninstall-clever-completion
-  '';
+  postInstall =
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd clever \
+        --bash <($out/bin/clever --bash-autocomplete-script $out/bin/clever) \
+        --zsh <($out/bin/clever --zsh-autocomplete-script $out/bin/clever)
+    ''
+    + ''
+      rm $out/bin/install-clever-completion
+      rm $out/bin/uninstall-clever-completion
+    '';
 
   meta = with lib; {
     homepage = "https://github.com/CleverCloud/clever-tools";

--- a/pkgs/by-name/cl/clever-tools/package.nix
+++ b/pkgs/by-name/cl/clever-tools/package.nix
@@ -27,6 +27,8 @@ buildNpmPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  makeWrapperArgs = [ "--set NO_UPDATE_NOTIFIER true" ];
+
   postInstall =
     lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       installShellCompletion --cmd clever \


### PR DESCRIPTION
## Description of changes

This PR adds the `NO_UPDATE_NOTIFIER` environment variable to `true` when using the `clever-tools` package.
This is to avoid showing the message below:
![Update available 3.5.0 → 3.8.2 Run npm i clever-tools to update](https://github.com/user-attachments/assets/852c018e-3e0e-4da1-9372-df3a9a2144a8)
As explained by the [`update-notifier` project](https://github.com/yeoman/update-notifier?tab=readme-ov-file#user-settings) used by the clever-tools CLI, the value of `NO_UPDATE_NOTIFIER` doesn't matter. As long as it's set, notifications are skipped.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
