### PR TITLE
nixos/tests/gitdaemon: fix user and group

### DIFF
--- a/nixos/tests/gitdaemon.nix
+++ b/nixos/tests/gitdaemon.nix
@@ -20,7 +20,7 @@ in {
 
         systemd.tmpfiles.rules = [
           # type path mode user group age arg
-          " d    /git 0755 root root  -   -"
+          " d    /git 0755 git  git   -   -"
         ];
 
         services.gitDaemon = {
@@ -55,6 +55,10 @@ in {
             "git -C /project push",
             "rm -r /project",
         )
+
+    # Change user/group to default daemon user/group from module
+    # to avoid "fatal: detected dubious ownership in repository at '/git/project.git'"
+    server.succeed("chown git:git -R /git/project.git")
 
     with subtest("git daemon starts"):
         server.wait_for_unit("git-daemon.service")


### PR DESCRIPTION
- change tmpfiles rule user/group to default daemon user/group set by gitDaemon module - git:git
- add chown of created repo to user/group of daemon after local subtest on server (that run from root user) pass. Without it next subtest doing clone from remote fails with "detected dubious ownership in repository" on server side.

## Description of changes

Fixes build of `nixosTests.gitdaemon` (fails since `2024-05-22`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.gitdaemon.x86_64-linux
https://hydra.nixos.org/build/271662704
Error log:
```text
subtest: client can clone project.git
client: must succeed: git clone git://server/project.git /project
client # Cloning into '/project'...
server # [   13.445508] git-daemon-start[941]: [941] Connection from [2001:db8:1::1]:41522
server # [   13.447531] git-daemon-start[941]: [941] Extended attribute "host": server
server # [   13.448622] git-daemon-start[941]: [941] Extended attribute "protocol": version=2
server # [   13.449787] git-daemon-start[941]: [941] Request upload-pack for '/project.git'
server # [   13.453287] git-daemon-start[941]: fatal: detected dubious ownership in repository at '/git/project.git'
server # [   13.454645] git-daemon-start[941]: To add an exception for this directory, call:
server # [   13.455763] git-daemon-start[941]:  git config --global --add safe.directory /git/project.git
client # fatal: Could not read from remote repository.
client # 
client # Please make sure you have the correct access rights
server # [   13.458152] git-daemon-start[854]: [854] [941] Disconnected (with error)
```
Third subtest does not work as daemon on server uses `git:git` user/group, but repo was created and modified from `root:root`.
Currently `services.gitDaemon` module uses `git:git` user/group for daemon by default.
The alternative to doing `chown` is to run everything from `root`, but `git:git` seems to stray away from module defaults less.

---
Listed test maintainer:
@tilpner 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
