### PR TITLE
nixos/reposilite: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -151,6 +151,8 @@
 
 - [Rathole](https://github.com/rapiz1/rathole), a lightweight and high-performance reverse proxy for NAT traversal. Available as [services.rathole](#opt-services.rathole.enable).
 
+- [Reposilite](https://reposilite.com), a lightweight and easy-to-use repository manager for Maven based artifacts in JVM ecosystem. Available as [services.reposilite](#opt-services.reposilite.enable)
+
 - [Proton Mail bridge](https://proton.me/mail/bridge), a desktop application that runs in the background, encrypting and decrypting messages as they enter and leave your computer. It lets you add your Proton Mail account to your favorite email client via IMAP/SMTP by creating a local email server on your computer.
 
 - [chromadb](https://www.trychroma.com/), an open-source AI application

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1490,6 +1490,7 @@
   ./services/web-apps/pretix.nix
   ./services/web-apps/privatebin.nix
   ./services/web-apps/prosody-filer.nix
+  ./services/web-apps/reposilite.nix
   ./services/web-apps/rimgo.nix
   ./services/web-apps/rutorrent.nix
   ./services/web-apps/screego.nix

--- a/nixos/modules/services/web-apps/reposilite.md
+++ b/nixos/modules/services/web-apps/reposilite.md
@@ -1,0 +1,45 @@
+# Reposilite {#module-services-reposilite}
+
+Reposilite is a self-hosted repository manager for Maven based artifacts in JVM ecosystem.
+
+Visit [the Reposilite project page](https://reposilite.com) to learn
+more about it.
+
+## Quickstart {#module-services-reposilite-quickstart}
+
+Use the following configuration to start a public instance of Reposilite locally:
+
+```nix
+{
+  services.reposilite = {
+    enable = true;
+    settings = {
+      sslEnabled = true;
+    };
+    openFirewall = true;
+  };
+}
+```
+
+## Generating a Token {#module-services-reposilite-generating-a-token}
+
+You'll need to generate your first access token on the CLI (after which you can generate them in the web UI):
+
+```
+sudo systemctl stop reposilite.service
+reposilite --working-directory /var/lib/reposilite --port 8084 --database "sqlite reposilite.db" --token <tokenName:tokenSecret>
+```
+
+If you have modified the `database` option, update the flag in the command above as such.
+
+This creates a temporary token. With the server still running, access the web dashboard in a browser at `localhost:8084`, and create a permanent token by navigating to the `Console` tab and typing:
+
+```
+token-generate <name>
+```
+
+This will output a secret which you should save. You can then Ctrl-C to kill the Reposilite process and run the following command to restart the systemd service:
+
+```
+sudo systemctl start reposilite.service
+```

--- a/nixos/modules/services/web-apps/reposilite.nix
+++ b/nixos/modules/services/web-apps/reposilite.nix
@@ -1,0 +1,241 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.reposilite;
+
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkIf
+    getExe
+    types
+    optionals
+    ;
+
+  # Reposilite actually uses https://github.com/dzikoysk/cdn, but its format is similar enough to YAMLs to use pkgs.formats.yaml.
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  options.services.reposilite = {
+    enable = mkEnableOption "reposilite";
+    package = mkPackageOption pkgs "reposilite" { };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          hostname = mkOption {
+            description = ''
+              Hostname
+              The hostname can be used to limit which connections are accepted.
+              Use 0.0.0.0 to accept connections from anywhere.
+              127.0.0.1 will only allow connections from localhost.
+            '';
+            default = "0.0.0.0";
+            example = "127.0.0.1";
+            type = types.str;
+          };
+
+          port = mkOption {
+            description = "Port to bind";
+            default = 8080;
+            example = 5678;
+            type = types.port;
+          };
+
+          database = mkOption {
+            description = ''
+              Database configuration. Supported storage providers:
+              - mysql localhost:3306 database user password
+              - sqlite reposilite.db
+              - sqlite --temporary
+              Experimental providers (not covered with tests):
+              - postgresql localhost:5432 database user password
+              - h2 reposilite
+            '';
+            default = "sqlite reposilite.db";
+            example = "mysql localhost:3306 database user password";
+            type = types.str;
+          };
+
+          sslEnabled = mkOption {
+            description = "Support encrypted connections";
+            default = false;
+            type = types.bool;
+          };
+
+          sslPort = mkOption {
+            description = "SSL port to bind";
+            default = 443;
+            example = 5678;
+            type = types.port;
+          };
+
+          keyPath = mkOption {
+            description = ''
+              Key file to use.
+              You can specify absolute path to the given file or use ''${WORKING_DIRECTORY} variable.
+              If you want to use .pem certificate you need to specify its path next to the key path.
+              Example .pem paths setup:
+              keyPath = "''${WORKING_DIRECTORY}/cert.pem ''${WORKING_DIRECTORY}/key.pem"
+              Example .jks path setup:
+              keyPath = "''${WORKING_DIRECTORY}/keystore.jks"
+            '';
+            default = "\${WORKING_DIRECTORY}/cert.pem \${WORKING_DIRECTORY}/key.pem";
+            example = "\${WORKING_DIRECTORY}/keystore.jks";
+          };
+
+          keyPassword = mkOption {
+            description = "Key password to use";
+            default = "";
+            type = types.str;
+          };
+
+          enforeSsl = mkOption {
+            description = "Redirect HTTP traffic to HTTPS";
+            default = false;
+            type = types.bool;
+          };
+
+          webThreadPool = mkOption {
+            description = ''
+              Max amount of threads used by core thread pool (min: 5)
+              The web thread pool handles first few steps of incoming http connections, as soon as possible all tasks are redirected to IO thread pool.
+            '';
+            default = 16;
+            example = 32;
+            type = types.int;
+          };
+
+          ioThreadPool = mkOption {
+            description = ''
+              IO thread pool handles all tasks that may benefit from non-blocking IO (min: 2)
+              Because most of tasks are redirected to IO thread pool, it might be a good idea to keep it at least equal to web thread pool.
+            '';
+            default = 8;
+            example = 12;
+            type = types.int;
+          };
+
+          databaseThreadPool = mkOption {
+            description = ''
+              Database thread pool manages open connections to database (min: 1)
+              Embedded databases such as SQLite or H2 don't support truly concurrent connections, so the value will be always 1 for them if selected.
+            '';
+            default = 1;
+            example = 3;
+            type = types.int;
+          };
+
+          compressionStrategy = mkOption {
+            description = ''
+              Select compression strategy used by this instance.
+              Using 'none' reduces usage of CPU & memory, but ends up with higher transfer usage.
+              GZIP is better option if you're not limiting resources that much to increase overall request times.
+              Available strategies: none, gzip
+            '';
+            default = "none";
+            example = "gzip";
+            type = types.enum [
+              "none"
+              "gzip"
+            ];
+          };
+
+          idleTimeout = mkOption {
+            description = "Default idle timeout used by Jetty";
+            default = 30000;
+            example = 120000;
+            type = types.int;
+          };
+
+          bypassExternalCache = mkOption {
+            description = ''
+              Adds cache bypass headers to each request from /api/* scope served by this instance.
+              Helps to avoid various random issues caused by proxy provides (e.g. Cloudflare) and browsers.
+            '';
+            default = true;
+            type = types.bool;
+          };
+
+          cachedLogSize = mkOption {
+            description = "Amount of messages stored in cached logger.";
+            default = 32;
+            example = 64;
+            type = types.ints.unsigned;
+          };
+
+          defaultFrontend = mkOption {
+            description = "Enable default frontend with dashboard.";
+            default = true;
+            type = types.bool;
+          };
+
+          basePath = mkOption {
+            description = ''
+              Set custom base path for Reposilite instance.
+              It's not recommended to mount Reposilite under custom base path and you should always prioritize subdomain over this option.
+            '';
+            default = "/";
+            example = "/maven";
+            type = types.str;
+          };
+
+          debugEnabled = mkOption {
+            description = "Debug mode";
+            default = false;
+            type = types.bool;
+          };
+
+        };
+      };
+      description = "Configuration written to the config file for Reposilite.";
+      default = { };
+    };
+
+    openFirewall = mkOption {
+      description = ''
+        Whether to open the firewall for Reposilite.
+        This adds `services.reposilite.settings.port` and `services.reposilite.settings.sslPort` (if SSL is enabled)  to `networking.firewall.allowedTCPPorts`.
+      '';
+      default = false;
+      type = types.bool;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # This is done so that the reposilite command is available in PATH so users can setup their first token (see reposilite.md).
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.reposilite = {
+      description = "Reposilite server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        ExecStart =
+          let
+            config-cdn = settingsFormat.generate "reposilite.cdn" cfg.settings;
+          in
+          "${getExe cfg.package} --local-configuration ${config-cdn} --local-configuration-mode none --working-directory /var/lib/reposilite";
+        WorkingDirectory = "/var/lib/reposilite";
+        StateDirectory = "reposilite";
+        PrivateTmp = true;
+        DynamicUser = true;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall (
+      [ cfg.settings.server.port ]
+      ++ optionals cfg.settings.sslEnabled [ cfg.settings.server.sslPort ] [ ]
+    );
+  };
+
+  meta.doc = ./reposilite.md;
+  meta.maintainers = [ lib.maintainers.jamalam ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -865,6 +865,7 @@ in {
   redmine = handleTest ./redmine.nix {};
   renovate = handleTest ./renovate.nix {};
   replace-dependencies = handleTest ./replace-dependencies {};
+  reposilite = runTest ./reposilite.nix;
   restartByActivationScript = handleTest ./restart-by-activation-script.nix {};
   restic-rest-server = handleTest ./restic-rest-server.nix {};
   restic = handleTest ./restic.nix {};

--- a/nixos/tests/reposilite.nix
+++ b/nixos/tests/reposilite.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+
+{
+  name = "reposilite";
+
+  nodes = {
+    machine_default =
+      { pkgs, ... }:
+      {
+        services.reposilite = {
+          enable = true;
+        };
+      };
+  };
+
+  testScript = ''
+    machine_default.start()
+    machine_default.wait_for_unit("reposilite.service")
+    machine_default.wait_for_open_port(8080)
+  '';
+
+  meta.maintainers = [ lib.maintainers.jamalam ];
+}

--- a/pkgs/by-name/re/reposilite/package.nix
+++ b/pkgs/by-name/re/reposilite/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeWrapper, jre_headless }:
+{ stdenv, lib, fetchurl, makeWrapper, jre_headless, nixosTests }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "Reposilite";
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    reposilite = nixosTests.reposilite;
+  };
 
   meta = {
     description = "Lightweight and easy-to-use repository management software dedicated for the Maven based artifacts in the JVM ecosystem";


### PR DESCRIPTION
## Description of changes

Add a module for [Reposilite](https://reposilite.com). Also tested manually using my nixos machine.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
