### PR TITLE
[24.05] libtiff: patches for CVEs from libtiff 4.7.0

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , nix-update-script
 
 , autoreconfHook
@@ -41,6 +42,18 @@ stdenv.mkDerivation (finalAttrs: {
     # libc++abi 11 has an `#include <version>`, this picks up files name
     # `version` in the project's include paths
     ./rename-version.patch
+    # https://gitlab.com/libtiff/libtiff/-/issues/622
+    (fetchpatch {
+      name = "CVE-2023-52356.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/51558511bdbbcffdce534db21dbaf5d54b31638a.patch";
+      hash = "sha256-A1G23MEUS1AvoREcKFqoqV2sYtCqIMfzPaIIFpZNBWE=";
+    })
+    # https://gitlab.com/libtiff/libtiff/-/issues/624
+    (fetchpatch {
+      name = "CVE-2024-7006.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/818fb8ce881cf839fbc710f6690aadb992aa0f9e.patch";
+      hash = "sha256-XbRQtNxbNMofKTbeTsbHBKv96KTKSGngCepWPIVWLH4=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Add two patches from newest libtiff 4.7.0 which fix security problems.

Note (2024-09-08): libtiff 4.7.0 is already announced on [the libtiff homepage](https://libtiff.gitlab.io/libtiff/), however, that version isn't available in the [source repo](https://gitlab.com/libtiff/libtiff/-/tags) yet, nor on the [download page](https://download.osgeo.org/libtiff/).  Therefore, the pull request at hand uses 4.7.0rc1 and is marked as draft.  As soon as version 4.7.0 is published, I intend to remove the draft status after possibly adding more patches to the branch.

Note (2024-09-11): [libtiff 4.7.0rc2 is available](https://gitlab.com/libtiff/libtiff/-/tags/v4.7.0rc2), without any additional patches relevant for the pull request at hand.

Note (2024-09-18): [libtiff 4.7.0 finally got released](https://gitlab.com/libtiff/libtiff/-/releases/v4.7.0).  There are [no changes](https://gitlab.com/libtiff/libtiff/compare?from=v4.7.0rc2&to=v4.7.0) compared to v4.7.0rc2, so there are no additional patches relevant for the pull request at hand.

Reference: [pull request for nixpkgs unstable](https://github.com/NixOS/nixpkgs/pull/340566)

Notifying `libtiff` maintainer team (`geospatial`): @autra @imincik @l0b0 @nh2 @nialov @sikmir @willcohen

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More:

- [x] successfully built `libtiff.tests`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc