### PR TITLE
nixos/pcscd: add package option and reloadTriggers 

### DIFF
--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -7,14 +7,12 @@
 let
   cfg = config.services.pcscd;
   cfgFile = pkgs.writeText "reader.conf" (
-    builtins.concatStringsSep "\n\n" config.services.pcscd.readerConfigs
+    builtins.concatStringsSep "\n\n" cfg.readerConfigs
   );
-
-  package = if config.security.polkit.enable then pkgs.pcscliteWithPolkit else pkgs.pcsclite;
 
   pluginEnv = pkgs.buildEnv {
     name = "pcscd-plugins";
-    paths = map (p: "${p}/pcsc/drivers") config.services.pcscd.plugins;
+    paths = map (p: "${p}/pcsc/drivers") cfg.plugins;
   };
 
 in
@@ -35,6 +33,17 @@ in
 
   options.services.pcscd = {
     enable = lib.mkEnableOption "PCSC-Lite daemon, to access smart cards using SCard API (PC/SC)";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The pcsclite package to use.";
+      default = if config.security.polkit.enable then pkgs.pcscliteWithPolkit else pkgs.pcsclite;
+      defaultText = lib.literalExpression ''
+        if config.security.polkit.enable
+        then "pkgs.pcscliteWithPolkit"
+        else "pkgs.pcsclite"
+      '';
+    };
 
     plugins = lib.mkOption {
       type = lib.types.listOf lib.types.package;
@@ -68,11 +77,11 @@ in
     };
   };
 
-  config = lib.mkIf config.services.pcscd.enable {
+  config = lib.mkIf cfg.enable {
     environment.etc."reader.conf".source = cfgFile;
 
-    environment.systemPackages = [ package ];
-    systemd.packages = [ package ];
+    environment.systemPackages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
 
     services.pcscd.plugins = [ pkgs.ccid ];
 
@@ -91,7 +100,7 @@ in
       # https://github.com/NixOS/nixpkgs/issues/121088
       serviceConfig.ExecStart = [
         ""
-        "${lib.getExe package} -f -x -c ${cfgFile} ${lib.escapeShellArgs cfg.extraArgs}"
+        "${lib.getExe cfg.package} -f -x -c ${cfgFile} ${lib.escapeShellArgs cfg.extraArgs}"
       ];
     };
   };

--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -89,6 +89,7 @@ in
 
     systemd.services.pcscd = {
       environment.PCSCLITE_HP_DROPDIR = pluginEnv;
+      reloadTriggers = [ cfgFile ];
 
       # If the cfgFile is empty and not specified (in which case the default
       # /etc/reader.conf is assumed), pcscd will happily start going through the

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1131,6 +1131,7 @@ in
   paperless = runTest ./paperless.nix;
   parsedmarc = handleTest ./parsedmarc { };
   password-option-override-ordering = runTest ./password-option-override-ordering.nix;
+  pcscd = runTest ./pcscd.nix;
   pdns-recursor = runTest ./pdns-recursor.nix;
   pds = runTest ./pds.nix;
   peerflix = runTest ./peerflix.nix;

--- a/nixos/tests/pcscd.nix
+++ b/nixos/tests/pcscd.nix
@@ -1,0 +1,24 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+  {
+    name = "pcscd";
+    meta.maintainers = [ lib.maintainers.anthonyroussel ];
+
+    nodes = {
+      pcscd =
+        { ... }:
+        {
+          services.pcscd.enable = true;
+          security.polkit.enable = true;
+        };
+    };
+
+    testScript = ''
+      start_all()
+
+      pcscd.succeed("systemctl start pcscd")
+      pcscd.wait_for_unit("pcscd.service")
+      pcscd.wait_for_file("/run/pcscd/pcscd.pid")
+    '';
+  }
+)


### PR DESCRIPTION
## Description of changes

* Add services.pcscd.package option to let user specify the pcsclite package to use.
* Add systemd.services.pcscd.reloadTriggers to reload SystemD service when configuration file has changed.
* Add NixOS test (small one because it is difficult to mock PC/SC reader).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
