### PR TITLE
ffmpeg: add options for more subtitle decoding formats

### DIFF
--- a/pkgs/by-name/zv/zvbi/package.nix
+++ b/pkgs/by-name/zv/zvbi/package.nix
@@ -1,0 +1,57 @@
+{
+  autoreconfHook,
+  fetchFromGitHub,
+  gitUpdater,
+  lib,
+  libiconv,
+  stdenv,
+  testers,
+  validatePkgConfig,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zvbi";
+  version = "0.2.42";
+
+  src = fetchFromGitHub {
+    owner = "zapping-vbi";
+    repo = "zvbi";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-IeSGscgz51IndX6Xbu8Kw8GcJ9MLXXFhV+4LvnVkrLE=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    validatePkgConfig
+  ];
+
+  buildInputs = lib.optional stdenv.isDarwin libiconv;
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "Vertical Blanking Interval (VBI) utilities";
+    homepage = "https://github.com/zapping-vbi/zvbi";
+    changelog = "https://github.com/zapping-vbi/zvbi/blob/v${finalAttrs.version}/ChangeLog";
+    pkgConfigModules = [ "zvbi-0.2" ];
+    license = with lib.licenses; [
+      bsd2
+      bsd3
+      gpl2
+      gpl2Plus
+      lgpl21Plus
+      lgpl2Plus
+      mit
+    ];
+    maintainers = with lib.maintainers; [ jopejoe1 ];
+  };
+})

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -143,6 +143,7 @@
 , withZimg ? withHeadlessDeps
 , withZlib ? withHeadlessDeps
 , withZmq ? withFullDeps # Message passing
+, withZvbi ? withFullDeps # Teletext support
 
 /*
  *  Licensing options (yes some are listed twice, filters and such are not listed)
@@ -325,6 +326,7 @@
 , zeromq4
 , zimg
 , zlib
+, zvbi
 /*
  *  Darwin frameworks
  */
@@ -683,6 +685,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withZimg "libzimg")
     (enableFeature withZlib "zlib")
     (enableFeature withZmq "libzmq")
+    (enableFeature withZvbi "libzvbi")
     /*
      * Developer flags
      */
@@ -821,6 +824,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withZimg [ zimg ]
   ++ optionals withZlib [ zlib ]
   ++ optionals withZmq [ zeromq4 ]
+  ++ optionals withZvbi [ zvbi ]
   ;
 
   buildFlags = [ "all" ]

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -37,6 +37,7 @@
 , withAmf ? lib.meta.availableOn stdenv.hostPlatform amf # AMD Media Framework video encoding
 , withAom ? withHeadlessDeps # AV1 reference encoder
 , withAppKit ? withHeadlessDeps && stdenv.hostPlatform.isDarwin # Apple AppKit framework
+, withAribb24 ? withFullDeps # ARIB text and caption decoding
 , withAribcaption ? withFullDeps && lib.versionAtLeast version "6.1" # ARIB STD-B24 Caption Decoder/Renderer
 , withAss ? withHeadlessDeps && stdenv.hostPlatform == stdenv.buildPlatform # (Advanced) SubStation Alpha subtitle rendering
 , withAudioToolbox ? withHeadlessDeps && stdenv.hostPlatform.isDarwin # Apple AudioToolbox
@@ -226,6 +227,7 @@
 , alsa-lib
 , amf
 , amf-headers
+, aribb24
 , avisynthplus
 , bzip2
 , celt
@@ -556,6 +558,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withAmf "amf")
     (enableFeature withAom "libaom")
     (enableFeature withAppKit "appkit")
+    (enableFeature withAribb24 "libaribb24")
   ] ++ optionals (versionAtLeast version "6.1") [
     (enableFeature withAribcaption "libaribcaption")
   ] ++ [
@@ -729,6 +732,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withAmf [ amf-headers ]
   ++ optionals withAom [ libaom ]
   ++ optionals withAppKit [ AppKit ]
+  ++ optionals withAribb24 [ aribb24 ]
   ++ optionals withAribcaption [ libaribcaption ]
   ++ optionals withAss [ libass ]
   ++ optionals withAudioToolbox [ AudioToolbox ]


### PR DESCRIPTION
## Description of changes
This adds options to compile FFmpeg with support for teletext and aribb24 subtitle decoding.

I tested decoding locally on some example files I found.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
