### PR TITLE
systemd-boot: Add option for consoleMode to support SteamDeck

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -216,7 +216,7 @@ in {
     consoleMode = mkOption {
       default = "keep";
 
-      type = types.enum [ "0" "1" "2" "auto" "max" "keep" ];
+      type = types.enum [ "0" "1" "2" "5" "auto" "max" "keep" ];
 
       description = ''
         The resolution of the console. The following values are valid:
@@ -224,6 +224,7 @@ in {
         - `"0"`: Standard UEFI 80x25 mode
         - `"1"`: 80x50 mode, not supported by all devices
         - `"2"`: The first non-standard mode provided by the device firmware, if any
+        - `"5"`: Applicable for SteamDeck where this mode represent horizontal mode
         - `"auto"`: Pick a suitable mode automatically using heuristics
         - `"max"`: Pick the highest-numbered available mode
         - `"keep"`: Keep the mode selected by firmware (the default)


### PR DESCRIPTION
## Description of changes

Adds option for `systemd-boot` to display the menu horizontally and use efficiently space screen on the SteamDeck.

Fixes error during the build:
```
$ sudo nixos-rebuild switch
building the system configuration...
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nixos-system-Deck-24.11.20240809.5e0ca22'
         whose name attribute is located at /nix/store/0jr2kk95c34c0b6yxi75q4fqgb43kqkm-source/pkgs/stdenv/generic/make-derivation.nix:334:7

       … while evaluating attribute 'buildCommand' of derivation 'nixos-system-Deck-24.11.20240809.5e0ca22'

         at /nix/store/0jr2kk95c34c0b6yxi75q4fqgb43kqkm-source/nixos/modules/system/activation/top-level.nix:53:5:

           52|     passAsFile = [ "extraDependencies" ];
           53|     buildCommand = systemBuilder;
             |     ^
           54|

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: A definition for option `boot.loader.systemd-boot.consoleMode' is not of type `one of "0", "1", "2", "auto", "max", "keep"'. Definition values:
       - In `/nix/store/yjvf09m4pszcn3w0yphc7k2s0s8j27ri-source/configuration.nix': "5"
```


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


![2024-09-01-14-03-36-329](https://github.com/user-attachments/assets/c4bdf5d1-5efe-4f95-b629-b7e363232faf)

Here's thread with the suggestion:

https://github.com/systemd/systemd/issues/30120#issuecomment-2262194140