### PR TITLE
jalv: 1.6.6 -> 1.6.8

### DIFF
--- a/pkgs/applications/audio/jalv/default.nix
+++ b/pkgs/applications/audio/jalv/default.nix
@@ -1,18 +1,24 @@
-{ lib, stdenv, fetchurl, gtk2, libjack2, lilv, lv2, pkg-config, python3
-, serd, sord , sratom, suil, wafHook }:
+{ lib, stdenv, fetchurl, meson, ninja, pkg-config, wrapGAppsHook3
+, gtk2, gtk3, libjack2, lilv, lv2, serd, sord , sratom, suil
+}:
 
 stdenv.mkDerivation  rec {
   pname = "jalv";
-  version = "1.6.6";
+  version = "1.6.8";
 
   src = fetchurl {
-    url = "https://download.drobilla.net/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-ktFBeBtmQ3MgfDQ868XpuM7UYfryb9zLld8AB7BjnhY=";
+    url = "https://download.drobilla.net/${pname}-${version}.tar.xz";
+    hash = "sha256-7a53sSgOpE1MCytzJobe/TcP3iXtHaKJiW2fU7b8FeE=";
   };
 
-  nativeBuildInputs = [ pkg-config wafHook ];
-  buildInputs = [
-    gtk2 libjack2 lilv lv2 python3 serd sord sratom suil
+  nativeBuildInputs = [ meson ninja pkg-config wrapGAppsHook3 ];
+  buildInputs = [ gtk2 gtk3 libjack2 lilv lv2 serd sord sratom suil ];
+
+  mesonFlags = [
+    "-Dgtk2=enabled"
+    "-Dgtk3=enabled"
+    "-Dqt5=disabled"
+    "-Dportaudio=disabled" # portaudio and jack are mutually exclusive
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

This update switches to the meson build system and enables gtk3 backend.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
