### PR TITLE
python312Packages.nbconflux: fix broken build by replacing versioned code

### DIFF
--- a/pkgs/development/python-modules/nbconflux/default.nix
+++ b/pkgs/development/python-modules/nbconflux/default.nix
@@ -2,27 +2,32 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  isPy27,
   nbconvert,
   pytestCheckHook,
   requests,
   responses,
+  setuptools,
+  versioneer,
 }:
 
 buildPythonPackage rec {
   pname = "nbconflux";
   version = "0.7.0";
-  format = "setuptools";
-  disabled = isPy27; # no longer compatible with python 2 urllib
+  pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "Valassis-Digital-Media";
+    owner = "vericast";
     repo = "nbconflux";
     rev = "refs/tags/${version}";
     hash = "sha256-kHIuboFKLVsu5zlZ0bM1BUoQR8f1l0XWcaaVI9bECJw=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+    versioneer
+  ];
+
+  dependencies = [
     nbconvert
     requests
   ];
@@ -36,6 +41,11 @@ buildPythonPackage rec {
     # The original setup.py file is missing commas in the install_requires list
     ./setup-py.patch
   ];
+
+  postPatch = ''
+    # remove vendorized versioneer.py
+    rm versioneer.py
+  '';
 
   JUPYTER_PATH = "${nbconvert}/share/jupyter";
   disabledTests = [


### PR DESCRIPTION
## Description of changes

TL;dr Fixes a minor component  of `jupyter` that is blocking builds on aarch64-Darwin.

`python312Packages.nbconflux` fails to build due to its use of `SafeConfigParser` which was renamed to `ConfigParser` in Python 3.2. This comes from a versioned copy of `python312Packages.versioneer`. This results in builds failing on aarch64-Darwin as the package sources predate aarch64 by several years. Older systems got along just fine on the cached binary copy. 

Changes:
1. Replaces the vendorized copy of versioneer with a dependency. (Thank you @emilazy)
2. Moves the Python requirement from >= 2.7 to >= 3.2. 
3. Fixes the src.owner to account for the repo owners changing their org name several years back. It's pulling from the same source base as always. (After clearing the hash and updating it, it didn't change.)
4. Updates the build system to the current standard.

cc: @NixOS/darwin-maintainers
 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
