### PR TITLE
ffmpegthumbnailer: Make thumbnailer file point to absolute path

### DIFF
--- a/pkgs/development/libraries/ffmpegthumbnailer/default.nix
+++ b/pkgs/development/libraries/ffmpegthumbnailer/default.nix
@@ -39,6 +39,11 @@ stdenv.mkDerivation rec {
       --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
   '';
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/ffmpegthumbnailer.thumbnailer \
+      --replace-fail '=ffmpegthumbnailer' "=$out/bin/ffmpegthumbnailer"
+  '';
+
   meta = with lib; {
     description = "Lightweight video thumbnailer";
     longDescription = "FFmpegthumbnailer is a lightweight video


### PR DESCRIPTION
## Description of changes

Allows use with nautilus(bubblewrap) even if installed in home.packages

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
