### PR TITLE
super-productivity: 9.0.5 -> 10.0.2

### DIFF
--- a/pkgs/applications/office/super-productivity/default.nix
+++ b/pkgs/applications/office/super-productivity/default.nix
@@ -1,10 +1,4 @@
-{ stdenv
-, lib
-, fetchurl
-, appimageTools
-, makeWrapper
-, electron
-}:
+{ stdenv , lib , fetchurl , appimageTools , makeWrapper , electron }:
 
 stdenv.mkDerivation rec {
   pname = "super-productivity";

--- a/pkgs/applications/office/super-productivity/default.nix
+++ b/pkgs/applications/office/super-productivity/default.nix
@@ -44,10 +44,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "To-do list & time tracker for programmers and other digital workers with Jira, Github, and Gitlab integration";
     homepage = "https://super-productivity.com";
-    downloadPage = "https://github.com/johannesjo/super-productivity/releases";
+    downloadPage = "https://github.com/johannesjo/super-productivity";
     license = licenses.mit;
-    maintainers = with maintainers; [ offline ];
     platforms = [ "x86_64-linux" ];
-    mainProgram = pname;
+    maintainers = with maintainers; [ offline ];
+    mainProgram = "super-productivity";
   };
 }

--- a/pkgs/applications/office/super-productivity/default.nix
+++ b/pkgs/applications/office/super-productivity/default.nix
@@ -1,17 +1,24 @@
-{ stdenv , lib , fetchurl , appimageTools , makeWrapper , electron }:
+{ stdenv
+, lib
+, fetchurl
+, appimageTools
+, makeWrapper
+, electron
+}:
 
 stdenv.mkDerivation rec {
   pname = "super-productivity";
-  version = "9.0.5";
+  version = "10.0.2";
 
   src = fetchurl {
     url = "https://github.com/johannesjo/super-productivity/releases/download/v${version}/superProductivity-${version}.AppImage";
-    sha256 = "sha256-eNAoLcQWnsTDA7sG8i0Ur9BZ+pNt4AK1GOppFCD1ZGg=";
+    hash = "sha256-TPe2wijTzlro9rtESJHPL1phtraSW5kTHfctSTTumGs=";
     name = "${pname}-${version}.AppImage";
   };
 
   appimageContents = appimageTools.extractType2 {
-    inherit pname version src;
+    name = "${pname}-${version}";
+    inherit src;
   };
 
   dontUnpack = true;
@@ -41,11 +48,12 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "To Do List / Time Tracker with Jira Integration";
+    description = "To-do list & time tracker for programmers and other digital workers with Jira, Github, and Gitlab integration";
     homepage = "https://super-productivity.com";
+    downloadPage = "https://github.com/johannesjo/super-productivity/releases";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ offline ];
-    mainProgram = "super-productivity";
+    platforms = [ "x86_64-linux" ];
+    mainProgram = pname;
   };
 }


### PR DESCRIPTION
## Description of changes

Github release is 10.0.2 as of 7:26 9/9/2024 (GMT+3)
https://github.com/johannesjo/super-productivity/releases/tag/v10.0.2

Comparison:
https://github.com/johannesjo/super-productivity/compare/v9.0.5...v10.0.2

Home Page:
https://super-productivity.com/



## Things done
Updated the package version and hash and replaced the older sha256

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
