### PR TITLE
[Backport release-24.05] gauge: fix ruby and dotnet plugins, unbreak darwin

### DIFF
--- a/pkgs/development/tools/gauge/plugins/dotnet/default.nix
+++ b/pkgs/development/tools/gauge/plugins/dotnet/default.nix
@@ -1,6 +1,7 @@
 { lib
 , makeGaugePlugin
 , gauge-unwrapped
+, stdenv
 }:
 
 makeGaugePlugin {
@@ -10,6 +11,8 @@ makeGaugePlugin {
   repo = "getgauge/gauge-dotnet";
   releasePrefix = "gauge-dotnet-";
   isCrossArch = true;
+
+  buildInputs = [ stdenv.cc.cc.lib ];
 
   meta = {
     description = "Gauge plugin that lets you write tests in C#";

--- a/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
+++ b/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
@@ -2,6 +2,7 @@
 , fetchzip
 , lib
 , writeScript
+, autoPatchelfHook
 }:
 
 { pname
@@ -32,6 +33,8 @@ stdenvNoCC.mkDerivation (finalAttrs: (lib.recursiveUpdate {
     inherit url hash;
     stripRoot = false;
   };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
 
   installPhase = ''
     mkdir -p "$out/share/gauge-plugins/${pname}/${finalAttrs.version}"

--- a/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
+++ b/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation (finalAttrs: (lib.recursiveUpdate {
     stripRoot = false;
   };
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optional stdenvNoCC.hostPlatform.isLinux autoPatchelfHook;
 
   installPhase = ''
     mkdir -p "$out/share/gauge-plugins/${pname}/${finalAttrs.version}"


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Port of #323988 and https://github.com/NixOS/nixpkgs/commit/ad16a8d0524fee884fa38a5b7e145d2fa9827f9c to stable

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
