### PR TITLE
coqPackges: enable gappalib, itauto, coq-lsp, and serapi

### DIFF
--- a/pkgs/development/coq-modules/coq-lsp/default.nix
+++ b/pkgs/development/coq-modules/coq-lsp/default.nix
@@ -11,6 +11,7 @@
   release."0.1.9+8.17".sha256 = "sha256-BCsVRKSE9txeKgDfTsu7hQ6MebC+dX2AAqDF9iL7bYE=";
   release."0.2.0+8.18".sha256 = "sha256-OByBB1CLmj2N0AEieBXLVvP6OLGqi0HXra2jE9k3hXU=";
   release."0.2.0+8.19".sha256 = "sha256-G/UurWHxR2VzjClZCDHYcz7wAQAaYZt+DsADSXMybdk=";
+  release."0.2.0+8.20".sha256 = "sha256-+KRiYK+YCHC4R6/yDenRI8SqZiZ29X24xlDzegbPfrw=";
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
@@ -18,6 +19,7 @@
     { case = isEq "8.17"; out = "0.1.9+8.17"; }
     { case = isEq "8.18"; out = "0.2.0+8.18"; }
     { case = isEq "8.19"; out = "0.2.0+8.19"; }
+    { case = isEq "8.20"; out = "0.2.0+8.20"; }
   ] null;
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/development/coq-modules/gappalib/default.nix
+++ b/pkgs/development/coq-modules/gappalib/default.nix
@@ -6,7 +6,7 @@ mkCoqDerivation {
   owner = "gappa";
   domain = "gitlab.inria.fr";
   inherit version;
-  defaultVersion = if lib.versions.range "8.8" "8.19" coq.coq-version then "1.5.5" else null;
+  defaultVersion = if lib.versions.range "8.8" "8.20" coq.coq-version then "1.5.5" else null;
   release."1.5.5".sha256 = "sha256-qxi2Kg3N3o6+ncq7aPNEg98dBmQC5WCa86zROPJSDdo=";
   release."1.5.4".sha256 = "sha256-9PlkXqCu4rbFD7qnMF1GSpPCVmwJ3r593RfAvkJbbdA=";
   release."1.5.3".sha256 = "sha256-SuMopX5sm4jh2uBuE7zr6vhWhHYZYnab+epjqYJqg+s=";

--- a/pkgs/development/coq-modules/itauto/default.nix
+++ b/pkgs/development/coq-modules/itauto/default.nix
@@ -5,6 +5,7 @@
   owner = "fbesson";
   domain = "gitlab.inria.fr";
 
+  release."8.20.0".sha256 = "sha256-LYKGbI3O6yw6CiTJNUGL11PT4q4o+gJK1kQgKQL0/Hk=";
   release."8.19.0".sha256 = "sha256-xKWCF4dYvvlJUVGCZcR2RLCG55vlGzu2GN30MeRvVD4=";
   release."8.18.0".sha256 = "sha256-4mDDnKTeYrf27uRMkydQxO7j2tfgTFXOREW474d40eo=";
   release."8.17.0".sha256 = "sha256-fgdnKchNT1Hyrq14gU8KWYnlSfg3qlsSw5A4+RoA26w=";
@@ -14,6 +15,7 @@
   release."8.13+no".sha256 = "sha256-gXoxtLcHPoyjJkt7WqvzfCMCQlh6kL2KtCGe3N6RC/A=";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = isEq "8.20"; out = "8.20.0"; }
     { case = isEq "8.19"; out = "8.19.0"; }
     { case = isEq "8.18"; out = "8.18.0"; }
     { case = isEq "8.17"; out = "8.17.0"; }

--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -2,6 +2,7 @@
 
 let
   release = {
+    "8.20.0+0.20.0".sha256 = "sha256-Mll3m7CVfh52yA5zACDzMZk8lwhOONMMliqQ2l/ObKI=";
     "8.19.0+0.19.3".sha256 = "sha256-QWRXBTcjtAGskZBeLIuX7WDE95KfH6SxV8MJSMx8B2Q=";
     "8.18.0+0.18.3".sha256 = "sha256-3JGZCyn62LYJVpfXiwnSMxvdA2vQNTL7li2ZBPcjF0M=";
     "8.17.0+0.17.3".sha256 = "sha256-XolzpJd8zs4LLyJO4eWvCiAJ0HJSGBJTGVSBClQRGnw=";
@@ -17,10 +18,12 @@ in
 
 (mkCoqDerivation {
   pname = "serapi";
+  owner = "ejgallego";
   repo = "coq-serapi";
   inherit version release;
 
   defaultVersion = lib.switch coq.version [
+      { case = lib.versions.isEq "8.20"; out = "8.20.0+0.20.0"; }
       { case = lib.versions.isEq "8.19"; out = "8.19.0+0.19.3"; }
       { case = lib.versions.isEq "8.18"; out = "8.18.0+0.18.3"; }
       { case = lib.versions.isEq "8.17"; out = "8.17.0+0.17.3"; }


### PR DESCRIPTION
## Description of changes

Tested: https://github.com/coq-community/coq-nix-toolbox/pull/258

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
