### PR TITLE
ocis: init at 5.0.9

### DIFF
--- a/pkgs/by-name/oc/ocis/package.nix
+++ b/pkgs/by-name/oc/ocis/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  buildGoModule,
+  callPackage,
+  gnumake,
+  pnpm,
+  nodejs,
+  ocis,
+}:
+let
+  idp-assets = stdenvNoCC.mkDerivation {
+    pname = "idp-assets";
+    version = "0-unstable-2020-10-14";
+    src = fetchFromGitHub {
+      owner = "owncloud";
+      repo = "assets";
+      rev = "e8b6aeadbcee1865b9df682e9bd78083842d2b5c";
+      hash = "sha256-PzGff2Zx8xmvPYQa4lS4yz2h+y/lerKvUZkYI7XvAUw=";
+    };
+    installPhase = ''
+      mkdir -p $out/share
+      cp logo.svg favicon.ico $out/share/
+    '';
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+  };
+in
+buildGoModule rec {
+  pname = "ocis";
+  version = "5.0.9";
+
+  vendorHash = null;
+
+  src = fetchFromGitHub {
+    owner = "owncloud";
+    repo = "ocis";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-TsMrQx+P1F2t66e0tGG0VvRi4W7+pCpDHd0aNsacOsI=";
+  };
+
+  nativeBuildInputs = [
+    gnumake
+    nodejs
+    pnpm.configHook
+  ];
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit pname version src;
+    sourceRoot = "${src.name}/services/idp";
+    hash = "sha256-gNlN+u/bobnTsXrsOmkDcWs67D/trH3inT5AVQs3Brs=";
+  };
+  pnpmRoot = "services/idp";
+
+  buildPhase = ''
+    runHook preBuild
+    cp -r ${ocis.web}/share/* services/web/assets/
+    pnpm -C services/idp build
+
+    mkdir -p services/idp/assets/identifier/static
+    cp -r ${idp-assets}/share/* services/idp/assets/identifier/static/
+
+    make -C ocis VERSION=${version} DATE=${version} build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin/
+    cp ocis/bin/ocis $out/bin/
+    runHook postInstall
+  '';
+
+  passthru = {
+    web = callPackage ./web.nix { };
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    homepage = "https://github.com/owncloud/web";
+    description = "Next generation frontend for ownCloud Infinite Scale";
+    license = lib.licenses.asl20;
+    mainProgram = "ocis";
+    maintainers = with lib.maintainers; [ xinyangli ];
+  };
+}

--- a/pkgs/by-name/oc/ocis/update.sh
+++ b/pkgs/by-name/oc/ocis/update.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq gnugrep nix-update coreutils
+set -ex
+
+TAGS=$(curl -s https://api.github.com/repos/owncloud/ocis/releases | jq -r ".[].tag_name")
+
+for tag in $TAGS; do
+    main_version_old=$(echo "v$UPDATE_NIX_OLD_VERSION" | cut -d'.' -f1)
+    main_version_new=$(echo "$tag" | cut -d'.' -f1)
+
+    # Compare the main versions
+    if [[ "$main_version_old" == "$main_version_new" ]]; then
+        UPDATE_NIX_NEW_VERSION=$tag
+        break
+    else
+        continue
+    fi
+done
+
+OCIS_WEB_VERSION=$(curl -s https://raw.githubusercontent.com/owncloud/ocis/$UPDATE_NIX_NEW_VERSION/services/web/Makefile | grep -oP '(?<=WEB_ASSETS_VERSION = )v[0-9]+\.[0-9]+\.[0-9]+')
+nix-update -vr 'v(.*)' --version=$OCIS_WEB_VERSION ocis.web
+nix-update -vr 'v(.*)' --version=$UPDATE_NIX_NEW_VERSION ocis

--- a/pkgs/by-name/oc/ocis/web.nix
+++ b/pkgs/by-name/oc/ocis/web.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenvNoCC,
+  nodejs,
+  pnpm,
+  fetchFromGitHub,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "ocis-web";
+  version = "8.0.5";
+
+  src = fetchFromGitHub {
+    owner = "owncloud";
+    repo = "web";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-hupdtK/V74+X7/eXoDmUjFvSKuhnoOtNQz7o6TLJXG4=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm.configHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share
+    cp -r dist/* $out/share/
+    runHook postInstall
+  '';
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit pname version src;
+    hash = "sha256-3Erva6srdkX1YQ727trx34Ufx524nz19MUyaDQToz6M=";
+  };
+
+  meta = {
+    homepage = "https://github.com/owncloud/ocis";
+    description = "ownCloud Infinite Scale Stack";
+    maintainers = with lib.maintainers; [ xinyangli ];
+    license = lib.licenses.agpl3Only;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Build ownCloud Infinite Scale from source. It can be built successfully, but I do not have enough time to fully test the binary at the moment.

The [EULA](https://github.com/owncloud/ocis?tab=readme-ov-file#end-user-license-agreement) applies to release tarball. Can we safely mark this package as Apache 2.0 since we are building from source?

Related: https://github.com/NixOS/nixpkgs/issues/230190

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
