### PR TITLE
nixos/swap: use btrfs mkswapfile if possible

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -258,7 +258,7 @@ in
             wantedBy = [ "${realDevice'}.swap" ];
             before = [ "${realDevice'}.swap" "shutdown.target"];
             conflicts = [ "shutdown.target" ];
-            path = [ pkgs.util-linux pkgs.e2fsprogs ]
+            path = [ pkgs.util-linux pkgs.e2fsprogs pkgs.btrfs-progs ]
               ++ lib.optional sw.randomEncryption.enable pkgs.cryptsetup;
 
             environment.DEVICE = sw.device;
@@ -268,13 +268,19 @@ in
                 ${lib.optionalString (sw.size != null) ''
                   currentSize=$(( $(stat -c "%s" "$DEVICE" 2>/dev/null || echo 0) / 1024 / 1024 ))
                   if [[ ! -b "$DEVICE" && "${toString sw.size}" != "$currentSize" ]]; then
-                    # Disable CoW for CoW based filesystems like BTRFS.
-                    truncate --size 0 "$DEVICE"
-                    chattr +C "$DEVICE" 2>/dev/null || true
+                    if [[ $(stat -f -c %T $(dirname "${sw.device}")) == "btrfs" ]]; then
+                      # Use btrfs mkswapfile to speed up the creation of swapfile.
+                      rm -f "${sw.device}"
+                      btrfs filesystem mkswapfile --size "${toString sw.size}M" --uuid clear "${sw.device}"
+                    else
+                      # Disable CoW for CoW based filesystems like BTRFS.
+                      truncate --size 0 "$DEVICE"
+                      chattr +C "$DEVICE" 2>/dev/null || true
 
-                    echo "Creating swap file using dd and mkswap."
-                    dd if=/dev/zero of="$DEVICE" bs=1M count=${toString sw.size} status=progress
-                    ${lib.optionalString (!sw.randomEncryption.enable) "mkswap ${sw.realDevice}"}
+                      echo "Creating swap file using dd and mkswap."
+                      dd if=/dev/zero of="$DEVICE" bs=1M count=${toString sw.size} status=progress
+                      ${lib.optionalString (!sw.randomEncryption.enable) "mkswap ${sw.realDevice}"}
+                    fi
                   fi
                 ''}
                 ${lib.optionalString sw.randomEncryption.enable ''


### PR DESCRIPTION
## Description of changes

Use `btrfs filesystem mkswapfile` to speed up the creation of swapfile under a btrfs mountpoint.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
