### PR TITLE
nixos/etc-overlay: avoid rebuilding the initrd every time the etc contents change

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -20,6 +20,12 @@ let
       ''}
 
       ln -s ${config.system.build.etc}/etc $out/etc
+
+      ${lib.optionalString config.system.etc.overlay.enable ''
+        ln -s ${config.system.build.etcMetadataImage} $out/etc-metadata-image
+        ln -s ${config.system.build.etcBasedir} $out/etc-basedir
+      ''}
+
       ln -s ${config.system.path} $out/sw
       ln -s "$systemd" $out/systemd
 

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -516,6 +516,7 @@ in {
         };
         before = [ "shutdown.target" ];
         conflicts = [ "shutdown.target" ];
+        requiredBy = [ "initrd.target" ];
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = true;
@@ -579,7 +580,7 @@ in {
       ];
 
       services.initrd-nixos-activation = {
-        wants = [
+        requires = [
           config.boot.initrd.systemd.services.initrd-find-nixos-closure.name
         ];
         after = [
@@ -587,7 +588,12 @@ in {
           config.boot.initrd.systemd.services.initrd-find-nixos-closure.name
         ];
         requiredBy = [ "initrd.target" ];
-        unitConfig.AssertPathExists = "/etc/initrd-release";
+        unitConfig = {
+          AssertPathExists = "/etc/initrd-release";
+          RequiresMountsFor = [
+            "/sysroot/run"
+          ];
+        };
         serviceConfig.Type = "oneshot";
         description = "NixOS Activation";
 

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -507,12 +507,19 @@ in {
                          in nameValuePair "${n}.automount" (automountToUnit v)) cfg.automounts);
 
 
-      services.initrd-nixos-activation = {
-        after = [ "initrd-fs.target" ];
-        requiredBy = [ "initrd.target" ];
-        unitConfig.AssertPathExists = "/etc/initrd-release";
-        serviceConfig.Type = "oneshot";
-        description = "NixOS Activation";
+      services.initrd-find-nixos-closure = {
+        description = "Find NixOS closure";
+
+        unitConfig = {
+          RequiresMountsFor = "/sysroot/nix/store";
+          DefaultDependencies = false;
+        };
+        before = [ "shutdown.target" ];
+        conflicts = [ "shutdown.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
 
         script = /* bash */ ''
           set -uo pipefail
@@ -542,6 +549,8 @@ in {
           # Assume the directory containing the init script is the closure.
           closure="$(dirname "$closure")"
 
+          ln --symbolic "$closure" /nixos-closure
+
           # If we are not booting a NixOS closure (e.g. init=/bin/sh),
           # we don't know what root to prepare so we don't do anything
           if ! [ -x "/sysroot$(readlink "/sysroot$closure/prepare-root" || echo "$closure/prepare-root")" ]; then
@@ -550,12 +559,43 @@ in {
             exit 0
           fi
           echo 'NEW_INIT=' > /etc/switch-root.conf
+        '';
+      };
 
+      # We need to propagate /run for things like /run/booted-system
+      # and /run/current-system.
+      mounts = [
+        {
+          where = "/sysroot/run";
+          what = "/run";
+          options = "bind";
+          unitConfig = {
+            # See the comment on the mount unit for /run/etc-metadata
+            DefaultDependencies = false;
+          };
+          requiredBy = [ "initrd-fs.target" ];
+          before = [ "initrd-fs.target" ];
+        }
+      ];
 
-          # We need to propagate /run for things like /run/booted-system
-          # and /run/current-system.
-          mkdir -p /sysroot/run
-          mount --bind /run /sysroot/run
+      services.initrd-nixos-activation = {
+        wants = [
+          config.boot.initrd.systemd.services.initrd-find-nixos-closure.name
+        ];
+        after = [
+          "initrd-fs.target"
+          config.boot.initrd.systemd.services.initrd-find-nixos-closure.name
+        ];
+        requiredBy = [ "initrd.target" ];
+        unitConfig.AssertPathExists = "/etc/initrd-release";
+        serviceConfig.Type = "oneshot";
+        description = "NixOS Activation";
+
+        script = /* bash */ ''
+          set -uo pipefail
+          export PATH="/bin:${cfg.package.util-linux}/bin"
+
+          closure="$(realpath /nixos-closure)"
 
           # Initialize the system
           export IN_NIXOS_SYSTEMD_STAGE1=true

--- a/nixos/tests/activation/etc-overlay-immutable.nix
+++ b/nixos/tests/activation/etc-overlay-immutable.nix
@@ -26,6 +26,13 @@
   };
 
   testScript = ''
+    with subtest("/run/etc-metadata/ is mounted"):
+      print(machine.succeed("mountpoint /run/etc-metadata"))
+
+    with subtest("No temporary files leaked into stage 2"):
+      machine.succeed("[ ! -e /etc-metadata-image ]")
+      machine.succeed("[ ! -e /etc-basedir ]")
+
     with subtest("/etc is mounted as an overlay"):
       machine.succeed("findmnt --kernel --type overlay /etc")
 
@@ -49,6 +56,9 @@
 
     with subtest("switching to the same generation"):
       machine.succeed("/run/current-system/bin/switch-to-configuration test")
+
+    with subtest("the initrd didn't get rebuilt"):
+      machine.succeed("test /run/current-system/initrd -ef /run/current-system/specialisation/new-generation/initrd")
 
     with subtest("switching to a new generation"):
       machine.fail("stat /etc/newgen")

--- a/nixos/tests/activation/etc-overlay-immutable.nix
+++ b/nixos/tests/activation/etc-overlay-immutable.nix
@@ -15,6 +15,10 @@
     boot.kernelPackages = pkgs.linuxPackages_latest;
     time.timeZone = "Utc";
 
+    # The standard resolvconf service tries to write to /etc and crashes,
+    # which makes nixos-rebuild exit uncleanly when switching into the new generation
+    services.resolved.enable = true;
+
     environment.etc = {
       "mountpoint/.keep".text = "keep";
       "filemount".text = "keep";

--- a/nixos/tests/activation/etc-overlay-mutable.nix
+++ b/nixos/tests/activation/etc-overlay-mutable.nix
@@ -18,11 +18,21 @@
   };
 
   testScript = ''
+    with subtest("/run/etc-metadata/ is mounted"):
+      print(machine.succeed("mountpoint /run/etc-metadata"))
+
+    with subtest("No temporary files leaked into stage 2"):
+      machine.succeed("[ ! -e /etc-metadata-image ]")
+      machine.succeed("[ ! -e /etc-basedir ]")
+
     with subtest("/etc is mounted as an overlay"):
       machine.succeed("findmnt --kernel --type overlay /etc")
 
     with subtest("switching to the same generation"):
       machine.succeed("/run/current-system/bin/switch-to-configuration test")
+
+    with subtest("the initrd didn't get rebuilt"):
+      machine.succeed("test /run/current-system/initrd -ef /run/current-system/specialisation/new-generation/initrd")
 
     with subtest("switching to a new generation"):
       machine.fail("stat /etc/newgen")

--- a/nixos/tests/systemd-initrd-simple.nix
+++ b/nixos/tests/systemd-initrd-simple.nix
@@ -29,6 +29,8 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
         machine.succeed("[ -e /dev/shm ]") # /dev/shm
         machine.succeed("[ -e /dev/pts/ptmx ]") # /dev/pts
         machine.succeed("[ -e /run/keys ]") # /run/keys
+        # /nixos-closure didn't leak into stage-2
+        machine.succeed("[ ! -e /nixos-closure ]")
 
     with subtest("groups work"):
         machine.fail("journalctl -b 0 | grep 'systemd-udevd.*Unknown group.*ignoring'")


### PR DESCRIPTION
## Description of changes
Before this change, the hash of the etc metadata image was included in the mount unit that's responsible for mounting this metadata image in the initrd.
And because this metadata image changes with every change to the etc contents, the initrd would be rebuilt every time as well.
This can lead to a lot of rebuilds (especially when revision info is included in /etc/os-release) and all these initrd archives use up a lot of space on the ESP.

With this change, we instead include a symlink to the metadata image in the top-level directory, in the same way as we already do for things like init and prepare-root, and we deduce the store path from the init= kernel parameter, in the same way as we already do to find the path to init and prepare-root.

Doing so avoids rebuilding the initrd all the time.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
