### PR TITLE
lib.generators.toINI: allow lists of name-value pairs as section contents

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -26,6 +26,7 @@ let
     any
     attrNames
     attrValues
+    attrsToList
     concatLists
     concatMap
     concatMapStringsSep
@@ -195,11 +196,12 @@ rec {
       mkLine = k: v: indent + mkKeyValue k v + "\n";
       mkLines =
         if listsAsDuplicateKeys then
-          k: v: map (mkLine k) (if isList v then v else [ v ])
+          { name, value }: map (mkLine name) (if isList value then value else [ value ])
         else
-          k: v: [ (mkLine k v) ];
+          { name, value }: [ (mkLine name value) ];
     in
-    attrs: concatStrings (concatLists (mapAttrsToList mkLines attrs));
+    attrs:
+    concatStrings (concatLists (map mkLines (if isAttrs attrs then attrsToList attrs else attrs)));
 
   /**
     Generate an INI-style config file from an

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2645,6 +2645,40 @@ runTests {
     '';
   };
 
+  testToINIOrdered = {
+    expr = generators.toINI { } {
+      bar = [
+        {
+          name = "foo";
+          value = 1;
+        }
+        {
+          name = "qux";
+          value = 2;
+        }
+      ];
+      baz = [
+        {
+          name = "qux";
+          value = 2;
+        }
+        {
+          name = "foo";
+          value = 1;
+        }
+      ];
+    };
+    expected = ''
+      [bar]
+      foo=1
+      qux=2
+
+      [baz]
+      qux=2
+      foo=1
+    '';
+  };
+
   testToINIWithGlobalSectionEmpty = {
     expr = generators.toINIWithGlobalSection { } {
       globalSection = {


### PR DESCRIPTION
## Description of changes

Some software depends on the order of elements inside a section. For example, [aerc] needs the `filters` section
to be ordered from the most to least specific ([`aerc-config(5)`][aerc-config-filters]).

[aerc]: https://aerc-mail.org
[aerc-config-filters]: https://git.sr.ht/~rjarry/aerc/tree/master/item/doc/aerc-config.5.scd#L954

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
