### PR TITLE
nixos/tests/gnupg: fix prompt handling

### DIFF
--- a/nixos/tests/gnupg.nix
+++ b/nixos/tests/gnupg.nix
@@ -69,9 +69,11 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
           machine.wait_until_tty_matches("1", "Change")
           machine.send_chars("O\n")
           machine.wait_until_tty_matches("1", "Please enter")
-          machine.send_chars("pgp_p4ssphrase\n")
-          machine.wait_until_tty_matches("1", "Please re-enter")
-          machine.send_chars("pgp_p4ssphrase\n")
+          machine.send_chars("pgp_p4ssphrase")
+          machine.send_key("tab")
+          machine.send_chars("pgp_p4ssphrase")
+          machine.wait_until_tty_matches("1", "Passphrases match")
+          machine.send_chars("\n")
           machine.wait_until_tty_matches("1", "public and secret key created")
 
       with subtest("Confirm the key is in the keyring"):
@@ -90,9 +92,11 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
           machine.wait_until_tty_matches("1", "Enter passphrase")
           machine.send_chars("ssh_p4ssphrase\n")
           machine.wait_until_tty_matches("1", "Please enter")
-          machine.send_chars("ssh_agent_p4ssphrase\n")
-          machine.wait_until_tty_matches("1", "Please re-enter")
-          machine.send_chars("ssh_agent_p4ssphrase\n")
+          machine.send_chars("ssh_agent_p4ssphrase")
+          machine.send_key("tab")
+          machine.send_chars("ssh_agent_p4ssphrase")
+          machine.wait_until_tty_matches("1", "Passphrases match")
+          machine.send_chars("\n")
 
       with subtest("Confirm the SSH key has been registered"):
           machine.wait_until_succeeds(as_alice("ssh-add -l | grep -q alice@machine"))


### PR DESCRIPTION
- change send_chars and wait_until_tty_matches to handle new password prompt in one TUI. Switching with tab between enter and re-enter of password

## Description of changes

Fixes `nixosTests.gnupg` (fails since `2024-06-16`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.gnupg.x86_64-linux
https://hydra.nixos.org/build/271665032
Error log:
```text
(finished: waiting for Please enter to appear on tty 1, in 1.11 seconds)
machine: sending keys 'pgp_p4ssphrase\n'
(finished: sending keys 'pgp_p4ssphrase\n', in 0.15 seconds)
machine: waiting for Please re-enter to appear on tty 1
machine # [   80.011677] gpg-agent[1010]: command 'GENKEY' failed: Timeout <Pinentry>
...
machine: Last chance to match /Please re-enter/ on TTY1, which currently contains:  
�������������������������������������������������������������Ŀ                                                
� Please enter the passphrase to                              �
� protect your new key                                        �
�                                                             �
� does not match - try again                                  �
�                                                             �
� Passphrase: **************_________________________________ �
�                                                             �
� Repeat: ___________________________________________________ �
� ���������������������������������������������������������Ŀ  �
� ���������������������������100%���������������������������� �
� ����������������������������������������������������������� �
�        <OK>                                   <Cancel>      � 
���������������������������������������������������������������                                                
gpg: agent_genkey failed: Timeout                                                                                                                               
Key generation failed: Timeout                                                                                                                                  
                                                                                                                                                                
[alice@machine:~]$                                                                                                                                              
Test "Can generate a PGP key" failed with error: "action timed out after 900 seconds"
```

New password prompt has enter and re-enter in one TUI, so you need to: enter password, "tab" (to switch to next text field), re-enter password, "\n".
Instead of what test did before: enter password, "\n", re-enter password, "\n"
Current one waits for "Please re-enter" to appear in tty until 15 minute timeout runs out.

Listed test maintainer:
@rnhmjoj

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
