### PR TITLE
[24.05] sonarr: 4.0.4.1491 -> 4.0.9.2244

### DIFF
--- a/pkgs/servers/sonarr/default.nix
+++ b/pkgs/servers/sonarr/default.nix
@@ -10,15 +10,15 @@ let
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   hash = {
-    x64-linux_hash = "sha256-rtlOFfeiZLsoZR/bUPAtWicK1Cu/pxtiBhHdHYbGrHo=";
-    arm64-linux_hash = "sha256-jMp1kDVCQYtDhO28HoBuo7IAlEaoqPFW8EPYXc1zpKM=";
-    x64-osx_hash = "sha256-2wcTRqbvlQAFY20IeIQnqWGJYMB1P3z+PftKau1ucdk=";
-    arm64-osx_hash = "sha256-3CrNLxmk5oHiGHkrKt17tfo021+O6JZ6RKBdsaf0f1I=";
+    x64-linux_hash = "sha256-C61LCeYckO46E/Wm+64DyWS4LBl4mmkFFmY7FLdfFbA=";
+    arm64-linux_hash = "sha256-BKa1sk/ecEQXJ+4THOHbkburgL5/cBZ7/qZETRLxomU=";
+    x64-osx_hash = "sha256-AtmDPJUNa2pbmWxgubgVk0t1RoY/sG4d2RCUWPk209U=";
+    arm64-osx_hash = "sha256-K+ahg3XdrAnyTi4zm9IYxMfhlNRopR+5e7OTNKgnTK8=";
   }."${arch}-${os}_hash";
 in
 stdenv.mkDerivation rec {
   pname = "sonarr";
-  version = "4.0.4.1491";
+  version = "4.0.9.2244";
 
   src = fetchurl {
     url = "https://github.com/Sonarr/Sonarr/releases/download/v${version}/Sonarr.main.${version}.${os}-${arch}.tar.gz";


### PR DESCRIPTION
## Description of changes

Backports version bumps from the unstable channel that builds Sonarr from source since the changes cannot be automatically cherry-picked for release-24.05 channel (that uses prebuilt binary package).

Note that source build depends on a set of changes in the .NET language framework that are not eligible for backport, hence the manual package version update.

Relates changes:
- #338719
- https://github.com/NixOS/nixpkgs/commits/master/pkgs/by-name/so/sonarr

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
