### PR TITLE
maintainers/scripts/validate-commit-titles: Init

### DIFF
--- a/maintainers/scripts/validate-commit-titles/README.md
+++ b/maintainers/scripts/validate-commit-titles/README.md
@@ -1,0 +1,6 @@
+program to verify nixpkgs git commit titles
+
+title conventions
+
+https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#submitting-changes
+https://github.com/NixOS/ofborg#automatic-building

--- a/maintainers/scripts/validate-commit-titles/titles-invalid.txt
+++ b/maintainers/scripts/validate-commit-titles/titles-invalid.txt
@@ -1,0 +1,2 @@
+gupnp{_1_6}: fix cross
+Add alsa-plugins path to ALSA_PLUGIN_DIR

--- a/maintainers/scripts/validate-commit-titles/titles-valid.txt
+++ b/maintainers/scripts/validate-commit-titles/titles-valid.txt
@@ -1,0 +1,6 @@
+nginx: init at 2.0.1
+firefox: 54.0.1 -> 55
+nixos/hydra: add bazBaz option
+treewide: migrate more packages to scons_latest
+gupnp,gnupnp_1_6: fix cross
+gupnp{,_1_6}: fix cross

--- a/maintainers/scripts/validate-commit-titles/validate.rs
+++ b/maintainers/scripts/validate-commit-titles/validate.rs
@@ -1,0 +1,64 @@
+#!/usr/bin/env nix-shell
+//! ```cargo
+//! [dependencies]
+//! regex = "1"
+//! ```
+
+use std::{fs::read_to_string, process::{Command, Stdio, ExitCode}};
+use regex::Regex;
+/*
+#!nix-shell -i rust-script -p rustc -p rust-script -p cargo -p gh -p jq --
+*/
+
+fn validate(titles: Vec<&str>) -> bool {
+    let re = Regex::new(r"^[^{]+:.+$").unwrap();
+    let mut invalid_titles_found = false;
+    for title in titles {
+        if !re.is_match(title) {
+            invalid_titles_found = true;
+            eprintln!("title '{}' is not valid", title);
+        }
+    }
+    return invalid_titles_found
+}
+
+fn main() -> ExitCode {
+
+    let commits = Command::new("gh")
+        .args(["pr", "view", "--json", "commits" ])
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stdout = Command::new("jq")
+        .args([ ".[] | .[].messageHeadline", "--raw-output" ])
+        .stdin(Stdio::from(commits.stdout.unwrap()))
+        .output()
+        .unwrap()
+        .stdout;
+
+    let binding = String::from_utf8(stdout).unwrap();
+    let titles = binding.split_terminator("\n").collect();
+
+    let invalid_titles_found = validate(titles);
+
+    if invalid_titles_found {
+        return ExitCode::FAILURE;
+    }
+
+    return ExitCode::SUCCESS;
+
+}
+
+#[test]
+fn check_validate() {
+    let valid_file = read_to_string("./titles-valid.txt").expect("couldn't read titles-valid.txt");
+    let invalid_file = read_to_string("./titles-invalid.txt").expect("couldn't read titles-invalid.txt");
+
+    let mut combined: String = valid_file.to_owned();
+    combined.push_str(&invalid_file);
+
+    validate(combined.split_terminator("\n").collect())
+
+}
+// vim: ft=rust


### PR DESCRIPTION
Made this script in 2023, Making a PR so it's not lost in my stash

Can be used to validate the commit titles in the current branch.

Could be run in the CI separately or added to ofborg