### PR TITLE
nixos/overlayfs: add a switch to disable prefixing with `/sysroot` for initrd mounts

### DIFF
--- a/nixos/modules/tasks/filesystems/overlayfs.nix
+++ b/nixos/modules/tasks/filesystems/overlayfs.nix
@@ -1,17 +1,29 @@
-{ config, lib, pkgs, utils, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
 
 let
   # The scripted initrd contains some magic to add the prefix to the
   # paths just in time, so we don't add it here.
-  sysrootPrefix = fs:
-    if config.boot.initrd.systemd.enable && fs.overlay.useStage1BaseDirectories && (utils.fsNeededForBoot fs) then
+  sysrootPrefix =
+    fs:
+    if
+      config.boot.initrd.systemd.enable
+      && fs.overlay.useStage1BaseDirectories
+      && (utils.fsNeededForBoot fs)
+    then
       "/sysroot"
     else
       "";
 
   # Returns a service that creates the required directories before the mount is
   # created.
-  preMountService = _name: fs:
+  preMountService =
+    _name: fs:
     let
       prefix = sysrootPrefix fs;
 
@@ -21,106 +33,111 @@ let
       upperdir = prefix + fs.overlay.upperdir;
       workdir = prefix + fs.overlay.workdir;
     in
-    lib.mkIf (fs.overlay.upperdir != null)
-      {
-        "rw-${escapedMountpoint}" = {
-          requiredBy = [ mountUnit ];
-          before = [ mountUnit ];
-          unitConfig = {
-            DefaultDependencies = false;
-            RequiresMountsFor = "${upperdir} ${workdir}";
-          };
-          serviceConfig = {
-            Type = "oneshot";
-            ExecStart = "${pkgs.coreutils}/bin/mkdir -p -m 0755 ${upperdir} ${workdir}";
-          };
+    lib.mkIf (fs.overlay.upperdir != null) {
+      "rw-${escapedMountpoint}" = {
+        requiredBy = [ mountUnit ];
+        before = [ mountUnit ];
+        unitConfig = {
+          DefaultDependencies = false;
+          RequiresMountsFor = "${upperdir} ${workdir}";
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.coreutils}/bin/mkdir -p -m 0755 ${upperdir} ${workdir}";
+        };
+      };
+    };
+
+  overlayOpts =
+    {
+      config,
+      ...
+    }:
+    {
+      options.overlay = {
+        lowerdir = lib.mkOption {
+          type = with lib.types; nullOr (nonEmptyListOf (either str pathInStore));
+          default = null;
+          description = ''
+            The list of path(s) to the lowerdir(s).
+
+            To create a writable overlay, you MUST provide an `upperdir` and a
+            `workdir`.
+
+            You can create a read-only overlay when you provide multiple (at
+            least 2!) lowerdirs and neither an `upperdir` nor a `workdir`.
+          '';
+        };
+
+        upperdir = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            The path to the upperdir.
+
+            If this is null, a read-only overlay is created using the lowerdir.
+
+            If the filesystem is `neededForBoot`, this will be prefixed with `/sysroot`,
+            unless `useStage1BaseDirectories` is set to `true`.
+
+            If you set this to some value you MUST also set `workdir`.
+          '';
+        };
+
+        workdir = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            The path to the workdir.
+
+            If the filesystem is `neededForBoot`, this will be prefixed with `/sysroot`,
+            unless `useStage1BaseDirectories` is set to `true`.
+
+            This MUST be set if you set `upperdir`.
+          '';
+        };
+
+        useStage1BaseDirectories = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            If enabled, `lowerdir`, `upperdir` and `workdir` will be prefixed with `/sysroot`.
+
+            Disabling this can be useful to create an overlay over directories which aren't on the real root.
+
+            Disabling this does not work with the scripted (i.e. non-systemd) initrd.
+          '';
         };
       };
 
-  overlayOpts = { config, ... }: {
+      config = lib.mkIf (config.overlay.lowerdir != null) {
+        fsType = "overlay";
+        device = lib.mkDefault "overlay";
+        depends = map (x: "${x}") (
+          config.overlay.lowerdir
+          ++ lib.optionals (config.overlay.upperdir != null) [
+            config.overlay.upperdir
+            config.overlay.workdir
+          ]
+        );
 
-    options.overlay = {
+        options =
+          let
+            prefix = sysrootPrefix config;
 
-      lowerdir = lib.mkOption {
-        type = with lib.types; nullOr (nonEmptyListOf (either str pathInStore));
-        default = null;
-        description = ''
-          The list of path(s) to the lowerdir(s).
-
-          To create a writable overlay, you MUST provide an `upperdir` and a
-          `workdir`.
-
-          You can create a read-only overlay when you provide multiple (at
-          least 2!) lowerdirs and neither an `upperdir` nor a `workdir`.
-        '';
-      };
-
-      upperdir = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = ''
-          The path to the upperdir.
-
-          If this is null, a read-only overlay is created using the lowerdir.
-
-          If the filesystem is `neededForBoot`, this will be prefixed with `/sysroot`,
-          unless `useStage1BaseDirectories` is set to `true`.
-
-          If you set this to some value you MUST also set `workdir`.
-        '';
-      };
-
-      workdir = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = ''
-          The path to the workdir.
-
-          If the filesystem is `neededForBoot`, this will be prefixed with `/sysroot`,
-          unless `useStage1BaseDirectories` is set to `true`.
-
-          This MUST be set if you set `upperdir`.
-        '';
-      };
-
-      useStage1BaseDirectories = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          If enabled, `lowerdir`, `upperdir` and `workdir` will be prefixed with `/sysroot`.
-
-          Disabling this can be useful to create an overlay over directories which aren't on the real root.
-
-          Disabling this does not work with the scripted (i.e. non-systemd) initrd.
-        '';
+            lowerdir = map (s: prefix + s) config.overlay.lowerdir;
+            upperdir = prefix + config.overlay.upperdir;
+            workdir = prefix + config.overlay.workdir;
+          in
+          [
+            "lowerdir=${lib.concatStringsSep ":" lowerdir}"
+          ]
+          ++ lib.optionals (config.overlay.upperdir != null) [
+            "upperdir=${upperdir}"
+            "workdir=${workdir}"
+          ];
       };
     };
-
-    config = lib.mkIf (config.overlay.lowerdir != null) {
-      fsType = "overlay";
-      device = lib.mkDefault "overlay";
-      depends = map (x: "${x}") (config.overlay.lowerdir ++ lib.optionals (config.overlay.upperdir != null) [
-        config.overlay.upperdir
-        config.overlay.workdir
-      ]);
-
-      options =
-        let
-          prefix = sysrootPrefix config;
-
-          lowerdir = map (s: prefix + s) config.overlay.lowerdir;
-          upperdir = prefix + config.overlay.upperdir;
-          workdir = prefix + config.overlay.workdir;
-        in
-        [
-          "lowerdir=${lib.concatStringsSep ":" lowerdir}"
-        ] ++ lib.optionals (config.overlay.upperdir != null) [
-          "upperdir=${upperdir}"
-          "workdir=${workdir}"
-        ];
-    };
-
-  };
 in
 
 {

--- a/nixos/tests/filesystems-overlayfs.nix
+++ b/nixos/tests/filesystems-overlayfs.nix
@@ -24,40 +24,42 @@ in
 
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
-  nodes.machine = { config, pkgs, ... }: {
-    boot.initrd.systemd.enable = true;
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      boot.initrd.systemd.enable = true;
 
-    virtualisation.fileSystems = {
-      "/initrd-overlay" = {
-        overlay = {
-          lowerdir = [ initrdLowerdir ];
-          upperdir = "/.rw-initrd-overlay/upper";
-          workdir = "/.rw-initrd-overlay/work";
+      virtualisation.fileSystems = {
+        "/initrd-overlay" = {
+          overlay = {
+            lowerdir = [ initrdLowerdir ];
+            upperdir = "/.rw-initrd-overlay/upper";
+            workdir = "/.rw-initrd-overlay/work";
+          };
+          neededForBoot = true;
         };
-        neededForBoot = true;
-      };
-      "/userspace-overlay" = {
-        overlay = {
-          lowerdir = [ userspaceLowerdir ];
-          upperdir = "/.rw-userspace-overlay/upper";
-          workdir = "/.rw-userspace-overlay/work";
+        "/userspace-overlay" = {
+          overlay = {
+            lowerdir = [ userspaceLowerdir ];
+            upperdir = "/.rw-userspace-overlay/upper";
+            workdir = "/.rw-userspace-overlay/work";
+          };
         };
-      };
-      "/ro-initrd-overlay" = {
-        overlay.lowerdir = [
-          initrdLowerdir
-          initrdLowerdir2
-        ];
-        neededForBoot = true;
-      };
-      "/ro-userspace-overlay" = {
-        overlay.lowerdir = [
-          userspaceLowerdir
-          userspaceLowerdir2
-        ];
+        "/ro-initrd-overlay" = {
+          overlay.lowerdir = [
+            initrdLowerdir
+            initrdLowerdir2
+          ];
+          neededForBoot = true;
+        };
+        "/ro-userspace-overlay" = {
+          overlay.lowerdir = [
+            userspaceLowerdir
+            userspaceLowerdir2
+          ];
+        };
       };
     };
-  };
 
   testScript = ''
     machine.wait_for_unit("default.target")

--- a/nixos/tests/filesystems-overlayfs.nix
+++ b/nixos/tests/filesystems-overlayfs.nix
@@ -38,6 +38,14 @@ in
           };
           neededForBoot = true;
         };
+        "/initrd-real-root-overlay" = {
+          overlay = {
+            lowerdir = [ userspaceLowerdir ];
+            upperdir = "/run/upper"; # from initrd
+            workdir = "/run/work"; # from initrd
+            useStage1BaseDirectories = false;
+          };
+        };
         "/userspace-overlay" = {
           overlay = {
             lowerdir = [ userspaceLowerdir ];
@@ -68,6 +76,11 @@ in
       machine.wait_for_file("/initrd-overlay/initrd.txt", 5)
       machine.succeed("touch /initrd-overlay/writable.txt")
       machine.succeed("findmnt --kernel --types overlay /initrd-overlay")
+
+    with subtest("Userspace overlay with upper/workdir in initrd"):
+      machine.wait_for_file("/initrd-real-root-overlay/userspace.txt", 5)
+      machine.succeed("touch /initrd-real-root-overlay/writable.txt")
+      machine.succeed("findmnt --kernel --types overlay /initrd-real-root-overlay")
 
     with subtest("Userspace overlay"):
       machine.wait_for_file("/userspace-overlay/userspace.txt", 5)


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This enables mounting paths from the initrd into the real root with the overlayfs abstraction, which can be useful in some cases, e.g. to create an overlay in the real root without a visible upper-/workdir in the real root.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
