### PR TITLE
Gancio service fixes

### DIFF
--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -157,11 +157,18 @@ in
     };
 
     nginx = mkOption {
-      type = types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+      type = types.submodule (
+        lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
+          # enable encryption by default,
+          # as sensitive login credentials should not be transmitted in clear text.
+          options.forceSSL.default = true;
+          options.enableACME.default = true;
+        }
+      );
       default = { };
       example = {
-        enableACME = true;
-        forceSSL = true;
+        enableACME = false;
+        forceSSL = false;
       };
       description = "Extra configuration for the nginx virtual host of gancio.";
     };
@@ -260,8 +267,6 @@ in
       virtualHosts."${cfg.settings.hostname}" = mkMerge [
         cfg.nginx
         {
-          enableACME = mkDefault true;
-          forceSSL = mkDefault true;
           locations = {
             "/" = {
               index = "index.html";

--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -54,9 +54,12 @@ in
           };
           baseurl = mkOption {
             type = types.str;
-            default = "";
-            example = "/gancio";
-            description = "The URL path under which the server is reachable.";
+            default = "http${
+              lib.optionalString config.services.nginx.virtualHosts."${cfg.settings.hostname}".enableACME "s"
+            }://${cfg.settings.hostname}";
+            defaultText = lib.literalExpression ''"https://''${cfg.settings.hostname}"'';
+            example = "https://demo.gancio.org/gancio";
+            description = "The full URL under which the server is reachable.";
           };
           server = {
             socket = mkOption {

--- a/nixos/tests/gancio.nix
+++ b/nixos/tests/gancio.nix
@@ -71,7 +71,7 @@ import ./make-test-python.nix (
       server.wait_for_unit("postgresql")
       server.wait_for_unit("gancio")
       server.wait_for_unit("nginx")
-      server.wait_for_open_port(13120)
+      server.wait_for_file("/run/gancio/socket")
       server.wait_for_open_port(80)
 
       # Check can create user via cli


### PR DESCRIPTION
1. fix ssl by default (`mkDefault` was not enough to override default values)
2. use socket between nginx and gancio
3. add back default value for baseurl (I missed that it was removed when moved into settings)