### PR TITLE
git-identity: init at 1.1.1

### DIFF
--- a/pkgs/by-name/gi/git-identity/package.nix
+++ b/pkgs/by-name/gi/git-identity/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installShellFiles,
+  ronn,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "git-identity";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "madx";
+    repo = "git-identity";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-u4lIW0bntaKrVUwodXZ8ZwWxSZtLuhVSUAbIj8jjcLw=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    ronn
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    ronn --roff git-identity.1.ronn
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp git-identity $out/bin/git-identity
+    installManPage git-identity.1
+    installShellCompletion --cmd git-identity \
+      --bash git-identity.bash-completion \
+      --zsh git-identity.zsh-completion
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Manage your identity in Git";
+    mainProgram = "git-identity";
+    homepage = "https://github.com/madx/git-identity";
+    license = lib.licenses.wtfpl;
+    maintainers = with lib.maintainers; [ mynacol ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add a small tool to manage multiple git identities: https://github.com/madx/git-identity
The update-script can leverage repology: https://repology.org/project/git-identity/versions

I'm running it for months already without any problems.

The only possible additional changes/improvements I can think of:
- Split output into multiple outputs (e.g. for the man page)?
- Add some checks (e.g. bash syntax check, shellcheck)?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
