### PR TITLE
microsoft-identity-broker: fix the hash

### DIFF
--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_${version}_amd64.deb";
-    hash = "sha256-O9zbImSWMrRsaOozj5PsCRvQ3UsaJzLfoTohmLZvLkM=";
+    hash = "sha256-I4Q6ucT6ps8/QGiQTNbMXcKxq6UMcuwJ0Prcqvov56M=";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper openjdk11 zip ];

--- a/pkgs/by-name/mi/microsoft-identity-broker/update.sh
+++ b/pkgs/by-name/mi/microsoft-identity-broker/update.sh
@@ -12,15 +12,19 @@ echo "$index_file" | while read -r line; do
     if [[ "$line" =~ ^Version:[[:space:]]*(.*) ]]; then
         Version="${BASH_REMATCH[1]}"
     fi
+    if [[ "$line" =~ ^SHA256:[[:space:]]*(.*) ]]; then
+        SHA256="${BASH_REMATCH[1]}"
+    fi
 
     if ! [[ "$line" ]] && [[ "${Package}" == "microsoft-identity-broker" ]]; then
         if ( dpkg --compare-versions ${Version} gt ${latest_version} ); then
             latest_version="${Version}"
+            sri_hash=$(nix-hash --to-sri --type sha256 "$SHA256")
 
-            echo $latest_version
+            echo $latest_version $sri_hash
         fi
 
         Package=""
         Version=""
     fi
-done | tail -n 1 | (read version; update-source-version microsoft-identity-broker $version)
+done | tail -n 1 | (read version hash; update-source-version microsoft-identity-broker $version $hash)


### PR DESCRIPTION
## Description of changes

Somehow the hash used in the update #325436 was incorrect. Fix the hash and change the update script to use the SHA256 provided in the upstream `Packages` file, since one is available in it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
