### PR TITLE
treewide: replace pythonImportCheck(s) with pythonImportsCheck

### DIFF
--- a/pkgs/development/python-modules/geoparquet/default.nix
+++ b/pkgs/development/python-modules/geoparquet/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pythonImportCheck = "geoparquet";
+  pythonImportsCheck = [ "geoparquet" ];
 
   doCheck = false; # no tests
 

--- a/pkgs/development/python-modules/pyairports/default.nix
+++ b/pkgs/development/python-modules/pyairports/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   doCheck = false;
 
-  pythonImportChecks = [ "pyairports" ];
+  pythonImportsCheck = [ "pyairports" ];
 
   meta = with lib; {
     description = "pyairports is a package which enables airport lookup by 3-letter IATA code.";

--- a/pkgs/development/python-modules/pyfunctional/default.nix
+++ b/pkgs/development/python-modules/pyfunctional/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pythonImportCheck = "pyfunctional";
+  pythonImportsCheck = [ "functional" ];
 
   meta = {
     description = "Python library for creating data pipelines with chain functional programming";

--- a/pkgs/development/python-modules/python-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/python-ffmpeg/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pyee ];
 
   nativeBuildInputs = [ setuptools-scm ];
-  pythonImportCheck = [ "ffmpeg" ];
+  pythonImportsCheck = [ "ffmpeg" ];
 
   meta = {
     homepage = "https://github.com/jonghwanhyeon/python-ffmpeg";


### PR DESCRIPTION

## Description of changes

fixes #340809

- **python312Packages.geoparquet: fix typo**
- **python312Packages.pyaiports: fix typo**
- **python312Packages.pyfunctional: fix typo**
- **python312Packages.python-ffmpeg: fix typo**
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
