### PR TITLE
itk: unvendor eigen

### DIFF
--- a/pkgs/development/libraries/itk/generic.nix
+++ b/pkgs/development/libraries/itk/generic.nix
@@ -13,6 +13,7 @@
   castxml,
   swig,
   expat,
+  eigen,
   fftw,
   gdcm,
   hdf5-cpp,
@@ -106,9 +107,7 @@ stdenv.mkDerivation {
       "-DBUILD_SHARED_LIBS=ON"
       "-DITK_FORBID_DOWNLOADS=ON"
       "-DITK_USE_SYSTEM_LIBRARIES=ON" # finds common libraries e.g. hdf5, libpng, libtiff, zlib, but not GDCM, NIFTI, MINC, etc.
-      # note ITK_USE_SYSTEM_EIGEN, part of ITK_USE_SYSTEM_LIBRARIES,
-      # causes "...-itk-5.2.1/include/ITK-5.2/itkSymmetricEigenAnalysis.h:23:31: fatal error: Eigen/Eigenvalues: No such file or directory"
-      # when compiling c3d, but maybe an ITK 5.2/eigen version issue:
+      "-DITK_USE_SYSTEM_EIGEN=ON"
       "-DITK_USE_SYSTEM_EIGEN=OFF"
       "-DITK_USE_SYSTEM_GOOGLETEST=OFF" # ANTs build failure due to https://github.com/ANTsX/ANTs/issues/1489
       "-DITK_USE_SYSTEM_GDCM=ON"
@@ -144,6 +143,7 @@ stdenv.mkDerivation {
 
   buildInputs =
     [
+      eigen
       libX11
       libuuid
     ]


### PR DESCRIPTION
## Description of changes

Unvendor the eigen dependency from `itk` (and `itk_5_2`).

Unlike some other ITK dependencies I've unvendored, `eigen` didn't need to be added to `propagatedBuildInputs` (see code comments regarding this attribute), perhaps because it's a header-only library.

nixpkgs-review happy on x86 NixOS (pydicom-seg already broken, will look into this separately):

```
1 package marked as broken and skipped:

ezminc

 
4 packages failed to build:

python311Packages.pydicom-seg python311Packages.pydicom-seg.dist python312Packages.pydicom-seg python312Packages.pydicom-seg.dist

32 packages built:

ants c3d elastix intensity-normalization intensity-normalization.dist itk itk_5_2 mirtk mrtrix python311Packages.intensity-normalization python311Packages.intensity-normalization.dist python311Packages.medpy python311Packages.medpy.dist python311Packages.pymedio python311Packages.pymedio.dist python311Packages.pyradiomics python311Packages.pyradiomics.dist python311Packages.simpleitk python311Packages.simpleitk.dist python311Packages.torchio python311Packages.torchio.dist python312Packages.medpy python312Packages.medpy.dist python312Packages.pymedio python312Packages.pymedio.dist python312Packages.pyradiomics python312Packages.pyradiomics.dist python312Packages.simpleitk python312Packages.simpleitk.dist python312Packages.torchio python312Packages.torchio.dist simpleitk
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
