### PR TITLE
Update melpa package-build

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/melpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/melpa.nix
@@ -12,8 +12,8 @@ let
     src = fetchFromGitHub {
       owner = "melpa";
       repo = "package-build";
-      rev = "c48aa078c01b4f07b804270c4583a0a58ffea1c0";
-      sha256 = "sha256-MzPj375upIiYXdQR+wWXv3A1zMqbSrZlH0taLuxx/1M=";
+      rev = "d5661f1f1996a893fbcbacb4d290c57acab4fb0e";
+      hash = "sha256-zVhFR2kLLkCKC+esPBbIk3qOa033YND1HF9GiNI4JM8=";
     };
 
     patches = [ ./package-build-dont-use-mtime.patch ];

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -123226,8 +123226,8 @@
  },
  {
   "ename": "ttl-mode",
-  "commit": "0575169e8fb9a2537582f5aa77fc9950f1f1384c",
-  "sha256": "1fi8xxzwz3h7kgn69h4p1wlvhvia0v8qqh7k64pgh44b2fq040p1",
+  "commit": "8a7d0c7287d157f45ebcb7a6ba2a776b3ee2bc2d",
+  "sha256": "1v34axc96n5aqsm9w2j94z8h9mqfa41300lx8aqccwj8a5qwk90k",
   "fetcher": "github",
   "repo": "nxg/ttl-mode",
   "unstable": {


### PR DESCRIPTION
## Description of changes

MELPA has started to use `:rename` in the `:files` attribute of recipes (e.g., for `bbdb`), which is rejected as an invalid recipe by earlier versions of package-build, breaking, e.g., the `emacs-overlay`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>8 packages marked as broken and skipped:</summary>
  <ul>
    <li>emacsPackages.eterm-256color</li>
    <li>emacsPackages.instapaper</li>
    <li>emacsPackages.magit-stgit</li>
    <li>emacsPackages.melancholy-theme</li>
    <li>emacsPackages.nemerle</li>
    <li>emacsPackages.per-buffer-theme</li>
    <li>emacsPackages.shm</li>
    <li>emacsPackages.sql-presto</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>emacsPackages.clingo-mode</li>
  </ul>
</details>
<details>
  <summary>5849 packages built:</summary>
  <ul>
    <li>emacsPackages.a</li>
    <li>[…] (omitted, since GitHub restricts the maximal size of PR comments)</li>
    <li>emacsPackages.zzz-to-char</li>
  </ul>
</details>


Note that `clingo-mode` is already broken on current `master`, this wasn't changed by this PR.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
