### PR TITLE
rtlamr: init at 0.9.3-unstable-2023-08-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9892,6 +9892,12 @@
       { fingerprint = "816D 23F5 E672 EC58 7674  4A73 197F 9A63 2D13 9E30"; }
     ];
   };
+  jmendyk = {
+    email = "jakub@ndyk.me";
+    github = "JMendyk";
+    githubId = 9089004;
+    name = "Jakub Mendyk";
+  };
   jmettes = {
     email = "jonathan@jmettes.com";
     github = "jmettes";

--- a/pkgs/by-name/rt/rtlamr/package.nix
+++ b/pkgs/by-name/rt/rtlamr/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+buildGoModule rec {
+  pname = "rtlamr";
+  version = "0.9.3-unstable-2023-08-13";
+
+  src = fetchFromGitHub {
+    owner = "bemasher";
+    repo = "rtlamr";
+    rev = "dcdddc5a6e7717a038e9346d0adcf9669e4f60b7";
+    sha256 = "sha256-r3dMCpNBCQsqSlFYYfOtVMMgPOagWks6PPWOn5PsLZs";
+  };
+
+  vendorHash = "sha256-uT6zfsWgIot0EMNqwtwJNFXN/WaAyOGfcYJjuyOXT4g=";
+
+  meta = {
+    description = "Rtl-sdr receiver for Itron ERT compatible smart meters";
+    longDescription = ''
+      An rtl-sdr receiver for Itron ERT compatible smart meters operating
+      in the 900MHz ISM band
+    '';
+    homepage = "https://github.com/bemasher/rtlamr";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ jmendyk ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

The `rtlamr` is an rtl-sdr receiver for Itron ERT compatible smart meters operating in the 900MHz ISM band. The project is hosted at https://github.com/bemasher/rtlamr.

Tested with `rtl_tcp` (from `rtl-sdr` package) which provides data that `rtlamr` processes.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
