### PR TITLE
modifypatch: init

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -4,92 +4,52 @@
 # often change with updating of git or cgit.
 # stripLen acts as the -p parameter when applying a patch.
 
-{ lib, fetchurl, patchutils }:
+{
+  lib,
+  fetchurl,
+  patchutils,
+  modifypatchscript,
+}:
 
-{ relative ? null
-, stripLen ? 0
-, decode ? "cat" # custom command to decode patch e.g. base64 -d
-, extraPrefix ? null
-, excludes ? []
-, includes ? []
-, revert ? false
-, postFetch ? ""
-, nativeBuildInputs ? []
-, ...
+{
+  relative ? null,
+  stripLen ? 0,
+  decode ? "cat", # custom command to decode patch e.g. base64 -d
+  extraPrefix ? null,
+  excludes ? [ ],
+  includes ? [ ],
+  revert ? false,
+  postFetch ? "",
+  nativeBuildInputs ? [ ],
+  ...
 }@args:
-let
-  args' = if relative != null then {
-    stripLen = 1 + lib.length (lib.splitString "/" relative) + stripLen;
-    extraPrefix = lib.optionalString (extraPrefix != null) extraPrefix;
-  } else {
-    inherit stripLen extraPrefix;
-  };
-in let
-  inherit (args') stripLen extraPrefix;
-in
-lib.throwIfNot (excludes == [] || includes == [])
-  "fetchpatch: cannot use excludes and includes simultaneously"
-fetchurl ({
-  nativeBuildInputs = [ patchutils ] ++ nativeBuildInputs;
-  postFetch = ''
-    tmpfile="$TMPDIR/patch"
-
-    if [ ! -s "$out" ]; then
-      echo "error: Fetched patch file '$out' is empty!" 1>&2
-      exit 1
-    fi
-
-    set +e
-    ${decode} < "$out" > "$tmpfile"
-    if [ $? -ne 0 ] || [ ! -s "$tmpfile" ]; then
-        echo 'Failed to decode patch with command "'${lib.escapeShellArg decode}'"' >&2
-        echo 'Fetched file was (limited to 128 bytes):' >&2
-        od -A x -t x1z -v -N 128 "$out" >&2
-        exit 1
-    fi
-    set -e
-    mv "$tmpfile" "$out"
-
-    lsdiff \
-      ${lib.optionalString (relative != null) "-p1 -i ${lib.escapeShellArg relative}/'*'"} \
-      "$out" \
-    | sort -u | sed -e 's/[*?]/\\&/g' \
-    | xargs -I{} \
-      filterdiff \
-      --include={} \
-      --strip=${toString stripLen} \
-      ${lib.optionalString (extraPrefix != null) ''
-          --addoldprefix=a/${lib.escapeShellArg extraPrefix} \
-          --addnewprefix=b/${lib.escapeShellArg extraPrefix} \
-      ''} \
-      --clean "$out" > "$tmpfile"
-
-    if [ ! -s "$tmpfile" ]; then
-      echo "error: Normalized patch '$tmpfile' is empty (while the fetched file was not)!" 1>&2
-      echo "Did you maybe fetch a HTML representation of a patch instead of a raw patch?" 1>&2
-      echo "Fetched file was:" 1>&2
-      cat "$out" 1>&2
-      exit 1
-    fi
-
-    filterdiff \
-      -p1 \
-      ${builtins.toString (builtins.map (x: "-x ${lib.escapeShellArg x}") excludes)} \
-      ${builtins.toString (builtins.map (x: "-i ${lib.escapeShellArg x}") includes)} \
-      "$tmpfile" > "$out"
-
-    if [ ! -s "$out" ]; then
-      echo "error: Filtered patch '$out' is empty (while the original patch file was not)!" 1>&2
-      echo "Check your includes and excludes." 1>&2
-      echo "Normalized patch file was:" 1>&2
-      cat "$tmpfile" 1>&2
-      exit 1
-    fi
-  '' + lib.optionalString revert ''
-    interdiff "$out" /dev/null > "$tmpfile"
-    mv "$tmpfile" "$out"
-  '' + postFetch;
-} // builtins.removeAttrs args [
-  "relative" "stripLen" "decode" "extraPrefix" "excludes" "includes" "revert"
-  "postFetch" "nativeBuildInputs"
-])
+fetchurl (
+  {
+    nativeBuildInputs = [ patchutils ] ++ nativeBuildInputs;
+    postFetch = ''
+      ${modifypatchscript {
+        inherit
+          relative
+          stripLen
+          decode
+          extraPrefix
+          excludes
+          includes
+          revert
+          ;
+      }}
+      ${postFetch}
+    '';
+  }
+  // builtins.removeAttrs args [
+    "relative"
+    "stripLen"
+    "decode"
+    "extraPrefix"
+    "excludes"
+    "includes"
+    "revert"
+    "postFetch"
+    "nativeBuildInputs"
+  ]
+)

--- a/pkgs/by-name/mo/modifypatch/package.nix
+++ b/pkgs/by-name/mo/modifypatch/package.nix
@@ -1,0 +1,71 @@
+# This normalizes a patch/diff file.
+
+{
+  stdenvNoCC,
+  lib,
+  patchutils,
+  modifypatchscript,
+}:
+
+{
+  src,
+  name ? null,
+  nativeBuildInputs ? [ ],
+  preModify ? "",
+  postModify ? "",
+  derivationArgs ? { },
+
+  relative ? null,
+  stripLen ? 0,
+  decode ? "cat", # custom command to decode patch e.g. base64 -d
+  extraPrefix ? null,
+  excludes ? [ ],
+  includes ? [ ],
+  revert ? false,
+}:
+stdenvNoCC.mkDerivation (
+  {
+    inherit src;
+    passAsFile = [ "src" ];
+
+    name = if name != null then name else builtins.baseNameOf (builtins.toString src);
+
+    enableParallelBuilding = true;
+
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+
+    nativeBuildInputs = [ patchutils ] ++ nativeBuildInputs;
+    installPhase = ''
+      runHook preInstall
+      ${preModify}
+
+      ${modifypatchscript {
+        inherit
+          relative
+          stripLen
+          decode
+          extraPrefix
+          excludes
+          includes
+          revert
+          ;
+      }}
+
+      ${postModify}
+      runHook postInstall
+    '';
+  }
+  // lib.optionalAttrs (!derivationArgs ? meta) {
+    pos =
+      let
+        argNames = builtins.attrNames derivationArgs;
+      in
+      if builtins.length argNames > 0 then
+        builtins.unsafeGetAttrPos (builtins.head argNames) derivationArgs
+      else
+        null;
+  }
+  // derivationArgs
+)

--- a/pkgs/by-name/mo/modifypatchscript/package.nix
+++ b/pkgs/by-name/mo/modifypatchscript/package.nix
@@ -1,0 +1,104 @@
+{ lib }:
+
+# Get a script which modifies a patch file (stored in `$out`) in place.
+#
+# This is used to implement `modifypatch` and `fetchpatch` using the same code
+# without changing existing `fetchpatch` hashes.
+#
+# See: https://github.com/NixOS/nixpkgs/issues/25154
+#
+# The script will expect to have several binaries provided by `patchutils` and
+# `stdenvNoCC` available in the `$PATH`, including:
+# - `od`
+# - `sort`
+# - `xargs`
+# - `lsdiff`
+# - `filterdiff`
+# - `interdiff`
+{
+  relative ? null,
+  stripLen ? 0,
+  decode ? "cat", # custom command to decode patch e.g. base64 -d
+  extraPrefix ? null,
+  excludes ? [ ],
+  includes ? [ ],
+  revert ? false,
+}:
+let
+  args' =
+    if relative != null then
+      {
+        stripLen = 1 + lib.length (lib.splitString "/" relative) + stripLen;
+        extraPrefix = lib.optionalString (extraPrefix != null) extraPrefix;
+      }
+    else
+      {
+        inherit stripLen extraPrefix;
+      };
+in
+let
+  inherit (args') stripLen extraPrefix;
+in
+lib.throwIfNot (excludes == [ ] || includes == [ ])
+  "modifypatch/fetchpatch: cannot use excludes and includes simultaneously"
+  ''
+    tmpfile="patch"
+
+    if [ ! -s "$out" ]; then
+      echo "error: Fetched patch file '$out' is empty!" 1>&2
+      exit 1
+    fi
+
+    set +e
+    ${decode} < "$out" > "$tmpfile"
+    if [ $? -ne 0 ] || [ ! -s "$tmpfile" ]; then
+        echo 'Failed to decode patch with command "'${lib.escapeShellArg decode}'"' >&2
+        echo 'Patch was (limited to 128 bytes):' >&2
+        od -A x -t x1z -v -N 128 "$out" >&2
+        exit 1
+    fi
+    set -e
+    mv "$tmpfile" "$out"
+
+    lsdiff \
+      ${lib.optionalString (relative != null) "-p1 -i ${lib.escapeShellArg relative}/'*'"} \
+      "$out" \
+    | sort -u | sed -e 's/[*?]/\\&/g' \
+    | xargs -I{} \
+      filterdiff \
+      --include={} \
+      --strip=${toString stripLen} \
+      ${
+        lib.optionalString (extraPrefix != null) ''
+          --addoldprefix=a/${lib.escapeShellArg extraPrefix} \
+          --addnewprefix=b/${lib.escapeShellArg extraPrefix} \
+        ''
+      } \
+      --clean "$out" > "$tmpfile"
+
+    if [ ! -s "$tmpfile" ]; then
+      echo "error: Normalized patch '$tmpfile' is empty (while the fetched file was not)!" 1>&2
+      echo "Did you maybe fetch a HTML representation of a patch instead of a raw patch?" 1>&2
+      echo "Fetched file was:" 1>&2
+      cat "$out" 1>&2
+      exit 1
+    fi
+
+    filterdiff \
+      -p1 \
+      ${builtins.toString (builtins.map (x: "-x ${lib.escapeShellArg x}") excludes)} \
+      ${builtins.toString (builtins.map (x: "-i ${lib.escapeShellArg x}") includes)} \
+      "$tmpfile" > "$out"
+
+    if [ ! -s "$out" ]; then
+      echo "error: Filtered patch '$out' is empty (while the original patch file was not)!" 1>&2
+      echo "Check your includes and excludes." 1>&2
+      echo "Normalized patch file was:" 1>&2
+      cat "$tmpfile" 1>&2
+      exit 1
+    fi
+  ''
++ lib.optionalString revert ''
+  interdiff "$out" /dev/null > "$tmpfile"
+  mv "$tmpfile" "$out"
+''


### PR DESCRIPTION
`modifypatch` enables manipulating patch files like `fetchpatch` does, but without fetching a patch over the network: prefixes can be removed or modified from each path in the patch, files can be filtered with include or exclude glob lists, and patches can be reverted/inverted.

This will be a companion to `applyPatches`.

A new helper function, `modifypatchscript`, is added to share code between the two implementations without modifying the hashes of files built by `fetchpatch`.

### TODO

- [ ] Design review: confirm with maintainers that the design is approved (so I don't waste time writing docs and tests that have to be rewritten)
- [ ] Documentation
- [ ] Tests (other than `fetchpatch` tests)


<!--
## Description of changes

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.

## Things done

Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
-->

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
