### PR TITLE
cimg, gmic-qt: 3.4.0 -> 3.4.2

### DIFF
--- a/pkgs/by-name/ci/cimg/package.nix
+++ b/pkgs/by-name/ci/cimg/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cimg";
-  version = "3.4.0";
+  version = "3.4.2";
 
   src = fetchFromGitHub {
     owner = "GreycLab";
     repo = "CImg";
     rev = "refs/tags/v.${finalAttrs.version}";
-    hash = "sha256-BnDS1n1aIQh9HJZeZv0hR7vo2l6Kf9B/11fYFbb/cpQ=";
+    hash = "sha256-lYs8V/phdyM1kpcxBDS3vAjxFgGCaaOCdNHU3//dgDs=";
   };
 
   outputs = [ "out" "doc" ];

--- a/pkgs/by-name/gm/gmic-qt/package.nix
+++ b/pkgs/by-name/gm/gmic-qt/package.nix
@@ -49,13 +49,13 @@ assert lib.assertMsg
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gmic-qt${lib.optionalString (variant != "standalone") "-${variant}"}";
-  version = "3.4.0";
+  version = "3.4.2";
 
   src = fetchFromGitHub {
     owner = "c-koi";
     repo = "gmic-qt";
     rev = "v.${finalAttrs.version}";
-    hash = "sha256-IZMvvhWQwbnyxF3CkvEjySl3o3DB6UucpjqOFR9NjQ0=";
+    hash = "sha256-fM6dBxBC2b1/v+rfiP//QaAcTJmMtYPn4OUNwVqKhYk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/GreycLab/CImg/compare/refs/tags/v.3.4.0...refs/tags/v.3.4.2
https://github.com/c-koi/gmic-qt/compare/refs/tags/v.3.4.0...refs/tags/v.3.4.2

openroad is already failing on master

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>openroad</li>
  </ul>
</details>
<details>
  <summary>14 packages built:</summary>
  <ul>
    <li>ansel</li>
    <li>cimg</li>
    <li>cimg.doc</li>
    <li>darktable</li>
    <li>gimp-with-plugins</li>
    <li>gimpPlugins.gmic</li>
    <li>gmic</li>
    <li>gmic-qt</li>
    <li>gmic.dev</li>
    <li>gmic.lib</li>
    <li>gmic.man</li>
    <li>imgcat</li>
    <li>phash</li>
    <li>photoprism</li>
  </ul>
</details>

## Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>cimg</li>
    <li>cimg.doc</li>
    <li>darktable</li>
    <li>gimpPlugins.gmic</li>
    <li>gmic</li>
    <li>gmic-qt</li>
    <li>gmic.dev</li>
    <li>gmic.lib</li>
    <li>gmic.man</li>
    <li>imgcat</li>
    <li>phash</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc