### PR TITLE
gmic{,-qt}: enable OpenCV, OpenMP (Clang) and X11

### DIFF
--- a/pkgs/by-name/gm/gmic-qt/package.nix
+++ b/pkgs/by-name/gm/gmic-qt/package.nix
@@ -12,6 +12,7 @@
 , libpng
 , libsForQt5
 , libtiff
+, llvmPackages
 , ninja
 , nix-update-script
 , openexr
@@ -79,7 +80,9 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ (with libsForQt5; [
     qtbase
     qttools
-  ]) ++ variants.${variant}.extraDeps;
+  ]) ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ] ++ variants.${variant}.extraDeps;
 
   postPatch = ''
     patchShebangs \

--- a/pkgs/by-name/gm/gmic/package.nix
+++ b/pkgs/by-name/gm/gmic/package.nix
@@ -13,9 +13,12 @@
 , gnused
 , graphicsmagick
 , jq
+, libX11
+, libXext
 , libjpeg
 , libpng
 , libtiff
+, llvmPackages
 , ninja
 , opencv
 , openexr
@@ -55,18 +58,24 @@ stdenv.mkDerivation (finalAttrs: {
     cimg
     fftw
     graphicsmagick
+    libX11
+    libXext
     libjpeg
     libpng
     libtiff
     opencv
     openexr
     zlib
+  ] ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
   ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_LIB_STATIC" false)
     (lib.cmakeBool "ENABLE_CURL" false)
     (lib.cmakeBool "ENABLE_DYNAMIC_LINKING" true)
+    (lib.cmakeBool "ENABLE_OPENCV" true)
+    (lib.cmakeBool "ENABLE_XSHM" true)
     (lib.cmakeBool "USE_SYSTEM_CIMG" true)
   ];
 


### PR DESCRIPTION
## Description of changes

fixes #265966

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>10 packages built:</summary>
  <ul>
    <li>ansel</li>
    <li>darktable</li>
    <li>gimp-with-plugins</li>
    <li>gimpPlugins.gmic</li>
    <li>gmic</li>
    <li>gmic-qt</li>
    <li>gmic.dev</li>
    <li>gmic.lib</li>
    <li>gmic.man</li>
    <li>photoprism</li>
  </ul>
</details>

## Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>7 packages built:</summary>
  <ul>
    <li>darktable</li>
    <li>gimpPlugins.gmic</li>
    <li>gmic</li>
    <li>gmic-qt</li>
    <li>gmic.dev</li>
    <li>gmic.lib</li>
    <li>gmic.man</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc