### PR TITLE
auto-patchelf: refactor structuredAttrs support

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -53,19 +53,11 @@ autoPatchelf() {
         esac
     done
 
-    if [ -n "$__structuredAttrs" ]; then
-        local ignoreMissingDepsArray=( "${autoPatchelfIgnoreMissingDeps[@]}" )
-        local appendRunpathsArray=( "${appendRunpaths[@]}" )
-        local runtimeDependenciesArray=( "${runtimeDependencies[@]}" )
-        local patchelfFlagsArray=( "${patchelfFlags[@]}" )
-        local autoPatchelfFlagsArray=( "${autoPatchelfFlags[@]}" )
-    else
-        readarray -td' ' ignoreMissingDepsArray < <(echo -n "$autoPatchelfIgnoreMissingDeps")
-        local appendRunpathsArray=($appendRunpaths)
-        local runtimeDependenciesArray=($runtimeDependencies)
-        local patchelfFlagsArray=($patchelfFlags)
-        local autoPatchelfFlagsArray=($autoPatchelfFlags)
-    fi
+    concatTo ignoreMissingDepsArray autoPatchelfIgnoreMissingDeps
+    concatTo appendRunpathsArray appendRunpaths
+    concatTo runtimeDependenciesArray runtimeDependencies
+    concatTo patchelfFlagsArray patchelfFlags
+    concatTo autoPatchelfFlagsArray autoPatchelfFlags
 
     # Check if ignoreMissingDepsArray contains "1" and if so, replace it with
     # "*", printing a deprecation warning.

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -389,6 +389,8 @@ appendToVar() {
 # Arrays are simply concatenated, strings are split on whitespace.
 # Default values can be passed via name=default.
 concatTo() {
+    local -
+    set -o noglob
     local -n targetref="$1"; shift
     local arg default name type
     for arg in "$@"; do

--- a/pkgs/test/auto-patchelf-hook/package.nix
+++ b/pkgs/test/auto-patchelf-hook/package.nix
@@ -60,7 +60,6 @@ stdenv.mkDerivation {
   # Additional phase performing the actual test.
   installCheckPhase =
     let allDeps = runtimeDependencies ++ [
-        (lib.getLib stdenv.cc.libc)
         (lib.getLib freetype)
       ];
     in

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -101,7 +101,7 @@ let
       ({
         inherit name;
 
-        string = "a b";
+        string = "a *";
         list = ["c" "d"];
 
         passAsFile = [ "buildCommand" ] ++ lib.optionals (extraAttrs ? extraTest) [ "extraTest" ];
@@ -116,7 +116,7 @@ let
           concatTo flagsArray string list notset=e=f empty_array=g empty_string=h
           declare -p flagsArray
           [[ "''${flagsArray[0]}" == "a" ]] || (echo "'\$flagsArray[0]' was not 'a'" && false)
-          [[ "''${flagsArray[1]}" == "b" ]] || (echo "'\$flagsArray[1]' was not 'b'" && false)
+          [[ "''${flagsArray[1]}" == "*" ]] || (echo "'\$flagsArray[1]' was not '*'" && false)
           [[ "''${flagsArray[2]}" == "c" ]] || (echo "'\$flagsArray[2]' was not 'c'" && false)
           [[ "''${flagsArray[3]}" == "d" ]] || (echo "'\$flagsArray[3]' was not 'd'" && false)
           [[ "''${flagsArray[4]}" == "e=f" ]] || (echo "'\$flagsArray[4]' was not 'e=f'" && false)
@@ -127,7 +127,7 @@ let
           concatTo nonExistant string list notset=e=f empty_array=g empty_string=h
           declare -p nonExistant
           [[ "''${nonExistant[0]}" == "a" ]] || (echo "'\$nonExistant[0]' was not 'a'" && false)
-          [[ "''${nonExistant[1]}" == "b" ]] || (echo "'\$nonExistant[1]' was not 'b'" && false)
+          [[ "''${nonExistant[1]}" == "*" ]] || (echo "'\$nonExistant[1]' was not '*'" && false)
           [[ "''${nonExistant[2]}" == "c" ]] || (echo "'\$nonExistant[2]' was not 'c'" && false)
           [[ "''${nonExistant[3]}" == "d" ]] || (echo "'\$nonExistant[3]' was not 'd'" && false)
           [[ "''${nonExistant[4]}" == "e=f" ]] || (echo "'\$nonExistant[4]' was not 'e=f'" && false)
@@ -344,7 +344,7 @@ in
           concatTo flagsWithSpaces string listWithSpaces
           declare -p flagsWithSpaces
           [[ "''${flagsWithSpaces[0]}" == "a" ]] || (echo "'\$flagsWithSpaces[0]' was not 'a'" && false)
-          [[ "''${flagsWithSpaces[1]}" == "b" ]] || (echo "'\$flagsWithSpaces[1]' was not 'b'" && false)
+          [[ "''${flagsWithSpaces[1]}" == "*" ]] || (echo "'\$flagsWithSpaces[1]' was not '*'" && false)
           [[ "''${flagsWithSpaces[2]}" == "c c" ]] || (echo "'\$flagsWithSpaces[2]' was not 'c c'" && false)
           [[ "''${flagsWithSpaces[3]}" == "d d" ]] || (echo "'\$flagsWithSpaces[3]' was not 'd d'" && false)
         '';


### PR DESCRIPTION
## Description of changes

Follow up to #318614 to use `concatTo` in `setup-hooks/auto-patchelf.sh`.

This needs to support `*` in the non-structuredAttrs case, so adjusted `concatTo` for that.

Can be tested via `nix-build -A tests.auto-patchelf-hook`. This will fail - but in the same way as on current master and the output clearly shows that flags are passed correctly. Not sure whether it is *supposed* to fail, though? CC @ConnorBaker and @yannham, who introduced it in #272752.

CC @emilazy @philiptaron @tie

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
