### PR TITLE
rust: support structuredAttrs in setup hooks

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash disable=SC2154,SC2164
+
 cargoBuildHook() {
     echo "Executing cargoBuildHook"
 
@@ -7,9 +9,10 @@ cargoBuildHook() {
     # separateDebugInfo.
     export "CARGO_PROFILE_${cargoBuildType@U}_STRIP"=false
 
-    if [ ! -z "${buildAndTestSubdir-}" ]; then
+    if [ -n "${buildAndTestSubdir-}" ]; then
         # ensure the output doesn't end up in the subdirectory
-        export CARGO_TARGET_DIR="$(pwd)/target"
+        CARGO_TARGET_DIR="$(pwd)/target"
+        export CARGO_TARGET_DIR
 
         pushd "${buildAndTestSubdir}"
     fi
@@ -37,7 +40,7 @@ cargoBuildHook() {
     echoCmd 'cargoBuildHook flags' "${flagsArray[@]}"
     @setEnv@ cargo build "${flagsArray[@]}"
 
-    if [ ! -z "${buildAndTestSubdir-}" ]; then
+    if [ -n "${buildAndTestSubdir-}" ]; then
         popd
     fi
 

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -1,6 +1,3 @@
-declare -a checkFlags
-declare -a cargoTestFlags
-
 cargoCheckHook() {
     echo "Executing cargoCheckHook"
 
@@ -10,36 +7,36 @@ cargoCheckHook() {
         pushd "${buildAndTestSubdir}"
     fi
 
+    local flagsArray=("-j" "$NIX_BUILD_CORES")
+
     if [[ -z ${dontUseCargoParallelTests-} ]]; then
-        threads=$NIX_BUILD_CORES
+        prependToVar checkFlags "--test-threads=$NIX_BUILD_CORES"
     else
-        threads=1
+        prependToVar checkFlags "--test-threads=1"
     fi
 
     if [ "${cargoCheckType}" != "debug" ]; then
-        cargoCheckProfileFlag="--profile ${cargoCheckType}"
+        flagsArray+=("--profile" "${cargoCheckType}")
     fi
 
     if [ -n "${cargoCheckNoDefaultFeatures-}" ]; then
-        cargoCheckNoDefaultFeaturesFlag=--no-default-features
+        flagsArray+=("--no-default-features")
     fi
 
     if [ -n "${cargoCheckFeatures-}" ]; then
-        cargoCheckFeaturesFlag="--features=${cargoCheckFeatures// /,}"
+        flagsArray+=("--features=$(concatStringsSep "," cargoCheckFeatures)")
     fi
 
-    argstr="${cargoCheckProfileFlag} ${cargoCheckNoDefaultFeaturesFlag} ${cargoCheckFeaturesFlag}
-        --target @rustHostPlatformSpec@ --offline ${cargoTestFlags}"
-
-    (
-        set -x
-        cargo test \
-              -j $NIX_BUILD_CORES \
-              ${argstr} -- \
-              --test-threads=${threads} \
-              ${checkFlags} \
-              ${checkFlagsArray+"${checkFlagsArray[@]}"}
+    flagsArray+=(
+        "--target" "@rustHostPlatformSpec@"
+        "--offline"
     )
+
+    prependToVar checkFlags "--"
+    concatTo flagsArray cargoTestFlags checkFlags checkFlagsArray
+
+    echoCmd 'cargoCheckHook flags' "${flagsArray[@]}"
+    cargo test "${flagsArray[@]}"
 
     if [[ -n "${buildAndTestSubdir-}" ]]; then
         popd

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash disable=SC2154,SC2164
+
 cargoCheckHook() {
     echo "Executing cargoCheckHook"
 

--- a/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
@@ -1,6 +1,3 @@
-declare -a checkFlags
-declare -a cargoTestFlags
-
 cargoNextestHook() {
     echo "Executing cargoNextestHook"
 
@@ -10,35 +7,34 @@ cargoNextestHook() {
         pushd "${buildAndTestSubdir}"
     fi
 
+    local flagsArray=(
+        "--target" "@rustHostPlatformSpec@"
+        "--offline"
+    )
+
     if [[ -z ${dontUseCargoParallelTests-} ]]; then
-        threads=$NIX_BUILD_CORES
+        flagsArray+=("-j" "$NIX_BUILD_CORES")
     else
-        threads=1
+        flagsArray+=("-j" "1")
     fi
 
     if [ "${cargoCheckType}" != "debug" ]; then
-        cargoCheckProfileFlag="--cargo-profile ${cargoCheckType}"
+        flagsArray+=("--cargo-profile" "${cargoCheckType}")
     fi
 
     if [ -n "${cargoCheckNoDefaultFeatures-}" ]; then
-        cargoCheckNoDefaultFeaturesFlag=--no-default-features
+        flagsArray+=("--no-default-features")
     fi
 
     if [ -n "${cargoCheckFeatures-}" ]; then
-        cargoCheckFeaturesFlag="--features=${cargoCheckFeatures// /,}"
+        flagsArray+=("--features=$(concatStringsSep "," cargoCheckFeatures)")
     fi
 
-    argstr="${cargoCheckProfileFlag} ${cargoCheckNoDefaultFeaturesFlag} ${cargoCheckFeaturesFlag}
-        --target @rustHostPlatformSpec@ --offline ${cargoTestFlags}"
+    prependToVar checkFlags "--"
+    concatTo flagsArray cargoTestFlags checkFlags checkFlagsArray
 
-    (
-        set -x
-        cargo nextest run \
-              -j ${threads} \
-              ${argstr} -- \
-              ${checkFlags} \
-              ${checkFlagsArray+"${checkFlagsArray[@]}"}
-    )
+    echoCmd 'cargoNextestHook flags' "${flagsArray[@]}"
+    cargo nextest run "${flagsArray[@]}"
 
     if [[ -n "${buildAndTestSubdir-}" ]]; then
         popd

--- a/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash disable=SC2154,SC2164
+
 cargoNextestHook() {
     echo "Executing cargoNextestHook"
 

--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash disable=SC2154,SC2164
+
 maturinBuildHook() {
     echo "Executing maturinBuildHook"
 
@@ -6,7 +8,7 @@ maturinBuildHook() {
     # Put the wheel to dist/ so that regular Python tooling can find it.
     local dist="$PWD/dist"
 
-    if [ ! -z "${buildAndTestSubdir-}" ]; then
+    if [ -n "${buildAndTestSubdir-}" ]; then
         pushd "${buildAndTestSubdir}"
     fi
 
@@ -25,7 +27,7 @@ maturinBuildHook() {
     echoCmd 'maturinBuildHook flags' "${flagsArray[@]}"
     @setEnv@ maturin build "${flagsArray[@]}"
 
-    if [ ! -z "${buildAndTestSubdir-}" ]; then
+    if [ -n "${buildAndTestSubdir-}" ]; then
         popd
     fi
 

--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -10,18 +10,20 @@ maturinBuildHook() {
         pushd "${buildAndTestSubdir}"
     fi
 
-    (
-    set -x
-    @setEnv@ maturin build \
-        --jobs=$NIX_BUILD_CORES \
-        --offline \
-        --target @rustTargetPlatformSpec@ \
-        --manylinux off \
-        --strip \
-        --release \
-        --out "$dist" \
-        ${maturinBuildFlags-}
+    local flagsArray=(
+        "--jobs=$NIX_BUILD_CORES"
+        "--offline"
+        "--target" "@rustTargetPlatformSpec@"
+        "--manylinux" "off"
+        "--strip"
+        "--release"
+        "--out" "$dist"
     )
+
+    concatTo flagsArray maturinBuildFlags
+
+    echoCmd 'maturinBuildHook flags' "${flagsArray[@]}"
+    @setEnv@ maturin build "${flagsArray[@]}"
 
     if [ ! -z "${buildAndTestSubdir-}" ]; then
         popd

--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = lib.optional useMimalloc "mimalloc";
 
-  CFG_RELEASE = version;
+  env.CFG_RELEASE = version;
 
   inherit doCheck;
   preCheck = lib.optionalString doCheck ''


### PR DESCRIPTION
## Description of changes

Follow up to #318614 to support structuredAttrs in `rust`'s setup hooks. The changes in those hooks are a bit bigger, so I split them into a separate PR.

Same as before: For each hook, I built a package (mentioned in the commit message) with and without structuredAttrs turned on. Those would fail with structuredAttrs on master, but succeed with structuredAttrs after this PR.

CC @emilazy @philiptaron @tie

Since the changed setup hooks won't trigger ofborg to mention the maintainers: @NixOS/rust

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
