### PR TITLE
nixVersions.nix_2_24,git: mark vulnerable

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -184,7 +184,7 @@ in lib.makeExtensible (self: ({
     self_attribute_name = "nix_2_23";
   };
 
-  nix_2_24 = (common {
+  nix_2_24 = ((common {
     version = "2.24.3";
     hash = "sha256-aBuGXm0UwDekCYLl7xDyw+BAJOg7728i57TbSXzPacc=";
     self_attribute_name = "nix_2_24";
@@ -197,9 +197,13 @@ in lib.makeExtensible (self: ({
     # allocation function Clang uses with this setting actually works
     # all the way back to 10.6.
     stdenv = overrideSDK stdenv { darwinMinVersion = "10.13"; };
+  })).overrideAttrs (o: {
+    meta.knownVulnerabilities = [
+      "Nix >= 2.24.0 and master have a vulnerability. Please downgrade from nix_2_24 to nix_2_23"
+    ];
   });
 
-  git = (common rec {
+  git = ((common rec {
     version = "2.25.0";
     suffix = "pre20240807_${lib.substring 0 8 src.rev}";
     src = fetchFromGitHub {
@@ -218,9 +222,13 @@ in lib.makeExtensible (self: ({
     # allocation function Clang uses with this setting actually works
     # all the way back to 10.6.
     stdenv = overrideSDK stdenv { darwinMinVersion = "10.13"; };
+  })).overrideAttrs (o: {
+    meta.knownVulnerabilities = [
+      "Nix >= 2.24.0 and master have a vulnerability. Please downgrade from nixVersions.git to nixVersions.nix_2_23"
+    ];
   });
 
-  latest = self.nix_2_24;
+  latest = self.nix_2_23;
 
   # The minimum Nix version supported by Nixpkgs
   # Note that some functionality *might* have been backported into this Nix version,


### PR DESCRIPTION

## Description of changes

Backport of #340885 

(cherry picked from commit c8c6be2e20b575cd9379c206b6e58cfffc81321d)
(cherry picked from commit 17bbb49a84664df8bfb7f867dbb626111b134954)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
