### PR TITLE
mkWrapper: init function to generate a wrapper to a dummy script that  just runs the arguments

### DIFF
--- a/pkgs/build-support/make-wrapper.nix
+++ b/pkgs/build-support/make-wrapper.nix
@@ -1,0 +1,35 @@
+{
+  makeWrapper,
+  runCommand,
+  writeShellScript,
+}:
+
+name: extras: makeWrapperArgs:
+runCommand name
+  {
+    inherit makeWrapperArgs;
+
+    nativeBuildInputs = [ makeWrapper ] ++ extras;
+
+    payload = writeShellScript "execute" ''
+      exec "$@"
+    '';
+
+    dontWrapGApps = true;
+    dontWrapQtApps = true;
+
+  }
+  ''
+    [[ -v gappsWrapperArgs ]] && makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    [[ -v qtWrapperArgs ]] &&  makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+    mkdir -p $out/bin
+    echo makeWrapper args:
+    _makeWrapperArgs=()
+    for arg in "''${makeWrapperArgs[@]}"; do
+      if [ ! -z "$arg" ]; then
+        echo arg: $arg
+        _makeWrapperArgs+=("$arg")
+      fi
+    done
+    makeWrapper $payload $out/bin/$name "''${_makeWrapperArgs[@]}"
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16352,6 +16352,9 @@ with pkgs;
     inherit bintools libc;
   } // extraArgs; in self);
 
+
+  mkWrapper = callPackage ../build-support/make-wrapper.nix {};
+
   yaml-language-server = callPackage  ../development/tools/language-servers/yaml-language-server { };
 
   # prolog


### PR DESCRIPTION
## Description of changes
Basically adding makeWrapper as a function, the idea here is to allow someone to create a script that runs the arguments inside a wrapQtAppsHook environment but can be anything else wrapper related

I don't know for sure where to put this, suggestions welcome. The API may need some more iterations but I wanted to make it as simple and straightforward as possible.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
