### PR TITLE
nixos/podman: set `preferLocalBuild` on trivial `runCommand`s

### DIFF
--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -21,6 +21,7 @@ let
     {
       outputs = [ "out" "man" ];
       inherit (podmanPackage) meta;
+      preferLocalBuild = true;
     } ''
     mkdir -p $out/bin
     ln -s ${podmanPackage}/bin/podman $out/bin/docker
@@ -235,7 +236,10 @@ in
       systemd.tmpfiles.packages = [
         # The /run/podman rule interferes with our podman group, so we remove
         # it and let the systemd socket logic take care of it.
-        (pkgs.runCommand "podman-tmpfiles-nixos" { package = cfg.package; } ''
+        (pkgs.runCommand "podman-tmpfiles-nixos" {
+          package = cfg.package;
+          preferLocalBuild = true;
+        } ''
           mkdir -p $out/lib/tmpfiles.d/
           grep -v 'D! /run/podman 0700 root root' \
             <$package/lib/tmpfiles.d/podman.conf \


### PR DESCRIPTION
## Description of changes

In the NixOS podman module, added `preferLocalBuild` to `runCommand`'s arguments.

This does not preclude the use of substituters like `cache.nixos.org`, but ensures the trivial derivations aren't sent to distributed builders.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested `nixosTests.podman`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
