### PR TITLE
limine: 7.9.1 -> 8.0.11 + fix build

### DIFF
--- a/pkgs/by-name/li/limine/package.nix
+++ b/pkgs/by-name/li/limine/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation {
     # The platforms on that the Liminine binary and helper tools can run, not
     # necessarily the platforms for that bootable images can be created.
     platforms = platforms.unix;
-    badPlatforms = platforms.darwin;
     maintainers = [
       maintainers._48cf
       maintainers.phip1611


### PR DESCRIPTION
This is a **pragmatic approach to fix** the build problems with the cross-compiled bootloader artifacts of **Limine** (`pkgs.limine`). Please note that a useful Limine distribution needs a host-tool and cross-compiled bootloader-artifacts. Further, the version was bumped.

Closes #304746.

As the Nix derivation broke and was not easily fixable (see #304746), and because the Limine GitHub project reliably create release tags with the pre cross-compiled bootloader artifacts, we leverage them. This is not the most "Nixy" solution but a pragmatic step forward.

Unfortunately, we are losing the manpage output this way.


## Description of changes

- update `7.9.1` -> `8.0.11`
- Fixed #304746 by using pre-compiled bootloader artifacts (but not pre-compiled host tool) from repository

## Testing

I verified that this works. This branch (https://github.com/phip1611/nixos-configs/pull/123) has some tests where hybrid-bootable x86 images using Limine as bootloader run. Specifically, this commit tests that it is working:

https://github.com/phip1611/nixos-configs/pull/123/commits/67fdf1059f2ee77172cd9af26ce0b40b32bb70cb

You can verify this yourself by running:

`nix build github:phip1611/nixos-configs/nixos-24.11\#checks.x86_64-linux.allTests`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
