### PR TITLE
maintainers: add targeted fix for missing `pkgs/by-name/.../package.nix` files

### DIFF
--- a/maintainers/scripts/build.nix
+++ b/maintainers/scripts/build.nix
@@ -12,7 +12,27 @@
 # nix-build build.nix --argstr maintainer <yourname> --argstr system aarch64-linux
 
 let
-  pkgs = import ./../../default.nix (removeAttrs args [ "maintainer" ]);
+  # This avoids a common situation for maintainers, where due to Git's behavior of not tracking
+  # directories, they have an empty directory somewhere in `pkgs/by-name`. Because that directory
+  # exists, `pkgs/top-level/by-name-overlay.nix` picks it up and attempts to read `package.nix` out
+  # of it... which doesn't exist, since it's empty.
+  #
+  # We don't want to run the code below on every instantiation of `nixpkgs`, as the `pkgs/by-name`
+  # eval machinery is quite performance sensitive. So we use the internals of the `by-name` overlay
+  # to implement our own way to avoid an evaluation failure for this script.
+  #
+  # See <https://github.com/NixOS/nixpkgs/issues/338227> for more motivation for this code block.
+  overlay = self: super: {
+    _internalCallByNamePackageFile =
+      file: if builtins.pathExists file then super._internalCallByNamePackageFile file else null;
+  };
+
+  nixpkgsArgs = removeAttrs args [ "maintainer" "overlays" ] // {
+    overlays = args.overlays or [] ++ [ overlay ];
+  };
+
+  pkgs = import ./../../default.nix nixpkgsArgs;
+
   maintainer_ = pkgs.lib.maintainers.${maintainer};
   packagesWith = cond: return: set:
     (pkgs.lib.flatten


### PR DESCRIPTION
## Motivation for changes

- #338227 

Fixes #338227.

## Description of changes

This is my attempt at a more targeted fix for the issue described in #338227. @cafkafk proposed a fix in https://github.com/NixOS/nixpkgs/pull/340778 which has [performance implications](https://github.com/NixOS/nixpkgs/pull/340778#issuecomment-2339379939).

- [x] Added an overlay to the `pkgs` instantiation in `maintainers/scripts/build.nix`
- [ ] Might need to add it to others and make common if this problem shows up in other places.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).