### PR TITLE
syslogng: add option to enable grpc module

### DIFF
--- a/pkgs/by-name/sy/syslogng/package.nix
+++ b/pkgs/by-name/sy/syslogng/package.nix
@@ -33,6 +33,9 @@
 , libesmtp
 , rdkafka
 , gperf
+, withGrpc ? true
+, grpc
+, protobuf
 }:
 let
   python-deps = ps: with ps; [
@@ -94,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     paho-mqtt-c
     hiredis
     rdkafka
-  ];
+  ] ++ (lib.optionals withGrpc [ protobuf grpc ]);
 
   configureFlags = [
     "--enable-manpages"
@@ -111,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-systemd-journal=system"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--without-compile-date"
-  ];
+  ] ++ (lib.optionals withGrpc [ "--enable-grpc" ]);
 
   outputs = [ "out" "man" ];
 


### PR DESCRIPTION
This adds a package option to build with the grpc module.

This module is required for some outputs, like the `loki` destination, and other grpc related modules.

## Description of changes

Add the `withGrpc` (+build time dependencies) option to the `syslogng` package to enable the `--with-grpc` compile time option. This leads to the `grpc` module being included.

This is required for some destinations, like [`loki`](https://syslog-ng.github.io/admin-guide/070_Destinations/125_Loki/README).

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
  - (Tested on machine with `loki` destination)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
