### PR TITLE
nixos/nginx: add option typesHashMaxSize

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -129,12 +129,9 @@ let
   ''));
 
   commonHttpConfig = ''
-      # Load mime types.
+      # Load mime types and configure maximum size of the types hash tables.
       include ${cfg.defaultMimeTypes};
-      # When recommendedOptimisation is disabled nginx fails to start because the mailmap mime.types database
-      # contains 1026 entries and the default is only 1024. Setting to a higher number to remove the need to
-      # overwrite it because nginx does not allow duplicated settings.
-      types_hash_max_size 4096;
+      types_hash_max_size ${toString cfg.typesHashMaxSize};
 
       include ${cfg.package}/conf/fastcgi.conf;
       include ${cfg.package}/conf/uwsgi_params;
@@ -894,6 +891,19 @@ in
         description = ''
             Sets the maximum size of the server names hash tables.
           '';
+      };
+
+      typesHashMaxSize = mkOption {
+        type = types.ints.positive;
+        default = if cfg.defaultMimeTypes == "${pkgs.mailcap}/etc/nginx/mime.types" then 2688 else 1024;
+        defaultText = literalExpression ''if cfg.defaultMimeTypes == "''${pkgs.mailcap}/etc/nginx/mime.types" then 2688 else 1024'';
+        description = ''
+          Sets the maximum size of the types hash tables (`types_hash_max_size`).
+          It is recommended that the minimum size possible size is used.
+          If {option}`recommendedOptimisation` is disabled, nginx would otherwise
+          fail to start since the mailmap `mime.types` database has more entries
+          than the nginx default value 1024.
+        '';
       };
 
       proxyCachePath = mkOption {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -667,6 +667,7 @@ in {
   nginx-etag-compression = handleTest ./nginx-etag-compression.nix {};
   nginx-globalredirect = handleTest ./nginx-globalredirect.nix {};
   nginx-http3 = handleTest ./nginx-http3.nix {};
+  nginx-mime = handleTest ./nginx-mime.nix {};
   nginx-modsecurity = handleTest ./nginx-modsecurity.nix {};
   nginx-moreheaders = handleTest ./nginx-moreheaders.nix {};
   nginx-njs = handleTest ./nginx-njs.nix {};

--- a/nixos/tests/nginx-mime.nix
+++ b/nixos/tests/nginx-mime.nix
@@ -1,0 +1,26 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+  {
+    name = "nginx-mime";
+    meta.maintainers = with pkgs.lib.maintainers; [ izorkin ];
+
+    nodes = {
+      server =
+        { pkgs, ... }:
+        {
+          services.nginx = {
+            enable = true;
+            virtualHosts."localhost" = { };
+          };
+        };
+    };
+
+    testScript = ''
+      server.start()
+      server.wait_for_unit("nginx")
+      # Check optimal size of types_hash
+      server.fail("journalctl --unit nginx --grep 'could not build optimal types_hash'")
+      server.shutdown()
+    '';
+  }
+)

--- a/pkgs/data/misc/mailcap/default.nix
+++ b/pkgs/data/misc/mailcap/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, nixosTests
 
 # updater
 , git
@@ -43,6 +44,8 @@ stdenv.mkDerivation rec {
       head -n1)"
     exec nix-update --version "$VERSION" "$@"
   '';
+
+  passthru.tests.nginx-mime = nixosTests.nginx-mime;
 
   meta = with lib; {
     description = "Helper application and MIME type associations for file types";


### PR DESCRIPTION
## Description of changes
Allow to change maximum size of the types hash tables.
It is recommended to reduce the size if a custom file with mime-types is used.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
