### PR TITLE
excalidraw_export: init at v1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22152,6 +22152,12 @@
     githubId = 2856634;
     name = "Tyler Compton";
   };
+  venikx = {
+    email = "code@venikx.com";
+    github = "venikx";
+    githubId = 24815061;
+    name = "Kevin De Baerdemaeker";
+  };
   veprbl = {
     email = "veprbl@gmail.com";
     github = "veprbl";

--- a/pkgs/by-name/ex/excalidraw_export/package.nix
+++ b/pkgs/by-name/ex/excalidraw_export/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  cairo,
+  pango,
+  pkg-config,
+}:
+
+buildNpmPackage rec {
+  pname = "excalidraw_export";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Timmmm";
+    repo = "excalidraw_export";
+    rev = "320c8be92f468e5e19564f83e37709b80afc0e46";
+    hash = "sha256-E5kYI8+hzObd2WNVBd0aQDKMH1Sns539loCQfClJs1Q=";
+  };
+
+  npmDepsHash = "sha256-5yec7BCi1c/e+y00TqxIeoazs49+WdKdfsskAqnVkFs=";
+
+  npmBuildScript = "compile";
+
+  buildInputs = [
+    cairo
+    pango
+  ];
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = {
+    description = "CLI to export Excalidraw drawings to SVG and PDF";
+    homepage = "https://github.com/Timmmm/excalidraw_export";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ venikx ];
+    mainProgram = "excalidraw_export";
+  };
+}

--- a/pkgs/by-name/ex/excalidraw_export/package.nix
+++ b/pkgs/by-name/ex/excalidraw_export/package.nix
@@ -5,6 +5,7 @@
   cairo,
   pango,
   pkg-config,
+  stdenv,
 }:
 
 buildNpmPackage rec {
@@ -34,5 +35,6 @@ buildNpmPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ venikx ];
     mainProgram = "excalidraw_export";
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

The following npm package makes it possible to convert `.excalidraw` files to `.svg` files: https://github.com/Timmmm/excalidraw_export and is used by https://github.com/wdavew/org-excalidraw to handle excalidraw files inside org-mode in Emacs.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
