### PR TITLE
Revert "vimPlugins.nvim-treesitter: collate grammars"

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -4,9 +4,17 @@ self: super:
 
 let
   inherit (neovimUtils) grammarToPlugin;
-  generatedGrammars = callPackage ./generated.nix {
+
+  initialGeneratedGrammars = callPackage ./generated.nix {
     inherit (tree-sitter) buildGrammar;
   };
+  grammarOverrides = final: prev: {
+    nix = prev.nix.overrideAttrs {
+      # workaround for https://github.com/NixOS/nixpkgs/issues/332580
+      prePatch = "rm queries/highlights.scm";
+    };
+  };
+  generatedGrammars = lib.fix (lib.extends grammarOverrides (_: initialGeneratedGrammars));
 
   generatedDerivations = lib.filterAttrs (_: lib.isDerivation) generatedGrammars;
 

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -36,22 +36,8 @@ let
   # pkgs.vimPlugins.nvim-treesitter.withAllGrammars
   withPlugins =
     f: self.nvim-treesitter.overrideAttrs {
-      passthru.dependencies =
-        let
-          grammars = map grammarToPlugin
-            (f (tree-sitter.builtGrammars // builtGrammars));
-          copyGrammar = grammar:
-            let name = lib.last (lib.splitString "-" grammar.name); in
-            "ln -sf ${grammar}/parser/${name}.so $out/parser/${name}.so";
-        in
-        [
-          (runCommand "vimplugin-treesitter-grammars"
-            { meta.platforms = lib.platforms.all; }
-            ''
-              mkdir -p $out/parser
-              ${lib.concatMapStringsSep "\n" copyGrammar grammars}
-            '')
-        ];
+      passthru.dependencies = map grammarToPlugin
+        (f (tree-sitter.builtGrammars // builtGrammars));
     };
 
   withAllGrammars = withPlugins (_: allGrammars);


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This reverts PR #319233. It caused a lot of weird regressions and a lot of headaches for me. Even a 20% improvement isn't worth it. Also see https://github.com/NixOS/nixpkgs/pull/319233#issuecomment-2339271761

In addition, I added a workaround for #332580 as it is also a very annoying regression that will reappear after merging this (minimal reproduction example: https://github.com/NixOS/nixpkgs/issues/332580#issuecomment-2308526316)

Fixes #341442

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

CC @figsoda, @BirdeeHub
@MangoIV, could you try this with koka? Treesitter didn't detect its grammar for some reason for me

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
