### PR TITLE
upower: Upgrade to 1.90.6 and extend CriticalPowerActions

### DIFF
--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -179,13 +179,31 @@ in
         '';
       };
 
+      allowRiskyCriticalPowerAction = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable the risky critical power actions "Suspend" and "Ignore".
+        '';
+      };
+
       criticalPowerAction = lib.mkOption {
-        type = lib.types.enum [ "PowerOff" "Hibernate" "HybridSleep" ];
+        type = lib.types.enum [
+          "PowerOff"
+          "Hibernate"
+          "HybridSleep"
+          "Suspend"
+          "Ignore"
+        ];
         default = "HybridSleep";
         description = ''
           The action to take when `timeAction` or
           `percentageAction` has been reached for the batteries
-          (UPS or laptop batteries) supplying the computer
+          (UPS or laptop batteries) supplying the computer.
+
+          When set to `Suspend` or `Ignore`,
+          {option}`services.upower.allowRiskyCriticalPowerAction` must be set
+          to `true`.
         '';
       };
 
@@ -193,10 +211,28 @@ in
 
   };
 
-
   ###### implementation
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          let
+            inherit (builtins) elem;
+            riskyActions = [
+              "Suspend"
+              "Ignore"
+            ];
+            riskyActionEnabled = elem cfg.criticalPowerAction riskyActions;
+          in
+          riskyActionEnabled -> cfg.allowRiskyCriticalPowerAction;
+        message = ''
+          services.upower.allowRiskyCriticalPowerAction must be true if
+          services.upower.criticalPowerAction is set to
+          '${cfg.criticalPowerAction}'.
+        '';
+      }
+    ];
 
     environment.systemPackages = [ cfg.package ];
 
@@ -218,6 +254,7 @@ in
         TimeLow = cfg.timeLow;
         TimeCritical = cfg.timeCritical;
         TimeAction = cfg.timeAction;
+        AllowRiskyCriticalPowerAction = cfg.allowRiskyCriticalPowerAction;
         CriticalPowerAction = cfg.criticalPowerAction;
       };
     };

--- a/pkgs/by-name/up/upower/package.nix
+++ b/pkgs/by-name/up/upower/package.nix
@@ -18,6 +18,7 @@
 , libusb1
 , glib
 , gettext
+, polkit
 , nixosTests
 , useIMobileDevice ? true
 , libimobiledevice
@@ -34,7 +35,7 @@ assert withDocs -> withIntrospection;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "upower";
-  version = "1.90.4";
+  version = "1.90.6";
 
   outputs = [ "out" "dev" ]
     ++ lib.optionals withDocs [ "devdoc" ]
@@ -45,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "upower";
     repo = "upower";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-5twHuDLisVF07Y5KYwlqWMi12+p6UpARJvoBN/+tX2o=";
+    hash = "sha256-Y3MIB6a11P00B/6E3UyoyjLLP8TIT3vM2FDO7zlBz/w=";
   };
 
   patches = lib.optionals (stdenv.hostPlatform.system == "i686-linux") [
@@ -121,6 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [
     glib
+    polkit
   ];
 
   mesonFlags = [


### PR DESCRIPTION
## Description of changes

- Upgrade to 1.90.6
- Support Suspend and Ignore CriticalPowerActions introduced in this release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
