### PR TITLE
libgee, libgda, zile: fix compiling with clang

### DIFF
--- a/pkgs/applications/editors/zile/default.nix
+++ b/pkgs/applications/editors/zile/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
   # fiddle with the terminal.
   doCheck = false;
 
+  env.NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isClang "-Wno-error=incompatible-function-pointer-types";
+
   # XXX: Work around cross-compilation-unfriendly `gl_FUNC_FSTATAT' macro.
   gl_cv_func_fstatat_zero_flag="yes";
 

--- a/pkgs/development/libraries/libgda/6.x.nix
+++ b/pkgs/development/libraries/libgda/6.x.nix
@@ -85,6 +85,8 @@ stdenv.mkDerivation rec {
     postgresql
   ];
 
+  env.NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isClang "-Wno-error=incompatible-function-pointer-types";
+
   postPatch = ''
     patchShebangs \
       providers/raw_spec.py \

--- a/pkgs/development/libraries/libgda/default.nix
+++ b/pkgs/development/libraries/libgda/default.nix
@@ -82,6 +82,8 @@ stdenv.mkDerivation rec {
     "--enable-system-sqlite=${if stdenv.isDarwin then "no" else "yes"}"
   ];
 
+  env.NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isClang "-Wno-error=incompatible-function-pointer-types";
+
   enableParallelBuilding = true;
 
   hardeningDisable = [ "format" ];

--- a/pkgs/development/libraries/libgee/default.nix
+++ b/pkgs/development/libraries/libgee/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   env = {
+    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=incompatible-function-pointer-types";
     PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "dev"}/share/gir-1.0";
     PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "${placeholder "out"}/lib/girepository-1.0";
   };


### PR DESCRIPTION
## Description of changes

`-Wno-incompatible-function-pointer-types` was removed from vala's setup hook in b2d88d41e70c93a4cf8fbe8ab20834a854a7a58a. Without it, we're unable to compile libgee[^1], ligda and zile on Darwin. The libgda and zile failures were masked by libgee failing.

[^1]: https://hydra.nixos.org/build/271035513

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
