### PR TITLE
nixos/xen: init guest-agent module

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -31,7 +31,7 @@
   # https://github.com/torvalds/linux/blob/00b827f0cffa50abb6773ad4c34f4cd909dae1c8/drivers/hv/Kconfig#L7-L8
   virtualisation.hypervGuest.enable =
     pkgs.stdenv.hostPlatform.isx86 || pkgs.stdenv.hostPlatform.isAarch64;
-  services.xe-guest-utilities.enable = pkgs.stdenv.hostPlatform.isx86;
+  virtualisation.xen.guest.enable = pkgs.stdenv.hostPlatform.isx86;
   # The VirtualBox guest additions rely on an out-of-tree kernel module
   # which lags behind kernel releases, potentially causing broken builds.
   virtualisation.virtualbox.guest.enable = false;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1959,6 +1959,7 @@
   ./virtualisation/waydroid.nix
   ./virtualisation/xe-guest-utilities.nix
   ./virtualisation/xen-dom0.nix
+  ./virtualisation/xen-domU.nix
   # keep-sorted end
   {
     documentation.nixos.extraModules = [

--- a/nixos/modules/virtualisation/xe-guest-utilities.nix
+++ b/nixos/modules/virtualisation/xe-guest-utilities.nix
@@ -8,11 +8,7 @@ let
   cfg = config.services.xe-guest-utilities;
 in
 {
-  options = {
-    services.xe-guest-utilities = {
-      enable = lib.mkEnableOption "the XenServer guest utilities daemon";
-    };
-  };
+  options.services.xe-guest-utilities.enable = lib.mkEnableOption "the Citrix's XenServer guest utilities daemon";
   config = lib.mkIf cfg.enable {
     services.udev.packages = [ pkgs.xe-guest-utilities ];
     systemd.tmpfiles.rules = [ "d /run/xenstored 0755 - - -" ];


### PR DESCRIPTION
## Description of changes

Turns the profile meant for Xen guests into a proper module that can be enabled as an option.
We also enable it by default on the graphical ISO and differentiate the wording of the `xe-guest-agent` module, which is the Citrix XenServer guest utilities.

This is based on @matdibu's previous work.

A lot of testing is required before this can be merged. Any and all testers are welcome to help us out!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- Tested, as applicable: Invalid
  - We desperately need an automated testing suite. Manual testing has revealed no issues when providing a separately-built kernel and starting the NixOS activation script from the hypervisor.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 341129"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of ISO images, HVM domains and PV/PVH domains
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
