### PR TITLE
emiluaPlugins: introduce qt5 and qt6

### DIFF
--- a/pkgs/development/emilua-plugins/qt5/basic_test.lua
+++ b/pkgs/development/emilua-plugins/qt5/basic_test.lua
@@ -1,0 +1,12 @@
+local qt = require 'qt5'
+local qml = qt.load_qml(byte_span.append([[
+    import QtQml 2.0
+    QtObject {
+        function foobar(a: int, b: int): int {
+            return a + b
+        }
+    }
+]]))
+assert(qml.object('foobar(int,int)', 1, 2), 3)
+
+print("done 👍")

--- a/pkgs/development/emilua-plugins/qt5/default.nix
+++ b/pkgs/development/emilua-plugins/qt5/default.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  meson,
+  ninja,
+  fetchFromGitLab,
+  gperf,
+  gawk,
+  gitUpdater,
+  pkg-config,
+  boost,
+  luajit_openresty,
+  asciidoctor,
+  libsForQt5,
+  emilua,
+  liburing,
+  fmt,
+  runCommand,
+  xvfb-run,
+  qt5, # this
+}:
+
+stdenv.mkDerivation rec {
+  pname = "emilua-qt5";
+  version = "1.0.1";
+
+  src = fetchFromGitLab {
+    owner = "emilua";
+    repo = "qt5";
+    rev = "v${version}";
+    hash = "sha256-FkBfzGzUX7dvHjWRBjVwppU4jZBbY02gP+fIta8mjIw=";
+  };
+
+  buildInputs = [
+    luajit_openresty
+    boost
+    libsForQt5.qtdeclarative
+    emilua
+    liburing
+    fmt
+    libsForQt5.qtbase
+  ];
+
+  nativeBuildInputs = [
+    gperf
+    gawk
+    pkg-config
+    asciidoctor
+    meson
+    ninja
+    libsForQt5.wrapQtAppsHook
+    libsForQt5.qttools
+  ];
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+    tests.basic =
+      runCommand "test-basic-qt5"
+        {
+          buildInputs = [
+            emilua
+            qt5
+            libsForQt5.wrapQtAppsHook
+            xvfb-run
+          ];
+          dontWrapQtApps = true;
+        }
+        ''
+          makeWrapper ${lib.getExe emilua} payload \
+            ''${qtWrapperArgs[@]} \
+            --add-flags ${./basic_test.lua}
+          xvfb-run ./payload
+          touch $out
+        '';
+  };
+
+  meta = with lib; {
+    description = "Qt5 bindings for Emilua";
+    homepage = "https://emilua.org/";
+    license = licenses.boost;
+    maintainers = with maintainers; [
+      manipuladordedados
+      lucasew
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/emilua-plugins/qt6/basic_test.lua
+++ b/pkgs/development/emilua-plugins/qt6/basic_test.lua
@@ -1,0 +1,12 @@
+local qt = require 'qt6'
+local qml = qt.load_qml(byte_span.append([[
+    import QtQml 2.0
+    QtObject {
+        function foobar(a: int, b: int): int {
+            return a + b
+        }
+    }
+]]))
+assert(qml.object('foobar(int,int)', 1, 2), 3)
+
+print("done 👍")

--- a/pkgs/development/emilua-plugins/qt6/default.nix
+++ b/pkgs/development/emilua-plugins/qt6/default.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  asciidoctor,
+  ninja,
+  gperf,
+  gawk,
+  pkg-config,
+  boost,
+  luajit_openresty,
+  fmt,
+  meson,
+  emilua,
+  qt6Packages,
+  openssl,
+  liburing,
+  gitUpdater,
+  runCommand,
+  xvfb-run,
+  qt6, # this
+}:
+
+stdenv.mkDerivation rec {
+  pname = "emilua-qt6";
+  version = "1.0.3";
+
+  src = fetchFromGitLab {
+    owner = "emilua";
+    repo = "qt6";
+    rev = "v${version}";
+    hash = "sha256-azMnM17HQMzC0ExgWurQzbR3fX9EwBRSu4kVTm3U2Ic=";
+  };
+
+  buildInputs = with qt6Packages; [
+    qtbase
+    qtdeclarative
+    boost
+    luajit_openresty
+    emilua
+    fmt
+    openssl
+    liburing
+  ];
+
+  nativeBuildInputs = with qt6Packages; [
+    qttools
+    wrapQtAppsHook
+    gperf
+    gawk
+    asciidoctor
+    pkg-config
+    meson
+    ninja
+  ];
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+    tests.basic =
+      runCommand "test-basic-qt6"
+        {
+          buildInputs = [
+            emilua
+            qt6
+            qt6Packages.wrapQtAppsHook
+            qt6Packages.qtbase
+            qt6Packages.qtdeclarative
+            xvfb-run
+          ];
+          dontWrapQtApps = true;
+        }
+        ''
+          makeWrapper ${lib.getExe emilua} payload \
+            ''${qtWrapperArgs[@]} \
+            --add-flags ${./basic_test.lua}
+          xvfb-run ./payload
+          touch $out
+        '';
+  };
+
+  meta = with lib; {
+    description = "Qt6 bindings for Emilua";
+    homepage = "https://emilua.org/";
+    license = licenses.boost;
+    maintainers = with maintainers; [
+      manipuladordedados
+      lucasew
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/emilua-plugins.nix
+++ b/pkgs/top-level/emilua-plugins.nix
@@ -10,4 +10,5 @@ emilua:
   inherit emilua;
   beast = self.callPackage ../development/emilua-plugins/beast { };
   qt5 = self.callPackage ../development/emilua-plugins/qt5 { };
+  qt6 = self.callPackage ../development/emilua-plugins/qt6 { };
 }))

--- a/pkgs/top-level/emilua-plugins.nix
+++ b/pkgs/top-level/emilua-plugins.nix
@@ -9,4 +9,5 @@ emilua:
 (lib.makeScope newScope (self: {
   inherit emilua;
   beast = self.callPackage ../development/emilua-plugins/beast { };
+  qt5 = self.callPackage ../development/emilua-plugins/qt5 { };
 }))


### PR DESCRIPTION
## Description of changes
Those are bindings for qt5 and qt6 for emilua.

This is based on work done in #340201 

Closes #340201 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
