### PR TITLE
lix: use patched editline

### DIFF
--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -79,6 +79,17 @@ assert lib.assertMsg (docCargoHash != null || docCargoLock != null)
   "Either `lix-doc`'s cargoHash using `docCargoHash` or `lix-doc`'s `cargoLock.lockFile` using `docCargoLock` must be set!";
 let
   isLegacyParser = lib.versionOlder version "2.91";
+
+  editline-patched = editline.overrideAttrs (prev: {
+    patches = (prev.patches or [ ]) ++ [
+      # Recognize `Alt-Left` and `Alt-Right` for navigating by words in more
+      # terminals/shells/platforms.
+      #
+      # See: https://github.com/troglobit/editline/pull/70
+      # See: https://gerrit.lix.systems/c/lix/+/1883
+      ./editline.patch
+    ];
+  });
 in
 stdenv.mkDerivation {
   pname = "lix";
@@ -132,7 +143,7 @@ stdenv.mkDerivation {
       brotli
       bzip2
       curl
-      editline
+      editline-patched
       libsodium
       openssl
       sqlite

--- a/pkgs/tools/package-management/lix/editline.patch
+++ b/pkgs/tools/package-management/lix/editline.patch
@@ -1,0 +1,106 @@
+From d0f2a5bc2300b96b2434c7838184c1dfd6a639f5 Mon Sep 17 00:00:00 2001
+From: Rebecca Turner <rbt@sent.as>
+Date: Sun, 8 Sep 2024 15:42:42 -0700
+Subject: [PATCH 1/2] Recognize Meta+Left and Meta+Right
+
+Recognize `Alt-Left` and `Alt-Right` for navigating by words in more
+terminals/shells/platforms.
+
+I'm not sure exactly where to find canonical documentation for these
+codes, but this seems to match what my terminal produces (macOS + iTerm2
++ Fish + Tmux).
+
+It might also be nice to have some more support for editing the bindings
+for these characters; sequences of more than one character are not
+supported by `el_bind_key` and similar.
+
+Originally from: https://github.com/troglobit/editline/pull/70
+This patch is applied upstream: https://gerrit.lix.systems/c/lix/+/1883
+
+---
+ src/editline.c | 29 +++++++++++++++++++++++++++--
+ 1 file changed, 27 insertions(+), 2 deletions(-)
+
+diff --git a/src/editline.c b/src/editline.c
+index 5ec9afb..d1cfbbc 100644
+--- a/src/editline.c
++++ b/src/editline.c
+@@ -1034,6 +1034,30 @@ static el_status_t meta(void)
+         return CSeof;
+ 
+ #ifdef CONFIG_ANSI_ARROWS
++    /* See: https://en.wikipedia.org/wiki/ANSI_escape_code */
++    /* Recognize ANSI escapes for `Meta+Left` and `Meta+Right`. */
++    if (c == '\e') {
++        switch (tty_get()) {
++        case '[':
++        {
++            switch (tty_get()) {
++            /* \e\e[C = Meta+Left */
++            case 'C': return fd_word();
++            /* \e\e[D = Meta+Right */
++            case 'D': return bk_word();
++            default:
++                break;
++            }
++
++            return el_ring_bell();
++        }
++        default:
++            break;
++        }
++
++        return el_ring_bell();
++    }
++
+     /* Also include VT-100 arrows. */
+     if (c == '[' || c == 'O') {
+         switch (tty_get()) {
+@@ -1043,6 +1067,7 @@ static el_status_t meta(void)
+             char seq[4] = { 0 };
+             seq[0] = tty_get();
+ 
++            /* \e[1~ */
+             if (seq[0] == '~')
+                 return beg_line(); /* Home */
+ 
+@@ -1050,9 +1075,9 @@ static el_status_t meta(void)
+                 seq[c] = tty_get();
+ 
+             if (!strncmp(seq, ";5C", 3))
+-                return fd_word(); /* Ctrl+Right */
++                return fd_word(); /* \e[1;5C = Ctrl+Right */
+             if (!strncmp(seq, ";5D", 3))
+-                return bk_word(); /* Ctrl+Left */
++                return bk_word(); /* \e[1;5D = Ctrl+Left */
+ 
+             break;
+         }
+
+From 4c4455353a0a88bee09d5f27c28f81f747682fed Mon Sep 17 00:00:00 2001
+From: Rebecca Turner <rbt@sent.as>
+Date: Mon, 9 Sep 2024 09:44:44 -0700
+Subject: [PATCH 2/2] Add support for \e[1;3C and \e[1;3D
+
+---
+ src/editline.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/editline.c b/src/editline.c
+index d1cfbbc..350b5cb 100644
+--- a/src/editline.c
++++ b/src/editline.c
+@@ -1074,9 +1074,11 @@ static el_status_t meta(void)
+             for (c = 1; c < 3; c++)
+                 seq[c] = tty_get();
+ 
+-            if (!strncmp(seq, ";5C", 3))
++            if (!strncmp(seq, ";5C", 3)
++                || !strncmp(seq, ";3C", 3))
+                 return fd_word(); /* \e[1;5C = Ctrl+Right */
+-            if (!strncmp(seq, ";5D", 3))
++            if (!strncmp(seq, ";5D", 3)
++                || !strncmp(seq, ";3D", 3))
+                 return bk_word(); /* \e[1;5D = Ctrl+Left */
+ 
+             break;


### PR DESCRIPTION
## Description of changes

Lix has applied this patch upstream in order to recognize `Alt+Left` and `Alt+Right` for word navigation in `nix repl` on more terminals. If this is merged into `editline` upstream I'll update `editline` in Nixpkgs and then we can drop this patch.

See: https://github.com/troglobit/editline/pull/70
See: https://gerrit.lix.systems/c/lix/+/1883

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
