### PR TITLE
xen: 4.17.4 -> 4.17.5, 4.18.2 -> 4.18.3

### DIFF
--- a/pkgs/applications/virtualization/xen/4.17/default.nix
+++ b/pkgs/applications/virtualization/xen/4.17/default.nix
@@ -16,9 +16,6 @@ let
     with upstreamPatches;
     [
       QUBES_REPRODUCIBLE_BUILDS
-      XSA_458
-      XSA_460
-      XSA_461
     ]
   );
 in
@@ -26,12 +23,12 @@ in
 callPackage (import ../generic/default.nix {
   pname = "xen";
   branch = "4.17";
-  version = "4.17.4";
+  version = "4.17.5";
   latest = false;
   pkg = {
     xen = {
-      rev = "d530627aaa9b6e03c7f911434bb342fca3d13300";
-      hash = "sha256-4ltQUzo4XPzGT/7fGt1hnNMqBQBVF7VP+WXD9ZaJcGo=";
+      rev = "430ce6cd936546ad883ecd1c85ddea32d790604b";
+      hash = "sha256-UoMdXRW0yWSaQPPV0rgoTZVO2ghdnqWruBHn7+ZjKzI=";
       patches = [ ] ++ upstreamPatchList;
     };
     qemu = {

--- a/pkgs/applications/virtualization/xen/4.18/default.nix
+++ b/pkgs/applications/virtualization/xen/4.18/default.nix
@@ -16,9 +16,6 @@ let
     with upstreamPatches;
     [
       QUBES_REPRODUCIBLE_BUILDS
-      XSA_458
-      XSA_460
-      XSA_461
     ]
   );
 in
@@ -26,12 +23,12 @@ in
 callPackage (import ../generic/default.nix {
   pname = "xen";
   branch = "4.18";
-  version = "4.18.2";
+  version = "4.18.3";
   latest = false;
   pkg = {
     xen = {
-      rev = "d152a0424677d8b78e00ed1270a583c5dafff16f";
-      hash = "sha256-pHCjj+Bcy4xQfB9xHU9fccFwVdP2DXrUhdszwGvrdmY=";
+      rev = "bd51e573a730efc569646379cd59ccba967cde97";
+      hash = "sha256-OFiFdpPCXR+sWjzFHCORtY4DkWyggvxkcsGdgEyO1ts=";
       patches = [ ] ++ upstreamPatchList;
     };
     qemu = {


### PR DESCRIPTION
## Description of changes

- Updates the 4.17 branch to 4.17.5.
- Updates the 4.18 branch to 4.18.3.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - Both boot and pass XTF.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 341132"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] Updated release notes in the [associated module PR](https://github.com/NixOS/nixpkgs/pull/324911).
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
