### PR TITLE
flutter: roll forward missed patches to v3.23 and v3.24

### DIFF
--- a/pkgs/development/compilers/flutter/versions/3_23/patches/gradle-flutter-tools-wrapper.patch
+++ b/pkgs/development/compilers/flutter/versions/3_23/patches/gradle-flutter-tools-wrapper.patch
@@ -1,0 +1,44 @@
+This patch introduces an intermediate Gradle build step to alter the behavior
+of flutter_tools' Gradle project, specifically moving the creation of `build`
+and `.gradle` directories from within the Nix Store to somewhere in `$HOME/.cache/flutter/nix-flutter-tools-gradle/$engineShortRev`.
+
+Without this patch, flutter_tools' Gradle project tries to generate `build` and `.gradle`
+directories within the Nix Store. Resulting in read-only errors when trying to build a
+Flutter Android app at runtime.
+
+This patch takes advantage of the fact settings.gradle takes priority over settings.gradle.kts to build the intermediate Gradle project
+when a Flutter app runs `includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")`
+
+`rootProject.buildFileName = "/dev/null"` so that the intermediate project doesn't use `build.gradle.kts` that's in the same directory.
+
+The intermediate project makes a `settings.gradle` file in `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/` and `includeBuild`s it.
+This Gradle project will build the actual `packages/flutter_tools/gradle` project by setting
+`rootProject.projectDir = new File("$settingsDir")` and `apply from: new File("$settingsDir/settings.gradle.kts")`.
+
+Now the `.gradle` will be built in `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/`, but `build` doesn't.
+To move `build` to `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/` as well, we need to set `buildDirectory`.
+diff --git a/packages/flutter_tools/gradle/settings.gradle b/packages/flutter_tools/gradle/settings.gradle
+new file mode 100644
+index 0000000000..b2485c94b4
+--- /dev/null
++++ b/packages/flutter_tools/gradle/settings.gradle
+@@ -0,0 +1,19 @@
++rootProject.buildFileName = "/dev/null"
++
++def engineShortRev = (new File("$settingsDir/../../../bin/internal/engine.version")).text.take(10)
++def dir = new File("$System.env.HOME/.cache/flutter/nix-flutter-tools-gradle/$engineShortRev")
++dir.mkdirs()
++def file = new File(dir, "settings.gradle")
++
++file.text = """
++rootProject.projectDir = new File("$settingsDir")
++apply from: new File("$settingsDir/settings.gradle.kts")
++
++gradle.allprojects { project ->
++  project.beforeEvaluate {
++    project.layout.buildDirectory = new File("$dir/build")
++  }
++}
++"""
++
++includeBuild(dir)

--- a/pkgs/development/compilers/flutter/versions/3_24/patches/gradle-flutter-tools-wrapper.patch
+++ b/pkgs/development/compilers/flutter/versions/3_24/patches/gradle-flutter-tools-wrapper.patch
@@ -1,0 +1,44 @@
+This patch introduces an intermediate Gradle build step to alter the behavior
+of flutter_tools' Gradle project, specifically moving the creation of `build`
+and `.gradle` directories from within the Nix Store to somewhere in `$HOME/.cache/flutter/nix-flutter-tools-gradle/$engineShortRev`.
+
+Without this patch, flutter_tools' Gradle project tries to generate `build` and `.gradle`
+directories within the Nix Store. Resulting in read-only errors when trying to build a
+Flutter Android app at runtime.
+
+This patch takes advantage of the fact settings.gradle takes priority over settings.gradle.kts to build the intermediate Gradle project
+when a Flutter app runs `includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")`
+
+`rootProject.buildFileName = "/dev/null"` so that the intermediate project doesn't use `build.gradle.kts` that's in the same directory.
+
+The intermediate project makes a `settings.gradle` file in `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/` and `includeBuild`s it.
+This Gradle project will build the actual `packages/flutter_tools/gradle` project by setting
+`rootProject.projectDir = new File("$settingsDir")` and `apply from: new File("$settingsDir/settings.gradle.kts")`.
+
+Now the `.gradle` will be built in `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/`, but `build` doesn't.
+To move `build` to `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/` as well, we need to set `buildDirectory`.
+diff --git a/packages/flutter_tools/gradle/settings.gradle b/packages/flutter_tools/gradle/settings.gradle
+new file mode 100644
+index 0000000000..b2485c94b4
+--- /dev/null
++++ b/packages/flutter_tools/gradle/settings.gradle
+@@ -0,0 +1,19 @@
++rootProject.buildFileName = "/dev/null"
++
++def engineShortRev = (new File("$settingsDir/../../../bin/internal/engine.version")).text.take(10)
++def dir = new File("$System.env.HOME/.cache/flutter/nix-flutter-tools-gradle/$engineShortRev")
++dir.mkdirs()
++def file = new File(dir, "settings.gradle")
++
++file.text = """
++rootProject.projectDir = new File("$settingsDir")
++apply from: new File("$settingsDir/settings.gradle.kts")
++
++gradle.allprojects { project ->
++  project.beforeEvaluate {
++    project.layout.buildDirectory = new File("$dir/build")
++  }
++}
++"""
++
++includeBuild(dir)


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This `gradle-flutter-tools-wrapper.patch` is necessary for android builds using nixpkgs flutter. The patch file is present for prior package versions (3.16, 3.19, 3.22), but it looks like the previous update PR missed it (https://github.com/NixOS/nixpkgs/pull/336650).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
