### PR TITLE
Faster SquashFS decompression of Nix Store

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -726,7 +726,7 @@ in
     "/nix/.ro-store" = mkImageMediaOverride
       { fsType = "squashfs";
         device = "/iso/nix-store.squashfs";
-        options = [ "loop" ];
+        options = [ "loop" "threads=multi" ];
         neededForBoot = true;
       };
 

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -47,7 +47,7 @@ with lib;
     fileSystems."/nix/.ro-store" = mkImageMediaOverride
       { fsType = "squashfs";
         device = "../nix-store.squashfs";
-        options = [ "loop" ];
+        options = [ "loop" "threads=multi" ];
         neededForBoot = true;
       };
 


### PR DESCRIPTION
## Description of changes

The SquashFS filesystem supports running multiple decompression threads but this must be enabled via the `threads` mount option.

## Things done

Added `threads=multi` to ISO and netboot installer images where a squashfs Nix store is mounted.

Tested building and installing NixOS via a customized ISO installer that's ~5GB (ISO size) and ~16GB installed.

Found considerable performance improvement under both `XZ` and `Zstd` (used  isoImage.squashfsCompression = "zstd -Xcompression-level 5"). When `threads=multi` is used, the `mount` command will show the effective `theads=N` option used based on the running systems core count. In this case `theads=40`.
 
XZ + threads=single: 60 minutes
XZ + threads=40: 22 minutes

Zstd (level 5) + threads=single: 12 minutes
Zstd (level 5) + threads=40: 4 minutes

So about a 3x improvement for both XZ and Zstd SquashFS. This benchmark is of course very hardware dependent. The flash drive used had a read speed of ~150MB/s sequential. The installation system has a i7-1370P which has 20 threads (6P cores w/ HT, 8E cores w/o HT). The installation target drive is an NVMe drive. 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).