### PR TITLE
nixos/tests/pgjwt: fix test

### DIFF
--- a/nixos/tests/pgjwt.nix
+++ b/nixos/tests/pgjwt.nix
@@ -18,14 +18,14 @@ with pkgs; {
 
   testScript = { nodes, ... }:
   let
-    sqlSU = "${nodes.master.config.services.postgresql.superUser}";
+    sqlSU = "${nodes.master.services.postgresql.superUser}";
     pgProve = "${pkgs.perlPackages.TAPParserSourceHandlerpgTAP}";
   in
   ''
     start_all()
     master.wait_for_unit("postgresql")
     master.succeed(
-        "${pkgs.gnused}/bin/sed -e '12 i CREATE EXTENSION pgcrypto;\\nCREATE EXTENSION pgtap;\\nSET search_path TO tap,public;' ${pgjwt.src}/test.sql > /tmp/test.sql"
+        "${pkgs.gnused}/bin/sed -e '12 i SET search_path TO tap,public;' ${pgjwt.src}/test.sql > /tmp/test.sql"
     )
     master.succeed(
         "${pkgs.sudo}/bin/sudo -u ${sqlSU} PGOPTIONS=--search_path=tap,public ${pgProve}/bin/pg_prove -d postgres -v -f /tmp/test.sql"


### PR DESCRIPTION
- remove extra 'CREATE EXTENSION' statements added with sed to test.sql, current test.sql already has them.
- change 'nodes.master.config' to 'nodes.master' according to eval warn:
evaluation warning: Module argument `nodes.master.config` is deprecated. Use `nodes.master` instead.

## Description of changes

Fixes build failure of `nixosTests.pgjwt` (fails since `2022-10-15`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.pgjwt.x86_64-linux
https://hydra.nixos.org/build/272087360
Error log:
```text
jv0qkwrgacxkr1z488j0vsw1hzdf5fz0-perl5.36.0-TAP-Parser-SourceHandler-pgTAP-3.35/bin/pg_prove -d postgres -v -f /tmp/test.sql
master # [    9.178137] sudo[920]:     root : TTY=hvc0 ; PWD=/tmp ; USER=postgres ; ENV=PGOPTIONS=--search_path=tap,public ; COMMAND=/nix/store/jv0qkwrgacxkr1z488j0vsw1hzdf5fz0-perl5.36.0-TAP-Parser-SourceHandler-pgTAP-3.35/bin/pg_prove -d postgres -v -f /tmp/test.sql
master # [    9.181325] sudo[920]: pam_unix(sudo:session): session opened for user postgres(uid=71) by (uid=0)
master # [    9.463277] postgres[925]: [925] ERROR:  extension "pgcrypto" already exists
master # [    9.463953] postgres[925]: [925] STATEMENT:  CREATE EXTENSION pgcrypto;
master # psql:/tmp/test.sql:15: ERROR:  extension "pgcrypto" already exists
```

Current `sed -n` results in `/tmp/test.sql` with double `CREATE EXTENSION` statements for `pgcrypto` and `pgtap`:
```sql
CREATE EXTENSION pgcrypto;\nCREATE EXTENSION pgtap;\nSET search_path TO tap,public;
CREATE EXTENSION pgcrypto;
CREATE EXTENSION pgtap;
CREATE EXTENSION pgjwt;
```
removed them from `sed` command.

---

Listed test maintainers:
@spinus
@willibutz 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
