### PR TITLE
ollama: packaging fixes

### DIFF
--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -2,7 +2,6 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  fetchpatch,
   buildEnv,
   linkFarm,
   overrideCC,
@@ -51,28 +50,6 @@ let
   };
 
   vendorHash = "sha256-hSxcREAujhvzHVNwnRTfhi0MKI3s8HNavER2VLz6SYk=";
-
-  # ollama's patches of llama.cpp's example server
-  # `ollama/llm/generate/gen_common.sh` -> "apply temporary patches until fix is upstream"
-  # each update, these patches should be synchronized with the contents of `ollama/llm/patches/`
-  llamacppPatches = [
-    (preparePatch "01-load-progress.diff" "sha256-UTmnBS5hQjIL3eXDZc8RBDNJunLlkqJWH20LpXNiGRQ=")
-    (preparePatch "02-clip-log.diff" "sha256-rMWbl3QgrPlhisTeHwD7EnGRJyOhLB4UeS7rqa0tdXM=")
-    (preparePatch "03-load_exception.diff" "sha256-NJkT/k8Mf8HcEMb0XkaLmyUNKV3T+384JRPnmwDI/sk=")
-    (preparePatch "04-metal.diff" "sha256-bPBCfoT3EjZPjWKfCzh0pnCUbM/fGTj37yOaQr+QxQ4=")
-    (preparePatch "05-default-pretokenizer.diff" "sha256-mxqHnDbiy8yfKFUYryNTj/xay/lx9KDiZAiekFSkxr8=")
-    (preparePatch "06-embeddings.diff" "sha256-+4yAEAX1JJenOksG2OxDCwiLEoLj1glJQLIgV08BI5Q=")
-    (preparePatch "07-clip-unicode.diff" "sha256-1qMJoXhDewxsqPbmi+/7xILQfGaybZDyXc5eH0winL8=")
-  ];
-
-  preparePatch =
-    patch: hash:
-    fetchpatch {
-      url = "file://${src}/llm/patches/${patch}";
-      inherit hash;
-      stripLen = 1;
-      extraPrefix = "llm/llama.cpp/";
-    };
 
   validateFallback = lib.warnIf (config.rocmSupport && config.cudaSupport) (lib.concatStrings [
     "both `nixpkgs.config.rocmSupport` and `nixpkgs.config.cudaSupport` are enabled, "
@@ -174,12 +151,16 @@ goBuild (
       # disable uses of `git` in the `go generate` script
       # ollama's build script assumes the source is a git repo, but nix removes the git directory
       # this also disables necessary patches contained in `ollama/llm/patches/`
-      # those patches are added to `llamacppPatches`, and reapplied here in the patch phase
+      # those patches are applied in `postPatch`
       ./disable-git.patch
-    ] ++ llamacppPatches;
+    ];
+
     postPatch = ''
       # replace inaccurate version number with actual release version
       substituteInPlace version/version.go --replace-fail 0.0.0 '${version}'
+
+      # apply llama.cpp patches
+      for cur in llm/patches/*; do patch -p1 -d llm/llama.cpp < $cur; done
     '';
 
     overrideModAttrs = (

--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -181,6 +181,14 @@ goBuild (
       # replace inaccurate version number with actual release version
       substituteInPlace version/version.go --replace-fail 0.0.0 '${version}'
     '';
+
+    overrideModAttrs = (
+      finalAttrs: prevAttrs: {
+        # don't run llama.cpp build in the module fetch phase
+        preBuild = "";
+      }
+    );
+
     preBuild = ''
       # disable uses of `git`, since nix removes the git directory
       export OLLAMA_SKIP_PATCHING=true


### PR DESCRIPTION
## Description of changes

llama.cpp was getting built twice: once in the buildGoModules fetch phase (immediately discarded), and then again in the actual build. Resolved by dropping `preBuild` from the module fetch derivation.

llama.cpp patches were applied through `patches` through a roundabout mechanism involving a second FOD for reasons that are utterly beyond me. I've replaced it with just applying the patches in `postPatch` so that we don't have to keep an extra list of hashes updated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc