### PR TITLE
do not pass VFILES if version >= 1.1.0

### DIFF
--- a/pkgs/development/coq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/coq-modules/hierarchy-builder/default.nix
@@ -29,8 +29,6 @@ let hb = mkCoqDerivation {
 
   mlPlugin = true;
 
-  extraInstallFlags = [ "VFILES=structures.v" ];
-
   meta = with lib; {
     description = "High level commands to declare a hierarchy based on packed classes";
     maintainers = with maintainers; [ cohencyril siraben ];
@@ -43,4 +41,7 @@ hb.overrideAttrs (o:
   //
   lib.optionalAttrs (lib.versions.isGe "1.1.0" o.version || o.version == "dev")
   { installFlags = [ "DESTDIR=$(out)" ] ++ o.installFlags; }
+  //
+  lib.optionalAttrs (lib.versions.isLt "1.1.0" o.version)
+  { installFlags = [ "VFILES=structures.v" ] ++ o.installFlags; }
 )

--- a/pkgs/development/coq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/coq-modules/hierarchy-builder/default.nix
@@ -39,9 +39,8 @@ hb.overrideAttrs (o:
   lib.optionalAttrs (lib.versions.isGe "1.2.0" o.version || o.version == "dev")
     { buildPhase = "make build"; }
   //
-  lib.optionalAttrs (lib.versions.isGe "1.1.0" o.version || o.version == "dev")
-  { installFlags = [ "DESTDIR=$(out)" ] ++ o.installFlags; }
-  //
-  lib.optionalAttrs (lib.versions.isLt "1.1.0" o.version)
-  { installFlags = [ "VFILES=structures.v" ] ++ o.installFlags; }
+  (if lib.versions.isGe "1.1.0" o.version || o.version == "dev" then
+   { installFlags = [ "DESTDIR=$(out)" ] ++ o.installFlags; }
+   else
+   { installFlags = [ "VFILES=structures.v" ] ++ o.installFlags; })
 )


### PR DESCRIPTION
## Description of changes

Since 1.1.0 there is no need to pass VFILES=structures.v to the makefile, since all tests are separate.
Passing this option makes it impossible to move structures.v to another place in the upstream repo, see https://github.com/math-comp/hierarchy-builder/pull/444

I don't know nix, I hope what I wrote makes sense.

@CohenCyril @proux01 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
