### PR TITLE
nixos/wakapi: add database options; gate db creation behind database.createLocally

### DIFF
--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -66,6 +66,60 @@ in
         The path to a file containing the password for the smtp mailer used by Wakapi.
       '';
     };
+
+    database = {
+      createLocally = mkEnableOption ''
+        automatic database configuration.
+
+        ::: {.note}
+        Only PostgreSQL is supported for the time being.
+        :::
+      '';
+
+      dialect = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "postgres"
+            "sqlite3"
+            "mysql"
+            "cockroach"
+            "mssql"
+          ]
+        );
+        default = cfg.settings.db.dialect or null; # handle case where dialect is not set
+        defaultText = ''
+          Database dialect from settings if {option}`services.wakatime.settings.db.dialect`
+          is set, or `null` otherwise.
+        '';
+        description = ''
+          The database type to use for Wakapi.
+        '';
+      };
+
+      name = mkOption {
+        type = types.str;
+        default = cfg.settings.db.name or "wakapi";
+        defaultText = ''
+          Database name from settings if {option}`services.wakatime.settings.db.name`
+          is set, or "wakapi" otherwise.
+        '';
+        description = ''
+          The name of the database to use for Wakapi.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = cfg.settings.db.user or "wakapi";
+        defaultText = ''
+          User from settings if {option}`services.wakatime.settings.db.user`
+          is set, or "wakapi" otherwise.
+        '';
+        description = ''
+          The name of the user to use for Wakapi.
+        '';
+      };
+    };
   };
 
   config = mkIf cfg.enable {
@@ -73,10 +127,10 @@ in
       description = "Wakapi (self-hosted WakaTime-compatible backend)";
       wants = [
         "network-online.target"
-      ] ++ optional (cfg.settings.db.dialect == "postgres") "postgresql.service";
+      ] ++ optional (cfg.database.dialect == "postgres") "postgresql.service";
       after = [
         "network-online.target"
-      ] ++ optional (cfg.settings.db.dialect == "postgres") "postgresql.service";
+      ] ++ optional (cfg.database.dialect == "postgres") "postgresql.service";
       wantedBy = [ "multi-user.target" ];
 
       script = ''
@@ -134,6 +188,19 @@ in
         assertion = cfg.smtpPassword != null -> cfg.smtpPasswordFile != null;
         message = "Both `services.wakapi.smtpPassword` `services.wakapi.smtpPasswordFile` should not be set at the same time.";
       }
+      {
+        assertion = cfg.db.createLocally -> cfg.db.dialect != null;
+        message = "`services.wakapi.database.createLocally` is true, but a database dialect is not set!";
+      }
+    ];
+
+    warnings = [
+      (lib.optionalString (cfg.db.createLocall -> cfg.db.dialect != "postgres") ''
+        You have enabled automatic database configuration, but the database dialect is not set to "posgres".
+
+        The Wakapi module only supports for PostgreSQL. Please set `services.wakapi.database.createLocally`
+        to `false`, or switch to "postgres" as your database dialect.
+      '')
     ];
 
     users = {
@@ -145,10 +212,10 @@ in
       groups.wakapi = { };
     };
 
-    services.postgresql = mkIf (cfg.settings.db.dialect == "postgres") {
+    services.postgresql = mkIf (cfg.database.createLocally && cfg.database.dialect == "postgres") {
       enable = true;
 
-      ensureDatabases = singleton cfg.settings.db.name;
+      ensureDatabases = singleton cfg.database.name;
       ensureUsers = singleton {
         name = cfg.settings.db.user;
         ensureDBOwnership = true;
@@ -160,5 +227,8 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ isabelroses ];
+  meta.maintainers = with lib.maintainers; [
+    isabelroses
+    NotAShelf
+  ];
 }


### PR DESCRIPTION
Currently the NixOS module for Wakapi will create the database automagically if the user has database dialect configured in the Wakapi configuration file. By all means, this is undocumented behaviour and an anti-feature.

This MR adds a database.createLocally option that allows the end-user to create auto-creation behaviour, and lays out groundwork for automated database setups for different database dialects supported by Wakapi.

## Description of changes

Adds `services.wakapi.database.createLocally` and `servicees.wakapi.database.dialect` to fine-grain 
database creation behaviour. Fixes case where database would be created unconditionally when the 
user has DB dialect set in Wakapi config.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
