### PR TITLE
nixos/quorum: fix geth args, fix test

### DIFF
--- a/nixos/modules/services/networking/quorum.nix
+++ b/nixos/modules/services/networking/quorum.nix
@@ -201,11 +201,11 @@ in {
             --syncmode ${cfg.syncmode} \
             ${optionalString (cfg.permissioned)
             "--permissioned"} \
-            --mine --minerthreads 1 \
+            --mine --miner.threads 1 \
             ${optionalString (cfg.rpc.enable)
             "--rpc --rpcaddr ${cfg.rpc.address} --rpcport ${toString cfg.rpc.port} --rpcapi ${cfg.rpc.api}"} \
             ${optionalString (cfg.ws.enable)
-            "--ws --wsaddr ${cfg.ws.address} --wsport ${toString cfg.ws.port} --wsapi ${cfg.ws.api} --wsorigins ${cfg.ws.origins}"} \
+            "--ws --ws.addr ${cfg.ws.address} --ws.port ${toString cfg.ws.port} --ws.api ${cfg.ws.api} --ws.origins ${cfg.ws.origins}"} \
             --emitcheckpoints \
             --datadir ${dataDir} \
             --port ${toString cfg.port}'';

--- a/nixos/tests/quorum.nix
+++ b/nixos/tests/quorum.nix
@@ -62,6 +62,7 @@ in
               "0x0000000000000000000000000000000000000000000000000000000000000000";
             eip155Block = 1;
             eip158Block = 1;
+            homesteadBlock = 1;
             isQuorum = true;
             istanbul = {
               epoch = 30000;


### PR DESCRIPTION
nixos/quorum: update geth flags

- upstream commit changing `ws` args:
https://github.com/Consensys/quorum/commit/c989bca173681f4462985cec2d30616aa0774edd
- upstream commit changing `minerthreads` arg:
https://github.com/Consensys/quorum/commit/f0998415ba9a73f0add32f9b5aed2aec98b9a7f3

nixos/tests/quorum: fix test

- add `services.quorum.genesis.config.homesteadBlock = 1`. Without it test fails with error:
```text
quorum-pre-start[822]: Fatal: Failed to write genesis block: unsupported fork ordering: homesteadBlock not enabled, but eip150Block enabled at 1
```

## Description of changes

Fixes `nixosTests.quorum` (fails since `2023-09-30`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.quorum.x86_64-linux
https://hydra.nixos.org/build/272043647
Error log:
```text
machine # [   34.242043] quorum-pre-start[848]: Fatal: Failed to write genesis block: unsupported fork ordering: homesteadBlock not enabled, but eip150Block enabled at 1
machine # [   34.261231] systemd[1]: quorum.service: Control process exited, code=exited, status=1/FAILURE
machine # [   34.263964] systemd[1]: quorum.service: Failed with result 'exit-code'.
machine # [   34.271125] systemd[1]: Failed to start Quorum daemon.
machine # [   34.274217] systemd[1]: quorum.service: Consumed 1.430s CPU time, 26.3M memory peak.
machine # Job for quorum.service failed because the control process exited with error code.
```

with `homesteadBlock` added to test config `geth` errors on incorrect args:
```text
vm-test-run-quorum> machine # [   16.256542] geth[838]: Incorrect Usage. flag provided but not defined: -minerthreads
vm-test-run-quorum> machine # [   49.213644] geth[1026]: Incorrect Usage. flag provided but not defined: -wsaddr
```
`nixos/quourum` module commit fixes it, updating args to new ones.


Listed test maintainer:
@mmahut

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
