### PR TITLE
python3Packages.mamba-ssm: init at 2.2.2

### DIFF
--- a/pkgs/development/python-modules/causal-conv1d/default.nix
+++ b/pkgs/development/python-modules/causal-conv1d/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  ninja,
+  setuptools,
+  torch,
+  cudaPackages,
+  rocmPackages,
+  config,
+  cudaSupport ? config.cudaSupport,
+  which,
+}:
+
+buildPythonPackage rec {
+  pname = "causal-conv1d";
+  version = "1.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Dao-AILab";
+    repo = "causal-conv1d";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-p5x5u3zEmEMN3mWd88o3jmcpKUnovTvn7I9jIOj/ie0=";
+  };
+
+  build-system = [
+    ninja
+    setuptools
+    torch
+  ];
+
+  nativeBuildInputs = [ which ];
+
+  buildInputs = (
+    lib.optionals cudaSupport (
+      with cudaPackages;
+      [
+        cuda_cudart # cuda_runtime.h, -lcudart
+        cuda_cccl
+        libcusparse # cusparse.h
+        libcusolver # cusolverDn.h
+        cuda_nvcc
+        libcublas
+      ]
+    )
+  );
+
+  dependencies = [
+    torch
+  ];
+
+  # pytest tests not enabled due to nvidia GPU dependency
+  pythonImportsCheck = [ "causal_conv1d" ];
+
+  env = {
+    CAUSAL_CONV1D_FORCE_BUILD = "TRUE";
+  } // lib.optionalAttrs cudaSupport { CUDA_HOME = "${lib.getDev cudaPackages.cuda_nvcc}"; };
+
+  meta = with lib; {
+    description = "Causal depthwise conv1d in CUDA with a PyTorch interface";
+    homepage = "https://github.com/Dao-AILab/causal-conv1d";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cfhammill ];
+    # The package requires CUDA or ROCm, the ROCm build hasn't
+    # been completed or tested, so broken if not using cuda.
+    broken = !cudaSupport;
+  };
+}

--- a/pkgs/development/python-modules/mamba-ssm/default.nix
+++ b/pkgs/development/python-modules/mamba-ssm/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  causal-conv1d,
+  einops,
+  ninja,
+  setuptools,
+  torch,
+  transformers,
+  triton,
+  cudaPackages,
+  rocmPackages,
+  config,
+  cudaSupport ? config.cudaSupport,
+  which,
+}:
+
+buildPythonPackage rec {
+  pname = "mamba";
+  version = "2.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "state-spaces";
+    repo = "mamba";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-R702JjM3AGk7upN7GkNK8u1q4ekMK9fYQkpO6Re45Ng=";
+  };
+
+  build-system = [
+    ninja
+    setuptools
+    torch
+  ];
+
+  nativeBuildInputs = [ which ];
+
+  buildInputs = (
+    lib.optionals cudaSupport (
+      with cudaPackages;
+      [
+        cuda_cudart # cuda_runtime.h, -lcudart
+        cuda_cccl
+        libcusparse # cusparse.h
+        libcusolver # cusolverDn.h
+        cuda_nvcc
+        libcublas
+      ]
+    )
+  );
+
+  dependencies = [
+    causal-conv1d
+    einops
+    torch
+    transformers
+    triton
+  ];
+
+  env = {
+    MAMBA_FORCE_BUILD = "TRUE";
+  } // lib.optionalAttrs cudaSupport { CUDA_HOME = "${lib.getDev cudaPackages.cuda_nvcc}"; };
+
+  # pytest tests not enabled due to nvidia GPU dependency
+  pythonImportsCheck = [ "mamba_ssm" ];
+
+  meta = with lib; {
+    description = "Linear-Time Sequence Modeling with Selective State Spaces";
+    homepage = "https://github.com/state-spaces/mamba";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cfhammill ];
+    # The package requires CUDA or ROCm, the ROCm build hasn't
+    # been completed or tested, so broken if not using cuda.
+    broken = !cudaSupport;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2050,6 +2050,8 @@ self: super: with self; {
 
   cattrs = callPackage ../development/python-modules/cattrs { };
 
+  causal-conv1d = callPackage ../development/python-modules/causal-conv1d { };
+
   cbor2 = callPackage ../development/python-modules/cbor2 { };
 
   cbor = callPackage ../development/python-modules/cbor { };
@@ -7538,6 +7540,8 @@ self: super: with self; {
   mako = callPackage ../development/python-modules/mako { };
 
   malduck = callPackage ../development/python-modules/malduck { };
+
+  mamba-ssm = callPackage ../development/python-modules/mamba-ssm { };
 
   managesieve = callPackage ../development/python-modules/managesieve { };
 


### PR DESCRIPTION
## Description of changes

Adds python3Packages.mamba-ssm and its dependency python3Packages.causal-conv1d.

This PR is mostly a proof of concept, I have only tested on python311 with cuda, I have not attempted to figure out rocm, or cpu only execution.  Tests green for me after loading with

```
nix-shell -p '(import <nixpkgs> { config = { cudaSupport = true; cudaCapabilities = [ "8.0" ]; cudaEnableForwardCompat = false; allowUnfreePredicate = p: builtins.all ( license: license.free || builtins.elem license.shortName [ "CUDA EULA" "cuDNN EULA" "cuTENSOR EULA" "NVidia OptiX EULA" ] ) (if builtins.isList p.meta.license then p.meta.license else [ p.meta.license ]); permittedInsecurePackages = [ "electron-24.8.6" "zotero-6.0.27" ]; }; }).python311.withPackages 
  (ps: with ps; [ mamba-ssm causal-conv1d pytest einops ])'
```

cloning the mamba and causal-conv1d repos and running the test suites.

I'm not interested in being the sole maintainer of this, so if any of the cuda team wants to join and I can add you to the maintainer list.

cc: @ConnorBaker @samuela @SomeoneSerge @bcdarwin 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
