### PR TITLE
lib.mkOptions: allow arbitrary option metadata

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -143,7 +143,6 @@ let
       mkMergedOptionModule mkChangedOptionModule
       mkAliasOptionModule mkDerivedConfig doRename
       mkAliasOptionModuleMD;
-    evalOptionValue = lib.warn "External use of `lib.evalOptionValue` is deprecated. If your use case isn't covered by non-deprecated functions, we'd like to know more and perhaps support your use case well, instead of providing access to these low level functions. In this case please open an issue in https://github.com/nixos/nixpkgs/issues/." self.modules.evalOptionValue;
     inherit (self.options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption mergeUniqueOption
       getValues getFiles

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -843,7 +843,7 @@ let
           # The option path. Although the things we're checking happen to be options,
           # that's not what we're checking against, and that's what the prefix is
           # about. The checkable options are more like _file, and we'll make use of that.
-          prefix = [ "_modules" "optionMeta" ];
+          prefix = [ "options" ] ++ opt.loc ++ [ "meta" ];
           modules =
             [
               { options = _module.optionMeta or { }; }

--- a/lib/modules/default-meta-interface.nix
+++ b/lib/modules/default-meta-interface.nix
@@ -1,0 +1,36 @@
+{ lib, optionDeclaration, ... }:
+let
+  inherit (lib) types mkOption;
+in
+{
+  options = {
+    defaultText = mkOption {
+      apply =
+        v: if v == null && !optionDeclaration ? default then null else lib.options.renderOptionValue v;
+      type = types.raw;
+      default = optionDeclaration.default or null;
+    };
+    example = mkOption {
+      apply =
+        v: if v == null && !optionDeclaration ? default then null else lib.options.renderOptionValue v;
+      type = types.raw;
+      default = optionDeclaration.example or null;
+    };
+    description = mkOption {
+      type = types.nullOr types.str;
+      default = optionDeclaration.description or null;
+    };
+    internal = mkOption {
+      type = types.bool;
+      default = optionDeclaration.internal or false;
+    };
+    visible = mkOption {
+      type = types.enum [
+        true
+        false
+        "shallow"
+      ];
+      default = optionDeclaration.visible or true;
+    };
+  };
+}

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -85,6 +85,7 @@ rec {
     visible ? null,
     # Whether the option can be set only once
     readOnly ? null,
+    meta ? {},
     } @ attrs:
     attrs // { _type = "option"; };
 

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -67,6 +67,12 @@ rec {
     {
     # Default value used when no definition is given in the configuration.
     default ? null,
+    # Option type, providing type-checking and value merging.
+    type ? null,
+    # Whether the option can be set only once
+    readOnly ? null,
+
+
     # Textual representation of the default, for the manual.
     defaultText ? null,
     # Example value used in the manual.
@@ -75,16 +81,12 @@ rec {
     description ? null,
     # Related packages used in the manual (see `genRelatedPackages` in ../nixos/lib/make-options-doc/default.nix).
     relatedPackages ? null,
-    # Option type, providing type-checking and value merging.
-    type ? null,
     # Function that converts the option value to something else.
     apply ? null,
     # Whether the option is for NixOS developers only.
     internal ? null,
     # Whether the option shows up in the manual. Default: true. Use false to hide the option and any sub-options from submodules. Use "shallow" to hide only sub-options.
     visible ? null,
-    # Whether the option can be set only once
-    readOnly ? null,
     meta ? {},
     } @ attrs:
     attrs // { _type = "option"; };

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -151,6 +151,7 @@ checkConfigError '.*A definition for option .bad. is not of type .non-empty .lis
 checkConfigOutput '^true$' options.foo.meta.required ./option-meta.nix
 checkConfigError '.*The option .options\.undeclared\.meta\.reuired. does not exist.*' options.undeclared.meta.reuired ./option-meta.nix
 checkConfigError '.*option-meta\.nix:[0-9]+:[0-9]+.: false' options.undeclared.meta.reuired ./option-meta.nix
+checkConfigError '.*The option .options\.missingDef\.meta\.required. was accessed but has no value defined\. Try setting the option.*' options.missingDef.meta.required ./option-meta.nix
 
 # types.attrTag
 checkConfigOutput '^true$' config.okChecks ./types-attrTag.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -149,7 +149,7 @@ checkConfigError '.*This can happen if you e.g. declared your options in .types.
 checkConfigError '.*A definition for option .bad. is not of type .non-empty .list of .submodule...\.' config.bad ./error-nonEmptyListOf-submodule.nix
 
 checkConfigOutput '^true$' options.foo.meta.required ./option-meta.nix
-checkConfigError '.*The option ._modules\.optionMeta\.reuired. does not exist.*' options.undeclared.meta.reuired ./option-meta.nix
+checkConfigError '.*The option .options\.undeclared\.meta\.reuired. does not exist.*' options.undeclared.meta.reuired ./option-meta.nix
 checkConfigError '.*option-meta\.nix:[0-9]+:[0-9]+.: false' options.undeclared.meta.reuired ./option-meta.nix
 
 # types.attrTag

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -148,6 +148,10 @@ checkConfigError 'The option .sub.wrong2. does not exist. Definition values:' co
 checkConfigError '.*This can happen if you e.g. declared your options in .types.submodule.' config.sub ./error-mkOption-in-submodule-config.nix
 checkConfigError '.*A definition for option .bad. is not of type .non-empty .list of .submodule...\.' config.bad ./error-nonEmptyListOf-submodule.nix
 
+checkConfigOutput '^true$' options.foo.meta.required ./option-meta.nix
+checkConfigError '.*The option ._modules\.optionMeta\.reuired. does not exist.*' options.undeclared.meta.reuired ./option-meta.nix
+checkConfigError '.*option-meta\.nix:[0-9]+:[0-9]+.: false' options.undeclared.meta.reuired ./option-meta.nix
+
 # types.attrTag
 checkConfigOutput '^true$' config.okChecks ./types-attrTag.nix
 checkConfigError 'A definition for option .intStrings\.syntaxError. is not of type .attribute-tagged union' config.intStrings.syntaxError ./types-attrTag.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -149,6 +149,7 @@ checkConfigError '.*This can happen if you e.g. declared your options in .types.
 checkConfigError '.*A definition for option .bad. is not of type .non-empty .list of .submodule...\.' config.bad ./error-nonEmptyListOf-submodule.nix
 
 checkConfigOutput '^true$' options.foo.meta.required ./option-meta.nix
+checkConfigOutput '^"ok"$' config.assertions ./option-meta.nix
 checkConfigError '.*The option .options\.undeclared\.meta\.reuired. does not exist.*' options.undeclared.meta.reuired ./option-meta.nix
 checkConfigError '.*option-meta\.nix:[0-9]+:[0-9]+.: false' options.undeclared.meta.reuired ./option-meta.nix
 checkConfigError '.*The option .options\.missingDef\.meta\.required. was accessed but has no value defined\. Try setting the option.*' options.missingDef.meta.required ./option-meta.nix

--- a/lib/tests/modules/option-meta-required.nix
+++ b/lib/tests/modules/option-meta-required.nix
@@ -7,6 +7,8 @@ in
     required = lib.mkOption {
       type = types.bool;
       description = "Whether an option is required or something; just an example meta attribute for testing.";
+      # Most meta options should have a default, but for this test we don't define,
+      # as missingDef in ./option-meta.nix relies on this.
     };
   };
 }

--- a/lib/tests/modules/option-meta-required.nix
+++ b/lib/tests/modules/option-meta-required.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options._module.optionMeta = {
+    required = lib.mkOption {
+      type = types.bool;
+      description = "Whether an option is required or something; just an example meta attribute for testing.";
+    };
+  };
+}

--- a/lib/tests/modules/option-meta.nix
+++ b/lib/tests/modules/option-meta.nix
@@ -1,6 +1,12 @@
-{ lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) isAttrs mkOption types;
+  nullAttrs = lib.mapAttrs (_: _: null);
 in
 {
   imports = [
@@ -19,8 +25,21 @@ in
     missingDef = mkOption {
       type = lib.types.str;
     };
+    brokenMeta = mkOption {
+      meta = abort "brokenMeta.meta is broken and must not be evaluated as a matter of laziness, performance, robustness.";
+      default = "ok";
+    };
+
+    assertions = mkOption { };
   };
   config = {
     foo = "bar";
+    assertions =
+      assert options.foo.meta == { required = true; };
+      # laziness
+      assert isAttrs options.missingDef.meta;
+      assert nullAttrs options.missingDef.meta == { required = null; };
+      assert config.brokenMeta == "ok";
+      "ok";
   };
 }

--- a/lib/tests/modules/option-meta.nix
+++ b/lib/tests/modules/option-meta.nix
@@ -16,6 +16,9 @@ in
       # typo, no q
       meta.reuired = false;
     };
+    missingDef = mkOption {
+      type = lib.types.str;
+    };
   };
   config = {
     foo = "bar";

--- a/lib/tests/modules/option-meta.nix
+++ b/lib/tests/modules/option-meta.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  imports = [
+    ./option-meta-required.nix
+  ];
+  options = {
+    foo = lib.mkOption {
+      type = lib.types.str;
+      meta.required = true;
+    };
+    undeclared = lib.mkOption {
+      type = lib.types.str;
+      # typo, no q
+      meta.reuired = false;
+    };
+  };
+  config = {
+    foo = "bar";
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -684,7 +684,8 @@ rec {
             if tags?${choice}
             then
               { ${choice} =
-                  (lib.modules.evalOptionValue
+                  (lib.modules.evalOptionValue'
+                    { }  # Can't have option meta attributes in attrTag for now; needs `merge` function interface upgrade
                     (loc ++ [choice])
                     tags.${choice}
                     checkedValueDefs

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -685,7 +685,7 @@ rec {
             then
               { ${choice} =
                   (lib.modules.evalOptionValue'
-                    { }  # Can't have option meta attributes in attrTag for now; needs `merge` function interface upgrade
+                    { }  # Would need something like `attrTagWith { optionMeta = { }; }`, and a good way to retrieve the `meta`s
                     (loc ++ [choice])
                     tags.${choice}
                     checkedValueDefs

--- a/nixos/modules/misc/optionMeta.nix
+++ b/nixos/modules/misc/optionMeta.nix
@@ -1,0 +1,13 @@
+{ lib, optionDeclaration, ... }:
+let
+  inherit (lib) types mkOption;
+in
+{
+  # Additional options available in mkOption { ..., meta = { ... } }
+  options = {
+    relatedPackages = mkOption {
+      type = types.raw;
+      default = optionDeclaration.relatedPackages or [ ];
+    };
+  };
+}

--- a/nixos/modules/misc/register-optionMeta.nix
+++ b/nixos/modules/misc/register-optionMeta.nix
@@ -1,0 +1,3 @@
+{
+  _module.optionMeta = ./optionMeta.nix;
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -136,6 +136,7 @@
   ./misc/man-db.nix
   ./misc/mandoc.nix
   ./misc/meta.nix
+  ./misc/register-optionMeta.nix
   ./misc/nixops-autoluks.nix
   ./misc/nixpkgs.nix
   ./misc/nixpkgs-flake.nix


### PR DESCRIPTION
## Description of changes

Allows adding arbitrary metadata to options.
@roberth @infinisil   I am not sure if this is a good idea. But I could need it to build a nice user interface around the modules.

#### Examples 

```nix
foo = lib.mkOption {
      type = lib.types.str;
      meta.required = true;
};

foo-bar = lib.mkOption {
      type = lib.types.str;
      meta.title = "FooBar";
};

foo-bar = lib.mkOption {
      type = lib.types.str;
      meta.renderer = ''
         <input>
      '';
};
```

Justification for the examples:

(Especially when trying to build a more high level user interface)

- If a field is required or not might not be derivable from just looking if an option has a default. The value might be set via some config which means it could be optional from the user perspective, although it is required from the evalModules perspective.
- Options might want to specify how they want to be rendered.
- Options might be mapped into different domain, which doesn't allow some special characters (`-_* \/^`) or just where the name of the option might not make sense for a certain user anymore.  I.e. `title = "FooBar";` would allow to display the option with a more explanatory label without creating an intermediate option, just for the purpose of rendering.
- ... more examples possible

I am not sure if we should add those use-cases to the current keywords, or if we should just allow arbitrary names because i am not sure how the above described scenarios would ideally be represented through new keywords.


## Alternatives


```
{ ... }@attrs
```
instead of explicit `meta ? {} `

`passthru` instead of meta, maybe it is more clear.

Could produce less thunks but also is less safe towards future extensions of mkOption attrs.
 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
