### PR TITLE
python312Packages.eth-account: 0.9.0 -> 0.13.3

### DIFF
--- a/pkgs/development/python-modules/eth-account/default.nix
+++ b/pkgs/development/python-modules/eth-account/default.nix
@@ -9,6 +9,7 @@
   eth-rlp,
   eth-utils,
   websockets,
+  setuptools,
   hexbytes,
   pythonOlder,
   rlp,
@@ -16,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "eth-account";
-  version = "0.9.0";
+  version = "0.13.3";
   format = "setuptools";
   disabled = pythonOlder "3.7";
 
@@ -37,6 +38,7 @@ buildPythonPackage rec {
     hexbytes
     rlp
     websockets
+    setuptools
   ];
 
   # require buildinga npm project

--- a/pkgs/development/python-modules/eth-account/default.nix
+++ b/pkgs/development/python-modules/eth-account/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     hash = "sha256-657l7M7euUGXXKTrQyB/kVA4miyePr310enhkaSBJss=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     bitarray
     eth-abi
     eth-keyfile

--- a/pkgs/development/python-modules/eth-account/default.nix
+++ b/pkgs/development/python-modules/eth-account/default.nix
@@ -9,7 +9,6 @@
   eth-rlp,
   eth-utils,
   websockets,
-  setuptools,
   hexbytes,
   pythonOlder,
   rlp,
@@ -25,7 +24,7 @@ buildPythonPackage rec {
     owner = "ethereum";
     repo = "eth-account";
     rev = "v${version}";
-    hash = "sha256-Ps/vzJv0W1+wy1mSJaqRNNU6CoCMchReHIocB9kPrGs=";
+    hash = "sha256-657l7M7euUGXXKTrQyB/kVA4miyePr310enhkaSBJss=";
   };
 
   propagatedBuildInputs = [
@@ -38,7 +37,6 @@ buildPythonPackage rec {
     hexbytes
     rlp
     websockets
-    setuptools
   ];
 
   # require buildinga npm project


### PR DESCRIPTION
## Description of changes

This bumps the version of this library from 0.9.0 (2023-06-07) to 0.13.3 (2024-08-28).

It is a naive bump. Importing it appears to work, but the [setup.py file added a requirement](https://github.com/ethereum/eth-account/blob/main/setup.py#L61) on the library `ckzg`, which is not found in `nixpkgs` and has only been mentioned in https://github.com/NixOS/nixpkgs/pull/337542 

Closes #341204

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
