### PR TITLE
gforth: override swig, not swig3

### DIFF
--- a/pkgs/development/compilers/gforth/swig.nix
+++ b/pkgs/development/compilers/gforth/swig.nix
@@ -1,8 +1,12 @@
-{ swig3, fetchFromGitHub }:
+{
+  swig,
+  pcre,
+  fetchFromGitHub,
+}:
 
 ## for updating to swig4, see
 ## https://github.com/GeraldWodni/swig/pull/6
-swig3.overrideDerivation (old: {
+(swig.overrideAttrs (old: {
   version = "3.0.9-forth";
   src = fetchFromGitHub {
     owner = "GeraldWodni";
@@ -10,7 +14,6 @@ swig3.overrideDerivation (old: {
     rev = "a45b807e5f9d8ca1a43649c8265d2741a393862a";
     sha256 = "sha256-6nOOPFGFNaQInEkul0ZAh+ks9n3wqCQ6/tbduvG/To0=";
   };
-  configureFlags = old.configureFlags ++ [
-    "--enable-forth"
-  ];
-})
+  configureFlags = old.configureFlags ++ [ "--enable-forth" ];
+})).override
+  { pcre2 = pcre; }


### PR DESCRIPTION
## Description of changes

Removes one of two remaining usages of the top-level `swig3` expression. (The other comes from older `LLDB` versions.)

Also removes use of `overrideDerivation` in favour of preferred `overrideAttrs`.

Unfortunately `gforth` still needs a custom fork of swig 3.0.9, but if absolutely necessary we could perhaps remove the swig dependency altogether, at the cost of some C interface support (I don't exactly understand what is lost by removing support from the compiler vs removing access to a standalone Forth-compatible swig, though).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
