### PR TITLE
Chicken: fix env vars

### DIFF
--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -1,0 +1,92 @@
+{ lib, stdenv, fetchurl, makeWrapper, darwin, bootstrap-chicken ? null, testers }:
+
+let
+  platform = with stdenv;
+    if isDarwin then "macosx"
+    else if isCygwin then "cygwin"
+    else if (isFreeBSD || isOpenBSD) then "bsd"
+    else if isSunOS then "solaris"
+    else "linux"; # Should be a sane default
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chicken";
+  version = "5.4.0";
+
+  binaryVersion = 11;
+
+  src = fetchurl {
+    url = "https://code.call-cc.org/releases/${finalAttrs.version}/chicken-${finalAttrs.version}.tar.gz";
+    sha256 = "sha256-PF1KphwRZ79tm/nq+JHadjC6n188Fb8JUVpwOb/N7F8=";
+  };
+
+  # Disable two broken tests: "static link" and "linking tests"
+  postPatch = ''
+    sed -i tests/runtests.sh -e "/static link/,+4 { s/^/# / }"
+    sed -i tests/runtests.sh -e "/linking tests/,+11 { s/^/# / }"
+  '';
+
+  setupHook = lib.optional (bootstrap-chicken != null) ./setup-hook.sh;
+
+  # -fno-strict-overflow is not a supported argument in clang
+  hardeningDisable = lib.optionals stdenv.cc.isClang [ "strictoverflow" ];
+
+  makeFlags = [
+    "PLATFORM=${platform}"
+    "PREFIX=$(out)"
+    "C_COMPILER=$(CC)"
+    "CXX_COMPILER=$(CXX)"
+  ] ++ (lib.optionals stdenv.isDarwin [
+    "XCODE_TOOL_PATH=${darwin.binutils.bintools}/bin"
+    "LINKER_OPTIONS=-headerpad_max_install_names"
+    "POSTINSTALL_PROGRAM=install_name_tool"
+  ]) ++ (lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "HOSTSYSTEM=${stdenv.hostPlatform.config}"
+    "TARGET_C_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
+    "TARGET_CXX_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++"
+  ]);
+
+  nativeBuildInputs = [
+    makeWrapper
+  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+    darwin.autoSignDarwinBinariesHook
+  ];
+
+  buildInputs = lib.optionals (bootstrap-chicken != null) [
+    bootstrap-chicken
+  ];
+
+  doCheck = !stdenv.isDarwin;
+  postCheck = ''
+    ./csi -R chicken.pathname -R chicken.platform \
+       -p "(assert (equal? \"${toString finalAttrs.binaryVersion}\" (pathname-file (car (repository-path)))))"
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "csi -version";
+  };
+
+  postInstall = ''
+    for f in $out/bin/*
+    do
+      wrapProgram $f \
+        --prefix CHICKEN_REPOSITORY_PATH : "$out/lib/chicken/${toString finalAttrs.binaryVersion}:$CHICKEN_REPOSITORY_PATH" \
+        --prefix CHICKEN_INCLUDE_PATH : "$out/share"
+    done
+  '';
+
+  meta = {
+    homepage = "https://call-cc.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ corngood nagy konst-aa ];
+    platforms = lib.platforms.unix;
+    description = "Portable compiler for the Scheme programming language";
+    longDescription = ''
+      CHICKEN is a compiler for the Scheme programming language.
+      CHICKEN produces portable and efficient C, supports almost all
+      of the R5RS Scheme language standard, and includes many
+      enhancements and extensions. CHICKEN runs on Linux, macOS,
+      Windows, and many Unix flavours.
+    '';
+  };
+})


### PR DESCRIPTION
## Description of changes

Adjustment for Chicken's environment variables to properly allow for overrides for manual egg installations.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).