### PR TITLE
python312Packages.gpy: 1.13.1 -> 1.13.2

### DIFF
--- a/pkgs/development/python-modules/gpy/default.nix
+++ b/pkgs/development/python-modules/gpy/default.nix
@@ -16,18 +16,22 @@
 
 buildPythonPackage rec {
   pname = "gpy";
-  version = "1.13.1";
+  version = "1.13.2";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
-  # 1.13.0 not on PyPI yet
   src = fetchFromGitHub {
     owner = "SheffieldML";
     repo = "GPy";
     rev = "refs/tags/v${version}";
-    hash = "sha256-ykoGdXy1uagKrP9Nqn74mDESZwKVPq6wQgnHlCznevM=";
+    hash = "sha256-kggXePDKJcgw8qwLIBTxbwhiLw2H4dkx7082FguKP0Y=";
   };
+
+  pythonRelaxDeps = [
+    "paramz"
+    "scipy"
+  ];
 
   nativeBuildInputs = [ setuptools ];
   buildInputs = [ cython ];
@@ -47,14 +51,18 @@ buildPythonPackage rec {
     done
   '';
 
+  disabledTests = lib.optionals (stdenv.isDarwin && stdenv.hostPlatform.isx86_64) [
+    # Rounding difference break comparison
+    "TestGradientMultiOutputGPModel"
+  ];
+
   pythonImportsCheck = [ "GPy" ];
 
   meta = with lib; {
     description = "Gaussian process framework in Python";
     homepage = "https://sheffieldml.github.io/GPy";
-    changelog = "https://github.com/SheffieldML/GPy/releases/tag/v.${version}";
+    changelog = "https://github.com/SheffieldML/GPy/releases/tag/v${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bcdarwin ];
-    broken = stdenv.isDarwin; # See inscrutable error message here: https://github.com/NixOS/nixpkgs/pull/107653#issuecomment-751527547
   };
 }


### PR DESCRIPTION
## Description of changes

1. Version bump to 1.13.2
2. Disabled one test that fails on Darwin x86_64 due to a rounding error
3. Removed `broken` flag on Darwin

Re-do of #340866 due to a merging mistake (my bad)

cc: @NixOS/darwin-maintainers FYI for unlocking another broken package on Darwin.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
