### PR TITLE
tetrio-plus: split into seperate derivation

### DIFF
--- a/pkgs/by-name/te/tetrio-desktop/package.nix
+++ b/pkgs/by-name/te/tetrio-desktop/package.nix
@@ -1,13 +1,14 @@
-{ stdenv
-, lib
-, fetchzip
-, dpkg
-, makeWrapper
-, callPackage
-, addDriverRunpath
-, electron
-, withTetrioPlus ? false
-, tetrio-plus ? null
+{
+  stdenv,
+  lib,
+  fetchzip,
+  dpkg,
+  makeWrapper,
+  callPackage,
+  addDriverRunpath,
+  electron,
+  withTetrioPlus ? false,
+  tetrio-plus ? null,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,19 +28,15 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase =
     let
       tetrio-plus' =
-        if tetrio-plus == null
-        then
-          callPackage ./tetrio-plus.nix
-            {
-              tetrio-src = finalAttrs.src;
-              tetrio-version = finalAttrs.version;
-            }
-        else tetrio-plus;
+        if tetrio-plus == null then
+          callPackage ./tetrio-plus.nix {
+            tetrio-src = finalAttrs.src;
+            tetrio-version = finalAttrs.version;
+          }
+        else
+          tetrio-plus;
 
-      asarPath =
-        if withTetrioPlus
-        then "${tetrio-plus'}/app.asar"
-        else "opt/TETR.IO/resources/app.asar";
+      asarPath = if withTetrioPlus then "${tetrio-plus'}/app.asar" else "opt/TETR.IO/resources/app.asar";
     in
     ''
       runHook preInstall
@@ -74,7 +71,10 @@ stdenv.mkDerivation (finalAttrs: {
       Play against friends and foes all over the world, or claim a spot on the leaderboards - the stacker future is yours!
     '';
     mainProgram = "tetrio";
-    maintainers = with lib.maintainers; [ wackbyte huantian ];
+    maintainers = with lib.maintainers; [
+      wackbyte
+      huantian
+    ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };

--- a/pkgs/by-name/te/tetrio-desktop/package.nix
+++ b/pkgs/by-name/te/tetrio-desktop/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     makeShellWrapper '${lib.getExe electron}' $out/bin/tetrio \
       --prefix LD_LIBRARY_PATH : ${addDriverRunpath.driverLink}/lib \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime}}" \
       --add-flags $out/share/TETR.IO/app.asar
   '';
 

--- a/pkgs/by-name/te/tetrio-desktop/package.nix
+++ b/pkgs/by-name/te/tetrio-desktop/package.nix
@@ -12,10 +12,10 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tetrio-desktop";
-  version = "9.0.0";
+  version = "9";
 
   src = fetchzip {
-    url = "https://tetr.io/about/desktop/builds/${lib.versions.major finalAttrs.version}/TETR.IO%20Setup.deb";
+    url = "https://tetr.io/about/desktop/builds/${finalAttrs.version}/TETR.IO%20Setup.deb";
     hash = "sha256-TgegFy+sHjv0ILaiLO1ghyUhKXoj8v43ACJOJhKyI0c=";
     nativeBuildInputs = [ dpkg ];
   };

--- a/pkgs/by-name/te/tetrio-desktop/package.nix
+++ b/pkgs/by-name/te/tetrio-desktop/package.nix
@@ -52,13 +52,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     changelog = "https://tetr.io/about/desktop/history/";
-    description = "TETR.IO desktop client";
+    description = "Desktop client for TETR.IO, an online stacker game";
     downloadPage = "https://tetr.io/about/desktop/";
     homepage = "https://tetr.io";
     license = lib.licenses.unfree;
     longDescription = ''
-      TETR.IO is a modern yet familiar online stacker.
-      Play against friends and foes all over the world, or claim a spot on the leaderboards - the stacker future is yours!
+      TETR.IO is a free-to-win modern yet familiar online stacker.
+      Play multiplayer games against friends and foes all over the world, or claim a spot on the leaderboards - the stacker future is yours!
     '';
     mainProgram = "tetrio";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/te/tetrio-desktop/package.nix
+++ b/pkgs/by-name/te/tetrio-desktop/package.nix
@@ -4,11 +4,10 @@
   fetchzip,
   dpkg,
   makeWrapper,
-  callPackage,
   addDriverRunpath,
   electron,
   withTetrioPlus ? false,
-  tetrio-plus ? null,
+  tetrio-plus,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,16 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase =
     let
-      tetrio-plus' =
-        if tetrio-plus == null then
-          callPackage ./tetrio-plus.nix {
-            tetrio-src = finalAttrs.src;
-            tetrio-version = finalAttrs.version;
-          }
-        else
-          tetrio-plus;
-
-      asarPath = if withTetrioPlus then "${tetrio-plus'}/app.asar" else "opt/TETR.IO/resources/app.asar";
+      asarPath = if withTetrioPlus then tetrio-plus else "opt/TETR.IO/resources/app.asar";
     in
     ''
       runHook preInstall

--- a/pkgs/by-name/te/tetrio-desktop/tetrio-plus.nix
+++ b/pkgs/by-name/te/tetrio-desktop/tetrio-plus.nix
@@ -1,20 +1,21 @@
-{ lib
-, stdenv
-, fetchFromGitLab
-, rustPlatform
-, rustc
-, wasm-pack
-, wasm-bindgen-cli
-, binaryen
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  rustPlatform,
+  rustc,
+  wasm-pack,
+  wasm-bindgen-cli,
+  binaryen,
 
-, fetchYarnDeps
-, yarn
-, fixup-yarn-lock
-, nodejs
-, asar
+  fetchYarnDeps,
+  yarn,
+  fixup-yarn-lock,
+  nodejs,
+  asar,
 
-, tetrio-src
-, tetrio-version
+  tetrio-src,
+  tetrio-version,
 }:
 
 let
@@ -76,7 +77,10 @@ let
       description = "Self contained toolkit for creating, editing, and previewing TPSE files";
       homepage = "https://gitlab.com/UniQMG/tpsecore";
       license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [ huantian wackbyte ];
+      maintainers = with lib.maintainers; [
+        huantian
+        wackbyte
+      ];
       platforms = lib.platforms.linux;
     };
   };
@@ -160,7 +164,10 @@ stdenv.mkDerivation (finalAttrs: {
       # is a modified version of tetrio-desktop, which is unfree.
       lib.licenses.unfree
     ];
-    maintainers = with lib.maintainers; [ huantian wackbyte ];
+    maintainers = with lib.maintainers; [
+      huantian
+      wackbyte
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/te/tetrio-plus/package.nix
+++ b/pkgs/by-name/te/tetrio-plus/package.nix
@@ -25,21 +25,8 @@ let
     owner = "UniQMG";
     repo = "tetrio-plus";
     inherit rev;
-    hash = "sha256-PvTivTt1Zuvk5gaCcQDcIBFsUf/ZG7TJYXqm0NP++Bw=";
+    hash = "sha256-pcT8/YsfHeimSkeNziW9ha63hEgCg2vnvJSZAY1c7P0=";
     fetchSubmodules = true;
-
-    # tetrio-plus uses this info for displaying its version,
-    # so we need to deep clone to have all the revision history.
-    # After we're done, we emulate 'leaveDotGit = false' by removing
-    # all the .git folders.
-    leaveDotGit = true;
-    deepClone = true;
-    postFetch = ''
-      cd "$out"
-      git rev-parse --short HEAD~1 > resources/ci-commit-previous
-      git rev-parse --short HEAD > resources/ci-commit
-      find "$out" -name .git -print0 | xargs -0 rm -rf
-    '';
   };
 
   wasm-bindgen-82 = wasm-bindgen-cli.override {
@@ -105,13 +92,14 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    # 'out' is the directory that the tetrio-plus expects the vanilla asar to be
-    # and this is the directory that will contain the final result that we want
+    # tetrio-plus expects the vanilla asar to be extracted into 'out' and
+    # 'out' is the directory contianing the final patched asar's contents
     asar extract ${tetrio-desktop.src}/opt/TETR.IO/resources/app.asar out
-    cd out
 
     # Install custom package.json/yarn.lock that describe the additional node
     # dependencies that tetrio-plus needs to run, and install them in our output
+    cd out
+
     cp ../resources/desktop-ci/yarn.lock .
     patch package.json ../resources/desktop-ci/package.json.diff
 
@@ -123,24 +111,26 @@ stdenv.mkDerivation (finalAttrs: {
 
     cd ..
 
-    # The simple build script expects the vanilla asar located here
+    # The included build script expects the vanilla asar located here
     # This patches the vanilla code to load the tetrio-plus code
     ln -s ${tetrio-desktop.src}/opt/TETR.IO/resources/app.asar app.asar
     node ./scripts/build-electron.js
 
-    # Finally, we install the tetrio-plus code where the above patch script expects
+    # Actually install tetrio-plus where the above patch script expects
     cp -r $src out/tetrioplus
     chmod -R u+w out/tetrioplus
 
-    # Disable the uninstall button in the tetrio-plus popup,
-    # as it doesn't make sense to mutably uninstall it in a nix package
+    # Install tpsecore
+    cp ${tpsecore}/{tpsecore_bg.wasm,tpsecore.js} out/tetrioplus/source/lib/
+    # Remove uneeded tpsecore source code
+    rm -rf out/tetrioplus/tpsecore/
+
+    # Disable useless uninstall button in the tetrio-plus popup
     substituteInPlace out/tetrioplus/desktop-manifest.js \
       --replace-fail '"show_uninstaller_button": true' '"show_uninstaller_button": false'
 
-    # We don't need the tpsecore source code bundled
-    rm -rf out/tetrioplus/tpsecore/
-    # since we install the compiled version here
-    cp ${tpsecore}/{tpsecore_bg.wasm,tpsecore.js} out/tetrioplus/source/lib/
+    # Display 'nixpkgs' next to version in tetrio-plus popup
+    echo "nixpkgs" > out/tetrioplus/resources/override-commit
 
     runHook postBuild
   '';

--- a/pkgs/by-name/te/tetrio-plus/package.nix
+++ b/pkgs/by-name/te/tetrio-plus/package.nix
@@ -19,7 +19,7 @@
 
 let
   version = "0.27.2";
-  rev = "electron-v${version}-tetrio-v${lib.versions.major tetrio-desktop.version}";
+  rev = "electron-v${version}-tetrio-v${tetrio-desktop.version}";
 
   src = fetchFromGitLab {
     owner = "UniQMG";

--- a/pkgs/by-name/te/tetrio-plus/package.nix
+++ b/pkgs/by-name/te/tetrio-plus/package.nix
@@ -19,11 +19,12 @@
 
 let
   version = "0.27.2";
+  rev = "electron-v${version}-tetrio-v${lib.versions.major tetrio-desktop.version}";
 
   src = fetchFromGitLab {
     owner = "UniQMG";
     repo = "tetrio-plus";
-    rev = "electron-v${version}-tetrio-v${lib.versions.major tetrio-version}";
+    inherit rev;
     hash = "sha256-PvTivTt1Zuvk5gaCcQDcIBFsUf/ZG7TJYXqm0NP++Bw=";
     fetchSubmodules = true;
 
@@ -153,9 +154,13 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "TETR.IO customization tool suite";
-    downloadPage = "https://gitlab.com/UniQMG/tetrio-plus/-/releases";
+    description = "Modified TETR.IO desktop app.asar with many customization tools";
+    longDescription = ''
+      To use this, `override` the `withTetrioPlus` attribute of `tetrio-desktop`.
+    '';
     homepage = "https://gitlab.com/UniQMG/tetrio-plus";
+    downloadPage = "https://gitlab.com/UniQMG/tetrio-plus/-/releases";
+    changelog = "https://gitlab.com/UniQMG/tetrio-plus/-/releases/${rev}";
     license = [
       lib.licenses.mit
       # while tetrio-plus is itself mit, the result of this derivation

--- a/pkgs/by-name/te/tetrio-plus/package.nix
+++ b/pkgs/by-name/te/tetrio-plus/package.nix
@@ -14,8 +14,7 @@
   nodejs,
   asar,
 
-  tetrio-src,
-  tetrio-version,
+  tetrio-desktop,
 }:
 
 let
@@ -107,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # 'out' is the directory that the tetrio-plus expects the vanilla asar to be
     # and this is the directory that will contain the final result that we want
-    asar extract ${tetrio-src}/opt/TETR.IO/resources/app.asar out
+    asar extract ${tetrio-desktop.src}/opt/TETR.IO/resources/app.asar out
     cd out
 
     # Install custom package.json/yarn.lock that describe the additional node
@@ -125,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # The simple build script expects the vanilla asar located here
     # This patches the vanilla code to load the tetrio-plus code
-    ln -s ${tetrio-src}/opt/TETR.IO/resources/app.asar app.asar
+    ln -s ${tetrio-desktop.src}/opt/TETR.IO/resources/app.asar app.asar
     node ./scripts/build-electron.js
 
     # Finally, we install the tetrio-plus code where the above patch script expects
@@ -148,8 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preinstall
 
-    mkdir -p $out
-    asar pack out $out/app.asar
+    asar pack out $out
 
     runHook postinstall
   '';


### PR DESCRIPTION
## Description of changes
This allows the tetrio-plus package to be cached, so users don't have to compile tpsecore themselves.

@wackbyte let me know if this is something we even want to do. 

Questions:
- Do we want to switch `tetrio-desktop`'s `version` to just be `9`? Upstream seems to only be using integer versions, and it would save us some `lib.versions.major` calls.
- Is it OK to reference `tetrio-desktop`'s `src` and `version` like this in general?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
