### PR TITLE
awakened-poe-trade: init at 3.25.102

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14660,6 +14660,12 @@
     githubId = 7845120;
     name = "Alex Martens";
   };
+  nezia = {
+    email = "anthony@nezia.dev";
+    github = "nezia1";
+    githubId = 43719748;
+    name = "Anthony Rodriguez";
+  };
   ngerstle = {
     name = "Nicholas Gerstle";
     email = "ngerstle@gmail.com";

--- a/pkgs/by-name/aw/awakened-poe-trade/package.nix
+++ b/pkgs/by-name/aw/awakened-poe-trade/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  appimageTools,
+  makeWrapper,
+  electron,
+  xorg,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "awakened-poe-trade";
+  version = "3.25.102";
+
+  src = fetchurl {
+    url = "https://github.com/SnosMe/awakened-poe-trade/releases/download/v${version}/Awakened-PoE-Trade-${version}.AppImage";
+    hash = "sha256-lcdKJ+B8NQmyMsv+76+eeESSrfR/7Mq6svO5VKaoNUY=";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    name = "${pname}-${version}";
+    inherit src;
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/share/awakened-poe-trade $out/share/applications
+
+    cp -a ${appimageContents}/{locales,resources} $out/share/awakened-poe-trade
+    cp -a ${appimageContents}/awakened-poe-trade.desktop $out/share/applications/
+    cp -a ${appimageContents}/usr/share/icons $out/share
+
+    substituteInPlace $out/share/applications/awakened-poe-trade.desktop \
+    --replace-fail 'Exec=AppRun' 'Exec=awakened-poe-trade'
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+        makeWrapper ${lib.getExe electron} $out/bin/awakened-poe-trade \
+    --add-flags $out/share/awakened-poe-trade/resources/app.asar \
+    --prefix LD_LIBRARY_PATH : "${
+      lib.makeLibraryPath [
+        xorg.libXtst
+        xorg.libXt
+      ]
+    }"
+  '';
+
+  meta = {
+    description = "Path of Exile trading app for price checking";
+    homepage = "https://github.com/SnosMe/awakened-poe-trade";
+    changelog = "https://github.com/SnosMe/awakened-poe-trade/releases/tag/v${version}";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.nezia ];
+    platforms = lib.platforms.linux;
+    mainProgram = "awakened-poe-trade";
+  };
+}


### PR DESCRIPTION
## Description of changes

I've added [Awakened POE](https://github.com/SnosMe/awakened-poe-trade) (a Path of Exile trading app for price checking).

I ended up packaging it for Nix using the AppImage, as the build process for the app involves using a build script from upstream that uses `import electron`, which would use the Node.JS electron version and not take advantage of NixOS' dependency system. Upstream changes would likely need to be made to be packaged from source, or there is probably something I don't know (this is one of my first PRs to nixpkgs).

Closes #302672.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
