### PR TITLE
yaak: init at 2024.12.1

### DIFF
--- a/pkgs/by-name/ya/yaak/package.nix
+++ b/pkgs/by-name/ya/yaak/package.nix
@@ -1,0 +1,53 @@
+{
+  appimageTools,
+  hostPlatform,
+  fetchurl,
+  lib,
+}:
+
+let
+  pname = "yaak";
+  version = "2024.12.1";
+
+  source =
+    {
+      x86_64-linux = {
+        name = "${pname}_${version}_amd64";
+        hash = "sha256-23yG60O8oxO3kWf4ZM0b8MXU+Dh3K3eQ2Mn7p7aX+DM=";
+      };
+    }
+    .${hostPlatform.system} or (throw "${hostPlatform.system} is unsupported.");
+in
+appimageTools.wrapType2 rec {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://github.com/mountain-loop/yaak/releases/download/v${version}/${source.name}.AppImage";
+    inherit (source) hash;
+  };
+
+  contents = appimageTools.extract {
+    inherit pname version src;
+    postExtract = ''
+      substituteInPlace $out/yaak.desktop --replace-fail 'yaak-app' 'yaak'
+    '';
+  };
+
+  extraInstallCommands = ''
+    install -Dm444 ${contents}/yaak.desktop $out/share/applications/yaak.desktop
+
+    for size in "32x32" "128x128" "256x256@2"; do
+      install -Dm444 ${contents}/usr/share/icons/hicolor/$size/apps/yaak-app.png $out/share/icons/hicolor/$size/apps/yaak.png
+    done
+  '';
+
+  meta = {
+    description = "Desktop API client for organizing and executing REST, GraphQL, and gRPC requests";
+    homepage = "https://yaak.app/";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ syedahkam ];
+    mainProgram = "yaak";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes


fix: https://github.com/NixOS/nixpkgs/issues/341185

Yaak is a desktop API client for organizing and executing REST, GraphQL, and gRPC requests.

### Metadata

- Homepage URL: https://yaak.app/
- Source URL: https://github.com/yaakapp/app
- License: mit
- Platforms: linux, darwin (not supported right now)

I took the decision to initially wrap their appimage build instead of compiling from source, reason being: the project is still in its infancy and I barely was able to get it compiled on my nixos system. There are no proper build instructions available either -- its fair though considering the fact that they literally just went open-source.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
