### PR TITLE
{commafeed,h2,runelite,openrefine}: fix maven plugin versions

### DIFF
--- a/pkgs/applications/science/misc/openrefine/default.nix
+++ b/pkgs/applications/science/misc/openrefine/default.nix
@@ -47,13 +47,15 @@ in maven.buildMavenPackage {
 
   pname = "openrefine";
 
+  patches = [ ./fix-maven-plugin-versions.patch ];
+
   postPatch = ''
     cp -r ${npmPkg} main/webapp/modules/core/3rdparty
   '';
 
   mvnJdk = jdk;
   mvnParameters = "-pl !packaging";
-  mvnHash = "sha256-AuZp+uq5bmb4gnzKvqXeTmBrsCT6qmJOrwtJq9iCkRQ=";
+  mvnHash = "sha256-gJq9MyoLuSAEh2MKrToVsHfiKqYmxwBRULDniAuKc+w=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/science/misc/openrefine/fix-maven-plugin-versions.patch
+++ b/pkgs/applications/science/misc/openrefine/fix-maven-plugin-versions.patch
@@ -1,0 +1,55 @@
+diff --git a/pom.xml b/pom.xml
+index 49284c4..4a72009 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -368,6 +368,50 @@
+                 </execution>
+             </executions>
+         </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-enforcer-plugin</artifactId>
++        <version>3.5.0</version>
++        <executions>
++          <execution>
++            <id>require-all-plugin-versions-to-be-set</id>
++            <phase>validate</phase>
++            <goals>
++              <goal>enforce</goal>
++            </goals>
++            <configuration>
++              <rules>
++                <requirePluginVersions />
++              </rules>
++            </configuration>
++          </execution>
++        </executions>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-site-plugin</artifactId>
++        <version>3.20.0</version>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-clean-plugin</artifactId>
++        <version>${maven-clean-plugin.version}</version>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-install-plugin</artifactId>
++        <version>3.1.3</version>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-deploy-plugin</artifactId>
++        <version>${maven-clean-plugin.version}</version>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-jar-plugin</artifactId>
++        <version>${maven-jar-plugin.version}</version>
++      </plugin>
+     </plugins>
+   </build>
+ 

--- a/pkgs/by-name/co/commafeed/fix-maven-plugin-versions.patch
+++ b/pkgs/by-name/co/commafeed/fix-maven-plugin-versions.patch
@@ -1,0 +1,65 @@
+diff --git a/pom.xml b/pom.xml
+index da9fb82..3312c6f 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -35,6 +35,60 @@
+ 					</compilerArgs>
+ 				</configuration>
+ 			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-enforcer-plugin</artifactId>
++				<version>3.5.0</version>
++				<executions>
++					<execution>
++						<id>require-all-plugin-versions-to-be-set</id>
++						<phase>validate</phase>
++						<goals>
++							<goal>enforce</goal>
++						</goals>
++						<configuration>
++							<rules>
++								<requirePluginVersions />
++							</rules>
++						</configuration>
++					</execution>
++				</executions>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-clean-plugin</artifactId>
++				<version>3.4.0</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-install-plugin</artifactId>
++				<version>3.1.3</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-site-plugin</artifactId>
++				<version>3.20.0</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-deploy-plugin</artifactId>
++				<version>3.1.3</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-surefire-plugin</artifactId>
++				<version>3.3.1</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-jar-plugin</artifactId>
++				<version>3.4.2</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-resources-plugin</artifactId>
++				<version>3.3.1</version>
++			</plugin>
+ 		</plugins>
+ 	</build>
+ 

--- a/pkgs/by-name/co/commafeed/package.nix
+++ b/pkgs/by-name/co/commafeed/package.nix
@@ -52,7 +52,9 @@ maven.buildMavenPackage {
 
   pname = "commafeed";
 
-  mvnHash = "sha256-7nm8Cz05Qa44TMC0ioklvKAXQnE9J2wUDZFXLQt2A1w=";
+  patches = [ ./fix-maven-plugin-versions.patch ];
+
+  mvnHash = "sha256-Tr5HyvB/VboLLN6lJbkfGmUUNMsYqaDAbcg3GHrOENY=";
 
   mvnParameters = lib.escapeShellArgs [
     "-Dskip.installnodenpm"

--- a/pkgs/by-name/h2/h2/fix-maven-plugin-versions.patch
+++ b/pkgs/by-name/h2/h2/fix-maven-plugin-versions.patch
@@ -1,0 +1,60 @@
+diff --git a/h2/pom.xml b/h2/pom.xml
+index b748989..bf72f7b 100644
+--- a/h2/pom.xml
++++ b/h2/pom.xml
+@@ -289,6 +289,55 @@
+         </configuration>
+       </plugin>
+ 
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-enforcer-plugin</artifactId>
++        <version>3.5.0</version>
++        <executions>
++          <execution>
++            <id>require-all-plugin-versions-to-be-set</id>
++            <phase>validate</phase>
++            <goals>
++              <goal>enforce</goal>
++            </goals>
++            <configuration>
++              <rules>
++                <requirePluginVersions />
++              </rules>
++            </configuration>
++          </execution>
++        </executions>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-compiler-plugin</artifactId>
++        <version>3.13.0</version>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-clean-plugin</artifactId>
++        <version>3.4.0</version>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-install-plugin</artifactId>
++        <version>3.1.3</version>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-site-plugin</artifactId>
++        <version>3.20.0</version>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-resources-plugin</artifactId>
++        <version>3.3.1</version>
++      </plugin>
++      <plugin>
++        <groupId>org.apache.maven.plugins</groupId>
++        <artifactId>maven-deploy-plugin</artifactId>
++        <version>3.1.3</version>
++      </plugin>
+     </plugins>
+   </build>
+ 

--- a/pkgs/by-name/h2/h2/package.nix
+++ b/pkgs/by-name/h2/h2/package.nix
@@ -23,8 +23,10 @@ maven.buildMavenPackage rec {
     hash = "sha256-voqQ4JqYkHRxVdxMGsHmKirQXMP7s44rTXeasWWW2Jw=";
   };
 
+  patches = [ ./fix-maven-plugin-versions.patch ];
+
   mvnParameters = "-f h2/pom.xml";
-  mvnHash = "sha256-ue1X0fswi3C9uqJ/cVCf/qd2XStMve1k1qA+IsREOGk=";
+  mvnHash = "sha256-qPhYrodP/9Eb6jQqXpkX/17NJJJeqkMjFamTlMp7u7Y=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -21,12 +21,13 @@ maven.buildMavenPackage rec {
     hash = "sha256-ckeZ/7rACyZ5j+zzC5hv1NaXTi9q/KvOzMPTDd1crHQ=";
   };
 
+  patches = [ ./fix-maven-plugin-versions.patch ];
+
   mvnJdk = jdk17;
-  mvnHash = "sha256-FpfHtGIfo84z6v9/nzc47+JeIM43MR9mWhVOPSi0xhM=";
+  mvnHash = "sha256-eUP4L2Hz8nJdPfmTRkRGKm+suhwfaCSiea5n2W0qV6U=";
 
   desktop = makeDesktopItem {
     name = "RuneLite";
-    type = "Application";
     exec = "runelite";
     icon = "runelite";
     comment = "Open source Old School RuneScape client";

--- a/pkgs/games/runelite/fix-maven-plugin-versions.patch
+++ b/pkgs/games/runelite/fix-maven-plugin-versions.patch
@@ -1,0 +1,55 @@
+diff --git a/pom.xml b/pom.xml
+index 3859ea8..2001e73 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -383,6 +383,50 @@
+ 					</locks>
+ 				</configuration>
+ 			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-enforcer-plugin</artifactId>
++				<version>3.5.0</version>
++				<executions>
++					<execution>
++						<id>require-all-plugin-versions-to-be-set</id>
++						<phase>validate</phase>
++						<goals>
++							<goal>enforce</goal>
++						</goals>
++						<configuration>
++							<rules>
++								<requirePluginVersions />
++							</rules>
++						</configuration>
++					</execution>
++				</executions>
++            </plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-surefire-plugin</artifactId>
++				<version>3.3.1</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-clean-plugin</artifactId>
++				<version>3.4.0</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-install-plugin</artifactId>
++				<version>3.1.3</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-site-plugin</artifactId>
++				<version>3.20.0</version>
++			</plugin>
++			<plugin>
++				<groupId>org.apache.maven.plugins</groupId>
++				<artifactId>maven-deploy-plugin</artifactId>
++				<version>3.1.3</version>
++			</plugin>
+ 		</plugins>
+ 		<extensions>
+ 			<extension>


### PR DESCRIPTION
## Description of changes

This PR adds some patch files to a few maven-based packages so that the `mvnHash` doesn't become invalid when `maven` gets an update.

This does not cover every package that has this issue, as I don't want to do unnecessary work until there's a discussion about this.

You can see which package hashes needed updating in https://github.com/NixOS/nixpkgs/pull/324437

`maven-enforcer-plugin`'s `requirePluginVersions` rule help catch undeclared default lifecycle plugin versions.
It is not strictly required to be in the patch, but I believe it should stay.

---

I really wish we came up with a better solution than this, though.

Maybe this could somehow be done automatically with a script that uses `xmlstarlet` to edit the `pom.xml` files.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
