### PR TITLE
git-spice: 0.4.0 -> 0.5.2

### DIFF
--- a/pkgs/by-name/gi/git-spice/package.nix
+++ b/pkgs/by-name/gi/git-spice/package.nix
@@ -1,23 +1,32 @@
 {
   lib,
-  buildGoModule,
+  fetchpatch,
+  buildGo123Module,
   fetchFromGitHub,
   git,
   nix-update-script,
 }:
 
-buildGoModule rec {
+buildGo123Module rec {
   pname = "git-spice";
-  version = "0.4.0";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "abhinav";
     repo = "git-spice";
     rev = "refs/tags/v${version}";
-    hash = "sha256-D+kwH7fBRvi+H0/L7Gezn1FMBk3AkL9MbLULAwvrzrg=";
+    hash = "sha256-ftNLe/3akvk6nUrseBqpbJQSiUPEJO6cTEc7uEBKX3k=";
   };
 
-  vendorHash = "sha256-24jtlvp8xSMzNejyzqt+MiQHRKprps132Q+rP9wlA30=";
+  vendorHash = "sha256-f7bjlTVwCFoQrgbeyAvsVAS6vy5uE/AvMGKEutE1lfs=";
+
+  # Fixes flaky test. Remove next release.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/abhinav/git-spice/commit/92c28474bab81881443129e4a8e9bfc3f1564931.patch";
+      hash = "sha256-6v++jG7Wm6awqHRiNzwjX25BB8X9yGYhSzcUDNQKJ7k=";
+    })
+  ];
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
## Description of changes

Updates [git-spice](https://github.com/abhinav/git-spice) and includes patch from upstream that fixes flaky test

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
