### PR TITLE
picocom: support aarch64 darwin high baud rate

### DIFF
--- a/pkgs/tools/misc/picocom/aarch64-darwin-high-baud.patch
+++ b/pkgs/tools/misc/picocom/aarch64-darwin-high-baud.patch
@@ -1,0 +1,23 @@
+From f806bf28266cccdb75ba89d754de8d8fa64c6127 Mon Sep 17 00:00:00 2001
+From: Jack Ma <jack@radxa.com>
+Date: Thu, 16 Dec 2021 14:14:52 +0800
+Subject: [PATCH] macOS: support high baud rate on Apple arm64 processor
+
+Signed-off-by: Jack Ma <jack@radxa.com>
+---
+ custbaud.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/custbaud.h b/custbaud.h
+index c1734ce..6a3fd86 100644
+--- a/custbaud.h
++++ b/custbaud.h
+@@ -58,7 +58,7 @@
+ #elif TARGET_OS_IPHONE
+ /* Do not enable by default for iOS until it has been tested */
+ #elif TARGET_OS_MAC
+-#if defined (__i386__) || defined (__x86_64__)
++#if defined (__i386__) || defined (__x86_64__) || defined (__arm64__)
+ /* Enable by-default for Intel Mac, macOS / OSX >= 10.4 (Tiger) */
+ #ifndef USE_CUSTOM_BAUD
+ #define USE_CUSTOM_BAUD

--- a/pkgs/tools/misc/picocom/default.nix
+++ b/pkgs/tools/misc/picocom/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-cs2bxqZfTbnY5d+VJ257C5hssaFvYup3tBKz68ROnAo=";
   };
 
+  patches = [
+    # support high baud rates on Apple arm64 processor
+    # https://github.com/npat-efault/picocom/pull/129
+    ./aarch64-darwin-high-baud.patch
+  ];
+
   postPatch = ''
     substituteInPlace Makefile \
       --replace '.picocom_history' '.cache/picocom_history'


### PR DESCRIPTION
## Description of changes

https://github.com/npat-efault/picocom/commit/f806bf28266cccdb75ba89d754de8d8fa64c612.patch

enable custom baud rate code when `__arm64__` is defined for `TARGET_OS_MAC`

use same patch as homebrew
https://github.com/Homebrew/homebrew-core/blob/b49d41657ef16143c7e144c8aa7d9ef830f137a6/Formula/p/picocom.rb#L28

testing:
built on aarch64 darwin and verified that could set terminal to high baud rate (2MBaud)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
