### PR TITLE
python312Packages.ms-active-directory: 1.14.0 -> 1.14.1

### DIFF
--- a/pkgs/development/python-modules/ms-active-directory/default.nix
+++ b/pkgs/development/python-modules/ms-active-directory/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   dnspython,
   fetchFromGitHub,
-  fetchpatch,
   ldap3,
   pyasn1,
   pycryptodome,
@@ -15,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "ms-active-directory";
-  version = "1.14.0";
+  version = "1.14.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -24,17 +23,8 @@ buildPythonPackage rec {
     owner = "zorn96";
     repo = "ms_active_directory";
     rev = "refs/tags/v${version}";
-    hash = "sha256-E0GzKkpQU9pJ1a1N0NZjB2Q99yMlJkzNR0QzyiUzOpg=";
+    hash = "sha256-ZFIeG95+G9ofk54bYZpqu8uVfzjqsOrwWlIZvQgIWRI=";
   };
-
-  patches = [
-    # Fix introduced syntax errors, https://github.com/zorn96/ms_active_directory/pull/88
-    (fetchpatch {
-      name = "fix-syntax.patch";
-      url = "https://github.com/zorn96/ms_active_directory/pull/88/commits/35da06a224b9bff6d36ddbd2dee8fdedab7e17bc.patch";
-      hash = "sha256-0WGyr3Q4vcfFU72fox3/3AdHCmjzf6jGCGPx5vhhUvM=";
-    })
-  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
Diff: https://github.com/zorn96/ms_active_directory/compare/refs/tags/v1.14.0...v1.14.1

Changelog: https://github.com/zorn96/ms_active_directory/releases/tag/v1.14.1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
