### PR TITLE
gllvm: 1.3.1 -> 1.3.1-unstable-2024-04-28, fix build

### DIFF
--- a/pkgs/development/tools/gllvm/default.nix
+++ b/pkgs/development/tools/gllvm/default.nix
@@ -1,14 +1,14 @@
 { lib, buildGoModule, fetchFromGitHub, llvmPackages, getconf }:
 
-buildGoModule rec {
+buildGoModule {
   pname = "gllvm";
-  version = "1.3.1";
+  version = "1.3.1-unstable-2024-04-28";
 
   src = fetchFromGitHub {
     owner = "SRI-CSL";
     repo = "gllvm";
-    rev = "v${version}";
-    sha256 = "sha256-CoreqnMRuPuv+Ci1uyF3HJCJFwK2jwB79okynv6AHTA=";
+    rev = "154531bdd9c05cd9d01742bc1b35bdf200a487d3";
+    sha256 = "sha256-dxrtJFqEEDKx33+sOm+R7huBwbovlKzL4qFXoco8A4s=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
Diff: https://github.com/SRI-CSL/gllvm/compare/v1.3.1...154531bdd9c05cd9d01742bc1b35bdf200a487d3

New version has commit disabling failing test that makes build fail:
https://github.com/SRI-CSL/gllvm/commit/3e87c816bc96898c604a3d2517fdba54202e5170

## Description of changes

Fixes build failure of `gllvm` (fails since `2023-11-17`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.gllvm.x86_64-linux
https://hydra.nixos.org/build/272102724
Error log:
```text
Writing bitcode...
Bitcode file extracted to: ../data/bhello.bc.
--- FAIL: Test_file_type (0.00s)
    entry_test.go:142: GetBinaryType(../data/bhello) = Library
FAIL
FAIL    github.com/SRI-CSL/gllvm/tests  0.501s
FAIL
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
