### PR TITLE
unicodeit: init at 0.7.5

### DIFF
--- a/pkgs/by-name/un/unicodeit/package.nix
+++ b/pkgs/by-name/un/unicodeit/package.nix
@@ -1,0 +1,5 @@
+{
+  python3Packages,
+}:
+with python3Packages;
+toPythonApplication unicodeit

--- a/pkgs/development/python-modules/unicodeit/default.nix
+++ b/pkgs/development/python-modules/unicodeit/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "unicodeit";
+  version = "0.7.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "svenkreiss";
+    repo = "unicodeit";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-NeR3fGDbOzwyq85Sep9KuUiARCvefN6l5xcb8D/ntHE=";
+  };
+
+  build-system = [ setuptools ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [
+    "unicodeit"
+    "unicodeit.cli"
+  ];
+
+  meta = {
+    description = "Converts LaTeX tags to unicode";
+    homepage = "https://github.com/svenkreiss/unicodeit";
+    licenses = with lib.licenses; [
+      lppl13c
+      mit
+    ];
+    maintainers = with lib.maintainers; [ nicoo ];
+  };
+}

--- a/pkgs/development/python-modules/unicodeit/default.nix
+++ b/pkgs/development/python-modules/unicodeit/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     description = "Converts LaTeX tags to unicode";
     mainProgram = "unicodeit";
     homepage = "https://github.com/svenkreiss/unicodeit";
-    licenses = with lib.licenses; [
+    license = with lib.licenses; [
       lppl13c
       mit
     ];

--- a/pkgs/development/python-modules/unicodeit/default.nix
+++ b/pkgs/development/python-modules/unicodeit/default.nix
@@ -2,9 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   pytestCheckHook,
+  runCommand,
 
   setuptools,
+  unicodeit,
 }:
 buildPythonPackage rec {
   pname = "unicodeit";
@@ -18,6 +21,14 @@ buildPythonPackage rec {
     hash = "sha256-NeR3fGDbOzwyq85Sep9KuUiARCvefN6l5xcb8D/ntHE=";
   };
 
+  patches = [
+    (fetchpatch {
+      # Defines a CLI entry point, so `setuptools` generates an `unicodeit` executable
+      url = "https://github.com/svenkreiss/unicodeit/pull/79.patch";
+      hash = "sha256-mAhmU17K0adEFFAIf7ZeJ/cNohrzrL+sol7gYfWbPGo=";
+    })
+  ];
+
   build-system = [ setuptools ];
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -26,8 +37,20 @@ buildPythonPackage rec {
     "unicodeit.cli"
   ];
 
+  passthru.tests.entrypoint =
+    runCommand "python3-unicodeit-test-entrypoint"
+      {
+        nativeBuildInputs = [ unicodeit ];
+        preferLocalBuild = true;
+      }
+      ''
+        [[ "$(unicodeit "\BbbR")" = "ℝ" ]]
+        touch $out
+      '';
+
   meta = {
     description = "Converts LaTeX tags to unicode";
+    mainProgram = "unicodeit";
     homepage = "https://github.com/svenkreiss/unicodeit";
     licenses = with lib.licenses; [
       lppl13c

--- a/pkgs/development/python-modules/unicodeit/default.nix
+++ b/pkgs/development/python-modules/unicodeit/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   patches = [
     (fetchpatch {
       # Defines a CLI entry point, so `setuptools` generates an `unicodeit` executable
-      url = "https://github.com/svenkreiss/unicodeit/pull/79.patch";
+      url = "https://github.com/svenkreiss/unicodeit/pull/79/commits/9f4a4fee5cb62a101075adf3054832cdb1e6a5ad.patch";
       hash = "sha256-mAhmU17K0adEFFAIf7ZeJ/cNohrzrL+sol7gYfWbPGo=";
     })
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16795,6 +16795,8 @@ self: super: with self; {
 
   unicodedata2 = callPackage ../development/python-modules/unicodedata2 { };
 
+  unicodeit = callPackage ../development/python-modules/unicodeit { };
+
   unicode-rbnf = callPackage ../development/python-modules/unicode-rbnf { };
 
   unicode-slugify = callPackage ../development/python-modules/unicode-slugify { };


### PR DESCRIPTION
## Description of changes

- [x] Packaged `python3.pkgs.unicodeit`
- [x] Patched it (and sent a [PR upstream]) to expose the CLI entrypoint as a regular executable
- [x] Added a `pkgs/by-name` entry for users who just want the CLI

[PR upstream]: https://github.com/svenkreiss/unicodeit/pull/79


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Wrote and built [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
