### PR TITLE
buildEnv: add includeClosures option

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -208,7 +208,7 @@ let
     chmod u+w -R lib64/
 
     # symlink 32-bit ld-linux.so
-    ln -Ls ${staticUsrProfileTarget}/lib/32/ld-linux.so.2 lib/
+    ln -Lsf ${staticUsrProfileTarget}/lib/32/ld-linux.so.2 lib/
   '';
 
   setupLibDirs = if isTargetBuild

--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -255,6 +255,21 @@ while (scalar(keys %postponed) > 0) {
     }
 }
 
+my $extraPathsFilePath = $ENV{"extraPathsFrom"};
+if ($extraPathsFilePath) {
+    open FILE, $extraPathsFilePath or die "cannot open extra paths file $extraPathsFilePath: $!";
+
+    while(my $line = <FILE>) {
+        chomp $line;
+        addPkg($line,
+               $ENV{"ignoreCollisions"} eq "1",
+               $ENV{"checkCollisionContents"} eq "1",
+               1000)
+            if -d $line;
+    }
+
+    close FILE;
+}
 
 # Create the symlinks.
 my $nrLinks = 0;

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -1,7 +1,7 @@
 # buildEnv creates a tree of symlinks to the specified paths.  This is
 # a fork of the hardcoded buildEnv in the Nix distribution.
 
-{ buildPackages, runCommand, lib, substituteAll }:
+{ buildPackages, runCommand, lib, substituteAll, writeClosure }:
 
 let
   builder = substituteAll {
@@ -22,6 +22,9 @@ lib.makeOverridable
 
 , # Whether to ignore collisions or abort.
   ignoreCollisions ? false
+
+, # Whether to include closures of all input paths.
+  includeClosures ? false
 
 , # If there is a collision, check whether the contents and permissions match
   # and only if not, throw a collision error.
@@ -49,27 +52,31 @@ lib.makeOverridable
 , passthru ? {}
 , meta ? {}
 }:
+let
+  chosenOutputs = map (drv: {
+    paths =
+      # First add the usual output(s): respect if user has chosen explicitly,
+      # and otherwise use `meta.outputsToInstall`. The attribute is guaranteed
+      # to exist in mkDerivation-created cases. The other cases (e.g. runCommand)
+      # aren't expected to have multiple outputs.
+      (if (! drv ? outputSpecified || ! drv.outputSpecified)
+          && drv.meta.outputsToInstall or null != null
+        then map (outName: drv.${outName}) drv.meta.outputsToInstall
+        else [ drv ])
+      # Add any extra outputs specified by the caller of `buildEnv`.
+      ++ lib.filter (p: p!=null)
+        (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
+    priority = drv.meta.priority or lib.meta.defaultPriority;
+  }) paths;
 
-runCommand name
+  pathsForClosure = lib.flatten (map (p: p.paths) chosenOutputs);
+in runCommand name
   rec {
     inherit manifest ignoreCollisions checkCollisionContents passthru
             meta pathsToLink extraPrefix postBuild
             nativeBuildInputs buildInputs;
-    pkgs = builtins.toJSON (map (drv: {
-      paths =
-        # First add the usual output(s): respect if user has chosen explicitly,
-        # and otherwise use `meta.outputsToInstall`. The attribute is guaranteed
-        # to exist in mkDerivation-created cases. The other cases (e.g. runCommand)
-        # aren't expected to have multiple outputs.
-        (if (! drv ? outputSpecified || ! drv.outputSpecified)
-            && drv.meta.outputsToInstall or null != null
-          then map (outName: drv.${outName}) drv.meta.outputsToInstall
-          else [ drv ])
-        # Add any extra outputs specified by the caller of `buildEnv`.
-        ++ lib.filter (p: p!=null)
-          (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
-      priority = drv.meta.priority or lib.meta.defaultPriority;
-    }) paths);
+    pkgs = builtins.toJSON chosenOutputs;
+    extraPathsFrom = lib.optional includeClosures (writeClosure pathsForClosure);
     preferLocalBuild = true;
     allowSubstitutes = false;
     # XXX: The size is somewhat arbitrary


### PR DESCRIPTION
## Description of changes

And one small fix. This will be important for Steam later, and can also help other packages that do `LD_LIBRARY_PATH` fuckery.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
