### PR TITLE
go-ios: 1.0.121 -> 1.0.143

### DIFF
--- a/pkgs/tools/misc/go-ios/default.nix
+++ b/pkgs/tools/misc/go-ios/default.nix
@@ -2,33 +2,50 @@
 , buildGoModule
 , fetchFromGitHub
 , nix-update-script
+, pkg-config
+, libusb1
 }:
 
 buildGoModule rec {
   pname = "go-ios";
-  version = "1.0.121";
+  version = "1.0.143";
 
   src = fetchFromGitHub {
     owner = "danielpaulus";
     repo = "go-ios";
     rev = "v${version}";
-    sha256 = "sha256-zWaEtfxrJYaROQ05nBQvM5fiIRSG+hCecU+BVnpIuck=";
+    sha256 = "sha256-6RiKyhV5y6lOrhfZezSB2m/l17T3bHYaYRhsMf04wT8=";
   };
 
-  vendorHash = "sha256-0Wi9FCTaOD+kzO5cRjpqbXHqx5UAKSGu+hc9bpj+PWo=";
+  proxyVendor = true;
+  vendorHash = "sha256-GfVHAOlN2tL21ILQYPw/IaYQZccxitjHGQ09unfHcKg=";
 
   excludedPackages = [
     "restapi"
   ];
 
-  checkFlags = [
-    "-tags=fast"
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libusb1
   ];
 
   postInstall = ''
     # aligns the binary with what is expected from go-ios
     mv $out/bin/go-ios $out/bin/ios
   '';
+
+  # skips all the integration tests (requires iOS device) (`-tags=fast`)
+  # as well as tests that requires networking
+  checkFlags = let
+    skippedTests = [
+      "TestWorksWithoutProxy"
+      "TestUsesProxy"
+    ];
+  in [ "-tags=fast" ]
+  ++ [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
## Description of changes
Updates go-ios to the latest version, and disable networking tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
