### PR TITLE
picocom: switch to maintained fork; linenoise: use `fixDarwinDylibNames`

### DIFF
--- a/pkgs/by-name/pi/picocom/lrzsz-path.patch
+++ b/pkgs/by-name/pi/picocom/lrzsz-path.patch
@@ -1,0 +1,15 @@
+diff --git a/picocom.c b/picocom.c
+index ba2f9bd666..d4df60f2d3 100644
+--- a/picocom.c
++++ b/picocom.c
+@@ -243,8 +243,8 @@
+     .send_cmd = "",
+     .receive_cmd = "",
+ #else
+-    .send_cmd = "sz -vv",
+-    .receive_cmd = "rz -vv -E",
++    .send_cmd = "@lrzsz@/bin/sz -vv",
++    .receive_cmd = "@lrzsz@/bin/rz -vv -E",
+ #endif
+     .imap = M_I_DFL,
+     .omap = M_O_DFL,

--- a/pkgs/by-name/pi/picocom/package.nix
+++ b/pkgs/by-name/pi/picocom/package.nix
@@ -1,8 +1,10 @@
-{ lib, stdenv
-, fetchFromGitHub
-, installShellFiles
-, lrzsz
-, darwin
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  lrzsz,
+  darwin,
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/pi/picocom/package.nix
+++ b/pkgs/by-name/pi/picocom/package.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , installShellFiles
 , lrzsz
-, IOKit
+, darwin
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  buildInputs = lib.optional stdenv.isDarwin IOKit;
+  buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.IOKit ];
 
   installPhase = ''
     install -Dm555 -t $out/bin picocom

--- a/pkgs/by-name/pi/picocom/package.nix
+++ b/pkgs/by-name/pi/picocom/package.nix
@@ -3,8 +3,10 @@
   stdenv,
   fetchFromGitLab,
   replaceVars,
+  pkg-config,
   go-md2man,
   installShellFiles,
+  linenoise,
   darwin,
   lrzsz,
 }:
@@ -21,15 +23,19 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    ./use-system-linenoise.patch
     (replaceVars ./lrzsz-path.patch { inherit lrzsz; })
   ];
 
   nativeBuildInputs = [
+    pkg-config
     go-md2man
     installShellFiles
   ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.IOKit ];
+  buildInputs = [
+    linenoise
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.IOKit ];
 
   makeFlags = [
     "HISTFILE=.cache/picocom_history"

--- a/pkgs/by-name/pi/picocom/use-system-linenoise.patch
+++ b/pkgs/by-name/pi/picocom/use-system-linenoise.patch
@@ -1,0 +1,30 @@
+diff --git a/Makefile b/Makefile
+index 8fca24ee38..33b59b5b96 100644
+--- a/Makefile
++++ b/Makefile
+@@ -39,9 +39,9 @@
+ ## Comment these out to disable "linenoise"-library support
+ HISTFILE = .picocom_history
+ CPPFLAGS += -DHISTFILE=\"$(HISTFILE)\" \
+-	    -DLINENOISE
+-OBJS += linenoise-1.0/linenoise.o
+-linenoise-1.0/linenoise.o : linenoise-1.0/linenoise.c linenoise-1.0/linenoise.h
++	    -DLINENOISE \
++	    $(shell pkg-config --cflags linenoise)
++LDFLAGS += $(shell pkg-config --libs linenoise)
+ 
+ ## Comment this in to enable (force) custom baudrate support
+ ## even on systems not enabled by default.
+diff --git a/picocom.c b/picocom.c
+index 775ee9c3bb..ba2f9bd666 100644
+--- a/picocom.c
++++ b/picocom.c
+@@ -48,7 +48,7 @@
+ #include "split.h"
+ #include "term.h"
+ #ifdef LINENOISE
+-#include "linenoise-1.0/linenoise.h"
++#include <linenoise.h>
+ #endif
+ 
+ #include "custbaud.h"

--- a/pkgs/development/libraries/linenoise/default.nix
+++ b/pkgs/development/libraries/linenoise/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , validatePkgConfig
+, fixDarwinDylibNames
 }:
 
 stdenv.mkDerivation {
@@ -15,7 +16,8 @@ stdenv.mkDerivation {
     hash = "sha256-GsrYg16gpjHkkmpCU3yGzqNS/buZl+JoWALLvwzmT4A=";
   };
 
-  nativeBuildInputs = [ validatePkgConfig ];
+  nativeBuildInputs = [ validatePkgConfig ]
+    ++ lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32589,10 +32589,6 @@ with pkgs;
 
   picard = callPackage ../applications/audio/picard { };
 
-  picocom = callPackage ../tools/misc/picocom {
-    inherit (darwin.apple_sdk.frameworks) IOKit;
-  };
-
   picoloop = callPackage ../applications/audio/picoloop { };
 
   picosnitch = callPackage ../tools/networking/picosnitch { };


### PR DESCRIPTION
## Description of changes

The previous upstream has been dead for six years; this fork is by Linux kernel developer Wolfram Sang, and is already used by Fedora, openSUSE, and Buildroot.

It includes the patch from https://github.com/NixOS/nixpkgs/pull/341287 among many others.

cc @paparodeo for testing

Closes: #341287

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
