### PR TITLE
python312Packages.radian: 0.6.12 -> 0.6.13

### DIFF
--- a/pkgs/development/python-modules/radian/default.nix
+++ b/pkgs/development/python-modules/radian/default.nix
@@ -6,6 +6,7 @@
   pyte,
   pexpect,
   ptyprocess,
+  pythonOlder,
   jedi,
   git,
   lineedit,
@@ -14,27 +15,33 @@
   rchitect,
   R,
   rPackages,
-  pythonOlder,
+  setuptools,
+  setuptools-scm,
 }:
 
 buildPythonPackage rec {
   pname = "radian";
-  version = "0.6.12";
-  format = "setuptools";
+  version = "0.6.13";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "randy3k";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-cojKbDNqcUay5RxvWszQ96eC4jVI4G7iRv/ZYWgidCQ=";
+    hash = "sha256-gz2VczAgVbvISzvY/v0GvZ/Erv6ipZwPU61r6OJ+3Fo=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
       --replace '"pytest-runner"' ""
   '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   nativeBuildInputs = [
     R # needed at setup time to detect R_HOME

--- a/pkgs/development/python-modules/rchitect/default.nix
+++ b/pkgs/development/python-modules/rchitect/default.nix
@@ -3,33 +3,40 @@
   buildPythonPackage,
   fetchFromGitHub,
   cffi,
+  packaging,
   pytestCheckHook,
   pytest-mock,
   pythonOlder,
   R,
   rPackages,
+  setuptools,
+  setuptools-scm,
   six,
-  packaging,
 }:
 
 buildPythonPackage rec {
   pname = "rchitect";
-  version = "0.4.6";
-  format = "setuptools";
+  version = "0.4.7";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "randy3k";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-IVyYzf433m03RRfL5SmUOdaXFy0NHf/QuAdtUeUjIz0=";
+    hash = "sha256-M7OWDo3mEEOYtjIpzPIpzPMBtv2TZJKJkSfHczZYS8Y=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
       --replace '"pytest-runner"' ""
   '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   propagatedBuildInputs = [
     cffi


### PR DESCRIPTION
## Description of changes

* Updated radian from 0.6.12 -> 0.6.13 (Git diff: [randy3k/radian@v0.6.12...v0.6.13](https://github.com/randy3k/radian/compare/v0.6.12...v0.6.13))
* Updated rchitect from 0.4.6 -> 0.4.7 (Git diff: [randy3k/rchitect@v0.4.6...v0.4.7](https://github.com/randy3k/rchitect/compare/v0.4.6...v0.4.7))

Set `disable pythonOlder` to "3.9" and `pyproject = true` instead of `format = "setuptools"` and added `build-system = [ setuptools setuptools-scm ];`.

fyi @savyajha 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
