### PR TITLE
arpa2common: 2.2.18 -> 2.6.2

### DIFF
--- a/pkgs/development/libraries/arpa2common/default.nix
+++ b/pkgs/development/libraries/arpa2common/default.nix
@@ -1,28 +1,37 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , cmake
 
 , arpa2cm
 , doxygen
 , e2fsprogs
 , graphviz
+, libsodium
 , lmdb
 , openssl
 , pkg-config
 , ragel
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "arpa2common";
-  version = "2.2.18";
+  version = "2.6.2";
 
   src = fetchFromGitLab {
     owner = "arpa2";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-UpAVyDXCe07ZwjD307t6G9f/Nny4QYXxGxft1KsiYYg=";
+    repo = "arpa2common";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-eWfWaO6URCK2FWQ+NYAoeCONkovgsVDPSRQVCGFnW3s=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.com/arpa2/arpa2common/-/commit/13ea82df60b87a5367db00a8c6f3502e8ecb7298.patch";
+      hash = "sha256-V9Dhr6PeArqXnuXmFuDjcirlGl7xovq7VQZsrbbMFSk=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -34,15 +43,14 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [
     e2fsprogs
+    libsodium
     lmdb
     openssl
     ragel
   ];
 
-  # the project uses single argument `printf` throughout the program
-  hardeningDisable = [ "format" ];
-
   meta = {
+    changelog = "https://gitlab.com/arpa2/arpa2common/-/blob/v${finalAttrs.version}/CHANGES";
     description =
       "ARPA2 ID and ACL libraries and other core data structures for ARPA2";
     longDescription = ''
@@ -57,4 +65,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ fufexan ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/development/libraries/arpa2common/default.nix
+++ b/pkgs/development/libraries/arpa2common/default.nix
@@ -1,18 +1,19 @@
-{ lib
-, stdenv
-, fetchFromGitLab
-, fetchpatch
-, cmake
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fetchpatch,
+  cmake,
 
-, arpa2cm
-, doxygen
-, e2fsprogs
-, graphviz
-, libsodium
-, lmdb
-, openssl
-, pkg-config
-, ragel
+  arpa2cm,
+  doxygen,
+  e2fsprogs,
+  graphviz,
+  libsodium,
+  lmdb,
+  openssl,
+  pkg-config,
+  ragel,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -51,8 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     changelog = "https://gitlab.com/arpa2/arpa2common/-/blob/v${finalAttrs.version}/CHANGES";
-    description =
-      "ARPA2 ID and ACL libraries and other core data structures for ARPA2";
+    description = "ARPA2 ID and ACL libraries and other core data structures for ARPA2";
     longDescription = ''
       The ARPA2 Common Library package offers elementary services that can
       benefit many software packages.  They are designed to be easy to
@@ -61,7 +61,12 @@ stdenv.mkDerivation (finalAttrs: {
       liberate users.
     '';
     homepage = "https://gitlab.com/arpa2/arpa2common";
-    license = with lib.licenses; [ bsd2 cc-by-sa-40 cc0 isc ];
+    license = with lib.licenses; [
+      bsd2
+      cc-by-sa-40
+      cc0
+      isc
+    ];
     maintainers = with lib.maintainers; [ fufexan ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
## Description of changes

Update arpa2common to 2.6.2 and format using nixfmt-rfc-style.

[CHANGELOG](https://gitlab.com/arpa2/arpa2common/-/blob/master/CHANGES)

The project wasn't building from the release source, so I had to patch it. I've also opened a [MR to fix the problem upstream](https://gitlab.com/arpa2/arpa2common/-/merge_requests/42).

Fixes https://github.com/NixOS/nixpkgs/issues/341372.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
