### PR TITLE
postgresql: improve fake pg_config in default output

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -23,12 +23,12 @@ stdenv.mkDerivation rec {
   postPatch = ''
     for x in CMakeLists.txt sql/CMakeLists.txt; do
       substituteInPlace "$x" \
-        --replace 'DESTINATION "''${PG_SHAREDIR}/extension"' "DESTINATION \"$out/share/postgresql/extension\""
+        --replace-fail 'DESTINATION "''${PG_SHAREDIR}/extension"' "DESTINATION \"$out/share/postgresql/extension\""
     done
 
     for x in src/CMakeLists.txt src/loader/CMakeLists.txt tsl/src/CMakeLists.txt; do
       substituteInPlace "$x" \
-        --replace 'DESTINATION ''${PG_PKGLIBDIR}' "DESTINATION \"$out/lib\""
+        --replace-fail 'DESTINATION ''${PG_PKGLIBDIR}' "DESTINATION \"$out/lib\""
     done
   '';
 

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -6,7 +6,8 @@ let
       , glibc, zlib, readline, openssl, icu, lz4, zstd, systemdLibs, libossp_uuid
       , pkg-config, libxml2, tzdata, libkrb5, substituteAll, darwin
       , linux-pam
-      , removeReferencesTo
+
+      , removeReferencesTo, writeShellApplication
 
       # This is important to obtain a version of `libpq` that does not depend on systemd.
       , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs && !stdenv.hostPlatform.isStatic
@@ -54,6 +55,11 @@ let
         })
       else
         stdenv;
+
+    pg_config = writeShellApplication {
+      name = "pg_config";
+      text = builtins.readFile ./pg_config.sh;
+    };
   in stdenv'.mkDerivation (finalAttrs: {
     inherit version;
     pname = pname + lib.optionalString jitSupport "-jit";
@@ -201,15 +207,10 @@ let
         moveToOutput "lib/pgxs" "$dev"
 
         # Pretend pg_config is located in $out/bin to return correct paths, but
-        # actually have it in -dev to avoid pulling in all other outputs.
+        # actually have it in -dev to avoid pulling in all other outputs. See the
+        # pg_config.sh script's comments for details.
         moveToOutput "bin/pg_config" "$dev"
-        # To prevent a "pg_config: could not find own program executable" error, we fake
-        # pg_config in the default output.
-        cat << EOF > "$out/bin/pg_config" && chmod +x "$out/bin/pg_config"
-        #!${stdenv'.shell}
-        echo The real pg_config can be found in the -dev output.
-        exit 1
-        EOF
+        install -c -m 755 "${pg_config}"/bin/pg_config "$out/bin/pg_config"
         wrapProgram "$dev/bin/pg_config" --argv0 "$out/bin/pg_config"
 
         # postgres exposes external symbols get_pkginclude_path and similar. Those

--- a/pkgs/servers/sql/postgresql/pg_config.sh
+++ b/pkgs/servers/sql/postgresql/pg_config.sh
@@ -1,0 +1,35 @@
+# The real pg_config needs to be in the same path as the "postgres" binary
+# to return proper paths. However, we want it in the -dev output to prevent
+# cyclic references and to prevent blowing up the runtime closure. Thus, we
+# have wrapped -dev/bin/pg_config to fake its argv0 to be in the default
+# output. Unfortunately, pg_config tries to be smart and tries to find itself -
+# which will then fail with:
+#   pg_config: could not find own program executable
+# To counter this, we're creating *this* fake pg_config script and put it into
+# the default output. The real pg_config is happy.
+# Some extensions, e.g. timescaledb, use the reverse logic and look for pg_config
+# in the same path as the "postgres" binary to support multi-version-installs.
+# Thus, they will end up calling this script during build, even though the real
+# pg_config would be available on PATH, provided by nativeBuildInputs. To help
+# this case, we're redirecting the call to pg_config to the one found in PATH,
+# iff we can be convinced that it belongs to our -dev output.
+
+# Avoid infinite recursion
+if [[ ! -v PG_CONFIG_CALLED ]]; then
+    # compares "path of *this* script" with "path, which pg_config on PATH believes it is in"
+    if [[ "$(readlink -f -- "$0")" == "$(PG_CONFIG_CALLED=1 pg_config --bindir)/pg_config" ]]; then
+        # The pg_config in PATH returns the same bindir that we're actually called from.
+        # This means that the pg_config in PATH is the one from "our" -dev output.
+        # This happens when the -dev output has been put in native build
+        # inputs and allows us to call the real pg_config without referencing
+        # the -dev output itself.
+        exec pg_config "$@"
+    fi
+fi
+
+# This will happen in one of these cases:
+# - *this* script is the first on PATH
+# - np pg_config on PATH
+# - some other pg_config on PATH, not from our -dev output
+echo The real pg_config can be found in the -dev output.
+exit 1


### PR DESCRIPTION
## Description of changes

This fixes some build systems which look up the location of pg_config via the location of the postgres binary itself, e.g. timescaledb, instead of calling pg_config which is on PATH.

Since the -dev output is correctly placed before the default output of postgresql in PATH, we can rely on that and call "pg_config" from the default output's fake script. Only do that, when the one on PATH is actually a different file, though, to prevent infinite loops.

@Ma27 could you have a look?

Resolves #341408, CC @zoechi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
