### PR TITLE
Input-leap wayland support

### DIFF
--- a/pkgs/applications/misc/input-leap/default.nix
+++ b/pkgs/applications/misc/input-leap/default.nix
@@ -1,5 +1,5 @@
 { lib
-, mkDerivation
+, stdenv
 , fetchFromGitHub
 , cmake
 
@@ -16,31 +16,33 @@
 , libXrandr
 , libXtst
 , libei
-, libportal
+, libportal-qt6
 , openssl
 , pkg-config
 , qtbase
 , qttools
+, qt5compat
 , wrapGAppsHook3
+, wrapQtAppsHook
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "input-leap";
-  version = "unstable-2023-12-27";
+  version = "unstable-2024-08-01";
 
   src = fetchFromGitHub {
     owner = "input-leap";
     repo = "input-leap";
-    rev = "ecf1fb6645af7b79e6ea984d3c9698ca0ab6f391";
-    hash = "sha256-TEv1xR1wUG3wXNATLLIZKOtW05X96wsPNOlE77OQK54=";
+    rev = "3a95e113435c6433d2f718ee55a4f688ec1ff893";
+    hash = "sha256-g6Eufl/xQ5y1qXbqfmO4ziQN+cH2bw+3ky+BQPsPGL8=";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ pkg-config cmake wrapGAppsHook3 qttools ];
+  nativeBuildInputs = [ pkg-config cmake wrapGAppsHook3 qttools wrapQtAppsHook];
   buildInputs = [
-    curl qtbase avahi
+    curl qtbase avahi qt5compat
     libX11 libXext libXtst libXinerama libXrandr libXdmcp libICE libSM
-  ] ++ lib.optionals withLibei [ libei libportal ];
+  ] ++ lib.optionals withLibei [ libei libportal-qt6 ];
 
   cmakeFlags = [
     "-DINPUTLEAP_REVISION=${builtins.substring 0 8 src.rev}"

--- a/pkgs/development/libraries/libportal/default.nix
+++ b/pkgs/development/libraries/libportal/default.nix
@@ -11,14 +11,15 @@
 , gtk3
 , gtk4
 , libsForQt5
+, qt6Packages
 , variant ? null
 }:
 
-assert variant == null || variant == "gtk3" || variant == "gtk4" || variant == "qt5";
+assert variant == null || variant == "gtk3" || variant == "gtk4" || variant == "qt5" || variant == "qt6";
 
 stdenv.mkDerivation rec {
   pname = "libportal" + lib.optionalString (variant != null) "-${variant}";
-  version = "0.7.1";
+  version = "0.8.1";
 
   outputs = [ "out" "dev" ]
     ++ lib.optional (variant != "qt5") "devdoc";
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
     owner = "flatpak";
     repo = "libportal";
     rev = version;
-    sha256 = "sha256-3roZJHnGFM7ClxbB7I/haexPTwYskidz9F+WV3RL9Ho=";
+    sha256 = "sha256-NAkD5pAQpmAtVxsFZt74PwURv+RbGBfqENIwyxEEUSc=";
   };
 
   depsBuildBuild = [
@@ -53,12 +54,15 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (variant == "qt5") [
     libsForQt5.qtbase
     libsForQt5.qtx11extras
+  ] ++ lib.optionals (variant == "qt6") [
+    qt6Packages.qtbase
   ];
 
   mesonFlags = [
     (lib.mesonEnable "backend-gtk3" (variant == "gtk3"))
     (lib.mesonEnable "backend-gtk4" (variant == "gtk4"))
     (lib.mesonEnable "backend-qt5" (variant == "qt5"))
+    (lib.mesonEnable "backend-qt6" (variant == "qt6"))
     (lib.mesonBool "vapi" (variant != "qt5"))
     (lib.mesonBool "introspection" (variant != "qt5"))
     (lib.mesonBool "docs" (variant != "qt5")) # requires introspection=true

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29645,7 +29645,7 @@ with pkgs;
 
   icesl = callPackage ../applications/misc/icesl { };
 
-  input-leap = libsForQt5.callPackage ../applications/misc/input-leap {
+  input-leap = qt6Packages.callPackage ../applications/misc/input-leap {
     avahi = avahi.override { withLibdnssdCompat = true; };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9961,6 +9961,7 @@ with pkgs;
   libportal-gtk3 = libportal.override { variant = "gtk3"; };
   libportal-gtk4 = libportal.override { variant = "gtk4"; };
   libportal-qt5 = libportal.override { variant = "qt5"; };
+  libportal-qt6 = libportal.override { variant = "qt6"; };
 
   libmicrodns = callPackage ../development/libraries/libmicrodns { };
 


### PR DESCRIPTION
## Description of changes

update to input-leap and libportal as well as changes to qt6.
After those changes, I was able to start input-leap on wayland. Unfortunately I'm running KDE 6.0 which does not implement the necessary interface. 6.1 will do:

```
 ./result/bin/input-leaps -f --debug DEBUG --name sol --disable-client-cert-checking -c test.conf --address :24800
[2024-09-12T15:29:52] DEBUG: opening configuration "test.conf"
[2024-09-12T15:29:52] DEBUG: configuration read successfully
[2024-09-12T15:29:52] DEBUG: adopting new buffer
[2024-09-12T15:29:52] DEBUG: adopting new buffer
[2024-09-12T15:29:52] DEBUG: opened display
[2024-09-12T15:29:52] NOTE: clipboard sharing is disabled
[2024-09-12T15:29:52] DEBUG: GLib thread running
[2024-09-12T15:29:52] DEBUG: Setting up the InputCapture session
[2024-09-12T15:29:52] DEBUG: Session ready
[2024-09-12T15:29:52] ERROR: Failed to initialize InputCapture session, quitting: GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: No such interface “org.freedesktop.portal.InputCapture” on object at path /org/freedesktop/portal/desktop
started server (IPv4/IPv6), waiting for clients
[2024-09-12T15:29:52] DEBUG: event queue is ready
[2024-09-12T15:29:52] DEBUG: add pending events to buffer
[2024-09-12T15:29:52] DEBUG: Shutting down GLib thread
[2024-09-12T15:29:52] DEBUG: add pending events to buffer
[2024-09-12T15:29:52] DEBUG: event queue is ready
[2024-09-12T15:29:52] DEBUG: screen "sol" shape changed
[2024-09-12T15:29:52] DEBUG: closed display
[2024-09-12T15:29:52] DEBUG: adopting new buffer
[2024-09-12T15:29:52] DEBUG: discarding 1 event(s)
[2024-09-12T15:29:52] NOTE: stopped server
```

Previously not even the correct libportal function was called.
## Things done


libportal: 0.7.1 -> 0.8.1
* libportal-qt6 variant
input-leap: update to 2024-08-01
* change to qt6

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
