### PR TITLE
sgdboop: init at 1.2.8

### DIFF
--- a/pkgs/by-name/ca/canvasdraw/package.nix
+++ b/pkgs/by-name/ca/canvasdraw/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  lsb-release,
+  which,
+  pkg-config,
+  gtk3,
+  fontconfig,
+  ftgl,
+  libGLU,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "canvasdraw";
+  version = "5.14";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/canvasdraw/${version}/Docs%20and%20Sources/cd-${version}_Sources.tar.gz";
+    hash = "sha256-xE7cBBExyaakKTPIeaZE1r2CjWCyikuFWpzeYV/Fr08=";
+  };
+
+  nativeBuildInputs = [
+    lsb-release
+    which
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    fontconfig
+    ftgl
+    libGLU
+  ];
+
+  sourceRoot = "cd/src";
+
+  makeFlags = [
+    "USE_PKGCONFIG=Yes"
+    "USE_GTK3=Yes"
+    "cd"
+    "cdgl"
+    "cdcontextplus"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -d "$out/lib"
+    install -m644 ../lib/*/lib*.so "$out/lib"
+    install -m755 -d "$out/include"
+    install -m644 ../include/* "$out/include"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "C platform-independent graphics library, aka canvasdraw";
+    homepage = "http://www.tecgraf.puc-rio.br/cd/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ saturn745 ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/im/imtoolkit/package.nix
+++ b/pkgs/by-name/im/imtoolkit/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  lsb-release,
+  which,
+  pkg-config,
+  gtk3,
+  fontconfig,
+  ftgl,
+  libGLU,
+  fftw,
+  fftwFloat,
+  lua,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "imtoolkit";
+  version = "3.15";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/imtoolkit/${version}/Docs%20and%20Sources/im-${version}_Sources.tar.gz";
+    hash = "sha256-NsxCV/j1+BEouFS7O+KcXL3QkUdlKPMVr2ZtCTC5tX4=";
+  };
+
+  nativeBuildInputs = [
+    lsb-release
+    which
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    fontconfig
+    ftgl
+    libGLU
+    fftw
+    fftwFloat
+    lua
+  ];
+
+  sourceRoot = "im/src";
+
+  installPhase = ''
+    install -m755 -d "$out/lib"
+    install -m644 ../lib/*/lib*.so "$out/lib"
+    install -m755 -d "$out/include"
+    install -m644 ../include/* "$out/include"
+  '';
+
+  meta = {
+    description = "Toolkit for Digital Imaging";
+    homepage = "http://www.tecgraf.puc-rio.br/im/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ saturn745 ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/iu/iup/package.nix
+++ b/pkgs/by-name/iu/iup/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  lsb-release,
+  which,
+  pkg-config,
+  gtk3,
+  canvasdraw,
+  libGLU,
+  ftgl,
+  imtoolkit,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "iup";
+  version = "3.31";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/iup/${version}/Docs%20and%20Sources/${pname}-${version}_Sources.tar.gz";
+    hash = "sha256-rYL2KweC5G/31KsWdl3yHLF+Z6xrjnLFDMhVH/VKFHQ=";
+  };
+
+  nativeBuildInputs = [
+    lsb-release
+    which
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    canvasdraw
+    libGLU
+    ftgl
+    imtoolkit
+  ];
+
+  makeFlags = [
+    "USE_PKGCONFIG=Yes"
+    "USE_GTK3=Yes"
+    "USE_STATIC="
+    "LINK_CAIRO=Yes"
+
+    "iup"
+    "iupgtk"
+    "iupcd"
+    "iupcontrols"
+    "iupgl"
+    "iup_plot"
+    "iup_mglplot"
+    "iupglcontrols"
+    "iupim"
+    "iupole"
+    "iup_scintilla"
+    "iupim"
+    "iuptuio"
+    "iupimglib"
+    "ledc"
+    "iupview"
+  ];
+
+  installPhase = ''
+    install -m755 -d "$out/lib"
+    install -m644 lib/*/lib*.so "$out/lib"
+    install -m755 -d "$out/include"
+    install -m644 include/* "$out/include"
+  '';
+
+  meta = {
+    description = "C cross platform GUI toolkit";
+    homepage = "https://www.tecgraf.puc-rio.br/iup/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ saturn745 ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/sg/sgdboop/package.nix
+++ b/pkgs/by-name/sg/sgdboop/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  curl,
+  iup,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sgdboop";
+  version = "1.2.8";
+
+  src = fetchFromGitHub {
+    owner = "SteamGridDB";
+    repo = "SGDBoop";
+    rev = "v${version}";
+    hash = "sha256-bdSzTwObMEBe1pHTDwXeJ3GXmOwwFp4my7qTmifX218=";
+  };
+
+  makeFlags = [
+    # Makefile copies a bundled libiup.so, so put it somewhere it won't be found
+    "USER_LIB_PATH=ignored"
+
+    # The Flakepak install just copies things to /app - otherwise wants to do things with XDG
+    "FLATPAK_ID=fake"
+  ];
+
+  postPatch = ''
+    substituteInPlace "linux-release/com.steamgriddb.SGDBoop.desktop" \
+      --replace "Exec=" "Exec=$out/bin/"
+    substituteInPlace Makefile \
+      --replace "/app/" "$out/"
+  '';
+
+  postInstall = ''
+    rm -r "$out/share/metainfo"
+  '';
+
+  buildInputs = [
+    curl
+    iup
+  ];
+
+  meta = {
+    description = "A program used for applying custom artwork to Steam, using SteamGridDB";
+    homepage = "https://github.com/SteamGridDB/SGDBoop/";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ saturn745 ];
+    mainProgram = "SGDBoop";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a new PR based on @puffnfresh's original PR #269369, which went stale. I wasn't sure if I could do this or not, but I was told by a few people that I could so long as I kept Puffnfresh as a commiter, so I did. I also fixed trailing whitespace causing the editorconfig check to fail, [updated the license for SGDBoop](https://github.com/SteamGridDB/SGDBoop/commit/4f39135617df5b0fbdeb36681ecbd727e4ea9503), and moved all of the packages to a `by-name` structure. One thing I was sure about was whether to keep Puffnfresh as a maintainer of these packages since his original PR went stale and nothing has been said from him. I did remove him from the maintainers of these, but I will add him back if he does want to maintain them. 

I apologize for any mistakes. I am still learning some things, and please let me know of any issues.

Closes: #269369, #220937

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
