### PR TITLE
flutter: fix iOS/macOS builds in nix-shell

### DIFF
--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -1,4 +1,4 @@
-{ useNixpkgsEngine ? false, callPackage, fetchzip, fetchFromGitHub, dart, lib, stdenv }@args:
+{ useNixpkgsEngine ? false, callPackage, fetchzip, fetchFromGitHub, dart, lib, stdenv }:
 let
   mkCustomFlutter = args: callPackage ./flutter.nix args;
   wrapFlutter = flutter: callPackage ./wrapper.nix { inherit flutter; };
@@ -19,7 +19,7 @@ let
     , pubspecLock
     , artifactHashes
     , channel
-    }@fargs:
+    }:
     let
       args = {
         inherit version engineVersion engineSwiftShaderRev engineSwiftShaderHash engineHashes enginePatches patches pubspecLock artifactHashes useNixpkgsEngine channel;

--- a/pkgs/development/compilers/flutter/sdk-symlink.nix
+++ b/pkgs/development/compilers/flutter/sdk-symlink.nix
@@ -17,6 +17,28 @@ let
         if [ -d '${flutter.sdk}/.git' ]; then
           ln -s '${flutter.sdk}/.git' "$out"
         fi
+
+        # For iOS/macOS builds, *.xcframework/'s from the pre-built
+        # artifacts are copied into each built app. However, the symlinkJoin
+        # means that the *.xcframework's contain symlinks into the nix store,
+        # which causes issues when actually running the apps.
+        #
+        # We'll fix this by only linking to an outer *.xcframework dir instead
+        # of trying to symlinkJoin the files inside the *.xcframework.
+        artifactsDir="$out/bin/cache/artifacts/engine"
+        shopt -s globstar
+        for file in "$artifactsDir"/**/*.xcframework/Info.plist; do
+          # Get the unwrapped path from the Info.plist inside each .xcframework
+          origFile="$(readlink -f "$file")"
+          origFrameworkDir="$(dirname "$origFile")"
+
+          # Remove the symlinkJoin .xcframework dir and replace it with a symlink
+          # to the unwrapped .xcframework dir.
+          frameworkDir="$(dirname "$file")"
+          rm -r "$frameworkDir"
+          ln -s "$origFrameworkDir" "$frameworkDir"
+        done
+        shopt -u globstar
       '';
 
       passthru = flutter.passthru // {

--- a/pkgs/development/compilers/flutter/versions/3_24/patches/fix-ios-build-xcode-backend-sh.patch
+++ b/pkgs/development/compilers/flutter/versions/3_24/patches/fix-ios-build-xcode-backend-sh.patch
@@ -1,0 +1,69 @@
+From 6df275df3b8694daf16302b407520e3b1dee6724 Mon Sep 17 00:00:00 2001
+From: Philip Hayes <philiphayes9@gmail.com>
+Date: Thu, 12 Sep 2024 13:23:00 -0700
+Subject: [PATCH] fix: cleanup xcode_backend.sh to fix iOS build w/
+ `NixOS/nixpkgs` flutter
+
+This patch cleans up `xcode_backend.sh`. It now effectively just runs
+`exec $FLUTTER_ROOT/bin/dart ./xcode_backend.dart`.
+
+The previous `xcode_backend.sh` tries to discover `$FLUTTER_ROOT` from
+argv[0], even though its presence is already guaranteed (the wrapped
+`xcode_backend.dart` also relies on this env).
+
+When using nixpkgs flutter, the flutter SDK directory is composed of several
+layers, joined together using symlinks (called a `symlinkJoin`). Without this
+patch, the auto-discover traverses the symlinks into the wrong layer, and so it
+uses an "unwrapped" `dart` command instead of a "wrapped" dart that sets some
+important envs/flags (like `$FLUTTER_ROOT`).
+
+Using the "unwrapped" dart then manifests in this error when compiling, since
+it doesn't see the ios build-support artifacts:
+
+```
+$ flutter run -d iphone
+Running Xcode build...
+Xcode build done.                                            6.4s
+Failed to build iOS app
+Error (Xcode): Target debug_unpack_ios failed: Error: Flutter failed to create a directory at "/<nix-store>/XXXX-flutter-3.24.1-unwrapped/bin/cache/artifacts".
+```
+---
+ packages/flutter_tools/bin/xcode_backend.sh | 25 ++++-----------------
+ 1 file changed, 4 insertions(+), 21 deletions(-)
+
+diff --git a/packages/flutter_tools/bin/xcode_backend.sh b/packages/flutter_tools/bin/xcode_backend.sh
+index 2889d7c8e4..48b9d06c6e 100755
+--- a/packages/flutter_tools/bin/xcode_backend.sh
++++ b/packages/flutter_tools/bin/xcode_backend.sh
+@@ -6,24 +6,7 @@
+ # exit on error, or usage of unset var
+ set -euo pipefail
+ 
+-# Needed because if it is set, cd may print the path it changed to.
+-unset CDPATH
+-
+-function follow_links() (
+-  cd -P "$(dirname -- "$1")"
+-  file="$PWD/$(basename -- "$1")"
+-  while [[ -h "$file" ]]; do
+-    cd -P "$(dirname -- "$file")"
+-    file="$(readlink -- "$file")"
+-    cd -P "$(dirname -- "$file")"
+-    file="$PWD/$(basename -- "$file")"
+-  done
+-  echo "$file"
+-)
+-
+-PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
+-BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
+-FLUTTER_ROOT="$BIN_DIR/../../.."
+-DART="$FLUTTER_ROOT/bin/dart"
+-
+-"$DART" "$BIN_DIR/xcode_backend.dart" "$@"
++# Run `dart ./xcode_backend.dart` with the dart from $FLUTTER_ROOT.
++dart="${FLUTTER_ROOT}/bin/dart"
++xcode_backend_dart="${BASH_SOURCE[0]%.sh}.dart"
++exec "${dart}" "${xcode_backend_dart}" "$@"
+-- 
+2.46.0
+

--- a/pkgs/development/compilers/flutter/wrapper.nix
+++ b/pkgs/development/compilers/flutter/wrapper.nix
@@ -18,7 +18,6 @@
 , extraCFlags ? [ ]
 , extraLinkerFlags ? [ ]
 , makeWrapper
-, runCommandLocal
 , writeShellScript
 , wrapGAppsHook3
 , git
@@ -39,7 +38,6 @@
 , cmake
 , ninja
 , clang
-, lndir
 , symlinkJoin
 }:
 
@@ -56,7 +54,7 @@ let
       };
     }));
 
-  cacheDir = symlinkJoin rec {
+  cacheDir = symlinkJoin {
     name = "flutter-cache-dir";
     paths = builtins.attrValues flutterPlatformArtifacts;
     postBuild = ''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR contains two fixes so that nixpkgs flutter can successfully build iOS and macOS apps. Granted, this is when used inside a `nix shell`, but these fixes should also translate to the in-sandbox builds (which still has some more errors to work out).

### Changes

#### flutter: fix iOS build error

Without this patch, `xcode_backend.sh` in `flutter_tools` gets confused by the flutter SDK `symlinkJoin` and picks up the `dart` executable from `flutter-unwrapped`, which manifests as the following error during an iOS/macOS build:

```bash
$ flutter run -d iphone
Launching lib/main.dart on iPhone 15 Pro Max in debug mode...
Running pod install...                                           1,488ms
Running Xcode build...
Xcode build done.                                           16.8s
Failed to build iOS app
Error (Xcode): Target debug_unpack_ios failed: Error: Flutter failed to create a
directory at "/nix/store/xhcdmzj0m8x64fky1mdsyv5311f2sxs9-flutter-3.24.1-unwrapped/bin/cache/artifacts".
Could not build the application for the simulator.
Error launching application on iPhone 15 Pro Max.
```

See upstream PR: https://github.com/flutter/flutter/pull/155139

#### flutter: prevent built iOS/macOS apps from containing links to nix store

For iOS/macOS builds, *.xcframework/'s from the pre-built artifacts are copied into each built app. However, the symlinkJoin means that the *.xcframework's contain symlinks into the nix store, which causes issues when actually running the apps.

```bash
$ flutter run -d macos
Launching lib/main.dart on macOS in debug mode...
Running pod install...                                           1,321ms
Building macOS application...
✓ Built build/macos/Build/Products/Debug/Helloworld.app
[FATAL:flutter/fml/icu_util.cc(97)] Check failed: context->IsValid(). Must be able to initialize the ICU context. Tried: /Users/phlip9/dev/lexe/public/app/build/macos/Build/Products/Debug/Helloworld.app/Contents/Frameworks/FlutterMacOS.framework/Resources/icudtl.dat
```
                                                                     
This diff fixes the issue by only linking to an outer *.xcframework dir instead of trying to symlinkJoin the files inside the *.xcframework.

### Testing

You'll need an apple device, Xcode, and an iOS toolchain/simulator installed. I don't believe these can be provided with nixpkgs due to licensing reasons.

```bash
# checkout this pr and add `flutter` + `pod` to your shell
$ nix shell .#flutter324 .#cocoapods

# create a new flutter helloworld project
$ cd $(mktemp -d)
$ flutter create --platforms ios,macos helloworld
$ cd ./helloworld

# build + run on macOS
$ flutter run -d macos

# build + run on iOS (connect a device or open a simulator first)
$ flutter run -d iphone
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
