### PR TITLE
testers.testLibs: init

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -165,6 +165,59 @@ testers.shellcheck {
 A derivation that runs `shellcheck` on the given script(s).
 The build will fail if `shellcheck` finds any issues.
 
+## `testLibs` {#tester-testLibs}
+
+Some packages are sensitive to the version of the libraries they link against. The `testLibs` tester allows you to run an arbitrary command with the `LD_DEBUG` environment variable set to `libs`, which will cause the dynamic linker to print out the libraries it is loading. Through the `testLibs` tester, you can run assertions of the form:
+
+- soname was or was not searched for
+- soname was or was not loaded, optionally from a path matching a pattern
+
+:::{.example #ex-testLibs}
+# Run `testers.testLibs`
+
+```nix
+testers.testLibs {
+  name = "TODO";
+  bin = {
+    path = ./script.sh;
+    args = [ "arg1" "arg2" ];
+  };
+  assertions = [
+    { soname = "libfoo.so.1"; loaded = true; description = "Required library"; }
+    { soname = "libbar.so.2"; loaded = false; description = "Unnecessary library"; }
+    { soname = "libbaz.so.3"; loaded = true; path = "/path/to/libbaz.so.3"; }
+    { soname = "libqux.so.4"; loaded = false; path = "/path/to/libqux.so.4"; description = "Forbidden library"; }
+  ];
+}
+```
+
+:::
+
+### Inputs {#tester-testLibs-inputs}
+
+[`bin.path` (path or string)]{#tester-testLibs-param-bin-path}
+
+: The path to the executable to be run.
+  This is expected to be a single executable file.
+
+[`bin.args` (list of strings)]{#tester-testLibs-param-bin-args}
+
+: The arguments to pass to the executable.
+
+[`assertions` (list of attribute sets)]{#tester-testLibs-param-assertions}
+
+: A list of assertions to check.
+  Each assertion is an attribute set with the following attributes:
+
+  - `soname` (string): The soname of the library to check.
+  - `loaded` (boolean): Whether the library should be loaded.
+  - `path` (string, optional): The path the library should be loaded from.
+  - `description` (string, optional): A description of the assertion.
+
+### Return value {#tester-shellcheck-return}
+
+A derivation that runs `testLibs` on the given binary.
+
 ## `testVersion` {#tester-testVersion}
 
 Checks that the output from running a command contains the specified version string in it as a whole word.

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -181,4 +181,6 @@
   testMetaPkgConfig = callPackage ./testMetaPkgConfig/tester.nix { };
 
   shellcheck = callPackage ./shellcheck/tester.nix { };
+
+  testLibs = callPackage ./testLibs { };
 }

--- a/pkgs/build-support/testers/testLibs/NOTES.md
+++ b/pkgs/build-support/testers/testLibs/NOTES.md
@@ -1,0 +1,190 @@
+# NOTES
+
+Here's ChatGPT-4o's response when asked about
+
+## Question
+
+Here's output I got from running `LD_DEBUG=libs python3 --version`. Please explain the contents and structure of the output, breaking down the information on each line.
+
+```console
+   2753420:     find library=libpthread.so.0 [0]; searching
+   2753420:      search path=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/glibc-hwcaps/x86-64-v3:/home/connorbaker/micromamba/envs/testLibs/bin/../lib/glibc-hwcaps/x86-64-v2:/home/connorbaker/micromamba/envs/testLibs/bin/../lib          (RPATH from file /home/connorbaker/micromamba/envs/testLibs/bin/python3)
+   2753420:       trying file=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/glibc-hwcaps/x86-64-v3/libpthread.so.0
+   2753420:       trying file=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/glibc-hwcaps/x86-64-v2/libpthread.so.0
+   2753420:       trying file=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/libpthread.so.0
+   2753420:      search path=/run/current-system/sw/share/nix-ld/lib/glibc-hwcaps/x86-64-v3:/run/current-system/sw/share/nix-ld/lib/glibc-hwcaps/x86-64-v2:/run/current-system/sw/share/nix-ld/lib            (LD_LIBRARY_PATH)
+   2753420:       trying file=/run/current-system/sw/share/nix-ld/lib/glibc-hwcaps/x86-64-v3/libpthread.so.0
+   2753420:       trying file=/run/current-system/sw/share/nix-ld/lib/glibc-hwcaps/x86-64-v2/libpthread.so.0
+   2753420:       trying file=/run/current-system/sw/share/nix-ld/lib/libpthread.so.0
+   2753420:      search cache=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/etc/ld.so.cache
+   2753420:      search path=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/glibc-hwcaps/x86-64-v3:/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/glibc-hwcaps/x86-64-v2:/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v3:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v2:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib            (system search path)
+   2753420:       trying file=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/glibc-hwcaps/x86-64-v3/libpthread.so.0
+   2753420:       trying file=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/glibc-hwcaps/x86-64-v2/libpthread.so.0
+   2753420:       trying file=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libpthread.so.0
+   2753420:
+   2753420:     find library=libdl.so.2 [0]; searching
+   2753420:      search path=/home/connorbaker/micromamba/envs/testLibs/bin/../lib        (RPATH from file /home/connorbaker/micromamba/envs/testLibs/bin/python3)
+   2753420:       trying file=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/libdl.so.2
+   2753420:      search path=/run/current-system/sw/share/nix-ld/lib            (LD_LIBRARY_PATH)
+   2753420:       trying file=/run/current-system/sw/share/nix-ld/lib/libdl.so.2
+   2753420:      search cache=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/etc/ld.so.cache
+   2753420:      search path=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v3:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v2:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib                (system search path)
+   2753420:       trying file=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libdl.so.2
+   2753420:
+   2753420:     find library=libutil.so.1 [0]; searching
+   2753420:      search path=/home/connorbaker/micromamba/envs/testLibs/bin/../lib        (RPATH from file /home/connorbaker/micromamba/envs/testLibs/bin/python3)
+   2753420:       trying file=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/libutil.so.1
+   2753420:      search path=/run/current-system/sw/share/nix-ld/lib            (LD_LIBRARY_PATH)
+   2753420:       trying file=/run/current-system/sw/share/nix-ld/lib/libutil.so.1
+   2753420:      search cache=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/etc/ld.so.cache
+   2753420:      search path=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v3:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v2:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib                (system search path)
+   2753420:       trying file=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libutil.so.1
+   2753420:
+   2753420:     find library=libm.so.6 [0]; searching
+   2753420:      search path=/home/connorbaker/micromamba/envs/testLibs/bin/../lib        (RPATH from file /home/connorbaker/micromamba/envs/testLibs/bin/python3)
+   2753420:       trying file=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/libm.so.6
+   2753420:      search path=/run/current-system/sw/share/nix-ld/lib            (LD_LIBRARY_PATH)
+   2753420:       trying file=/run/current-system/sw/share/nix-ld/lib/libm.so.6
+   2753420:      search cache=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/etc/ld.so.cache
+   2753420:      search path=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v3:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v2:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib                (system search path)
+   2753420:       trying file=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libm.so.6
+   2753420:
+   2753420:     find library=libc.so.6 [0]; searching
+   2753420:      search path=/home/connorbaker/micromamba/envs/testLibs/bin/../lib        (RPATH from file /home/connorbaker/micromamba/envs/testLibs/bin/python3)
+   2753420:       trying file=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/libc.so.6
+   2753420:      search path=/run/current-system/sw/share/nix-ld/lib            (LD_LIBRARY_PATH)
+   2753420:       trying file=/run/current-system/sw/share/nix-ld/lib/libc.so.6
+   2753420:      search cache=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/etc/ld.so.cache
+   2753420:      search path=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v3:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib/glibc-hwcaps/x86-64-v2:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib                (system search path)
+   2753420:       trying file=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libc.so.6
+   2753420:
+   2753420:     find library=librt.so.1 [0]; searching
+   2753420:      search path=/run/current-system/sw/share/nix-ld/lib            (LD_LIBRARY_PATH)
+   2753420:       trying file=/run/current-system/sw/share/nix-ld/lib/librt.so.1
+   2753420:      search path=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib(system search path)
+   2753420:       trying file=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/librt.so.1
+   2753420:
+   2753420:     find library=libatomic.so.1 [0]; searching
+   2753420:      search path=/run/current-system/sw/share/nix-ld/lib            (LD_LIBRARY_PATH)
+   2753420:       trying file=/run/current-system/sw/share/nix-ld/lib/libatomic.so.1
+   2753420:
+   2753420:
+   2753420:     calling init: /lib64/ld-linux-x86-64.so.2
+   2753420:
+   2753420:
+   2753420:     calling init: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libc.so.6
+   2753420:
+   2753420:
+   2753420:     calling init: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libpthread.so.0
+   2753420:
+   2753420:
+   2753420:     calling init: /run/current-system/sw/share/nix-ld/lib/libatomic.so.1
+   2753420:
+   2753420:
+   2753420:     calling init: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/librt.so.1
+   2753420:
+   2753420:
+   2753420:     calling init: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libm.so.6
+   2753420:
+   2753420:
+   2753420:     calling init: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libutil.so.1
+   2753420:
+   2753420:
+   2753420:     calling init: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libdl.so.2
+   2753420:
+   2753420:
+   2753420:     calling init: /nix/store/dbjkr6mxbfgn1s8i5bz9mj3zkfcvlzkp-malloc-provider-mimalloc/lib/libmimalloc.so
+   2753420:
+   2753420:
+   2753420:     initialize program: /home/connorbaker/micromamba/envs/testLibs/bin/python3
+   2753420:
+   2753420:
+   2753420:     transferring control: /home/connorbaker/micromamba/envs/testLibs/bin/python3
+   2753420:
+   2753420:
+   2753420:     calling fini:  [0]
+   2753420:
+   2753420:
+   2753420:     calling fini: /nix/store/dbjkr6mxbfgn1s8i5bz9mj3zkfcvlzkp-malloc-provider-mimalloc/lib/libmimalloc.so [0]
+   2753420:
+   2753420:
+   2753420:     calling fini: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libdl.so.2 [0]
+   2753420:
+   2753420:
+   2753420:     calling fini: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libutil.so.1 [0]
+   2753420:
+   2753420:
+   2753420:     calling fini: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libm.so.6 [0]
+   2753420:
+   2753420:
+   2753420:     calling fini: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/librt.so.1 [0]
+   2753420:
+   2753420:
+   2753420:     calling fini: /run/current-system/sw/share/nix-ld/lib/libatomic.so.1 [0]
+   2753420:
+   2753420:
+   2753420:     calling fini: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libpthread.so.0 [0]
+   2753420:
+   2753420:
+   2753420:     calling fini: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libc.so.6 [0]
+   2753420:
+   2753420:
+   2753420:     calling fini: /lib64/ld-linux-x86-64.so.2 [0]
+   2753420:
+```
+
+## Answer
+
+This output is the result of setting `LD_DEBUG=libs` while running the `python3` command, which provides detailed information about how the dynamic linker resolves and loads shared libraries during program execution. Here's a breakdown of the content and structure:
+
+### General Format:
+Each line has the following format:
+```plaintext
+   <process id>: <debug message>
+```
+Here, the process ID is `2753420` for all lines. The message contains information about dynamic linking, such as searching for libraries and initializing or finalizing them.
+
+### Key Sections of the Output:
+
+1. **Finding and Loading Shared Libraries:**
+   - Example: `find library=libpthread.so.0 [0]; searching`
+     - The linker is trying to find the shared library `libpthread.so.0`. The `[0]` indicates that no previous instance of this library has been found.
+     
+2. **Search Paths for Libraries:**
+   - Example: `search path=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/glibc-hwcaps/x86-64-v3`
+     - The linker searches various directories for the specified library. It looks through paths derived from the environment variables and default system paths:
+     - **RPATH**: Directories specified at the time the binary was built.
+     - **LD_LIBRARY_PATH**: User-defined library paths.
+     - **ld.so.cache**: A cache of libraries that the dynamic linker maintains for faster lookup.
+   
+   - Example:
+     ```plaintext
+     search path=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib:/nix/store/5k2fkrnnp9w7kjvf7s0ancb5rlnml100-xgcc-13.3.0-libgcc/lib
+     ```
+     This indicates the dynamic linker is also searching within the Nix store paths.
+
+3. **Trying Specific Files:**
+   - Example: `trying file=/home/connorbaker/micromamba/envs/testLibs/bin/../lib/libpthread.so.0`
+     - The linker attempts to load the file from the specified path. This shows whether the library is present at a particular path.
+
+4. **Using the Cache:**
+   - Example: `search cache=/nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/etc/ld.so.cache`
+     - If the library cannot be found in the searched paths, the linker consults the cache (`ld.so.cache`) to resolve the location of the library.
+
+5. **Calling Initialization Functions:**
+   - Example: `calling init: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libpthread.so.0`
+     - Once a library is found and loaded, the linker invokes its initialization functions (e.g., `init` sections in libraries), which set up the necessary state for that library to be used.
+
+6. **Finalizing Loaded Libraries:**
+   - Example: `calling fini: /nix/store/dbwp0scbb0rk78m636sb7cvycz8xzgyh-glibc-2.39-52/lib/libpthread.so.0 [0]`
+     - The linker invokes the finalization functions of each library when the program finishes, ensuring proper cleanup of resources.
+
+7. **Control Transfer:**
+   - Example: `transferring control: /home/connorbaker/micromamba/envs/testLibs/bin/python3`
+     - This indicates that after resolving all necessary libraries, the linker transfers control to the main program (`python3`), allowing it to start execution.
+
+### Special Points:
+- **glibc-hwcaps**: The search paths include "hwcaps" subdirectories (hardware capabilities). These directories contain optimized versions of libraries for specific CPU architectures (e.g., x86-64-v3, x86-64-v2).
+- **Nix Store Paths**: Many of the libraries are being loaded from the Nix package manager's store paths, indicating that the environment is using Nix to manage system libraries.
+  
+This output shows how the dynamic linker is methodically finding, loading, initializing, and finalizing shared libraries as `python3` is executed in a Nix and Micromamba-managed environment.

--- a/pkgs/build-support/testers/testLibs/test_libs.py
+++ b/pkgs/build-support/testers/testLibs/test_libs.py
@@ -1,0 +1,387 @@
+# pyright: strict
+from collections.abc import Sequence
+from dataclasses import dataclass
+import logging
+import subprocess
+import re
+from pathlib import Path
+from typing import Final
+
+# NOTES on output of LD_DEBUG=libs
+# - Seems like the output is always slightly indented (three spaces?)
+
+LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
+
+type PID = int
+
+# Have some function which switches depending on the type of the line
+
+def continuation_trying_file(line: str):
+    """
+    Continuation function for the trying file line.
+    """
+    match line.split("=", maxsplit=1):
+        case ("trying file", rest):
+            return parse_trying_file(rest)
+        case ("search cache", rest):
+            return parse_search_cache(rest)
+        case ("search path", rest):
+            return parse_search_path(rest)
+        case [""]:
+            return 
+        case _:
+            raise ValueError(f"Failed to match line: {line}")
+
+def parse_trying_file(line: str):
+    """
+    When we get a line which matches "trying file=", we parse the line and return a function
+    which should be applied to the following line.
+    """
+    pat = re.compile(r"^trying\ file=(?P<path>[^\s]+)$")
+    match = pat.match(line)
+    if match is None:
+        raise ValueError(f"Failed to match line: {line}")
+
+    path = Path(match.group("path"))
+
+    return TryingFile(path=path), continuation_trying_file
+
+def parse_search_path(line: str):
+    """
+    When we get a line which matches "search path=", we parse the line and return a function
+    which should be applied to the following line.
+    """
+    pat = re.compile(r"^search\ path=(?P<paths>[^\s]+)\s*(?P<source>\(.+\))\s*$")
+    match = pat.match(line)
+    if match is None:
+        raise ValueError(f"Failed to match line: {line}")
+
+    paths = list(map(Path, match.group("paths").split(":")))
+    source = match.group("source")
+
+    # Search path is always followed by a trying file
+
+    return SearchPath(path=path)
+
+def parse_search_cache(line: str):
+    """
+    When we get a line which matches "search cache=", we parse the line and return a function
+    which should be applied to the following line.
+    """
+    pat = re.compile(r"^search\ cache=(?P<path>[^\s]+)$")
+    match = pat.match(line)
+    if match is None:
+        raise ValueError(f"Failed to match line: {line}")
+
+    path = Path(match.group("path"))
+
+    # Search cache is always followed by a search path
+
+
+
+    return SearchCache(path=path)
+
+
+def parse_find_library(line: str):
+    """
+    When we get a line which matches "find library=", we parse the line and return a function
+    which should be applied to the following line.
+    """
+    pat = re.compile(r"^find\ library=(?P<soname>[^\s]+)\[(?P<times_found>\d+)\];\ searching$")
+    match = pat.match(line)
+    if match is None:
+        raise ValueError(f"Failed to match line: {line}")
+
+    soname = match.group("soname")
+    times_found = int(match.group("times_found"))
+
+
+
+    def continuation(line: str):
+        """
+        Continuation function for the find library line.
+        """
+        match line.split("=", maxsplit=1):
+            case ("search cache", rest):
+                return parse_search_cache(rest)
+            case ("search path", rest):
+                return parse_search_path(soname, rest)
+            case _:
+                raise ValueError(f"Failed to match line: {line}")
+
+
+# (RPATH from file /home/connorbaker/micromamba/envs/testLibs/bin/python3)
+# (LD_LIBRARY_PATH)
+# (system search path)
+
+
+@dataclass
+class TryingFile:
+    path: Path
+
+
+@dataclass
+class SearchPathSystemPath:
+    path: list[Path]
+    tries: list[TryingFile]
+
+
+@dataclass
+class SearchPathLdLibraryPath:
+    path: list[Path]
+    tries: list[TryingFile]
+
+
+@dataclass
+class SearchPathRPath:
+    path: list[Path]
+    from_file: Path
+    tries: list[TryingFile]
+
+
+type SearchPath = SearchPathSystemPath | SearchPathLdLibraryPath | SearchPathRPath
+
+
+@dataclass
+class SearchCache:
+    path: Path
+
+
+@dataclass
+class FindLibrary:
+    soname: str  # The name of the library
+    entries: list[SearchPath | SearchCache]
+
+
+type SearchLineObject = FindLibrary | SearchPath | SearchCache
+
+
+@dataclass
+class CallingInit:
+    path: Path
+
+
+@dataclass
+class InitializeProgram:
+    path: Path
+
+
+@dataclass
+class TransferringControl:
+    path: Path
+
+
+@dataclass
+class CallingFini:
+    path: None | Path
+
+
+def parse_pid(line: str) -> tuple[PID, str]:
+    """
+    Returns the PID and the remainder of the line.
+    """
+    line = line.strip()
+    match line.split(":", maxsplit=1):
+        case (pid, payload):
+            return int(pid), payload
+        case _:
+            raise ValueError(f"Failed to parse line: {line}")
+
+
+def parse_line_type(line: str) -> tuple[LineType, None | str]:
+    line = line.strip()
+    if line == "":
+        return LineBreakType(), None
+
+    # Test for search line type
+    match line.split("=", maxsplit=1):
+        case ("find library", rest):
+            return FindLibraryType(), rest
+        case ("search path", rest):
+            return SearchPathType(), rest
+        case ("trying file", rest):
+            return TryingFileType(), rest
+        case ("search cache", rest):
+            return SearchCacheType(), rest
+        case _:
+            pass
+
+    # Test for control line type
+    match line.split(": ", maxsplit=1):
+        case ("calling init", rest):
+            return CallingInitType(), rest
+        case ("initialize program", rest):
+            return InitializeProgramType(), rest
+        case ("transferring control", rest):
+            return TransferringControlType(), rest
+        case ("calling fini", rest):
+            return CallingFiniType(), rest
+        case _:
+            pass
+
+    raise ValueError(f"Failed to parse line: {line}")
+
+
+type TopLevelType = FindLibraryType | CallingInitType | InitializeProgramType | TransferringControlType | CallingFiniType
+
+def chunks_by_pid(lines: Sequence[str]) -> dict[PID, list[tuple[TopLevelType, list[str]]]]:
+    pids: dict[PID, list[list[str]]] = {}
+    for line in lines:
+        pid, rest = parse_pid(line)
+        chunks = pids.setdefault(pid, [])
+
+        rest = rest.strip()
+
+        # If rest is empty, then we have a line break
+        if rest == "":
+            chunks.append([])
+            continue
+        else:
+            current_chunk.append(rest)
+
+    # Remove any empty chunks
+    pids = {pid: [chunk for chunk in chunks if chunk] for pid, chunks in pids.items()}
+
+    return pids
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+
+    result = subprocess.run(
+        args=["/home/connorbaker/micromamba/envs/testLibs/bin/python3", "--version"],
+        env={"LD_DEBUG": "libs"},
+        capture_output=True,
+        text=True,
+    )
+
+    for pid, chunks in chunks_by_pid(result.stderr.splitlines()).items():
+        LOGGER.debug("PID: %s", pid)
+        for chunk in chunks:
+            LOGGER.debug("Chunk:")
+            for line in chunk:
+                LOGGER.debug("  %s", line)
+
+    # context: dict[PID, dict[NonEmptyLineType, ]] = {}
+    # finished: dict[PID, dict[NonEmptyLineType, list[str]]] = {}
+    # for line in result.stderr.splitlines():
+    #     pid, rest = parse_pid(line)
+    #     pid_context = context.get(pid, {})
+
+    #     line_type, rest = parse_line_type(rest)
+    #     match line_type:
+    #         case LineBreakType():
+    #             # Finalize the context for the PID
+    #             raise NotImplementedError("LineBreakType not implemented")
+
+    #         # All of the following cases involve creating a new object to add to the context
+    #         case FindLibraryType():
+
+    #     LOGGER.debug("PID: %s, Line Type: %s", pid, line_type)
+
+    # structured_lines = []
+
+    # pid_matcher = re.compile(
+    #     r"""
+    #     ^ # Start of line
+    #     \s+ # Leading indentation
+    #     (?P<pid>\d+) # Process ID
+    #     : # Colon
+    #     \s* # Possible leading assuming not a newline
+    #     (?P<payload> # Start of optional payload
+    #         (?P<find_library> # Start case: find library
+    #             find\ library=
+    #             (?P<find_library_soname>[^\s]+)
+    #             (?P<find_library_rest>.*) # Rest of the line
+    #         )  # End case: find library
+
+    #         | # OR
+
+    #         (?P<search_path> # Start case: search path
+    #             search\ path=
+    #             (?P<search_path_path>[^\s]+)
+    #             (?P<search_path_rest>.*) # Rest of the line
+    #             # TODO: Add type of search path
+    #         ) # End case: search path
+
+    #         | # OR
+
+    #         (?P<trying_file> # Start case: trying file
+    #             trying\ file=
+    #             (?P<trying_file_path>[^\s]+)
+    #             (?P<trying_file_rest>.*) # Rest of the line
+    #         ) # End case: trying file
+
+    #         | # OR
+
+    #         (?P<search_cache> # Start case: search cache
+    #             search\ cache=
+    #             (?P<search_cache_path>[^\s]+)
+    #             (?P<search_cache_rest>.*) # Rest of the line
+    #         ) # End case: search cache
+
+    #         | # OR
+
+    #         (?P<calling_init> # Start case: calling init
+    #             calling\ init:\
+    #             (?P<calling_init_path>[^\s]+)
+    #             (?P<calling_init_rest>.*) # Rest of the line
+    #         ) # End case: calling init
+
+    #         | # OR
+
+    #         (?P<initialize_program> # Start case: initialize program
+    #             initialize\ program:\
+    #             (?P<initialize_program_path>[^\s]+)
+    #             (?P<initialize_program_rest>.*) # Rest of the line
+    #         ) # End case: initialize program
+
+    #         | # OR
+
+    #         (?P<transferring_control> # Start case: transferring control
+    #             transferring\ control:\
+    #             (?P<transferring_control_path>[^\s]+)
+    #             (?P<transferring_control_rest>.*) # Rest of the line
+    #         ) # End case: transferring control
+
+    #         | # OR
+
+    #         (?P<calling_fini> # Start case: calling fini
+    #             calling\ fini:\
+    #             (?P<calling_fini_path>[^\s]+)
+    #             (?P<calling_fini_rest>.*) # Rest of the line
+    #         ) # End case: calling fini
+    #     )? # End of optional payload
+    #     $ # End of line
+    #     """,
+    #     re.VERBOSE,
+    # )
+    # for line in result.stderr.splitlines():
+    #     match = pid_matcher.match(line)
+    #     if match is None:
+    #         LOGGER.error("Failed to match line %s", line)
+    #         sys.exit(1)
+
+    #     if not match.group("payload"):
+    #         LOGGER.debug("Linebreak")
+    #         continue
+    #     elif match.group("find_library"):
+    #         LOGGER.debug("find library: %s", match.group("find_library_soname"))
+    #     elif match.group("search_path"):
+    #         LOGGER.debug("search path: %s", match.group("search_path_path"))
+    #     elif match.group("trying_file"):
+    #         LOGGER.debug("trying file: %s", match.group("trying_file_path"))
+    #     elif match.group("search_cache"):
+    #         LOGGER.debug("search cache: %s", match.group("search_cache_path"))
+    #     elif match.group("calling_init"):
+    #         LOGGER.debug("calling init: %s", match.group("calling_init_path"))
+    #     elif match.group("initialize_program"):
+    #         LOGGER.debug(
+    #             "initialize program: %s", match.group("initialize_program_path")
+    #         )
+    #     elif match.group("transferring_control"):
+    #         LOGGER.debug(
+    #             "transferring control: %s", match.group("transferring_control_path")
+    #         )
+    #     elif match.group("calling_fini"):
+    #         LOGGER.debug("calling fini: %s", match.group("calling_fini_path"))


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> [!IMPORTANT]
>
> This is a work in progress PR.

The inspiration for this tester comes from @SomeoneSerge.

The goal of this PR is to provide a tester in `pkgs.testers` which allows running a command with the `LD_DEBUG` environment variable set to `libs`, and checking assertions against the output. Assertions are of the variety

- ensure a path was or was not searched for a library
- ensure a library was or was not loaded (optionally from a path matching a pattern)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
