### PR TITLE
openpnp: init at 2.0

### DIFF
--- a/pkgs/by-name/op/openpnp/package.nix
+++ b/pkgs/by-name/op/openpnp/package.nix
@@ -1,0 +1,37 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  # needs to be jre8 due to https://github.com/openpnp/openpnp/issues/1361
+  jre8,
+  makeWrapper,
+}:
+stdenv.mkDerivation {
+  pname = "openpnp";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "https://s3-us-west-2.amazonaws.com/openpnp/OpenPnP-unix-develop.tar.gz";
+    hash = "sha256-PwBumcz2T+pMBQRmP22GBEwDbwsvxyMYGASSD2qz510=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/libexec/openpnp
+    cp openpnp-gui-0.0.1-alpha-SNAPSHOT.jar $out/libexec/openpnp/
+    cp lib/*.jar $out/libexec/openpnp/
+
+    mkdir -p $out/bin
+    makeWrapper ${jre8}/bin/java $out/bin/openpnp \
+      --add-flags "-cp $out/libexec/openpnp/\* org.openpnp.Main"
+  '';
+
+  meta = with lib; {
+    description = "Open Source SMT pick and place system";
+    homepage = "https://openpnp.org/";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.flokli ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
This packages OpenPnP, "an Open Source SMT pick and place system that includes ready to run software, and hardware designs that you can build and modify. You can also use OpenPnP software to run a pick and place machine of your own design, or with existing commercial machines, giving them abilities they never had with their OEM software".

We pick the .jar files from their release tarball. Due to an upstream issue, it's not possible to run this with the default JRE (17).

The application welcome dialog complains about not being able to find OPENPNP_2_0.md, which it seems to try to pick up from the current working directory, or `Main.getSourceUri()` - so it's unclear how this could have worked in first place in anything else than a source checkout.

After pressing OK, the GUI seems to start up.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
