### PR TITLE
nixosTests.terminal-emulators: Fix lomiri-terminal-app test after mesa change

### DIFF
--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -62,6 +62,9 @@ let tests = {
       konsole.pkg = p: p.plasma5Packages.konsole;
 
       lomiri-terminal-app.pkg = p: p.lomiri.lomiri-terminal-app;
+      # after recent Mesa change, borked software rendering config under x86_64 icewm?
+      # BGR colour display on x86_64, RGB on aarch64
+      lomiri-terminal-app.colourTest = false;
 
       lxterminal.pkg = p: p.lxterminal;
 


### PR DESCRIPTION
## Description of changes

<details>
  <summary>Bisection log</summary>

```
git bisect start
# Status: warte auf guten und schlechten Commit
# good: [23a88afe88281a624483ec37326957fba61f15be] Merge pull request #247112 from OPNA2608/init/lomiri/lomiri-terminal-app
git bisect good 23a88afe88281a624483ec37326957fba61f15be
# Status: warte auf schlechten Commit, 1 guter Commit bekannt
# bad: [24194a801194f2efecde10ffa9e5fdf842077a57] jitsi-meet-electron: 2024.3.0 -> 2024.6.0 (#341228)
git bisect bad 24194a801194f2efecde10ffa9e5fdf842077a57
# good: [bb2b1b234ba32cd0a0b357c14e1b55cfa78402d2] Merge pull request #311541 from r-ryantm/auto-update/sendme
git bisect good bb2b1b234ba32cd0a0b357c14e1b55cfa78402d2
# good: [fbc1b0eff7665ca43db5e98bab709bb1c7b4b541] Merge master into staging-next
git bisect good fbc1b0eff7665ca43db5e98bab709bb1c7b4b541
# skip: [07cdc1d32e3e7085c8511fbc407aa072ea8cb256] Merge pull request #333208 from dotlambda/python3Packages.beniget
git bisect skip 07cdc1d32e3e7085c8511fbc407aa072ea8cb256
# good: [842451244d71c20a13e3f24f90069871d73c009d] gdb: use meta.badPlatforms instead of assert (#338858)
git bisect good 842451244d71c20a13e3f24f90069871d73c009d
# good: [6ca18cee348cb50ba7ec1d77e7cac67ec9787cb8] zfs: Fix samba freeform settings and 2.1 build (#340165)
git bisect good 6ca18cee348cb50ba7ec1d77e7cac67ec9787cb8
# skip: [d10b2b7ea8faa99794503aa6ab421ad1ef84faf0] hydrus: 581 -> 588 (#328501)
git bisect skip d10b2b7ea8faa99794503aa6ab421ad1ef84faf0
# bad: [8e008bae7fd5be75cfc83dbec8f182f4fc8f94ff] python312Packages.mypy-boto3-s3control: 1.35.0 -> 1.35.12
git bisect bad 8e008bae7fd5be75cfc83dbec8f182f4fc8f94ff
# good: [36db91b3f8d5610dc4d45e595beb33ddc5f95fd1] thunderbird-115: 115.14.0 -> 115.15.0 (#340672)
git bisect good 36db91b3f8d5610dc4d45e595beb33ddc5f95fd1
# skip: [55fb76dc7e6ba219db53931bc7f8843832da8dc8] iosevka-bin: 30.3.3 -> 31.4.0 (#332636)
git bisect skip 55fb76dc7e6ba219db53931bc7f8843832da8dc8
# skip: [5fdd8a00891c88a41061c6594d73808ce96bb4f2] ungit: 1.5.26 -> 1.5.27 (#336573)
git bisect skip 5fdd8a00891c88a41061c6594d73808ce96bb4f2
# good: [1b449528cc56cbfa2be8383a847da43c4f281e4e] gitkraken: 10.2.0 -> 10.3.0
git bisect good 1b449528cc56cbfa2be8383a847da43c4f281e4e
# bad: [f3e8528ff71095c243faed4136da2966c3335ad0] Merge master into staging-next
git bisect bad f3e8528ff71095c243faed4136da2966c3335ad0
# good: [99f63237227b6fed1bb1a5f1cf6a461b64ae1c29] Vulkan 1.3.290 (#338599)
git bisect good 99f63237227b6fed1bb1a5f1cf6a461b64ae1c29
# good: [d09f96c13c412b23d98c1c6b55be9182bb5350d3] steam/fhsenv: use normal curl (#340710)
git bisect good d09f96c13c412b23d98c1c6b55be9182bb5350d3
# bad: [02a4d9a728489f78a8265d84c6fd6c1057f449d1] mesa: cherry-pick fixes for software rendering fallback
git bisect bad 02a4d9a728489f78a8265d84c6fd6c1057f449d1
# good: [f0a86e6d119877f47452a790157def800aef5a61] libunwind.meta.pkgConfigModules: init
git bisect good f0a86e6d119877f47452a790157def800aef5a61
# good: [23b4832da067cfaecc2e4ee4f7c88cd10fe8d056] Merge remote-tracking branch 'origin/master' into staging-next
git bisect good 23b4832da067cfaecc2e4ee4f7c88cd10fe8d056
# good: [563bb0fbc22b877da37672b4afdfa8928bbdd4a9] Merge master into staging-next
git bisect good 563bb0fbc22b877da37672b4afdfa8928bbdd4a9
# good: [b00b35b402fe99705c19cd091f0ec55b434c87d5] Merge master into staging-next
git bisect good b00b35b402fe99705c19cd091f0ec55b434c87d5
# good: [5ffe217cd9b3834cdd916720723d2a28be6cae50] mongodb-ce: remove custom `curl` override
git bisect good 5ffe217cd9b3834cdd916720723d2a28be6cae50
# good: [a946e0a47309325fe0db81f0691b038bdfd66b0f] mongodb-ce: remove custom `curl` override (#339615)
git bisect good a946e0a47309325fe0db81f0691b038bdfd66b0f
# first bad commit: [02a4d9a728489f78a8265d84c6fd6c1057f449d1] mesa: cherry-pick fixes for software rendering fallback
```

</details>

02a4d9a728489f78a8265d84c6fd6c1057f449d1 made the colour output of the terminal(?) in the icewm environment on x86_64 BGR instead of RGB. Disable the colour test for now.

![image](https://github.com/user-attachments/assets/ffd75704-8df0-4efc-9625-657ba946be88)

Under Lomiri the output is still correct, no matter the architecture.

![image](https://github.com/user-attachments/assets/76c89f4e-af9a-4f7e-9be0-35efb19a11fd)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
