### PR TITLE
nixos-facter: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ni/nixos-facter/package.nix
+++ b/pkgs/by-name/ni/nixos-facter/package.nix
@@ -66,5 +66,6 @@ buildGoModule rec {
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.brianmcgee ];
     mainProgram = "nixos-facter";
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ni/nixos-facter/package.nix
+++ b/pkgs/by-name/ni/nixos-facter/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  hwinfo,
+  libusb1,
+  gcc,
+  pkg-config,
+  util-linux,
+  pciutils,
+  stdenv,
+}:
+let
+  # We are waiting on some changes to be merged upstream: https://github.com/openSUSE/hwinfo/pulls
+  hwinfoOverride = hwinfo.overrideAttrs {
+    src = fetchFromGitHub {
+      owner = "numtide";
+      repo = "hwinfo";
+      rev = "42b014495b2de8735eeec950bc2d3afbefc65ec4";
+      hash = "sha256-OXbGF8M1r8GSgqeY4TqfjF+IO0SXXB/dX2jE2JtkPUk=";
+    };
+  };
+in
+buildGoModule rec {
+  pname = "nixos-facter";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "numtide";
+    repo = "nixos-facter";
+    rev = "v${version}";
+    hash = "sha256-TBSzIaOuD/IEObgwSx0UwFFAkqF1pAAWhDrNDtQShdY=";
+  };
+
+  vendorHash = "sha256-8yQO7topYvXL6bP0oSVN1rApiPjse4Q2bjFNM5jVl8c=";
+
+  CGO_ENABLED = 1;
+
+  buildInputs = [
+    libusb1
+    hwinfoOverride
+  ];
+
+  nativeBuildInputs = [
+    gcc
+    pkg-config
+  ];
+
+  runtimeInputs = [
+    libusb1
+    util-linux
+    pciutils
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X git.numtide.com/numtide/nixos-facter/build.Name=nixos-facter"
+    "-X git.numtide.com/numtide/nixos-facter/build.Version=v${version}"
+    "-X github.com/numtide/nixos-facter/pkg/build.System=${stdenv.hostPlatform.system}"
+  ];
+
+  meta = {
+    description = "Declarative hardware configuration for NixOS";
+    homepage = "https://github.com/numtide/nixos-facter";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.brianmcgee ];
+    mainProgram = "nixos-facter";
+  };
+}


### PR DESCRIPTION
## Description of changes

Initialises [nixos-facter](https://github.com/numtide/nixos-facter) at version `0.1.0`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
