### PR TITLE
python312Packages.great-tables: init at 0.11.0

### DIFF
--- a/pkgs/development/python-modules/great-tables/default.nix
+++ b/pkgs/development/python-modules/great-tables/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  pytestCheckHook,
+  pytest-cov-stub,
+  babel,
+  commonmark,
+  htmltools,
+  importlib-metadata,
+  importlib-resources,
+  ipykernel,
+  ipython,
+  numpy,
+  typing-extensions,
+  pandas,
+  polars,
+  pyarrow,
+  requests,
+  syrupy,
+}:
+
+buildPythonPackage rec {
+  pname = "great-tables";
+  version = "0.11.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "posit-dev";
+    repo = "great-tables";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ccS//fSFa6sytKv0izRxIdnHoNICr7P90Eo+v62RmVA=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    babel
+    commonmark
+    htmltools
+    importlib-metadata
+    importlib-resources
+    numpy
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "great_tables" ];
+
+  nativeCheckInputs = [
+    ipykernel
+    ipython
+    pandas
+    polars
+    pyarrow
+    pytestCheckHook
+    pytest-cov-stub
+    requests
+    syrupy
+  ];
+
+  disabledTestPaths = [
+    "tests/test_shiny.py" # requires `shiny` python package, not in Nixpkgs
+  ];
+
+  disabledTests = [
+    # require selenium with chrome driver:
+    "test_save_image_file"
+    "test_save_non_png"
+  ];
+
+  meta = {
+    description = "Library for rendering and formatting dataframes";
+    homepage = "https://github.com/posit-dev/great-tables";
+    changelog = "https://github.com/posit-dev/great-tables/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5358,6 +5358,8 @@ self: super: with self; {
 
   greatfet = callPackage ../development/python-modules/greatfet { };
 
+  great-tables = callPackage ../development/python-modules/great-tables { };
+
   greeclimate = callPackage ../development/python-modules/greeclimate { };
 
   green = callPackage ../development/python-modules/green { };


### PR DESCRIPTION
## Description of changes

Init python3Packages.great-tables, a [package for formatting and rendering Pandas and Polars dataframes into notebooks and HTML](https://github.com/posit-dev/great-tables).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
