### PR TITLE
nixos/{wg-quick,wireguard}: add AmneziaWG support

### DIFF
--- a/nixos/modules/services/networking/wg-quick.nix
+++ b/nixos/modules/services/networking/wg-quick.nix
@@ -11,6 +11,15 @@ let
   interfaceOpts = { ... }: {
     options = {
 
+      type = mkOption {
+        example = "amneziawg";
+        default = "wireguard";
+        type = types.enum ["wireguard" "amneziawg"];
+        description = ''
+          The type of the interface. Currently only "wireguard" and "amneziawg" are supported.
+        '';
+      };
+
       configFile = mkOption {
         example = "/secret/wg0.conf";
         default = null;
@@ -151,6 +160,22 @@ let
         description = "Peers linked to the interface.";
         type = with types; listOf (submodule peerOpts);
       };
+
+      extraOptions = mkOption {
+        type = with types; attrsOf (oneOf [ str int ]);
+        default = { };
+        example = {
+          Jc = 5;
+          Jmin = 10;
+          Jmax = 42;
+          S1 = 60;
+          S2 = 90;
+          H4 = 12345;
+        };
+        description = ''
+          Extra options to append to the interface section. Can be used to define AmneziaWG-specific options.
+        '';
+      };
     };
   };
 
@@ -227,7 +252,7 @@ let
 
   writeScriptFile = name: text: ((pkgs.writeShellScriptBin name text) + "/bin/${name}");
 
-  generatePrivateKeyScript = privateKeyFile: ''
+  generatePrivateKeyScript = privateKeyFile: wgBin: ''
     set -e
 
     # If the parent dir does not already exist, create it.
@@ -236,7 +261,7 @@ let
 
     if [ ! -f "${privateKeyFile}" ]; then
       # Write private key file with atomically-correct permissions.
-      (set -e; umask 077; wg genkey > "${privateKeyFile}")
+      (set -e; umask 077; ${wgBin} genkey > "${privateKeyFile}")
     fi
   '';
 
@@ -244,11 +269,19 @@ let
     assert assertMsg (values.configFile != null || ((values.privateKey != null) != (values.privateKeyFile != null))) "Only one of privateKey, configFile or privateKeyFile may be set";
     assert assertMsg (values.generatePrivateKeyFile == false || values.privateKeyFile != null) "generatePrivateKeyFile requires privateKeyFile to be set";
     let
-      generateKeyScriptFile = if values.generatePrivateKeyFile then writeScriptFile "generatePrivateKey.sh" (generatePrivateKeyScript values.privateKeyFile) else null;
+      wgBin = {
+        wireguard = "wg";
+        amneziawg = "awg";
+      }.${values.type};
+      generateKeyScriptFile =
+        if values.generatePrivateKeyFile then
+          writeScriptFile "generatePrivateKey.sh" (generatePrivateKeyScript values.privateKeyFile wgBin)
+        else
+          null;
       preUpFile = if values.preUp != "" then writeScriptFile "preUp.sh" values.preUp else null;
       postUp =
-            optional (values.privateKeyFile != null) "wg set ${name} private-key <(cat ${values.privateKeyFile})" ++
-            (concatMap (peer: optional (peer.presharedKeyFile != null) "wg set ${name} peer ${peer.publicKey} preshared-key <(cat ${peer.presharedKeyFile})") values.peers) ++
+            optional (values.privateKeyFile != null) "${wgBin} set ${name} private-key <(cat ${values.privateKeyFile})" ++
+            (concatMap (peer: optional (peer.presharedKeyFile != null) "${wgBin} set ${name} peer ${peer.publicKey} preshared-key <(cat ${peer.presharedKeyFile})") values.peers) ++
             optional (values.postUp != "") values.postUp;
       postUpFile = if postUp != [] then writeScriptFile "postUp.sh" (concatMapStringsSep "\n" (line: line) postUp) else null;
       preDownFile = if values.preDown != "" then writeScriptFile "preDown.sh" values.preDown else null;
@@ -276,6 +309,7 @@ let
         optionalString (postUpFile != null) "PostUp = ${postUpFile}\n" +
         optionalString (preDownFile != null) "PreDown = ${preDownFile}\n" +
         optionalString (postDownFile != null) "PostDown = ${postDownFile}\n" +
+        concatLines (mapAttrsToList (n: v: "${n} = ${toString v}") values.extraOptions) +
         concatMapStringsSep "\n" (peer:
           assert assertMsg (!((peer.presharedKeyFile != null) && (peer.presharedKey != null))) "Only one of presharedKey or presharedKeyFile may be set";
           "[Peer]\n" +
@@ -301,7 +335,10 @@ let
         wantedBy = optional values.autostart "multi-user.target";
         environment.DEVICE = name;
         path = [
-          pkgs.wireguard-tools
+          {
+            wireguard = pkgs.wireguard-tools;
+            amneziawg = pkgs.amneziawg-tools;
+          }.${values.type}
           config.networking.firewall.package   # iptables or nftables
           config.networking.resolvconf.package # openresolv or systemd
         ];
@@ -312,11 +349,11 @@ let
         };
 
         script = ''
-          ${optionalString (!config.boot.isContainer) "${pkgs.kmod}/bin/modprobe wireguard"}
+          ${optionalString (!config.boot.isContainer) "${pkgs.kmod}/bin/modprobe ${values.type}"}
           ${optionalString (values.configFile != null) ''
             cp ${values.configFile} ${configPath}
           ''}
-          wg-quick up ${configPath}
+          ${wgBin}-quick up ${configPath}
         '';
 
         serviceConfig = {
@@ -325,7 +362,7 @@ let
         };
 
         preStop = ''
-          wg-quick down ${configPath}
+          ${wgBin}-quick down ${configPath}
         '';
       };
 in {
@@ -357,8 +394,12 @@ in {
   ###### implementation
 
   config = mkIf (cfg.interfaces != {}) {
-    boot.extraModulePackages = optional (versionOlder kernel.kernel.version "5.6") kernel.wireguard;
-    environment.systemPackages = [ pkgs.wireguard-tools ];
+    boot.extraModulePackages =
+      optional (any (x: x.type == "wireguard") (attrValues cfg.interfaces) && (versionOlder kernel.kernel.version "5.6")) kernel.wireguard
+      ++ optional (any (x: x.type == "amneziawg") (attrValues cfg.interfaces)) kernel.amneziawg;
+    environment.systemPackages =
+      optional (any (x: x.type == "wireguard") (attrValues cfg.interfaces)) pkgs.wireguard-tools
+      ++ optional (any (x: x.type == "amneziawg") (attrValues cfg.interfaces)) pkgs.amneziawg-tools;
     systemd.services = mapAttrs' generateUnit cfg.interfaces;
 
     # Prevent networkd from clearing the rules set by wg-quick when restarted (e.g. when waking up from suspend).

--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -186,6 +186,10 @@ in
             assertion = interface.interfaceNamespace == null;
             message = "networking.wireguard.interfaces.${name}.interfaceNamespace cannot be used with networkd.";
           }
+          {
+            assertion = interface.type == "wireguard";
+            message = "networking.wireguard.interfaces.${name}.type value must be \"wireguard\" when used with networkd.";
+          }
         ]
         ++ flip concatMap interface.ips (ip: [
           # IP assertions

--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -15,6 +15,15 @@ let
 
     options = {
 
+      type = mkOption {
+        example = "amneziawg";
+        default = "wireguard";
+        type = types.enum ["wireguard" "amneziawg"];
+        description = ''
+          The type of the interface. Currently only "wireguard" and "amneziawg" are supported.
+        '';
+      };
+
       ips = mkOption {
         example = [ "192.168.2.1/24" ];
         default = [];
@@ -204,6 +213,22 @@ let
           :::
         '';
       };
+
+      extraOptions = mkOption {
+        type = with types; attrsOf (oneOf [ str int ]);
+        default = { };
+        example = {
+          Jc = 5;
+          Jmin = 10;
+          Jmax = 42;
+          S1 = 60;
+          S2 = 90;
+          H4 = 12345;
+        };
+        description = ''
+          Extra options to append to the interface section. Can be used to define AmneziaWG-specific options.
+        '';
+      };
     };
 
   };
@@ -342,6 +367,16 @@ let
 
   };
 
+  wgBins = {
+    wireguard = "wg";
+    amneziawg = "awg";
+  };
+
+  wgPackages = {
+    wireguard = pkgs.wireguard-tools;
+    amneziawg = pkgs.amneziawg-tools;
+  };
+
   generateKeyServiceUnit = name: values:
     assert values.generatePrivateKeyFile;
     nameValuePair "wireguard-${name}-key"
@@ -350,7 +385,7 @@ let
         wantedBy = [ "wireguard-${name}.service" ];
         requiredBy = [ "wireguard-${name}.service" ];
         before = [ "wireguard-${name}.service" ];
-        path = with pkgs; [ wireguard-tools ];
+        path = [ wgPackages.${values.type} ];
 
         serviceConfig = {
           Type = "oneshot";
@@ -366,7 +401,7 @@ let
 
           if [ ! -f "${values.privateKeyFile}" ]; then
             # Write private key file with atomically-correct permissions.
-            (set -e; umask 077; wg genkey > "${values.privateKeyFile}")
+            (set -e; umask 077; ${wgBins.${values.type}} genkey > "${values.privateKeyFile}")
           fi
         '';
       };
@@ -391,7 +426,7 @@ let
       src = interfaceCfg.socketNamespace;
       dst = interfaceCfg.interfaceNamespace;
       ip = nsWrap "ip" src dst;
-      wg = nsWrap "wg" src dst;
+      wg = nsWrap wgBins.${interfaceCfg.type} src dst;
       dynamicEndpointRefreshSeconds = dynamicRefreshSeconds interfaceCfg peer;
       dynamicRefreshEnabled = dynamicEndpointRefreshSeconds != 0;
       # We generate a different name (a `-refresh` suffix) when `dynamicEndpointRefreshSeconds`
@@ -408,7 +443,7 @@ let
         wantedBy = [ "wireguard-${interfaceName}.service" ];
         environment.DEVICE = interfaceName;
         environment.WG_ENDPOINT_RESOLUTION_RETRIES = "infinity";
-        path = with pkgs; [ iproute2 wireguard-tools ];
+        path = with pkgs; [ iproute2 wgPackages.${interfaceCfg.type} ];
 
         serviceConfig =
           if !dynamicRefreshEnabled
@@ -497,7 +532,7 @@ let
         dst = values.interfaceNamespace;
         ipPreMove  = nsWrap "ip" src null;
         ipPostMove = nsWrap "ip" src dst;
-        wg = nsWrap "wg" src dst;
+        wg = nsWrap wgBins.${values.type} src dst;
         ns = if dst == "init" then "1" else dst;
 
     in
@@ -508,7 +543,7 @@ let
         wants = [ "network.target" ];
         before = [ "network.target" ];
         environment.DEVICE = name;
-        path = with pkgs; [ kmod iproute2 wireguard-tools ];
+        path = with pkgs; [ kmod iproute2 wgPackages.${values.type} ];
 
         serviceConfig = {
           Type = "oneshot";
@@ -516,10 +551,10 @@ let
         };
 
         script = concatStringsSep "\n" (
-          optional (!config.boot.isContainer) "modprobe wireguard || true"
+          optional (!config.boot.isContainer) "modprobe ${values.type} || true"
           ++ [
             values.preSetup
-            ''${ipPreMove} link add dev "${name}" type wireguard''
+            ''${ipPreMove} link add dev "${name}" type ${values.type}''
           ]
           ++ optional (values.interfaceNamespace != null && values.interfaceNamespace != values.socketNamespace) ''${ipPreMove} link set "${name}" netns "${ns}"''
           ++ optional (values.mtu != null) ''${ipPostMove} link set "${name}" mtu ${toString values.mtu}''
@@ -531,6 +566,7 @@ let
             [ ''${wg} set "${name}" private-key "${privKey}"'' ]
             ++ optional (values.listenPort != null) ''listen-port "${toString values.listenPort}"''
             ++ optional (values.fwMark != null) ''fwmark "${values.fwMark}"''
+            ++ mapAttrsToList (k: v: ''${toLower k} "${toString v}"'') values.extraOptions
             ))
             ''${ipPostMove} link set up dev "${name}"''
             values.postSetup
@@ -550,6 +586,9 @@ let
       ns = last nsList;
     in
       if (length nsList > 0 && ns != "init") then ''ip netns exec "${ns}" "${cmd}"'' else cmd;
+
+  usingWg = any (x: x.type == "wireguard") (attrValues cfg.interfaces);
+  usingAwg = any (x: x.type == "amneziawg") (attrValues cfg.interfaces);
 in
 
 {
@@ -624,9 +663,11 @@ in
           message = "networking.wireguard.interfaces.${interfaceName} peer «${peer.publicKey}» has both presharedKey and presharedKeyFile set, but only one can be used.";
         }) all_peers;
 
-    boot.extraModulePackages = optional (versionOlder kernel.kernel.version "5.6") kernel.wireguard;
-    boot.kernelModules = [ "wireguard" ];
-    environment.systemPackages = [ pkgs.wireguard-tools ];
+    boot.extraModulePackages =
+      optional (usingWg && (versionOlder kernel.kernel.version "5.6")) kernel.wireguard
+      ++ optional usingAwg kernel.amneziawg;
+    boot.kernelModules = optional usingWg "wireguard" ++ optional usingAwg "amneziawg";
+    environment.systemPackages = optional usingWg pkgs.wireguard-tools ++ optional usingAwg pkgs.amneziawg-tools;
 
     systemd.services = mkIf (!cfg.useNetworkd) (
       (mapAttrs' generateInterfaceUnit cfg.interfaces)

--- a/nixos/tests/wireguard/amneziawg-quick.nix
+++ b/nixos/tests/wireguard/amneziawg-quick.nix
@@ -1,0 +1,125 @@
+import ../make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    kernelPackages ? null,
+    nftables ? false,
+    ...
+  }:
+  let
+    wg-snakeoil-keys = import ./snakeoil-keys.nix;
+    peer = import ./make-peer.nix { inherit lib; };
+    commonConfig = {
+      boot.kernelPackages = lib.mkIf (kernelPackages != null) kernelPackages;
+      networking.nftables.enable = nftables;
+      # Make sure iptables doesn't work with nftables enabled
+      boot.blacklistedKernelModules = lib.mkIf nftables [ "nft_compat" ];
+    };
+    extraOptions = {
+      Jc = 5;
+      Jmin = 10;
+      Jmax = 42;
+      S1 = 60;
+      S2 = 90;
+    };
+  in
+  {
+    name = "amneziawg-quick";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [
+        averyanalex
+        azahi
+      ];
+    };
+
+    nodes = {
+      peer0 = peer {
+        ip4 = "192.168.0.1";
+        ip6 = "fd00::1";
+        extraConfig = lib.mkMerge [
+          commonConfig
+          {
+            networking.firewall.allowedUDPPorts = [ 23542 ];
+            networking.wg-quick.interfaces.wg0 = {
+              type = "amneziawg";
+
+              address = [
+                "10.23.42.1/32"
+                "fc00::1/128"
+              ];
+              listenPort = 23542;
+
+              inherit (wg-snakeoil-keys.peer0) privateKey;
+
+              peers = lib.singleton {
+                allowedIPs = [
+                  "10.23.42.2/32"
+                  "fc00::2/128"
+                ];
+
+                inherit (wg-snakeoil-keys.peer1) publicKey;
+              };
+
+              dns = [
+                "10.23.42.2"
+                "fc00::2"
+                "wg0"
+              ];
+
+              inherit extraOptions;
+            };
+          }
+        ];
+      };
+
+      peer1 = peer {
+        ip4 = "192.168.0.2";
+        ip6 = "fd00::2";
+        extraConfig = lib.mkMerge [
+          commonConfig
+          {
+            networking.useNetworkd = true;
+            networking.wg-quick.interfaces.wg0 = {
+              type = "amneziawg";
+
+              address = [
+                "10.23.42.2/32"
+                "fc00::2/128"
+              ];
+              inherit (wg-snakeoil-keys.peer1) privateKey;
+
+              peers = lib.singleton {
+                allowedIPs = [
+                  "0.0.0.0/0"
+                  "::/0"
+                ];
+                endpoint = "192.168.0.1:23542";
+                persistentKeepalive = 25;
+
+                inherit (wg-snakeoil-keys.peer0) publicKey;
+              };
+
+              dns = [
+                "10.23.42.1"
+                "fc00::1"
+                "wg0"
+              ];
+
+              inherit extraOptions;
+            };
+          }
+        ];
+      };
+    };
+
+    testScript = ''
+      start_all()
+
+      peer0.wait_for_unit("wg-quick-wg0.service")
+      peer1.wait_for_unit("wg-quick-wg0.service")
+
+      peer1.succeed("ping -c5 fc00::1")
+      peer1.succeed("ping -c5 10.23.42.1")
+    '';
+  }
+)

--- a/nixos/tests/wireguard/amneziawg.nix
+++ b/nixos/tests/wireguard/amneziawg.nix
@@ -1,0 +1,111 @@
+import ../make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    kernelPackages ? null,
+    ...
+  }:
+  let
+    wg-snakeoil-keys = import ./snakeoil-keys.nix;
+    peer = (import ./make-peer.nix) { inherit lib; };
+    extraOptions = {
+      Jc = 5;
+      Jmin = 10;
+      Jmax = 42;
+      S1 = 60;
+      S2 = 90;
+    };
+  in
+  {
+    name = "amneziawg";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [
+        averyanalex
+        azahi
+      ];
+    };
+
+    nodes = {
+      peer0 = peer {
+        ip4 = "192.168.0.1";
+        ip6 = "fd00::1";
+        extraConfig = {
+          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+          networking.firewall.allowedUDPPorts = [ 23542 ];
+          networking.wireguard.interfaces.wg0 = {
+            type = "amneziawg";
+            ips = [
+              "10.23.42.1/32"
+              "fc00::1/128"
+            ];
+            listenPort = 23542;
+
+            inherit (wg-snakeoil-keys.peer0) privateKey;
+
+            peers = lib.singleton {
+              allowedIPs = [
+                "10.23.42.2/32"
+                "fc00::2/128"
+              ];
+
+              inherit (wg-snakeoil-keys.peer1) publicKey;
+            };
+
+            inherit extraOptions;
+          };
+        };
+      };
+
+      peer1 = peer {
+        ip4 = "192.168.0.2";
+        ip6 = "fd00::2";
+        extraConfig = {
+          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+          networking.wireguard.interfaces.wg0 = {
+            type = "amneziawg";
+            ips = [
+              "10.23.42.2/32"
+              "fc00::2/128"
+            ];
+            listenPort = 23542;
+            allowedIPsAsRoutes = false;
+
+            inherit (wg-snakeoil-keys.peer1) privateKey;
+
+            peers = lib.singleton {
+              allowedIPs = [
+                "0.0.0.0/0"
+                "::/0"
+              ];
+              endpoint = "192.168.0.1:23542";
+              persistentKeepalive = 25;
+
+              inherit (wg-snakeoil-keys.peer0) publicKey;
+            };
+
+            postSetup =
+              let
+                inherit (pkgs) iproute2;
+              in
+              ''
+                ${iproute2}/bin/ip route replace 10.23.42.1/32 dev wg0
+                ${iproute2}/bin/ip route replace fc00::1/128 dev wg0
+              '';
+
+            inherit extraOptions;
+          };
+        };
+      };
+    };
+
+    testScript = ''
+      start_all()
+
+      peer0.wait_for_unit("wireguard-wg0.service")
+      peer1.wait_for_unit("wireguard-wg0.service")
+
+      peer1.succeed("ping -c5 fc00::1")
+      peer1.succeed("ping -c5 10.23.42.1")
+    '';
+  }
+)

--- a/nixos/tests/wireguard/default.nix
+++ b/nixos/tests/wireguard/default.nix
@@ -14,6 +14,7 @@ let
     networkd = callTest ./networkd.nix;
     wg-quick = callTest ./wg-quick.nix;
     wg-quick-nftables = args: callTest ./wg-quick.nix ({ nftables = true; } // args);
+    amneziawg-quick = callTest ./amneziawg-quick.nix;
     generated = callTest ./generated.nix;
     dynamic-refresh = callTest ./dynamic-refresh.nix;
     dynamic-refresh-networkd = args: callTest ./dynamic-refresh.nix ({ useNetworkd = true; } // args);

--- a/nixos/tests/wireguard/default.nix
+++ b/nixos/tests/wireguard/default.nix
@@ -10,6 +10,7 @@ with pkgs.lib;
 let
   tests = let callTest = p: args: import p ({ inherit system pkgs; } // args); in {
     basic = callTest ./basic.nix;
+    amneziawg = callTest ./amneziawg.nix;
     namespaces = callTest ./namespaces.nix;
     networkd = callTest ./networkd.nix;
     wg-quick = callTest ./wg-quick.nix;


### PR DESCRIPTION
## Description of changes

Censorship-resistant VPN based on wireguard.

https://amnezia.org/

Depends on #331598 and #331582.
Closes #360866.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
