### PR TITLE
canokey-usbip: init at unstable-2024-03-11

### DIFF
--- a/pkgs/by-name/ca/canokey-usbip/package.nix
+++ b/pkgs/by-name/ca/canokey-usbip/package.nix
@@ -1,0 +1,47 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  python3,
+  stdenv,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "canokey-usbip";
+  version = "0-unstable-2024-03-11";
+
+  src = fetchFromGitHub {
+    owner = "canokeys";
+    repo = "canokey-usbip";
+    rev = "cc7087277096f185401b05143f9a028711d43557";
+    hash = "sha256-+7sGW2eGelRQ2TDvgUITbPdcsXo7Pp6Pp+r3RmyQAZM=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    sed -i 's/COMMAND git describe.*\(>>.*\)/COMMAND echo ${finalAttrs.src.rev} \1/' canokey-core/CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  postInstall = ''
+    install -D --target-directory=$out/bin canokey-usbip
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "CanoKey USB/IP Virt Card";
+    homepage = "https://github.com/canokeys/canokey-usbip";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jmbaur ];
+    mainProgram = "canokey-usbip";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

canokey-usbip is a program that implements a virtual FIDO2 token over USB IP. Canokey has special integration with qemu and this tool can be used for testing FIDO2 tokens in virtualized environments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
