### PR TITLE
nixos/windmill: add database.url option and defaults

### DIFF
--- a/nixos/modules/services/web-apps/windmill.nix
+++ b/nixos/modules/services/web-apps/windmill.nix
@@ -34,13 +34,24 @@ in
         description = "Database user.";
       };
 
+      url = lib.mkOption {
+        type = lib.types.str;
+        default = "postgres://${config.services.windmill.database.name}?host=/var/run/postgresql";
+        defaultText = lib.literalExpression ''
+          "postgres://\$\{config.services.windmill.database.name}?host=/var/run/postgresql";
+        '';
+        description = "Database url. Note that any secret here would be world-readable. Use `services.windmill.database.urlPath` unstead to include secrets in the url.";
+      };
+
       urlPath = lib.mkOption {
-        type = lib.types.path;
+        type = lib.types.nullOr lib.types.path;
         description = ''
           Path to the file containing the database url windmill should connect to. This is not deducted from database user and name as it might contain a secret
         '';
+        default = null;
         example = "config.age.secrets.DATABASE_URL_FILE.path";
       };
+
       createLocally = lib.mkOption {
         type = lib.types.bool;
         default = true;
@@ -50,6 +61,10 @@ in
 
     baseUrl = lib.mkOption {
       type = lib.types.str;
+      default = "https://localhost:${toString config.services.windmill.serverPort}";
+      defaultText = lib.literalExpression ''
+        "https://localhost:\$\{toString config.services.windmill.serverPort}";
+      '';
       description = ''
         The base url that windmill will be served on.
       '';
@@ -79,6 +94,7 @@ in
 
    systemd.services =
     let
+      useUrlPath = (cfg.database.urlPath != null);
       serviceConfig = {
         DynamicUser = true;
         # using the same user to simplify db connection
@@ -86,9 +102,15 @@ in
         ExecStart = "${pkgs.windmill}/bin/windmill";
 
         Restart = "always";
+      } // lib.optionalAttrs useUrlPath {
         LoadCredential = [
           "DATABASE_URL_FILE:${cfg.database.urlPath}"
         ];
+      };
+      db_url_envs = lib.optionalAttrs useUrlPath {
+        DATABASE_URL_FILE = "%d/DATABASE_URL_FILE";
+      } // lib.optionalAttrs (!useUrlPath) {
+        DATABASE_URL = cfg.database.url;
       };
     in
     {
@@ -132,12 +154,11 @@ EOF
         serviceConfig = serviceConfig // { StateDirectory = "windmill";};
 
         environment = {
-          DATABASE_URL_FILE = "%d/DATABASE_URL_FILE";
           PORT = builtins.toString cfg.serverPort;
           WM_BASE_URL = cfg.baseUrl;
           RUST_LOG = cfg.logLevel;
           MODE = "server";
-        };
+        } // db_url_envs;
       };
 
      windmill-worker = {
@@ -148,13 +169,12 @@ EOF
         serviceConfig = serviceConfig // { StateDirectory = "windmill-worker";};
 
         environment = {
-          DATABASE_URL_FILE = "%d/DATABASE_URL_FILE";
           WM_BASE_URL = cfg.baseUrl;
           RUST_LOG = cfg.logLevel;
           MODE = "worker";
           WORKER_GROUP = "default";
           KEEP_JOB_DIR = "false";
-        };
+        } // db_url_envs;
       };
 
      windmill-worker-native = {
@@ -165,12 +185,11 @@ EOF
         serviceConfig = serviceConfig // { StateDirectory = "windmill-worker-native";};
 
         environment = {
-          DATABASE_URL_FILE = "%d/DATABASE_URL_FILE";
           WM_BASE_URL = cfg.baseUrl;
           RUST_LOG = cfg.logLevel;
           MODE = "worker";
           WORKER_GROUP = "native";
-        };
+        } // db_url_envs;
       };
     };
   };


### PR DESCRIPTION
## Description of changes

The goal is to make the windmill module work with `services.windmill.enable = true`, without a need for additional configuration if it's not necessary:

1. Set default baseUrl to localhost:port.
2. Add a database.url option that can be used if there's no need for secrets, and set default to the `/var/run/postgresql` unix socket the postgres module opens by default (by default, it doesn't need credentials).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Tag maintainers

@happysalada (dit7ya marked as busy, so not tagging; should I?)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc