### PR TITLE
polyphone: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/applications/audio/polyphone/default.nix
+++ b/pkgs/applications/audio/polyphone/default.nix
@@ -1,46 +1,62 @@
-{ stdenv, lib, mkDerivation, fetchFromGitHub, qmake, pkg-config, alsa-lib, libjack2, portaudio, libogg, flac, libvorbis, rtmidi, qtsvg, qttools }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  qmake,
+  qttools,
+  wrapQtAppsHook,
+  alsa-lib,
+  flac,
+  libjack2,
+  libogg,
+  libvorbis,
+  qtsvg,
+  qtwayland,
+  rtmidi,
+}:
 
-mkDerivation rec {
-  version = "2.3.0";
+stdenv.mkDerivation rec {
+  version = "2.4.0";
   pname = "polyphone";
 
   src = fetchFromGitHub {
     owner = "davy7125";
     repo = "polyphone";
     rev = version;
-    sha256 = "09habv51pw71wrb39shqi80i2w39dx5a39klzswsald5j9sia0ir";
+    hash = "sha256-cPHLmqsS4ReqOCcsgOf77V/ShIkk7chGoJ6bU4W5ejs=";
   };
+
+  nativeBuildInputs = [
+    pkg-config
+    qmake
+    qttools
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     alsa-lib
-    libjack2
-    portaudio
-    libogg
     flac
+    libjack2
+    libogg
     libvorbis
-    rtmidi
     qtsvg
+    qtwayland
+    rtmidi
   ];
-
-  nativeBuildInputs = [ qmake qttools pkg-config ];
 
   preConfigure = ''
     cd ./sources/
   '';
 
-  installPhase = ''
-    runHook preInstall
-    install -d $out/bin
-    install -m755 bin/polyphone $out/bin/
-
-    install -Dm444 ./contrib/com.polyphone_soundfonts.polyphone.desktop -t $out/share/applications/
-    install -Dm444 ./contrib/polyphone.svg -t $out/share/icons/hicolor/scalable/apps/
-    runHook postInstall
+  postConfigure = ''
+    # Work around https://github.com/NixOS/nixpkgs/issues/214765
+    substituteInPlace Makefile \
+      --replace-fail "$(dirname $QMAKE)/lrelease" "${lib.getBin qttools}/bin/lrelease"
   '';
 
   qmakeFlags = [
     "DEFINES+=USE_LOCAL_STK"
-    "DEFINES+=USE_LOCAL_QCUSTOMPLOT"
   ];
 
   meta = with lib; {
@@ -49,7 +65,10 @@ mkDerivation rec {
     mainProgram = "polyphone";
     homepage = "https://www.polyphone-soundfonts.com/";
     license = licenses.gpl3;
-    maintainers = [ maintainers.maxdamantus ];
+    maintainers = with maintainers; [
+      maxdamantus
+      orivej
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32094,7 +32094,7 @@ with pkgs;
 
   yambar-hyprland-wses = callPackage ../applications/misc/yambar-hyprland-wses { };
 
-  polyphone = libsForQt5.callPackage ../applications/audio/polyphone { };
+  polyphone = qt6.callPackage ../applications/audio/polyphone { };
 
   psi-notify = callPackage ../applications/misc/psi-notify { };
 


### PR DESCRIPTION
## Description of changes

Regular update + switch to Qt6 (with a workaround for #214765)
https://github.com/davy7125/polyphone/releases/tag/2.4.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
