### PR TITLE
unpackPhase: fail when tar extract would overwrite files

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -4,18 +4,10 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "tzdata";
   version = "2024a";
 
-  srcs = [
-    (fetchurl {
-      url = "https://data.iana.org/time-zones/releases/tzdata${finalAttrs.version}.tar.gz";
-      hash = "sha256-DQQ0RZrL0gWaeo2h8zBKhKhlkfbtacYkj/+lArbt/+M=";
-    })
-    (fetchurl {
-      url = "https://data.iana.org/time-zones/releases/tzcode${finalAttrs.version}.tar.gz";
-      hash = "sha256-gAcolK3/WkWPHRQ+FuTKHYsqEiycU5naSCy2jLpqH/g=";
-    })
-  ];
-
-  sourceRoot = ".";
+  src = (fetchurl {
+    url = "https://data.iana.org/time-zones/releases/tzdb-${finalAttrs.version}.tar.lz";
+    hash = "sha256-URr2tGf0Cx7JrDaE0XAXk69HDz4p3fuXuCvkOOhgGno=";
+  });
 
   patches = lib.optionals stdenv.hostPlatform.isWindows [
     ./0001-Add-exe-extension-for-MS-Windows-binaries.patch

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1219,12 +1219,16 @@ _defaultUnpack() {
                 # disregard the error code from the xz invocation. Otherwise,
                 # it can happen that tar exits earlier, causing xz to fail
                 # from a SIGPIPE.
-                (XZ_OPT="--threads=$NIX_BUILD_CORES" xz -d < "$fn"; true) | tar xf - --mode=+w --warning=no-timestamp
+                #
+                # keep-old-files will cause tar to fail if it would overwrite files with the same name but
+                # different cases on case insensitive filesystems (darwin) preventing cross-platform
+                # package hash mismatches
+                (XZ_OPT="--threads=$NIX_BUILD_CORES" xz -d < "$fn"; true) | tar xf - --keep-old-files --mode=+w --warning=no-timestamp
                 ;;
             *.tar | *.tar.* | *.tgz | *.tbz2 | *.tbz)
                 # GNU tar can automatically select the decompression method
                 # (info "(tar) gzip").
-                tar xf "$fn" --mode=+w --warning=no-timestamp
+                tar xf "$fn" --keep-old-files --mode=+w --warning=no-timestamp
                 ;;
             *)
                 return 1

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1209,7 +1209,7 @@ _defaultUnpack() {
     else
 
         case "$fn" in
-            *.tar.xz | *.tar.lzma | *.txz)
+            *.tar.xz | *.tar.lz | *.tar.lzma | *.txz)
                 # Don't rely on tar knowing about .xz.
                 # Additionally, we have multiple different xz binaries with different feature sets in different
                 # stages. The XZ_OPT env var is only used by the full "XZ utils" implementation, which supports


### PR DESCRIPTION
## Description of changes

In `unpackPhase` when extracting with `tar` pass `--keep-old-files` which will cause tar to fail when it would normally silently overwrite files of the same name but with differing case on case insensitive filesystems (darwin).

This prevents errors when building packages such as https://github.com/NixOS/nixpkgs/pull/341455 .  Which causes packages to have differing hashes.
 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
