### PR TITLE
amazon-cloudwatch-agent: init at 1.300044.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -126,6 +126,8 @@
 
 - [ToDesk](https://www.todesk.com/linux.html), a remote desktop applicaton. Available as [services.todesk.enable](#opt-services.todesk.enable).
 
+- [Amazon CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Agent-commandline-fleet.html#install-CloudWatch-Agent-iam_user-first), an agent for collecting metrics and logs and sending them to *Amazon CloudWatch*.
+
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}
 
 - `transmission` package has been aliased with a `trace` warning to `transmission_3`. Since [Transmission 4 has been released last year](https://github.com/transmission/transmission/releases/tag/4.0.0), and Transmission 3 will eventually go away, it was decided perform this warning alias to make people aware of the new version. The `services.transmission.package` defaults to `transmission_3` as well because the upgrade can cause data loss in certain specific usage patterns (examples: [#5153](https://github.com/transmission/transmission/issues/5153), [#6796](https://github.com/transmission/transmission/issues/6796)). Please make sure to back up to your data directory per your usage:

--- a/nixos/modules/services/monitoring/amazon-cloudwatch-agent.nix
+++ b/nixos/modules/services/monitoring/amazon-cloudwatch-agent.nix
@@ -1,0 +1,147 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    attrsets
+    mkEnableOption
+    mkOption
+    optionalAttrs
+    types
+    ;
+
+  cfg = config.services.amazon-cloudwatch-agent;
+
+  assembledConfig = attrsets.mergeAttrsList [
+    (optionalAttrs (cfg.configAgent != null) { agent = cfg.configAgent; })
+    (optionalAttrs (cfg.configMetrics != null) { metrics = cfg.configMetrics; })
+    (optionalAttrs (cfg.configLogs != null) { logs = cfg.configLogs; })
+    (optionalAttrs (cfg.configTraces != null) { traces = cfg.configTraces; })
+  ];
+
+  agentConfigFile = (pkgs.formats.json { }).generate "config.json" assembledConfig;
+
+  awsCredsFile = (pkgs.formats.ini { }).generate "aws-credentials" {
+    AmazonCloudWatchAgent = cfg.configAwsCreds;
+  };
+
+  commonConfigTomlFile = (pkgs.formats.toml { }).generate "common-config.toml" {
+    credentials = {
+      shared_credential_file = "${awsCredsFile}";
+      shared_credential_profile = "AmazonCloudWatchAgent";
+    };
+  };
+in
+{
+  options = {
+    services.amazon-cloudwatch-agent = {
+      package = lib.mkPackageOption pkgs "amazon-cloudwatch-agent" { };
+
+      enable = mkEnableOption ''
+        Amazon CloudWatch Amazon
+      '';
+
+      configAwsCreds = mkOption {
+        type = types.submodule {
+          freeformType = with types; attrsOf str;
+        };
+        description = "AWS credentials for CloudWatch Agent (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Agent-on-premise.html)";
+        default = {
+          aws_access_key_id = "FILL-IN";
+          aws_secret_access_key = "FILL-IN";
+          region = "FILL-IN";
+        };
+      };
+
+      configAgent = mkOption {
+        type = types.submodule {
+          freeformType = types.oneOf [
+            (pkgs.formats.json { }).type
+            null
+          ];
+        };
+        description = "Agent section of the CloudWatch Agent configuration (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html)";
+        default = null;
+      };
+
+      configMetrics = mkOption {
+        type = types.submodule {
+          freeformType = types.oneOf [
+            (pkgs.formats.json { }).type
+            null
+          ];
+        };
+        description = "Metrics section of the CloudWatch Agent configuration (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html)";
+        default = null;
+      };
+
+      configLogs = mkOption {
+        type = types.nullOr (
+          types.submodule {
+            freeformType = (pkgs.formats.json { }).type;
+          }
+        );
+        description = "Logs section of the CloudWatch Agent configuration (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html)";
+        default = null; # not empty object because, if we specify the key, we must also specify certain child attributes.
+      };
+
+      configTraces = mkOption {
+        type = types.nullOr (
+          types.submodule {
+            freeformType = (pkgs.formats.json { }).type;
+          }
+        );
+        description = "Traces section of the CloudWatch Agent configuration (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html)";
+        default = null; # not empty object because, if we specify the key, we must also specify certain child attributes.
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ]; # FIXME: what does this do?
+
+    users.users.cwagent = {
+      description = "amazon-cloudwatch-agent daemon user";
+      isSystemUser = true;
+      group = "cwagent";
+    };
+
+    users.groups.cwagent = { };
+
+    systemd.tmpfiles.rules = [
+      "D /opt/aws/amazon-cloudwatch-agent/etc 750 cwagent cwagent" # for symlinks made by this file, and where the agent wants to write the toml config
+      "D /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d 750 cwagent cwagent" # where the agent wants to write to
+      "D /opt/aws/amazon-cloudwatch-agent/logs 750 cwagent cwagent"
+      "D /opt/aws/amazon-cloudwatch-agent/var 750 cwagent cwagent"
+      "L+ /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml - - - - ${commonConfigTomlFile}"
+      "L+ /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json - - - - ${agentConfigFile}"
+      "L+ /opt/aws/amazon-cloudwatch-agent/bin - - - - ${cfg.package}/bin"
+    ];
+
+    systemd.services.amazon-cloudwatch-agent = {
+      enable = true;
+      description = "Amazon CloudWatch Agent";
+      documentation = [
+        "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html"
+      ];
+
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        # systemd runs the agent as root, then the agent will switch to the dedicated user
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = 60;
+        ExecStart = "${cfg.package}/bin/start-amazon-cloudwatch-agent";
+        KillMode = "process";
+        # According to systemd documentation, the simple type does not need this, but we have it anyway, so can't hurt to specify it.
+        PIDFile = "/opt/aws/amazon-cloudwatch-agent/var/amazon-cloudwatch-agent.pid";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
+++ b/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
@@ -1,0 +1,83 @@
+{
+  config,
+  lib,
+  buildGoModule,
+  fetchgit,
+  pkgs,
+}:
+
+buildGoModule rec {
+  pname = "amazon-cloudwatch-agent";
+  version = "1.300044.0";
+
+  src = fetchgit {
+    url = "https://github.com/aws/amazon-cloudwatch-agent.git";
+    rev = "v${version}";
+    sha256 = "sha256-sG0dvmTagpob23/5L2QB32bwFmmRygEQKrAmgAWgEOE=";
+  };
+
+  vendorHash = "sha256-a1xjnVXvSinYGqjFOmlCxJwWc9sc9OAfSuAMRCAlxCM=";
+
+  meta = with lib; {
+    description = "Amazon CloudWatch Agent";
+    homepage = "https://github.com/aws/amazon-cloudwatch-agent";
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ pmw ];
+    # The agent supports MacOS and Windows, but it's not currently working for me on macOS:
+    # > cannot execute binary file: Exec format error
+    # so I am declaring support only for Linux where I tested it personally.
+    platforms = with lib.platforms; linux;
+  };
+
+  doCheck = false;
+
+  patchPhase = ''
+
+    echo "" >> Makefile
+    echo "amazon-cloudwatch-agent-nixos-linux: copy-version-file" >> Makefile
+    echo -e "\t@echo Building CloudWatchAgent for Linux,Debian with ARM64 and AMD64" >> Makefile
+    echo -e "\t\$(LINUX_AMD64_BUILD)/config-downloader github.com/aws/amazon-cloudwatch-agent/cmd/config-downloader" >> Makefile
+    echo -e "\t\$(LINUX_AMD64_BUILD)/config-translator github.com/aws/amazon-cloudwatch-agent/cmd/config-translator" >> Makefile
+    echo -e "\t\$(LINUX_AMD64_BUILD)/amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent" >> Makefile
+    echo -e "\t\$(LINUX_AMD64_BUILD)/start-amazon-cloudwatch-agent github.com/aws/amazon-cloudwatch-agent/cmd/start-amazon-cloudwatch-agent" >> Makefile
+    echo -e "\t\$(LINUX_AMD64_BUILD)/amazon-cloudwatch-agent-config-wizard github.com/aws/amazon-cloudwatch-agent/cmd/amazon-cloudwatch-agent-config-wizard" >> Makefile
+
+  '';
+
+  buildPhase = ''
+
+    export FAKEBUILD="false"
+
+    if [ $FAKEBUILD == "true" ]
+    then
+      mkdir -p build/bin/linux_amd64
+      touch build/bin/linux_amd64/fakebin
+    else
+      make amazon-cloudwatch-agent-nixos-linux
+    fi
+
+  '';
+
+  installPhase = ''
+
+    runHook preInstall
+
+    mkdir -p $out/etc
+
+    cp -av build/bin/linux_amd64 $out/bin
+
+    cp LICENSE $out/
+    cp NOTICE $out/
+    cp licensing/THIRD-PARTY-LICENSES $out/
+    cp RELEASE_NOTES $out/
+    cp packaging/dependencies/amazon-cloudwatch-agent-ctl $out/bin/
+
+    # TODO in patchPhase
+
+    mkdir -p /tmp/amazon-cloudwatch-agent
+    touch /tmp/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log
+    ln -s /tmp/amazon-cloudwatch-agent/log $out/log
+
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
This commit also introduces a corresponding NixOS service module to manage the Amazon Cloudwatch Agent via systemd.

Based on
https://github.com/wearetechnative/amazon-cloudwatch-agent-nix/blob/main/module.nix

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**Amazon Cloudwatch Agent** is an agent that collects data about the running server and sends metrics and logs to the *Amazon Cloudwatch* service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
