### PR TITLE
hackgregator: init at 0.5.0-unstable-2023-12-05

### DIFF
--- a/pkgs/by-name/ha/hackgregator/package.nix
+++ b/pkgs/by-name/ha/hackgregator/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  pkg-config,
+  wrapGAppsHook4,
+  libadwaita,
+  openssl,
+  webkitgtk_6_0,
+  sqlite,
+  glib-networking,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "hackgregator";
+  version = "0.5.0-unstable-2023-12-05";
+
+  src = fetchFromGitLab {
+    owner = "gunibert";
+    repo = "hackgregator";
+    rev = "594bdcdc3919c7216d611ddbbc77ab4d0c1f4f2b";
+    hash = "sha256-RE0x4YWquWAcQzxGk9zdNjEp1pijrBtjV1EMBu9c5cs=";
+  };
+
+  cargoHash = "sha256-OPlYFUhAFRHqXS2vad0QYlhcwyyxdxi1kjpTxVlgyxs=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+    openssl
+    webkitgtk_6_0
+    sqlite
+    glib-networking
+  ];
+
+  # 'error[E0432]: unresolved import' when compiling checks
+  doCheck = false;
+
+  postInstall = ''
+    rm $out/bin/xtask
+    mkdir -p $out/share
+    pushd hackgregator/data
+      cp -r icons $out/share/icons
+      install -Dm644 de.gunibert.Hackgregator.desktop -t $out/share/applications
+      install -Dm644 de.gunibert.Hackgregator.appdata.xml -t $out/share/appdata
+    popd
+  '';
+
+  meta = {
+    description = "Comfortable GTK reader application for news.ycombinator.com";
+    homepage = "https://gitlab.com/gunibert/hackgregator";
+    license = with lib.licenses; [
+      gpl3Plus
+      # and
+      cc0
+    ];
+    mainProgram = "hackgregator";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Tested

![image](https://github.com/user-attachments/assets/05f9a57c-2d10-4a9e-9215-326f288bc2e7)

![image](https://github.com/user-attachments/assets/22b3fc0d-979f-4f46-870d-ceaa1262ce1b)

Using this commit instead of last tag because it required webkitgtk5 which was removed, and updated to webkitgtk6 in this commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
