### PR TITLE
emacs: factor out common overrides for elpa and nongnu packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
@@ -1,0 +1,55 @@
+pkgs:
+
+self: super:
+
+let
+  libExt = pkgs.stdenv.hostPlatform.extensions.sharedLibrary;
+in
+{
+  # TODO delete this when we get upstream fix https://debbugs.gnu.org/cgi/bugreport.cgi?bug=73241
+  eglot = super.eglot.overrideAttrs (old: {
+    postInstall =
+      old.postInstall or ""
+      + ''
+        local info_file=eglot.info
+        pushd $out/share/emacs/site-lisp/elpa/eglot-*
+        # specify output info file to override the one defined in eglot.texi
+        makeinfo --output=$info_file eglot.texi
+        install-info $info_file dir
+        popd
+      '';
+  });
+
+  # native compilation for tests/seq-tests.el never ends
+  # delete tests/seq-tests.el to workaround this
+  seq = super.seq.overrideAttrs (old: {
+    dontUnpack = false;
+    postUnpack =
+      old.postUnpack or ""
+      + "\n"
+      + ''
+        local content_directory=$(echo seq-*)
+        rm --verbose $content_directory/tests/seq-tests.el
+        src=$PWD/$content_directory.tar
+        tar --create --verbose --file=$src $content_directory
+      '';
+  });
+
+  xeft = super.xeft.overrideAttrs (old: {
+    dontUnpack = false;
+    buildInputs = old.buildInputs or [ ] ++ [ pkgs.xapian ];
+    buildPhase =
+      old.buildPhase or ""
+      + ''
+        $CXX -shared -o xapian-lite${libExt} xapian-lite.cc $NIX_CFLAGS_COMPILE -lxapian
+      '';
+    postInstall =
+      old.postInstall or ""
+      + "\n"
+      + ''
+        outd=$out/share/emacs/site-lisp/elpa/xeft-*
+        install -m444 -t $outd xapian-lite${libExt}
+        rm $outd/xapian-lite.cc $outd/emacs-module.h $outd/emacs-module-prelude.h $outd/demo.gif $outd/Makefile
+      '';
+  });
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-packages.nix
@@ -47,52 +47,16 @@ self: let
 
     super = imported;
 
-    overrides = {
-      eglot = super.eglot.overrideAttrs (old: {
-        postInstall = (old.postInstall or "") + ''
-          local info_file=eglot.info
-          pushd $out/share/emacs/site-lisp/elpa/eglot-*
-          # specify output info file to override the one defined in eglot.texi
-          makeinfo --output=$info_file eglot.texi
-          install-info $info_file dir
-          popd
-        '';
-      });
+    commonOverrides = import ./elpa-common-overrides.nix pkgs;
 
+    overrides = self: super: {
       pq = super.pq.overrideAttrs (old: {
         buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.postgresql ];
       });
-
-      xeft = super.xeft.overrideAttrs (old: let
-        libExt = pkgs.stdenv.hostPlatform.extensions.sharedLibrary;
-      in {
-        dontUnpack = false;
-
-        buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.xapian ];
-        buildPhase = (old.buildPhase or "") + ''
-          $CXX -shared -o xapian-lite${libExt} xapian-lite.cc $NIX_CFLAGS_COMPILE -lxapian
-        '';
-        postInstall = (old.postInstall or "") + "\n" + ''
-          outd=$out/share/emacs/site-lisp/elpa/xeft-*
-          install -m444 -t $outd xapian-lite${libExt}
-          rm $outd/xapian-lite.cc $outd/emacs-module.h $outd/emacs-module-prelude.h $outd/demo.gif $outd/Makefile
-        '';
-      });
-
-      # native compilation for tests/seq-tests.el never ends
-      # delete tests/seq-tests.el to workaround this
-      seq = super.seq.overrideAttrs (old: {
-        dontUnpack = false;
-        postUnpack = (old.postUnpack or "") + "\n" + ''
-          local content_directory=$(echo seq-*)
-          rm --verbose $content_directory/tests/seq-tests.el
-          src=$PWD/$content_directory.tar
-          tar --create --verbose --file=$src $content_directory
-        '';
-      });
     };
 
-    elpaDevelPackages = super // overrides;
+    elpaDevelPackages =
+      let super' = super // (commonOverrides self super); in super' // (overrides self super');
 
   in elpaDevelPackages);
 

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -47,7 +47,9 @@ self: let
 
     super = imported;
 
-    overrides = {
+    commonOverrides = import ./elpa-common-overrides.nix pkgs;
+
+    overrides = self: super: {
       # upstream issue: Wrong type argument: arrayp, nil
       org-transclusion =
         if super.org-transclusion.version == "1.2.0"
@@ -98,17 +100,6 @@ self: let
         };
       });
 
-      eglot = super.eglot.overrideAttrs (old: {
-        postInstall = (old.postInstall or "") + ''
-          local info_file=eglot.info
-          pushd $out/share/emacs/site-lisp/elpa/eglot-*
-          # specify output info file to override the one defined in eglot.texi
-          makeinfo --output=$info_file eglot.texi
-          install-info $info_file dir
-          popd
-        '';
-      });
-
       jinx = super.jinx.overrideAttrs (old: let
         libExt = pkgs.stdenv.hostPlatform.extensions.sharedLibrary;
       in {
@@ -150,38 +141,11 @@ self: let
         }
       );
 
-      xeft = super.xeft.overrideAttrs (old: let
-        libExt = pkgs.stdenv.hostPlatform.extensions.sharedLibrary;
-      in {
-        dontUnpack = false;
-
-        buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.xapian ];
-        buildPhase = (old.buildPhase or "") + ''
-          $CXX -shared -o xapian-lite${libExt} xapian-lite.cc $NIX_CFLAGS_COMPILE -lxapian
-        '';
-        postInstall = (old.postInstall or "") + "\n" + ''
-          outd=$out/share/emacs/site-lisp/elpa/xeft-*
-          install -m444 -t $outd xapian-lite${libExt}
-          rm $outd/xapian-lite.cc $outd/emacs-module.h $outd/emacs-module-prelude.h $outd/demo.gif $outd/Makefile
-        '';
-      });
-
-      # native compilation for tests/seq-tests.el never ends
-      # delete tests/seq-tests.el to workaround this
-      seq = super.seq.overrideAttrs (old: {
-        dontUnpack = false;
-        postUnpack = (old.postUnpack or "") + "\n" + ''
-          local content_directory=$(echo seq-*)
-          rm --verbose $content_directory/tests/seq-tests.el
-          src=$PWD/$content_directory.tar
-          tar --create --verbose --file=$src $content_directory
-        '';
-      });
-
 
     };
 
-    elpaPackages = super // overrides;
+    elpaPackages =
+      let super' = super // (commonOverrides self super); in super' // (overrides self super');
 
   in elpaPackages);
 

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
@@ -1,0 +1,21 @@
+pkgs:
+
+self: super:
+
+{
+  p4-16-mode = super.p4-16-mode.overrideAttrs {
+    # workaround https://github.com/NixOS/nixpkgs/issues/301795
+    prePatch = ''
+      mkdir tmp-untar-dir
+      pushd tmp-untar-dir
+
+      tar --extract --verbose --file=$src
+      content_directory=$(echo p4-16-mode-*)
+      cp --verbose $content_directory/p4-16-mode-pkg.el $content_directory/p4-pkg.el
+      src=$PWD/$content_directory.tar
+      tar --create --verbose --file=$src $content_directory
+
+      popd
+    '';
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-packages.nix
@@ -10,7 +10,11 @@
   3. Run `git commit -m "nongnu-devel-packages $(date -Idate)" -- nongnu-devel-generated.nix`
 */
 
-{ lib, buildPackages }:
+{
+  lib,
+  pkgs,
+  buildPackages,
+}:
 
 self:
 let
@@ -35,26 +39,15 @@ let
 
       super = imported;
 
-      overrides = {
-        p4-16-mode = super.p4-16-mode.overrideAttrs {
-          # workaround https://github.com/NixOS/nixpkgs/issues/301795
-          prePatch = ''
-            mkdir tmp-untar-dir
-            pushd tmp-untar-dir
+      commonOverrides = import ./nongnu-common-overrides.nix pkgs;
 
-            tar --extract --verbose --file=$src
-            content_directory=$(echo p4-16-mode-*)
-            cp --verbose $content_directory/p4-16-mode-pkg.el $content_directory/p4-pkg.el
-            src=$PWD/$content_directory.tar
-            tar --create --verbose --file=$src $content_directory
-
-            popd
-          '';
-        };
-      };
+      overrides = self: super: { };
 
     in
-    super // overrides
+    let
+      super' = super // (commonOverrides self super);
+    in
+    super' // (overrides self super')
   );
 
 in

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
@@ -12,7 +12,7 @@ To update the list of packages from nongnu (ELPA),
 
 */
 
-{ lib, buildPackages }:
+{ lib, pkgs, buildPackages }:
 
 self: let
 
@@ -29,24 +29,11 @@ self: let
 
     super = imported;
 
-    overrides = {
-      p4-16-mode = super.p4-16-mode.overrideAttrs {
-        # workaround https://github.com/NixOS/nixpkgs/issues/301795
-        prePatch = ''
-          mkdir tmp-untar-dir
-          pushd tmp-untar-dir
+    commonOverrides = import ./nongnu-common-overrides.nix pkgs;
 
-          tar --extract --verbose --file=$src
-          content_directory=$(echo p4-16-mode-*)
-          cp --verbose $content_directory/p4-16-mode-pkg.el $content_directory/p4-pkg.el
-          src=$PWD/$content_directory.tar
-          tar --create --verbose --file=$src $content_directory
+    overrides = self: super: { };
 
-          popd
-        '';
-      };
-    };
-
-  in super // overrides);
+  in
+  let super' = super // (commonOverrides self super); in super' // (overrides self super'));
 
 in generateNongnu { }

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -34,12 +34,12 @@ let
   };
 
   mkNongnuDevelPackages = { pkgs, lib }: import ../applications/editors/emacs/elisp-packages/nongnu-devel-packages.nix {
-    inherit (pkgs) buildPackages;
+    inherit (pkgs) pkgs buildPackages;
     inherit lib;
   };
 
   mkNongnuPackages = { pkgs, lib }: import ../applications/editors/emacs/elisp-packages/nongnu-packages.nix {
-    inherit (pkgs) buildPackages;
+    inherit (pkgs) pkgs buildPackages;
     inherit lib;
   };
 


### PR DESCRIPTION
## Description of changes

This PR implements part of https://github.com/NixOS/nixpkgs/issues/269550.  It factors out common overrides for `elpaPackages` and `elpaDevelPackages`.  It also does so for nongnu packages.

This PR does not provide common overrides for `elpa(Devel)Packages` and `nongnu(Devel)Packages` because their intersection set contains only one package.

27% `elpaPackages` are in `melpaPackages` and 89% `nongnuPackages` are in `melpaPackages`.  This PR does not provide common overrides between them because currently we build them differently[1] so presumably the common overrides set is very small.

[1]: For a MELPA package, we first build a tarball for its source code and then install that tarball.  For an ELPA package, we download a tarball instead of building it from source, then we install that tarball.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
