### PR TITLE
video-compare: init at 20250223

### DIFF
--- a/pkgs/by-name/vi/video-compare/package.nix
+++ b/pkgs/by-name/vi/video-compare/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  SDL2,
+  SDL2_ttf,
+  ffmpeg,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "video-compare";
+  version = "20250223";
+
+  src = fetchFromGitHub {
+    owner = "pixop";
+    repo = "video-compare";
+    tag = version;
+    hash = "sha256-h74TWXPcbIjfejGfHnjKZqKzpV0DIkC5llSD1jmiDDY=";
+  };
+
+  postPatch = ''
+    # Fix build on Darwin by using $CXX set by setup-hook
+    substituteInPlace makefile \
+      --replace-fail 'CXX = g++' ""
+  '';
+
+  buildInputs = [
+    SDL2
+    SDL2_ttf
+    ffmpeg
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2}/include/SDL2";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt $out/bin video-compare
+
+    runHook postInstall
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "https://github.com/pixop/video-compare";
+    description = "Split screen video comparison tool";
+    maintainers = with lib.maintainers; [ orivej ];
+    license = lib.licenses.gpl2Only;
+    mainProgram = "video-compare";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add a tool to compare video files, particularly useful when choosing video compression settings.
`20240818` is the actual tag (version), not just a date.
https://github.com/pixop/video-compare

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
