### PR TITLE
fcft: devendor nanosvg

### DIFF
--- a/pkgs/development/libraries/fcft/default.nix
+++ b/pkgs/development/libraries/fcft/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchFromGitea, pkg-config, meson, ninja, scdoc
-, freetype, fontconfig, pixman, tllist, check
+{ stdenv, lib, fetchFromGitea, fetchpatch, pkg-config, meson, ninja, scdoc
+, freetype, fontconfig, nanosvg, pixman, tllist, check
 # Text shaping methods to enable, empty list disables all text shaping.
 # See `availableShapingTypes` or upstream meson_options.txt for available types.
 , withShapingTypes ? [ "grapheme" "run" ]
@@ -27,15 +27,26 @@ stdenv.mkDerivation rec {
     hash = "sha256-Wgm2QdW4rg573soF/8HhDmlyN4S2cA0VWOejow464gU=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "system-nanosvg.patch";
+      url = "https://codeberg.org/dnkl/fcft/commit/5cee776e1d7f1bdb0df383c3dd798831a6fe4fa0.patch";
+      excludes = [ "CHANGELOG.md" ];
+      hash = "sha256-yRBtKCKT/Oih66/OQqt4GPg3GfHmhiLM8mlLEWYYRC0=";
+    })
+  ];
+
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ pkg-config meson ninja scdoc ];
-  buildInputs = [ freetype fontconfig pixman tllist ]
+  buildInputs = [ freetype fontconfig nanosvg pixman tllist ]
     ++ lib.optionals (withShapingTypes != []) [ harfbuzz ]
     ++ lib.optionals (builtins.elem "run" withShapingTypes) [ utf8proc ];
   nativeCheckInputs = [ check ];
 
   mesonBuildType = "release";
-  mesonFlags = builtins.map (t:
+  mesonFlags = [
+    (lib.mesonEnable "system-nanosvg" true)
+  ] ++ builtins.map (t:
     lib.mesonEnable "${t}-shaping" (lib.elem t withShapingTypes)
   ) availableShapingTypes;
 


### PR DESCRIPTION
## Description of changes

This fixes an uninitialized memory error with GCC 14.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
