### PR TITLE
nixos/tests/libreswan: fix test

### DIFF
--- a/nixos/tests/libreswan.nix
+++ b/nixos/tests/libreswan.nix
@@ -37,6 +37,8 @@ let
     useDHCP = false;
     interfaces.eth1.ipv4.addresses = lib.mkVMOverride [];
     interfaces.eth2.ipv4.addresses = lib.mkVMOverride [];
+    interfaces.eth1.ipv6.addresses = lib.mkVMOverride [];
+    interfaces.eth2.ipv6.addresses = lib.mkVMOverride [];
     # open a port for testing
     firewall.allowedUDPPorts = [ 1234 ];
   };


### PR DESCRIPTION
## Description of changes

Fix libreswan tests. It was broken by the introduction of automatic IPv6 addressing in the test infrastructure.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested with `nixosTests.libreswan`
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
