### PR TITLE
vapoursynth-mvtools: 23 -> 24, move to by-name and reformat

### DIFF
--- a/pkgs/by-name/va/vapoursynth-mvtools/package.nix
+++ b/pkgs/by-name/va/vapoursynth-mvtools/package.nix
@@ -1,5 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook,
-  vapoursynth, nasm, fftwFloat
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  autoreconfHook,
+  vapoursynth,
+  nasm,
+  fftwFloat,
 }:
 
 stdenv.mkDerivation rec {
@@ -7,15 +14,20 @@ stdenv.mkDerivation rec {
   version = "24";
 
   src = fetchFromGitHub {
-    owner  = "dubhater";
-    repo   = "vapoursynth-mvtools";
-    rev    = "v${version}";
-    hash   = "sha256-bEifU1PPNOBr6o9D6DGIzTaG4xjygBxkQYnZxd/4SwQ=";
+    owner = "dubhater";
+    repo = "vapoursynth-mvtools";
+    rev = "v${version}";
+    hash = "sha256-bEifU1PPNOBr6o9D6DGIzTaG4xjygBxkQYnZxd/4SwQ=";
   };
 
-  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
   buildInputs = [
-    nasm vapoursynth fftwFloat
+    nasm
+    vapoursynth
+    fftwFloat
   ];
 
   configureFlags = [ "--libdir=$(out)/lib/vapoursynth" ];
@@ -23,7 +35,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Set of filters for motion estimation and compensation";
     homepage = "https://github.com/dubhater/vapoursynth-mvtools";
-    license  = licenses.gpl2;
+    license = licenses.gpl2;
     maintainers = with maintainers; [ rnhmjoj ];
   };
 }

--- a/pkgs/development/libraries/vapoursynth-mvtools/default.nix
+++ b/pkgs/development/libraries/vapoursynth-mvtools/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vapoursynth-mvtools";
-  version = "23";
+  version = "24";
 
   src = fetchFromGitHub {
     owner  = "dubhater";
     repo   = "vapoursynth-mvtools";
     rev    = "v${version}";
-    sha256 = "0lngkvxnzn82rz558nvl96rvclrck07ja1pny7wcfixp9b68ppkn";
+    hash   = "sha256-bEifU1PPNOBr6o9D6DGIzTaG4xjygBxkQYnZxd/4SwQ=";
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19842,8 +19842,6 @@ with pkgs;
 
   vapoursynth-editor = libsForQt5.callPackage ../by-name/va/vapoursynth/editor.nix { };
 
-  vapoursynth-mvtools = callPackage ../development/libraries/vapoursynth-mvtools { };
-
   vmmlib = callPackage ../development/libraries/vmmlib {
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
   };


### PR DESCRIPTION
## Description of changes

Version bump

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
  - [x] Tested as usual with 
     ```
     nix build -f. mpv --arg overlays '[(self: super: { mpv-unwrapped = super.mpv-unwrapped.override { vapoursynthSupport = true; vapoursynth = self.vapoursynth.withPlugins [ self.vapoursynth-mvtools ]; }; })]'
    ```
    and this filter
    <details>

    ```
    import vapoursynth as vs
    import sys

    clip = video_in
    dst_fps = int(display_fps)

    if isinstance(video_in, bytes):
        # vspipe
        clip = vs.core.ffms2.Source(source=video_in)
    else:
        # mpv
        clip = video_in

    # Interpolating to fps higher than 60 is too CPU-expensive, smoothmotion can handle the rest.
    if int(container_fps) < 60:
        src_fps_num = int(int(container_fps) * 10**8)
        src_fps_den = 10**8
        dst_fps_num = int(dst_fps * 10**4)
        dst_fps_den = 10**4

        # Needed because clip FPS is missing
        clip = vs.core.std.AssumeFPS(clip, fpsnum=src_fps_num, fpsden=src_fps_den)
        print("Reflowing {:.1f}Hz → {:.1f}Hz".format(src_fps_num/src_fps_den,
                                            dst_fps_num/dst_fps_den))

        sup  = vs.core.mv.Super(clip, pel=2, hpad=16, vpad=16)
        bvec = vs.core.mv.Analyse(sup, blksize=16, isb=True , chroma=True, search=3, searchparam=1)
        fvec = vs.core.mv.Analyse(sup, blksize=16, isb=False, chroma=True, search=3, searchparam=1)
        clip = vs.core.mv.BlockFPS(clip, sup, bvec, fvec, num=dst_fps_num, den=dst_fps_den, mode=1, thscd2=12)

    clip.set_output()
    ```

    </details>
   
- [x] Tested compilation of all packages that depend on this change (just vapoursynth-mvtools)
- [x] Tested basic functionality of all binary files (none, it's a library)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
