### PR TITLE
muse-sounds-manager: init at 1.1.0.587

### DIFF
--- a/pkgs/by-name/mu/muse-sounds-manager/package.nix
+++ b/pkgs/by-name/mu/muse-sounds-manager/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  fontconfig,
+  zlib,
+  icu,
+  libX11,
+  libXext,
+  libXi,
+  libXrandr,
+  libICE,
+  libSM,
+  openssl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "muse-sounds-manager";
+  version = "1.1.0.587";
+
+  # Use web.archive.org since upstream does not provide a stable (versioned) URL.
+  # To see if there are new versions on the Web Archive, visit
+  # http://web.archive.org/cdx/search/cdx?url=https://muse-cdn.com/Muse_Sounds_Manager_Beta.deb
+  # then replace the date in the URL below with date when the SHA1
+  # changes (currently A3NX3WHFZWXCHZVME2ABUL2VRENTWOD5) and replace
+  # the version above with the version in the .deb metadata (or in the
+  # settings of muse-sounds-manager).
+  src = fetchurl {
+    url = "https://web.archive.org/web/20240826143936/https://muse-cdn.com/Muse_Sounds_Manager_Beta.deb";
+    hash = "sha256-wzZAIjme1cv8+jMLiKT7kUQvCb+UhsvOnLDV4hCL3hw=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    fontconfig
+    stdenv.cc.cc
+    zlib
+  ] ++ runtimeDependencies;
+
+  runtimeDependencies = map lib.getLib [
+    icu
+    libX11
+    libXext
+    libXi
+    libXrandr
+    libICE
+    libSM
+    openssl
+  ];
+
+  unpackPhase = "dpkg -x $src .";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    mv usr/* opt $out/
+    substituteInPlace $out/bin/muse-sounds-manager --replace-fail /opt/ $out/opt/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Manage Muse Sounds (Muse Hub) libraries for MuseScore";
+    homepage = "https://musescore.org/";
+    license = lib.licenses.unfree;
+    mainProgram = "muse-sounds-manager";
+    maintainers = with lib.maintainers; [ orivej ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add muse-sounds-manager which downloads MuseSampler (into `~/.local/share/MuseSampler`) and its sound banks (into `~/.muse-hub/downloads/Instruments/` by default) for use with MuseScore (when Muse Sounds are activated in its View -> Playback setup dialog).

This works for me in one instance of MuseScore 4.4.1, but Muse Sounds do not load (are inactive in Playback setup) in further instances of MuseScore (when opening multiple scores at once) where it plays without Muse Sounds, as in #318210. This may be a bug in MuseScore.

Closes #216432

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
