### PR TITLE
python312Packages.pylance: skip failing tests on darwin

### DIFF
--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -100,6 +100,17 @@ buildPythonPackage rec {
     cd python/python/tests
   '';
 
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
+    "test_convert_int_tensors"
+    "test_ground_truth"
+    "test_index_cast_centroids"
+    "test_index_with_no_centroid_movement"
+    "test_iter_filter"
+    "test_iter_over_dataset_fixed_shape_tensor"
+    "test_iter_over_dataset_fixed_size_lists"
+  ];
+
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--generate-lockfile"

--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -125,5 +125,8 @@ buildPythonPackage rec {
     changelog = "https://github.com/lancedb/lance/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ natsukium ];
+    # test_indices.py ...sss.Fatal Python error: Fatal Python error: Illegal instructionIllegal instruction
+    # File "/nix/store/wiiccrs0vd1qbh4j6ki9p40xmamsjix3-python3.12-pylance-0.17.0/lib/python3.12/site-packages/lance/indices.py", line 237 in train_ivf
+    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }


### PR DESCRIPTION
## Description of changes

Currently failing (on `darwin`) with:
```
=========================== short test summary info ============================
FAILED test_vector_index.py::test_index_with_no_centroid_movement - AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
FAILED test_vector_index.py::test_index_cast_centroids - AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
FAILED torch_tests/test_bench_utils.py::test_ground_truth - AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
FAILED torch_tests/test_data.py::test_iter_over_dataset_fixed_shape_tensor - AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
FAILED torch_tests/test_data.py::test_iter_over_dataset_fixed_size_lists - AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
FAILED torch_tests/test_data.py::test_iter_filter - AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
FAILED torch_tests/test_data.py::test_convert_int_tensors[uint8] - AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
FAILED torch_tests/test_data.py::test_convert_int_tensors[int64] - AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
======= 8 failed, 263 passed, 27 skipped, 5 warnings in 95.11s (0:01:35) =======
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
