### PR TITLE
libnss_nis: init at 3.2

### DIFF
--- a/pkgs/by-name/li/libnss_nis/package.nix
+++ b/pkgs/by-name/li/libnss_nis/package.nix
@@ -1,0 +1,44 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  autoreconfHook,
+  libxcrypt,
+  libnsl,
+  libtirpc,
+  pkg-config,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libnss_nis";
+  version = "3.2";
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libxcrypt
+    libnsl
+    libtirpc
+  ];
+
+  src = fetchFromGitHub {
+    owner = "thkukuk";
+    repo = "libnss_nis";
+    rev = "v${version}";
+    hash = "sha256-dt5wL+v98Heg6395BOwNssXLXmoOKFnRXGqlOknYYPs=";
+  };
+
+  outputs = [ "out" ];
+
+  meta = {
+    description = "NSS module for glibc, to provide NIS support for glibc";
+    changelog = "https://github.com/thkukuk/libnss_nis/blob/master/NEWS";
+    homepage = "https://github.com/thkukuk/libnss_nis";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ BarrOff ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This PR adds the *libnss_nis* NSS module package.
It allows [NSS](https://en.wikipedia.org/wiki/Name_Service_Switch) to query [NIS](https://en.wikipedia.org/wiki/Network_Information_Service) for information.
More information is available on the [project's homepage](https://github.com/thkukuk/libnss_nis)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] tested the package against a real world NIS system