### PR TITLE
python312Packages.great-tables: fix on darwin

### DIFF
--- a/pkgs/development/python-modules/great-tables/default.nix
+++ b/pkgs/development/python-modules/great-tables/default.nix
@@ -1,24 +1,29 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
   setuptools-scm,
-  pytestCheckHook,
-  pytest-cov-stub,
+
+  # dependencies
   babel,
   commonmark,
   htmltools,
   importlib-metadata,
   importlib-resources,
-  ipykernel,
-  ipython,
   numpy,
   typing-extensions,
+
+  # tests
+  ipykernel,
+  ipython,
   pandas,
   polars,
   pyarrow,
+  pytestCheckHook,
+  pytest-cov-stub,
   requests,
   syrupy,
 }:
@@ -27,8 +32,6 @@ buildPythonPackage rec {
   pname = "great-tables";
   version = "0.11.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "posit-dev";

--- a/pkgs/development/python-modules/great-tables/default.nix
+++ b/pkgs/development/python-modules/great-tables/default.nix
@@ -79,6 +79,8 @@ buildPythonPackage rec {
     "test_save_non_png"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     description = "Library for rendering and formatting dataframes";
     homepage = "https://github.com/posit-dev/great-tables";


### PR DESCRIPTION
## Description of changes

One test on darwin was failing with:
```
>       self.socket.bind(self.server_address)
E       PermissionError: [Errno 1] Operation not permitted
/nix/store/9pj4rzx5pbynkkxq1srzwjhywmcfxws3-python3-3.12.5/lib/python3.12/socketserver.py:473: PermissionError
```

Adding `__darwinAllowLocalNetworking` fixed it.

- **python312Packages.great-tables: cleaning**
- **python312Packages.great-tables: allow local networking on darwin to fix a failing test**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
