### PR TITLE
hcipy: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/hcipy/default.nix
+++ b/pkgs/development/python-modules/hcipy/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  numpy,
+  scipy,
+  matplotlib,
+  pillow,
+  pyyaml,
+  astropy,
+  imageio,
+  xxhash,
+  numexpr,
+  asdf,
+
+  # tests
+  pytest-cov-stub,
+  pytestCheckHook,
+  mpmath,
+  dill,
+}:
+
+buildPythonPackage rec {
+  pname = "hcipy";
+  version = "0.6.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Kt2T6EgCrPTJGiygjmFUh1HH1DthFcZ2mMlnlu0HxsE=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    numpy
+    scipy
+    matplotlib
+    pillow
+    pyyaml
+    astropy
+    imageio
+    xxhash
+    numexpr
+    asdf
+  ];
+
+  pythonImportsCheck = [ "hcipy" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    mpmath
+    dill
+  ];
+
+  meta = {
+    description = "Framework for performing optical propagation simulations, meant for high contrast imaging";
+    changelog = "https://github.com/ehpor/hcipy/blob/master/doc/changelog.rst";
+    homepage = "https://hcipy.org/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ BarrOff ];
+    # seems to be broken on arm, see: https://github.com/NixOS/nixpkgs/pull/341906
+    broken = stdenv.isAarch64;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5561,6 +5561,8 @@ self: super: with self; {
 
   haystack-ai = callPackage ../development/python-modules/haystack-ai { };
 
+  hcipy = callPackage ../development/python-modules/hcipy { };
+
   hcloud = callPackage ../development/python-modules/hcloud { };
 
   hcs-utils = callPackage ../development/python-modules/hcs-utils { };


### PR DESCRIPTION
This PR adds the HCIPy python library.
HCIPy is an open-source, modular Python package for high-contrast imaging on current and future telescopes.
More information available on the [projects homepage](https://hcipy.org/).

I have successfully built the package and tested it's functionality.

This is the first time I add a Python package.
Help is really appreciated if I missed something.  

## Things done

- Built on platform(s)
  - [x] x86_64-linux