### PR TITLE
gimp: Fix AVIF/HEIC support

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -77,6 +77,14 @@ in stdenv.mkDerivation (finalAttrs: {
     # Use absolute paths instead of relying on PATH
     # to make sure plug-ins are loaded by the correct interpreter.
     ./hardcode-plugin-interpreters.patch
+
+    # GIMP queries libheif.pc for builtin encoder/decoder support to determine if AVIF/HEIC files are supported
+    # (see https://gitlab.gnome.org/GNOME/gimp/-/blob/a8b1173ca441283971ee48f4778e2ffd1cca7284/configure.ac?page=2#L1846-1852)
+    # These variables have been removed since libheif 1.18.0
+    # (see https://github.com/strukturag/libheif/commit/cf0d89c6e0809427427583290547a7757428cf5a)
+    # This has already been fixed for the upcoming GIMP 3, but the fix has not been backported to 2.x yet
+    # (see https://gitlab.gnome.org/GNOME/gimp/-/issues/9080)
+    ./force-enable-libheif.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -42,6 +42,7 @@
 , mypaint-brushes1
 , libwebp
 , libheif
+, libxslt
 , libgudev
 , openexr
 , desktopToDarwinBundle
@@ -85,6 +86,7 @@ in stdenv.mkDerivation (finalAttrs: {
     gettext
     makeWrapper
     gtk-doc
+    libxslt
   ] ++ lib.optionals stdenv.isDarwin [
     desktopToDarwinBundle
   ];

--- a/pkgs/applications/graphics/gimp/force-enable-libheif.patch
+++ b/pkgs/applications/graphics/gimp/force-enable-libheif.patch
@@ -1,0 +1,22 @@
+diff --git a/configure.ac b/configure.ac
+index 48c3c77892..3189781817 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1843,13 +1843,13 @@ can_export_heic=no
+ can_import_avif=no
+ can_export_avif=no
+ if test "x$have_libheif" = xyes; then
+-  can_import_heic=`$PKG_CONFIG --variable=builtin_h265_decoder libheif`
+-  can_export_heic=`$PKG_CONFIG --variable=builtin_h265_encoder libheif`
++  can_import_heic=yes
++  can_export_heic=yes
+   if test "x$can_import_heic" = xyes; then
+     MIME_TYPES="$MIME_TYPES;image/heif;image/heic"
+   fi
+-  can_import_avif=`$PKG_CONFIG --variable=builtin_avif_decoder libheif`
+-  can_export_avif=`$PKG_CONFIG --variable=builtin_avif_encoder libheif`
++  can_import_avif=yes
++  can_export_avif=yes
+   if test "x$can_import_avif" = xyes; then
+     MIME_TYPES="$MIME_TYPES;image/avif"
+   fi


### PR DESCRIPTION
## Description of changes

Gimp supports AVIF since [2.10.22](https://www.gimp.org/news/2020/10/07/gimp-2-10-22-released/#heif-improved-heic-and-newly-added-avif-support), on the [`2.10` Installation instructions](https://developer.gimp.org/core/setup/build/2.10/INSTALL#:~:text=13.%20HEIF%20support%20depends%20on%20the%20libheif%20library.%20If%20you%20don%27t%20have%0A%20%20%20%20%20access%20to%20pre%2Dbuilt%20packages%2C%20the%20code%20is%20available%20at%3A) it only calls for `libheif`, but that seems to not be enough. On [`2.99` (Pre-release) Installation instructions](https://developer.gimp.org/core/setup/build/2.99/INSTALL#:~:text=14.%20HEIF%20support,is%20mostly%20useless.), which specifically mentions `AVIF`, it says:

```
 14. HEIF support depends on the libheif library. If you don't have
     access to pre-built packages, the code is available at:

        https://github.com/strukturag/libheif

     Make sure you build libheif with libde265 and libx265 support (for
     respectively decoding and encoding of HEVC, i.e. HEIC files), and
     libaom decoder and encoder (for AV1, i.e. AVIF files), otherwise
     the plug-in is mostly useless.
```

Not sure what `libx265` is, but that name isn't in the store. `libheif` has `libaom` on its `buildInputs` currently. 

Regardless, adding either `libavif` or `libaom` to the `builInputs` enables AVIF support for GIMP, since there is no mention of `libavif` here, I just added `libaom`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
