### PR TITLE
lxqt-build-tools: fix invalid setup-hook

### DIFF
--- a/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
@@ -1,42 +1,41 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, pkg-config
-, pcre
-, qtbase
-, glib
-, perl
-, wrapQtAppsHook
-, gitUpdater
-, version ? "2.0.0"
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  pcre,
+  qtbase,
+  glib,
+  perl,
+  wrapQtAppsHook,
+  gitUpdater,
+  version ? "2.0.0",
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lxqt-build-tools";
   inherit version;
 
+  setupHook = ./setup-hook.sh;
+  passthru.updateScript = gitUpdater { };
+
   src = fetchFromGitHub {
     owner = "lxqt";
-    repo = pname;
+    repo = finalAttrs.pname;
     rev = version;
-    hash = {
-      "0.13.0" = "sha256-4/hVlEdqqqd6CNitCRkIzsS1R941vPJdirIklp4acXA=";
-      "2.0.0" = "sha256-ZFvnIumP03Mp+4OHPe1yMVsSYhMmYUY1idJGCAy5IhA=";
-    }."${version}";
+    hash =
+      {
+        "0.13.0" = "sha256-4/hVlEdqqqd6CNitCRkIzsS1R941vPJdirIklp4acXA=";
+        "2.0.0" = "sha256-ZFvnIumP03Mp+4OHPe1yMVsSYhMmYUY1idJGCAy5IhA=";
+      }
+      ."${version}";
   };
 
-  postPatch = ''
-    # Nix clang on darwin identifies as 'Clang', not 'AppleClang'
-    # Without this, dependants fail to link.
-    substituteInPlace cmake/modules/LXQtCompilerSettings.cmake \
-      --replace-fail AppleClang Clang
-  '';
-
   nativeBuildInputs = [
+    finalAttrs.setupHook
+
     cmake
     pkg-config
-    setupHook
     wrapQtAppsHook
   ];
 
@@ -50,15 +49,18 @@ stdenv.mkDerivation rec {
     perl # needed by LXQtTranslateDesktop.cmake
   ];
 
-  setupHook = ./setup-hook.sh;
+  postPatch = ''
+    # Nix clang on darwin identifies as 'Clang', not 'AppleClang'
+    # Without this, dependants fail to link.
+    substituteInPlace cmake/modules/LXQtCompilerSettings.cmake \
+      --replace-fail AppleClang Clang
+  '';
 
   # We're dependent on this macro doing add_definitions in most places
   # But we have the setup-hook to set the values.
   postInstall = ''
     cp ${./LXQtConfigVars.cmake} $out/share/cmake/lxqt${lib.optionalString (lib.versionAtLeast version "2.0.0") "2"}-build-tools/modules/LXQtConfigVars.cmake
   '';
-
-  passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-build-tools";
@@ -68,4 +70,4 @@ stdenv.mkDerivation rec {
     platforms = with platforms; unix;
     maintainers = teams.lxqt.members;
   };
-}
+})

--- a/pkgs/desktops/lxqt/lxqt-build-tools/setup-hook.sh
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/setup-hook.sh
@@ -12,4 +12,4 @@ LXQtCMakePostHook() {
 
 }
 
-postHooks+=(LXQtCMakePostHook)
+postHook+=(LXQtCMakePostHook)


### PR DESCRIPTION
## Description of changes
Part of https://github.com/NixOS/nixpkgs/issues/341930

Originally I was going to remove it entirely and use `cmakeFlags`, but I realize that this derivation passes around a cmake that depends on the values set in the `setupHook`. These values would not propagate if we use a simple `cmakeFlags`, therefore this approach is necessary.

While we have this PR if there's actual cleanup to do for this drv I'd be more than happy. I'm not sure how good this approach is given today's standards, and I'd happily clean it up provided a bit of guidance.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
