### PR TITLE
linkding: init at 1.36.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -72,6 +72,8 @@ Alongside many enhancements to NixOS modules and general system improvements, th
 
 - [ytdl-sub](https://github.com/jmbannon/ytdl-sub), a tool that downloads media via yt-dlp and prepares it for your favorite media player, including Kodi, Jellyfin, Plex, Emby, and modern music players. Available as [services.ytdl-sub](#opt-services.ytdl-sub.instances).
 
+- [linkding](https://linkding.link/), self-hosted bookmark manager. Available as [services.linkding](options.html#opt-services.linkding).
+
 - [MaryTTS](https://github.com/marytts/marytts), an open-source, multilingual text-to-speech synthesis system written in pure Java. Available as [services.marytts](#opt-services.marytts.enable).
 
 - [Continuwuity](https://continuwuity.org/), a federated chat server implementing the Matrix protocol, forked from Conduwuit. Available as [services.matrix-continuwuity](#opt-services.matrix-continuwuity.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1613,6 +1613,7 @@
   ./services/web-apps/lemmy.nix
   ./services/web-apps/libretranslate.nix
   ./services/web-apps/limesurvey.nix
+  ./services/web-apps/linkding.nix
   ./services/web-apps/mainsail.nix
   ./services/web-apps/mastodon.nix
   ./services/web-apps/matomo.nix

--- a/nixos/modules/services/web-apps/linkding.nix
+++ b/nixos/modules/services/web-apps/linkding.nix
@@ -1,0 +1,270 @@
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}:
+{
+  options.services.linkding = {
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/linkding/data";
+      description = "The directory where linkding stores its data files.";
+    };
+
+    enable = lib.mkEnableOption "linkding service";
+
+    package = lib.mkPackageOption pkgs "linkding" { };
+
+    # Service configuration, in order of https://linkding.link/options/#list-of-options
+    enableBackgroundTasks = lib.mkOption {
+      default = true;
+      description = ''
+        Enable background tasks, such as creating snapshots for bookmarks on the the [Internet Archive Wayback Machine](https://archive.org/web/)
+        (`LD_DISABLE_BACKGROUND_TASKS` environment variable)[https://linkding.link/options/#ld_disable_background_tasks].
+      '';
+      type = lib.types.bool;
+    };
+
+    enableUrlValidation = lib.mkOption {
+      default = true;
+      description = ''
+        Enable URL validation for bookmarks
+        (`LD_DISABLE_URL_VALIDATION` environment variable)[https://linkding.link/options/#ld_disable_url_validation].
+      '';
+      type = lib.types.bool;
+    };
+
+    requestTimeoutSeconds = lib.mkOption {
+      default = 60;
+      description = ''
+        Request timeout in the uwsgi application server
+        (`LD_REQUEST_TIMEOUT` environment variable)[https://linkding.link/options/#ld_request_timeout].
+      '';
+      type = lib.types.ints.unsigned;
+    };
+
+    host = lib.mkOption {
+      default = "::1";
+      description = ''
+        Address for socket to bind to
+        (`LD_SERVER_HOST` environment variable)[https://linkding.link/options/#ld_server_host].
+      '';
+      type = lib.types.str;
+    };
+
+    port = lib.mkOption {
+      default = 9090;
+      description = ''
+        Port number
+        (`LD_SERVER_PORT` environment variable)[https://linkding.link/options/#ld_server_port].
+      '';
+      type = lib.types.port;
+    };
+
+    contextPath = lib.mkOption {
+      default = null;
+      description = ''
+        Context path of the website
+        (`LD_CONTEXT_PATH` environment variable)[https://linkding.link/options/#ld_context_path].
+      '';
+      type = lib.types.nullOr lib.types.str;
+    };
+
+    enableAuthProxy = lib.mkOption {
+      default = false;
+      description = ''
+        Enable support for authentication proxy
+        (`LD_ENABLE_AUTH_PROXY` environment variable)[https://linkding.link/options/#ld_enable_auth_proxy].
+      '';
+      type = lib.types.bool;
+    };
+
+    enableOidc = lib.mkOption {
+      default = false;
+      description = ''
+        Enable support for OpenID Connect (OIDC) authentication
+        (`LD_ENABLE_OIDC` environment variable)[https://linkding.link/options/#ld_enable_oidc].
+      '';
+      type = lib.types.bool;
+    };
+
+    csrfTrustedOrigins = lib.mkOption {
+      default = [ ];
+      description = ''
+        List of trusted origins to allow for POST requests
+        (`LD_CSRF_TRUSTED_ORIGINS` environment variable)[https://linkding.link/options/#ld_csrf_trusted_origins].
+      '';
+      type = lib.types.listOf lib.types.str;
+    };
+
+    logXForwardedFor = lib.mkOption {
+      default = false;
+      description = ''
+        Set uWSGI [log-x-forwarded-for](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?#log-x-forwarded-for) parameter
+        (`LD_LOG_X_FORWARDED_FOR` environment variable)[https://linkding.link/options/#ld_log_x_forwarded_for].
+      '';
+      type = lib.types.bool;
+    };
+
+    databaseEngine = lib.mkOption {
+      default = "sqlite";
+      description = ''
+        Database engine used by linkding to store data
+        (`LD_DB_ENGINE` environment variable)[https://linkding.link/options/#ld_db_engine].
+      '';
+      type = lib.types.enum [
+        "postgres"
+        "sqlite"
+      ];
+    };
+
+    databaseName = lib.mkOption {
+      default = "linkding";
+      description = ''
+        Database name
+        (`LD_DB_DATABASE` environment variable)[https://linkding.link/options/#ld_db_database].
+      '';
+      type = lib.types.str;
+    };
+
+    databaseUser = lib.mkOption {
+      default = "linkding";
+      description = ''
+        Database username
+        (`LD_DB_USER` environment variable)[https://linkding.link/options/#ld_db_user].
+      '';
+      type = lib.types.str;
+    };
+
+    databasePassword = lib.mkOption {
+      default = null;
+      description = ''
+        Database username
+        (`LD_DB_PASSWORD` environment variable)[https://linkding.link/options/#ld_db_password].
+      '';
+      type = lib.types.nullOr lib.types.str;
+    };
+
+    databaseHost = lib.mkOption {
+      default = "127.0.0.1";
+      description = ''
+        Hostname or IP address of the database server
+        (`LD_DB_HOST` environment variable)[https://linkding.link/options/#ld_db_host].
+      '';
+      type = lib.types.str;
+    };
+
+    databasePort = lib.mkOption {
+      default = null;
+      description = ''
+        Database server port number
+        (`LD_DB_PORT` environment variable)[https://linkding.link/options/#ld_db_port].
+      '';
+      type = lib.types.nullOr lib.types.port;
+    };
+
+    databaseOptions = lib.mkOption {
+      default = { };
+      description = ''
+        Database server port number
+        (`LD_DB_OPTIONS` environment variable)[https://linkding.link/options/#ld_db_options].
+      '';
+      type = lib.types.attrsOf lib.types.str;
+    };
+
+    faviconProviderUrl = lib.mkOption {
+      default = "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url={url}&size=32";
+      description = ''
+        URL used for downloading favicons
+        (`LD_FAVICON_PROVIDER` environment variable)[https://linkding.link/options/#ld_favicon_provider].
+      '';
+      type = lib.types.str;
+    };
+
+    singleFileTimeoutSeconds = lib.mkOption {
+      default = 60.0;
+      description = ''
+        How long to wait for the snapshot to complete
+        (`LD_REQUEST_TIMEOUT` environment variable)[https://linkding.link/options/#ld_request_timeout].
+      '';
+      type = lib.types.addCheck (
+        lib.types.float
+        // {
+          name = "nonnegativeFloat";
+          description = "nonnegative floating point number, meaning >=0";
+          descriptionClass = "nonRestrictiveClause";
+        }
+      ) (n: n >= 0);
+    };
+
+    singleFileOptions = lib.mkOption {
+      default = null;
+      description = ''
+        `single-file` options for creating HTML archive snapshots
+        (`LD_SINGLEFILE_OPTIONS` environment variable)[https://linkding.link/options/#ld_singlefile_options].
+      '';
+      type = lib.types.nullOr lib.types.str;
+    };
+
+    enableRequestLogs = lib.mkOption {
+      default = true;
+      description = ''
+        Set uWSGI [disable-logging](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#disable-logging) parameter
+        (`LD_DISABLE_REQUEST_LOGS` environment variable)[https://linkding.link/options/#ld_disable_request_logs].
+      '';
+      type = lib.types.bool;
+    };
+  };
+
+  config = lib.mkIf config.services.linkding.enable {
+    systemd.services.linkding = {
+      description = "linkding";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment =
+        let
+          boolToPythonRepr = value: if value then "True" else "False";
+        in
+        {
+          LD_DISABLE_BACKGROUND_TASKS = boolToPythonRepr (!config.services.linkding.enableBackgroundTasks);
+          LD_DISABLE_URL_VALIDATION = boolToPythonRepr (!config.services.linkding.enableUrlValidation);
+          LD_REQUEST_TIMEOUT = builtins.toString config.services.linkding.requestTimeoutSeconds;
+          LD_SERVER_HOST = config.services.linkding.host;
+          LD_SERVER_PORT = builtins.toString config.services.linkding.port;
+          LD_ENABLE_AUTH_PROXY = boolToPythonRepr config.services.linkding.enableAuthProxy;
+          LD_ENABLE_OIDC = boolToPythonRepr config.services.linkding.enableOidc;
+          LD_LOG_X_FORWARDED_FOR = boolToPythonRepr config.services.linkding.logXForwardedFor;
+          LD_DB_ENGINE = config.services.linkding.databaseEngine;
+          LD_DB_DATABASE = config.services.linkding.databaseName;
+          LD_DB_USER = config.services.linkding.databaseUser;
+          LD_DB_HOST = config.services.linkding.databaseHost;
+          LD_DB_OPTIONS = builtins.toJSON config.services.linkding.databaseOptions;
+          LD_FAVICON_PROVIDER = config.services.linkding.faviconProviderUrl;
+          LD_SINGLEFILE_TIMEOUT_SEC = builtins.toString config.services.linkding.singleFileTimeoutSeconds;
+          LD_DISABLE_REQUEST_LOGS = boolToPythonRepr (!config.services.linkding.enableRequestLogs);
+        }
+        // lib.optionalAttrs (config.services.linkding.contextPath != null) {
+          LD_CONTEXT_PATH = config.services.linkding.contextPath;
+        }
+        // lib.optionalAttrs (config.services.linkding.csrfTrustedOrigins != [ ]) {
+          LD_CSRF_TRUSTED_ORIGINS = lib.strings.concatStringsSep "," config.services.linkding.csrfTrustedOrigins;
+        }
+        // lib.optionalAttrs (config.services.linkding.databasePassword != null) {
+          LD_DB_PASSWORD = config.services.linkding.databasePassword;
+        }
+        // lib.optionalAttrs (config.services.linkding.databasePort != null) {
+          LD_DB_PORT = config.services.linkding.databasePort;
+        }
+        // lib.optionalAttrs (config.services.linkding.singleFileOptions != null) {
+          LD_SINGLEFILE_OPTIONS = config.services.linkding.singleFileOptions;
+        };
+      serviceConfig.ExecStart = "${config.services.linkding.package}/bootstrap.sh";
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.l0b0 ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -690,6 +690,7 @@ in
   invidious = runTest ./invidious.nix;
   iosched = runTest ./iosched.nix;
   isolate = runTest ./isolate.nix;
+  linkding = runTest ./web-apps/linkding/overrides.nix;
   livebook-service = runTest ./livebook-service.nix;
   pyload = runTest ./pyload.nix;
   oci-containers = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./oci-containers.nix { };

--- a/nixos/tests/web-apps/linkding/default.nix
+++ b/nixos/tests/web-apps/linkding/default.nix
@@ -1,0 +1,5 @@
+{ handleTest }:
+{
+  defaults = handleTest ./defaults.nix { };
+  overrides = handleTest ./overrides.nix { };
+}

--- a/nixos/tests/web-apps/linkding/defaults.nix
+++ b/nixos/tests/web-apps/linkding/defaults.nix
@@ -1,0 +1,20 @@
+import ../../make-test-python.nix (
+  { lib, ... }:
+  let
+    nodeName = "server";
+  in
+  {
+    name = "linkding-defaults";
+
+    nodes."${nodeName}" = {
+      services.linkding.enable = true;
+    };
+
+    testScript = ''
+      ${nodeName}.wait_for_unit("linkding.service")
+      ${nodeName}.succeed("curl --fail http://127.0.0.1:9090")
+    '';
+
+    meta.maintainers = [ lib.maintainers.l0b0 ];
+  }
+)

--- a/nixos/tests/web-apps/linkding/overrides.nix
+++ b/nixos/tests/web-apps/linkding/overrides.nix
@@ -1,0 +1,34 @@
+import ../../make-test-python.nix (
+  { lib, ... }:
+  let
+    nodeName = "server";
+  in
+  {
+    name = "linkding-overrides";
+
+    nodes."${nodeName}" =
+      {
+        options,
+        pkgs,
+        ...
+      }:
+      {
+        services.linkding = {
+          dataDir = "/tmp/linkding";
+          enable = true;
+          package = pkgs.linkding.overrideAttrs (_old: {
+            name = "custom-linkding";
+          });
+          host = "127.0.0.2";
+          port = options.services.linkding.port.default + 1;
+        };
+      };
+
+    testScript = ''
+      ${nodeName}.wait_for_unit("linkding.service")
+      ${nodeName}.succeed("curl --fail http://127.0.0.2:8000")
+    '';
+
+    meta.maintainers = [ lib.maintainers.l0b0 ];
+  }
+)

--- a/pkgs/by-name/li/linkding/package.nix
+++ b/pkgs/by-name/li/linkding/package.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  lib,
+  nix-update-script,
+  nixosTests,
+  nodejs,
+  npmHooks,
+  playwright-driver,
+  python3Packages,
+  uwsgi,
+}:
+let
+  pname = "linkding";
+  version = "1.36.0";
+
+  src = fetchFromGitHub {
+    owner = "sissbruecker";
+    repo = "linkding";
+    tag = "v${version}";
+    hash = "sha256-AePxd7uc1DvMwzhWluYIzXnFDlH/kiWNjBMzj/p68Mk=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    name = "${pname}-npm-deps";
+    hash = "sha256-BA7PurUcB5glgaBIpuZLPRSg3GDdi4CLniUjoa/32yc=";
+  };
+
+in
+python3Packages.buildPythonApplication {
+  inherit
+    npmDeps
+    pname
+    src
+    version
+    ;
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = [
+    python3Packages.asgiref
+    python3Packages.beautifulsoup4
+    python3Packages.bleach
+    python3Packages.bleach-allowlist
+    python3Packages.certifi
+    python3Packages.cffi
+    python3Packages.charset-normalizer
+    python3Packages.click
+    python3Packages.confusable-homoglyphs
+    python3Packages.cryptography
+    python3Packages.django
+    python3Packages.django-registration
+    python3Packages.django-widget-tweaks
+    python3Packages.djangorestframework
+    python3Packages.huey
+    python3Packages.idna
+    python3Packages.josepy
+    python3Packages.markdown
+    python3Packages.mozilla-django-oidc
+    python3Packages.psycopg2
+    python3Packages.pycparser
+    python3Packages.pyopenssl
+    python3Packages.python-dateutil
+    python3Packages.requests
+    python3Packages.setuptools
+    python3Packages.six
+    python3Packages.soupsieve
+    python3Packages.sqlparse
+    python3Packages.supervisor
+    python3Packages.urllib3
+    python3Packages.waybackpy
+    python3Packages.webencodings
+    uwsgi
+  ];
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Based on $src/docker/alpine.Dockerfile
+    # node-build stage
+    npm run build
+
+    mkdir --parents data/{assets,favicons,previews} dist
+
+    npm run build
+
+    python manage.py collectstatic
+
+    cp --no-preserve=all --recursive . "$out/"
+
+    runHook postBuild
+  '';
+
+  nativeCheckInputs = [
+    python3Packages.django-debug-toolbar
+    python3Packages.playwright
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    python manage.py test bookmarks.tests
+
+    export PLAYWRIGHT_BROWSERS_PATH=${playwright-driver.browsers}
+    python manage.py test bookmarks.e2e --pattern="e2e_test_*.py"
+
+    runHook postCheck
+  '';
+
+  passthru = {
+    tests = {
+      nixos = nixosTests.linkding;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Self-hosted bookmark manager";
+    homepage = "https://github.com/sissbruecker/linkding";
+    changelog = "https://github.com/sissbruecker/linkding/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.l0b0 ];
+  };
+}

--- a/pkgs/development/python-modules/django-registration/default.nix
+++ b/pkgs/development/python-modules/django-registration/default.nix
@@ -6,12 +6,19 @@
   confusable-homoglyphs,
   coverage,
   django,
+  fetchFromGitHub,
+  nox,
+  pdm-backend,
+  pythonAtLeast,
+  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "django-registration";
   version = "5.1.0";
   pyproject = true;
+
+  disabled = pythonOlder "3.9" || pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "ubernostrum";
@@ -24,11 +31,13 @@ buildPythonPackage rec {
 
   dependencies = [
     confusable-homoglyphs
+    django
   ];
 
   nativeCheckInputs = [
     coverage
     django
+    nox
   ];
 
   installCheckPhase = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3981,6 +3981,8 @@ self: super: with self; {
 
   django-pydantic-field = callPackage ../development/python-modules/django-pydantic-field { };
 
+  django-registration = callPackage ../development/python-modules/django-registration { };
+
   django-q2 = callPackage ../development/python-modules/django-q2 { };
 
   django-ranged-response = callPackage ../development/python-modules/django-ranged-response { };


### PR DESCRIPTION
## Description of changes

From the [project](https://github.com/sissbruecker/linkding):

>  Self-hosted bookmark manager that is designed be to be minimal, fast, and easy to set up using Docker.

Closes #341665.

FYI @sissbruecker

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
