### PR TITLE
monero-cli: update submodule version; disable aarch64-darwin

### DIFF
--- a/pkgs/applications/blockchains/monero-cli/default.nix
+++ b/pkgs/applications/blockchains/monero-cli/default.nix
@@ -27,7 +27,7 @@
 }:
 
 let
-  # submodules
+  # submodules; revs are taken from monero repo's `/external` at the given monero version tag.
   supercop = fetchFromGitHub {
     owner = "monero-project";
     repo = "supercop";
@@ -37,12 +37,11 @@ let
   trezor-common = fetchFromGitHub {
     owner = "trezor";
     repo = "trezor-common";
-    rev = "bc28c316d05bf1e9ebfe3d7df1ab25831d98d168";
-    hash = "sha256-F1Hf1WwHqXMd/5OWrdkpomszACTozDuC7DQXW3p6248=";
+    rev = "bff7fdfe436c727982cc553bdfb29a9021b423b0";
+    hash = "sha256-VNypeEz9AV0ts8X3vINwYMOgO8VpNmyUPC4iY3OOuZI=";
   };
 
 in
-
 stdenv.mkDerivation rec {
   pname = "monero-cli";
   version = "0.18.3.4";
@@ -111,14 +110,28 @@ stdenv.mkDerivation rec {
       "-DCMAKE_CXX_FLAGS=-fpermissive"
     ];
 
-  outputs = [ "out" "source" ];
+  outputs = [
+    "out"
+    "source"
+  ];
 
   meta = {
     description = "Private, secure, untraceable currency";
     homepage = "https://getmonero.org/";
     license = lib.licenses.bsd3;
-    platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ rnhmjoj ];
+
+    platforms = with lib.platforms; linux;
+
+    # macOS/ARM has a working `monerod` (at least), but `monero-wallet-cli`
+    # segfaults on start after entering the wallet password, when built in release mode.
+    # Building the same revision in debug mode to root-cause the above problem doesn't work
+    # because of https://github.com/monero-project/monero/issues/9486
+    badPlatforms = [ "aarch64-darwin" ];
+
+    maintainers = with lib.maintainers; [
+      pmw
+      rnhmjoj
+    ];
     mainProgram = "monero-wallet-cli";
   };
 }


### PR DESCRIPTION
## Description of changes

`trezor-common` submodule updated to match the rev at the version tag,
as per the conversation here:
https://github.com/NixOS/nixpkgs/pull/341980#discussion_r1760381016

Mark as disabled on macOS/ARM because it does not build.

Formatted with `nixfmt-rfc-style`.

Tested on macOS M1 both via `nix-build -A monero-cli` and via
`nixpkgs-review`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
