### PR TITLE
nixos/mullvad-vpn: remove unneeded hacks

### DIFF
--- a/nixos/modules/services/networking/mullvad-vpn.nix
+++ b/nixos/modules/services/networking/mullvad-vpn.nix
@@ -10,7 +10,6 @@ with lib;
       default = false;
       description = ''
         This option enables Mullvad VPN daemon.
-        This sets {option}`networking.firewall.checkReversePath` to "loose", which might be undesirable for security.
       '';
     };
 
@@ -36,12 +35,6 @@ with lib;
 
     environment.systemPackages = [ cfg.package ];
 
-    # mullvad-daemon writes to /etc/iproute2/rt_tables
-    networking.iproute2.enable = true;
-
-    # See https://github.com/NixOS/nixpkgs/issues/113589
-    networking.firewall.checkReversePath = "loose";
-
     # See https://github.com/NixOS/nixpkgs/issues/176603
     security.wrappers.mullvad-exclude = mkIf cfg.enableExcludeWrapper {
       setuid = true;
@@ -59,13 +52,9 @@ with lib;
         "NetworkManager.service"
         "systemd-resolved.service"
       ];
-      path = [
-        pkgs.iproute2
-        # Needed for ping
-        "/run/wrappers"
-        # See https://github.com/NixOS/nixpkgs/issues/262681
-      ] ++ (lib.optional config.networking.resolvconf.enable
-        config.networking.resolvconf.package);
+      # See https://github.com/NixOS/nixpkgs/issues/262681
+      path = lib.optional config.networking.resolvconf.enable
+        config.networking.resolvconf.package;
       startLimitBurst = 5;
       startLimitIntervalSec = 20;
       serviceConfig = {


### PR DESCRIPTION
iproute2 rt_tables are no longer used upstream

and loose Reverse-Path seems to no longer be needed, according to my local test

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
