### PR TITLE
pdf-parser: 0.7.4 -> 0.7.9

### DIFF
--- a/pkgs/tools/misc/pdf-parser/default.nix
+++ b/pkgs/tools/misc/pdf-parser/default.nix
@@ -1,12 +1,19 @@
-{ lib, python3Packages, fetchzip }:
+{
+  lib,
+  python3Packages,
+  fetchzip,
+  writeScript,
+}:
 
-python3Packages.buildPythonApplication {
+python3Packages.buildPythonApplication rec {
   pname = "pdf-parser";
   version = "0.7.4";
 
   src = fetchzip {
-    url = "https://didierstevens.com/files/software/pdf-parser_V0_7_4.zip";
-    sha256 = "1j39yww2yl4cav8xgd4zfl5jchbbkvffnrynkamkzvz9dd5np2mh";
+    url = "https://didierstevens.com/files/software/pdf-parser_V${
+      lib.replaceStrings [ "." ] [ "_" ] version
+    }.zip";
+    hash = "sha256-sIprS2vp7z+rmtZn69yea0EmC3WftNfRVoxQLzj3acg=";
   };
 
   format = "other";
@@ -20,16 +27,28 @@ python3Packages.buildPythonApplication {
       --replace '/usr/bin/python' '${python3Packages.python}/bin/python'
   '';
 
-  meta = with lib; {
+  passthru.updateScript = writeScript "update-pdf-parser" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts curl pcre2
+
+    set -eu -o pipefail
+
+    version="$(curl -s https://blog.didierstevens.com/programs/pdf-tools/ |
+      pcre2grep -O '$1.$2.$3' '\bpdf-parser_V(\d+)_(\d+)_(\d+)\.zip\b.*')"
+
+    update-source-version "$UPDATE_NIX_ATTR_PATH" "$version"
+  '';
+
+  meta = {
     description = "Parse a PDF document";
     longDescription = ''
       This tool will parse a PDF document to identify the fundamental elements used in the analyzed file.
       It will not render a PDF document.
     '';
     homepage = "https://blog.didierstevens.com/programs/pdf-tools/";
-    license = licenses.publicDomain;
-    maintainers = [ maintainers.lightdiscord ];
-    platforms = platforms.all;
+    license = lib.licenses.publicDomain;
+    maintainers = [ lib.maintainers.lightdiscord ];
+    platforms = lib.platforms.all;
     mainProgram = "pdf-parser.py";
   };
 }

--- a/pkgs/tools/misc/pdf-parser/default.nix
+++ b/pkgs/tools/misc/pdf-parser/default.nix
@@ -7,16 +7,26 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pdf-parser";
-  version = "0.7.4";
+  version = "0.7.9";
+  pyproject = false;
 
   src = fetchzip {
     url = "https://didierstevens.com/files/software/pdf-parser_V${
       lib.replaceStrings [ "." ] [ "_" ] version
     }.zip";
-    hash = "sha256-sIprS2vp7z+rmtZn69yea0EmC3WftNfRVoxQLzj3acg=";
+    hash = "sha256-1mFThtTe1LKkM/MML44RgskGv3FZborNVBsTqSKanks=";
   };
 
-  format = "other";
+  postPatch = ''
+    # quote regular expressions correctly
+    substituteInPlace pdf-parser.py \
+      --replace-fail \
+        "re.sub('" \
+        "re.sub(r'" \
+      --replace-fail \
+        "re.match('" \
+        "re.match(r'"
+  '';
 
   installPhase = ''
     install -Dm555 pdf-parser.py $out/bin/pdf-parser.py
@@ -24,7 +34,7 @@ python3Packages.buildPythonApplication rec {
 
   preFixup = ''
     substituteInPlace $out/bin/pdf-parser.py \
-      --replace '/usr/bin/python' '${python3Packages.python}/bin/python'
+      --replace-fail '/usr/bin/python' '${python3Packages.python}/bin/python'
   '';
 
   passthru.updateScript = writeScript "update-pdf-parser" ''


### PR DESCRIPTION
## Description of changes

https://github.com/DidierStevens/DidierStevensSuite/compare/5f81a8f7a8aac15b580413f6f3a2ec3d72c5d10c..91faa8f5d101e9216de0206af44d9864818ba233#diff-901accb21b87dbbf58011e6c337f4f45cd040ed7b65e61cbc266089767e3fb38

add updateScript

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package built:</summary>
  <ul>
    <li>pdf-parser</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc