### PR TITLE
python312Packages.django-allauth: 0.61.1 -> 64.2.1

### DIFF
--- a/pkgs/development/python-modules/django-allauth/default.nix
+++ b/pkgs/development/python-modules/django-allauth/default.nix
@@ -1,77 +1,69 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  pythonOlder,
-  python,
-
-  # build-system
-  setuptools,
-
-  # build-time dependencies
-  gettext,
-
-  # dependencies
-  django,
-  python3-openid,
-  requests,
-  requests-oauthlib,
-  pyjwt,
-
-  # optional-dependencies
-  python3-saml,
-  qrcode,
-
-  # tests
-  pillow,
-  pytestCheckHook,
-  pytest-django,
-
-  # passthru tests
   dj-rest-auth,
+  django,
+  fetchFromGitHub,
+  gettext,
+  pillow,
+  pyjwt,
+  pytest-django,
+  pytestCheckHook,
+  python,
+  fido2,
+  python3-openid,
+  python3-saml,
+  pythonOlder,
+  qrcode,
+  requests-oauthlib,
+  requests,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "django-allauth";
-  version = "0.61.1";
+  version = "64.2.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pennersr";
     repo = "django-allauth";
     rev = "refs/tags/${version}";
-    hash = "sha256-C9SYlL1yMnSb+Zpi2opvDw1stxAHuI9/XKHyvkM36Cg=";
+    hash = "sha256-JKjM+zqrXidxpbi+fo6wbvdXlw2oDYH51EsvQ5yp3R8=";
   };
 
-  nativeBuildInputs = [
-    gettext
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
-    django
-    pyjwt
-    python3-openid
-    requests
-    requests-oauthlib
-  ] ++ pyjwt.optional-dependencies.crypto;
+  nativeBuildInputs = [ gettext ];
 
-  preBuild = "${python.interpreter} -m django compilemessages";
+  dependencies = [ django ];
 
   passthru.optional-dependencies = {
     saml = [ python3-saml ];
-    mfa = [ qrcode ];
+    mfa = [
+      fido2
+      qrcode
+    ];
+    openid = [ python3-openid ];
+    steam = [ python3-openid ];
+    socialaccount = [
+      requests-oauthlib
+      requests
+      pyjwt
+    ] ++ pyjwt.optional-dependencies.crypto;
   };
-
-  pythonImportsCheck = [ "allauth" ];
 
   nativeCheckInputs = [
     pillow
     pytestCheckHook
     pytest-django
   ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+
+  preBuild = "${python.interpreter} -m django compilemessages";
+
+  pythonImportsCheck = [ "allauth" ];
 
   disabledTests = [
     # Tests require network access
@@ -83,10 +75,10 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    changelog = "https://github.com/pennersr/django-allauth/blob/${version}/ChangeLog.rst";
     description = "Integrated set of Django applications addressing authentication, registration, account management as well as 3rd party (social) account authentication";
     downloadPage = "https://github.com/pennersr/django-allauth";
     homepage = "https://www.intenct.nl/projects/django-allauth";
+    changelog = "https://github.com/pennersr/django-allauth/blob/${version}/ChangeLog.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ derdennisop ];
   };


### PR DESCRIPTION
Diff: https://github.com/pennersr/django-allauth/compare/refs/tags/0.61.1...64.2.1

Changelog: https://github.com/pennersr/django-allauth/blob/64.2.1/ChangeLog.rst

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
