### PR TITLE
fetchRepoProject: support `hash` attribute

### DIFF
--- a/pkgs/by-name/am/amdvlk/package.nix
+++ b/pkgs/by-name/am/amdvlk/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     name = "amdvlk-src";
     manifest = "https://github.com/GPUOpen-Drivers/AMDVLK.git";
     rev = "refs/tags/v-${finalAttrs.version}";
-    sha256 = "1Svdr93ShjhaWJUTLn5y1kBM4hHey1dUVDiHqFIKgrU=";
+    hash = "sha256-1Svdr93ShjhaWJUTLn5y1kBM4hHey1dUVDiHqFIKgrU=";
   };
 
   buildInputs =


### PR DESCRIPTION
## Description of changes

- `fetchRepoProject`: support the modern `hash` attribute ;
  see #325892 
- `amdvlk`: convert `sha256` to `hash`, as a working example.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested compilation of all effected packages using `nixpkgs-review`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
