### PR TITLE
buildBazelPackage: support `fetchAttrs.hash`

### DIFF
--- a/pkgs/by-name/pe/perf_data_converter/package.nix
+++ b/pkgs/by-name/pe/perf_data_converter/package.nix
@@ -26,7 +26,7 @@ buildBazelPackage rec {
   ];
 
   fetchAttrs = {
-    sha256 = "sha256-Qm6Ng9cXvKx043P7qyNHyyMvdGK9aNarX1ZKeCp3mgY=";
+    hash = "sha256-Qm6Ng9cXvKx043P7qyNHyyMvdGK9aNarX1ZKeCp3mgY=";
   };
 
   nativeBuildInputs = [ jdk ];

--- a/pkgs/by-name/pr/protoc-gen-js/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-js/package.nix
@@ -19,7 +19,7 @@ buildBazelPackage rec {
 
   LIBTOOL = lib.optionalString stdenv.isDarwin "${cctools}/bin/libtool";
 
-  fetchAttrs.sha256 = "sha256-WOBlZ0XNrl5UxIaSDxZeOfzS2a8ZkrKdTLKHBDC9UNQ=";
+  fetchAttrs.hash = "sha256-WOBlZ0XNrl5UxIaSDxZeOfzS2a8ZkrKdTLKHBDC9UNQ=";
 
   buildAttrs.installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/ve/verible/package.nix
+++ b/pkgs/by-name/ve/verible/package.nix
@@ -37,7 +37,7 @@ buildBazelPackage rec {
   ];
 
   fetchAttrs = {
-    sha256 = "sha256-bKASgc5KftCWtMvJkGA4nweBAtgdnyC9uXIJxPjKYS0=";
+    hash = "sha256-bKASgc5KftCWtMvJkGA4nweBAtgdnyC9uXIJxPjKYS0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

- `buildBazelPackage`: support a `fetchAttrs.hash` attribute instead of the `sha256` one;
  see #325892
- Update `perf_data_converter`, `protoc-gen-js`, and `verible` to use the new attribute, as a proof-of-concept.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all affected packages using `nixpkgs-review`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
