### PR TITLE
python3Packages.brotlicffi: fix cross, clean up

### DIFF
--- a/pkgs/development/python-modules/brotlicffi/default.nix
+++ b/pkgs/development/python-modules/brotlicffi/default.nix
@@ -16,9 +16,9 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "python-hyper";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-oW4y1WBJ7+4XwNwwSSR0qUqN03cZYXUYQ6EAwce9dzI=";
+    repo = "brotlicffi";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-oW4y1WBJ7+4XwNwwSSR0qUqN03cZYXUYQ6EAwce9dzI=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/brotlicffi/default.nix
+++ b/pkgs/development/python-modules/brotlicffi/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   buildPythonPackage,
   pythonOlder,
+  setuptools,
   cffi,
   brotli,
 }:
@@ -10,7 +11,7 @@
 buildPythonPackage rec {
   pname = "brotlicffi";
   version = "1.1.0.0";
-  format = "setuptools";
+  pyproject = true;
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
@@ -20,11 +21,14 @@ buildPythonPackage rec {
     sha256 = "sha256-oW4y1WBJ7+4XwNwwSSR0qUqN03cZYXUYQ6EAwce9dzI=";
   };
 
+  build-system = [
+    setuptools
+    cffi
+  ];
+
   buildInputs = [ brotli ];
 
-  propagatedNativeBuildInputs = [ cffi ];
-
-  propagatedBuildInputs = [ cffi ];
+  dependencies = [ cffi ];
 
   preBuild = ''
     export USE_SHARED_BROTLI=1

--- a/pkgs/development/python-modules/pymunk/default.nix
+++ b/pkgs/development/python-modules/pymunk/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchPypi,
   python,
+  setuptools,
   cffi,
   pytestCheckHook,
   pythonOlder,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "pymunk";
   version = "6.5.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -23,7 +24,11 @@ buildPythonPackage rec {
     hash = "sha256-AV6upaZcnbKmQm9tTItRB6LpckappjdHvMH/awn/KeE=";
   };
 
-  propagatedBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [ cffi ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ ApplicationServices ];
 

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   bitstring,
   buildPythonPackage,
+  buildPackages,
   cffi,
   fetchPypi,
   pycparser,
@@ -29,6 +30,10 @@ buildPythonPackage rec {
     cffi
     pycparser
   ];
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = [ cffi ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace vex/Makefile-gcc \

--- a/pkgs/development/python-modules/rtmixer/default.nix
+++ b/pkgs/development/python-modules/rtmixer/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "rtmixer";
-  version = "0.1.4";
+  version = "0.1.7";
   format = "setuptools";
   disabled = isPy27;
 
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "spatialaudio";
     repo = "python-rtmixer";
     rev = "refs/tags/${version}";
-    hash = "sha256-S8aVfxoG0o5GarDX5ZIDQ3GKOT32NtttQJ449FI9Fy0=";
+    hash = "sha256-K5w6XWnDdA5HrzDOMhqinlxrg/09AF6c5CWZEsfVHb4=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/python-modules/rtmixer/default.nix
+++ b/pkgs/development/python-modules/rtmixer/default.nix
@@ -2,6 +2,7 @@
   fetchFromGitHub,
   buildPythonPackage,
   isPy27,
+  setuptools,
   cython,
   portaudio,
   cffi,
@@ -24,10 +25,16 @@ buildPythonPackage rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ portaudio ];
-  nativeBuildInputs = [ cython ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  buildInputs = [ portaudio ];
+
+  nativeBuildInputs = [
+    cython
+    cffi
+  ];
+
+  dependencies = [
     cffi
     pa-ringbuffer
     sounddevice

--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "sounddevice";
-  version = "0.4.7";
+  version = "0.5.0";
   format = "setuptools";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-abOGgY1QotUYYH1LlzRC6NUkdgx81si4vgPYyY/EvOc=";
+    hash = "sha256-DelSd2VLPUA9nBXe08bO3zB+myfMnOe9mVookdDJVa8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchPypi,
   isPy27,
+  setuptools,
   cffi,
   numpy,
   portaudio,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "sounddevice";
   version = "0.5.0";
-  format = "setuptools";
+  pyproject = true;
   disabled = isPy27;
 
   src = fetchPypi {
@@ -21,11 +22,15 @@ buildPythonPackage rec {
     hash = "sha256-DelSd2VLPUA9nBXe08bO3zB+myfMnOe9mVookdDJVa8=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     cffi
     numpy
     portaudio
   ];
+
+  nativeBuildInputs = [ cffi ];
 
   # No tests included nor upstream available.
   doCheck = false;


### PR DESCRIPTION
## Description of changes

This removes references to the build Python from the output, checked via `nix path-info -r ./result`.

Before:
```
$ nix path-info -r ./result | grep -v aarch64
/nix/store/lw2macnzp3av47m41qv6vcnq2daibgl1-libunistring-1.2
/nix/store/8hq38sx1hjgganlj6dn0fvvba0g7gcpi-libidn2-2.3.7
/nix/store/x45xiwvk2v97bw1yp1vb6rnmvhagpgyz-xgcc-13.3.0-libgcc
/nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52
/nix/store/4ybgqxv43z9sk9lccwq6dgmz6j32syr1-libffi-3.4.6
/nix/store/1w90l4fm5lzhlybipfilyjij2das6w98-openssl-3.0.14
/nix/store/q0iz2x35ki1aaqpjagjfi8s7q053cmc5-gcc-13.3.0-libgcc
/nix/store/22nxhmsfcv2q2rpkmfvzwg2w5z1l231z-gcc-13.3.0-lib
/nix/store/3hxxbbjc8r66nravvjind6ixhz7cpij1-mpdecimal-4.0.0
/nix/store/3zrkasqf3sqr9ff6sv5fddhlbf072a36-mailcap-2.1.54
/nix/store/4w3c2c11j2kmwxrznji2i7is53z5aldi-xz-5.6.2
/nix/store/897xqnq52vw76991r5m80h9j91370vj9-tzdata-2024a
/nix/store/8ad0k7rbn3rr9qiya29464g52asndxqi-gdbm-1.24-lib
/nix/store/f0dmadrh535bpayz2r4q5lslg0m17lnw-expat-2.6.2
/nix/store/rqs1zrcncqz3966khjndg1183cpdnqxs-zlib-1.3.1
/nix/store/g2i5j8i0bwfih7hg2wbc15k2969bckn3-sqlite-3.46.0
/nix/store/izpf49b74i15pcr9708s3xdwyqs4jxwl-bash-5.2p32
/nix/store/lhfgwjwwdacygiq702yvbahvpqmxivpx-libxcrypt-4.4.36
/nix/store/qhf8n3srrg0vdd44k7q71fb0p5az15b5-bzip2-1.0.8
/nix/store/z7nr6aqlzv51pk5ar8bgzg2alfqvi8fd-ncurses-6.4.20221231
/nix/store/xxcf5gwyn5pldv4b4wa2jw6vqg7v55y6-readline-8.2p10
/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5
/nix/store/f4kd84nwjrac6sbkgb3w8q2jmfdnq9vn-python3.12-pycparser-2.22
/nix/store/0jzljimwigmf28kz0323vv6xbkg21g6w-python3.12-cffi-1.17.0
```

After:
```
$ nix path-info -r ./result | grep -v aarch64
<no results>
```

Noticed this while trying to understand how wrong pythons can end up in the build by looking at `python3Packages.maestral`. Built in `x86_64-linux` without binfmt enabled, ran the program with binfmt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
