### PR TITLE
llvmPackages.*: Add devExtraCmakeFlags parameter

### DIFF
--- a/pkgs/development/compilers/llvm/common/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/common/bolt/default.nix
@@ -12,6 +12,7 @@
   python3,
   buildLlvmTools,
   patches ? [ ],
+  devExtraCmakeFlags ? [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,9 +44,11 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
   ];
 
-  cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmTools.llvm}/bin/llvm-tblgen")
-  ];
+  cmakeFlags =
+    lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmTools.llvm}/bin/llvm-tblgen")
+    ]
+    ++ devExtraCmakeFlags;
 
   postUnpack = ''
     chmod -R u+w -- $sourceRoot/..

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -17,6 +17,7 @@
 , fixDarwinDylibNames
 , enableManpages ? false
 , clang-tools-extra_src ? null
+, devExtraCmakeFlags ? []
 }:
 
 let
@@ -69,7 +70,9 @@ let
       # `clang-pseudo-gen`: https://github.com/llvm/llvm-project/commit/cd2292ef824591cc34cc299910a3098545c840c7
       "-DCLANG_TIDY_CONFUSABLE_CHARS_GEN=${buildLlvmTools.libclang.dev}/bin/clang-tidy-confusable-chars-gen"
       "-DCLANG_PSEUDO_GEN=${buildLlvmTools.libclang.dev}/bin/clang-pseudo-gen"
-    ]) ++ lib.optional (stdenv.targetPlatform.useLLVM or false) "-DCLANG_DEFAULT_CXX_STDLIB=ON";
+    ]) ++ lib.optionals (stdenv.targetPlatform.useLLVM or false) [
+      "-DCLANG_DEFAULT_CXX_STDLIB=ON"
+    ] ++ devExtraCmakeFlags;
 
     postPatch = ''
       # Make sure clang passes the correct location of libLTO to ld64

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -27,6 +27,7 @@
 # `libcompiler_rt` library, at least under certain configurations. Some
 # platforms stil expect this, however, so we symlink one into place.
 , forceLinkCompilerRt ? stdenv.hostPlatform.isOpenBSD
+, devExtraCmakeFlags ? []
 }:
 
 let
@@ -132,9 +133,9 @@ stdenv.mkDerivation ({
     "-DCOMPILER_RT_ENABLE_IOS=OFF"
   ]) ++ lib.optionals (lib.versionAtLeast version "19" && stdenv.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13") [
     "-DSANITIZER_MIN_OSX_VERSION=10.10"
-  ]  ++ lib.optionals (noSanitizers && lib.versionAtLeast release_version "19") [
+  ] ++ lib.optionals (noSanitizers && lib.versionAtLeast release_version "19") [
     "-DCOMPILER_RT_BUILD_CTX_PROFILE=OFF"
-  ];
+  ] ++ devExtraCmakeFlags;
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -16,6 +16,7 @@
 , cxxabi ? if stdenv.hostPlatform.isFreeBSD then freebsd.libcxxrt else null
 , libunwind
 , enableShared ? !stdenv.hostPlatform.isStatic
+, devExtraCmakeFlags ? []
 }:
 
 # external cxxabi is not supported on Darwin as the build will not link libcxx
@@ -103,7 +104,8 @@ let
     "-DCMAKE_CXX_COMPILER_WORKS=ON"
     "-DUNIX=ON" # Required otherwise libc++ fails to detect the correct linker
   ] ++ cxxCMakeFlags
-    ++ lib.optionals (cxxabi == null) cxxabiCMakeFlags;
+    ++ lib.optionals (cxxabi == null) cxxabiCMakeFlags
+    ++ devExtraCmakeFlags;
 
 in
 

--- a/pkgs/development/compilers/llvm/common/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/common/libunwind/default.nix
@@ -12,6 +12,7 @@
 , python3
 , libcxx
 , enableShared ? !stdenv.hostPlatform.isStatic
+, devExtraCmakeFlags ? []
 }:
 let
   pname = "libunwind";
@@ -68,7 +69,8 @@ stdenv.mkDerivation (rec {
   ];
 
   cmakeFlags = lib.optional (lib.versionAtLeast release_version "15") "-DLLVM_ENABLE_RUNTIMES=libunwind"
-    ++ lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
+    ++ lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF"
+    ++ devExtraCmakeFlags;
 
   meta = llvm_meta // {
     # Details: https://github.com/llvm/llvm-project/blob/main/libunwind/docs/index.rst

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -13,6 +13,7 @@
 , libxml2
 , libllvm
 , version
+, devExtraCmakeFlags ? []
 }:
 let
   pname = "lld";
@@ -55,7 +56,7 @@ stdenv.mkDerivation (rec {
     "-DLLD_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/cmake/lld"
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
-  ];
+  ] ++ devExtraCmakeFlags;
 
   # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";

--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -23,6 +23,7 @@
 , monorepoSrc ? null
 , patches ? [ ]
 , enableManpages ? false
+, devExtraCmakeFlags ? [ ]
 , ...
 }:
 
@@ -142,7 +143,7 @@ stdenv.mkDerivation (rec {
   ]) ++ lib.optionals doCheck [
     "-DLLDB_TEST_C_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
     "-DLLDB_TEST_CXX_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++"
-  ];
+  ] ++ devExtraCmakeFlags;
 
   doCheck = false;
   doInstallCheck = lib.versionOlder release_version "15";

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -40,6 +40,7 @@
   && !stdenv.hostPlatform.isAarch
 , enablePolly ? lib.versionAtLeast release_version "14"
 , enableTerminfo ? true
+, devExtraCmakeFlags ? []
 }:
 
 let
@@ -399,7 +400,7 @@ stdenv.mkDerivation (rec {
         nativeInstallFlags
       ])
     )
-  ];
+  ] ++ devExtraCmakeFlags;
 
   postInstall = ''
     mkdir -p $python/share

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -10,6 +10,7 @@
 , libllvm
 , version
 , doCheck ? (!stdenv.isx86_32 /* TODO: why */) && (!stdenv.hostPlatform.isMusl)
+, devExtraCmakeFlags ? []
 }:
 
 stdenv.mkDerivation rec {
@@ -63,7 +64,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals ((stdenv.hostPlatform != stdenv.buildPlatform) && !(stdenv.buildPlatform.canExecute stdenv.hostPlatform)) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
     "-DMLIR_TABLEGEN_EXE=${buildLlvmTools.mlir}/bin/mlir-tblgen"
-  ];
+  ] ++ devExtraCmakeFlags;
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -15,6 +15,7 @@
 , perl
 , pkg-config
 , version
+, devExtraCmakeFlags ? []
 }:
 let
   pname = "openmp";
@@ -60,7 +61,7 @@ stdenv.mkDerivation (rec {
     "-DCLANG_TOOL=${clang-unwrapped}/bin/clang"
     "-DOPT_TOOL=${llvm}/bin/opt"
     "-DLINK_TOOL=${llvm}/bin/llvm-link"
-  ];
+  ] ++ devExtraCmakeFlags;
 
   meta = llvm_meta // {
     homepage = "https://openmp.llvm.org/";


### PR DESCRIPTION
## Description of changes

cmake flags have a 'last flag wins' logic, so by appending to the end of
the flags it is possible to override any cmake flag.

It also ignores (and warns) if a flag is unused, so passing flags across
all packages should be safe if you want to ~target one package~ pass flags which aren't supported by all packages.

In combination with #320261, this PR allows consistently overriding all
packages within LLVM with additional cmake arguments. Consistency here
means for example 'if you override LLVM, then all dependencies on it 
also see the overridden LLVM in their input'. Consistency is hard to
achieve with the other obvious way of implementing this as a user: if
you use overrideAttrs then you have to write a big mess of override code
in order to override all dependents, and this can be very difficult in a
cross-compilation scenario using crossSystem and useLLVM, for example.

With this PR it is possible to write an overlay which overlays
`llvmPackages` with `super.llvmPackages.override { devExtraCmakeFlags = [ ... ]; }`,
and then the toolchain used with useLLVM in effect should respect
these flags.

This is useful in development for experimenting with the effect of
various flags, hence the chosen name `devCmakeFlags`.

This won't work out of the box without #341855 applied, which fixes
override passthrough.

See-Also: #320261, #341855

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
