### PR TITLE
pkgsStatic.haskellPackages: run checks by default

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2268,6 +2268,14 @@ self: super: {
   #  compilation failed
   hashable = dontCheckIf pkgs.stdenv.hostPlatform.isStatic super.hashable;
 
+  # Fails to build in pkgsStatic with:
+  #  Building test suite 'unliftio-spec' for unliftio-0.2.25.0..
+  #  ghc: could not execute: hspec-discover
+  #
+  # Because of this in Spec.hs:
+  #  {-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+  unliftio = dontCheckIf pkgs.stdenv.hostPlatform.isStatic super.unliftio;
+
   # BSON defaults to requiring network instead of network-bsd which is
   # required nowadays: https://github.com/mongodb-haskell/bson/issues/26
   bson = appendConfigureFlag "-f-_old_network" (super.bson.override {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2261,6 +2261,13 @@ self: super: {
   # Too strict bound on hspec (<2.11)
   utf8-light = doJailbreak super.utf8-light;
 
+  # Fails to build in pkgsStatic with:
+  #  Preprocessing test suite 'hashable-tests' for hashable-1.4.4.0..
+  #  Mmap.hsc: In function ‘_hsc2hs_test13’:
+  #  Mmap.hsc:54:20: error: storage size of ‘test_array’ isn’t constant
+  #  compilation failed
+  hashable = dontCheckIf pkgs.stdenv.hostPlatform.isStatic super.hashable;
+
   # BSON defaults to requiring network instead of network-bsd which is
   # required nowadays: https://github.com/mongodb-haskell/bson/issues/26
   bson = appendConfigureFlag "-f-_old_network" (super.bson.override {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2284,6 +2284,14 @@ self: super: {
   #  {-# OPTIONS_GHC -fforce-recomp -F -pgmF hspec-discover #-}
   infer-license = dontCheckIf pkgs.stdenv.hostPlatform.isStatic super.infer-license;
 
+  # Fails to build in pkgsStatic with:
+  #  Building test suite 'spec' for interpolate-0.2.1..
+  #  ghc: could not execute: hspec-discover
+  #
+  # Because of this in Spec.hs:
+  #  {-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+  interpolate = dontCheckIf pkgs.stdenv.hostPlatform.isStatic super.interpolate;
+
   # BSON defaults to requiring network instead of network-bsd which is
   # required nowadays: https://github.com/mongodb-haskell/bson/issues/26
   bson = appendConfigureFlag "-f-_old_network" (super.bson.override {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2276,6 +2276,14 @@ self: super: {
   #  {-# OPTIONS_GHC -F -pgmF hspec-discover #-}
   unliftio = dontCheckIf pkgs.stdenv.hostPlatform.isStatic super.unliftio;
 
+  # Fails to build in pkgsStatic with:
+  #  Building test suite 'spec' for infer-license-0.2.0..
+  #  ghc: could not execute: hspec-discover
+  #
+  # Because of this in Spec.hs:
+  #  {-# OPTIONS_GHC -fforce-recomp -F -pgmF hspec-discover #-}
+  infer-license = dontCheckIf pkgs.stdenv.hostPlatform.isStatic super.infer-license;
+
   # BSON defaults to requiring network instead of network-bsd which is
   # required nowadays: https://github.com/mongodb-haskell/bson/issues/26
   bson = appendConfigureFlag "-f-_old_network" (super.bson.override {

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -43,7 +43,7 @@ in
 , buildFlags ? []
 , haddockFlags ? []
 , description ? null
-, doCheck ? !isCross
+, doCheck ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
 , doBenchmark ? false
 , doHoogle ? true
 , doHaddockQuickjump ? doHoogle


### PR DESCRIPTION
## Description of changes

The default for `doCheck` is meant to disable tests, when they can't be executed in cross environments. However, `pkgsStatic` and some other package sets are technically implemented as cross, even though the binaries **can** be executed just fine. Using `canExecute` is a much better check for this, thus enabling test on `pkgsStatic` by default.

I found one package already which has broken tests for `pkgsStatic` only, thus I disabled them. There are very likely many more, but we'd need to build many more packages to find out...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (packages mentioned for pkgsStatic in release-haskell)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
