### PR TITLE
[Backport release-24.05] papers: Make thumbnailer file point to absolute path

### DIFF
--- a/pkgs/by-name/pa/papers/package.nix
+++ b/pkgs/by-name/pa/papers/package.nix
@@ -105,6 +105,11 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dkeyring=disabled"
   ];
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/papers.thumbnailer \
+      --replace-fail '=papers-thumbnailer' "=$out/bin/papers-thumbnailer"
+  '';
+
   preFixup = ''
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
   '';


### PR DESCRIPTION
Backport to release-24.05, from https://github.com/NixOS/nixpkgs/pull/340624.
