### PR TITLE
scion: vmTest should fail if certs expire

### DIFF
--- a/nixos/tests/scion/freestanding-deployment/default.nix
+++ b/nixos/tests/scion/freestanding-deployment/default.nix
@@ -131,25 +131,35 @@ in
       addresses="42-ffaa:1:1 42-ffaa:1:2 42-ffaa:1:3 42-ffaa:1:4 42-ffaa:1:5"
       timeout=100
       wait_for_all() {
+        ret=0
         for as in "$@"
         do
           scion showpaths $as --no-probe > /dev/null
-          return 1
+          ret=$?
+          if [ "$ret" -ne "0" ]; then
+            break
+          fi
         done
-        return 0
+        return $ret
       }
       ping_all() {
+        ret=0
         for as in "$@"
         do
           scion ping "$as,127.0.0.1" -c 3
+          ret=$?
+          if [ "$ret" -ne "0" ]; then
+            break
+          fi
         done
-        return 0
+        return $ret
       }
       for i in $(seq 0 $timeout); do
-        wait_for_all $addresses && exit 0
-        ping_all $addresses && exit 0
         sleep 1
+        wait_for_all $addresses || continue
+        ping_all $addresses && exit 0
       done
+      exit 1
     '';
   in
   ''

--- a/nixos/tests/scion/freestanding-deployment/default.nix
+++ b/nixos/tests/scion/freestanding-deployment/default.nix
@@ -193,6 +193,9 @@ in
     # Wait for scion-control.service on all instances
     wait_for_unit("scion-control.service")
 
+    # Ensure cert is valid against TRC
+    succeed("scion-pki certificate verify --trc /etc/scion/certs/*.trc /etc/scion/crypto/as/*.pem >&2")
+
     # Execute pingAll command on all instances
     succeed("${pingAll} >&2")
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The freestanding test suffers from certificate expiration errors after certificates are cached in the `/nix/store`. This
currently is an existing limitation with the test. However, the test was passing regardless. I have fixed these falsely
passing tests and included a certificate verification check via `scion-pki` to ensure that the certificates are valid
prior to running the rest of the test suite. Long term I think it could be a good idea to mock the system and hardware
clocks so that the vms run at a known datetime during the test.

Testing the failure case is a little hard because you have to either generate certificates that are already expired or
wait for already generated certs in your `/nix/store` to expire (10 days) then rerun the tests. I have left my cache
with the expired certs alone in order to test these failure cases and bump the TRC certificate template by a day to
rebuild the cache.

## Details

During some recent testing I was getting the following error on any of the scion nodes in the freestanding test. Example of
being unable to get `scion ping` to work from `scion01 (42-ffaa:1:1)`:

```
$ scion ping 42-ffaa:1:2,127.0.0.1 2>&1
Error: fetching paths: no path available
```

I noticed the following error in `scion-control`:

```
$ systemctl status scion-control -l
● scion-control.service - SCION Control Service
     Loaded: loaded (/etc/systemd/system/scion-control.service; enabled; preset: enabled)
     Active: active (running) since Sun 2024-09-15 00:55:42 UTC; 1min 55s ago
 Invocation: 5c474136670746da801582bd90858d46
   Main PID: 612 (scion-control)
         IP: 0B in, 0B out
         IO: 0B read, 0B written
      Tasks: 7 (limit: 1139)
     Memory: 22.1M (peak: 22.4M)
        CPU: 1.115s
     CGroup: /system.slice/scion-control.service
             └─612 /nix/store/ivbfaqfghkbaivrmqz34ch530ay07vqh-scion-0.11.0/bin/scion-control --config /nix/store/45p54wxmyw0yg0zav1nhiihabc96xwpk-scion-control.toml

Sep 15 00:57:25 scion01 scion-control[612]: 2024-09-15 00:57:25.593885+0000        INFO           beaconing/originator.go:118        Unable to originate on interface        {"debug_id": "03e10c0a", "egress_interface": 3, "err": {"msg": "creating beacon", "cause": {"msg": "extending segment", "cause": {"msg": "getting signer", "cause": {"msg": "no signer cached, reload interval has not passed", "stacktrace": ["github.com/scionproto/scion/control/trust.(*CachingSignerGen).Generate github.com/scionproto/scion/control/trust/signer_gen.go:53", "main.realMain.func18 github.com/scionproto/scion/control/cmd/control/main.go:782", "github.com/scionproto/scion/control/beaconing.SignerGenFunc.Generate github.com/scionproto/scion/control/beaconing/extender.go:52", "github.com/scionproto/scion/control/beaconing.(*DefaultExtender).Extend github.com/scionproto/scion/control/beaconing/extender.go:114", "github.com/scionproto/scion/control/beaconing.(*beaconOriginator).createBeacon github.com/scionproto/scion/control/beaconing/originator.go:208", "github.com/scionproto/scion/control/beaconing.(*beaconOriginator).originateBeacon github.com/scionproto/scion/control/beaconing/originator.go:163", "github.com/scionproto/scion/control/beaconing.(*Originator).originateBeacons.func2 github.com/scionproto/scion/control/beaconing/originator.go:117"]}}}, "egress_interface": 3}}
Sep 15 00:57:25 scion01 scion-control[612]: 2024-09-15 00:57:25.594380+0000        INFO           beaconing/originator.go:118        Unable to originate on interface        {"debug_id": "03e10c0a", "egress_interface": 1, "err": {"msg": "creating beacon", "cause": {"msg": "extending segment", "cause": {"msg": "getting signer", "cause": {"msg": "no signer cached, reload interval has not passed", "stacktrace": ["github.com/scionproto/scion/control/trust.(*CachingSignerGen).Generate github.com/scionproto/scion/control/trust/signer_gen.go:53", "main.realMain.func18 github.com/scionproto/scion/control/cmd/control/main.go:782", "github.com/scionproto/scion/control/beaconing.SignerGenFunc.Generate github.com/scionproto/scion/control/beaconing/extender.go:52", "github.com/scionproto/scion/control/beaconing.(*DefaultExtender).Extend github.com/scionproto/scion/control/beaconing/extender.go:114", "github.com/scionproto/scion/control/beaconing.(*beaconOriginator).createBeacon github.com/scionproto/scion/control/beaconing/originator.go:208", "github.com/scionproto/scion/control/beaconing.(*beaconOriginator).originateBeacon github.com/scionproto/scion/control/beaconing/originator.go:163", "github.com/scionproto/scion/control/beaconing.(*Originator).originateBeacons.func2 github.com/scionproto/scion/control/beaconing/originator.go:117"]}}}, "egress_interface": 1}}
...
```


Which revealed an expiration for the datetime of the certificates that were catched in my `/nix/store` from the previous
week:

```
$ scion-pki certificate verify --trc certs/*.trc crypto/as/*.pem 2>&1
Error: verification failed: chain did not verify against any selected TRC {errors=[verifying chain {trc_base=1; trc_serial=1}: x509: certificate has expired or is not yet valid: current time 2024-09-15T00:52:49Z is after 2024-09-13T20:35:35Z]}
```

Indead the certificate for the AS was expired:

```
$ scion-pki certificate inspect crypto/as/*.pem
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 1024874062564332414198402120506238248102663886261 (0xb384f1411f24853df54726f98766998a105915b5)
    Signature Algorithm: ECDSA-SHA256
        Issuer: CN=42-ffaa:1:1 CA cert,UnknownOID=1.3.6.1.4.1.55324.1.2.1
        Validity
            Not Before: Sep 10 20:35:35 2024 UTC
            Not After : Sep 13 20:35:35 2024 UTC
        Subject: CN=42-ffaa:1:1 AS cert,UnknownOID=1.3.6.1.4.1.55324.1.2.1
        Subject Public Key Info:
            Public Key Algorithm: ECDSA
                Public-Key: (256 bit)
                X:
                    ce:19:51:cb:25:dd:66:30:7a:86:7f:69:99:06:37:
                    b9:d8:fc:ce:42:2b:af:36:ff:20:7b:c7:9b:83:e4:
                    e5:2e
                Y:
                    43:65:98:3c:c7:0e:b9:dd:ee:48:03:65:15:61:9e:
                    eb:f5:ec:d8:f4:c2:84:75:e5:f6:6e:7e:96:d9:be:
                    62:f8
                Curve: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature
            X509v3 Extended Key Usage:
                Server Authentication, Client Authentication, Time Stamping
            X509v3 Subject Key Identifier:
                18:65:21:2A:59:AF:46:DF:81:7C:CF:D7:72:AB:47:64:E8:89:8D:EA
            X509v3 Authority Key Identifier:
                keyid:06:4C:A1:B5:63:39:D6:78:E9:13:A7:6E:33:59:78:64:8B:7A:CF:D9
    Signature Algorithm: ECDSA-SHA256
         30:44:02:20:15:ce:c7:ff:af:a1:f4:5b:86:61:52:15:e5:76:
         57:37:6f:8d:cb:b0:52:31:14:73:3b:3f:f9:3c:74:78:34:cf:
         02:20:04:1a:f7:29:5f:69:77:63:1c:b7:c3:71:73:86:ae:67:
         39:ac:36:cc:55:ed:ed:66:49:a1:f9:c6:42:72:c5:84
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 590278764195878617523045400181256210267404885984 (0x676503e5ce797b2dc4a9e57595493f56312ddfe0)
    Signature Algorithm: ECDSA-SHA256
        Issuer: CN=42-ffaa:1:1 cp root cert,UnknownOID=1.3.6.1.4.1.55324.1.2.1
        Validity
            Not Before: Sep 10 20:35:35 2024 UTC
            Not After : Sep 21 20:35:35 2024 UTC
        Subject: CN=42-ffaa:1:1 CA cert,UnknownOID=1.3.6.1.4.1.55324.1.2.1
        Subject Public Key Info:
            Public Key Algorithm: ECDSA
                Public-Key: (256 bit)
                X:
                    fb:60:43:56:5e:c8:12:a4:20:80:34:b0:b9:f9:3a:
                    3f:3a:23:1a:1e:b1:a4:d9:c7:f6:e2:0e:35:77:0c:
                    35:0b
                Y:
                    35:98:87:69:f6:ae:c1:2f:ad:4f:30:d8:5b:0d:00:
                    46:ab:d6:aa:53:bf:b8:7b:2c:5a:6b:36:2e:ba:0f:
                    f7:c0
                Curve: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Certificate Sign
            X509v3 Basic Constraints: critical
                CA:TRUE, pathlen:0
            X509v3 Subject Key Identifier:
                06:4C:A1:B5:63:39:D6:78:E9:13:A7:6E:33:59:78:64:8B:7A:CF:D9
            X509v3 Authority Key Identifier:
                keyid:09:AE:7D:CA:EC:39:4D:94:4F:BA:1C:B1:24:45:D6:C7:8C:13:1D:DE
    Signature Algorithm: ECDSA-SHA256
         30:46:02:21:00:fe:55:18:50:d8:f3:72:8f:54:77:f6:66:54:
         46:34:e5:a8:eb:a0:b0:1e:4b:b0:f2:35:64:00:07:01:9b:fa:
         1a:02:21:00:96:0d:68:5e:c5:18:2f:ff:f3:18:01:cd:6f:68:
         4a:99:e3:08:61:eb:30:b7:4f:06:aa:11:f0:1c:83:11:93:ce
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
