### PR TITLE
cudaPackages_{10*,11*}: warn about upcoming removal

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -9,6 +9,10 @@
   Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
   If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports back to Mac OS X Snow Leopard 10.6.
 
+- This will be the last release of Nixpkgs to support versions of CUDA prior to CUDA 12.0.
+  These versions only work with old compiler versions that will be unsupported by the time of the Nixpkgs 25.05 release.
+  In future, users should expect CUDA versions to be dropped as the compiler versions they require leave upstream support windows.
+
 - Convenience options for `amdgpu`, open source driver for Radeon cards, is now available under `hardware.amdgpu`.
 
 - [AMDVLK](https://github.com/GPUOpen-Drivers/AMDVLK), AMD's open source Vulkan driver, is now available to be configured as `hardware.amdgpu.amdvlk` option.

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -123,4 +123,10 @@ let
     fixedPoints.extends composedExtension passthruFunction
   );
 in
-cudaPackages
+# We want to warn users about the upcoming deprecation of old CUDA
+# versions, without breaking Nixpkgs CI with evaluation warnings. This
+# gross hack ensures that the warning only triggers if aliases are
+# enabled, which is true by default, but not for ofborg.
+lib.warnIf (cudaPackages.cudaOlder "12.0" && config.allowAliases)
+  "CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information"
+  cudaPackages

--- a/pkgs/top-level/pkg-config/tests.nix
+++ b/pkgs/top-level/pkg-config/tests.nix
@@ -1,6 +1,6 @@
 # cd nixpkgs
 # nix-build -A tests.pkg-config
-{ lib, stdenv, ... }:
+{ lib, config, stdenv, ... }:
 
 let
   # defaultPkgConfigPackages test needs a Nixpkgs with allowUnsupportedPlatform
@@ -10,7 +10,7 @@ let
   allPkgs = import ../default.nix {
     system = stdenv.hostPlatform.system;
     localSystem = stdenv.buildPlatform.system;
-    config = {
+    config = config // {
       allowUnsupportedSystem = true;
     };
     overlays = [];


### PR DESCRIPTION
## Description of changes

We currently package all CUDA versions from 10.0 onwards. In some cases, CUDA is the only thing preventing us from removing old versions of GCC. Since we currently don’t deprecate or remove CUDA versions, this will be an increasing drag on compiler maintenance in Nixpkgs going forward unless we establish a sensible policy. After discussing this with @SomeoneSerge in the context of old versions of GCC, I learned that there was already a desire to remove at least versions prior to 11.3, as those versions were only packaged in the old “runfile” format, but that it was blocked on someone doing the work to warn about the upcoming deprecation for a release cycle.

This change adds a release note and warnings indicating that CUDA 10.x and 11.x will be removed in Nixpkgs 25.05, about 8 months from now.

I chose this version cut‐off because these versions of CUDA require GCC < 12. GCC releases a major version every year, and seems to support about four releases at a time, releasing the last update to the oldest version and marking it as unsupported on their site around the time of the release of the next major version. Therefore, by the time of the 25.05 release, we should expect GCC 15 to be released and GCC 11 to become unsupported. Adding a warning and communicating the policy of only shipping CUDA versions that work with supported compilers in the release notes means that we should be able to clean up old versions as required without any issue or extensive deprecation period in future, without obligating us to do so if there is a strongly compelling reason to be more lenient. That should help solve both shipping an indefinitely‐growing list of CUDA versions and an indefinitely‐growing list of GCC and LLVM versions.

As I’m not a user of CUDA myself, I can’t be sure of how sensible this version support policy is, but I think it’s fair to say that it’s reasonable for Nixpkgs to choose not to maintain compiler versions that are unsupported upstream just for the sake of versions of CUDA that are also unmaintained. CUDA 11.x has not received an update for two years already, and would only become unsupported in Nixpkgs in over half a year’s time.

CUDA 10.x is currently unused in‐tree except for the unmaintained Caffe and NVIDIA DCGM, which depends on multiple CUDA versions solely so that it can provide plugins for those versions. The latest DCGM version has already removed support for CUDA 10.x and is just awaiting an update in Nixpkgs. They maintain a list of supported versions to build plugins for in their CMake build system, so it should be simple enough for us to only build support for the versions of CUDA that we support in Nixpkgs.

From what I can tell, CUDA 11.x is currently used by the following packages other than DCGM:

* `catboost`, because of <https://github.com/catboost/catboost/issues/2540>. It looks like upstream has since redesigned this part of their build system, so perhaps the problem is no longer present, or would be easier to fix.

* `magma_2_6_2`, an old version from before upstream added CUDA 12 support. This seems okay to break to me; that version is not maintained and will never be updated for new CUDA versions, and the CUDA support is optional.

* `paddlepaddle`, which, uh, also requires OpenSSL 1.1 of all things. <https://github.com/PaddlePaddle/Paddle/issues/67571> states that PaddlePaddle supports up to 12.3.

* `python3Packages.cupy`, which is listed as “possibly incompatible with cutensor 2.0 that comes with `cudaPackages_12`”. I’m not sure what the “possibly” means here, but according to <https://github.com/cupy/cupy/tree/v13.3.0?tab=readme-ov-file#installation> they ship binary wheels using CUDA 12.x so I think this should be fine.

* `python3Packages.tensorrt`, which supports CUDA 12.x going by <https://github.com/NVIDIA/TensorRT/blob/release/10.4/CMakeLists.txt#L111>.

* TensorFlow, which has a link to <https://www.tensorflow.org/install/source#gpu> above the `python3Packages.tensorflow-bin` definition, but that page lists the versions we package as supporting CUDA 12.x.

Given the years since CUDA 11.x received any update upstream, and the seemingly very limited set of packages that truly require it, I think the policy of being able to drop versions that require unsupported compilers starting from the next Nixpkgs release is a reasonable one, but of course I’m open to feedback from the CUDA maintainers about this.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>disko</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
