### PR TITLE
bcachefs-tools: remove johnrtitor as maintainer

### DIFF
--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -130,7 +130,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
       davidak
-      johnrtitor
       Madouura
     ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
## Description of changes

I have moved to ext4 LVM to look for stability.
After constant breaking changes for the past 6 months, even in mid rc kernel, and with each kernel update requiring fscks (and data corruption), I have decided to give in. Due to me no longer using bcachefs, I don't think I can be a maintainer of this.

I am still willing to merge non-complex updates and such if necessary, but keep in mind that I can not test them.

Interested `bcachefs` users and nixpkgs maintainers should be encouraged to pick this up. And I am happy to assist if needed.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
