### PR TITLE
veryl: init at 0.13.0

### DIFF
--- a/pkgs/by-name/ve/veryl/package.nix
+++ b/pkgs/by-name/ve/veryl/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  dbus,
+  stdenv,
+  darwin,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "veryl";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "veryl-lang";
+    repo = "veryl";
+    rev = "v${version}";
+    hash = "sha256-U4ikR2jRmHUwRycAL/t2XJtvHQniKu6skRKWn8XDIgM=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-t2q3rbY84+0ayxt7a/TCD0exCm7KEs+8UbQjCtqZPoE=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      dbus
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.CoreFoundation
+      darwin.apple_sdk.frameworks.CoreServices
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
+
+  checkFlags = [
+    # takes over an hour
+    "--skip=tests::progress"
+    # tempfile::tempdir().unwrap() -> "No such file or directory"
+    "--skip=tests::bump_version"
+    "--skip=tests::bump_version_with_commit"
+    "--skip=tests::check"
+    "--skip=tests::load"
+    "--skip=tests::lockfile"
+    "--skip=tests::publish"
+    "--skip=tests::publish_with_commit"
+    # "Permission Denied", while making its cache dir?
+    "--skip=analyzer::test_25_dependency"
+    "--skip=analyzer::test_68_std"
+    "--skip=emitter::test_25_dependency"
+    "--skip=emitter::test_68_std"
+
+  ];
+
+  meta = {
+    description = "Modern Hardware Description Language";
+    homepage = "https://veryl-lang.org/";
+    changelog = "https://github.com/veryl-lang/veryl/blob/${src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ pbsds ];
+    mainProgram = "veryl";
+  };
+}


### PR DESCRIPTION
## Description of changes

https://veryl-lang.org/

I tried the usual tricks of making a TMPDIR and HOME, but the tests failures didn't care /shrug

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
