### PR TITLE
nixos/syncthing: define and handle encryptionPassword option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -518,6 +518,8 @@
 - `nix.channel.enable = false` no longer implies `nix.settings.nix-path = []`.
   Since Nix 2.13, a `nix-path` set in `nix.conf` cannot be overriden by the `NIX_PATH` configuration variable.
 
+- `services.syncthing` now accepts an `attrSet` for `folders[<folder>].devices`, allowing to set `encryptionPassword` file for a device.
+
 ## Detailed migration information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -34,12 +34,22 @@ let
       The options services.syncthing.settings.folders.<name>.{rescanInterval,watch,watchDelay}
       were removed. Please use, respectively, {rescanIntervalS,fsWatcherEnabled,fsWatcherDelayS} instead.
     '' {
-    devices = map (device:
-      if builtins.isString device then
-        { deviceId = cfg.settings.devices.${device}.id; }
+    devices = let
+      folderDevices = folder.devices;
+    in
+      if builtins.isList folderDevices then
+        map (device:
+          if builtins.isString device then
+            { deviceId = cfg.settings.devices.${device}.id; }
+          else
+            device
+        ) folderDevices
+      else if builtins.isAttrs folderDevices then
+        mapAttrsToList (deviceName: deviceValue:
+          deviceValue // { deviceId = cfg.settings.devices.${deviceName}.id; }
+        ) folderDevices
       else
-        device
-    ) folder.devices;
+        throw "Invalid type for devices in folder '${folderName}'; expected list or attrset.";
   }) (filterAttrs (_: folder:
     folder.enable
   ) cfg.settings.folders);
@@ -435,11 +445,30 @@ in {
                   };
 
                   devices = mkOption {
-                    type = types.listOf types.str;
+                    type = types.oneOf [
+                      (types.listOf types.str)
+                      (types.attrsOf (types.submodule ({ name, ... }: {
+                        freeformType = settingsFormat.type;
+                        options = {
+                          encryptionPassword = mkOption {
+                            type = types.nullOr types.str;
+                            default = null;
+                            description = ''
+                              Path to encryption password. If set, the file will be read during
+                              service activation, without being embedded in derivation.
+                            '';
+                          };
+                        };
+                      }))
+                    )];
                     default = [];
                     description = ''
                       The devices this folder should be shared with. Each device must
                       be defined in the [devices](#opt-services.syncthing.settings.devices) option.
+
+                      Either a list of strings, or an attribute set, where keys are defined in the
+                      [devices](#opt-services.syncthing.settings.devices) option, and values are
+                      device configurations.
                     '';
                   };
 

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -103,9 +103,66 @@ let
         # don't exist in the array given. That's why we use here `POST`, and
         # only if s.override == true then we DELETE the relevant folders
         # afterwards.
-        (map (new_cfg: ''
-          curl -d ${lib.escapeShellArg (builtins.toJSON new_cfg)} -X POST ${s.baseAddress}
-        ''))
+        (map (new_cfg:
+          let
+            isSecret = attr: value: builtins.isString value && attr == "encryptionPassword";
+
+            resolveSecrets = attr: value:
+              if builtins.isAttrs value then
+                # Attribute set: process each attribute
+                builtins.mapAttrs (name: val: resolveSecrets name val) value
+              else if builtins.isList value then
+                # List: process each element
+                map (item: resolveSecrets "" item) value
+              else if isSecret attr value then
+                # String that looks like a path: replace with placeholder
+                let
+                  varName = "secret_${builtins.hashString "sha256" value}";
+                in
+                  "\${${varName}}"
+              else
+                # Other types: return as is
+                value;
+
+            # Function to collect all file paths from the configuration
+            collectPaths = attr: value:
+              if builtins.isAttrs value then
+                concatMap (name: collectPaths name value.${name}) (builtins.attrNames value)
+              else if builtins.isList value then
+                concatMap (name: collectPaths "" name) value
+              else if isSecret attr value then
+                [ value ]
+              else
+                [];
+
+            # Function to generate variable assignments for the secrets
+            generateSecretVars = paths:
+              concatStringsSep "\n" (map (path:
+                let
+                  varName = "secret_${builtins.hashString "sha256" path}";
+                in
+                  ''
+                    if [ ! -r ${path} ]; then
+                      echo "${path} does not exist"
+                      exit 1
+                    fi
+                    ${varName}=$(<${path})
+                  ''
+              ) paths);
+
+            resolved_cfg = resolveSecrets "" new_cfg;
+            secretPaths = collectPaths "" new_cfg;
+            secretVarsScript = generateSecretVars secretPaths;
+
+            jsonString = builtins.toJSON resolved_cfg;
+            escapedJson = builtins.replaceStrings ["\""] ["\\\""] jsonString;
+          in
+          ''
+            ${secretVarsScript}
+
+            curl -d "${escapedJson}" -X POST ${s.baseAddress}
+          ''
+        ))
         (lib.concatStringsSep "\n")
       ]
       /* If we need to override devices/folders, we iterate all currently configured

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -945,6 +945,7 @@ in {
   syncthing-no-settings = handleTest ./syncthing/no-settings.nix {};
   syncthing-init = handleTest ./syncthing/init.nix {};
   syncthing-many-devices = handleTest ./syncthing/many-devices.nix {};
+  syncthing-folders = handleTest ./syncthing/folders.nix {};
   syncthing-relay = handleTest ./syncthing-relay.nix {};
   sysinit-reactivation = runTest ./sysinit-reactivation.nix;
   systemd = handleTest ./systemd.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -941,10 +941,10 @@ in {
   switchTestNg = handleTest ./switch-test.nix { ng = true; };
   sx = handleTest ./sx.nix {};
   sympa = handleTest ./sympa.nix {};
-  syncthing = handleTest ./syncthing.nix {};
-  syncthing-no-settings = handleTest ./syncthing-no-settings.nix {};
-  syncthing-init = handleTest ./syncthing-init.nix {};
-  syncthing-many-devices = handleTest ./syncthing-many-devices.nix {};
+  syncthing = handleTest ./syncthing/default.nix {};
+  syncthing-no-settings = handleTest ./syncthing/no-settings.nix {};
+  syncthing-init = handleTest ./syncthing/init.nix {};
+  syncthing-many-devices = handleTest ./syncthing/many-devices.nix {};
   syncthing-relay = handleTest ./syncthing-relay.nix {};
   sysinit-reactivation = runTest ./sysinit-reactivation.nix;
   systemd = handleTest ./systemd.nix {};

--- a/nixos/tests/syncthing/default.nix
+++ b/nixos/tests/syncthing/default.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ lib, pkgs, ... }: {
+import ../make-test-python.nix ({ lib, pkgs, ... }: {
   name = "syncthing";
   meta.maintainers = with pkgs.lib.maintainers; [ chkno ];
 

--- a/nixos/tests/syncthing/folders.nix
+++ b/nixos/tests/syncthing/folders.nix
@@ -10,6 +10,8 @@ import ../make-test-python.nix (
       '';
     idA = genNodeId "a";
     idB = genNodeId "b";
+    idC = genNodeId "c";
+    testPasswordFile = pkgs.writeText "syncthing-test-password" "it's a secret";
   in
   {
     name = "syncthing";
@@ -23,12 +25,15 @@ import ../make-test-python.nix (
           cert = "${idA}/cert.pem";
           key = "${idA}/key.pem";
           settings = {
-            devices.b = {
-              id = lib.fileContents "${idB}/id";
-            };
+            devices.b.id = lib.fileContents "${idB}/id";
+            devices.c.id = lib.fileContents "${idC}/id";
             folders.foo = {
               path = "/var/lib/syncthing/foo";
               devices = [ "b" ];
+            };
+            folders.bar = {
+              path = "/var/lib/syncthing/bar";
+              devices.c.encryptionPassword = "${testPasswordFile}";
             };
           };
         };
@@ -40,12 +45,35 @@ import ../make-test-python.nix (
           cert = "${idB}/cert.pem";
           key = "${idB}/key.pem";
           settings = {
-            devices.a = {
-              id = lib.fileContents "${idA}/id";
-            };
+            devices.a.id = lib.fileContents "${idA}/id";
+            devices.c.id = lib.fileContents "${idC}/id";
             folders.foo = {
               path = "/var/lib/syncthing/foo";
               devices = [ "a" ];
+            };
+            folders.bar = {
+              path = "/var/lib/syncthing/bar";
+              devices.c.encryptionPassword = "${testPasswordFile}";
+            };
+          };
+        };
+      };
+      c = {
+        services.syncthing = {
+          enable = true;
+          openDefaultPorts = true;
+          cert = "${idC}/cert.pem";
+          key = "${idC}/key.pem";
+          settings = {
+            devices.a.id = lib.fileContents "${idA}/id";
+            devices.b.id = lib.fileContents "${idB}/id";
+            folders.bar = {
+              path = "/var/lib/syncthing/bar";
+              devices = [
+                "a"
+                "b"
+              ];
+              type = "receiveencrypted";
             };
           };
         };
@@ -54,16 +82,39 @@ import ../make-test-python.nix (
 
     testScript = ''
       start_all()
+
       a.wait_for_unit("syncthing.service")
       b.wait_for_unit("syncthing.service")
+      c.wait_for_unit("syncthing.service")
       a.wait_for_open_port(22000)
       b.wait_for_open_port(22000)
+      c.wait_for_open_port(22000)
+
+      # Test foo
+
       a.wait_for_file("/var/lib/syncthing/foo")
       b.wait_for_file("/var/lib/syncthing/foo")
+
       a.succeed("echo a2b > /var/lib/syncthing/foo/a2b")
       b.succeed("echo b2a > /var/lib/syncthing/foo/b2a")
+
       a.wait_for_file("/var/lib/syncthing/foo/b2a")
       b.wait_for_file("/var/lib/syncthing/foo/a2b")
+
+      # Test bar
+
+      a.wait_for_file("/var/lib/syncthing/bar")
+      b.wait_for_file("/var/lib/syncthing/bar")
+      c.wait_for_file("/var/lib/syncthing/bar")
+
+      a.succeed("echo plaincontent > /var/lib/syncthing/bar/plainname")
+
+      # B should be able to decrypt, check that content of file matches
+      b.wait_for_file("/var/lib/syncthing/bar/plainname")
+      b.succeed("grep plaincontent /var/lib/syncthing/bar/plainname")
+
+      # Bar on C is untrusted, check that content is not in cleartext
+      c.fail("grep -R plaincontent /var/lib/syncthing/bar")
     '';
   }
 )

--- a/nixos/tests/syncthing/folders.nix
+++ b/nixos/tests/syncthing/folders.nix
@@ -1,0 +1,69 @@
+import ../make-test-python.nix (
+  { lib, pkgs, ... }:
+  let
+    genNodeId =
+      name:
+      pkgs.runCommand "syncthing-test-certs-${name}" { } ''
+        mkdir -p $out
+        ${pkgs.syncthing}/bin/syncthing generate --config=$out
+        ${pkgs.libxml2}/bin/xmllint --xpath 'string(configuration/device/@id)' $out/config.xml > $out/id
+      '';
+    idA = genNodeId "a";
+    idB = genNodeId "b";
+  in
+  {
+    name = "syncthing";
+    meta.maintainers = with pkgs.lib.maintainers; [ zarelit ];
+
+    nodes = {
+      a = {
+        services.syncthing = {
+          enable = true;
+          openDefaultPorts = true;
+          cert = "${idA}/cert.pem";
+          key = "${idA}/key.pem";
+          settings = {
+            devices.b = {
+              id = lib.fileContents "${idB}/id";
+            };
+            folders.foo = {
+              path = "/var/lib/syncthing/foo";
+              devices = [ "b" ];
+            };
+          };
+        };
+      };
+      b = {
+        services.syncthing = {
+          enable = true;
+          openDefaultPorts = true;
+          cert = "${idB}/cert.pem";
+          key = "${idB}/key.pem";
+          settings = {
+            devices.a = {
+              id = lib.fileContents "${idA}/id";
+            };
+            folders.foo = {
+              path = "/var/lib/syncthing/foo";
+              devices = [ "a" ];
+            };
+          };
+        };
+      };
+    };
+
+    testScript = ''
+      start_all()
+      a.wait_for_unit("syncthing.service")
+      b.wait_for_unit("syncthing.service")
+      a.wait_for_open_port(22000)
+      b.wait_for_open_port(22000)
+      a.wait_for_file("/var/lib/syncthing/foo")
+      b.wait_for_file("/var/lib/syncthing/foo")
+      a.succeed("echo a2b > /var/lib/syncthing/foo/a2b")
+      b.succeed("echo b2a > /var/lib/syncthing/foo/b2a")
+      a.wait_for_file("/var/lib/syncthing/foo/b2a")
+      b.wait_for_file("/var/lib/syncthing/foo/a2b")
+    '';
+  }
+)

--- a/nixos/tests/syncthing/init.nix
+++ b/nixos/tests/syncthing/init.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ lib, pkgs, ... }: let
+import ../make-test-python.nix ({ lib, pkgs, ... }: let
 
   testId = "7CFNTQM-IMTJBHJ-3UWRDIU-ZGQJFR6-VCXZ3NB-XUH3KZO-N52ITXR-LAIYUAU";
 

--- a/nixos/tests/syncthing/many-devices.nix
+++ b/nixos/tests/syncthing/many-devices.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ lib, pkgs, ... }:
+import ../make-test-python.nix ({ lib, pkgs, ... }:
 
 # This nixosTest is supposed to check the following:
 #

--- a/nixos/tests/syncthing/no-settings.nix
+++ b/nixos/tests/syncthing/no-settings.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ lib, pkgs, ... }: {
+import ../make-test-python.nix ({ lib, pkgs, ... }: {
   name = "syncthing";
   meta.maintainers = with pkgs.lib.maintainers; [ chkno ];
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Redefine `devices` to accept either a list of strings, or an attrset.
- If attrset, allow specifying `encryptionPassword` as a reference to password to use for device.
- Modify activation script to read all encryption passwords and concatinate them to JSON without hitting nix store.

Closes https://github.com/NixOS/nixpkgs/issues/121286

cc @kira-bruneau @WillPower3309 @bjornfor

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
