### PR TITLE
python312Packages.pyhanko: mark as broken on darwin; clean

### DIFF
--- a/pkgs/development/python-modules/pyhanko/default.nix
+++ b/pkgs/development/python-modules/pyhanko/default.nix
@@ -1,41 +1,46 @@
 {
   lib,
   stdenv,
-  aiohttp,
-  asn1crypto,
   buildPythonPackage,
-  certomancer,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  asn1crypto,
   click,
   cryptography,
-  defusedxml,
-  fetchFromGitHub,
-  fonttools,
-  freezegun,
-  oscrypto,
-  pillow,
   pyhanko-certvalidator,
-  pytest-aiohttp,
-  pytestCheckHook,
-  python-barcode,
-  python-pae,
-  python-pkcs11,
-  pythonOlder,
   pyyaml,
   qrcode,
   requests,
-  requests-mock,
-  setuptools,
   tzlocal,
+
+  # optional-dependencies
+  oscrypto,
+  defusedxml,
+  fonttools,
   uharfbuzz,
+  pillow,
+  python-barcode,
+  python-pkcs11,
+  aiohttp,
   xsdata,
+
+  # tests
+  certomancer,
+  freezegun,
+  pytest-aiohttp,
+  pytestCheckHook,
+  python-pae,
+  requests-mock,
 }:
 
 buildPythonPackage rec {
   pname = "pyhanko";
   version = "0.25.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "MatthiasValvekens";
@@ -57,7 +62,7 @@ buildPythonPackage rec {
     tzlocal
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     extra-pubkey-algs = [ oscrypto ];
     xmp = [ defusedxml ];
     opentype = [
@@ -77,11 +82,11 @@ buildPythonPackage rec {
     aiohttp
     certomancer
     freezegun
-    python-pae
     pytest-aiohttp
-    requests-mock
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+    python-pae
+    requests-mock
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTestPaths = [
     # ModuleNotFoundError: No module named 'csc_dummy'
@@ -116,12 +121,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyhanko" ];
 
-  meta = with lib; {
+  meta = {
     description = "Sign and stamp PDF files";
     mainProgram = "pyhanko";
     homepage = "https://github.com/MatthiasValvekens/pyHanko";
     changelog = "https://github.com/MatthiasValvekens/pyHanko/blob/v${version}/docs/changelog.rst";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
     # Most tests fail with:
     # OSError: One or more parameters passed to a function were not valid.

--- a/pkgs/development/python-modules/pyhanko/default.nix
+++ b/pkgs/development/python-modules/pyhanko/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   aiohttp,
   asn1crypto,
   buildPythonPackage,
@@ -122,5 +123,8 @@ buildPythonPackage rec {
     changelog = "https://github.com/MatthiasValvekens/pyHanko/blob/v${version}/docs/changelog.rst";
     license = licenses.mit;
     maintainers = [ ];
+    # Most tests fail with:
+    # OSError: One or more parameters passed to a function were not valid.
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

It has been broken for a while on darwin.

<details>

```
=========================== short test summary info ============================
FAILED pyhanko_tests/cli_tests/test_cli_ltv.py::test_cli_lta_update[rsa] - AssertionError:
FAILED pyhanko_tests/cli_tests/test_cli_ltv.py::test_cli_ltvfix[rsa] - AssertionError:
FAILED pyhanko_tests/cli_tests/test_cli_ltv.py::test_cli_lta_update[ecdsa] - AssertionError:
FAILED pyhanko_tests/cli_tests/test_cli_ltv.py::test_cli_ltvfix[ecdsa] - AssertionError:
FAILED pyhanko_tests/cli_tests/test_cli_ltv.py::test_cli_lta_update[ed25519] - AssertionError:
FAILED pyhanko_tests/cli_tests/test_cli_ltv.py::test_cli_ltvfix[ed25519] - AssertionError:
FAILED pyhanko_tests/cli_tests/test_cli_signing.py::test_cli_pades_lta[rsa] - AssertionError:
FAILED pyhanko_tests/cli_tests/test_cli_signing.py::test_cli_timestamp[rsa] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_signing.py::test_cli_pades_lta[ecdsa] - AssertionError:
FAILED pyhanko_tests/cli_tests/test_cli_signing.py::test_cli_timestamp[ecdsa] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_signing.py::test_cli_pades_lta[ed25519] - AssertionError:
FAILED pyhanko_tests/cli_tests/test_cli_signing.py::test_cli_timestamp[ed25519] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate[rsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate[rsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_summary[rsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_summary[rsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_pretty_print[rsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_pretty_print[rsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_validation_time[rsa-regular] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_validation_time[rsa-encrypted] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_claimed_time[rsa-regular] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_claimed_time[rsa-encrypted] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_default_context[rsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_default_context[rsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_explicit_context[rsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_explicit_context[rsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_detached_validate[rsa-pem] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_detached_validate[rsa-der] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate[ecdsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate[ecdsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_summary[ecdsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_summary[ecdsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_pretty_print[ecdsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_pretty_print[ecdsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_validation_time[ecdsa-regular] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_validation_time[ecdsa-encrypted] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_claimed_time[ecdsa-regular] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_claimed_time[ecdsa-encrypted] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_default_context[ecdsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_default_context[ecdsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_explicit_context[ecdsa-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_explicit_context[ecdsa-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_detached_validate[ecdsa-pem] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_detached_validate[ecdsa-der] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate[ed25519-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate[ed25519-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_summary[ed25519-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_summary[ed25519-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_pretty_print[ed25519-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_pretty_print[ed25519-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_validation_time[ed25519-regular] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_validation_time[ed25519-encrypted] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_claimed_time[ed25519-regular] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_claimed_time[ed25519-encrypted] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_default_context[ed25519-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_default_context[ed25519-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_explicit_context[ed25519-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_explicit_context[ed25519-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_detached_validate[ed25519-pem] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_detached_validate[ed25519-der] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate[ed448-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate[ed448-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_summary[ed448-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_summary[ed448-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_pretty_print[ed448-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_pretty_print[ed448-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_validation_time[ed448-regular] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_validation_time[ed448-encrypted] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_claimed_time[ed448-regular] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_claimed_time[ed448-encrypted] - AssertionError: 2030-07-30 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_default_context[ed448-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_default_context[ed448-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_explicit_context[ed448-regular] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_explicit_context[ed448-encrypted] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_detached_validate[ed448-pem] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_detached_validate[ed448-der] - AssertionError: 2020-08-01 00:00:00,000 - cli - ERROR - Generic processing ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_with_weak_hash - assert 'sha1_rsa is not allowed' in '2020-08-01 00:00:00,000 - cli - ERROR ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_signed_with_wrong_key[default] - assert 'INVALID' in '2020-08-01 00:00:00,000 - cli - ERROR - Generic proces...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_signed_with_wrong_key[verbose] - assert 'INVALID' in '2020-08-01 00:00:00,000 - root - DEBUG - Running with ...
FAILED pyhanko_tests/cli_tests/test_cli_validation.py::test_basic_validate_signed_with_wrong_key[pretty] - assert 'INVALID' in '2020-08-01 00:00:00,000 - cli - ERROR - Generic proces...
FAILED pyhanko_tests/test_cms.py::test_detached_cms_with_wrong_tst - OSError: One or more parameters passed to a function were not valid.
FAILED pyhanko_tests/test_cms.py::test_detached_cms_with_duplicated_attr - OSError: One or more parameters passed to a function were not valid.
FAILED pyhanko_tests/test_cms.py::test_no_certificates[True] - OSError: One or more parameters passed to a function were not valid.
FAILED pyhanko_tests/test_cms.py::test_no_certificates[False] - OSError: One or more parameters passed to a function were not valid.
FAILED pyhanko_tests/test_diff_analysis.py::test_diff_analysis_add_extensions_dict[extensions-direct.pdf] - OSError: One or more parameters passed to a function were not valid.
FAILED pyhanko_tests/test_diff_analysis.py::test_diff_analysis_add_extensions_dict[extensions-indirect.pdf] - OSError: One or more parameters passed to a function were not valid.
FAILED pyhanko_tests/test_diff_analysis.py::test_diff_analysis_add_extensions_dict[extensions-update-indirect.pdf] - OSError: One or more parameters passed to a function were not valid.
FAILED pyhanko_tests/test_diff_analysis.py::test_diff_analysis_add_extensions_dict[extensions-update-direct.pdf] - OSError: One or more parameters passed to a function were not valid.
FAILED pyhanko_tests/test_diff_analysis.py::test_diff_analysis_update_indirect_extensions_not_all_paths - OSError: One or more parameters passed to a function were not valid.
FAILED pyhanko_tests/test_signing.py::test_ocsp_without_nextupdate_embed - OSError: One or more parameters passed to a function were not valid.
= 90 failed, 1778 passed, 124 skipped, 45 deselected, 58 warnings in 960.03s (0:16:00) =
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
