### PR TITLE
radicle-explorer: init at 0.17.0

### DIFF
--- a/pkgs/by-name/ra/radicle-explorer/0001-remove-dependency-on-plausible.patch
+++ b/pkgs/by-name/ra/radicle-explorer/0001-remove-dependency-on-plausible.patch
@@ -1,0 +1,77 @@
+From cc4718cbea1bd70de21a2be515a944802246ffc7 Mon Sep 17 00:00:00 2001
+From: Vincent Ambo <mail@tazj.in>
+Date: Sun, 15 Sep 2024 03:08:28 +0300
+Subject: [PATCH] remove dependency on plausible
+
+---
+ package-lock.json | 9 ---------
+ package.json      | 1 -
+ src/App.svelte    | 8 --------
+ 3 files changed, 18 deletions(-)
+
+diff --git a/package-lock.json b/package-lock.json
+index d52de6c0..d96e342f 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -29,7 +29,6 @@
+         "marked-katex-extension": "^5.1.1",
+         "marked-linkify-it": "^3.1.11",
+         "md5": "^2.3.0",
+-        "plausible-tracker": "^0.3.9",
+         "svelte": "^4.2.19",
+         "twemoji": "^14.0.2",
+         "zod": "^3.23.8"
+@@ -3697,14 +3696,6 @@
+         "url": "https://github.com/sponsors/jonschlinkert"
+       }
+     },
+-    "node_modules/plausible-tracker": {
+-      "version": "0.3.9",
+-      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.9.tgz",
+-      "integrity": "sha512-hMhneYm3GCPyQon88SZrVJx+LlqhM1kZFQbuAgXPoh/Az2YvO1B6bitT9qlhpiTdJlsT5lsr3gPmzoVjb5CDXA==",
+-      "engines": {
+-        "node": ">=10"
+-      }
+-    },
+     "node_modules/playwright": {
+       "version": "1.46.1",
+       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
+diff --git a/package.json b/package.json
+index 6d569ad9..61e8d892 100644
+--- a/package.json
++++ b/package.json
+@@ -73,7 +73,6 @@
+     "marked-katex-extension": "^5.1.1",
+     "marked-linkify-it": "^3.1.11",
+     "md5": "^2.3.0",
+-    "plausible-tracker": "^0.3.9",
+     "svelte": "^4.2.19",
+     "twemoji": "^14.0.2",
+     "zod": "^3.23.8"
+diff --git a/src/App.svelte b/src/App.svelte
+index 8161c390..4281ba61 100644
+--- a/src/App.svelte
++++ b/src/App.svelte
+@@ -1,6 +1,4 @@
+ <script lang="ts">
+-  import Plausible from "plausible-tracker";
+-
+   import * as router from "@app/lib/router";
+   import { unreachable } from "@app/lib/utils";
+ 
+@@ -28,12 +26,6 @@
+ 
+   void router.loadFromLocation();
+ 
+-  if (import.meta.env.PROD) {
+-    const plausible = Plausible({ domain: "app.radicle.xyz" });
+-
+-    plausible.enableAutoPageviews();
+-  }
+-
+   $: document.documentElement.setAttribute("data-codefont", $codeFont);
+   $: document.documentElement.setAttribute("data-theme", $theme);
+ </script>
+-- 
+2.46.0
+

--- a/pkgs/by-name/ra/radicle-explorer/package.nix
+++ b/pkgs/by-name/ra/radicle-explorer/package.nix
@@ -1,0 +1,130 @@
+{
+  radicle-httpd,
+  fetchFromGitHub,
+  fetchgit,
+  lib,
+  buildNpmPackage,
+  writeText,
+  jq,
+  runCommand,
+}:
+
+let
+  # radicle-explorer bundles these freely available Emoji assets, but does not
+  # redistribute them.
+  twemojiAssets = fetchFromGitHub {
+    owner = "twitter";
+    repo = "twemoji";
+    rev = "v14.0.2";
+    hash = "sha256-YoOnZ5uVukzi/6bLi22Y8U5TpplPzB7ji42l+/ys5xI=";
+    meta.license = [ lib.licenses.cc-by-40 ];
+  };
+
+  mkPassthru = self: args: {
+    # radicle-explorer is configured through static build time configuration.
+    #
+    # Using this function you can override the this configuration, for example,
+    # to configure alternative preferred peers (which are shown in the UI by
+    # default).
+    #
+    # Example usage:
+    #
+    # ```nix
+    # radicle-explorer.withConfig {
+    #   preferredSeeds = [{
+    #     hostname = "seed.example.com";
+    #     port = 443;
+    #     scheme = "https";
+    #   }];
+    # }
+    # ```
+    withConfig =
+      config:
+      let
+        overrides = writeText "config-overrides.json" (builtins.toJSON config);
+        newConfig = runCommand "config.json" { } ''
+          ${jq}/bin/jq -s '.[0] * .[1]' ${(self args).src}/config/default.json ${overrides} > $out
+        '';
+      in
+      lib.fix (
+        final:
+        (self args).overrideAttrs (prev: {
+          preBuild = ''
+            ${prev.preBuild or ""}
+            cp ${newConfig} config/local.json
+          '';
+
+          passthru = prev.passthru // mkPassthru final args;
+        })
+      );
+
+    # By default, radicle-explorer includes a dependency that sends requests
+    # to a web analytics tracking service. Using this attribute yields a
+    # version of radicle-explorer with this dependency removed.
+    withoutTrackers = self {
+      patches = [ ./0001-remove-dependency-on-plausible.patch ];
+      npmDepsHash = "sha256:1hbrzfjkfc0q8qk03yi6qb9zqm57h7hnkn7fl0yxkrzbrljaljaz";
+    };
+  };
+in
+lib.fix (
+  self:
+  lib.makeOverridable (
+    {
+      npmDepsHash ? "sha256:0kw6rvqm0s21j1rss35idvgcrzzczfy6qi3323y385djw4ygk5xs",
+      patches ? [ ],
+    }@args:
+    buildNpmPackage {
+      pname = "radicle-explorer";
+      version = radicle-httpd.version;
+      inherit patches npmDepsHash;
+
+      # radicle-explorer uses the radicle-httpd API, and they are developed in the
+      # same repo. For this reason we pin the sources to each other, but due to
+      # radicle-httpd using a more limited sparse checkout we need to carry a
+      # separate hash.
+      src = fetchgit {
+        inherit (radicle-httpd.src) url rev;
+        hash = "sha256:09m13238h6j7g02r6332ihgyyzbjx90pgz14rz29pgv7936h6il8";
+      };
+
+      postPatch = ''
+        patchShebangs --build ./scripts
+        mkdir -p "public/twemoji"
+        cp -t public/twemoji -r -- ${twemojiAssets}/assets/svg/*
+        : >scripts/install-twemoji-assets
+      '';
+
+      dontConfigure = true;
+      doCheck = false;
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out"
+        cp -r -t "$out" build/*
+        runHook postInstall
+      '';
+
+      passthru = mkPassthru self args;
+
+      meta = {
+        description = "Web frontend for Radicle";
+        longDescription = ''
+          Radicle Explorer is a web-frontend for Radicle which supports browsing
+          repositories, issues and patches on publicly available Radicle seeds.
+
+          This package builds the web interface, ready to be served by any web
+          server.
+        '';
+
+        homepage = "https://radicle.xyz";
+        license = lib.licenses.gpl3;
+
+        maintainers = with lib.maintainers; [
+          tazjin
+          lorenzleutgeb
+        ];
+      };
+    }
+  )
+) { }

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -16,12 +16,14 @@ rustPlatform.buildRustPackage rec {
   version = "0.17.0";
   env.RADICLE_VERSION = version;
 
+  # You must update the radicle-explorer source hash when changing this.
   src = fetchgit {
     url = "https://seed.radicle.xyz/z4V1sjrXqjvFdnCUbxPFqd5p4DtH5.git";
     rev = "refs/namespaces/z6MkkfM3tPXNPrPevKr3uSiQtHPuwnNhu2yUVjgd2jXVsVz5/refs/tags/v${version}";
     hash = "sha256-nstyb1rSll3Sl0DlA9JAAwvr6JN8okJ03WoQnE4dXEk=";
     sparseCheckout = [ "radicle-httpd" ];
   };
+
   sourceRoot = "${src.name}/radicle-httpd";
   cargoHash = "sha256-M4tDtUXS99/Zb1Z71CTdW9gMgRR30rbwA6wK7nlwblQ=";
 


### PR DESCRIPTION
This commit adds radicle-explorer, a web interface for Radicle which displays repositories, issues and patches.

The package builds the web interface itself, but a web server still needs to be configured to serve it. This is out-of-scope for this commit, but may be added to the related NixOS modules in the future.

The web interface is based on the API exposed by radicle-httpd. For this reason the sources and version of the web interface have been tied directly to the radicle-httpd package, necessitating corresponding updates on this package whenever httpd is updated.

There's a little bit of fixed-point magic in this change to enable two features:

* Overriding build-time configuration (required to, for example, display a different Radicle seed by default). Documentation for this is available in the upstream repo.

* Building radicle-explorer without plausible, a web tracking package which sends user-data to a remote host by default.

These are configured through slightly different overriding mechanisms, but I hope to simplify this in the future with some upstream patches.

*(Note: The formatting is not my fault, I used the new `nixfmt` formatter which creates the new RFC style.)*

-------

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
