### PR TITLE
lowdown: patch to fix macOS and UTF-8 bugs

### DIFF
--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchurl, fixDarwinDylibNames, which, dieHook
+, fetchpatch
 , enableShared ? !stdenv.hostPlatform.isStatic
 , enableStatic ? stdenv.hostPlatform.isStatic
 # for passthru.tests
@@ -15,6 +16,40 @@ stdenv.mkDerivation rec {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
     hash = "sha512-EpAWTz7Zy+2qqJGgzLrt0tK7WEZ+hHbdyqzAmMiaqc6uNXscR88git6/UbTjvB9Yanvetvw9huSuyhcORCEIug==";
   };
+
+  patches = [
+    # Improve UTF-8 handling on macOS by not treating bytes >=0x80, which tend to be
+    # UTF-8 continuation bytes, as control characters.
+    #
+    # This leaves control characters U+0080 through U+009F in the output
+    # (incorrectly) but doesn't mangle other UTF-8 characters, so it's a net
+    # win.
+    #
+    # See: https://github.com/kristapsdz/lowdown/pull/140
+    (fetchpatch {
+      url = "https://github.com/kristapsdz/lowdown/commit/5a02866dd682363a8e4f6b344c223cfe8b597da9.diff";
+      hash = "sha256-7tGhZJQQySeBv4h6A4r69BBbQkPRX/3JTw/80A8YXjQ=";
+    })
+    (fetchpatch {
+      url = "https://github.com/kristapsdz/lowdown/commit/c033a6886e4d6efb948782fbc389fe5f673acf36.diff";
+      hash = "sha256-7DvKFerAMoPifuTn7rOX4ru888HfBkpspH1opIbzj08=";
+    })
+
+    # Don't output a newline after .SH
+    #
+    # This fixes `makewhatis` output on macOS and (as a result) `man`
+    # completions for `fish` on macOS.
+    #
+    # See: https://github.com/kristapsdz/lowdown/pull/138
+    (fetchpatch {
+      url = "https://github.com/kristapsdz/lowdown/commit/e05929a09a697de3d2eb14d0f0a087a6fae22e11.diff";
+      hash = "sha256-P03W+hFeBKwfJB+DhGCPq0DtiOiLLc+0ZvWrWqXFvVU=";
+    })
+    (fetchpatch {
+      url = "https://github.com/kristapsdz/lowdown/commit/9906f8ceac586c54eb39ae78105fd84653a89c33.diff";
+      hash = "sha256-nBnAgTb8RDe/QpUhow3lyeR7UIVJX2o4lmP78e2fw/E=";
+    })
+  ];
 
   nativeBuildInputs = [ which dieHook ]
     ++ lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];


### PR DESCRIPTION
## Description of changes

- Improve UTF-8 handling by not treating bytes >=0x80, which tend to be UTF-8 continuation bytes, as control characters.

  This leaves control characters U+0080 through U+009F in the output (incorrectly) but doesn't mangle other UTF-8 characters, so it's a net win.

  See: https://github.com/kristapsdz/lowdown/pull/140

- Don't output a newline between a `.SH` and a heading.

  This fixes `makewhatis` output on macOS and (as a result) `man` completions for `fish` on macOS.

  See: https://github.com/kristapsdz/lowdown/pull/138

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
