### PR TITLE
zfs: Make latestCompatibleLinuxPackages always point at a vanilla kernel

### DIFF
--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -134,7 +134,7 @@ It's a common issue that the latest stable version of ZFS doesn't support the la
 available Linux kernel. It is recommended to use the latest available LTS that's compatible
 with ZFS. Usually this is the default kernel provided by nixpkgs (i.e. `pkgs.linuxPackages`).
 
-Alternatively, it's possible to pin the system to the latest available kernel
+Alternatively, it's possible to pin the system to the latest available vanilla kernel
 version _that is supported by ZFS_ like this:
 
 ```nix

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -201,7 +201,7 @@ let
 
     passthru = {
       inherit enableMail kernelModuleAttribute;
-      latestCompatibleLinuxPackages = lib.pipe linuxKernel.packages [
+      latestCompatibleLinuxPackages = lib.pipe linuxKernel.vanillaPackages [
         builtins.attrValues
         (builtins.filter (kPkgs: (builtins.tryEval kPkgs).success && kPkgs ? kernel && kPkgs.kernel.pname == "linux" && kernelCompatible kPkgs.kernel))
         (builtins.sort (a: b: (lib.versionOlder a.kernel.version b.kernel.version)))


### PR DESCRIPTION
As it was before, this would filter all available kernel packages and pick the one with the highest version that was supported by zfs. This included variants like linux_libre and linux_rt. When multiple kernels of the same version were available, the choice of which one was selected was ill-defined (determined by ordering of attrs I think).

The result was that while zfs support was lagging behind the latest LTS, this almost always pointed at a mainline kernel, but since 636134b8ed2112412c1da441b4cc4d47a24e3bd3 it pointed at a linux_libre. This is effectively a breaking change, so should be avoided.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - ran `nix-build -A nixosTests.zfs`
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
