### PR TITLE
emacs: do not do native compilation for .dir-locals.el

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -86,7 +86,7 @@ libBuildHelper.extendMkDerivation' stdenv.mkDerivation (finalAttrs:
     source ${./emacs-funcs.sh}
     addEmacsVars "$out"
 
-    find $out/share/emacs -type f -name '*.el' -print0 \
+    find $out/share/emacs -type f -name '*.el' -not -name ".dir-locals.el" -print0 \
       | xargs --verbose -0 -I {} -n 1 -P $NIX_BUILD_CORES sh -c \
           "emacs \
              --batch \


### PR DESCRIPTION
This file is not a valid Emacs lisp file.

Some packages, such as auctex, el-get, helm and org, include this file without using no-byte-compile in file-local variables to skip native compilation, causing native compilation error like this:

Wrong type argument: "/nix/store/<hash>-emacs-org-9.7.10/share/emacs/site-lisp/elpa/org-9.7.10/.dir-locals.el", proper-list-p, (#<symbol org-edit-src-content-indentation at 304> . 0)

[Some][1] [of][2] [them][3] decide to exclude this file.  Org includes this file intendedly[4] but may add no-byte-compile to file-local variables.  Hopefully, newer versions of them do not have this error. However, to support old versions of them and potentially other new packages with this problem, let's filter out this file in Nixpkgs.

[1]: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=73215
[2]: https://github.com/melpa/melpa/pull/9164
[3]: https://github.com/melpa/melpa/pull/9165
[4]: https://lists.gnu.org/archive/html/emacs-orgmode/2024-09/msg00179.html

part of https://github.com/NixOS/nixpkgs/issues/335442

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
