### PR TITLE
fix typo that breaks services.nfs.settings

### DIFF
--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -16,7 +16,7 @@ let
     lib.optionalAttrs (cfg.server.nproc != null) {
       nfsd.threads = cfg.server.nproc;
     } // lib.optionalAttrs (cfg.server.hostName != null) {
-      nfsd.host= cfg.hostName;
+      nfsd.host = cfg.server.hostName;
     } // lib.optionalAttrs (cfg.server.mountdPort != null) {
       mountd.port = cfg.server.mountdPort;
     } // lib.optionalAttrs (cfg.server.statdPort != null) {


### PR DESCRIPTION
Currently will always fail when `services.nfs.server.hostName` is specified alongside `services.nfs.settings`.

## Description of changes

Almost nothing; just use the same `cfg` value we just checked exists; instead of a different one that will never exist.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
