### PR TITLE
emacs: make sure native compilation output dir is in $out

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -90,6 +90,7 @@ libBuildHelper.extendMkDerivation' stdenv.mkDerivation (finalAttrs:
       | xargs --verbose -0 -I {} -n 1 -P $NIX_BUILD_CORES sh -c \
           "emacs \
              --batch \
+             --eval '(setq native-comp-eln-load-path (cdr native-comp-eln-load-path))' \
              --eval '(setq large-file-warning-threshold nil)' \
              --eval '(setq byte-compile-error-on-warn ${if finalAttrs.turnCompilationWarningToError then "t" else "nil"})' \
              -f batch-native-compile {} \

--- a/pkgs/applications/editors/emacs/elisp-packages/lib-override-helper.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/lib-override-helper.nix
@@ -25,4 +25,14 @@ rec {
         broken = true;
       };
     });
+
+  mkHome =
+    pkg:
+    pkg.overrideAttrs (previousAttrs: {
+      preInstall =
+        ''
+          HOME=$(mktemp -d)
+        ''
+        + previousAttrs.preInstall or "";
+    });
 }


### PR DESCRIPTION
Native compilation output dir is the first writable one specified by native-comp-eln-load-path[1].  The first[2] dir in native-comp-eln-load-path is in $HOME.  In the nix build sandbox, $HOME normally does not exist so this first dir is not writable.  The second dir is in $out and thus is writable.  So it is chosen as the native compilation output dir.

Some packages, such as auctex[3], needs a writable $HOME when being compiled.  To avoid compilation error, it is necessary to create a writable $HOME.  To make sure native compilation output dir is in $out, we can make the first dir of native-comp-eln-load-path, the one in $HOME, read-only.  Or we can explicitly choose the second dir. This patch use the second explicit method.

[1]: (info "(elisp) Native-Compilation Functions")
[2]: https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/startup.el?id=f27553c30a772a0103d2e6762e4d7f588f302e4b#n615
[3]: https://hydra.nixos.org/build/271252219/nixlog/1

part of https://github.com/NixOS/nixpkgs/issues/335442

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
