### PR TITLE
xorg.libXpm: provide gzip path for cross

### DIFF
--- a/nixos/modules/services/web-apps/flarum.nix
+++ b/nixos/modules/services/web-apps/flarum.nix
@@ -203,10 +203,13 @@ in {
         ln -sf ${cfg.package}/share/php/flarum/public/index.php public/
       '' + optionalString (cfg.createDatabaseLocally && cfg.database.driver == "mysql") ''
         if [ ! -f config.php ]; then
-            php flarum install --file=${flarumInstallConfig}
+          php flarum install --file=${flarumInstallConfig}
         fi
-        php flarum migrate
-        php flarum cache:clear
+      '' + ''
+        if [ -f config.php ]; then
+          php flarum migrate
+          php flarum cache:clear
+        fi
       '';
     };
   };

--- a/pkgs/applications/networking/browsers/firefox-bin/update.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/update.nix
@@ -12,6 +12,7 @@
 , baseName ? "firefox"
 , basePath ? "pkgs/applications/networking/browsers/firefox-bin"
 , baseUrl
+, versionSuffix ? ""
 }:
 
 let
@@ -47,7 +48,7 @@ in writeScript "update-${pname}" ''
            grep "^[0-9]" | \
            sort --version-sort | \
            grep -v "funnelcake" | \
-           grep -e "${lib.optionalString isBeta "b"}\([[:digit:]]\|[[:digit:]][[:digit:]]\)$" | ${lib.optionalString (!isBeta) "grep -v \"b\" |"} \
+           grep -e "${lib.optionalString isBeta "b"}\([[:digit:]]\|[[:digit:]][[:digit:]]\)${versionSuffix}$" | ${lib.optionalString (!isBeta) "grep -v \"b\" |"} \
            tail -1`
 
   curl --silent -o $HOME/shasums "$url$version/SHA256SUMS"

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -3,48 +3,10 @@
 # To update `thunderbird-bin`'s `release_sources.nix`, run from the nixpkgs root:
 #
 #     nix-shell maintainers/scripts/update.nix --argstr package pkgs.thunderbird-bin-unwrapped
-{ lib, stdenv, fetchurl, config, wrapGAppsHook3
+{ lib, stdenv, fetchurl, config, wrapGAppsHook3, autoPatchelfHook
 , alsa-lib
-, atk
-, cairo
 , curl
-, cups
-, dbus-glib
-, dbus
-, fontconfig
-, freetype
-, gdk-pixbuf
-, glib
-, glibc
-, gtk2
 , gtk3
-, libkrb5
-, libX11
-, libXScrnSaver
-, libxcb
-, libXcomposite
-, libXcursor
-, libXdamage
-, libXext
-, libXfixes
-, libXi
-, libXinerama
-, libXrender
-, libXrandr
-, libXt
-, libXtst
-, libcanberra
-, libnotify
-, adwaita-icon-theme
-, libGLU, libGL
-, nspr
-, nss_latest
-, pango
-, pipewire
-, pciutils
-, heimdal
-, libpulseaudio
-, systemd
 , writeScript
 , writeText
 , xidel
@@ -52,10 +14,9 @@
 , gnused
 , gnugrep
 , gnupg
-, ffmpeg
 , runtimeShell
-, mesa # thunderbird wants gbm for drm+dmabuf
 , systemLocale ? config.i18n.defaultLocale or "en_US"
+, patchelfUnstable  # have to use patchelfUnstable to support --no-clobber-old-sections
 , generated
 }:
 
@@ -86,83 +47,30 @@ let
     else lib.replaceStrings ["_"] ["-"] systemLocale;
 
   source = lib.findFirst (sourceMatches mozLocale) defaultSource sources;
+
+  pname = "thunderbird-bin";
 in
 
 stdenv.mkDerivation {
-  pname = "thunderbird-bin";
-  inherit version;
+  inherit pname version;
 
   src = fetchurl {
     url = "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/${version}/${source.arch}/${source.locale}/thunderbird-${version}.tar.bz2";
     inherit (source) sha256;
   };
 
-  libPath = lib.makeLibraryPath
-    [ stdenv.cc.cc
-      alsa-lib
-      atk
-      cairo
-      curl
-      cups
-      dbus-glib
-      dbus
-      fontconfig
-      freetype
-      gdk-pixbuf
-      glib
-      glibc
-      gtk2
-      gtk3
-      libkrb5
-      mesa
-      libX11
-      libXScrnSaver
-      libXcomposite
-      libXcursor
-      libxcb
-      libXdamage
-      libXext
-      libXfixes
-      libXi
-      libXinerama
-      libXrender
-      libXrandr
-      libXt
-      libXtst
-      libcanberra
-      libnotify
-      libGLU libGL
-      nspr
-      nss_latest
-      pango
-      pipewire
-      pciutils
-      heimdal
-      libpulseaudio
-      systemd
-      ffmpeg
-    ] + ":" + lib.makeSearchPathOutput "lib" "lib64" [
-      stdenv.cc.cc
-    ];
-
-  inherit gtk3;
-
-  nativeBuildInputs = [ wrapGAppsHook3 ];
-
-  buildInputs = [ gtk3 adwaita-icon-theme ];
-
-  # "strip" after "patchelf" may break binaries.
-  # See: https://github.com/NixOS/patchelf/issues/10
-  dontStrip = true;
-  dontPatchELF = true;
+  nativeBuildInputs = [ wrapGAppsHook3 autoPatchelfHook patchelfUnstable ];
+  buildInputs = [
+    alsa-lib
+  ];
+  # Thunderbird uses "relrhack" to manually process relocations from a fixed offset
+  patchelfFlags = [ "--no-clobber-old-sections" ];
 
   patchPhase = ''
     # Don't download updates from Mozilla directly
     echo 'pref("app.update.auto", "false");' >> defaults/pref/channel-prefs.js
   '';
 
-  # See "Note on GPG support" in `../thunderbird/default.nix` for explanations
-  # on adding `gnupg` and `gpgme` into PATH/LD_LIBRARY_PATH.
   installPhase =
     ''
       mkdir -p "$prefix/usr/lib/thunderbird-bin-${version}"
@@ -170,21 +78,6 @@ stdenv.mkDerivation {
 
       mkdir -p "$out/bin"
       ln -s "$prefix/usr/lib/thunderbird-bin-${version}/thunderbird" "$out/bin/"
-
-      for executable in \
-        thunderbird thunderbird-bin plugin-container \
-        updater crashreporter webapprt-stub \
-        glxtest vaapitest
-      do
-        if [ -e "$out/usr/lib/thunderbird-bin-${version}/$executable" ]; then
-          patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-            "$out/usr/lib/thunderbird-bin-${version}/$executable"
-        fi
-      done
-
-      find . -executable -type f -exec \
-        patchelf --set-rpath "$libPath" \
-          "$out/usr/lib/thunderbird-bin-${version}/{}" \;
 
       # wrapThunderbird expects "$out/lib" instead of "$out/usr/lib"
       ln -s "$out/usr/lib" "$out/lib"
@@ -197,8 +90,7 @@ stdenv.mkDerivation {
     '';
 
   passthru.updateScript = import ./../../browsers/firefox-bin/update.nix {
-    inherit lib writeScript xidel coreutils gnused gnugrep curl gnupg runtimeShell;
-    pname = "thunderbird-bin";
+    inherit pname lib writeScript xidel coreutils gnused gnugrep curl gnupg runtimeShell;
     baseName = "thunderbird";
     channel = "release";
     basePath = "pkgs/applications/networking/mailreaders/thunderbird-bin";
@@ -208,6 +100,8 @@ stdenv.mkDerivation {
 
   passthru = {
     binaryName = "thunderbird";
+    gssSupport = true;
+    gtk3 = gtk3;
   };
 
   meta = with lib; {

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -203,6 +203,7 @@ stdenv.mkDerivation {
     channel = "release";
     basePath = "pkgs/applications/networking/mailreaders/thunderbird-bin";
     baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
+    versionSuffix = "esr";
   };
 
   passthru = {

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "115.13.0";
+  version = "128.1.0esr";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/af/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/af/thunderbird-128.1.0esr.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "73600c9de1e75f0a2baf7e13d9ecded491e93f7fb4d5aa63e8e4ec2f5c95ab2d";
+      sha256 = "f7caede50674b6714f95a267ee31cb8a31d60a3820b8ea516b5c88f82730e1a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ar/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ar/thunderbird-128.1.0esr.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "8eee06c6f5d347d23fa2401862bc733065162415e15a8decba31d7f71afaf8f5";
+      sha256 = "75deca12178b9f7c474b57b37a027ebed6a4bb10d6eb8b608c89674cf857b7c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ast/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ast/thunderbird-128.1.0esr.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "6ebcc36fc7306e49513ce6ba9090817acbfcc65eefacac552d4c1fbb3d2ee452";
+      sha256 = "6c9d1834a477ae2a072fe210515209cf542ac5899226f431a401b4987b2e827b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/be/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/be/thunderbird-128.1.0esr.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "386cd002e1986c4ae5e3d05e3279713994b610453745b25199906427db3874ee";
+      sha256 = "d3ef3a02f45fd5629dde08063a723ae422a484be87d57bdda8c3cc9d7bec00b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/bg/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/bg/thunderbird-128.1.0esr.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "c909a752e7f09c37ce67cd7995562eaa30cdb5f604bda70a222e376eacdab8b2";
+      sha256 = "fd0257f2d3167a55b5577942cc72e251ff9f856be0a7dcbcfe7c2128cb87213f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/br/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/br/thunderbird-128.1.0esr.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "511f1af492da3cd5a6aea641a8cc67f5f779196cbd81a940f3b0390dc0c1809f";
+      sha256 = "cac04ec5e0635a38e568d306c2b47158b893b6c8e54b4a533cf51d351b76242f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ca/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ca/thunderbird-128.1.0esr.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "c7f087af3ed5b3fa60b94cd5380aabf019397479591be08b60d23ca782ac144d";
+      sha256 = "9fd607242f7d568e6ad3b49e87b4b6a71b9a807f6aa4fc96b84ea4e42e29d896";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/cak/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/cak/thunderbird-128.1.0esr.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "fe7c6fe3e99f0d4d8d6e2561e1fb2e5e8ce6def6caa119d4bb73c55605c3222d";
+      sha256 = "e81b6472ab864af62b4c4090013c7f3615c9594bc84bdfb3b7fb36f78f394e6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/cs/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/cs/thunderbird-128.1.0esr.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "222a9a0898375e5edfe09ff67a6db89a340eab4c7b195f895dbe891b5157846c";
+      sha256 = "f672b08496915f71c00cf9df0b214aea30b9db7f396340dc98ef5402780ee997";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/cy/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/cy/thunderbird-128.1.0esr.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "19e3060fb67039a6fd70bbbce712aeab7def908528a3d54cc77387cac8c58d83";
+      sha256 = "6c002ffcc742fd0a01ec160ae8729a05d11267e17d32269c3fc6c03b3bf37d64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/da/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/da/thunderbird-128.1.0esr.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "a2462934c90fb2433692b8ccf342c1669770a20be0c3703ecc54f65e5aaa2487";
+      sha256 = "dee1fe8dfff06a276e4cb3018cd1a60ede76ee5baf09e34cf715912bc26c52a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/de/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/de/thunderbird-128.1.0esr.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "d45733c83c65abc1a3df8f6fc0cb2880c55405a4b2a798a5062304dc93f4ac43";
+      sha256 = "d7fa4df3f309a06e53c8d3336d337e14c7e19f9b64d6b4b424eb6212d2d511e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/dsb/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/dsb/thunderbird-128.1.0esr.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "e91883128422d834b7713f1ffc0d8095882e4f4e594940c5adf825f38ca8c1e7";
+      sha256 = "796db274ba2945d2212cf0015d0100465a754322fff4dd80d3d660b655bc64ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/el/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/el/thunderbird-128.1.0esr.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "f54b76e5ae958ad3eb5bf651f892fbfef460732dee8364df70ed5f8b24a77a5c";
+      sha256 = "2bbfef60b2c46da6d338ce7f0822e4261ed6a85253eaa3073a0ae94e88a53565";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/en-CA/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/en-CA/thunderbird-128.1.0esr.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "fff09666b871aff621cc513aa8fab7843cb1d019e1914c9b654e8af797edfc04";
+      sha256 = "0b589335683709ec57c272f2cfa1caae530718c8a6e57aafec1ed7933a8896e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/en-GB/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/en-GB/thunderbird-128.1.0esr.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "2762b9c0c2da7b1d35b51231f395b34d6e7ed8a8c34c56a3c36fd1af40152d57";
+      sha256 = "a02fe116c48a0afcceab7a40b70c3537037bd28fda6f5d1c649486d3307fdb8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/en-US/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/en-US/thunderbird-128.1.0esr.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "b70d487213fca89aaed8c2a1da07e179597cf70c6bc56e5fcc93855afdf66365";
+      sha256 = "f6f383c86f60c96b0bf2e338ab363d0d72f6e53e972429203c1920939fd8509a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/es-AR/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/es-AR/thunderbird-128.1.0esr.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "37341713a27b90cd8324585cbe2b4413ed0ce3415366b27f1cbfb97f91595e22";
+      sha256 = "752e6409c562de5cd25f73c519f016a4602df937f317b91028512a4a9ead4c77";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/es-ES/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/es-ES/thunderbird-128.1.0esr.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "c2412ebe923dfcdc464bd6d7576c0fdfde748d26b5684b75618b21fa3396d69a";
+      sha256 = "aaa9b5e1ef3f642675c5804ba62a11e387762edc9b0dff9c8204e32b6cc9fe19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/es-MX/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/es-MX/thunderbird-128.1.0esr.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "6a1e03cdf4605b768feb802502dc00b9cf7567804c8c2cc7eebf7855c10e555c";
+      sha256 = "5812b135c2655d72e099de4a2fdf72293e3f89bf8cd1fa7b96a5dca40157ea6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/et/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/et/thunderbird-128.1.0esr.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e8d92ff29455577680ea1c24f5025387ec502ae5ce65a528c3d526dc2b0e23d5";
+      sha256 = "ee02e5e31281fd38f62d6e48fffbfe9435779089613d98d738eebf0288bc96cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/eu/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/eu/thunderbird-128.1.0esr.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "0added0bc1846f7231a8806bbf5d4478743fb9dab3ba12270a540cb298ce2e12";
+      sha256 = "6a9988e9b67d8582fb4b9c456afd383c8b464c7cfb2a14e065baa38fb774ca94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/fi/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/fi/thunderbird-128.1.0esr.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "08ecb359ec9f1bb79271fae375f4094f32232ca17ba516b4dc68d33a49fe26a4";
+      sha256 = "55aa8e6f0782fdc8a41cb26288d84bfbdd6b88661d4e398b0b121ba6539b586c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/fr/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/fr/thunderbird-128.1.0esr.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "5cbb360a2f824a63a06996d8d7bd11184f04a154acca6d11f9d9ad149add7211";
+      sha256 = "ace271f70d85aef98649e72d230417821ac7b457a985000851c6a2def90b7199";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/fy-NL/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/fy-NL/thunderbird-128.1.0esr.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "8c489d2e33c2c0d0d1ecb7c8d8766fce2498ee1256cd37e12f4c975b5533a98d";
+      sha256 = "404d0c3e9bd086ed00209f40ec31ddd2f65ce8f05c246099f67ac1cfd4ccf18f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ga-IE/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ga-IE/thunderbird-128.1.0esr.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "5841ef91f177e47ff8a272e76cb57968863c341531b45a42c14bac80979b3187";
+      sha256 = "c787eb2ad7490b18537a5dbf18c05a77479d9a38e46697f40db0b325c89197ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/gd/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/gd/thunderbird-128.1.0esr.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "a07eacd6df3834980886517a9eb1f5d4a6c05d087bb6aac024456b1867079ab6";
+      sha256 = "11c0bbfe4c0ee4c29e00755659cd3eec2c89fd002c35ca9dcf9a36d8e36637e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/gl/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/gl/thunderbird-128.1.0esr.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "d5359822c6817dc8937a3d24e3e50efa27d450c1f9d48d5b79c63b7ffce54439";
+      sha256 = "f3dc0ba2f53249baa82a85f47370e7d2d33144549099c58685c8e2b629fbd188";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/he/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/he/thunderbird-128.1.0esr.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "5320ef08555bf368c4e09a80524429482f2b23fb27b8b2850ef4a1f60eaf34b0";
+      sha256 = "0fc4eb9da6f9b1fb833662aeeb6e3bc68ee111ec4b95a249b697f43e3b6bfd0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/hr/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/hr/thunderbird-128.1.0esr.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "dd6a69a320ed40b662814da28af7165ac499cbcdca1371bba86ef4c84f0d0949";
+      sha256 = "4c19e84f14610515371c00e4bfdf0d1a9c6d93326767d2a049e18a3286ac4f86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/hsb/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/hsb/thunderbird-128.1.0esr.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "fdc547651aa09c3874366180d4e3fcca407fc8efba5745344cfca1f5c4597003";
+      sha256 = "f908d18d7ce4997d46ad05e61b54c002f6039cdda67a4b06df1b2e21b9b01994";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/hu/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/hu/thunderbird-128.1.0esr.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "85b1b6f9b3f52258ddae7fd03dcd12dc87564d5d797cf7dd8c9fa6f1278da233";
+      sha256 = "1ef3b469e5cc01b78d0f9b0397cbfdb08a115b040d5ff5b93f6b7ef22e53ce7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/hy-AM/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/hy-AM/thunderbird-128.1.0esr.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "13c0f0e3b112ac7d4ec0c794458b81057f9965ca718b10bf2b7880be4f4a85fd";
+      sha256 = "ee4072bb5bc8ef35d4a95d8e0f00b7ece382246b3343da889022da71961f56a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/id/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/id/thunderbird-128.1.0esr.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "700393b3b121a6398e3f809d035e5b90fd8f3879f0a751a4ed362fb973b3ccfd";
+      sha256 = "3267e6e36c93ed79c2cd4171d037d2b5016d9b66d0da60e078d980930c7ee872";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/is/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/is/thunderbird-128.1.0esr.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "8eb368b9ffc00aa06238af03c16c3b183858aff829d5741100e515498bee065a";
+      sha256 = "8807acfc9b004d6010087424bb7742de208625b177ba340eabf395a35c5dc5f1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/it/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/it/thunderbird-128.1.0esr.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "c3d8d2136e3a0096c07413c0c591cc60e322ee1b929b5f6cd99708413014913c";
+      sha256 = "7a65820f86686e1a8f3176533839a41fa361eb8d5ae7d25eb3ba25552469303e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ja/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ja/thunderbird-128.1.0esr.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "af6109dade0343a3354e5b8c82df8505ecca189bb9eae0037a578db4fcf99f1b";
+      sha256 = "3715455a068e1917905080d346e684237f15ea98cd3aef4b8cca4cb1f1a66beb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ka/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ka/thunderbird-128.1.0esr.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "ad7c22e31b575f28268794b390d75021bcf67cb2a4d7ecbdfc3a5bce8f547160";
+      sha256 = "a4920bd4c5013bd4e8574515f6064358c85036a666620bc15bb23ed891b309bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/kab/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/kab/thunderbird-128.1.0esr.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "0356017444c3a046c85599f7188d012f1a8260a5a76d42e8bddb3e937ff1d0db";
+      sha256 = "0b9879b77e8efc4a40b1e11b93a0c45be7c4d195a523bc202261f33dbd138d1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/kk/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/kk/thunderbird-128.1.0esr.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "d278f53f92f4514b1a1b0cc87a6329e1cfe53d82c815557d2d1038b192fb0a03";
+      sha256 = "4da60f136c95c915eeb6047d647d1aad066e9194620ccfa6b0d2d649a2bc539b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ko/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ko/thunderbird-128.1.0esr.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "0cda6697ab6041f0983447e5594158e185905d34a7b3ec70022f258403dba6d5";
+      sha256 = "9d497d4e26bddc96a7f4b2cd7b21a54a7c159ae4245e7f10e0534cb73ee9d0db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/lt/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/lt/thunderbird-128.1.0esr.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "f783e465629993c2e5d7c5f71fa421b289ca1051ab461ea4e128a9facf370e21";
+      sha256 = "25e2f903fb2d894eeada038728f43e2e195e0997e13d7e961bb8429a442041e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/lv/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/lv/thunderbird-128.1.0esr.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "b64684c99509c9b2751d4afaced2a2f6067251345f672eb84d2337f9082fee67";
+      sha256 = "3a85ba4e1b15d9d2400d1000b1215356c4b6674e21cd8abe6957860cff108c77";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ms/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ms/thunderbird-128.1.0esr.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "a001272f61877db602f26aa80c485f0ad7be82acc26343fbf18a95040aeed429";
+      sha256 = "e136424aec855ff15f43fb4082cf3270928d3de5cfd65af25cacfbb7c1fd2262";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/nb-NO/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/nb-NO/thunderbird-128.1.0esr.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "6d9b817608399d59a20d34da172529eacb950e19ddb3cb3966f8acb2704099e1";
+      sha256 = "3332ae00538d48b2842a66ad4a7383c021bd0f4d4f01845229e8a3d10330f0c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/nl/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/nl/thunderbird-128.1.0esr.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "259e8b433b7c757c507f8deb5ae9453f593f353a7544ec6d8e4b798b3c9958e1";
+      sha256 = "4278329ed3b2fb58f15def543c27cc6bbe67e70d8b7c38e09ea37091b3a2e04d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/nn-NO/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/nn-NO/thunderbird-128.1.0esr.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "0af2bea6b0b4b56dfbbf0b3a4845d5540d17a2998ee000c16a9dee0e63814ee7";
+      sha256 = "6816386d06eb3faa8d6ee533157153f5f3ff1cc9f9fbc1ab871baa32d3e5de3b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/pa-IN/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/pa-IN/thunderbird-128.1.0esr.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "7a686986ed8d899ffd00dd770c04c16a0ba5ef66e6889dbf34e86d9794d27448";
+      sha256 = "eb8fe69a9a88593f1c4cf953a4066cd0c79c8f61c270f65177ef5de196481744";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/pl/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/pl/thunderbird-128.1.0esr.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "d736d10c5c57a2b8b5c7ddd8620eea673e83a4efb66288dcac4f39fb9cafdeef";
+      sha256 = "c7e97e39ca32dc0369da1e2cbbb714b3b2614e552c932e328d9ec01c28dcfa88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/pt-BR/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/pt-BR/thunderbird-128.1.0esr.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "2666dfb8ed5cdcc747d91b5a8f396a268243c9e46aada60b26a62ac1904f11d0";
+      sha256 = "5cbf7fddd22b227ef57b9902273820be8ab518511a9a4305941a178fcaadc5d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/pt-PT/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/pt-PT/thunderbird-128.1.0esr.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "ba1a76293cac33601f8317e538b54c4a05b277f862d3e76e11944a0d51d0b4c2";
+      sha256 = "23bae7cbb8528b607ea8b7e8d5fba51edd85682e50e823525b7d88633cba67cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/rm/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/rm/thunderbird-128.1.0esr.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d55625a4a75b671cc614f04fa55337df80d0949906256c8852274b0c73f9d8c1";
+      sha256 = "3e47ef468d5608badb81a085a4bdb4e5e471698afd613430b36b55203b6392a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ro/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ro/thunderbird-128.1.0esr.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "ff56d88c4c003bf8e5aa245b65ae17d0d2a3f40ab5cf341fedf7b2bbcfec7088";
+      sha256 = "dc819bba617164a42f4564584a727a33cff2fb9c9fa6795f154d0ba836700016";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/ru/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ru/thunderbird-128.1.0esr.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "a9eb569ff312c13fc651c44f192c64cd46eb27624f71a4ad9399b0531cdf1a57";
+      sha256 = "92b8d9dfbd033c00ae7860d4d3912e713c193b75bb533088b1eac1ae4d5cb131";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/sk/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sk/thunderbird-128.1.0esr.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "82bb11f5491a90404d40692218848a36c62ee1f73294f94abaf89102c185dfae";
+      sha256 = "694460056e16866c1b807864c6ea0593d01d45157178adfb3f29ad8277554491";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/sl/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sl/thunderbird-128.1.0esr.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "b5400b07f12e0712157bbaedafd9f88e7d2326e1407b9a989ae9da8fc245c558";
+      sha256 = "41451768b19248de4827ced8f13fe794401405016adbdf15c80929544c619216";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/sq/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sq/thunderbird-128.1.0esr.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "cff26cd2e27db6c374d1b34da18bd513010bd4572a5abd3179cb6b0bb062a750";
+      sha256 = "9ee7df88f187862c039c75a68d7fe9e509b4a88c94cfe69adb1b00bbc11b7dbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/sr/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sr/thunderbird-128.1.0esr.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "bce534608ef8da85ea0083dfc86c40759b4b073c90369f94ed98df3d41c3e1c9";
+      sha256 = "d4d6ac39c1296ea136f7dc7f85655aa26a3e9bea9499d38be171ba419cc3d146";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/sv-SE/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sv-SE/thunderbird-128.1.0esr.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "3a2e9f610436b140e3a7098ac27516c3ce5fe2dd672e23a85050bbd896bb2738";
+      sha256 = "ffed8cf698a067490ec9749c66dc8829bdea9f217d7762c3a0d02bace29e9e3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/th/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/th/thunderbird-128.1.0esr.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "3753527489a666c2e89cc1c4be85d85a52890069700ef9bd809e14a50d253d37";
+      sha256 = "537d70eb286b63faa280c0547059ce0df8c1fc70775f82c3e7865c589005ee0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/tr/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/tr/thunderbird-128.1.0esr.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "90d37e9512c46db20d8ce44863dabb1c72b196fb26e462e310f83bf7472763b1";
+      sha256 = "e079b676a41c5d7a2011965f7e42bfbc75ef8f85521ea94bafd01bda0dfb28ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/uk/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/uk/thunderbird-128.1.0esr.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "07f8d8809d3dc079e9f5d25f0b553b96efa975c69f4b94ddc5772bbb07c6f2a9";
+      sha256 = "0f899cf16ecb4f10456b271ef98672b3c7f043d3dd50190c1140fb4ae4701e1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/uz/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/uz/thunderbird-128.1.0esr.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "7d3d207fe4f427b5492771a6db5f6716d0f49ea2452f3521c53d06da15090135";
+      sha256 = "3a2cbcd225ec53410dec278d28f08a9af8d23a852304b00325411aa3fefb7134";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/vi/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/vi/thunderbird-128.1.0esr.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "48de00ce91f678f9e2b2fdddd57b164feee7c06079c10796707cd1be67452cf1";
+      sha256 = "456a2eed712a8853bfd014cc556aa1caddcedb0159f8d2fc63d6ee61d5b8bcbc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/zh-CN/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/zh-CN/thunderbird-128.1.0esr.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "686dd1d40c6e5d473b7f768919567d71d7a32bf277aa4f20ee160850d4a19812";
+      sha256 = "f55e16ecdb55927efff18ac94a6703f86972642a2310948604c2573d281ed2d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-x86_64/zh-TW/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/zh-TW/thunderbird-128.1.0esr.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "3be64c8cb88ab2e93ce85249110e91da26f958f5f667f9b2c3524d9337aa3ae6";
+      sha256 = "e62968e0457ca8691fb6e474c3b945202912ed019b99caaf7f786ce56e94399a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/af/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/af/thunderbird-128.1.0esr.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "fc6f36e813419ef33d9491c0317c8f73a7d08a10d2767446a6e708499d0664db";
+      sha256 = "6872446b235915fddcffcf9024e83424159977f25c1c9435274c795356645621";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ar/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ar/thunderbird-128.1.0esr.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d7134af862d2f588623a9414d0e09702b04c20577f674ade2c67269db25e7bbf";
+      sha256 = "0dc5ca84ac378cb187b629ea9e138080f5fdef33ad80e2293ae092a742d7a73e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ast/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ast/thunderbird-128.1.0esr.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "5632d2264f4ad78115c66542bb9a30bd92044e2e480612f0755d1f2bbac1fa39";
+      sha256 = "9b2744787c0e3d2f26d86cea92d79202f4905a4ccae52128507a38a1e6d803be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/be/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/be/thunderbird-128.1.0esr.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "522b1219b3586e028023a0b40b5a0b807fd5bbf26981ae0b28fed41111dfd97f";
+      sha256 = "29e667cfb4a280399da8805e1cdf5f924d40ec544b5f6e1450d8b6b0e5417f43";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/bg/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/bg/thunderbird-128.1.0esr.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "cee2dbcb5d3e6cff325cc5a9132d574c48cc356a524b619ab0efea481fed87a5";
+      sha256 = "dcb4ea76cbadbc4693e5bb480513b55216c0456fd757a9819f95e385a38274ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/br/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/br/thunderbird-128.1.0esr.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "5583cf26d49f32dfaf5a7000c8c670d3b7fd1e839595960bc73e81e5bed8b2b1";
+      sha256 = "606d741e05d8769f3dafd72540a29e5a98fde968e5c83152554adb705178f1db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ca/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ca/thunderbird-128.1.0esr.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "7ecbeb64308d4a8962c86a75742dcf86ac4f3a0009fa60071f1ba90e3fd89cc3";
+      sha256 = "77585d968f7a34c10f54244c64997094dd22bf1b86d7fd72f36699ba65a11363";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/cak/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/cak/thunderbird-128.1.0esr.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "4c55e8fa96c9763d1b8e9d8c47b55683827dfceac982514206c422edd34afe37";
+      sha256 = "99b192e2153fba6d39c609dc59078956603079d3af0758a203c9c179d3814aba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/cs/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/cs/thunderbird-128.1.0esr.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "6f0e483d77b6322fcd50decd868994c9a22e8f7f8ede4a8cc6def64cebf3fd36";
+      sha256 = "92bb4fb6261e695c3122c5797edf92084e844a509ed3b77199927f408e780c8d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/cy/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/cy/thunderbird-128.1.0esr.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "0c727b6364d07666417f7ab03dbf9e8e1cc040d855cbe361e1385cb2d4aa4242";
+      sha256 = "2736bbdb40c174ba13be89efb36c77da6842d32a8f589e7e72085e9d5ae0dc0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/da/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/da/thunderbird-128.1.0esr.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "819b01b0fb03eab22d58de73f464e98133778154e122463d20693b4aa1090ecb";
+      sha256 = "6a1cebef252ab884cf56824045ca6699ba092526ee2c8944f7041fbaa3ec8316";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/de/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/de/thunderbird-128.1.0esr.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "84db18d8ebc383fac729a9e5be2554169368aaaac34523450151ec9c4f8015b1";
+      sha256 = "21fc083977e9bee76118ae38e05cffcf5f77e3c2916f1dba4c6762060603a04e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/dsb/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/dsb/thunderbird-128.1.0esr.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "4d23aead7db91ca8f657f6eefc3cb37d08be537586d492122b2583c5e4bac516";
+      sha256 = "74361c681c861a3e298b494feda3d51489881a8da614726d3d539bafb6eca5bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/el/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/el/thunderbird-128.1.0esr.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "44833b968bf29d784163776cc7343d23a9c4a781aa36728dcea9fad23b776aa8";
+      sha256 = "22f9f3dc25c4de5ea33e98ccdf9743540d04dc6bc6b501da638db31531ee9464";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/en-CA/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/en-CA/thunderbird-128.1.0esr.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "c29f159ff4a8aa234f8117c936fc1621aac4ad12841ac261a85c7326d9ad8704";
+      sha256 = "bac464a25326ae1062fac17430911a34a89f0c8fffc3c7b2032f1cc146dd9b29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/en-GB/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/en-GB/thunderbird-128.1.0esr.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "51a2633ed89f3eb08df77153a1a894983b9609fab6aed998cbad7e78129845aa";
+      sha256 = "b41780d9a1aa4e801f905a87b11763305b32bd0fa50b0c3c23876b5833bb7b73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/en-US/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/en-US/thunderbird-128.1.0esr.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "badce662962c90cc0fe4a0e89c7b69185fcf11ac1fdebcb12078226d06eec7cd";
+      sha256 = "89a8f5019cf334a1cfd957f1dc9a4bf53eccf5ff0b23ef2db6058756453f3b68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/es-AR/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/es-AR/thunderbird-128.1.0esr.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "6e26898de69237d3915c7b7b18ee565e1b882a0a62ff89d0c64de74f4cf32b06";
+      sha256 = "042d331b9f57dd7074c3a7c50e1b038eb8e3f08881b149bb9af6c5146c92f374";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/es-ES/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/es-ES/thunderbird-128.1.0esr.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "8de6a6bc3c688375239fd56a72c8f9b5db45dbc01793cdb4e508b89b600957cf";
+      sha256 = "46b136ade4bb3dcb1be7fcb18924693786930d6218c84d86e92f8f004cb2db4f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/es-MX/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/es-MX/thunderbird-128.1.0esr.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "d7fa892b266cde71881c6bc1a2926c273ac9990a5f555a1da7ad92e8da7d2079";
+      sha256 = "2242396853b6568562cf8c6864b90be994773a1139cb91ea7d65c61ee0dcbb0b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/et/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/et/thunderbird-128.1.0esr.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "7e3f6026fd7eb69fcc716b1fd512e43bb24e666fd9792b9c0fcdecc6c2080c64";
+      sha256 = "6bd30efd3e297214dd0ab0cd5fa8c4b21791674ff8c86bff7f5a38a692fb7a10";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/eu/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/eu/thunderbird-128.1.0esr.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "6992361227e6455834651d2d4c322d68b2772e81f5d41495bc891c6968a31fb3";
+      sha256 = "8a69d159cb93c3bb441b2b33a4b3251eba02bc10025ff29b39cdb54817cf930f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/fi/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/fi/thunderbird-128.1.0esr.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "eb2f64b6079a7fc82ac9cb300a3263682c30f5d5ca88b7e8ffc239b0eeff2e4b";
+      sha256 = "676004498bfb20b8b1fad723bb254ca210cd2bd6ee3141df41e0460fb5dcba2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/fr/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/fr/thunderbird-128.1.0esr.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "2cd90fda0de39c0c5f880967d5b3c887b82a4b2b2cff68e563cacf918d1067c2";
+      sha256 = "7dcb30ece74cf8e0fcda595cb44d84b43059fc00939da120372e908bd158f1e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/fy-NL/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/fy-NL/thunderbird-128.1.0esr.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "79e3d745529f8ba10c47bf47c530d251a60fba60ae6434c28b21d6d920715343";
+      sha256 = "394b3e2d5e7fb772c45c94cd38849e181cb414362bac279abdc545bc920917d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ga-IE/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ga-IE/thunderbird-128.1.0esr.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "eecef1ff59423519f2dcda87e5bbe2d627324c1e2812d2ee8554fe4624ae5f13";
+      sha256 = "58f1dfa592cd1d02e782bb832a2eeecb69c5438000a2700f3b1b0a5d6c25ed52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/gd/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/gd/thunderbird-128.1.0esr.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "98061b5bbba7663a76ba1fd81c45da1b819dc60d7eb328865bb4e6054893e68c";
+      sha256 = "e385995eceac9f84dbffb561851784a5c7c4b1560994631f9d6e31c9c09ed50f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/gl/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/gl/thunderbird-128.1.0esr.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "20b27324d5d1007898432a5149be39e023d0574cd9412e1981644fa437559462";
+      sha256 = "1bccd0f5870159883b3b77226050b8475d61252c581bcebe89067da9a110d0b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/he/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/he/thunderbird-128.1.0esr.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d0b623cb12b09e8da788a248d9d0c73075a47ab400cd5e9636d63f802d81239f";
+      sha256 = "2652f6723d7aa4b6abf517fa23d493deabde1f37891d7ce8e190f04bc72d550f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/hr/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/hr/thunderbird-128.1.0esr.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "a4c6f3c8c4e39677e4fa7a7260bff44764fa66e571919d70349f615429ded199";
+      sha256 = "a941a94afc2692c3329b22afe40cbcd2b6c3bfb964178bf66f699f5dd0ee3ce5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/hsb/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/hsb/thunderbird-128.1.0esr.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "e059202e8add45d767878d96af50d08e540e21af6239e101825153ad3bcde087";
+      sha256 = "2eea4f3167ffdcbdb3e6712c2ac67d03c6f84cf8fc611e854491c5d2d7759ada";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/hu/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/hu/thunderbird-128.1.0esr.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "a02b0c0460e6bdc54f4d9be92e78ff5c6f8730e1f7199f5f0eceefc220d585ab";
+      sha256 = "c0811928b99556f2de5876fc22520bfdf1d38ecf97c8e7ded2bb882b85cbbe33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/hy-AM/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/hy-AM/thunderbird-128.1.0esr.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "53b02544de8294c1292311510f5e72b0b0c6c0209e3d01d92d603e5e52f988b6";
+      sha256 = "29bb49dadf3bcc501d829c451cc1c541f103ab27c58bb94a50af6deb63dc139e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/id/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/id/thunderbird-128.1.0esr.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "014a9d5214ccd346df23168d1f523374bc5058d247a3817fa8a3df1af7255230";
+      sha256 = "eda238b6f688bff2396d4aed23c3a24929883a6bfe814873b44fd256f1cffc19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/is/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/is/thunderbird-128.1.0esr.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "f81280dd398b1e5f6e003ec040052f739d20e3f5bc6ebf79ba5ddef068ab9cd7";
+      sha256 = "6b5f7cec11eadddc310140dfc109c801e1d10e711b41d3a132d55bce91923402";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/it/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/it/thunderbird-128.1.0esr.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "54a9b84390fe010708a901aeedd95a1a6b51aeeb44c47760ee68c261898fa52a";
+      sha256 = "c24f656d53c604cd06a05388d03e93c424bd831c355b75ef64f1072f307d2305";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ja/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ja/thunderbird-128.1.0esr.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "a3a1e497d31244a7acc5ea99a1cd4129c28fc00d82d750b5ce360165e7c6b915";
+      sha256 = "810b09ed1875094440eb966e5b2e91afef8becaa62901806310235d0c6cde253";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ka/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ka/thunderbird-128.1.0esr.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "df4ea755689a82315627d851fa7b59d5cb9730064785099273431e1993ccb529";
+      sha256 = "924e98fbf30c7e05d2d5d65fc9908e9a9ef69113ef8f9a19becda6a5e110cced";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/kab/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/kab/thunderbird-128.1.0esr.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "e40f72751b40fe6896ab0cdd78ab540ece04d1650c35d1d9af944f5e9983da69";
+      sha256 = "304fc281009a152c4c9987d332d8d295e151de889a52bb760ad1027fab257e4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/kk/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/kk/thunderbird-128.1.0esr.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "aee0ac4b2bf06468b0fd4d302507693c3e5a76426d4aa2b4deb9081f054156b3";
+      sha256 = "dc0e71b08952382d816f2d814bb0e5d8b9f0ca94043bdd482338b08fbc08f401";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ko/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ko/thunderbird-128.1.0esr.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "32cbdac8073fdc47feda1e17754a1966d668d10b881d137d593f10ef61f1c8a8";
+      sha256 = "979378c1aae8a61b6cd0a091a44c65169cddb10d9e8e8fc0629dbdfe284c6427";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/lt/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/lt/thunderbird-128.1.0esr.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "be4a3241453d43ec04586d27c7a2d09c96ab0558eba5c52a6242b5cc39f7be89";
+      sha256 = "a3deb9c4288291d8ebf1597e931fd997329c0b3e703f7856dc79d2f0da8b0627";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/lv/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/lv/thunderbird-128.1.0esr.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "6b92c31b2e2cbb9f2dcf73d29004233f4a4128dfa315fcc0e642aab59ea65c82";
+      sha256 = "618a9034c7d4a16be49f8ff69732a54350a57398b7d453258809502fcc13d560";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ms/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ms/thunderbird-128.1.0esr.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "87cc4f4a7cf59361c899990e023a57ffd6cd7f8b575fa4f06b5045d71b7d0ba8";
+      sha256 = "7c8a8b9afa8a34c3372b2cb45350ef6aa45d4635ad8a41f3a9b480a49c5d925e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/nb-NO/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/nb-NO/thunderbird-128.1.0esr.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "5a21efede9c8f142e77c37dd569a42467408c9863c03b791b26153c4e09a962a";
+      sha256 = "4aea3cc49dfda9e4415f918577d398a93f7bf603f809f63181a2d25272614c63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/nl/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/nl/thunderbird-128.1.0esr.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "d6158645ee629b89a6d518d1e62f6777f3f453e6546ad177979473f432dfb376";
+      sha256 = "261bf62d63b066811d586305ffc923ae83c78e5ae17ca445cdc5b3f96bc3a06d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/nn-NO/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/nn-NO/thunderbird-128.1.0esr.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "1528148ba47eabfce476ca351ba0c7341a5454d38c798c3b6dfb1c2f02efd3f8";
+      sha256 = "60def136f945da719dd5809764ad726c0c0158b82f358599757a009aa0fcc90d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/pa-IN/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/pa-IN/thunderbird-128.1.0esr.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "8d6c1f3ce92af5e19e24661aa7bbbe815e3c9ac7ff3e9b6db7c2662e8f56f97c";
+      sha256 = "c2c2d4a5dada97059408382cc70a87bcf5455af05a7476dccfa07d11574da695";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/pl/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/pl/thunderbird-128.1.0esr.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "b26ab380e57e442047092f8f12ce701fc062d3dffb3fb905ffde8ec1c2bd9975";
+      sha256 = "eab954d862710fd80254b5106ff5daa9f94d3a1a4b145b4dfc2b665854356fe0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/pt-BR/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/pt-BR/thunderbird-128.1.0esr.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "23ff7b60b2a754c34bf243851ce7896cba6918126615ebffb030180fc4df754b";
+      sha256 = "ca5bac344bcc1ba4471221a0a51611ddc69319d508ce558d43d0e09541891e48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/pt-PT/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/pt-PT/thunderbird-128.1.0esr.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "f6667f60d0a54f4e5c25b7c15d843f7215fb0ff8f65962b9ed219f9fa1cac9c1";
+      sha256 = "cc60009903fef2a55059b42fa50c08d68b75187691b339ce0caeecc6dd22bea8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/rm/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/rm/thunderbird-128.1.0esr.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "c6c6d412f9a01824bedb46094239caec8c8f32b249f5c9bcce455166472e0c8a";
+      sha256 = "37c112550593f33eab61427b60f2450d22b35c3419ddc811fc91dc485cc13a17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ro/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ro/thunderbird-128.1.0esr.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "d87bb9e6262ca8639db9c72dc512ccd6e2c5c644b2540b76f1d8db2c6cc11681";
+      sha256 = "60f1aa505c5fe359795722f552546c39b65a9615676d889f2946a001f4897840";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/ru/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ru/thunderbird-128.1.0esr.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "933509f254d0a83807eb8423a812b44fa293a34302179bde31f8e7c63f29f17a";
+      sha256 = "e7f6ed6889366a6bd925dd5becf567ff4caa61b8f66549ec18478ece1bbc2848";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/sk/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sk/thunderbird-128.1.0esr.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "7075f022ecbc76d4c00a9816f85f22a08998bd44080b3edf7bb2b15f78a5ca98";
+      sha256 = "327afe61acc5a1ee0a8b73e88393c98d1970d594bb45295ffe50b042ff515764";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/sl/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sl/thunderbird-128.1.0esr.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "66bd3ea1238198fdf240fa471c846b83ae6ddcb7bb164d3e0bad8480c2b0c9cc";
+      sha256 = "42e721f86d33aa897e13c3881ed7157194fbdcf3e8f19e7e38767605c957427e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/sq/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sq/thunderbird-128.1.0esr.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "0fa98fbe0ebd473ffb247546fba6e7ebcb994bbd4bbbbffb868c2d27984ed8e2";
+      sha256 = "e00555fb3e07cc211053ab7532bed98b1bc0d33165cc9f407f8aece16a472a4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/sr/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sr/thunderbird-128.1.0esr.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "8388932ebc71148cfd3be78d5fd31754c78c4e249930ec5290876655e115207a";
+      sha256 = "de2c3ae4976ebe92b08bdcc5d8f22e51112b9b5e09c3e16b4bdebfc13829c54e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/sv-SE/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sv-SE/thunderbird-128.1.0esr.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "793f43ad4062323b408527cbf98988291452fb5007938fc6c75f794a95f6fbbd";
+      sha256 = "59148b62f82f6bf64a06e6bff89118bb6f34f41c0be05c634765f19b6fb16888";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/th/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/th/thunderbird-128.1.0esr.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "ccd43eb6dd39d0be2af3ab4581a1d49563b78aa1389ff227b5b9c7ae83a782b1";
+      sha256 = "2fb1973f1dd26dc1c25fc73dedd911f47c7664df09f58fa12fd822e995f89fa1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/tr/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/tr/thunderbird-128.1.0esr.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "61cef2f34fba3606af62ed2cdeff626f73d1bf628af17c9a30b151da4f7357e2";
+      sha256 = "0d99bf6f23a52442a09248c46a88523fbe629a95af74dcb45f0c18cade169c90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/uk/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/uk/thunderbird-128.1.0esr.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "51daf721ea9864fb199eab9908792b67031005238067543f4a69ebc5ad4fb10c";
+      sha256 = "172909dfa64f1659edb440fbc1e2ff2d45ae690dfb859bad63b645cfafe3f16f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/uz/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/uz/thunderbird-128.1.0esr.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "83acb46cce8a7e94e16bb0dd323af816284728d507c2787ae3a8e77fd78662d9";
+      sha256 = "7804f6b2270e6cde60ec996e3ff4c1ecf6b9c7b3e16b05caddf000a270e8c7d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/vi/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/vi/thunderbird-128.1.0esr.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "2ddc9a1b085f1a936e1ac10fb84440cb6159d77baab95ee7a2073202b3341987";
+      sha256 = "ce35721456873a1619379623c505f825d82b558c20c220ff29c16514f5f11619";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/zh-CN/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/zh-CN/thunderbird-128.1.0esr.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "6468070bca4ab013646945206c04a03a9b5ac5bac5b07cd48543aa0b7e980353";
+      sha256 = "9e6bee2ab2c647e55fff98509cda69fd61e721bcab83c35df91dfffba6f5edbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/115.13.0/linux-i686/zh-TW/thunderbird-115.13.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/zh-TW/thunderbird-128.1.0esr.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "27a73e84abdea7e4f9d4fe595129f08dd92dc9fdb4d2a3c275481096be90cb8a";
+      sha256 = "f395a5e9cc54ddf0d883e10d129f0111c992f33fba46981622832665f491480b";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "128.1.0esr";
+  version = "128.2.0esr";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/af/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/af/thunderbird-128.2.0esr.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "f7caede50674b6714f95a267ee31cb8a31d60a3820b8ea516b5c88f82730e1a6";
+      sha256 = "f4b3a3087afc240c9c1b4439316b1f0fda190143cca1da0d0c10d537ec47fdf2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ar/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ar/thunderbird-128.2.0esr.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "75deca12178b9f7c474b57b37a027ebed6a4bb10d6eb8b608c89674cf857b7c1";
+      sha256 = "d49d17d785de3f9145f5640e3c835a1cd6ec7b205868be4c0a598160835bfe25";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ast/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ast/thunderbird-128.2.0esr.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "6c9d1834a477ae2a072fe210515209cf542ac5899226f431a401b4987b2e827b";
+      sha256 = "7d2e82951778bf97279fe5c1eb9a36010af6d28ac3eaaaec7cff6da26cb51593";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/be/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/be/thunderbird-128.2.0esr.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "d3ef3a02f45fd5629dde08063a723ae422a484be87d57bdda8c3cc9d7bec00b6";
+      sha256 = "e77107193165eb5050286965e752b326fa15f33cc891e011f01ab09b90e92d91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/bg/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/bg/thunderbird-128.2.0esr.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "fd0257f2d3167a55b5577942cc72e251ff9f856be0a7dcbcfe7c2128cb87213f";
+      sha256 = "f64b546fe7803e808a82de46f9bd118b897004afdfb10baa2de9a190e3572ce0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/br/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/br/thunderbird-128.2.0esr.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "cac04ec5e0635a38e568d306c2b47158b893b6c8e54b4a533cf51d351b76242f";
+      sha256 = "a64ed5e163431a5fccfa452a565b109badbc80556cbe13bf00285afdb6fa1c1f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ca/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ca/thunderbird-128.2.0esr.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "9fd607242f7d568e6ad3b49e87b4b6a71b9a807f6aa4fc96b84ea4e42e29d896";
+      sha256 = "b0fb10db25845009c25e1bdbb408a1cc6935dd742c8cc1acd7c398bff4a600d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/cak/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/cak/thunderbird-128.2.0esr.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "e81b6472ab864af62b4c4090013c7f3615c9594bc84bdfb3b7fb36f78f394e6c";
+      sha256 = "74a8c917565f27eced4b9ec952fee871da7e51c2323e509225227ccdb231cb79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/cs/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/cs/thunderbird-128.2.0esr.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "f672b08496915f71c00cf9df0b214aea30b9db7f396340dc98ef5402780ee997";
+      sha256 = "63537a0b0efff24f47e9e8ea35bd28a55c6b96917c06a2dfa141d8f107f3194c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/cy/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/cy/thunderbird-128.2.0esr.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "6c002ffcc742fd0a01ec160ae8729a05d11267e17d32269c3fc6c03b3bf37d64";
+      sha256 = "fd459d4fcd1c6143f7a03ae3069073f4e4b8d097733d504dd0221069520fcc6e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/da/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/da/thunderbird-128.2.0esr.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "dee1fe8dfff06a276e4cb3018cd1a60ede76ee5baf09e34cf715912bc26c52a4";
+      sha256 = "7b75d5ab21254ef75a96217d715fc0a951ab38e8da61c2411820daea4b2ab979";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/de/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/de/thunderbird-128.2.0esr.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "d7fa4df3f309a06e53c8d3336d337e14c7e19f9b64d6b4b424eb6212d2d511e0";
+      sha256 = "cb05aa781c9cb360b23c597ab4566954e2506c01e214b14b0f7e863b2d5cadc0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/dsb/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/dsb/thunderbird-128.2.0esr.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "796db274ba2945d2212cf0015d0100465a754322fff4dd80d3d660b655bc64ab";
+      sha256 = "0d79340c7ae3af1e3be717ec92fe1ee14a53a680991ee2fb092dc9d4894b62c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/el/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/el/thunderbird-128.2.0esr.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "2bbfef60b2c46da6d338ce7f0822e4261ed6a85253eaa3073a0ae94e88a53565";
+      sha256 = "58049b7f1224ed79f63e053c1dabf795f851e6441c09044e6b7272074cbaeb15";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/en-CA/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/en-CA/thunderbird-128.2.0esr.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "0b589335683709ec57c272f2cfa1caae530718c8a6e57aafec1ed7933a8896e1";
+      sha256 = "338d69c084b4a9dcf93b0536417ab8a3dfa258647229e74e2f6b487a3d381900";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/en-GB/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/en-GB/thunderbird-128.2.0esr.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "a02fe116c48a0afcceab7a40b70c3537037bd28fda6f5d1c649486d3307fdb8b";
+      sha256 = "cc87b7ea712cc7f426129245a32d26724047932c12c4f5ac262e52ca551d7378";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/en-US/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/en-US/thunderbird-128.2.0esr.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "f6f383c86f60c96b0bf2e338ab363d0d72f6e53e972429203c1920939fd8509a";
+      sha256 = "4200c48e8b57bddde15c7ad6757077e560d2f52a29da1902a35bcce945e751aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/es-AR/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/es-AR/thunderbird-128.2.0esr.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "752e6409c562de5cd25f73c519f016a4602df937f317b91028512a4a9ead4c77";
+      sha256 = "a1cf08ad3e0a80b90814c779e031a97aa9dba9797b02acf8c2e45fb1e994d54f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/es-ES/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/es-ES/thunderbird-128.2.0esr.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "aaa9b5e1ef3f642675c5804ba62a11e387762edc9b0dff9c8204e32b6cc9fe19";
+      sha256 = "2e0a4a2d9001c587b9f61478de6611a94de912ab8fe1ed3bace2959f3bfb57ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/es-MX/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/es-MX/thunderbird-128.2.0esr.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "5812b135c2655d72e099de4a2fdf72293e3f89bf8cd1fa7b96a5dca40157ea6f";
+      sha256 = "e47fb45e3c8e05a0027bff1bf2b9a9fe07b73c28144beeceef5fe40b40fbd5a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/et/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/et/thunderbird-128.2.0esr.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "ee02e5e31281fd38f62d6e48fffbfe9435779089613d98d738eebf0288bc96cb";
+      sha256 = "c45c5801a736a578c06993f3e061e0df5c798fefc49f415d5ed1196c93d3b07f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/eu/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/eu/thunderbird-128.2.0esr.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "6a9988e9b67d8582fb4b9c456afd383c8b464c7cfb2a14e065baa38fb774ca94";
+      sha256 = "f709c4440888772dca99dd6cc667a9d72d20a6e1eb5c84dfbb0a7a8e488a6f74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/fi/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/fi/thunderbird-128.2.0esr.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "55aa8e6f0782fdc8a41cb26288d84bfbdd6b88661d4e398b0b121ba6539b586c";
+      sha256 = "e6f32dfc0095065326ce886f0ccc46259a13ae4339f609b2519f74226cf88e02";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/fr/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/fr/thunderbird-128.2.0esr.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "ace271f70d85aef98649e72d230417821ac7b457a985000851c6a2def90b7199";
+      sha256 = "92ba3a5b2ebddd5e6f60c52e948f3336360e69fb3c21ca97f5629f16b6c74158";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/fy-NL/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/fy-NL/thunderbird-128.2.0esr.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "404d0c3e9bd086ed00209f40ec31ddd2f65ce8f05c246099f67ac1cfd4ccf18f";
+      sha256 = "7f905d1e7d17dd314f3e58286bdac0f4fcfacdddf1df809dd95a80a992f3ac03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ga-IE/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ga-IE/thunderbird-128.2.0esr.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "c787eb2ad7490b18537a5dbf18c05a77479d9a38e46697f40db0b325c89197ac";
+      sha256 = "10421949c685172e8c842fa99ab11ee249a4e8357b9595a10d9a93659d5f45b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/gd/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/gd/thunderbird-128.2.0esr.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "11c0bbfe4c0ee4c29e00755659cd3eec2c89fd002c35ca9dcf9a36d8e36637e4";
+      sha256 = "8861ac36c0c65b00e15fbe3ecb6b288c612b4226bc06d688189548e95abe46f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/gl/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/gl/thunderbird-128.2.0esr.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "f3dc0ba2f53249baa82a85f47370e7d2d33144549099c58685c8e2b629fbd188";
+      sha256 = "44259d867c523488b62c06b41a340e5efdceda7e42faa98564643249c6409110";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/he/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/he/thunderbird-128.2.0esr.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "0fc4eb9da6f9b1fb833662aeeb6e3bc68ee111ec4b95a249b697f43e3b6bfd0d";
+      sha256 = "56b6152345ae31bf2e721aa1c4256493214969d1e6237bb3d861b784d0ff61d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/hr/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/hr/thunderbird-128.2.0esr.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "4c19e84f14610515371c00e4bfdf0d1a9c6d93326767d2a049e18a3286ac4f86";
+      sha256 = "64c7bf327329149f0f8f0138db5759fd0d2f032d58ea795b95f23c44e6cd2124";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/hsb/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/hsb/thunderbird-128.2.0esr.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "f908d18d7ce4997d46ad05e61b54c002f6039cdda67a4b06df1b2e21b9b01994";
+      sha256 = "b23577fb06f2813a6b8a0a0e8b76d029ec0d129758814696de4b5679e8b46d3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/hu/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/hu/thunderbird-128.2.0esr.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "1ef3b469e5cc01b78d0f9b0397cbfdb08a115b040d5ff5b93f6b7ef22e53ce7c";
+      sha256 = "9f2a7bb6990dfdd7b35922132701ead5505343ad53b12ef44743fffef8d4878e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/hy-AM/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/hy-AM/thunderbird-128.2.0esr.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "ee4072bb5bc8ef35d4a95d8e0f00b7ece382246b3343da889022da71961f56a5";
+      sha256 = "176130e7a7701022fdb308edfa8504c432639794e2582c214807d9496583de95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/id/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/id/thunderbird-128.2.0esr.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "3267e6e36c93ed79c2cd4171d037d2b5016d9b66d0da60e078d980930c7ee872";
+      sha256 = "80d9b02e4125d1e8f59cb7384c2ea6559c77a517675c84e286f8574d86459aeb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/is/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/is/thunderbird-128.2.0esr.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "8807acfc9b004d6010087424bb7742de208625b177ba340eabf395a35c5dc5f1";
+      sha256 = "677d0f4bc43d2efefc1fb052706cf7307ccf7b8bd529c76c1860e6f121daaf2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/it/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/it/thunderbird-128.2.0esr.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "7a65820f86686e1a8f3176533839a41fa361eb8d5ae7d25eb3ba25552469303e";
+      sha256 = "f7160c5183922bdcecdaf87100b1556081072dc31c2436690ac707e47511d36b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ja/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ja/thunderbird-128.2.0esr.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "3715455a068e1917905080d346e684237f15ea98cd3aef4b8cca4cb1f1a66beb";
+      sha256 = "9b1144c1911f0186d4ad6b1b4526d55aad0a6de2157e02cd8bf593c827ac28f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ka/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ka/thunderbird-128.2.0esr.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "a4920bd4c5013bd4e8574515f6064358c85036a666620bc15bb23ed891b309bf";
+      sha256 = "1dbc9c8419f6f7d131c00851d54bab714ca30f75be97529bf5f679a859014050";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/kab/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/kab/thunderbird-128.2.0esr.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "0b9879b77e8efc4a40b1e11b93a0c45be7c4d195a523bc202261f33dbd138d1d";
+      sha256 = "fe5fbf0b7c3e5f10846a0ab019baf5ddddc7b7bbb04b32e56cfca6bde5d92fb6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/kk/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/kk/thunderbird-128.2.0esr.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "4da60f136c95c915eeb6047d647d1aad066e9194620ccfa6b0d2d649a2bc539b";
+      sha256 = "77055d3004bbe6fce489cb4ea8c9e6f75d19ad35d0015caceb24920d372036f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ko/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ko/thunderbird-128.2.0esr.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "9d497d4e26bddc96a7f4b2cd7b21a54a7c159ae4245e7f10e0534cb73ee9d0db";
+      sha256 = "1711d530249728789931831680cb3062c1da2addd90482a195d27ccb2d69cb33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/lt/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/lt/thunderbird-128.2.0esr.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "25e2f903fb2d894eeada038728f43e2e195e0997e13d7e961bb8429a442041e7";
+      sha256 = "e3fd07e0bf2c1c6586b5826c92e4aa2341faea04791e686c8e6213a0d0f4e00c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/lv/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/lv/thunderbird-128.2.0esr.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "3a85ba4e1b15d9d2400d1000b1215356c4b6674e21cd8abe6957860cff108c77";
+      sha256 = "432cce43817a60790d8295c49b6e04b5d595811a3bf5024d733302ea755ab1c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ms/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ms/thunderbird-128.2.0esr.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "e136424aec855ff15f43fb4082cf3270928d3de5cfd65af25cacfbb7c1fd2262";
+      sha256 = "110ea1d59a3d00d45198505ecb15100d9cbcc77bfba69fb9000ecdfcc9db1d4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/nb-NO/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/nb-NO/thunderbird-128.2.0esr.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "3332ae00538d48b2842a66ad4a7383c021bd0f4d4f01845229e8a3d10330f0c3";
+      sha256 = "7d7bac855a4e27055e0a8561172cde744058e74aa8233554504d87dfc68f29f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/nl/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/nl/thunderbird-128.2.0esr.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "4278329ed3b2fb58f15def543c27cc6bbe67e70d8b7c38e09ea37091b3a2e04d";
+      sha256 = "4820f08e4979e9eddc4182fea39d023defcb450e7edac9c8a2d3b09c62669959";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/nn-NO/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/nn-NO/thunderbird-128.2.0esr.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "6816386d06eb3faa8d6ee533157153f5f3ff1cc9f9fbc1ab871baa32d3e5de3b";
+      sha256 = "835b1befa30afa3d8cd50f4cd9a2922cb63815ac1c9b240c491d114f4e8542cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/pa-IN/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/pa-IN/thunderbird-128.2.0esr.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "eb8fe69a9a88593f1c4cf953a4066cd0c79c8f61c270f65177ef5de196481744";
+      sha256 = "cee9b2f3aee4e978772222f2946c99986ce36695f34e51708cae928bc66ab6ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/pl/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/pl/thunderbird-128.2.0esr.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "c7e97e39ca32dc0369da1e2cbbb714b3b2614e552c932e328d9ec01c28dcfa88";
+      sha256 = "ba29593feccd45c43605c6aaaddaa99afd25308e810e6059ca873a162a054eae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/pt-BR/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/pt-BR/thunderbird-128.2.0esr.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "5cbf7fddd22b227ef57b9902273820be8ab518511a9a4305941a178fcaadc5d6";
+      sha256 = "5e1bb94d66d757a62e093835f91b097586980702985931813d2825bf7b90f5c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/pt-PT/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/pt-PT/thunderbird-128.2.0esr.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "23bae7cbb8528b607ea8b7e8d5fba51edd85682e50e823525b7d88633cba67cb";
+      sha256 = "f437bdc00cc4cd70995000c4a23dc7407f8b0b42dd42d3e536e95ea6d79f0ebf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/rm/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/rm/thunderbird-128.2.0esr.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "3e47ef468d5608badb81a085a4bdb4e5e471698afd613430b36b55203b6392a2";
+      sha256 = "b068a55935501994c69390b2d45b3592e2d3f7fb8e270fb058aec8882a353e90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ro/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ro/thunderbird-128.2.0esr.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "dc819bba617164a42f4564584a727a33cff2fb9c9fa6795f154d0ba836700016";
+      sha256 = "6f6fce04d2676a21dad81a77f0b875a3730e996810f249452fd49d277d13b39a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/ru/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/ru/thunderbird-128.2.0esr.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "92b8d9dfbd033c00ae7860d4d3912e713c193b75bb533088b1eac1ae4d5cb131";
+      sha256 = "2044141931cb4735ef1236b8c000aeed718266cbbd3c28b5d3fd3ddda4f64317";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sk/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/sk/thunderbird-128.2.0esr.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "694460056e16866c1b807864c6ea0593d01d45157178adfb3f29ad8277554491";
+      sha256 = "bdf6d92e16397237d5c9168d3d5f14d0ffc8df04e9b435a5f1e7a49138cf593f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sl/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/sl/thunderbird-128.2.0esr.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "41451768b19248de4827ced8f13fe794401405016adbdf15c80929544c619216";
+      sha256 = "21aa9cd554c5a5d6f23f433c4697e47e3fca90d957f9a413d3b7aeb030055544";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sq/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/sq/thunderbird-128.2.0esr.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "9ee7df88f187862c039c75a68d7fe9e509b4a88c94cfe69adb1b00bbc11b7dbf";
+      sha256 = "f8bfdbb24d67341cd5d3e88012883835a2d48f18e0d6efe33c1b726431bc279b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sr/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/sr/thunderbird-128.2.0esr.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "d4d6ac39c1296ea136f7dc7f85655aa26a3e9bea9499d38be171ba419cc3d146";
+      sha256 = "f906ca1bd4391ccad57eed53d247d32fd62b3328a005e034e5f76e74ea37aa4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/sv-SE/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/sv-SE/thunderbird-128.2.0esr.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "ffed8cf698a067490ec9749c66dc8829bdea9f217d7762c3a0d02bace29e9e3a";
+      sha256 = "697c1c80cc743f5446c3d6744cfac640bf5968d9b8322697546af9a4cffe6517";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/th/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/th/thunderbird-128.2.0esr.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "537d70eb286b63faa280c0547059ce0df8c1fc70775f82c3e7865c589005ee0e";
+      sha256 = "62bf8a81688e3405ebde85623df7cbb9c87a41ed0b86ef32f791c1a3b383c185";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/tr/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/tr/thunderbird-128.2.0esr.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "e079b676a41c5d7a2011965f7e42bfbc75ef8f85521ea94bafd01bda0dfb28ba";
+      sha256 = "af3b01def0092f1abd3dc7517ac68e41d92fa816ff0ee0045a14fffd257dc732";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/uk/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/uk/thunderbird-128.2.0esr.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "0f899cf16ecb4f10456b271ef98672b3c7f043d3dd50190c1140fb4ae4701e1e";
+      sha256 = "0b5c83c3e28b59c7feeba5ce953b0b60d115f33f567e7942d450c804e4f0d236";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/uz/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/uz/thunderbird-128.2.0esr.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "3a2cbcd225ec53410dec278d28f08a9af8d23a852304b00325411aa3fefb7134";
+      sha256 = "45091cbd6336995b86d3e2b5e0ef82792dc5484a90ca94de905526d3122853c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/vi/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/vi/thunderbird-128.2.0esr.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "456a2eed712a8853bfd014cc556aa1caddcedb0159f8d2fc63d6ee61d5b8bcbc";
+      sha256 = "448a8ed43b80448994b918f3f91c3de3698b106f578b776efbaa7b4e4c4d3fc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/zh-CN/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/zh-CN/thunderbird-128.2.0esr.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "f55e16ecdb55927efff18ac94a6703f86972642a2310948604c2573d281ed2d0";
+      sha256 = "53cbdf5039e2f6d724b45ecf948c63af367e7df4f7766e628fb945fce33734f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-x86_64/zh-TW/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-x86_64/zh-TW/thunderbird-128.2.0esr.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "e62968e0457ca8691fb6e474c3b945202912ed019b99caaf7f786ce56e94399a";
+      sha256 = "147e2983179d906c7878a889a4e05be792fb54336f029b7c4c7f26f115ed9217";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/af/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/af/thunderbird-128.2.0esr.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "6872446b235915fddcffcf9024e83424159977f25c1c9435274c795356645621";
+      sha256 = "282558d2d07b3c44de23c5684771e8f2eab9f67f5fef844f569f84474687da04";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ar/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ar/thunderbird-128.2.0esr.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "0dc5ca84ac378cb187b629ea9e138080f5fdef33ad80e2293ae092a742d7a73e";
+      sha256 = "972d674e174433e6dd91627942a1d2e3e06b16c9fcc5288b9ab1f92a0a2526f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ast/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ast/thunderbird-128.2.0esr.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "9b2744787c0e3d2f26d86cea92d79202f4905a4ccae52128507a38a1e6d803be";
+      sha256 = "bb7c12421185c2a1db8e94bcd7d0c7b9d461272652ab22fa5a05f08e83a226c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/be/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/be/thunderbird-128.2.0esr.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "29e667cfb4a280399da8805e1cdf5f924d40ec544b5f6e1450d8b6b0e5417f43";
+      sha256 = "0a731f7c5caa910719d3efbf8d65a8d7149a3195631263de13e0ccdc51eb5268";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/bg/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/bg/thunderbird-128.2.0esr.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "dcb4ea76cbadbc4693e5bb480513b55216c0456fd757a9819f95e385a38274ed";
+      sha256 = "af55dd242ea2edceb2b7faabcf26f1c976efb9f8b5ff76d5b07cfbd9c6eb55d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/br/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/br/thunderbird-128.2.0esr.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "606d741e05d8769f3dafd72540a29e5a98fde968e5c83152554adb705178f1db";
+      sha256 = "b5b249a78710ba4c7d1bc696fccfa7a63a517d537ac4f011ba7a22f2d3fffb0a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ca/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ca/thunderbird-128.2.0esr.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "77585d968f7a34c10f54244c64997094dd22bf1b86d7fd72f36699ba65a11363";
+      sha256 = "2dc876760e6520cd3ace249943e37d363f98388e799c0e0fb2d51e751404de40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/cak/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/cak/thunderbird-128.2.0esr.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "99b192e2153fba6d39c609dc59078956603079d3af0758a203c9c179d3814aba";
+      sha256 = "836350ae188d39899231a26d7e10eaa029559c83a3395b7c74536d37f73d795f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/cs/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/cs/thunderbird-128.2.0esr.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "92bb4fb6261e695c3122c5797edf92084e844a509ed3b77199927f408e780c8d";
+      sha256 = "1b3bdd19f3e880bab7428e831f490c0ce69fe1db20b8699402e956f09b77c5ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/cy/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/cy/thunderbird-128.2.0esr.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "2736bbdb40c174ba13be89efb36c77da6842d32a8f589e7e72085e9d5ae0dc0c";
+      sha256 = "b1153a70b2bcf6e9f0deaaaf175a5085921f7d1e1a1f319136c94ce57bef54ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/da/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/da/thunderbird-128.2.0esr.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "6a1cebef252ab884cf56824045ca6699ba092526ee2c8944f7041fbaa3ec8316";
+      sha256 = "a2eb8ba6175dd4b7336ab05fe4834527a31ab5e13abb0381f187e91f836031e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/de/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/de/thunderbird-128.2.0esr.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "21fc083977e9bee76118ae38e05cffcf5f77e3c2916f1dba4c6762060603a04e";
+      sha256 = "1c23af1559f2e8f090cc651c827d4130e74f7141daae585ddc43c0287b8b0e0a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/dsb/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/dsb/thunderbird-128.2.0esr.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "74361c681c861a3e298b494feda3d51489881a8da614726d3d539bafb6eca5bd";
+      sha256 = "341d6a892f5b79836bb18fcd97df1b2fab695791a50af6ded0d966f1d0439008";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/el/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/el/thunderbird-128.2.0esr.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "22f9f3dc25c4de5ea33e98ccdf9743540d04dc6bc6b501da638db31531ee9464";
+      sha256 = "8eb920d8e41cc1ca8607580f124061f9c10a549377b591ac5cfb53b2859248d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/en-CA/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/en-CA/thunderbird-128.2.0esr.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "bac464a25326ae1062fac17430911a34a89f0c8fffc3c7b2032f1cc146dd9b29";
+      sha256 = "ca2c7d3eee2129e3da7bc4a7d25db4b867c23408084a9438c4a600c1d35c9853";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/en-GB/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/en-GB/thunderbird-128.2.0esr.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "b41780d9a1aa4e801f905a87b11763305b32bd0fa50b0c3c23876b5833bb7b73";
+      sha256 = "f8f1aeddf0b5711e10ae4a4d785380230a9f8871d73baebe95ae43f3bf4b2a45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/en-US/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/en-US/thunderbird-128.2.0esr.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "89a8f5019cf334a1cfd957f1dc9a4bf53eccf5ff0b23ef2db6058756453f3b68";
+      sha256 = "c89cda02e8a17ff8e455085ef22c1a14f8d42217239e68133ab0d3076a4df170";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/es-AR/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/es-AR/thunderbird-128.2.0esr.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "042d331b9f57dd7074c3a7c50e1b038eb8e3f08881b149bb9af6c5146c92f374";
+      sha256 = "30b6d06405cdc824d2ea2e8ae3352403d631e02d182621035c9c4b89a2f5d3e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/es-ES/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/es-ES/thunderbird-128.2.0esr.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "46b136ade4bb3dcb1be7fcb18924693786930d6218c84d86e92f8f004cb2db4f";
+      sha256 = "4a52ee0cad2c6adb85a5e847b71761fa931f2baa34f310c2135249a1f74d1e81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/es-MX/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/es-MX/thunderbird-128.2.0esr.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "2242396853b6568562cf8c6864b90be994773a1139cb91ea7d65c61ee0dcbb0b";
+      sha256 = "5e3ee38af26a47df39c542da9cad4f0f5fcd761b93cc25aa3b3e484afea342a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/et/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/et/thunderbird-128.2.0esr.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "6bd30efd3e297214dd0ab0cd5fa8c4b21791674ff8c86bff7f5a38a692fb7a10";
+      sha256 = "bad8263e3754045770662250327c14ea50a11d46d786fcf0d41f761e0cc2c60f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/eu/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/eu/thunderbird-128.2.0esr.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "8a69d159cb93c3bb441b2b33a4b3251eba02bc10025ff29b39cdb54817cf930f";
+      sha256 = "8433875ae5b054541f6fc70ef566482acabc9f013a0010d4d3125c09acbd4e2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/fi/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/fi/thunderbird-128.2.0esr.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "676004498bfb20b8b1fad723bb254ca210cd2bd6ee3141df41e0460fb5dcba2a";
+      sha256 = "4a077df147a2a27eff7cae97bf33c1d2ed92c11f6f6f6e71307bda9951137fe7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/fr/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/fr/thunderbird-128.2.0esr.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "7dcb30ece74cf8e0fcda595cb44d84b43059fc00939da120372e908bd158f1e8";
+      sha256 = "4373edef98045ff52146a9899159f4d0614cefc0a49740c538ea52692097d45b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/fy-NL/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/fy-NL/thunderbird-128.2.0esr.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "394b3e2d5e7fb772c45c94cd38849e181cb414362bac279abdc545bc920917d0";
+      sha256 = "0397b53ac71755e8ce65a946d3aa1eb2d025ee3e211857d31519f13d560e99f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ga-IE/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ga-IE/thunderbird-128.2.0esr.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "58f1dfa592cd1d02e782bb832a2eeecb69c5438000a2700f3b1b0a5d6c25ed52";
+      sha256 = "ea0f51dce8b5f51cb857c112eda213599a0cf85f03de718c3cccb575afe8c311";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/gd/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/gd/thunderbird-128.2.0esr.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "e385995eceac9f84dbffb561851784a5c7c4b1560994631f9d6e31c9c09ed50f";
+      sha256 = "4f2f2d90b84349889b93be998eadff420dc547b36ed2e232c3cdf6a4269a7c1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/gl/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/gl/thunderbird-128.2.0esr.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "1bccd0f5870159883b3b77226050b8475d61252c581bcebe89067da9a110d0b6";
+      sha256 = "8737b1b7a116da2e2a7054c579d5898ecca15abff78a179d86734ea9a58e717e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/he/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/he/thunderbird-128.2.0esr.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "2652f6723d7aa4b6abf517fa23d493deabde1f37891d7ce8e190f04bc72d550f";
+      sha256 = "2260a9384ac575b3232dc5ceed92e76d56ffd44072784d26f4efaa30a7c4d33c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/hr/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/hr/thunderbird-128.2.0esr.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "a941a94afc2692c3329b22afe40cbcd2b6c3bfb964178bf66f699f5dd0ee3ce5";
+      sha256 = "30ffe91315ac17eaecbe112d4f7db5482c464843c80dcf45f2cb7739b6f957c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/hsb/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/hsb/thunderbird-128.2.0esr.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "2eea4f3167ffdcbdb3e6712c2ac67d03c6f84cf8fc611e854491c5d2d7759ada";
+      sha256 = "4ab8a3ad84614e9b5efeb953e34a7258cdad035235d4de1e802351c04d135889";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/hu/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/hu/thunderbird-128.2.0esr.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "c0811928b99556f2de5876fc22520bfdf1d38ecf97c8e7ded2bb882b85cbbe33";
+      sha256 = "e710ec3beb0656fb14962cfae06b29be24d30f5c2cefd1cbb4e8e09471193d54";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/hy-AM/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/hy-AM/thunderbird-128.2.0esr.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "29bb49dadf3bcc501d829c451cc1c541f103ab27c58bb94a50af6deb63dc139e";
+      sha256 = "18941e2454d60b17aeebdc95aad7854b989e71c4e928b0147c0beb36eff54f3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/id/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/id/thunderbird-128.2.0esr.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "eda238b6f688bff2396d4aed23c3a24929883a6bfe814873b44fd256f1cffc19";
+      sha256 = "029c210861312a5d2d3c59f69b692692b133296b27d125367ac2cc2419e0a8d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/is/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/is/thunderbird-128.2.0esr.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "6b5f7cec11eadddc310140dfc109c801e1d10e711b41d3a132d55bce91923402";
+      sha256 = "bdc4447638fc299cf5974adf5ca268d6d4a46f6d1b22b51e54b2de46f1c266c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/it/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/it/thunderbird-128.2.0esr.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "c24f656d53c604cd06a05388d03e93c424bd831c355b75ef64f1072f307d2305";
+      sha256 = "b3a39203e13635e59b6f58fbd053ebe630c5da786325c48f62f2493e00237d32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ja/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ja/thunderbird-128.2.0esr.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "810b09ed1875094440eb966e5b2e91afef8becaa62901806310235d0c6cde253";
+      sha256 = "d684e3c5423710c07f5f6918257acabff6ee3c7fa685fb19269f482a6c6f9c61";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ka/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ka/thunderbird-128.2.0esr.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "924e98fbf30c7e05d2d5d65fc9908e9a9ef69113ef8f9a19becda6a5e110cced";
+      sha256 = "5363ebecae103a8b5d37dbd0011e6bdc284e28beb4a32dae17314d3ab420cd22";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/kab/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/kab/thunderbird-128.2.0esr.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "304fc281009a152c4c9987d332d8d295e151de889a52bb760ad1027fab257e4d";
+      sha256 = "06a8be9cd3cdd3a7b6dd1c9d854a92858c3bde93a1ec49986a9e9325d883527a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/kk/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/kk/thunderbird-128.2.0esr.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "dc0e71b08952382d816f2d814bb0e5d8b9f0ca94043bdd482338b08fbc08f401";
+      sha256 = "48f9e2bb1efd842fa78cd593305771b43c80d25bbc5ae3336123af43a50a8676";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ko/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ko/thunderbird-128.2.0esr.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "979378c1aae8a61b6cd0a091a44c65169cddb10d9e8e8fc0629dbdfe284c6427";
+      sha256 = "09c25ebf06fb2524b3717f17a63c4ffc95925a626d0f102ce926108ba1fb4f0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/lt/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/lt/thunderbird-128.2.0esr.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a3deb9c4288291d8ebf1597e931fd997329c0b3e703f7856dc79d2f0da8b0627";
+      sha256 = "721c02bd8e8016494d7a32465cb69cac923fb8ba48bd32dbedde6c7e3d88a1be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/lv/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/lv/thunderbird-128.2.0esr.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "618a9034c7d4a16be49f8ff69732a54350a57398b7d453258809502fcc13d560";
+      sha256 = "2f60dcfa5fbadb856aeb15b3542f27952469aa8b333fcb91d3d1e7f69cb9b3a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ms/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ms/thunderbird-128.2.0esr.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "7c8a8b9afa8a34c3372b2cb45350ef6aa45d4635ad8a41f3a9b480a49c5d925e";
+      sha256 = "cdf054772acb4130e300ba0aac0e803298387e775af0d890476239e3d7be7c05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/nb-NO/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/nb-NO/thunderbird-128.2.0esr.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "4aea3cc49dfda9e4415f918577d398a93f7bf603f809f63181a2d25272614c63";
+      sha256 = "1c56b63aff8096f946388498eee83ba509c46b2f8a609665eded59f13b729d22";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/nl/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/nl/thunderbird-128.2.0esr.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "261bf62d63b066811d586305ffc923ae83c78e5ae17ca445cdc5b3f96bc3a06d";
+      sha256 = "d93de2c117308f4843d9c9377ad336730834132ce823d2d0a1f49c40160c0933";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/nn-NO/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/nn-NO/thunderbird-128.2.0esr.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "60def136f945da719dd5809764ad726c0c0158b82f358599757a009aa0fcc90d";
+      sha256 = "4f183fe49f3725defcd1c2b4ae65bd95a5ff135b5f2ba0ef348fdecf04c2f7d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/pa-IN/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/pa-IN/thunderbird-128.2.0esr.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "c2c2d4a5dada97059408382cc70a87bcf5455af05a7476dccfa07d11574da695";
+      sha256 = "f9c8787bd95bdedc4e21fb9ee13b2d4ce7bb051bc3890d104b805b5f859ab922";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/pl/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/pl/thunderbird-128.2.0esr.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "eab954d862710fd80254b5106ff5daa9f94d3a1a4b145b4dfc2b665854356fe0";
+      sha256 = "f536ba3b737d23dc9e0b0f9bf6d0bef06c08c35f37ae92e8f56ce49760422614";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/pt-BR/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/pt-BR/thunderbird-128.2.0esr.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "ca5bac344bcc1ba4471221a0a51611ddc69319d508ce558d43d0e09541891e48";
+      sha256 = "5d7a8b873affd479fcefbe88db6677fdbe616ad67031ccf7fdeee4e740e99653";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/pt-PT/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/pt-PT/thunderbird-128.2.0esr.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "cc60009903fef2a55059b42fa50c08d68b75187691b339ce0caeecc6dd22bea8";
+      sha256 = "999f812b3ca0cec36503a425b0d756555bc159e2a1cd952a06d65034d28aa0f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/rm/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/rm/thunderbird-128.2.0esr.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "37c112550593f33eab61427b60f2450d22b35c3419ddc811fc91dc485cc13a17";
+      sha256 = "081809c7c14f8056db296ff3ac97e2a9aaaf56302a40ffb8ede62d83e17fc944";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ro/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ro/thunderbird-128.2.0esr.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "60f1aa505c5fe359795722f552546c39b65a9615676d889f2946a001f4897840";
+      sha256 = "61ffe80eb8d740dda615ced1365b96f6a453947cd174bc3e96577538e3ffb8b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/ru/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/ru/thunderbird-128.2.0esr.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "e7f6ed6889366a6bd925dd5becf567ff4caa61b8f66549ec18478ece1bbc2848";
+      sha256 = "c71adef5e11819e3cb7d8ba9c4081058e76f5e3a07e57f8e6c66dd4baf53945c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sk/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/sk/thunderbird-128.2.0esr.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "327afe61acc5a1ee0a8b73e88393c98d1970d594bb45295ffe50b042ff515764";
+      sha256 = "28f2ead6651a8fd9d2e75ad3eca88161e93aa13b0ab4e4efa22a5b4e0f77804d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sl/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/sl/thunderbird-128.2.0esr.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "42e721f86d33aa897e13c3881ed7157194fbdcf3e8f19e7e38767605c957427e";
+      sha256 = "ace141250862bd1ed339e2a808c059e453ee48cc655e1fec00539c44c12fc77a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sq/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/sq/thunderbird-128.2.0esr.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e00555fb3e07cc211053ab7532bed98b1bc0d33165cc9f407f8aece16a472a4b";
+      sha256 = "4463332d93d5f055a39aefefee061c496e4df909c5f605e561bdad524df0ec8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sr/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/sr/thunderbird-128.2.0esr.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "de2c3ae4976ebe92b08bdcc5d8f22e51112b9b5e09c3e16b4bdebfc13829c54e";
+      sha256 = "c6b2bc17a929cce1f829809870cbee9be414c0847ce00a51afa923977a1e0bb7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/sv-SE/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/sv-SE/thunderbird-128.2.0esr.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "59148b62f82f6bf64a06e6bff89118bb6f34f41c0be05c634765f19b6fb16888";
+      sha256 = "71241892935c67e156ea3b37e46056896ac9e60ec90f328ff6fbde1d3fc15bff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/th/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/th/thunderbird-128.2.0esr.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "2fb1973f1dd26dc1c25fc73dedd911f47c7664df09f58fa12fd822e995f89fa1";
+      sha256 = "23a404e4f2ad01295a8a6b8439e6a4a733b4ee26eeb709c71ef76a6fb859a244";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/tr/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/tr/thunderbird-128.2.0esr.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "0d99bf6f23a52442a09248c46a88523fbe629a95af74dcb45f0c18cade169c90";
+      sha256 = "e418a2be53df374d9ea08fd64a890dbe076e420d9b0e2db3dd58035433801d57";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/uk/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/uk/thunderbird-128.2.0esr.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "172909dfa64f1659edb440fbc1e2ff2d45ae690dfb859bad63b645cfafe3f16f";
+      sha256 = "0185113bbdda3bf7fc03578ff8cd7c2cabf691608d3ff67e598bb669c60690fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/uz/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/uz/thunderbird-128.2.0esr.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "7804f6b2270e6cde60ec996e3ff4c1ecf6b9c7b3e16b05caddf000a270e8c7d4";
+      sha256 = "dda399a258e14ce9f38b5b1c4b9c366c52ed0d3158ae8eda45da3e28648bba6e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/vi/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/vi/thunderbird-128.2.0esr.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ce35721456873a1619379623c505f825d82b558c20c220ff29c16514f5f11619";
+      sha256 = "fadfa641fd7363d82856b2957645a619c9f8f582c9bda78b6a74a825729aec91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/zh-CN/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/zh-CN/thunderbird-128.2.0esr.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "9e6bee2ab2c647e55fff98509cda69fd61e721bcab83c35df91dfffba6f5edbe";
+      sha256 = "667e7244f358e12973df794afd4077bb1ceb7e4cbaee88f0832cb2c25d151d1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.1.0esr/linux-i686/zh-TW/thunderbird-128.1.0esr.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/128.2.0esr/linux-i686/zh-TW/thunderbird-128.2.0esr.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "f395a5e9cc54ddf0d883e10d129f0111c992f33fba46981622832665f491480b";
+      sha256 = "becf451ca9483fb8a8d0b9d76942eac71df2d4ea063ff8f5411e84d9b8392898";
     }
     ];
 }

--- a/pkgs/by-name/ll/llm-ls/fix-time-compilation-failure.patch
+++ b/pkgs/by-name/ll/llm-ls/fix-time-compilation-failure.patch
@@ -1,0 +1,97 @@
+From cb0a3da737d933614bcd011e91048f2009036d09 Mon Sep 17 00:00:00 2001
+From: a-kenji <aks.kenji@protonmail.com>
+Date: Wed, 14 Aug 2024 09:29:18 +0200
+Subject: [PATCH] Fix `time` compilation failure
+
+This allows `llm-ls` to be compiled with `rustc --version`: 1.80, using
+the Cargo.lock file.
+
+Reference: https://github.com/rust-lang/rust/issues/127343
+---
+ Cargo.lock | 34 ++++++++++++++++++++++++++--------
+ 1 file changed, 26 insertions(+), 8 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 1806f0be28f65ab1283954c5a72ae20594044624..e8328e602e50fd5e47ba55c5dc9c7881a308a0a5 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -487,9 +487,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "deranged"
+-version = "0.3.8"
++version = "0.3.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
++checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
++dependencies = [
++ "powerfmt",
++]
+ 
+ [[package]]
+ name = "derive_builder"
+@@ -1210,6 +1213,12 @@ dependencies = [
+  "winapi",
+ ]
+ 
++[[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
+ [[package]]
+ name = "num_cpus"
+ version = "1.16.0"
+@@ -1403,6 +1412,12 @@ version = "0.3.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+ 
++[[package]]
++name = "powerfmt"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
++
+ [[package]]
+ name = "ppv-lite86"
+ version = "0.2.17"
+@@ -2033,12 +2048,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.28"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
++ "num-conv",
++ "powerfmt",
+  "serde",
+  "time-core",
+  "time-macros",
+@@ -2046,16 +2063,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "time-core"
+-version = "0.1.1"
++version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
++checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.14"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+ 

--- a/pkgs/by-name/ll/llm-ls/package.nix
+++ b/pkgs/by-name/ll/llm-ls/package.nix
@@ -1,8 +1,13 @@
 { lib
+, stdenv
 , rustPlatform
 , fetchFromGitHub
+, fetchpatch
 , pkg-config
-, openssl
+, libiconv
+, darwin
+, testers
+, llm-ls
 }:
 
 let
@@ -19,13 +24,31 @@ rustPlatform.buildRustPackage {
     hash = "sha256-ICMM2kqrHFlKt2/jmE4gum1Eb32afTJkT3IRoqcjJJ8=";
   };
 
-  cargoHash = "sha256-Fat67JxTYIkxkdwGNAyTfnuLt8ofUGVJ2609sbn1frU=";
+  cargoHash = "sha256-m/w9aJZCCh1rgnHlkGQD/pUDoWn2/WRVt5X4pFx9nC4=";
+
+  cargoPatches = [
+    # https://github.com/huggingface/llm-ls/pull/102
+    ./fix-time-compilation-failure.patch
+    (fetchpatch {
+      name = "fix-version.patch";
+      url = "https://github.com/huggingface/llm-ls/commit/479401f3a5173f2917a888c8068f84e29b7dceed.patch?full_index=1";
+      hash = "sha256-4gXasfMqlrrP8II+FiV/qGfO7a9qFkDQMiax7yEua5E=";
+    })
+  ];
 
   buildAndTestSubdir = "crates/llm-ls";
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [
+    libiconv
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = llm-ls;
+  };
 
   meta = with lib; {
     description = "LSP server leveraging LLMs for code completion (and more?)";
@@ -33,7 +56,6 @@ rustPlatform.buildRustPackage {
     license = licenses.asl20;
     maintainers = with maintainers; [ jfvillablanca ];
     platforms = platforms.all;
-    badPlatforms = platforms.darwin;
     mainProgram = "llm-ls";
   };
 }

--- a/pkgs/by-name/rt/rtorrent/package.nix
+++ b/pkgs/by-name/rt/rtorrent/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation {
   pname = "rakshasa-rtorrent";
-  version = "0.9.8-unstable-2024-08-31";
+  version = "0.9.8-unstable-2024-09-07";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "rtorrent";
-    rev = "4e246a401f2572d6c8a3295cbe0335baa316cd24";
-    hash = "sha256-tq/0Vq+rIyCn1UQlyo7lcTSVf6WW1I8MTfxiAwQYD/o=";
+    rev = "9a93281ded3f6c6bb40593f9bbd3597683cff263";
+    hash = "sha256-dbZ0Q6v6vu8rlr7p1rPc3Cx/9R53OelkoTNsdAVQAxE=";
   };
 
   outputs = [ "out" "man" ];

--- a/pkgs/by-name/sp/spacectl/package.nix
+++ b/pkgs/by-name/sp/spacectl/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "spacectl";
-  version = "1.0.1";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "spacelift-io";
     repo = "spacectl";
     rev = "v${version}";
-    hash = "sha256-w49nsPzEWfYeYxWNOl4VrWdQvL3zGafLxL5kUH4YaqM=";
+    hash = "sha256-wEu7AmFn1782XTKKb7JxQWn/ZSHrQbuZ/SDldn6pUNo=";
   };
 
-  vendorHash = "sha256-hVAQaM8Xank+l283D1Tq9TA/yiOiLGO7/3IyZkXj15Q=";
+  vendorHash = "sha256-SYfXG6YM0Q2rCnoTM2tYvE17uBCD8yQiW/5DTCxMPWo=";
 
   meta = {
     homepage = "https://github.com/spacelift-io/spacectl";

--- a/pkgs/by-name/ya/yamlscript/package.nix
+++ b/pkgs/by-name/ya/yamlscript/package.nix
@@ -2,11 +2,11 @@
 
 buildGraalvmNativeImage rec {
   pname = "yamlscript";
-  version = "0.1.74";
+  version = "0.1.75";
 
   src = fetchurl {
     url = "https://github.com/yaml/yamlscript/releases/download/${version}/yamlscript.cli-${version}-standalone.jar";
-    hash = "sha256-kAuUXOc3QQ9gxBO+HKZDGm5Y4H/lKeFzyiDlz+GMjv8=";
+    hash = "sha256-GdnrEHVdJmwcs6l1Fw3pXJ8hS+spcNpDQ346d6F0OTM=";
   };
 
   executable = "ys";

--- a/pkgs/development/coq-modules/mtac2/default.nix
+++ b/pkgs/development/coq-modules/mtac2/default.nix
@@ -1,0 +1,22 @@
+{ lib, mkCoqDerivation, coq, unicoq, version ? null }:
+
+mkCoqDerivation {
+  pname = "Mtac2";
+  owner = "Mtac2";
+  inherit version;
+  defaultVersion = with lib.versions; lib.switch coq.version [
+    { case = range "8.19" "8.19"; out = "1.4-coq${coq.coq-version}"; }
+  ] null;
+  release."1.4-coq8.19".sha256 = "sha256-G9eK0eLyECdT20/yf8yyz7M8Xq2WnHHaHpxVGP0yTtU=";
+  releaseRev = v: "v${v}";
+  mlPlugin = true;
+  propagatedBuildInputs = [ unicoq ];
+  meta = with lib; {
+    description = "Typed tactic language for Coq";
+    license = licenses.mit;
+  };
+  preBuild = ''
+    coq_makefile -f _CoqProject -o Makefile
+    patchShebangs tests/sf-5/configure.sh
+  '';
+}

--- a/pkgs/development/coq-modules/unicoq/default.nix
+++ b/pkgs/development/coq-modules/unicoq/default.nix
@@ -1,0 +1,20 @@
+{ lib, mkCoqDerivation, coq, version ? null }:
+
+mkCoqDerivation {
+  pname = "unicoq";
+  owner = "unicoq";
+  inherit version;
+  defaultVersion = with lib.versions; lib.switch coq.version [
+    { case = range "8.19" "8.19"; out = "1.6-${coq.coq-version}"; }
+  ] null;
+  release."1.6-8.19".sha256 = "sha256-fDk60B8AzJwiemxHGgWjNu6PTu6NcJoI9uK7Ww2AT14=";
+  releaseRev = v: "v${v}";
+  mlPlugin = true;
+  meta = with lib; {
+    description = "An enhanced unification algorithm for Coq";
+    license = licenses.mit;
+  };
+  preBuild = ''
+    coq_makefile -f _CoqProject -o Makefile
+  '';
+}

--- a/pkgs/development/python-modules/manifestoo-core/default.nix
+++ b/pkgs/development/python-modules/manifestoo-core/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "manifestoo-core";
-  version = "1.7";
+  version = "1.8";
   format = "pyproject";
 
   src = fetchPypi {
     inherit version;
     pname = "manifestoo_core";
-    hash = "sha256-CLYySNkMysd81ZBA2yfHGSvBuuf8vEvVXkzVsTeEoNM=";
+    hash = "sha256-AjvwG9j2TILslTR4GwK6eHfql4l7I+QIwUd6XQ2ojmg=";
   };
 
   nativeBuildInputs = [ hatch-vcs ];

--- a/pkgs/development/tools/gomplate/default.nix
+++ b/pkgs/development/tools/gomplate/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "gomplate";
-  version = "4.0.1";
+  version = "4.1.0";
 
   src = fetchFromGitHub {
     owner = "hairyhenderson";
     repo = "gomplate";
     rev = "refs/tags/v${version}";
-    hash = "sha256-+oc7/CFqLA1xvA1c5opKBUa+6AJ2SK7SwFeaNqw3x08=";
+    hash = "sha256-shbG0q86wlSjoCK2K7hNdUCwNPiQp94GWQJ1e71A1T0=";
   };
 
-  vendorHash = "sha256-xifJNyw8BCRoQVyBvyRRA1S03e3x5/ORwjpmGlKcA0g=";
+  vendorHash = "sha256-UKqSKypAm6gt2JUCZh/DyfWo8uJeMp0M+4FiqwzzHIA=";
 
   ldflags = [
     "-s"

--- a/pkgs/development/tools/gomplate/default.nix
+++ b/pkgs/development/tools/gomplate/default.nix
@@ -5,37 +5,36 @@
 
 buildGoModule rec {
   pname = "gomplate";
-  version = "3.11.8";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "hairyhenderson";
-    repo = pname;
+    repo = "gomplate";
     rev = "refs/tags/v${version}";
-    hash = "sha256-pE9TLEBY1KQvgMFwVJfn5kojESqZURcbCwRt4jrexhk=";
+    hash = "sha256-+oc7/CFqLA1xvA1c5opKBUa+6AJ2SK7SwFeaNqw3x08=";
   };
 
-  vendorHash = "sha256-09QUEudbWnO11iwJafF9zoYqbTr7SVBUiPWTHGnZ06Q=";
+  vendorHash = "sha256-xifJNyw8BCRoQVyBvyRRA1S03e3x5/ORwjpmGlKcA0g=";
 
-  postPatch = ''
+  ldflags = [
+    "-s"
+    "-X github.com/${src.owner}/${pname}/v4/version.Version=${version}"
+  ];
+
+  preCheck = ''
     # some tests require network access
     rm net/net_test.go \
       internal/tests/integration/datasources_blob_test.go \
-      internal/tests/integration/datasources_git_test.go
+      internal/tests/integration/datasources_git_test.go \
+      render_test.go
     # some tests rely on external tools we'd rather not depend on
     rm internal/tests/integration/datasources_consul_test.go \
       internal/tests/integration/datasources_vault*_test.go
   '';
 
-  # TestInputDir_RespectsUlimit
-  preCheck = ''
-    ulimit -n 1024
+  postInstall = ''
+    rm $out/bin/gen
   '';
-
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/${src.owner}/${pname}/v3/version.Version=${version}"
-  ];
 
   meta = with lib; {
     description = "Flexible commandline tool for template rendering";

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,6 +1,6 @@
 { callPackage,
   lib, stdenv, makeWrapper, fetchurl, fetchpatch, fetchFromGitLab, buildPackages,
-  automake, autoconf, libiconv, libtool, intltool, gettext, python3, perl,
+  automake, autoconf, libiconv, libtool, intltool, gettext, gzip, python3, perl,
   freetype, tradcpp, fontconfig, meson, ninja, ed, fontforge,
   libGL, spice-protocol, zlib, libGLU, dbus, libunwind, libdrm, netbsd,
   ncompress, updateAutotoolsGnuConfigScriptsHook,
@@ -397,6 +397,8 @@ self: super:
     outputs = [ "bin" "dev" "out" ]; # tiny man in $bin
     patchPhase = "sed -i '/USE_GETTEXT_TRUE/d' sxpm/Makefile.in cxpm/Makefile.in";
     XPM_PATH_COMPRESS = lib.makeBinPath [ ncompress ];
+    XPM_PATH_GZIP = lib.makeBinPath [ gzip ];
+    XPM_PATH_UNCOMPRESS = lib.makeBinPath [ gzip ];
     meta = attrs.meta // { mainProgram = "sxpm"; };
   });
 

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -115,6 +115,7 @@ let
       metacoq-safechecker  = self.metacoq.safechecker;
       metacoq-erasure      = self.metacoq.erasure;
       metalib = callPackage ../development/coq-modules/metalib { };
+      mtac2 = callPackage ../development/coq-modules/mtac2 {};
       multinomials = callPackage ../development/coq-modules/multinomials {};
       odd-order = callPackage ../development/coq-modules/odd-order { };
       paco = callPackage ../development/coq-modules/paco {};
@@ -138,6 +139,7 @@ let
       tlc = callPackage ../development/coq-modules/tlc {};
       topology = callPackage ../development/coq-modules/topology {};
       trakt = callPackage ../development/coq-modules/trakt {};
+      unicoq = callPackage ../development/coq-modules/unicoq {};
       vcfloat = callPackage ../development/coq-modules/vcfloat (lib.optionalAttrs
         (lib.versions.range "8.16" "8.18" self.coq.version) {
           interval = self.interval.override { version = "4.9.0"; };


### PR DESCRIPTION
According to the manual, libXpm "deals with compressed files by forking an uncompress or gzip process" and "writes to a piped compress or gzip process".

Before this commit a path to the host version of `uncompress` is provided, but the build picks up the build version of `gzip`, so the build doesn't fail, but it uses the wrong `gzip`.

This commit adds the correct paths.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
