### PR TITLE
neovimRequireCheckHook: Fix dependency list

### DIFF
--- a/pkgs/applications/editors/vim/plugins/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/neovim-require-check-hook.sh
@@ -10,7 +10,7 @@ neovimRequireCheckHook () {
 		# editorconfig-checker-disable
         export HOME="$TMPDIR"
         @nvimBinary@ -es --headless -n -u NONE -i NONE --clean -V1 \
-            --cmd "set rtp+=$out,${dependencies/ /,}" \
+            --cmd "set rtp+=$out,${dependencies// /,}" \
             --cmd "lua require('$nvimRequireCheck')"
     fi
 }


### PR DESCRIPTION
## Description of changes

Fix neovimRequireCheckHook for plugins that have more than two dependencies.

The error looks like this and is due to missing comma between the dependencies listed on command line:
```
Error detected while processing pre-vimrc command line:
E518: Unknown option: /nix/store/vk7s8q1m0f0vl2ilcyv06vyna33qnzk0-vimplugin-lua5.1-plenary.nvim-scm-1-unstable-2024-05-20
```

This was discovered while packaging vimPlugins.avante-nvim in https://github.com/NixOS/nixpkgs/pull/339921 and https://github.com/NixOS/nixpkgs/pull/341927.

There was already one plugin that uses neovimRequireCheckHook and has more than two dependencies (vimPlugins.image-nvim).
Not sure why that one didn't trigger the failure.
Update: Investigated - turns out it somehow passed only one dependency to neovimRequireCheckHook.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
