### PR TITLE
python3Packages.sounddevice: 0.4.7 -> 0.5.1, convert to pyproject, fix cross

### DIFF
--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "sounddevice";
-  version = "0.5.0";
+  version = "0.5.1";
   pyproject = true;
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-DelSd2VLPUA9nBXe08bO3zB+myfMnOe9mVookdDJVa8=";
+    hash = "sha256-CcqZHa7ajOS+mskeFamoHI+B76a2laNIyRceoMFssEE=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "sounddevice";
-  version = "0.4.7";
+  version = "0.5.0";
   format = "setuptools";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-abOGgY1QotUYYH1LlzRC6NUkdgx81si4vgPYyY/EvOc=";
+    hash = "sha256-DelSd2VLPUA9nBXe08bO3zB+myfMnOe9mVookdDJVa8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
     portaudio
   ];
 
+  nativeBuildInputs = [ cffi ];
+
   # No tests included nor upstream available.
   doCheck = false;
 

--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchPypi,
   isPy27,
+  setuptools,
   cffi,
   numpy,
   portaudio,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "sounddevice";
   version = "0.5.0";
-  format = "setuptools";
+  pyproject = true;
   disabled = isPy27;
 
   src = fetchPypi {
@@ -21,7 +22,9 @@ buildPythonPackage rec {
     hash = "sha256-DelSd2VLPUA9nBXe08bO3zB+myfMnOe9mVookdDJVa8=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     cffi
     numpy
     portaudio

--- a/pkgs/development/python-modules/sounddevice/fix-portaudio-library-path.patch
+++ b/pkgs/development/python-modules/sounddevice/fix-portaudio-library-path.patch
@@ -1,11 +1,11 @@
-diff --git i/sounddevice.py w/sounddevice.py
-index c7c1d62..aabcb12 100644
---- i/sounddevice.py
-+++ w/sounddevice.py
-@@ -58,29 +58,7 @@ from ctypes.util import find_library as _find_library
+diff --git a/sounddevice.py b/sounddevice.py
+index 0974289..2d56c28 100644
+--- a/sounddevice.py
++++ b/sounddevice.py
+@@ -58,32 +58,7 @@ from ctypes.util import find_library as _find_library
  from _sounddevice import ffi as _ffi
-
-
+ 
+ 
 -try:
 -    for _libname in (
 -            'portaudio',  # Default name on POSIX systems
@@ -22,7 +22,10 @@ index c7c1d62..aabcb12 100644
 -    if _platform.system() == 'Darwin':
 -        _libname = 'libportaudio.dylib'
 -    elif _platform.system() == 'Windows':
--        _libname = 'libportaudio' + _platform.architecture()[0] + '.dll'
+-        if 'SD_ENABLE_ASIO' in _os.environ:
+-            _libname = 'libportaudio' + _platform.architecture()[0] + '-asio.dll'
+-        else:
+-            _libname = 'libportaudio' + _platform.architecture()[0] + '.dll'
 -    else:
 -        raise
 -    import _sounddevice_data
@@ -30,6 +33,6 @@ index c7c1d62..aabcb12 100644
 -        next(iter(_sounddevice_data.__path__)), 'portaudio-binaries', _libname)
 -    _lib = _ffi.dlopen(_libname)
 +_lib = _ffi.dlopen('@portaudio@')
-
+ 
  _sampleformats = {
      'float32': _lib.paFloat32,


### PR DESCRIPTION
## Description of changes

One last attempt at (incrementally) fixing some things.

Before this change the build process fails for `nix build .#pkgsCross.aarch64-multiplatform.python3Packages.sounddevice`, but adding `cffi` to `nativeBuildInputs` fixes it.

I've tested this change at runtime as well by cross-compiling a Python env with this package, copying the closure to a Raspberry Pi, and importing the module on the Raspberry Pi. The build machine is `x86_64` and binfmt is disabled (checked by trying to run the cross-compiled environment, and I correctly got "cannot execute binary file: Exec format error"). `nix path-info -r ./result | grep -v aarch` returns no results so it looks clean to me.

@Artturin Last attempt for now - if this is a correct way of fixing it I have some more packages that I can apply similar treatment to. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
