### PR TITLE
nixos/networkd: allow strings for `addresses`

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1945,7 +1945,7 @@ let
 
   };
 
-  networkOptions = commonNetworkOptions // {
+  networkOptions = { name, ... }: { options = commonNetworkOptions // {
 
     linkConfig = mkOption {
       default = {};
@@ -2470,6 +2470,7 @@ let
     address = mkOption {
       default = [ ];
       type = types.listOf types.str;
+      apply = warn "`systemd.network.networks.\"${name}\".address` is deprecated, use  `systemd.network.networks.\"${name}\".addresses` instead.";
       description = ''
         A list of addresses to be added to the network section of the
         unit.  See {manpage}`systemd.network(5)` for details.
@@ -2587,7 +2588,10 @@ let
     addresses = mkOption {
       default = [ ];
       example = [ { Address = "192.168.0.100/24"; } ];
-      type = types.listOf (mkSubsectionType "addressConfig" check.network.sectionAddress);
+      type = types.coercedTo
+        (types.listOf types.str)
+        (map (Address: { inherit Address; }))
+        (types.listOf (mkSubsectionType "addressConfig" check.network.sectionAddress));
       description = ''
         A list of address sections to be added to the unit.  See
         {manpage}`systemd.network(5)` for details.
@@ -2614,7 +2618,7 @@ let
       '';
     };
 
-  };
+  }; };
 
   networkConfig = { config, ... }: {
     config = {
@@ -2707,7 +2711,7 @@ let
     networks = mkOption {
       default = {};
       inherit visible;
-      type = with types; attrsOf (submodule [ { options = networkOptions; } networkConfig ]);
+      type = with types; attrsOf (submodule [ networkOptions networkConfig ]);
       description = "Definition of systemd networks.";
     };
 

--- a/nixos/tests/systemd-networkd.nix
+++ b/nixos/tests/systemd-networkd.nix
@@ -39,7 +39,7 @@ let generateNodeConf = { lib, pkgs, config, privk, pubk, peerId, nodeId, ...}: {
           };
           "90-wg0" = {
             matchConfig = { Name = "wg0"; };
-            address = [ "10.0.0.${nodeId}/32" ];
+            addresses = [ "10.0.0.${nodeId}/32" ];
             routes = [
               { Gateway = "10.0.0.${nodeId}"; Destination = "10.0.0.0/24"; }
               { Gateway = "10.0.0.${nodeId}"; Destination = "10.0.0.0/24"; Table = "custom"; }


### PR DESCRIPTION

## Description of changes

:warning: __Note:__ this is a draft on purpose and I didn't fix up all the uses of `address` yet. First I'd like to discuss if

* this makes sense to you.
* we want to keep `address` or deprecate it.

---

The difference between `address` and `addresses` is that the former adds an `Address` key into the `[Network]` section whereas the latter creates its own `[Address]` section. However, these are effectively equivalent as far as systemd-networkd is concerned (from `systemd.network(5)`):

    This is a short-hand for an [Address] section only containing an
    Address key (see below).

I think it's pretty awkward that you have to remember which one to use.

This patch alters the type of `addresses` to allow both `[Address]`-config encoded as Nix attribute-set and strings that will be rendered to

    [Address]
    Address=...

As a result, the `address` option is obsolete, so I decided to deprecate it.

---

cc @NixOS/systemd @mweinelt 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
