### PR TITLE
nixos/tests/tmate-ssh-server: fix test

### DIFF
--- a/nixos/tests/tmate-ssh-server.nix
+++ b/nixos/tests/tmate-ssh-server.nix
@@ -52,6 +52,7 @@ in
     server.succeed("scp ${sshOpts} /tmp/tmate.conf client:/tmp/tmate.conf")
 
     client.wait_for_file("/tmp/tmate.conf")
+    client.wait_until_tty_matches("1", "login:")
     client.send_chars("root\n")
     client.sleep(2)
     client.send_chars("tmate -f /tmp/tmate.conf\n")
@@ -62,7 +63,8 @@ in
     client.wait_for_file("/tmp/ssh_command")
     ssh_cmd = client.succeed("cat /tmp/ssh_command")
 
-    client2.succeed("mkdir -p ~/.ssh; ssh-keyscan -p 2223 server > ~/.ssh/known_hosts")
+    client2.succeed("mkdir -p ~/.ssh; ssh-keyscan -4 -p 2223 server > ~/.ssh/known_hosts")
+    client2.wait_until_tty_matches("1", "login:")
     client2.send_chars("root\n")
     client2.sleep(2)
     client2.send_chars(ssh_cmd.strip() + "\n")


### PR DESCRIPTION
- add `wait_until_tty_matches` to wait for tty login screen before sending "root\n" to log in
- add `-4` to `ssh-keyscan` to force using IPv4, without it command returns exit code 1 with no output

## Description of changes

Fixes `nixosTests.tmate-ssh-server` (fails since `2024-07-18`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.tmate-ssh-server.x86_64-linux
https://hydra.nixos.org/build/272609135
Error log:
```text
(finished: must succeed: sleep 2, in 2.05 seconds)
client: sending keys 'tmate -f /tmp/tmate.conf\n'
(finished: sending keys 'tmate -f /tmp/tmate.conf\n', in 0.27 seconds)
client: must succeed: sleep 2
client # [   20.164494] login[823]: pam_unix(login:auth): check pass; user unknown
client # [   20.166364] login[823]: pam_unix(login:auth): authentication failure; logname=LOGIN uid=0 euid=0 tty=/dev/tty1 ruser= rhost=
(finished: must succeed: sleep 2, in 2.04 seconds)
client: sending keys 'q'
(finished: sending keys 'q', in 0.01 seconds)
client: must succeed: sleep 2
client # [   22.099590] login[823]: FAILED LOGIN (1) on '/dev/tty1' FOR 'UNKNOWN', Authentication failure
(finished: must succeed: sleep 2, in 2.04 seconds)
client: sending keys "tmate display -p '#{tmate_ssh}' > /tmp/ssh_command\n"
(finished: sending keys "tmate display -p '#{tmate_ssh}' > /tmp/ssh_command\n", in 0.54 seconds)
client: waiting for file '/tmp/ssh_command'
...
File "/nix/store/07i3r7lw48irrnhgdv2ma25360z44a59-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/machine.py", line 134, in retry
    raise Exception(f"action timed out after {timeout} seconds")
Exception: action timed out after 900 seconds
```
Could not reproduce locally, but seems like a race with "root\n" for login sent before login on tty is shown.
Added `wait_until_tty_matches("1", "login:")` to avoid it.

After that test fails on:
https://hydra.nixos.org/build/269177221
```text
client2: must succeed: mkdir -p ~/.ssh; ssh-keyscan -p 2223 server > ~/.ssh/known_hosts
...
Traceback (most recent call last):
  File "/nix/store/rw3yy0imbg71ad72g2q8b4szadf7jhxv-nixos-test-driver-1.1/bin/.nixos-test-driver-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/rw3yy0imbg71ad72g2q8b4szadf7jhxv-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/__init__.py", line 146, in main
    driver.run_tests()
  File "/nix/store/rw3yy0imbg71ad72g2q8b4szadf7jhxv-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/driver.py", line 166, in run_tests
    self.test_script()
  File "/nix/store/rw3yy0imbg71ad72g2q8b4szadf7jhxv-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/driver.py", line 158, in test_script
    exec(self.tests, symbols, None)
  File "<string>", line 33, in <module>
  File "/nix/store/rw3yy0imbg71ad72g2q8b4szadf7jhxv-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/machine.py", line 611, in succeed
    raise Exception(f"command `{command}` failed (exit code {status})")
Exception: command `mkdir -p ~/.ssh; ssh-keyscan -p 2223 server > ~/.ssh/known_hosts` failed (exit code 1)
kill vlan (pid 5)
```
Added `-4` to `ssh-keyscan` to force it to use IPv4, without it output is always empty and it returns exit code 1.
I assume it may be related to #319308 somehow considering timing of it breaking, thought did not investigate further.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
