### PR TITLE
disko: depend on nixos-install directly

### DIFF
--- a/pkgs/by-name/di/disko/package.nix
+++ b/pkgs/by-name/di/disko/package.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , bash
 , nix
-, nixos-install-tools
+, nixos-install
 , coreutils
 }:
 
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     for i in disko disko-install; do
       sed -e "s|libexec_dir=\".*\"|libexec_dir=\"$out/share/disko\"|" "$i" > "$out/bin/$i"
       chmod 755 "$out/bin/$i"
-      wrapProgram "$out/bin/$i" --prefix PATH : ${lib.makeBinPath [ nix coreutils nixos-install-tools ]}
+      wrapProgram "$out/bin/$i" --prefix PATH : ${lib.makeBinPath [ nix coreutils nixos-install ]}
     done
     runHook postInstall
   '';

--- a/pkgs/by-name/ni/nixos-enter/nixos-enter.sh
+++ b/pkgs/by-name/ni/nixos-enter/nixos-enter.sh
@@ -3,6 +3,8 @@
 
 set -e
 
+export PATH=@path@:$PATH
+
 # Re-exec ourselves in a private mount namespace so that our bind
 # mounts get cleaned up automatically.
 if [ -z "$NIXOS_ENTER_REEXEC" ]; then

--- a/pkgs/by-name/ni/nixos-enter/package.nix
+++ b/pkgs/by-name/ni/nixos-enter/package.nix
@@ -24,5 +24,11 @@ substituteAll {
     installManPage ${./nixos-enter.8}
   '';
 
-  meta.mainProgram = "nixos-enter";
+  meta = {
+    description = "Run a command in a NixOS chroot environment";
+    homepage = "https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/ni/nixos-install";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "nixos-enter";
+  };
 }

--- a/pkgs/by-name/ni/nixos-install/package.nix
+++ b/pkgs/by-name/ni/nixos-install/package.nix
@@ -29,5 +29,10 @@ substituteAll {
     installManPage ${./nixos-install.8}
   '';
 
-  meta.mainProgram = "nixos-install";
+  meta = {
+    description = "Install bootloader and NixOS";
+    homepage = "https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/ni/nixos-install";
+    license = lib.licenses.mit;
+    mainProgram = "nixos-install";
+  };
 }

--- a/pkgs/tools/nix/nixos-install-tools/default.nix
+++ b/pkgs/tools/nix/nixos-install-tools/default.nix
@@ -6,6 +6,8 @@
   # TODO: replace indirect self-reference by proper self-reference
   #       https://github.com/NixOS/nixpkgs/pull/119942
   nixos-install-tools,
+  nixos-install,
+  nixos-enter,
   runCommand,
   nixosTests,
   binlore,
@@ -18,9 +20,8 @@ in
   name = "nixos-install-tools-${version}";
   paths = lib.attrValues {
     # See nixos/modules/installer/tools/tools.nix
-    inherit (config.system.build)
-      nixos-install nixos-generate-config nixos-enter;
-
+    inherit (config.system.build) nixos-generate-config;
+    inherit nixos-install nixos-enter;
     inherit (config.system.build.manual) nixos-configuration-reference-manpage;
   };
 


### PR DESCRIPTION
## Description of changes

These scripts do not depend on the nixos module system and are useful to install nixos from other Linux distributions or enter nixos installation from non-nixos rescue systems.

This addresses https://github.com/NixOS/nixpkgs/pull/336300#issuecomment-2352414806

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
