### PR TITLE
verapdf-bin: init at 1.26.2

### DIFF
--- a/pkgs/by-name/ve/verapdf-bin/package.nix
+++ b/pkgs/by-name/ve/verapdf-bin/package.nix
@@ -1,0 +1,131 @@
+{
+  stdenvNoCC,
+  fetchzip,
+  fetchurl,
+  lib,
+  writeTextFile,
+  buildFHSEnv,
+  makeWrapper,
+  jre,
+  makeDesktopItem,
+  copyDesktopItems,
+  enableCorpusAndValidationModel ? false,
+  enableDocumentation ? false,
+  enableGUI ? true,
+  enableMacAndNixScripts ? true,
+  enableSamplePlugin ? false,
+}:
+let
+  icon = fetchurl {
+    name = "vera.png";
+    url = "https://avatars.githubusercontent.com/u/9946925";
+    hash = "sha256-i5tsVLlK6KBPQDgjvwTpcxFOMexwjygjUtGZgEYn4Yo=";
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "veraPDF-bin";
+  version = "1.26.2";
+
+  src = fetchzip {
+    url = "https://software.verapdf.org/rel/${lib.versions.majorMinor finalAttrs.version}/verapdf-greenfield-${finalAttrs.version}-installer.zip";
+    hash = "sha256-PtNZoXUjFbVI33StFffEI2FdZgkuwoWWEcMBny25bYw=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    jre
+    makeWrapper
+  ];
+
+  installPhase =
+    let
+      gui = lib.boolToString enableGUI;
+      doc = lib.boolToString enableDocumentation;
+      scripts = lib.boolToString enableMacAndNixScripts;
+      models = lib.boolToString enableCorpusAndValidationModel;
+      plugin = lib.boolToString enableSamplePlugin;
+      auto-install-xml = ''
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <AutomatedInstallation langpack="eng">
+        <com.izforge.izpack.panels.htmlhello.HTMLHelloPanel id="welcome"/>
+        <com.izforge.izpack.panels.target.TargetPanel id="install_dir">
+          <installpath>@out@/bin</installpath>
+        </com.izforge.izpack.panels.target.TargetPanel>
+        <com.izforge.izpack.panels.packs.PacksPanel id="sdk_pack_select">
+          <pack index="0" name="veraPDF GUI" selected="${gui}"/>
+          <pack index="1" name="veraPDF Mac and *nix Scripts" selected="${scripts}"/>
+          <pack index="2" name="veraPDF Corpus and Validation model" selected="${models}"/>
+          <pack index="3" name="veraPDF Documentation" selected="${doc}"/>
+          <pack index="4" name="veraPDF Sample Plugins" selected="${plugin}"/>
+        </com.izforge.izpack.panels.packs.PacksPanel>
+        <com.izforge.izpack.panels.install.InstallPanel id="install"/>
+        <com.izforge.izpack.panels.finish.FinishPanel id="finish"/>
+        </AutomatedInstallation>
+      '';
+      auto-install = writeTextFile {
+        name = "auto-install.xml";
+        text = auto-install-xml;
+      };
+
+      # the installer expects chmod to be found in /bin/chmod
+      installEnv = buildFHSEnv {
+        name = "verapdf-installer-env";
+        runScript = "./verapdf-install auto-install.xml";
+
+        # https://github.com/NixOS/nixpkgs/issues/239017
+        extraBwrapArgs = [
+          "--bind $out $out"
+        ];
+      };
+    in
+    ''
+      runHook preInstall
+
+      substituteAll ${auto-install} auto-install.xml
+
+      mkdir $out
+      ${installEnv}/bin/${installEnv.name}
+
+      rm -r $out/bin/{.installationinformation,Uninstaller}
+      for i in $out/bin/verapdf{,-gui}; do
+        wrapProgram $i --set JAVA_HOME ${jre}
+      done
+
+      install -Dm644 ${icon} $out/share/icons/hicolor/256x256/apps/verapdf.png
+
+      runHook postInstall
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "veraPDF";
+      comment = finalAttrs.meta.description;
+      desktopName = "veraPDF";
+      genericName = "PDF/A Conformance Checker";
+      exec = "verapdf-gui";
+      icon = "verapdf";
+      categories = [
+        "Development"
+        "Utility"
+      ];
+      keywords = [ "PDF" ];
+      mimeTypes = [ "application/pdf" ];
+    })
+  ];
+
+  meta = {
+    description = "Industry Supported PDF/A Validation";
+    homepage = "https://verapdf.org/";
+    license = with lib.licenses; [
+      gpl3Plus # or
+      mpl20
+    ];
+    longDescription = ''
+      purpose-built, open source, file-format validator covering all PDF/A parts and conformance levels
+    '';
+    mainProgram = "verapdf-gui";
+    maintainers = with lib.maintainers; [ kilianar ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+  };
+})


### PR DESCRIPTION
## Description of changes
This pull request introduces [verapdf](https://github.com/veraPDF/veraPDF-apps), an open-source, industry-supported PDF/A validation tool, maintained by the Open Preservation Foundation. Initially, I attempted to build the package from source but encountered difficulties. After seeking assistance on [Discourse](https://discourse.nixos.org/t/help-needed-with-packaging-verapdf/25430), it was suggested to package verapdf using the prebuilt binaries, even though building from source is not yet possible.

The upstream distribution provides a graphical installer, which can be automated in a headless environment by configuring options in an XML file. This method has been used to package verapdf for nixpkgs.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
