### PR TITLE
lib: add `lib.attrsets.collect'`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -198,6 +198,7 @@ let
         foldlAttrs
         foldAttrs
         collect
+        collect'
         nameValuePair
         mapAttrs
         mapAttrs'

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -36,6 +36,7 @@ let
     cartesianProduct
     cli
     collect
+    collect'
     composeExtensions
     composeManyExtensions
     concatLines
@@ -319,6 +320,58 @@ runTests {
       [
         1
         1
+      ]
+    ];
+  };
+
+  testCollect' = {
+    expr = [
+      (collect' (x: x ? special) {
+        a.b.c.special = true;
+        x.y.z.special = false;
+      })
+      (collect' (x: x == 1) {
+        a = 1;
+        b = 2;
+        c = 3;
+        d.inner = 1;
+      })
+    ];
+    expected = [
+      [
+        {
+          path = [
+            "a"
+            "b"
+            "c"
+          ];
+          value = {
+            special = true;
+          };
+        }
+        {
+          path = [
+            "x"
+            "y"
+            "z"
+          ];
+          value = {
+            special = false;
+          };
+        }
+      ]
+      [
+        {
+          path = [ "a" ];
+          value = 1;
+        }
+        {
+          path = [
+            "d"
+            "inner"
+          ];
+          value = 1;
+        }
       ]
     ];
   };

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -35,6 +35,7 @@ let
     callPackageWith
     cartesianProduct
     cli
+    collect
     composeExtensions
     composeManyExtensions
     concatLines
@@ -294,6 +295,31 @@ runTests {
       false
       false
       true
+    ];
+  };
+
+  testCollect = {
+    expr = [
+      (collect (x: x ? special) {
+        a.b.c.special = true;
+        x.y.z.special = false;
+      })
+      (collect (x: x == 1) {
+        a = 1;
+        b = 2;
+        c = 3;
+        d.inner = 1;
+      })
+    ];
+    expected = [
+      [
+        { special = true; }
+        { special = false; }
+      ]
+      [
+        1
+        1
+      ]
     ];
   };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds a new function `lib.attrsets.collect'`. Similarly to `collect`, it will recursively collect items that satisfy a predicate from an attrset tree, but this version will also track the attribute path to the items it collects.

This can be useful for collecting leaves in a tree, and either reporting detailed errors to the user, or for use in configuration file generation.

I've also added tests for the normal `collect` implementation, since it seemed to be missing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
