### PR TITLE
nixos/doc: recommend usage of `--use-remote-sudo` when switching configurations

### DIFF
--- a/nixos/doc/manual/installation/changing-config.chapter.md
+++ b/nixos/doc/manual/installation/changing-config.chapter.md
@@ -5,7 +5,7 @@ configuration of your machine. Whenever you've [changed
 something](#ch-configuration) in that file, you should do
 
 ```ShellSession
-# nixos-rebuild switch
+$ nixos-rebuild switch --use-remote-sudo
 ```
 
 to build the new configuration, make it the default configuration for
@@ -26,7 +26,7 @@ from a root shell or by prefixing them with `sudo -i`.
 You can also do
 
 ```ShellSession
-# nixos-rebuild test
+$ nixos-rebuild test --use-remote-sudo
 ```
 
 to build the configuration and switch the running system to it, but
@@ -37,7 +37,7 @@ configuration.
 There is also
 
 ```ShellSession
-# nixos-rebuild boot
+$ nixos-rebuild boot --use-remote-sudo
 ```
 
 to build the configuration and make it the boot default, but not switch
@@ -47,7 +47,7 @@ You can make your configuration show up in a different submenu of the
 GRUB 2 boot screen by giving it a different *profile name*, e.g.
 
 ```ShellSession
-# nixos-rebuild switch -p test
+$ nixos-rebuild switch -p test --use-remote-sudo
 ```
 
 which causes the new configuration (and previous ones created using
@@ -58,7 +58,7 @@ configurations.
 A repl, or read-eval-print loop, is also available. You can inspect your configuration and use the Nix language with
 
 ```ShellSession
-# nixos-rebuild repl
+$ nixos-rebuild repl
 ```
 
 Your configuration is loaded into the `config` variable. Use tab for autocompletion, use the `:r` command to reload the configuration files. See `:?` or [`nix repl` in the Nix manual](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-repl.html) to learn more.

--- a/nixos/doc/manual/installation/changing-config.chapter.md
+++ b/nixos/doc/manual/installation/changing-config.chapter.md
@@ -8,9 +8,10 @@ something](#ch-configuration) in that file, you should do
 $ nixos-rebuild switch --use-remote-sudo
 ```
 
-to build the new configuration, make it the default configuration for
-booting, and try to realise the configuration in the running system
-(e.g., by restarting system services).
+to build the new configuration as your current user, and as the root user,
+make it the default configuration for booting. `switch` will also try to
+realise the configuration in the running system (e.g., by restarting system
+services).
 
 ::: {.warning}
 This command doesn't start/stop [user services](#opt-systemd.user.services)
@@ -19,8 +20,17 @@ user services.
 :::
 
 ::: {.warning}
-These commands must be executed as root, so you should either run them
-from a root shell or by prefixing them with `sudo -i`.
+Applying a configuration is an action that must be done by the root user, so the
+`switch`, `boot` and `test` commands should be ran with the `--use-remote-sudo`
+flag. Despite its odd name, this flag runs the activation script with elevated
+permissions, regardless of whether or not the target system is remote, without
+affecting the other stages of the `nixos-rebuild` call. This allows unprivileged
+users to rebuild the system and only elevate their permissions when necessary.
+
+Alternatively, one can run the whole command as root while preserving user
+environment variables by prefixing the command with `sudo -E`. However, this
+method may create root-owned files in `$HOME/.cache` if Nix decides to use the
+cache during evaluation.
 :::
 
 You can also do


### PR DESCRIPTION
## Description of changes

Recommends the usage of `--use-remote-sudo` on the `changing-config` chapter. This is based on a discussion in Matrix with a new user to discourage building system configurations through the root user, and only escalate when necessary.

This has some hastily-made wording changes. Please review the grammar and cohesion of the altered phrases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
