### PR TITLE
workout-tracker: add assets

### DIFF
--- a/pkgs/by-name/wo/workout-tracker/package.nix
+++ b/pkgs/by-name/wo/workout-tracker/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
   buildGoModule,
+  buildNpmPackage,
   fetchFromGitHub,
   nix-update-script,
   nixosTests,
   ...
 }:
-
-buildGoModule rec {
+let
   pname = "workout-tracker";
   version = "1.18.1";
 
@@ -18,7 +18,30 @@ buildGoModule rec {
     hash = "sha256-Sn6SOHrsp1ZgsPntc2+cmlAEPVBUrYv1vKLKAQvT9m4=";
   };
 
+  assets = buildNpmPackage {
+    pname = "${pname}-assets";
+    inherit version src;
+    npmDepsHash = "sha256-jHpvCMgjGvaAOfbslaIKfIRiPafScpn3WLnYamm+lbs=";
+    dontNpmBuild = true;
+    postPatch = ''
+      rm Makefile
+    '';
+    installPhase = ''
+      runHook preInstall
+      cp -r . "$out"
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule rec {
+  inherit pname version src;
+
   vendorHash = null;
+
+  postPatch = ''
+    ln -s ${assets}/node_modules ./node_modules
+    make build-dist
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
## Description of changes
From server log:
```sh
12:58PM WRN Not Found app=workout-tracker version=local sha=local module=webserver request.time="2024-09-15 12:58:39.875195 +0400 +04" request.method=GET request.host=localhost:8080 request.path=/assets/dist/htmx.min.js request.query="" request.params=map[*:/dist/htmx.min.js] request.route=/assets* request.ip=127.0.0.1 request.referer=http://localhost:8080/user/signin request.length=0 response.time="2024-09-15 12:58:39.875636 +0400 +04" response.latency=441.574µs response.status=404 response.length=0 error="map[code:404 internal:<nil> message:Not Found]"
```

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
