### PR TITLE
nixos/{assertions,warnings}: implement as tree-like attrs

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1697,19 +1697,18 @@ let
           x:
           throw "The option `${showOption optionName}' can no longer be used since it's been removed. ${replacementInstructions}";
       });
-      config.assertions =
+      config.assertions = setAttrByPath (optionName ++ [ "removed" ]) (
         let
           opt = getAttrFromPath optionName options;
         in
-        [
-          {
-            assertion = !opt.isDefined;
-            message = ''
-              The option definition `${showOption optionName}' in ${showFiles opt.files} no longer has any effect; please remove it.
-              ${replacementInstructions}
-            '';
-          }
-        ];
+        {
+          assertion = !opt.isDefined;
+          message = ''
+            The option definition `${showOption optionName}' in ${showFiles opt.files} no longer has any effect; please remove it.
+            ${replacementInstructions}
+          '';
+        }
+      );
     };
 
   /**
@@ -1837,15 +1836,20 @@ let
       );
 
       config = {
-        warnings = filter (x: x != "") (
+        warnings = foldl' recursiveUpdate { } (
           map (
-            f:
-            let
-              val = getAttrFromPath f config;
-              opt = getAttrFromPath f options;
-            in
-            optionalString (val != "_mkMergedOptionModule")
-              "The option `${showOption f}' defined in ${showFiles opt.files} has been changed to `${showOption to}' that has a different type. Please read `${showOption to}' documentation and update your configuration accordingly."
+            path:
+            setAttrByPath (path ++ [ "mergedOption" ]) {
+              condition = (getAttrFromPath path config) != "_mkMergedOptionModule";
+              message =
+                let
+                  opt = getAttrFromPath path options;
+                in
+                ''
+                  The option `${showOption path}' defined in ${showFiles opt.files} has been changed to `${showOption to}' that has a different type.
+                  Please read `${showOption to}' documentation and update your configuration accordingly.
+                '';
+            }
           ) from
         );
       }
@@ -2050,9 +2054,10 @@ let
       );
       config = mkIf condition (mkMerge [
         (optionalAttrs (options ? warnings) {
-          warnings =
-            optional (warn && fromOpt.isDefined)
-              "The option `${showOption from}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption to}'.";
+          warnings = setAttrByPath (from ++ [ "aliased" ]) {
+            condition = warn && fromOpt.isDefined;
+            message = "The option `${showOption from}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption to}'.";
+          };
         })
         (
           if withPriority then

--- a/lib/tests/modules/doRename-warnings.nix
+++ b/lib/tests/modules/doRename-warnings.nix
@@ -17,12 +17,35 @@
     })
   ];
   options = {
-    warnings = lib.mkOption { type = lib.types.listOf lib.types.str; };
+    warnings = lib.mkOption {
+      type =
+        let
+          checkedWarningItemType =
+            let
+              check = x: x ? condition && x ? message;
+            in
+            lib.types.addCheck (lib.types.attrsOf lib.types.anything) check;
+
+          nestedWarningAttrsType =
+            let
+              nestedWarningItemType = lib.types.either checkedWarningItemType (
+                lib.types.attrsOf nestedWarningItemType
+              );
+            in
+            nestedWarningItemType;
+        in
+        lib.types.submodule { freeformType = nestedWarningAttrsType; };
+    };
+
     c.d.e = lib.mkOption { };
     result = lib.mkOption { };
   };
   config = {
     a.b = 1234;
-    result = lib.concatStringsSep "%" config.warnings;
+    result =
+      let
+        warning = config.warnings.a.b.aliased;
+      in
+      lib.optionalString warning.condition warning.message;
   };
 }

--- a/nixos/doc/manual/development/assertions.section.md
+++ b/nixos/doc/manual/development/assertions.section.md
@@ -12,16 +12,13 @@ This is an example of using `warnings`.
 { config, lib, ... }:
 {
   config = lib.mkIf config.services.foo.enable {
-    warnings =
-      if config.services.foo.bar then
-        [
-          ''
-            You have enabled the bar feature of the foo service.
-                           This is known to cause some specific problems in certain situations.
-          ''
-        ]
-      else
-        [ ];
+    warnings.services.foo.beCarefulWithBar = {
+      condition = config.services.foo.bar;
+      message = ''
+        You have enabled the bar feature of the foo service.
+        This is known to cause some specific problems in certain situations.
+      '';
+    };
   };
 }
 ```
@@ -34,12 +31,10 @@ This example, extracted from the [`syslogd` module](https://github.com/NixOS/nix
 { config, lib, ... }:
 {
   config = lib.mkIf config.services.syslogd.enable {
-    assertions = [
-      {
-        assertion = !config.services.rsyslogd.enable;
-        message = "rsyslogd conflicts with syslogd";
-      }
-    ];
+    assertions.services.syslogd.rsyslogdConflict = {
+      assertion = !config.services.rsyslogd.enable;
+      message = "rsyslogd conflicts with syslogd";
+    };
   };
 }
 ```

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -271,6 +271,12 @@
   "ssec-testing-user-units": [
     "index.html#ssec-testing-user-units"
   ],
+  "test-opt-assertions.__flattened._.assertion": [
+    "index.html#test-opt-assertions.__flattened._.assertion"
+  ],
+  "test-opt-assertions.__flattened._.message": [
+    "index.html#test-opt-assertions.__flattened._.message"
+  ],
   "test-opt-containerDefaults": [
     "index.html#test-opt-containerDefaults"
   ],

--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -190,7 +190,9 @@ in
       };
     test = lib.lazyDerivation {
       # lazyDerivation improves performance when only passthru items and/or meta are used.
-      derivation = lib.asserts.checkAssertWarn config.assertions config.warnings config.rawTestDerivation;
+      derivation =
+        lib.asserts.checkAssertWarn config.assertions.__flattened config.warnings.__flattened
+          config.rawTestDerivation;
       inherit (config) passthru meta;
     };
 

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -19,6 +19,7 @@ let
     flatten
     flip
     foldr
+    genAttrs
     generators
     getAttr
     hasAttr
@@ -26,6 +27,7 @@ let
     length
     listToAttrs
     literalExpression
+    mapAttrs
     mapAttrs'
     mapAttrsToList
     match
@@ -624,11 +626,6 @@ let
   sdInitrdGidsAreUnique = idsAreUnique (filterAttrs (
     n: g: g.gid != null
   ) config.boot.initrd.systemd.groups) "gid";
-  groupNames = lib.mapAttrsToList (n: g: g.name) cfg.groups;
-  usersWithoutExistingGroup = lib.filterAttrs (
-    n: u: u.group != "" && !lib.elem u.group groupNames
-  ) cfg.users;
-  usersWithNullShells = attrNames (filterAttrs (name: cfg: cfg.shell == null) cfg.users);
 
   spec = pkgs.writeText "users-groups.json" (
     builtins.toJSON {
@@ -1042,39 +1039,30 @@ in
         };
       };
 
-      assertions = [
-        {
+      assertions.boot.initrd.systemd.users = flip mapAttrs config.boot.initrd.systemd.users (
+        name: user: {
+          noCryptsetupAskpass = {
+            assertion = config.boot.initrd.systemd.enable -> (baseNameOf user.shell != "cryptsetup-askpass");
+            message = ''
+              cryptsetup-askpass is not available in systemd stage 1. Please remove it from: boot.initrd.systemd.users.${name}.shell
+
+              Use `systemctl default` instead; see the NixOS 26.05 release notes for details. If you want to continue restricting the command for SSH login, you can use `command="systemctl default"` in SSH authorized keys instead; see `sshd(8)`.
+            '';
+          };
+        }
+      );
+
+      assertions.users = {
+        uidsGidsUnique = {
           assertion = !cfg.enforceIdUniqueness || (uidsAreUnique && gidsAreUnique);
           message = "UIDs and GIDs must be unique!";
-        }
-        {
+        };
+        systemdInitrdUidsGidsUnique = {
           assertion = !cfg.enforceIdUniqueness || (sdInitrdUidsAreUnique && sdInitrdGidsAreUnique);
           message = "systemd initrd UIDs and GIDs must be unique!";
-        }
-        {
-          assertion = usersWithoutExistingGroup == { };
-          message =
-            let
-              errUsers = lib.attrNames usersWithoutExistingGroup;
-              missingGroups = lib.unique (lib.mapAttrsToList (n: u: u.group) usersWithoutExistingGroup);
-              mkConfigHint = group: "users.groups.${group} = {};";
-            in
-            ''
-              The following users have a primary group that is undefined: ${lib.concatStringsSep " " errUsers}
-              Hint: Add this to your NixOS configuration:
-                ${lib.concatStringsSep "\n  " (map mkConfigHint missingGroups)}
-            '';
-        }
-        {
-          assertion = !cfg.mutableUsers -> length usersWithNullShells == 0;
-          message = ''
-            users.mutableUsers = false has been set,
-            but found users that have their shell set to null.
-            If you wish to disable login, set their shell to pkgs.shadow (the default).
-            Misconfigured users: ${lib.concatStringsSep " " usersWithNullShells}
-          '';
-        }
-        {
+        };
+
+        noLockout = {
           # If mutableUsers is false, to prevent users creating a
           # configuration that locks them out of the system, ensure that
           # there is at least one "privileged" account that has a
@@ -1113,23 +1101,20 @@ in
             However you are most probably better off by setting users.mutableUsers = true; and
             manually running passwd root to set the root password.
           '';
-        }
-      ]
-      ++ flip mapAttrsToList config.boot.initrd.systemd.users (
-        name: user: {
-          assertion = config.boot.initrd.systemd.enable -> (baseNameOf user.shell != "cryptsetup-askpass");
-          message = ''
-            cryptsetup-askpass is not available in systemd stage 1. Please remove it from: boot.initrd.systemd.users.${name}.shell
+        };
 
-            Use `systemctl default` instead; see the NixOS 26.05 release notes for details. If you want to continue restricting the command for SSH login, you can use `command="systemctl default"` in SSH authorized keys instead; see `sshd(8)`.
-          '';
-        }
-      )
-      ++ flatten (
-        flip mapAttrsToList cfg.users (
-          name: user:
-          [
-            (
+        users = flip mapAttrs cfg.users (
+          name: user: {
+            declarativeUserNoNullShell = {
+              assertion = !cfg.mutableUsers -> user.shell != null;
+              message = ''
+                users.mutableUsers = false has been set,
+                but user '${name}' have their shell set to null.
+                If you wish to disable login, set their shell to pkgs.shadow (the default).
+              '';
+            };
+
+            validUsername =
               let
                 # Things fail in various ways with especially non-ascii usernames.
                 # This regex mirrors the one from shadow's is_valid_name:
@@ -1142,37 +1127,39 @@ in
               {
                 assertion = builtins.match nameRegex user.name != null;
                 message = "The username \"${user.name}\" is not valid, it does not match the regex \"${nameRegex}\".";
-              }
-            )
-            {
+              };
+
+            noColonInHashedPassword = {
               assertion = (user.hashedPassword != null) -> (match ".*:.*" user.hashedPassword == null);
               message = ''
                 The password hash of user "${user.name}" contains a ":" character.
                 This is invalid and would break the login system because the fields
                 of /etc/shadow (file where hashes are stored) are colon-separated.
-                Please check the value of option `users.users."${user.name}".hashedPassword`.'';
-            }
-            {
+                Please check the value of option `users.users."${user.name}".hashedPassword`.
+              '';
+            };
+
+            normalUserUIDBelow1000 = {
               assertion = user.isNormalUser && user.uid != null -> user.uid >= 1000;
               message = ''
                 A user cannot have a users.users.${user.name}.uid set below 1000 and set users.users.${user.name}.isNormalUser.
                 Either users.users.${user.name}.isSystemUser must be set to true instead of users.users.${user.name}.isNormalUser
                 or users.users.${user.name}.uid must be changed to 1000 or above.
               '';
-            }
-            {
+            };
+
+            userKindDefined = {
               assertion =
                 let
-                  # we do an extra check on isNormalUser here, to not trigger this assertion when isNormalUser is set and uid to < 1000
-                  isEffectivelySystemUser =
-                    user.isSystemUser || (user.uid != null && user.uid < 1000 && !user.isNormalUser);
+                  isEffectivelySystemUser = user.isSystemUser || (user.uid != null && user.uid < 1000);
                 in
                 xor isEffectivelySystemUser user.isNormalUser;
               message = ''
                 Exactly one of users.users.${user.name}.isSystemUser and users.users.${user.name}.isNormalUser must be set.
               '';
-            }
-            {
+            };
+
+            userHasPrimaryGroup = {
               assertion = user.group != "";
               message = ''
                 users.users.${user.name}.group is unset. This used to default to
@@ -1181,8 +1168,19 @@ in
                 users.users.${user.name}.group = "${user.name}";
                 users.groups.${user.name} = {};
               '';
-            }
-            {
+            };
+
+            userPrimaryGroupExists = {
+              assertion = cfg.groups ? ${user.group};
+              message = ''
+                users.users.${user.name}.group is set to "${user.group}", but this group is not defined.
+
+                Hint: Add this to your NixOS configuration:
+                  "users.groups.${user.group} = {};";
+              '';
+            };
+
+            onlyLingerWhenLingeringEnabled = {
               assertion = user.linger != null -> cfg.manageLingering;
               message = ''
                 users.manageLingering is set to false, but
@@ -1197,78 +1195,79 @@ in
                 This is the default setting provided system.stateVersion is at
                 least "25.11".
               '';
-            }
-          ]
-          ++ (map
-            (shell: {
-              assertion =
-                !user.ignoreShellProgramCheck
-                -> (user.shell == pkgs.${shell})
-                -> (config.programs.${shell}.enable == true);
-              message = ''
-                users.users.${user.name}.shell is set to ${shell}, but
-                programs.${shell}.enable is not true. This will cause the ${shell}
-                shell to lack the basic nix directories in its PATH and might make
-                logging in as that user impossible. You can fix it with:
-                programs.${shell}.enable = true;
+            };
 
-                If you know what you're doing and you are fine with the behavior,
-                set users.users.${user.name}.ignoreShellProgramCheck = true;
-                instead.
-              '';
-            })
-            [
-              "fish"
-              "xonsh"
-              "zsh"
-            ]
-          )
-        )
-      );
+            shells =
+              genAttrs
+                [
+                  "fish"
+                  "xonsh"
+                  "zsh"
+                ]
+                (shell: {
+                  assertion =
+                    !user.ignoreShellProgramCheck
+                    -> (user.shell == pkgs.${shell})
+                    -> (config.programs.${shell}.enable == true);
+                  message = ''
+                    users.users.${user.name}.shell is set to ${shell}, but
+                    programs.${shell}.enable is not true. This will cause the ${shell}
+                    shell to lack the basic nix directories in its PATH and might make
+                    logging in as that user impossible. You can fix it with:
+                    programs.${shell}.enable = true;
 
-      warnings =
-        flip concatMap (attrValues cfg.users) (
-          user:
-          let
-            passwordOptions = [
-              "hashedPassword"
-              "hashedPasswordFile"
-              "password"
-            ]
-            ++ optionals cfg.mutableUsers [
-              # For immutable users, initialHashedPassword is set to hashedPassword,
-              # so using these options would always trigger the assertion.
-              "initialHashedPassword"
-              "initialPassword"
-            ];
-            unambiguousPasswordConfiguration =
-              1 >= length (filter (x: x != null) (map (flip getAttr user) passwordOptions));
-          in
-          optional (!unambiguousPasswordConfiguration) ''
-            The user '${user.name}' has multiple of the options
-            `initialHashedPassword`, `hashedPassword`, `initialPassword`, `password`
-            & `hashedPasswordFile` set to a non-null value.
+                    If you know what you're doing and you are fine with the behavior,
+                    set users.users.${user.name}.ignoreShellProgramCheck = true;
+                    instead.
+                  '';
+                });
+          }
+        );
+      };
 
-            ${multiplePasswordsWarning}
-            ${overrideOrderText cfg.mutableUsers}
-            The values of these options are:
-            ${concatMapStringsSep "\n" (
-              value: "* users.users.\"${user.name}\".${value}: ${generators.toPretty { } user.${value}}"
-            ) passwordOptions}
-          ''
-        )
-        ++ filter (x: x != null) (
-          flip mapAttrsToList cfg.users (
-            _: user:
-            # This regex matches a subset of the Modular Crypto Format (MCF)[1]
-            # informal standard. Since this depends largely on the OS or the
-            # specific implementation of crypt(3) we only support the (sane)
-            # schemes implemented by glibc and BSDs. In particular the original
-            # DES hash is excluded since, having no structure, it would validate
-            # common mistakes like typing the plaintext password.
-            #
-            # [1]: https://en.wikipedia.org/wiki/Crypt_(C)
+      warnings.users.users = flip mapAttrs cfg.users (
+        name: user: {
+          ambiguousPasswordConfiguration =
             let
+              unambiguousPasswordConfiguration =
+                1 >= length (
+                  filter (x: x != null) (
+                    [
+                      user.hashedPassword
+                      user.hashedPasswordFile
+                      user.password
+                    ]
+                    ++ optionals cfg.mutableUsers [
+                      # For immutable users, initialHashedPassword is set to hashedPassword,
+                      # so using these options would always trigger the assertion.
+                      user.initialHashedPassword
+                      user.initialPassword
+                    ]
+                  )
+                );
+            in
+            {
+              condition = !unambiguousPasswordConfiguration;
+              message = ''
+                The user '${user.name}' has multiple of the options
+                `hashedPassword`, `password`, `hashedPasswordFile`, `initialPassword`
+                & `initialHashedPassword` set to a non-null value.
+                The options silently discard others by the order of precedence
+                given above which can lead to surprising results. To resolve this warning,
+                set at most one of the options above to a non-`null` value.
+              '';
+            };
+
+          invalidPasswordHash =
+            let
+              # This regex matches a subset of the Modular Crypto Format (MCF)[1]
+              # informal standard. Since this depends largely on the OS or the
+              # specific implementation of crypt(3) we only support the (sane)
+              # schemes implemented by glibc and BSDs. In particular the original
+              # DES hash is excluded since, having no structure, it would validate
+              # common mistakes like typing the plaintext password.
+              #
+              # [1]: https://en.wikipedia.org/wiki/Crypt_(C)
               sep = "\\$";
               base64 = "[a-zA-Z0-9./]+";
               id = cryptSchemeIdPatternGroup;
@@ -1279,29 +1278,26 @@ in
               content = "${base64}${sep}${base64}(${sep}${base64})?";
               mcf = "^${sep}${scheme}${sep}${content}$";
             in
-            if
-              (
+            {
+              condition =
                 allowsLogin user.hashedPassword
                 && user.hashedPassword != "" # login without password
-                && match mcf user.hashedPassword == null
-              )
-            then
-              ''
+                && match mcf user.hashedPassword == null;
+              message = ''
                 The password hash of user "${user.name}" may be invalid. You must set a
                 valid hash or the user will be locked out of their account. Please
-                check the value of option `users.users."${user.name}".hashedPassword`.''
-            else
-              null
-          )
-          ++ flip mapAttrsToList cfg.users (
-            name: user:
-            if user.passwordFile != null then
-              ''The option `users.users."${name}".passwordFile' has been renamed ''
-              + ''to `users.users."${name}".hashedPasswordFile'.''
-            else
-              null
-          )
-        );
-    };
+                check the value of option `users.users."${user.name}".hashedPassword`.
+              '';
+            };
 
+          passwordFileDeprecation = {
+            condition = user.passwordFile != null;
+            message = ''
+              The option `users.users."${user.name}".passwordFile' has been renamed
+              to `users.users."${user.name}".hashedPasswordFile'.
+            '';
+          };
+        }
+      );
+    };
 }

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -394,7 +394,7 @@ in
               inherit fileSystems definitionsDirectory mkfsEnv;
             };
           in
-          lib.asserts.checkAssertWarn cfg.assertions cfg.warnings val;
+          lib.asserts.checkAssertWarn cfg.assertions.__flattened cfg.warnings.__flattened val;
 
         assertions = lib.mapAttrsToList (
           fileName: partitionConfig:

--- a/nixos/modules/misc/assertions.nix
+++ b/nixos/modules/misc/assertions.nix
@@ -1,18 +1,176 @@
 { lib, ... }:
+let
+  collect' =
+    let
+      collect'' =
+        path: pred: value:
+        if pred value then
+          [ { inherit path value; } ]
+        else if lib.isAttrs value then
+          lib.concatMap ({ name, value }: collect'' (path ++ [ name ]) pred value) (lib.attrsToList value)
+        else
+          [ ];
+    in
+    collect'' [ ];
+in
 {
-
   options = {
-
     assertions = lib.mkOption {
-      type = lib.types.listOf lib.types.unspecified;
+      type =
+        let
+          assertionItemType = lib.types.submodule (
+            { config, ... }:
+            {
+              options = {
+                enable = lib.mkOption {
+                  description = ''
+                    Whether to enable this assertion.
+
+                    This option is mostly useful for users, in order to forcefully disable assertions they believe to be
+                    erroneous while waiting for someone to fix the assertion upstream.
+                  '';
+                  type = lib.types.bool;
+                  default = true;
+                  example = false;
+                };
+
+                assertion = lib.mkOption {
+                  description = "Condition to be asserted. If this is `false`, the evaluation will throw the error";
+                  type = lib.types.bool;
+                  example = false;
+                };
+
+                message = lib.mkOption {
+                  description = "The contents of the error message that should be shown upon triggering a false assertion";
+                  type = if config.lazy then lib.types.unspecified else lib.types.nonEmptyStr;
+                  example = "This is an example error message";
+                };
+
+                lazy = lib.mkOption {
+                  description = ''
+                    Whether to avoid evaluating the message contents until the assertion condition occurs.
+
+                    This will also disable typechecking.
+
+                    ::: {.note}
+                    We do not recommend you enable this. It is mostly intended for backwards compatibility.
+                    If you do need to enable it, make sure to double check that your `message` always will
+                    evaluate successfully whenever the assertion would trigger.
+                    :::
+                  '';
+                  type = lib.types.bool;
+                  default = false;
+                  example = true;
+                };
+              };
+            }
+          );
+
+          flattenedAssertionItemType = lib.types.submodule {
+            options = {
+              assertion = lib.mkOption {
+                type = lib.types.bool;
+                description = "Condition to be asserted. If this is `false`, the evaluation will throw the error";
+              };
+              message = lib.mkOption {
+                type = lib.types.nonEmptyStr;
+                description = "The contents of the error message that should be shown upon triggering a false assertion";
+              };
+            };
+          };
+
+          # This may be replaced when `types.record` or similar is available,
+          # see https://github.com/NixOS/nixpkgs/pull/334680
+          checkedAssertionItemType =
+            let
+              check = x: x ? assertion && x ? message;
+            in
+            lib.types.addCheck assertionItemType check;
+
+          nestedAssertionAttrsType =
+            with lib.types;
+            let
+              isBranchNode = x: x == { } || lib.any lib.isAttrs (lib.attrValues x);
+
+              nestedAssertionItemType =
+                (oneOf [
+                  checkedAssertionItemType
+                  (addCheck (attrsOf nestedAssertionItemType) isBranchNode)
+                ])
+                // {
+                  description = "nested attrs of (${assertionItemType.description})";
+                };
+            in
+            nestedAssertionItemType;
+
+          # Backwards compatibility for assertions that are still written as attrs inside a list.
+          #
+          # Unlike warnings where all messages are hidden behind `mkIf` statements, giving a relatively good guarantee
+          # that a message will evaluate correctly when it appears, assertions are present even when the condition holds.
+          # Some assertions might not expect their message to be evaluated unless the assertion fails, so we can't use
+          # the hash of the message for naming. Instead, we use a number derived from the order in which the assertions
+          # was discovered. This is not very stable, so it's not really recommended to use this name to set `enable = false`
+          coercedAssertionAttrs =
+            let
+              coerce = xs: {
+                legacy = lib.listToAttrs (
+                  lib.imap0 (i: assertion: lib.nameValuePair "anon-${toString i}" (assertion // { lazy = true; })) xs
+                );
+              };
+            in
+            with lib.types;
+            coercedTo (listOf (attrsOf unspecified)) coerce (
+              submodule (
+                { config, ... }: {
+                  freeformType = nestedAssertionAttrsType;
+                  options = {
+                    __flattened = lib.mkOption {
+                      type = listOf flattenedAssertionItemType;
+                      internal = true;
+                      description = ''
+                        All failed assertions collected down to a flat list, provided in the
+                        `{ assertion, message }` shape expected by `lib.asserts.checkAssertWarn`.
+                      '';
+                    };
+                  };
+
+                  config.__flattened = lib.mkForce (
+                    let
+                      assertionItems = collect' (x: lib.isAttrs x && x ? assertion && x ? enable && x ? message) (
+                        removeAttrs config [
+                          "__flattened"
+                          "_module"
+                        ]
+                      );
+
+                      failedAssertions = lib.filter (
+                        x: x.value.enable == true && x.value.assertion == false
+                      ) assertionItems;
+                    in
+                    map (x: {
+                      inherit (x.value) assertion;
+                      message = "assertions." + (lib.showAttrPath x.path) + ":\n" + x.value.message;
+                    }) failedAssertions
+                  );
+                }
+              )
+            );
+        in
+        coercedAssertionAttrs;
       internal = true;
-      default = [ ];
-      example = [
+      default = { };
+      example = lib.literalExpression ''
         {
-          assertion = false;
-          message = "you can't enable this for that reason";
+          programs.foo.dontUseSomeOption = {
+            assertion = !config.programs.foo.settings.someOption;
+            message = "You can't enable foo's someOption for some reason";
+          };
+          services.bar.mutuallyExclusiveWithFoo = {
+            assertion = config.services.bar.enable -> !config.programs.foo.enable;
+            message = "You can't use the 'foo' program if you're using the 'bar' service";
+          };
         }
-      ];
+      '';
       description = ''
         This option allows modules to express conditions that must
         hold for the evaluation of the system configuration to
@@ -21,16 +179,131 @@
     };
 
     warnings = lib.mkOption {
+      type =
+        let
+          warningItemType = lib.types.submodule {
+            options = {
+              enable = lib.mkOption {
+                description = ''
+                  Whether to enable this warning.
+
+                  This option is mostly useful for users, in order to forcefully disable warnings they believe to be
+                  erroneous while waiting for someone to fix the condition upstream.
+                '';
+                type = lib.types.bool;
+                default = true;
+                example = false;
+              };
+
+              condition = lib.mkOption {
+                description = "Condition that triggers the warning message. If this is `true`, the warning will be shown";
+                type = lib.types.bool;
+                example = true;
+              };
+
+              message = lib.mkOption {
+                description = "The contents of the warning message that should be shown upon triggering the condition";
+                type = lib.types.nonEmptyStr;
+                example = "This is an example warning message";
+              };
+            };
+          };
+
+          # This might be replaced when tagged submodules or similar are available,
+          # see https://github.com/NixOS/nixpkgs/pull/254790
+          checkedWarningItemType =
+            let
+              check = x: x ? condition && x ? message;
+            in
+            lib.types.addCheck warningItemType check;
+
+          nestedWarningAttrsType =
+            with lib.types;
+            let
+              isBranchNode = x: x == { } || lib.any lib.isAttrs (lib.attrValues x);
+
+              nestedWarningItemType =
+                (oneOf [
+                  checkedWarningItemType
+                  (addCheck (attrsOf nestedWarningItemType) isBranchNode)
+                ])
+                // {
+                  description = "nested attrs of (${warningItemType.description})";
+                };
+            in
+            nestedWarningItemType;
+
+          # Backwards compatibility for warnings that are still written as strings inside a list.
+          # The attribute name will be set to the sha256 sum of the warning message, e.g. `warnings."<sha256>" = { ... }`
+          coercedWarningAttrs =
+            let
+              coerce = xs: {
+                legacy = lib.listToAttrs (
+                  map (
+                    message:
+                    lib.nameValuePair (builtins.hashString "sha256" message) {
+                      inherit message;
+                      condition = true;
+                    }
+                  ) xs
+                );
+              };
+            in
+            with lib.types;
+            coercedTo (listOf str) coerce (
+              submodule (
+                { config, ... }: {
+                  freeformType = nestedWarningAttrsType;
+                  options = {
+                    __flattened = lib.mkOption {
+                      type = listOf str;
+                      internal = true;
+                      description = ''
+                        All triggered warnings collected down to a flat list of strings as
+                        expected by `lib.asserts.checkAssertWarn`.
+                      '';
+                    };
+                  };
+
+                  config.__flattened = lib.mkForce (
+                    let
+                      warningItems = collect' (x: lib.isAttrs x && x ? condition && x ? enable && x ? message) (
+                        removeAttrs config [
+                          "__flattened"
+                          "_module"
+                        ]
+                      );
+
+                      triggeredWarnings = lib.filter (
+                        x: x.value.enable == true && x.value.condition == true && lib.isString x.value.message
+                      ) warningItems;
+                    in
+                    map (x: "warnings." + (lib.showAttrPath x.path) + ":\n" + x.value.message) triggeredWarnings
+                  );
+                }
+              )
+            );
+        in
+        coercedWarningAttrs;
       internal = true;
-      default = [ ];
-      type = lib.types.listOf lib.types.str;
-      example = [ "The `foo' service is deprecated and will go away soon!" ];
+      default = { };
+      example = lib.literalExpression ''
+        {
+          services.foo.deprecationNotice = {
+            condition = config.services.foo.enable;
+            message = "The `foo' service is deprecated and will go away soon!";
+          };
+          services.bar.otherWarning = {
+            condition = !config.services.bar.settings.importantOption;
+            message = "You might want to enable services.bar.settings.importantOption, or everything is going to break";
+          };
+        }
+      '';
       description = ''
         This option allows modules to show warnings to users during
         the evaluation of the system configuration.
       '';
     };
-
   };
   # impl of assertions is in
   # - <nixpkgs/nixos/modules/system/activation/top-level.nix>

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -260,15 +260,18 @@ in
   };
 
   ###### implementation
-  config = lib.mkIf config.security.enableWrappers {
-
-    assertions = lib.mapAttrsToList (name: opts: {
-      assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
-      message = ''
-        The security.wrappers.${name} wrapper is not valid:
-            setuid/setgid and capabilities are mutually exclusive.
-      '';
-    }) wrappers;
+  config = {
+    assertions.security.wrappers = lib.flip lib.mapAttrs wrappers (
+      name: opts: {
+        setuidSetgidCapabilitiesAreMutuallyExclusive = {
+          assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
+          message = ''
+            The security.wrappers.${name} wrapper is not valid:
+                setuid/setgid and capabilities are mutually exclusive.
+          '';
+        };
+      }
+    );
 
     security.wrappers =
       let

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -449,16 +449,16 @@ in
   config = mkMerge (
     [
       {
-        assertions = [
-          {
+        assertions.services.prometheus.exporters = {
+          ipmi.nonEmptyConfigFile = {
             assertion =
               cfg.ipmi.enable -> (cfg.ipmi.configFile != null) -> (!(lib.hasPrefix "/tmp/" cfg.ipmi.configFile));
             message = ''
               Config file specified in `services.prometheus.exporters.ipmi.configFile' must
                 not reside within /tmp - it won't be visible to the systemd service.
             '';
-          }
-          {
+          };
+          ipmi.nonEmptyWebConfigFile = {
             assertion =
               cfg.ipmi.enable
               -> (cfg.ipmi.webConfigFile != null)
@@ -467,69 +467,69 @@ in
               Config file specified in `services.prometheus.exporters.ipmi.webConfigFile' must
                 not reside within /tmp - it won't be visible to the systemd service.
             '';
-          }
-          {
+          };
+          restic.nonEmptyRepositoryFile = {
             assertion =
               cfg.restic.enable -> ((cfg.restic.repository == null) != (cfg.restic.repositoryFile == null));
             message = ''
               Please specify either 'services.prometheus.exporters.restic.repository'
                 or 'services.prometheus.exporters.restic.repositoryFile'.
             '';
-          }
-          {
+          };
+          snmp.nonEmptyConfiguration = {
             assertion =
               cfg.snmp.enable -> ((cfg.snmp.configurationPath == null) != (cfg.snmp.configuration == null));
             message = ''
               Please ensure you have either `services.prometheus.exporters.snmp.configuration'
                 or `services.prometheus.exporters.snmp.configurationPath' set!
             '';
-          }
-          {
+          };
+          mikrotik.nonEmptyConfiguration = {
             assertion =
               cfg.mikrotik.enable -> ((cfg.mikrotik.configFile == null) != (cfg.mikrotik.configuration == null));
             message = ''
               Please specify either `services.prometheus.exporters.mikrotik.configuration'
                 or `services.prometheus.exporters.mikrotik.configFile'.
             '';
-          }
-          {
+          };
+          mail.nonEmptyConfiguration = {
             assertion = cfg.mail.enable -> ((cfg.mail.configFile == null) != (cfg.mail.configuration == null));
             message = ''
               Please specify either 'services.prometheus.exporters.mail.configuration'
                 or 'services.prometheus.exporters.mail.configFile'.
             '';
-          }
-          {
+          };
+          mysqld.serverEnabledIfRunAsLocalSuperUser = {
             assertion = cfg.mysqld.runAsLocalSuperUser -> config.services.mysql.enable;
             message = ''
               The exporter is configured to run as 'services.mysql.user', but
                 'services.mysql.enable' is set to false.
             '';
-          }
-          {
+          };
+          nextcloud.nonEmptyPassword = {
             assertion =
               cfg.nextcloud.enable -> ((cfg.nextcloud.passwordFile == null) != (cfg.nextcloud.tokenFile == null));
             message = ''
               Please specify either 'services.prometheus.exporters.nextcloud.passwordFile' or
                 'services.prometheus.exporters.nextcloud.tokenFile'
             '';
-          }
-          {
+          };
+          sql.nonEmptyConfiguration = {
             assertion = cfg.sql.enable -> ((cfg.sql.configFile == null) != (cfg.sql.configuration == null));
             message = ''
               Please specify either 'services.prometheus.exporters.sql.configuration' or
                 'services.prometheus.exporters.sql.configFile'
             '';
-          }
-          {
+          };
+          idrac.nonEmptyConfiguration = {
             assertion =
               cfg.idrac.enable -> ((cfg.idrac.configurationPath == null) != (cfg.idrac.configuration == null));
             message = ''
               Please ensure you have either `services.prometheus.exporters.idrac.configuration'
                 or `services.prometheus.exporters.idrac.configurationPath' set!
             '';
-          }
-          {
+          };
+          deluge.nonEmptyPassword = {
             assertion =
               cfg.deluge.enable
               -> ((cfg.deluge.delugePassword == null) != (cfg.deluge.delugePasswordFile == null));
@@ -537,8 +537,8 @@ in
               Please ensure you have either `services.prometheus.exporters.deluge.delugePassword'
                 or `services.prometheus.exporters.deluge.delugePasswordFile' set!
             '';
-          }
-          {
+          };
+          pgbouncer.nonEmptyConnection = {
             assertion =
               cfg.pgbouncer.enable
               -> (xor (cfg.pgbouncer.connectionEnvFile == null) (cfg.pgbouncer.connectionString == null));
@@ -546,29 +546,35 @@ in
               Options `services.prometheus.exporters.pgbouncer.connectionEnvFile` and
               `services.prometheus.exporters.pgbouncer.connectionString` are mutually exclusive!
             '';
-          }
-        ]
-        ++ (flip map (attrNames exporterOpts) (exporter: {
-          assertion = cfg.${exporter}.firewallFilter != null -> cfg.${exporter}.openFirewall;
-          message = ''
-            The `firewallFilter'-option of exporter ${exporter} doesn't have any effect unless
-            `openFirewall' is set to `true'!
-          '';
-        }))
-        warnings = [
-          (mkIf
-            (
+          };
+        }
+        // (lib.listToAttrs (
+          map (
+            exporter:
+            lib.nameValuePair exporter {
+              assertion = cfg.${exporter}.firewallFilter != null -> cfg.${exporter}.openFirewall;
+              message = ''
+                The `firewallFilter'-option of exporter ${exporter} doesn't have any effect unless
+                `openFirewall' is set to `true'!
+              '';
+            }
+          ) (attrNames exporterOpts)
+        ))
+        // (removeAttrs config.services.prometheus.exporters.assertions [ "__flattened" ]);
+
+        warnings = {
+          services.prometheus.exporters.idrac.configurationPathOverrides = {
+            condition =
               config.services.prometheus.exporters.idrac.enable
-              && config.services.prometheus.exporters.idrac.configurationPath != null
-            )
-            ''
+              && config.services.prometheus.exporters.idrac.configurationPath != null;
+            message = ''
               Configuration file in `services.prometheus.exporters.idrac.configurationPath` may override
               `services.prometheus.exporters.idrac.listenAddress` and/or `services.prometheus.exporters.idrac.port`.
               Consider using `services.prometheus.exporters.idrac.configuration` instead.
-            ''
-          )
-        ]
-        ++ config.services.prometheus.exporters.warnings;
+            '';
+          };
+        }
+        // config.services.prometheus.exporters.warnings;
       }
     ]
     ++ [

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -555,7 +555,6 @@ in
             `openFirewall' is set to `true'!
           '';
         }))
-        ++ config.services.prometheus.exporters.assertions;
         warnings = [
           (mkIf
             (

--- a/nixos/modules/services/web-servers/fcgiwrap.nix
+++ b/nixos/modules/services/web-servers/fcgiwrap.nix
@@ -119,30 +119,28 @@ in
   };
 
   config = {
-    assertions = concatLists (
-      mapAttrsToList (name: cfg: [
-        {
-          assertion = cfg.socket.type == "unix" -> cfg.socket.user != null;
-          message = "Socket owner is required for the UNIX socket type.";
-        }
-        {
-          assertion = cfg.socket.type == "unix" -> cfg.socket.group != null;
-          message = "Socket owner is required for the UNIX socket type.";
-        }
-        {
-          assertion = cfg.socket.user != null -> cfg.socket.type == "unix";
-          message = "Socket owner can only be set for the UNIX socket type.";
-        }
-        {
-          assertion = cfg.socket.group != null -> cfg.socket.type == "unix";
-          message = "Socket owner can only be set for the UNIX socket type.";
-        }
-        {
-          assertion = cfg.socket.mode != null -> cfg.socket.type == "unix";
-          message = "Socket mode can only be set for the UNIX socket type.";
-        }
-      ]) config.services.fcgiwrap.instances
-    );
+    assertions.services.fcgiwrap.instances = mapAttrs (name: cfg: {
+      socketOwnerRequired = {
+        assertion = cfg.socket.type == "unix" -> cfg.socket.user != null;
+        message = "Socket owner is required for the UNIX socket type.";
+      };
+      socketGroupRequired = {
+        assertion = cfg.socket.type == "unix" -> cfg.socket.group != null;
+        message = "Socket group is required for the UNIX socket type.";
+      };
+      socketOwnerOnlyForUnix = {
+        assertion = cfg.socket.user != null -> cfg.socket.type == "unix";
+        message = "Socket owner can only be set for the UNIX socket type.";
+      };
+      socketGroupOnlyForUnix = {
+        assertion = cfg.socket.group != null -> cfg.socket.type == "unix";
+        message = "Socket group can only be set for the UNIX socket type.";
+      };
+      socketModeOnlyForUnix = {
+        assertion = cfg.socket.mode != null -> cfg.socket.type == "unix";
+        message = "Socket mode can only be set for the UNIX socket type.";
+      };
+    }) config.services.fcgiwrap.instances;
 
     systemd.services = forEachInstance (cfg: {
       after = [ "nss-user-lookup.target" ];

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -74,8 +74,9 @@ let
     }
   );
 
-  # Handle assertions and warnings
-  baseSystemAssertWarn = lib.asserts.checkAssertWarn config.assertions config.warnings baseSystem;
+  baseSystemAssertWarn =
+    lib.asserts.checkAssertWarn config.assertions.__flattened config.warnings.__flattened
+      baseSystem;
 
   # Replace runtime dependencies
   system =

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -17,6 +17,7 @@ let
     flip
     head
     literalExpression
+    mapAttrs
     mkDefault
     mkEnableOption
     mkIf
@@ -435,7 +436,7 @@ in
 
   config = {
 
-    assertions =
+    assertions.fileSystems =
       let
         ls = sep: concatMapStringsSep sep (x: x.mountPoint);
         resizableFSes = [
@@ -444,43 +445,44 @@ in
           "btrfs"
           "xfs"
         ];
-        notAutoResizable = fs: fs.autoResize && !(builtins.elem fs.fsType resizableFSes);
       in
-      [
-        {
+      {
+        topologicallySorted = {
           assertion = !(fileSystems' ? cycle);
-          message = "The ‘fileSystems’ option can't be topologically sorted: mountpoint dependency path ${ls " -> " fileSystems'.cycle} loops to ${ls ", " fileSystems'.loops}";
-        }
-        {
-          assertion = !(any notAutoResizable fileSystems);
-          message =
-            let
-              fs = head (filter notAutoResizable fileSystems);
-            in
-            ''
-              Mountpoint '${fs.mountPoint}': 'autoResize = true' is not supported for 'fsType = "${fs.fsType}"'
-              ${optionalString (fs.fsType == "auto") "fsType has to be explicitly set and"}
-              only the following support it: ${lib.concatStringsSep ", " resizableFSes}.
-            '';
-        }
-        {
-          assertion = !(any (fs: fs.formatOptions != null) fileSystems);
           message = ''
-            'fileSystems.<name>.formatOptions' has been removed, since
-            systemd-makefs does not support any way to provide formatting
-            options.
+            The ‘fileSystems’ option can't be topologically sorted:
+            mountpoint dependency path ${ls " -> " fileSystems'.cycle or [ ]} loops to ${
+              ls ", " fileSystems'.loops or [ ]
+            }
           '';
-        }
-      ]
-      ++ lib.map (fs: {
-        assertion = fs.label != null -> fs.device == "/dev/disk/by-label/${escape fs.label}";
-        message = ''
-          The filesystem with mount point ${fs.mountPoint} has its label and device set to inconsistent values:
-            label: ${toString fs.label}
-            device: ${toString fs.device}
-          'filesystems.<name>.label' and 'filesystems.<name>.device' are mutually exclusive. Please set only one.
-        '';
-      }) fileSystems;
+        };
+        resizable = mapAttrs (name: fs: {
+          assertion = fs.autoResize -> builtins.elem fs.fsType resizableFSes;
+          message = ''
+            Mountpoint '${fs.mountPoint}': 'autoResize = true' is not supported for 'fsType = "${fs.fsType}"'
+            ${optionalString (fs.fsType == "auto") "fsType has to be explicitly set and"}
+            only the following support it: ${lib.concatStringsSep ", " resizableFSes}.
+          '';
+        }) config.fileSystems;
+        formatOptionsDeprecated = mapAttrs (name: fs: {
+          assertion = fs.formatOptions == null;
+          message = ''
+            The filesystem with mount point ${fs.mountPoint} has its label and device set to inconsistent values:
+              label: ${toString fs.label}
+              device: ${toString fs.device}
+            'filesystems.<name>.label' and 'filesystems.<name>.device' are mutually exclusive. Please set only one.
+          '';
+        }) config.fileSystems;
+        consistentDeviceLabelMountPoint = mapAttrs (name: fs: {
+          assertion = fs.label != null -> fs.device == "/dev/disk/by-label/${escape fs.label}";
+          message = ''
+            The filesystem with mount point ${fs.mountPoint} has its label and device set to inconsistent values:
+              label: ${toString fs.label}
+              device: ${toString fs.device}
+            'filesystems.<name>.label' and 'filesystems.<name>.device' are mutually exclusive. Please set only one.
+          '';
+        }) config.fileSystems;
+      };
 
     # Export for use in other modules
     system.build.fileSystems = fileSystems;

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -129,17 +129,19 @@ let
       bond: (filterAttrs (attrName: attr: elem attrName deprecated && attr != null) bond);
   };
 
-  bondWarnings =
-    let
-      oneBondWarnings =
-        bondName: bond: mapAttrsToList (bondText bondName) (bondDeprecation.filterDeprecated bond);
-      bondText =
-        bondName: optName: _:
-        "${bondName}.${optName} is deprecated, use ${bondName}.driverOptions";
-    in
-    {
-      warnings = flatten (mapAttrsToList oneBondWarnings cfg.bonds);
-    };
+  bondWarnings = {
+    warnings.networking.bonds.deprecatedOptions = lib.mapAttrs (
+      bondName: bond:
+      lib.mergeAttrsList (
+        map (optName: {
+          ${optName} = {
+            condition = (cfg.bonds.${bondName}.${optName} or null) != null;
+            message = "${bondName}.${optName} is deprecated, use ${bondName}.driverOptions";
+          };
+        }) bondDeprecation.deprecated
+      )
+    ) cfg.bonds;
+  };
 
   normalConfig = {
     systemd.network.links =

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -32,8 +32,6 @@ let
       )
     ) (attrValues cfg.vswitches);
 
-  slaveIfs = map (i: cfg.interfaces.${i}) (filter (i: cfg.interfaces ? ${i}) slaves);
-
   rstpBridges = flip filterAttrs cfg.bridges (_: { rstp, ... }: rstp);
 
   needsMstpd = rstpBridges != { };
@@ -1722,46 +1720,58 @@ in
   meta.maintainers = with lib.maintainers; [ rnhmjoj ];
 
   config = {
-    warnings =
-      (concatMap (i: i.warnings) interfaces)
-      ++ (lib.optional (config.systemd.network.enable && cfg.useDHCP && !cfg.useNetworkd) ''
-        The combination of `systemd.network.enable = true`, `networking.useDHCP = true` and `networking.useNetworkd = false` can cause both networkd and dhcpcd to manage the same interfaces. This can lead to loss of networking. It is recommended you choose only one of networkd (by also enabling `networking.useNetworkd`) or scripting (by disabling `systemd.network.enable`)
-      '');
+    warnings.networking.interfaces = lib.mapAttrs (
+      _: i: removeAttrs i.warnings [ "__flattened" ]
+    ) cfg.interfaces;
+    warnings.networking.systemdNetworkdDhcpdClash = {
+      condition = config.systemd.network.enable && cfg.useDHCP && !cfg.useNetworkd;
+      message = ''
+        The combination of `systemd.network.enable = true`, `networking.useDHCP = true` and `networking.useNetworkd = false`
+        can cause both networkd and dhcpcd to manage the same interfaces. This can lead to loss of networking.
+        It is recommended you choose only one of networkd (by also enabling `networking.useNetworkd`) or scripting
+        (by disabling `systemd.network.enable`)
+      '';
+    };
 
-    assertions =
-      (forEach interfaces (i: {
-        # With the linux kernel, interface name length is limited by IFNAMSIZ
-        # to 16 bytes, including the trailing null byte.
-        # See include/linux/if.h in the kernel sources
-        assertion = stringLength i.name < 16;
-        message = ''
-          The name of networking.interfaces."${i.name}" is too long, it needs to be less than 16 characters.
-        '';
-      }))
-      ++ (forEach slaveIfs (i: {
-        assertion = i.ipv4.addresses == [ ] && i.ipv6.addresses == [ ];
-        message = ''
-          The networking.interfaces."${i.name}" must not have any defined ips when it is a slave.
-        '';
-      }))
-      ++ (forEach interfaces (i: {
-        assertion = i.tempAddress != "disabled" -> cfg.enableIPv6;
-        message = ''
-          Temporary addresses are only needed when IPv6 is enabled.
-        '';
-      }))
-      ++ (forEach interfaces (i: {
-        assertion = (i.virtual && i.virtualType == "tun") -> i.macAddress == null;
-        message = ''
-          Setting a MAC Address for tun device ${i.name} isn't supported.
-        '';
-      }))
-      ++ [
-        {
-          assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);
-          message = "Invalid value given to the networking.hostId option.";
-        }
-      ];
+    assertions.networking.interfaces = lib.flip lib.mapAttrs cfg.interfaces (
+      iName: iCfg: {
+        nameLessThan16Chars = {
+          # With the linux kernel, interface name length is limited by IFNAMSIZ
+          # to 16 bytes, including the trailing null byte.
+          # See include/linux/if.h in the kernel sources
+          assertion = stringLength iName < 16;
+          message = ''
+            The name of networking.interfaces."${iName}" is too long, it needs to be less than 16 characters.
+          '';
+        };
+
+        slaveInterfacesMustNotHaveIpAddresses = {
+          assertion = elem iName slaves -> (iCfg.ipv4.addresses == [ ] && iCfg.ipv6.addresses == [ ]);
+          message = ''
+            The networking.interfaces."${iName}" must not have any defined ips when it is a slave.
+          '';
+        };
+
+        tempAddressOnlyForIpv6 = {
+          assertion = iCfg.tempAddress != "disabled" -> cfg.enableIPv6;
+          message = ''
+            Temporary addresses are only needed when IPv6 is enabled.
+          '';
+        };
+
+        noMacAddressForTunDevices = {
+          assertion = (iCfg.virtual && iCfg.virtualType == "tun") -> iCfg.macAddress == null;
+          message = ''
+            Setting a MAC Address for tun device ${iName} isn't supported.
+          '';
+        };
+      }
+    );
+
+    assertions.networking.validHostId = {
+      assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);
+      message = "Invalid value given to the networking.hostId option.";
+    };
 
     boot.kernelModules =
       [ ]

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1722,7 +1722,6 @@ in
   meta.maintainers = with lib.maintainers; [ rnhmjoj ];
 
   config = {
-
     warnings =
       (concatMap (i: i.warnings) interfaces)
       ++ (lib.optional (config.systemd.network.enable && cfg.useDHCP && !cfg.useNetworkd) ''

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -93,7 +93,12 @@ lib.recurseIntoAttrs {
           { hi, lib, ... }:
           {
             config = {
-              assertions = [ { assertion = hi; } ];
+              assertions = [
+                {
+                  assertion = hi;
+                  message = "hi must be true";
+                }
+              ];
             };
             options = {
               itsProofYay = lib.mkOption { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR reworks the `assertions` module to take a freeform tree-like structure for `assertions` and `warnings`. This has one major advantage over the existing list structure, which is the ability for a downstream user to forcefully disable an assertion or warning they believe to be erroneous without needing to resort to any tricky hacks. It might also open up for ideas where we could add more metadata or properties to the assertions/warnings, like different types of warnings or whether the message should be lazily evaluated. It will also let you extract the tree structure of non-firing warnings/assertions for whatever kinds of research purposes you might need it for. I don't suspect that an entire manual appendix of warnings/assertions is particularly useful, but maybe the data is useful for some?

### Example

Here is an example of the old and new way to write assertions and warnings:

```nix
# Old
{
  warnings = lib.mkIf config.services.foo.bar [
    "Some example warning"
  ];
  
  assertions = [{
    assertion = config.services.foo.baz;
    message = ''
      You forgot to enable baz.
    '';
  }];
}

# New
{
  warnings.services.foo.beCarefulWithBar = {
    # ⬐ New option for storing the boolean that triggers the warning
    condition = config.services.foo.bar;
    message = "Some example warning";
  ];
  
  assertions.services.foo.makeSureToEnableBaz = {
    assertion = config.services.foo.baz;
    message = ''
      You forgot to enable baz.
    '';
  };
}
```

If the user believes either of these to be an error in nixpkgs, they should of course make an issue first, but in the meanwhile they can do this:

```nix
{
  warnings.services.foo.beCarefulWithBar.enable = false;
  assertions.services.foo.makeSureToEnableBaz.enable = false;
}
```

### Backwards compatibility

The module takes any existing assertions/warnings that are declared as lists, and coerces them to the new format under `{assertions,warnings}.legacy.<sha256-sum of message string>`. While this makes them a bit harder to disable, it ensures a smooth transition. While `assertions` and `warnings` are marked with `internal = true`, I believe a lot of people are using them for out-of-tree modules. I have explicitly opted out of adding a note to the release docs, but I have changed the nixos manual.

### Other things worth mentioning, and maybe discussing

- This PR depends on https://github.com/NixOS/nixpkgs/pull/342330

- I've modified some of the core modules and library functions to use the new scheme, in addition to a few modules with a large set of assertions/warnings as a proof of concept. Most assertions have just been placed in the tree, but some needed slight modifications. Some assertions and warnings that earlier were aggregated have been split up to be separate assertions.

- There is obviously no established scheme for the naming or namespacing of assertions and warnings. I've tried naming them roughly to reflect what they are warning about and what they are trying to assert, but I'm very open for changes and/or standardisation of some kind of scheme.

- Should we consider making these options non-internal, considering widespread use outside nixpkgs?

- I'm not sure about the evaluation speed impact of all the coercion stuff I've added. It doesn't seem much slower on my PC, but I haven't made any measurements.

- <s>Due to typechecking of the assertion/warning submodule, the message strings will now become non-lazy. In one way, that's a good thing because we get to typecheck the messages. On another hand, there are some message strings that depend on their boolean error condition to make any sense (e.g if the assertion asserts that a setting should not be set, the message might refer to the content of that setting without any regard for what happens if the setting is not there). The warning `mkIf`s handle this properly, but the assertions might not. I'm not sure whether we should try to hunt these down, or make typechecking opt-in, or how to go about this? Building all the nixos tests is a good start I suppose.</s> This is not the case anymore. Lazyness is on by default for legacy assertions, and opt-out for new ones. 

- <s>There might be a case where identical assertions that were earlier part of the assertion list can have differing boolean values while still getting the same hash. I believe this could trigger an eval error where the same option is set to differing values? I'm not sure if we should handle those cases as they come and move towards the new format, or try to handle it with something like `lib.types.boolByOr`</s> This is not relevant as long as `assertions` is using `lib.imap0` for type coercion.

### Testing

I've only done basic testing, opening a nix repl and evaluated attributes as follows: 

```nix
# Using traceValSeqN for some reason has the sideeffect of pretty printing,
# in contrast to some of the other trace functions 
nix-repl> lib.traceValSeqN 40 legacyPackages.x86_64-linux.nixosTests._3proxy.config.nodes.peer0.assertions

... # Too much here, it's the entire expanded tree of all assertions

{
  boot = { ... };
  console = { ... };
  documentation = { ... };
  environment = { ... };
  fileSystems = { ... };
  fonts = { ... };
  hardware = { ... };
  i18n = { ... };
  krb5 = { ... };
  legacy = { ... };
  nesting = { ... };
  networking = { ... };
  nix = { ... };
  programs = { ... };
  security = { ... };
  services = { ... };
  sound = { ... };
  stubby = { ... };
  systemd = { ... };
  users = { ... };
  virtualisation = { ... };
  xdg = { ... };
  zramSwap = { ... };
}

nix-repl> lib.traceValSeqN 40 legacyPackages.x86_64-linux.nixosTests._3proxy.config.nodes.peer0.warning

... # Expanded tree here as well

{
  boot = { ... };
  docker-containers = { ... };
  documentation = { ... };
  environment = { ... };
  fonts = { ... };
  hardware = { ... };
  i18n = { ... };
  jobs = { ... };
  legacy = { ... };
  networking = { ... };
  nix = { ... };
  programs = { ... };
  qt5 = { ... };
  security = { ... };
  services = { ... };
  snapraid = { ... };
  system = { ... };
  systemd = { ... };
  unifi-poller = { ... };
  users = { ... };
  virtualisation = { ... };
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
