### PR TITLE
mautrix-meta: update to 0.4.0

### DIFF
--- a/pkgs/by-name/ma/mautrix-meta/package.nix
+++ b/pkgs/by-name/ma/mautrix-meta/package.nix
@@ -14,21 +14,21 @@
 
 buildGoModule rec {
   pname = "mautrix-meta";
-  version = "0.3.2";
+  version = "0.4.0";
 
-  subPackages = [ "." ];
+  subPackages = [ "cmd/mautrix-meta" ];
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "meta";
     rev = "v${version}";
-    hash = "sha256-whBqhdB2FSFfrbtGtq8v3pjXW7QMt+I0baHTXVGPWVg=";
+    hash = "sha256-KJuLBJy/g4ShcylkqIG4OuUalwboUSErSif3p7x4Zo4=";
   };
 
   buildInputs = lib.optional (!withGoolm) olm;
   tags = lib.optional withGoolm "goolm";
 
-  vendorHash = "sha256-rP9wvF6yYW0TdQ+vQV6ZcVMxnCtqz8xRcd9v+4pYYio=";
+  vendorHash = "sha256-ErY40xIDhhOHQI/jYa8DcnfjOI998neIMgb/IQNP/JQ=";
 
   passthru = {
     tests = {


### PR DESCRIPTION
This update cannot be done by the nixpkgs bot, as
the structure of the project has been changed, so why wait.

The mautrix-meta project has been moved under "cmd/mautrix-meta" There is also "cmd/lscli", but since this package is mainly about mautrix-meta, I think we can stay with this specific cmd. If we wanted, we could switch to both of them by removing this `subPackages` attribute.

CC: @eyJhb