### PR TITLE
nixos/macos-builder: pin `stateVersion`

### DIFF
--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -196,14 +196,8 @@ in
       # To prevent gratuitous rebuilds on each change to Nixpkgs
       nixos.revision = null;
 
-      stateVersion = lib.mkDefault (throw ''
-        The macOS linux builder should not need a stateVersion to be set, but a module
-        has accessed stateVersion nonetheless.
-        Please inspect the trace of the following command to figure out which module
-        has a dependency on stateVersion.
-
-          nix-instantiate --attr darwin.linux-builder --show-trace
-      '');
+      # to be updated by module maintainers, see nixpkgs#325610
+      stateVersion = "24.05";
     };
 
     users.users."${user}" = {


### PR DESCRIPTION
## Description of changes

Pin `stateVersion` in the `darwin-builder` profile; it would previously fail to eval whenever a module depended on `stateVersion`, causing maintainance issues for seemingly unrelated modules.

Closes #325610
Supercedes #325674, in which discussion I suggested this solution instead of blocking an arbitrary set of modules from using `stateVersion`.


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- No applicable tests in `nixos/tests`
- [x] Tested compilation of all affected packages using `nixpkgs-review`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
