### PR TITLE
nixos/tests/freetube: fix ocr

### DIFF
--- a/nixos/tests/freetube.nix
+++ b/nixos/tests/freetube.nix
@@ -35,7 +35,7 @@ let
         machine.wait_for_text('Your Subscription list is currently empty')
         machine.screenshot("main.png")
         machine.send_key("ctrl-comma")
-        machine.wait_for_text('General Settings', timeout=30)
+        machine.wait_for_text('Data Settings', timeout=60)
         machine.screenshot("preferences.png")
       '';
     });


### PR DESCRIPTION
- change text that is waited for on preferences page, as previous one stopped being recognized by OCR on xorg after freetube update to 0.21.0
- increase timeout from 30 sec to 60 sec as OCR is sometimes slow

## Description of changes

Fixes `nixosTests.freetube.xorg` (fails since `2024-06-22`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.freetube.xorg.x86_64-linux
https://hydra.nixos.org/build/272717478
Error log:
```text
xorg: sending key 'ctrl-comma'
(finished: sending key 'ctrl-comma', in 0.01 seconds)
xorg: waiting for General Settings to appear on screen
xorg: Last OCR attempt failed. Text was: ['-\n\n—\n\nr!\n\nP\n\nTube\n\nSearch / Go to URL\n\nﬂ\n\nSubscriptions\n\n7 D Expand All Settings Sections\n\n. D Sort Settings Sections (A-Z)\n\nChannels\n\n6\n\n.,G?"?.’.a\'rst.e“\'?9i\n\nTrending\n\nQC.\n\n0.\n\n-\n\nagyegggaings\n\nMost Popular\n\nu.~\'..~u.~u.~...~u.......ﬂu...“.....u.................u...........u.................u...........u.................u...........u.................u...........u.................u...........u.................u..........._.............................................................................................................u...........u.................u........~u.~u.~...~u.~u.\n\nI\n\nPlayl ists\n\na“??? 9??? WT???\n\nELLQJiEQion\'séit—Ir\'igs\n\n“3\n\n“am-.."—.-.-..",v-----.~-..-.-..-.-.NV--------....-.-..-.NV-------.~.~-.~---.~-..-.-..-.-...............e.-------------------. ...............v..----------.-.-..-.--...............,.-------------------. ...............v..----------.-.-..-.--...............,.-------------------. n.“\n\nHistory\n\nDistraction Free Settings\n\n.~..”-.~n”-.~..”-.~..”-.~........~........~........~........~........~........~........~........~....-........~.....~.....,..-........~.....~.....~.-........~.....~.....~.-........~.....~.....~.-........~.....,......~.-........~.....~.....~.-........~.....~.....~.-........~.....~.....~.-........~.....~.....~.-........~.....,......~.-........~..-.~..-.~.-___..~...\n\nSettings\n\n\'f"ffﬁ¥..?9‘fl??_f-.,.,\n\nbéta\'smiﬁgs\'\n\n. “mm“ -..”-....-.m..-.m..-.m..--m-M...“ “mm“ -..........-.m..-.m-.....A “mm“ -..........-.m..-.m-.....A “mm“ -..........-.m..-.m-.....A “mm“ "a...“ “mm“ “4 “mm“ “4 “mm“ “4 “mm“ "a...“ “mm“ -..........-.m..-.m-.....A “mm“ “Mm—"Mu\n\nAbout\n\nProxy Settings\n\n—s«~\\s\'s “we. “WM—weuww“NM.“N-WMN “we. “WM—weuww“NM.“N-WMN “we. “WM—weuww“NM.“N-WMN “we. “we. “we. “WM—weuww“NM.“N-WMN “we. mwewwmauwww.‘mmuwww.‘mauwwm.‘mmuww“NM.“N“NM.“N-w‘u. “we. “WM—weuww“NM.“N-WMN “w\n\nDownload Settings\n\n._.._....... _. _......_.._-. ...... _. _......_.._-. ...... _. mm... _.._... _.._... _.._... _.._.,_.._-. ...... _. _......_.._-. “a.-. ...... _. _......_.._-. “a.-. ...... _. _......_.._-. “a.-. ...... _. _......_.._-. ...... _. _......_.._-. ...... _. _......_.._-. ...... _. mm... _.._... _.._... _.._... _.._....... _. _......_.._-. ...... _. _......_.._-. ......\n\nParental Control Settings\n\n..,_-,......_-,“....-,_.,......""<......,..-,.....-""<.....-,...,......"_-<......,...,.."n-_-"-""-""-""-"n-_-"-""-""-""-"n-_-"-""-""-""-"_-s....""<......,._-,.....-""<.....-,._.,......"_-<......,._.,.....-""<......,._-,......_-"<.....-,..."manna..."._-.......\n\nSponsorBlock Settings\n\x0c', 'LJ\n\nem—\n\nLy\n\nb>\n\nTube\n\nSearch / Go to URL\n\nAN\n\nSubscriptions\n\nJP Expand All Settings Sections\n\nJP Sort Settings Sections (A-Z)\n\nChannels\n\n(J\n\nathinhatiad\n\nHGH HD\n\nP= 9\n\ne_0\n\na\n\nTRVRTI\n\nMost Popular\n\nee ee eV UU ES ERR Ae\n\nN\n\nPlaylists\n\njab dehatuiady\n\nrr,\n\n0)\n\nrr rT ————————————————— ————————————— ———————————————————————— ARAN AERA A BA A BRASS SAS\n\nHistory\n\nDistraction Free Settings\n\nET TT EI TT IE ET RT ET I I EE EE ET II I RE EE IR RO TE I EE RT TE I EIR.\n\nYUE\n\niin htiad\n\nData Settings\n\nEEE er EE Be a RR eR EE EE Ea EE EE A Es a EB SA a Be Ee Ee RB eR a a EE a EE BE BE eB Ba\n\nAbout\n\n2 (OAT Ugo\n\nER ee pee\n\nDownload Settings\n\nFTP DP SR PD RHP PPP ROP SDD PPP DE EDS OD EDR PPO ROPE RASPES EPP IPR SREP\n\nParental Control Settings\n\naT a eT Le ne aa rT a ee ee\n\nSponsorBlock Settings\n\x0c', 'L]\n\nem—\n\nLy\n\nb\n\nTube\n\nSearch / Go to URL\n\nﬁ\n\nSubscriptions\n\nI Expand All Settings Sections\n\nI Sort Settings Sections (A-Z)\n\nChannels\n\n()\n\nathinhatiad\n\nHGHE DD\n\nP 9\n\ne_0\n\na\n\nTRV\n\nMost Popular\n\ne e e e VU TP U S R e\n\nN\n\nPlaylists\n\nbt dehatuady\n\n.\n\n0]\n\nT ————————————————— ————————————— - ———————————————————————— AN A A B K KA A B SRS SRS\n\nHistory\n\nDistraction Free Settings\n\nT T T T I R T T I T R R T T I T I I I T I I R O I R R O O T O I R T T I IR TII..\n\nYU\n\nik bl\n\nData Settings\n\nB N e e R B S e R R N e R e e R A e s S e N, B S A i B e e e e s e e R e T B R B e B A e i R B e e e U B e e B e B e e R B e e B e B\n\nAbout\n\nM (O VAT g Te S\n\nR e e\n\nDownload Settings\n\nTP D P R PP RSP RO S DD PP DD DR D DR PP PO RO RSO RRES SR IPR SRS\n\nParental Control Settings\n\nT e e T e e e e e e T e e e\n\nSponsorBlock Settings\n\x0c']
cleanup
kill machine (pid 8)
qemu-kvm: terminating on signal 15 from pid 5 (/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/bin/python3.12)
(finished: cleanup, in 0.01 seconds)
Traceback (most recent call last):
  File "/nix/store/nbdw99sc4cc4s3xgsbkb8zr91m08q0km-nixos-test-driver-1.1/bin/.nixos-test-driver-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/nbdw99sc4cc4s3xgsbkb8zr91m08q0km-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/__init__.py", line 146, in main
    driver.run_tests()
  File "/nix/store/nbdw99sc4cc4s3xgsbkb8zr91m08q0km-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/driver.py", line 166, in run_tests
    self.test_script()
  File "/nix/store/nbdw99sc4cc4s3xgsbkb8zr91m08q0km-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/driver.py", line 158, in test_script
    exec(self.tests, symbols, None)
  File "<string>", line 8, in <module>
  File "/nix/store/nbdw99sc4cc4s3xgsbkb8zr91m08q0km-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/machine.py", line 999, in wait_for_text
    retry(screen_matches, timeout)
  File "/nix/store/nbdw99sc4cc4s3xgsbkb8zr91m08q0km-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/machine.py", line 134, in retry
    raise Exception(f"action timed out after {timeout} seconds")
Exception: action timed out after 30 seconds
kill vlan (pid 6)
```
Seems to be some change in `0.20.0 -> 0.21.0` freetube update(#321423) that made OCR not work.
Thought screen itself still has `"General Settings"` and it is recognized in `wayland` test, but somehow is not in `xorg` test.
After text change both tests pass.

Listed test maintainer:
@kirillrdy

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
