### PR TITLE
plasma-pa: drop GConf dependency

### DIFF
--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -28,7 +28,6 @@
 , lib
 , config
 , fetchurl
-, gconf
 , gsettings-desktop-schemas
 }:
 
@@ -156,7 +155,7 @@ let
       plasma-mobile = callPackage ./plasma-mobile { };
       plasma-nano = callPackage ./plasma-nano { };
       plasma-nm = callPackage ./plasma-nm { };
-      plasma-pa = callPackage ./plasma-pa.nix { inherit gconf; };
+      plasma-pa = callPackage ./plasma-pa.nix { };
       plasma-remotecontrollers = callPackage ./plasma-remotecontrollers.nix { };
       plasma-sdk = callPackage ./plasma-sdk.nix { };
       plasma-systemmonitor = callPackage ./plasma-systemmonitor.nix { };

--- a/pkgs/desktops/plasma-5/plasma-pa.nix
+++ b/pkgs/desktops/plasma-5/plasma-pa.nix
@@ -11,7 +11,6 @@
 , plasma-framework
 , qtbase
 , qtdeclarative
-, gconf
 , glib
 , libcanberra-gtk3
 , libpulseaudio
@@ -22,7 +21,6 @@ mkDerivation {
   pname = "plasma-pa";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    gconf
     glib
     libcanberra-gtk3
     libpulseaudio

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -40,7 +40,6 @@ makeScopeWithSplicing' {
     attrs = {
       inherit libsForQt5;
       inherit (pkgs) config lib fetchurl;
-      gconf = pkgs.gnome2.GConf;
       inherit (pkgs) gsettings-desktop-schemas;
     };
   in (lib.makeOverridable mkPlasma5 attrs);


### PR DESCRIPTION
Removed from upsteam at 5.24.90/5.25.0

Sources:
- https://invent.kde.org/plasma/plasma-pa/-/merge_requests/117
- https://invent.kde.org/plasma/plasma-pa/-/commit/36d6eb9c2bac53cc6653b4aa45a1ac42f0ce68c7

Part of https://github.com/NixOS/nixpkgs/issues/39976 and https://github.com/NixOS/nixpkgs/pull/340612

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
