### PR TITLE
dockerTools.pullImage: accept `hash` parameter

### DIFF
--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -909,7 +909,7 @@ Writing manifest to image destination
 {
   imageName = "nixos/nix";
   imageDigest = "sha256:498fa2d7f2b5cb3891a4edf20f3a8f8496e70865099ba72540494cd3e2942634";
-  sha256 = "1q6cf2pdrasa34zz0jw7pbs6lvv52rq2aibgxccbwcagwkg2qj1q";
+  hash = "sha256-OEgs3uRPMb4Y629FJXAWZW9q9LqHS/A/GUqr3K5wzOA=";
   finalImageName = "nixos/nix";
   finalImageTag = "latest";
 }

--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -868,7 +868,7 @@ dockerTools.pullImage {
   imageDigest = "sha256:b8ea88f763f33dfda2317b55eeda3b1a4006692ee29e60ee54ccf6d07348c598";
   finalImageName = "nix";
   finalImageTag = "2.19.3";
-  sha256 = "zRwlQs1FiKrvHPaf8vWOR/Tlp1C5eLn1d9pE4BZg3oA=";
+  hash = "sha256-zRwlQs1FiKrvHPaf8vWOR/Tlp1C5eLn1d9pE4BZg3oA=";
 }
 ```
 :::
@@ -885,7 +885,7 @@ dockerTools.pullImage {
   imageDigest = "sha256:24a23053f29266fb2731ebea27f915bb0fb2ae1ea87d42d890fe4e44f2e27c5d";
   finalImageName = "etcd";
   finalImageTag = "v3.5.11";
-  sha256 = "Myw+85f2/EVRyMB3axECdmQ5eh9p1q77FWYKy8YpRWU=";
+  hash = "sha256-Myw+85f2/EVRyMB3axECdmQ5eh9p1q77FWYKy8YpRWU=";
 }
 ```
 :::

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -372,7 +372,7 @@ in
           (pkgs.dockerTools.pullImage {
             imageName = "docker.io/bitnami/keycloak";
             imageDigest = "sha256:714dfadc66a8e3adea6609bda350345bd3711657b7ef3cf2e8015b526bac2d6b";
-            sha256 = "0imblp0kw9vkcr7sp962jmj20fpmb3hvd3hmf4cs4x04klnq3k90";
+            hash = "sha256-IM2BLZ0EdKIZcRWOtuFY9TogZJXCpKtPZnMnPsGlq0Y=";
             finalImageTag = "21.1.2-debian-11-r0";
           })
 

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -115,7 +115,7 @@ rec {
   nixFromDockerHub = pullImage {
     imageName = "nixos/nix";
     imageDigest = "sha256:85299d86263a3059cf19f419f9d286cc9f06d3c13146a8ebbb21b3437f598357";
-    sha256 = "19fw0n3wmddahzr20mhdqv6jkjn1kanh6n2mrr08ai53dr8ph5n7";
+    hash = "sha256-xxZ4UW6jRIVAzlVYA62awcopzcYNViDyh6q1yocF3KU=";
     finalImageTag = "2.2.1";
     finalImageName = "nix";
   };
@@ -124,7 +124,7 @@ rec {
   testNixFromDockerHub = pkgs.testers.invalidateFetcherByDrvHash pullImage {
     imageName = "nixos/nix";
     imageDigest = "sha256:85299d86263a3059cf19f419f9d286cc9f06d3c13146a8ebbb21b3437f598357";
-    sha256 = "19fw0n3wmddahzr20mhdqv6jkjn1kanh6n2mrr08ai53dr8ph5n7";
+    hash = "sha256-xxZ4UW6jRIVAzlVYA62awcopzcYNViDyh6q1yocF3KU=";
     finalImageTag = "2.2.1";
     finalImageName = "nix";
   };

--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -133,7 +133,7 @@ else
 fi
 
 # Compute the hash.
-imageHash=$(nix-hash --flat --type $hashType --base32 "$tmpFile")
+imageHash=$(nix-hash --flat --type $hashType --sri "$tmpFile")
 
 # Add the downloaded file to Nix store.
 finalPath=$(nix-store --add-fixed "$hashType" "$tmpFile")
@@ -152,7 +152,7 @@ cat <<EOF
 {
   imageName = "$imageName";
   imageDigest = "$imageDigest";
-  sha256 = "$imageHash";
+  hash = "$imageHash";
   finalImageName = "$finalImageName";
   finalImageTag = "$finalImageTag";
 }
@@ -164,7 +164,7 @@ cat <<EOF
 {
   "imageName": "$imageName",
   "imageDigest": "$imageDigest",
-  "sha256": "$imageHash",
+  "hash": "$imageHash",
   "finalImageName": "$finalImageName",
   "finalImageTag": "$finalImageTag"
 }


### PR DESCRIPTION
## Description of changes

Follow-up on #342072, contains its commits.

- [x] accept `hash` parameter in `dockerTools.pullImage`
- [x] produce a `hash` parameter in SRI format, from `nix-prefetch-docker`
- [x] update `doc/dockertools`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
