### PR TITLE
nixos/kubernetes: Add authz and authn kubeconfigs to control-plane

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -478,6 +478,8 @@
 
 - The kubelet configuration file can now be amended with arbitrary additional content using the `services.kubernetes.kubelet.extraConfig` option.
 
+- Kubernetes' kube-controller-manager and kube-scheduler now gained the ability to set authorization and authentication kubeconfigs. These default to the components' standard kubeconfig and can be set to an alternate kubeconfig if desired using `services.kubernetes.kube-controller-manager.authorizationKubeconfig`, `services.kubernetes.kube-controller-manager.authenticationKubeconfig`, `services.kubernetes.kube-scheduler.authorizationKubeconfig`, and `services.kubernetes.kube-scheduler.authenticationKubeconfig`.
+
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -50,7 +50,11 @@ in
       type = attrsOf bool;
     };
 
-    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes controller manager";
+    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes scheduler" null;
+
+    authorizationKubeconfig = top.lib.mkKubeConfigOptions "Kubernetes scheduler authorization" cfg.kubeconfig;
+
+    authenticationKubeconfig = top.lib.mkKubeConfigOptions "Kubernetes scheduler authentication" cfg.kubeconfig;
 
     leaderElect = mkOption {
       description = "Whether to start leader election before executing main loop.";
@@ -124,6 +128,8 @@ in
           ${optionalString (cfg.featureGates != {})
             "--feature-gates=${concatStringsSep "," (builtins.attrValues (mapAttrs (n: v: "${n}=${trivial.boolToString v}") cfg.featureGates))}"} \
           --kubeconfig=${top.lib.mkKubeConfig "kube-controller-manager" cfg.kubeconfig} \
+          --authorization-kubeconfig=${top.lib.mkKubeConfig "kube-controller-manager" cfg.authorizationKubeconfig} \
+          --authentication-kubeconfig=${top.lib.mkKubeConfig "kube-controller-manager" cfg.authenticationKubeconfig} \
           --leader-elect=${boolToString cfg.leaderElect} \
           ${optionalString (cfg.rootCaFile!=null)
             "--root-ca-file=${cfg.rootCaFile}"} \

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -75,29 +75,30 @@ let
 
   secret = name: "${cfg.secretsPath}/${name}.pem";
 
-  mkKubeConfigOptions = prefix: {
+  mkKubeConfigOptions = prefix: follows: {
     server = mkOption {
       description = "${prefix} kube-apiserver server address.";
       type = types.str;
+      default = if follows != null then follows.server else "";
     };
 
     caFile = mkOption {
       description = "${prefix} certificate authority file used to connect to kube-apiserver.";
       type = types.nullOr types.path;
-      default = cfg.caFile;
+      default = if follows != null then follows.caFile else cfg.caFile;
       defaultText = literalExpression "config.${opt.caFile}";
     };
 
     certFile = mkOption {
       description = "${prefix} client certificate file used to connect to kube-apiserver.";
       type = types.nullOr types.path;
-      default = null;
+      default = if follows != null then follows.certFile else null;
     };
 
     keyFile = mkOption {
       description = "${prefix} client key file used to connect to kube-apiserver.";
       type = types.nullOr types.path;
-      default = null;
+      default = if follows != null then follows.keyFile else null;
     };
   };
 in {
@@ -124,7 +125,7 @@ in {
 
     package = mkPackageOption pkgs "kubernetes" { };
 
-    kubeconfig = mkKubeConfigOptions "Default kubeconfig";
+    kubeconfig = mkKubeConfigOptions "Default kubeconfig" null;
 
     apiserverAddress = mkOption {
       description = ''

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -218,7 +218,7 @@ in
       type = str;
     };
 
-    kubeconfig = top.lib.mkKubeConfigOptions "Kubelet";
+    kubeconfig = top.lib.mkKubeConfigOptions "Kubelet" null;
 
     manifests = mkOption {
       description = "List of manifests to bootstrap with kubelet (only pods can be created as manifest entry)";

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -43,7 +43,7 @@ in
       type = str;
     };
 
-    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes proxy";
+    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes proxy" null;
 
     verbosity = mkOption {
       description = ''

--- a/nixos/modules/services/cluster/kubernetes/scheduler.nix
+++ b/nixos/modules/services/cluster/kubernetes/scheduler.nix
@@ -32,7 +32,11 @@ in
       type = attrsOf bool;
     };
 
-    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes scheduler";
+    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes scheduler" null;
+
+    authorizationKubeconfig = top.lib.mkKubeConfigOptions "Kubernetes scheduler authorization" cfg.kubeconfig;
+
+    authenticationKubeconfig = top.lib.mkKubeConfigOptions "Kubernetes scheduler authentication" cfg.kubeconfig;
 
     leaderElect = mkOption {
       description = "Whether to start leader election before executing main loop.";
@@ -70,6 +74,8 @@ in
           ${optionalString (cfg.featureGates != {})
             "--feature-gates=${concatStringsSep "," (builtins.attrValues (mapAttrs (n: v: "${n}=${trivial.boolToString v}") cfg.featureGates))}"} \
           --kubeconfig=${top.lib.mkKubeConfig "kube-scheduler" cfg.kubeconfig} \
+          --authorization-kubeconfig=${top.lib.mkKubeConfig "kube-scheduler" cfg.authorizationKubeconfig} \
+          --authentication-kubeconfig=${top.lib.mkKubeConfig "kube-scheduler" cfg.authenticationKubeconfig} \
           --leader-elect=${boolToString cfg.leaderElect} \
           --secure-port=${toString cfg.port} \
           ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \


### PR DESCRIPTION
## Description of changes

Currently, no authz or authn kubeconfigs are supplied to `kube-controller-manager` and `kube-scheduler`. This means that these components won't be able to authenticate requests made from other components (users, serviceaccounts, etc.) to their API.

Practically, this means that things like `prometheus-operator` attempting to fetch those components' metrics via a

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: whatever
rules:
  - nonResourceURLs:
      - "/metrics"
    verbs: ["get"]
```

RBAC role will fail with the component 403ing and telling you that `system:anonymous` isn't allowed to access this API.

I initially thought that hard-coding these parameters to the standard `kubeconfig` would be good enough but in my experience, there's nothing worse than stuff hard-coded in nixpkgs you need to hack around in your own config when you want to get something working from a different point of view than the module author's so I think it's nice to provide a sane default and let people override it if needed.

So, I extended `mkKubeconfigOptions` to allow you to set the defaults of the kubeconfig options you're creating to another kubeconfig's value. By default the plain kubeconfig you pass in will be used for authn and authz and you can override it to whatever you wish if you have a specific use-case I haven't thought of.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---
cc: @NixOS/kubernetes 
Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
