### PR TITLE
smartmontools: build with systemdLibs on linux

### DIFF
--- a/nixos/modules/services/monitoring/smartd.nix
+++ b/nixos/modules/services/monitoring/smartd.nix
@@ -269,7 +269,10 @@ in
     systemd.services.smartd = {
       description = "S.M.A.R.T. Daemon";
       wantedBy = [ "multi-user.target" ];
-      serviceConfig.ExecStart = "${pkgs.smartmontools}/sbin/smartd ${lib.concatStringsSep " " cfg.extraOptions} --no-fork --configfile=${smartdConf}";
+      serviceConfig = {
+        Type = "notify";
+        ExecStart = "${pkgs.smartmontools}/sbin/smartd ${lib.concatStringsSep " " cfg.extraOptions} --no-fork --configfile=${smartdConf}";
+      };
     };
 
     services.systembus-notify.enable = mkDefault ns.enable;

--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -6,6 +6,7 @@
 , gnused
 , hostname
 , mailutils
+, systemdLibs
 , IOKit
 , ApplicationServices
 }:
@@ -45,7 +46,8 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = lib.optionals stdenv.isDarwin [ IOKit ApplicationServices ];
+  buildInputs = lib.optionals stdenv.isLinux [ systemdLibs ]
+    ++ lib.optionals stdenv.isDarwin [ IOKit ApplicationServices ];
   enableParallelBuilding = true;
 
   meta = with lib; {

--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -1,14 +1,15 @@
-{ lib
-, stdenv
-, fetchurl
-, autoreconfHook
-, enableMail ? false
-, gnused
-, hostname
-, mailutils
-, systemdLibs
-, IOKit
-, ApplicationServices
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoreconfHook,
+  enableMail ? false,
+  gnused,
+  hostname,
+  mailutils,
+  systemdLibs,
+  IOKit,
+  ApplicationServices,
 }:
 
 let
@@ -19,7 +20,13 @@ let
     sha256 = "sha256-0dtLev4JjeHsS259+qOgg19rz4yjkeX4D3ooUgS4RTI=";
     name = "smartmontools-drivedb.h";
   };
-  scriptPath = lib.makeBinPath ([ gnused hostname ] ++ lib.optionals enableMail [ mailutils ]);
+  scriptPath = lib.makeBinPath (
+    [
+      gnused
+      hostname
+    ]
+    ++ lib.optionals enableMail [ mailutils ]
+  );
 
 in
 stdenv.mkDerivation rec {
@@ -46,8 +53,12 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = lib.optionals stdenv.isLinux [ systemdLibs ]
-    ++ lib.optionals stdenv.isDarwin [ IOKit ApplicationServices ];
+  buildInputs =
+    lib.optionals stdenv.isLinux [ systemdLibs ]
+    ++ lib.optionals stdenv.isDarwin [
+      IOKit
+      ApplicationServices
+    ];
   enableParallelBuilding = true;
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Enables better integration with systemd on linux.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>11 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_6_10.zfs_2_1</li>
    <li>linuxKernel.packages.linux_6_11.zfs</li>
    <li>linuxKernel.packages.linux_6_11.zfs_2_1</li>
    <li>linuxKernel.packages.linux_6_11.zfs_unstable</li>
    <li>linuxKernel.packages.linux_latest_libre.zfs</li>
    <li>linuxKernel.packages.linux_latest_libre.zfs_2_1</li>
    <li>linuxKernel.packages.linux_latest_libre.zfs_unstable</li>
    <li>linuxKernel.packages.linux_lqx.zfs_2_1</li>
    <li>linuxKernel.packages.linux_xanmod_latest.zfs_2_1</li>
    <li>linuxKernel.packages.linux_xanmod_stable.zfs_2_1</li>
    <li>linuxKernel.packages.linux_zen.zfs_2_1</li>
  </ul>
</details>
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>quickgui</li>
    <li>quickgui.debug</li>
    <li>quickgui.pubcache</li>
  </ul>
</details>
<details>
  <summary>138 packages built:</summary>
  <ul>
    <li>appvm</li>
    <li>booster</li>
    <li>ceph</li>
    <li>ceph-client</li>
    <li>ceph-csi</li>
    <li>ceph.dev</li>
    <li>ceph.doc</li>
    <li>libceph (ceph.lib ,libceph.dev ,libceph.doc ,libceph.lib ,libceph.man)</li>
    <li>ceph.man</li>
    <li>check_smartmon</li>
    <li>check_zfs</li>
    <li>collectd</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>disko</li>
    <li>docker-machine-kvm2</li>
    <li>easysnap</li>
    <li>facter</li>
    <li>gnome-boxes</li>
    <li>gnomeExtensions.freon</li>
    <li>gsmartcontrol</li>
    <li>guestfs-tools</li>
    <li>hddfancontrol</li>
    <li>hddfancontrol.dist</li>
    <li>htcondor</li>
    <li>hw-probe</li>
    <li>kdePackages.kpmcore</li>
    <li>kdePackages.kpmcore.debug</li>
    <li>kdePackages.kpmcore.dev</li>
    <li>kdePackages.kpmcore.devtools</li>
    <li>kdePackages.partitionmanager</li>
    <li>kdePackages.partitionmanager.debug</li>
    <li>kdePackages.partitionmanager.dev</li>
    <li>kdePackages.partitionmanager.devtools</li>
    <li>kdePackages.plasma-disks</li>
    <li>kdePackages.plasma-disks.debug</li>
    <li>kdePackages.plasma-disks.dev</li>
    <li>kdePackages.plasma-disks.devtools</li>
    <li>libguestfs</li>
    <li>libguestfs-with-appliance</li>
    <li>librenms</li>
    <li>libsForQt5.kinfocenter</li>
    <li>libsForQt5.partitionmanager</li>
    <li>libvirt</li>
    <li>libvirt-glib</li>
    <li>libvirt-glib.dev</li>
    <li>libvirt-glib.devdoc</li>
    <li>libvmi</li>
    <li>libvmi.dev</li>
    <li>libvmi.lib</li>
    <li>linuxKernel.packages.linux_4_19.zfs (linuxKernel.packages.linux_4_19.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_4_19.zfs_2_1</li>
    <li>linuxKernel.packages.linux_4_19_hardened.zfs (linuxKernel.packages.linux_4_19_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_4_19_hardened.zfs_2_1</li>
    <li>linuxKernel.packages.linux_5_10.zfs (linuxKernel.packages.linux_5_10.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_10.zfs_2_1</li>
    <li>linuxKernel.packages.linux_5_10_hardened.zfs (linuxKernel.packages.linux_5_10_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_10_hardened.zfs_2_1</li>
    <li>linuxKernel.packages.linux_5_15.zfs (linuxKernel.packages.linux_5_15.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_15.zfs_2_1</li>
    <li>linuxKernel.packages.linux_5_15_hardened.zfs (linuxKernel.packages.linux_5_15_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_15_hardened.zfs_2_1</li>
    <li>linuxKernel.packages.linux_5_4.zfs (linuxKernel.packages.linux_5_4.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_4.zfs_2_1</li>
    <li>linuxKernel.packages.linux_5_4_hardened.zfs (linuxKernel.packages.linux_5_4_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_4_hardened.zfs_2_1</li>
    <li>linuxKernel.packages.linux_6_1.zfs (linuxKernel.packages.linux_6_1.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_1.zfs_2_1</li>
    <li>linuxKernel.packages.linux_6_10.zfs (linuxKernel.packages.linux_6_10.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_1_hardened.zfs (linuxKernel.packages.linux_6_1_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_1_hardened.zfs_2_1</li>
    <li>linuxKernel.packages.linux_6_6.zfs (linuxKernel.packages.linux_6_6.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_6.zfs_2_1</li>
    <li>linuxKernel.packages.linux_hardened.zfs (linuxKernel.packages.linux_6_6_hardened.zfs ,linuxKernel.packages.linux_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_hardened.zfs_2_1 (linuxKernel.packages.linux_6_6_hardened.zfs_2_1)</li>
    <li>linuxKernel.packages.linux_libre.zfs (linuxKernel.packages.linux_libre.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_libre.zfs_2_1</li>
    <li>linuxKernel.packages.linux_lqx.zfs (linuxKernel.packages.linux_lqx.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_xanmod.zfs (linuxKernel.packages.linux_xanmod.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_xanmod.zfs_2_1</li>
    <li>linuxKernel.packages.linux_xanmod_latest.zfs (linuxKernel.packages.linux_xanmod_latest.zfs_unstable ,linuxKernel.packages.linux_xanmod_stable.zfs ,linuxKernel.packages.linux_xanmod_stable.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_zen.zfs (linuxKernel.packages.linux_zen.zfs_unstable)</li>
    <li>mgmt</li>
    <li>minikube</li>
    <li>multipass</li>
    <li>nwipe</li>
    <li>ocamlPackages.ocaml_libvirt</li>
    <li>perl536Packages.SysVirt</li>
    <li>perl536Packages.SysVirt.devdoc</li>
    <li>perl538Packages.SysVirt</li>
    <li>perl538Packages.SysVirt.devdoc</li>
    <li>prometheus-smartctl-exporter</li>
    <li>python311Packages.guestfs</li>
    <li>python311Packages.guestfs.dist</li>
    <li>python311Packages.libvirt</li>
    <li>python311Packages.libvirt.dist</li>
    <li>python311Packages.py-libzfs</li>
    <li>python311Packages.py-libzfs.dist</li>
    <li>python311Packages.pysmart</li>
    <li>python311Packages.pysmart.dist</li>
    <li>python312Packages.guestfs</li>
    <li>python312Packages.guestfs.dist</li>
    <li>python312Packages.libvirt</li>
    <li>python312Packages.libvirt.dist</li>
    <li>python312Packages.py-libzfs</li>
    <li>python312Packages.py-libzfs.dist</li>
    <li>python312Packages.pysmart</li>
    <li>python312Packages.pysmart.dist</li>
    <li>qdiskinfo</li>
    <li>qemu_full</li>
    <li>qemu_full.debug</li>
    <li>qemu_full.ga</li>
    <li>quickemu</li>
    <li>rubyPackages.ruby-libvirt</li>
    <li>rubyPackages_3_1.ruby-libvirt</li>
    <li>rubyPackages_3_2.ruby-libvirt</li>
    <li>samba4Full</li>
    <li>samba4Full.dev</li>
    <li>samba4Full.man</li>
    <li>sanoid</li>
    <li>scrutiny-collector</li>
    <li>smartmontools</li>
    <li>snapraid</li>
    <li>tlp</li>
    <li>vagrant</li>
    <li>virt-manager</li>
    <li>virt-manager-qt</li>
    <li>virt-manager.dist</li>
    <li>virt-top</li>
    <li>virt-viewer</li>
    <li>zfs (zfs_unstable)</li>
    <li>zfs.dev (zfs_unstable.dev)</li>
    <li>zfs_2_1</li>
    <li>zfs_2_1.dev</li>
    <li>zfstools</li>
    <li>zpool-auto-expand-partitions</li>
    <li>zxfer</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
