### PR TITLE
treewide: use finalAttrs.finalPackage in testers.testVersion

### DIFF
--- a/pkgs/applications/graphics/komorebi/default.nix
+++ b/pkgs/applications/graphics/komorebi/default.nix
@@ -13,17 +13,16 @@
 , ninja
 , wrapGAppsHook3
 , testers
-, komorebi
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "komorebi";
   version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "Komorebi-Fork";
     repo = "komorebi";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-vER69dSxu4JuWNAADpkxHE/zjOMhQp+Fc21J+JHQ8xk=";
   };
 
@@ -44,7 +43,7 @@ stdenv.mkDerivation rec {
     clutter-gst
   ];
 
-  passthru.tests.version = testers.testVersion { package = komorebi; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     description = "Beautiful and customizable wallpaper manager for Linux";
@@ -53,4 +52,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ kranzes ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -2,7 +2,6 @@
 , pkg-config, gnupg
 , xapian, gmime3, sfsexp, talloc, zlib
 , doxygen, perl, texinfo
-, notmuch
 , pythonPackages
 , emacs
 , ruby
@@ -157,7 +156,7 @@ stdenv.mkDerivation (finalAttrs: {
       paths = with ruby.gems; [ mail ];
       pathsToLink = [ "/lib" "/nix-support" ];
     };
-    tests.version = testers.testVersion { package = notmuch; };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
     updateScript = gitUpdater {
       url = "https://git.notmuchmail.org/git/notmuch";

--- a/pkgs/by-name/al/alephone/package.nix
+++ b/pkgs/by-name/al/alephone/package.nix
@@ -28,7 +28,6 @@
   unzip,
   zlib,
   zziplib,
-  alephone,
   testers,
 }:
 
@@ -94,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests.version =
     # test that the version is correct
-    testers.testVersion { package = alephone; };
+    testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = {
     description = "Aleph One is the open source continuation of Bungie’s Marathon 2 game engine";
@@ -112,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
       version,
       zip,
       meta,
-      icon ? alephone.icons + "/alephone.png",
+      icon ? finalAttrs.finalPackage.icons + "/alephone.png",
       ...
     }@extraArgs:
     stdenv.mkDerivation (
@@ -142,14 +141,14 @@ stdenv.mkDerivation (finalAttrs: {
           mkdir -p $out/bin $out/data/$pname $out/share/applications
           cp -a * $out/data/$pname
           cp $desktopItem/share/applications/* $out/share/applications
-          makeWrapper ${alephone}/bin/alephone $out/bin/$pname \
+          makeWrapper ${finalAttrs.finalPackage}/bin/alephone $out/bin/$pname \
             --add-flags $out/data/$pname
         '';
       }
       // extraArgs
       // {
         meta =
-          alephone.meta
+          finalAttrs.finalPackage.meta
           // {
             license = lib.licenses.free;
             mainProgram = pname;

--- a/pkgs/by-name/du/dunst/package.nix
+++ b/pkgs/by-name/du/dunst/package.nix
@@ -23,7 +23,6 @@
 , xorgproto
 , librsvg
 , testers
-, dunst
 , withX11 ? true
 , withWayland ? true
 }:
@@ -89,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "jq" "${lib.getExe jq}"
   '';
 
-  passthru.tests.version = testers.testVersion { package = dunst; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     description = "Lightweight and customizable notification daemon";

--- a/pkgs/by-name/io/ios-webkit-debug-proxy/package.nix
+++ b/pkgs/by-name/io/ios-webkit-debug-proxy/package.nix
@@ -13,7 +13,6 @@
   libusb1,
   openssl,
 
-  ios-webkit-debug-proxy,
   nix-update-script,
   testers,
 }:
@@ -61,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = ios-webkit-debug-proxy; };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/lg/lgogdownloader/package.nix
+++ b/pkgs/by-name/lg/lgogdownloader/package.nix
@@ -15,19 +15,18 @@
   html-tidy,
   libsForQt5,
   testers,
-  lgogdownloader,
 
   enableGui ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lgogdownloader";
   version = "3.15";
 
   src = fetchFromGitHub {
     owner = "Sude-";
     repo = "lgogdownloader";
-    rev = "refs/tags/v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-h2N5pRwwZZ3jAvRrT4Ebk4N5WO9tQjDrp8KRqriwUi4=";
   };
 
@@ -56,7 +55,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = lib.optional enableGui "-DUSE_QT_GUI=ON";
 
   passthru.tests = {
-    version = testers.testVersion { package = lgogdownloader; };
+    version = testers.testVersion { package = finalAttrs.finalPackage; };
   };
 
   meta = {
@@ -67,4 +66,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ _0x4A6F ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -7,7 +7,6 @@
   overrideSDK,
   pnpm_9,
   python3,
-  renovate,
   testers,
   xcbuild,
   nixosTests,
@@ -91,7 +90,7 @@ stdenv'.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
-      version = testers.testVersion { package = renovate; };
+      version = testers.testVersion { package = finalAttrs.finalPackage; };
       vm-test = nixosTests.renovate;
     };
     updateScript = nix-update-script { };

--- a/pkgs/by-name/un/undetected-chromedriver/package.nix
+++ b/pkgs/by-name/un/undetected-chromedriver/package.nix
@@ -6,10 +6,9 @@
   python3,
 
   testers,
-  undetected-chromedriver,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "undetected-chromedriver";
   inherit (chromedriver) version;
 
@@ -34,11 +33,11 @@ stdenv.mkDerivation {
     install -D -m 0555 chromedriver $out/bin/undetected-chromedriver
   '';
 
-  passthru.tests.version = testers.testVersion { package = undetected-chromedriver; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = chromedriver.meta // {
     description = "Custom Selenium ChromeDriver that passes all bot mitigation systems";
     mainProgram = "undetected-chromedriver";
     maintainers = with lib.maintainers; [ paveloom ];
   };
-}
+})

--- a/pkgs/by-name/vi/violet/package.nix
+++ b/pkgs/by-name/vi/violet/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   nix-update-script,
   stdenv,
-  violet,
   testers,
 }:
 
@@ -24,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
-    tests = testers.testVersion { package = violet; };
+    tests = testers.testVersion { package = finalAttrs.finalPackage; };
   };
 
   meta = {

--- a/pkgs/by-name/ya/yandex-cloud/package.nix
+++ b/pkgs/by-name/ya/yandex-cloud/package.nix
@@ -12,14 +12,13 @@
   nix,
   # tests
   testers,
-  yandex-cloud,
 }:
 let
   pname = "yandex-cloud";
   sources = lib.importJSON ./sources.json;
   inherit (sources) version binaries;
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname version;
 
   src = fetchurl binaries.${stdenv.hostPlatform.system};
@@ -68,7 +67,7 @@ stdenv.mkDerivation {
         (lib.makeBinPath [ nix ])
       ];
     } ./update.py;
-    tests.version = testers.testVersion { package = yandex-cloud; };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
   };
 
   meta = {
@@ -96,4 +95,4 @@ stdenv.mkDerivation {
     ];
     mainProgram = "yc";
   };
-}
+})

--- a/pkgs/development/libraries/magic-enum/default.nix
+++ b/pkgs/development/libraries/magic-enum/default.nix
@@ -4,7 +4,6 @@
 , cmake
 , nix-update-script
 , testers
-, magic-enum
 }:
 stdenv.mkDerivation rec{
   pname = "magic-enum";
@@ -29,7 +28,6 @@ stdenv.mkDerivation rec{
 
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = magic-enum; };
   };
 
   meta = {

--- a/pkgs/development/tools/detekt/default.nix
+++ b/pkgs/development/tools/detekt/default.nix
@@ -1,12 +1,12 @@
-{ detekt, lib, stdenv, fetchurl, makeWrapper, jre_headless, testers }:
-stdenv.mkDerivation rec {
+{ lib, stdenv, fetchurl, makeWrapper, jre_headless, testers }:
+stdenv.mkDerivation (finalAttrs: {
   pname = "detekt";
   version = "1.23.7";
 
-  jarfilename = "${pname}-${version}-executable.jar";
+  jarfilename = "detekt-${finalAttrs.version}-executable.jar";
 
   src = fetchurl {
-    url = "https://github.com/detekt/detekt/releases/download/v${version}/detekt-cli-${version}-all.jar";
+    url = "https://github.com/detekt/detekt/releases/download/v${finalAttrs.version}/detekt-cli-${finalAttrs.version}-all.jar";
     sha256 = "sha256-hL7e0oMBLLKzi8rvSZZFL81gadLpynS1Dqp54K0hiX4=";
   };
 
@@ -17,15 +17,15 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -D "$src" "$out/share/java/${jarfilename}"
+    install -D "$src" "$out/share/java/${finalAttrs.jarfilename}"
 
     makeWrapper ${jre_headless}/bin/java $out/bin/detekt \
-      --add-flags "-jar $out/share/java/${jarfilename}"
+      --add-flags "-jar $out/share/java/${finalAttrs.jarfilename}"
 
     runHook postInstall
   '';
 
-  passthru.tests.version = testers.testVersion { package = detekt; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     description = "Static code analysis for Kotlin";
@@ -36,4 +36,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ mdr ];
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
   };
-}
+})

--- a/pkgs/development/tools/infisical/default.nix
+++ b/pkgs/development/tools/infisical/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, testers, infisical, installShellFiles }:
+{ stdenv, lib, fetchurl, testers, installShellFiles }:
 
 # this expression is mostly automated, and you are STRONGLY
 # RECOMMENDED to use to nix-update for updating this expression when new
@@ -36,7 +36,7 @@ let
     fetchurl { inherit name url hash; };
 
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "infisical";
   version = version;
   inherit src;
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
 
   passthru = {
     updateScript = ./update.sh;
-    tests.version = testers.testVersion { package = infisical; };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
   };
 
   meta = with lib; {
@@ -84,4 +84,4 @@ stdenv.mkDerivation {
       "x86_64-darwin"
     ];
   };
-}
+})

--- a/pkgs/development/tools/packcc/default.nix
+++ b/pkgs/development/tools/packcc/default.nix
@@ -2,21 +2,20 @@
   bats,
   fetchFromGitHub,
   lib,
-  packcc,
   python3,
   stdenv,
   testers,
   uncrustify,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "packcc";
   version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "arithy";
     repo = "packcc";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-k1C/thvr/5fYrgu/j8YN3kwXp4k26sC9AhYhYAKQuX0=";
   };
 
@@ -61,7 +60,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.tests.version = testers.testVersion { package = packcc; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     description = "Parser generator for C";
@@ -72,10 +71,10 @@ stdenv.mkDerivation rec {
       - Supports direct and indirect left-recursive grammar rules.
     '';
     homepage = "https://github.com/arithy/packcc";
-    changelog = "https://github.com/arithy/packcc/releases/tag/${src.rev}";
+    changelog = "https://github.com/arithy/packcc/releases/tag/${finalAttrs.src.rev}";
     license = licenses.mit;
     maintainers = with maintainers; [ azahi ];
     platforms = platforms.unix;
     mainProgram = "packcc";
   };
-}
+})

--- a/pkgs/misc/drivers/infnoise/default.nix
+++ b/pkgs/misc/drivers/infnoise/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, libftdi
-, infnoise, testers }:
+, testers }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "infnoise";
   version = "0.3.2";
 
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  GIT_COMMIT = src.rev;
-  GIT_VERSION = version;
+  GIT_COMMIT = finalAttrs.src.rev;
+  GIT_VERSION = finalAttrs.version;
   GIT_DATE = "2019-08-12";
 
   buildInputs = [ libftdi ];
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    tests.version = testers.testVersion { package = infnoise; };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
   };
 
   meta = with lib; {
@@ -57,4 +57,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ StijnDW zhaofengli ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/servers/photoprism/default.nix
+++ b/pkgs/servers/photoprism/default.nix
@@ -1,4 +1,5 @@
-{ pkgs, lib, stdenv, fetchFromGitHub, fetchzip, darktable, rawtherapee, ffmpeg_7, libheif, exiftool, imagemagick, makeWrapper, testers
+{ lib, stdenv, fetchFromGitHub, fetchzip, darktable, rawtherapee, ffmpeg_7, libheif, exiftool, imagemagick, makeWrapper, testers
+, callPackage
 , nixosTests
 , librsvg }:
 
@@ -13,9 +14,9 @@ let
     hash = "sha256-ihDv5c5RUjDbFcAHJjzp/8qCwKfA+rlFXPziaYarzs8=";
   };
 
-  libtensorflow = pkgs.callPackage ./libtensorflow.nix { };
-  backend = pkgs.callPackage ./backend.nix { inherit libtensorflow src version; };
-  frontend = pkgs.callPackage ./frontend.nix { inherit src version; };
+  libtensorflow = callPackage ./libtensorflow.nix { };
+  backend = callPackage ./backend.nix { inherit libtensorflow src version; };
+  frontend = callPackage ./frontend.nix { inherit src version; };
 
   fetchModel = { name, hash }:
     fetchzip {
@@ -41,7 +42,7 @@ let
 
   assets_path = "$out/share/${pname}";
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname version;
 
   nativeBuildInputs = [
@@ -78,7 +79,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.tests.version = testers.testVersion { package = pkgs.photoprism; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
   passthru.tests.photoprism = nixosTests.photoprism;
 
   meta = with lib; {
@@ -89,4 +90,4 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ benesim ];
     mainProgram = "photoprism";
   };
-}
+})

--- a/pkgs/tools/misc/datefmt/default.nix
+++ b/pkgs/tools/misc/datefmt/default.nix
@@ -1,17 +1,17 @@
-{ lib, stdenv, fetchurl, datefmt, testers }:
+{ lib, stdenv, fetchurl, testers }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "datefmt";
   version = "0.2.2";
 
   src = fetchurl {
-    url = "https://cdn.jb55.com/tarballs/datefmt/datefmt-${version}.tar.gz";
+    url = "https://cdn.jb55.com/tarballs/datefmt/datefmt-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-HgW/vOGVEmAbm8k3oIwIa+cogq7qmX7MfTmHqxv9lhY=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  passthru.tests.version = testers.testVersion { package = datefmt; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     homepage = "https://jb55.com/datefmt";
@@ -21,4 +21,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ jb55 ];
     mainProgram = "datefmt";
   };
-}
+})

--- a/pkgs/tools/misc/gummy/default.nix
+++ b/pkgs/tools/misc/gummy/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitea
 , testers
-, gummy
 , cmake
 , libX11
 , libXext
@@ -17,7 +16,7 @@
 , spdlog
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gummy";
   version = "0.6.0";
 
@@ -25,7 +24,7 @@ stdenv.mkDerivation rec {
     domain = "codeberg.org";
     owner = "fusco";
     repo = "gummy";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-kATieFf+dEpcYgSEPoETacP7R+u2dOrg7rOhIkNQ1uE=";
   };
 
@@ -65,7 +64,7 @@ stdenv.mkDerivation rec {
     ln -s $out/libexec/gummyd $out/bin/gummyd
   '';
 
-  passthru.tests.version = testers.testVersion { package = gummy; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     homepage = "https://codeberg.org/fusco/gummy";
@@ -77,4 +76,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/tools/networking/pmacct/default.nix
+++ b/pkgs/tools/networking/pmacct/default.nix
@@ -14,17 +14,16 @@
 , withMysql ? true, libmysqlclient, zlib, numactl
 , gnutlsSupport ? false, gnutls
 , testers
-, pmacct
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "1.7.9";
   pname = "pmacct";
 
   src = fetchFromGitHub {
     owner = "pmacct";
     repo = "pmacct";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-3gV6GUhTQnH09NRIJQI0xBn05Bgo3AJsE2cSxNPXITo=";
   };
 
@@ -55,7 +54,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional gnutlsSupport "--enable-gnutls";
 
   passthru.tests = {
-    version = testers.testVersion { package = pmacct; command = "pmacct -V"; };
+    version = testers.testVersion { package = finalAttrs.finalPackage; command = "pmacct -V"; };
   };
 
   meta = with lib; {
@@ -70,4 +69,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ _0x4A6F ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/tools/security/dieharder/default.nix
+++ b/pkgs/tools/security/dieharder/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchurl, gsl
-, dieharder, testers }:
+, testers }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dieharder";
   version = "3.31.1";
 
   src = fetchurl {
-    url = "http://webhome.phy.duke.edu/~rgb/General/dieharder/dieharder-${version}.tgz";
+    url = "http://webhome.phy.duke.edu/~rgb/General/dieharder/dieharder-${finalAttrs.version}.tgz";
     hash = "sha256-bP8P+DlMVTVJrHQzNZzPyVX7JnlCYDFGIN+l5M1Lcn8=";
   };
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gsl ];
 
   passthru = {
-    tests.version = testers.testVersion { package = dieharder; };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
   };
 
   meta = with lib; {
@@ -34,4 +34,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ zhaofengli ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/tools/security/donkey/default.nix
+++ b/pkgs/tools/security/donkey/default.nix
@@ -4,20 +4,19 @@
 , coreutils
 , lib
 , testers
-, donkey
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "donkey";
   version = "1.2.0";
 
   src = fetchFromGitLab {
     owner = "donkey";
     repo = "donkey";
-    rev = "tags/release/${version}";
+    rev = "tags/release/${finalAttrs.version}";
     hash = "sha256-2xgb9l0Eko39HJVROAWEIP3qLg5t/5h/rm2MoXoKnJI=";
   };
-  sourceRoot = "${src.name}/src";
+  sourceRoot = "${finalAttrs.src.name}/src";
 
   buildInputs = [ libmd ];
 
@@ -27,7 +26,7 @@ stdenv.mkDerivation rec {
     export INSTALL_DATA="${coreutils}/bin/install -m 444"
   '';
 
-  passthru.tests.version = testers.testVersion { package = donkey; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     description = "Alternative for S/KEY's 'key' command";
@@ -51,4 +50,4 @@ The name "Donkey" is an acronym of "Don't Key".
     maintainers = with maintainers; [ raboof ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/tools/text/crowdin-cli/default.nix
+++ b/pkgs/tools/text/crowdin-cli/default.nix
@@ -7,17 +7,16 @@
 , installShellFiles
 , jre
 , makeWrapper
-, crowdin-cli
 , testers
 , unzip
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "crowdin-cli";
   version = "4.2.0";
 
   src = fetchurl {
-    url = "https://github.com/crowdin/${pname}/releases/download/${version}/${pname}.zip";
+    url = "https://github.com/crowdin/crowdin-cli/releases/download/${finalAttrs.version}/crowdin-cli.zip";
     hash = "sha256-158zbgYw4FP/vQVsSs9tt9VcisBWpRn/D4ORiM24PYY=";
   };
 
@@ -38,7 +37,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.tests.version = testers.testVersion { package = crowdin-cli; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     mainProgram = "crowdin";
@@ -48,4 +47,4 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ DamienCassou ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

candidates were located using `rg -F 'testers.testVersion { package =' | grep -v finalAttrs | cut -d: -f1 | xargs grep -E '(buildRustPackage|buildGoModule)' -L | xargs grep mkDerivation -l`

There are surprisingly many examples of `finalAttrs` migrations that don't change `testers.testVersion`

should be 0 rebuilds

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
