### PR TITLE
sqruff: init at 0.17.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8401,6 +8401,13 @@
     githubId = 33969028;
     name = "Sebastian Hasler";
   };
+  hasnep = {
+    name = "Hannes";
+    email = "h@nnes.dev";
+    matrix = "@hasnep:matrix.org";
+    github = "Hasnep";
+    githubId = 25184102;
+  };
   hausken = {
     name = "Hausken";
     email = "hauskens-git@disp.lease>";

--- a/pkgs/by-name/sq/sqruff/package.nix
+++ b/pkgs/by-name/sq/sqruff/package.nix
@@ -7,8 +7,7 @@
   darwin,
   rust-jemalloc-sys,
   nix-update-script,
-  testers,
-  sqruff,
+  versionCheckHook,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "sqruff";
@@ -40,9 +39,12 @@ rustPlatform.buildRustPackage rec {
       'config.program.program = "../../target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/sqruff".into();'
   '';
 
+  nativeCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = sqruff; };
   };
 
   meta = {

--- a/pkgs/by-name/sq/sqruff/package.nix
+++ b/pkgs/by-name/sq/sqruff/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+  darwin,
+  rust-jemalloc-sys,
+  nix-update-script,
+  testers,
+  sqruff,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "sqruff";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "quarylabs";
+    repo = "sqruff";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-uUtbVf4U59jne5uORXpyzpqhFQoviKi2O9KQ5s1CfhU=";
+  };
+
+  cargoHash = "sha256-kIBjPh+rL4vzIAqGNYMpw39A0vADbHxi/PkhoG+QL6c=";
+
+  # Requires nightly features (feature(let_chains) and feature(trait_upcasting))
+  RUSTC_BOOTSTRAP = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [
+    rust-jemalloc-sys
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.CoreServices ];
+
+  # Patch the tests to find the binary
+  postPatch = ''
+    substituteInPlace crates/cli/tests/ui.rs \
+      --replace-fail \
+      'config.program.program = format!("../../target/{profile}/sqruff").into();' \
+      'config.program.program = "../../target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/sqruff".into();'
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = sqruff; };
+  };
+
+  meta = {
+    description = "Fast SQL formatter/linter";
+    homepage = "https://github.com/quarylabs/sqruff";
+    changelog = "https://github.com/quarylabs/sqruff/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    mainProgram = "sqruff";
+    maintainers = with lib.maintainers; [ hasnep ];
+  };
+}


### PR DESCRIPTION
## Description of changes

[sqruff](https://github.com/quarylabs/sqruff) is a fast SQL linter and formatter.

fix https://github.com/NixOS/nixpkgs/issues/336098

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
