### PR TITLE
pre-commit: fix import bug for built-in hooks

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -1,18 +1,19 @@
-{ lib
-, fetchFromGitHub
-, python3Packages
-, libiconv
-, cargo
-, coursier
-, dotnet-sdk
-, git
-, glibcLocales
-, go
-, nodejs
-, perl
-, cabal-install
-, testers
-, pre-commit
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  libiconv,
+  cargo,
+  coursier,
+  dotnet-sdk,
+  git,
+  glibcLocales,
+  go,
+  nodejs,
+  perl,
+  cabal-install,
+  testers,
+  pre-commit,
 }:
 
 with python3Packages;
@@ -81,24 +82,26 @@ buildPythonApplication rec {
     "--forked"
   ];
 
-  preCheck = lib.optionalString (!(stdenv.isLinux && stdenv.isAarch64)) ''
-    # Disable outline atomics for rust tests on aarch64-linux.
-    export RUSTFLAGS="-Ctarget-feature=-outline-atomics"
-  '' + ''
-    export GIT_AUTHOR_NAME=test GIT_COMMITTER_NAME=test \
-           GIT_AUTHOR_EMAIL=test@example.com GIT_COMMITTER_EMAIL=test@example.com \
-           VIRTUALENV_NO_DOWNLOAD=1 PRE_COMMIT_NO_CONCURRENCY=1 LANG=en_US.UTF-8
+  preCheck =
+    lib.optionalString (!(stdenv.isLinux && stdenv.isAarch64)) ''
+      # Disable outline atomics for rust tests on aarch64-linux.
+      export RUSTFLAGS="-Ctarget-feature=-outline-atomics"
+    ''
+    + ''
+      export GIT_AUTHOR_NAME=test GIT_COMMITTER_NAME=test \
+             GIT_AUTHOR_EMAIL=test@example.com GIT_COMMITTER_EMAIL=test@example.com \
+             VIRTUALENV_NO_DOWNLOAD=1 PRE_COMMIT_NO_CONCURRENCY=1 LANG=en_US.UTF-8
 
-    # Resolve `.NET location: Not found` errors for dotnet tests
-    export DOTNET_ROOT="${dotnet-sdk}"
+      # Resolve `.NET location: Not found` errors for dotnet tests
+      export DOTNET_ROOT="${dotnet-sdk}"
 
-    export HOME=$(mktemp -d)
+      export HOME=$(mktemp -d)
 
-    git init -b master
+      git init -b master
 
-    python -m venv --system-site-packages venv
-    source "$PWD/venv/bin/activate"
-  '';
+      python -m venv --system-site-packages venv
+      source "$PWD/venv/bin/activate"
+    '';
 
   postCheck = ''
     deactivate

--- a/pkgs/tools/misc/pre-commit/system-hooks-use-calling-environment-paths.patch
+++ b/pkgs/tools/misc/pre-commit/system-hooks-use-calling-environment-paths.patch
@@ -1,0 +1,94 @@
+diff --git a/pre_commit/all_languages.py b/pre_commit/all_languages.py
+index 476bad9..742172a 100644
+--- a/pre_commit/all_languages.py
++++ b/pre_commit/all_languages.py
+@@ -21,6 +21,7 @@ from pre_commit.languages import rust
+ from pre_commit.languages import script
+ from pre_commit.languages import swift
+ from pre_commit.languages import system
++from pre_commit.languages import meta
+ 
+ 
+ languages: dict[str, Language] = {
+@@ -44,6 +45,7 @@ languages: dict[str, Language] = {
+     'script': script,
+     'swift': swift,
+     'system': system,
++    'meta': meta,
+     # TODO: fully deprecate `python_venv`
+     'python_venv': python,
+ }
+diff --git a/pre_commit/clientlib.py b/pre_commit/clientlib.py
+index d0651ca..008307b 100644
+--- a/pre_commit/clientlib.py
++++ b/pre_commit/clientlib.py
+@@ -265,8 +265,8 @@ META_HOOK_DICT = cfgv.Map(
+     'Hook', 'id',
+     cfgv.Required('id', cfgv.check_string),
+     cfgv.Required('id', cfgv.check_one_of(tuple(k for k, _ in _meta))),
+-    # language must be system
+-    cfgv.Optional('language', cfgv.check_one_of({'system'}), 'system'),
++    # language must be meta
++    cfgv.Optional('language', cfgv.check_one_of({'meta'}), 'meta'),
+     # entry cannot be overridden
+     NotAllowed('entry', cfgv.check_any),
+     *(
+diff --git a/pre_commit/lang_base.py b/pre_commit/lang_base.py
+index 4a993ea..eba8f3e 100644
+--- a/pre_commit/lang_base.py
++++ b/pre_commit/lang_base.py
+@@ -130,6 +130,27 @@ def no_install(
+ def no_env(prefix: Prefix, version: str) -> Generator[None, None, None]:
+     yield
+ 
++@contextlib.contextmanager
++def outer_env(prefix: Prefix, version: str) -> Generator[None, None, None]:
++
++
++    # access the non-nix-modified environment
++    # which was captured pre-modifications by the wrapper script
++    # which was configured by the postFixup hook here:
++    # nixpkgs/pkgs/tools/misc/pre-commit/default.nix
++    backups = {}
++    for var in ["PATH", "PYTHONPATH"]:
++        val = os.environ.get(var)
++        outer_val = os.environ.get("OUTER_" + var)
++        if outer_val:
++            backups[var] = val
++            os.environ[var] = outer_val
++
++    yield
++
++    # restore the nix-modified environment
++    for k, v in backups.items():
++        os.environ[k] = v
+ 
+ def target_concurrency() -> int:
+     if 'PRE_COMMIT_NO_CONCURRENCY' in os.environ:
+diff --git a/pre_commit/languages/meta.py b/pre_commit/languages/meta.py
+new file mode 100644
+index 0000000..f6ad688
+--- /dev/null
++++ b/pre_commit/languages/meta.py
+@@ -0,0 +1,10 @@
++from __future__ import annotations
++
++from pre_commit import lang_base
++
++ENVIRONMENT_DIR = None
++get_default_version = lang_base.basic_get_default_version
++health_check = lang_base.basic_health_check
++install_environment = lang_base.no_install
++in_env = lang_base.no_env
++run_hook = lang_base.basic_run_hook
+diff --git a/pre_commit/languages/system.py b/pre_commit/languages/system.py
+index f6ad688..d8237e7 100644
+--- a/pre_commit/languages/system.py
++++ b/pre_commit/languages/system.py
+@@ -6,5 +6,5 @@ ENVIRONMENT_DIR = None
+ get_default_version = lang_base.basic_get_default_version
+ health_check = lang_base.basic_health_check
+ install_environment = lang_base.no_install
+-in_env = lang_base.no_env
++in_env = lang_base.outer_env
+ run_hook = lang_base.basic_run_hook

--- a/pkgs/tools/misc/pre-commit/tests.nix
+++ b/pkgs/tools/misc/pre-commit/tests.nix
@@ -1,0 +1,45 @@
+{
+  git,
+  pre-commit,
+  runCommand,
+  testers,
+}:
+{
+  check-meta-hooks =
+    runCommand "check-meta-hooks"
+      {
+        nativeBuildInputs = [
+          git
+          pre-commit
+        ];
+      }
+      ''
+        cd "$(mktemp --directory)"
+        export HOME="$PWD"
+        cat << 'EOF' > .pre-commit-config.yaml
+        repos:
+          - repo: local
+            hooks:
+              - id: echo
+                name: echo
+                entry: echo
+                files: \.yaml$
+                language: system
+          - repo: meta
+            hooks:
+              - id: check-hooks-apply
+              - id: check-useless-excludes
+              - id: identity
+        EOF
+        git config --global user.email "you@example.com"
+        git config --global user.name "Your Name"
+        git init --initial-branch=main
+        git add .
+        pre-commit run --all-files
+        touch $out
+      '';
+
+  version = testers.testVersion {
+    package = pre-commit;
+  };
+}


### PR DESCRIPTION
## Description of changes

Pre-commit's "system" language is a sort of escape hach from the encapsulation which pre-commit typically provides.  It just runs commands without thinking too hard about setting up or tearing down environments.

But it is used for two things: user-provided hooks which reference things in calling environment, and pre-commit-provided hooks which live in the pre-commit package (I'm calling these "meta" hooks).

The challenge becomes: which PATH and PYTHONPATH variables do we expose to pre-commit?  If it's the calling environment, the meta hooks break, and if it's the packaged environment, the external-facing system hooks break.

In order to make both of these work at the same time, this commit separates 'system' into two languages: 'system', and 'meta'. System hooks get access to the calling environment, and meta hooks get access to the packaged environment.

## Things done

Rebase #251418 with https://github.com/MatrixManAtYrService/nixpkgs/pull/1 on top of current master, which seems to fix the [broken builds](https://github.com/NixOS/nixpkgs/pull/251418/#issuecomment-2085337473):

```console
❯ nix-build --attr pre-commit --attr python311Packages.asteroid-filterbanks --attr python311Packages.pyannote-audio
/nix/store/9gj7wz6nvs66cxhbaxynyx3hynn4ch48-pre-commit-3.7.1
/nix/store/6fy6mkv761aynq1sbxbn3ms99q4ix3qs-python3.11-asteroid-filterbanks-0.4.0
/nix/store/mz50n7jy8zvcqvy5yy2dkp4676rdd74j-python3.11-pyannote-audio-3.3.0
```

Verify that this fixes the issue with the `check-useless-excludes` meta-hook:

```console
❯ cd [other project]
❯ ~/my\ projects/nixpkgs/result/bin/pre-commit run --all-files
Check for useless excludes...............................................Passed
```

Format the Nix files using `nixfmt-rfc-style`.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
