### PR TITLE
test/release: do not add `.git` to the store

### DIFF
--- a/pkgs/test/release/default.nix
+++ b/pkgs/test/release/default.nix
@@ -19,13 +19,13 @@ pkgs.runCommand "all-attrs-eval-under-tryEval" {
   src = with lib.fileset; toSource {
     root = pkgs-path;
     fileset = unions [
-      ./default.nix
-      ./doc
-      ./lib
-      ./maintainers
-      ./nixos
-      ./pkgs
-      ./.version
+      ../../../default.nix
+      ../../../doc
+      ../../../lib
+      ../../../maintainers
+      ../../../nixos
+      ../../../pkgs
+      ../../../.version
     ];
   };
 }

--- a/pkgs/test/release/default.nix
+++ b/pkgs/test/release/default.nix
@@ -15,6 +15,19 @@ pkgs.runCommand "all-attrs-eval-under-tryEval" {
     pkgs.gitMinimal
   ] ++ lib.optional pkgs.stdenv.isLinux pkgs.inotify-tools;
   strictDeps = true;
+
+  src = with lib.fileset; toSource {
+    root = pkgs-path;
+    fileset = unions [
+      ./default.nix
+      ./doc
+      ./lib
+      ./maintainers
+      ./nixos
+      ./pkgs
+      ./.version
+    ];
+  };
 }
 ''
   datadir="${nix}/share"
@@ -31,15 +44,8 @@ pkgs.runCommand "all-attrs-eval-under-tryEval" {
 
   nix-store --init
 
-  cp -r ${pkgs-path}/lib lib
-  cp -r ${pkgs-path}/pkgs pkgs
-  cp -r ${pkgs-path}/default.nix default.nix
-  cp -r ${pkgs-path}/nixos nixos
-  cp -r ${pkgs-path}/maintainers maintainers
-  cp -r ${pkgs-path}/.version .version
-  cp -r ${pkgs-path}/doc doc
   echo "Running pkgs/top-level/release-attrpaths-superset.nix"
-  nix-instantiate --eval --strict --json pkgs/top-level/release-attrpaths-superset.nix -A names > /dev/null
+  nix-instantiate --eval --strict --json $src/pkgs/top-level/release-attrpaths-superset.nix -A names > /dev/null
 
   mkdir $out
   echo success > $out/${nix.version}


### PR DESCRIPTION
## Description of changes

`pkgs/test/release` copied all of nixpkgs (including `.git`) to the store, then copies a desired subset from the store into its working directory.

- [x] Use `lib.fileset` to only copy the desired contents to the store
  excluding `.git` alone saves 5 GiB per invocation
- [x] Run `nix-instantiate` against store's version, rather than copying it again into the working directory.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - `nix-build pkgs/tests/release`
  - `nix-build lib/tests/release.nix`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
