### PR TITLE
haskell.compiler.ghc9*: fix rpath on aarch64

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -444,6 +444,12 @@ stdenv.mkDerivation (rec {
   # For building runtime libs
   depsBuildTarget = toolsForTarget;
 
+  # Prevent stage0 ghc from leaking into the final result. This was an issue
+  # with GHC 9.6.
+  disallowedReferences = [
+    bootPkgs.ghc
+  ];
+
   buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
 
   depsTargetTarget = map lib.getDev (libDeps targetPlatform);

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -557,6 +557,12 @@ stdenv.mkDerivation ({
     ncurses
   ];
 
+  # Prevent stage0 ghc from leaking into the final result. This was an issue
+  # with GHC 9.6.
+  disallowedReferences = [
+    bootPkgs.ghc
+  ];
+
   buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
 
   depsTargetTarget = map lib.getDev (libDeps targetPlatform);

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -462,6 +462,12 @@ stdenv.mkDerivation (rec {
   # For building runtime libs
   depsBuildTarget = toolsForTarget;
 
+  # Prevent stage0 ghc from leaking into the final result. This was an issue
+  # with GHC 9.6.
+  disallowedReferences = [
+    bootPkgs.ghc
+  ];
+
   buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
 
   depsTargetTarget = map lib.getDev (libDeps targetPlatform);

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -270,6 +270,11 @@ in {
           bb.packages.ghc928
         else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
           bb.packages.ghc928
+        else if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isLinux then
+          # For unknown reasons, compiling with a bindist GHC causes the final
+          # GHC's rpaths to contain the boot compiler on aarch64-linux / GHC 9.6.*.
+          # Note: Unclear if this is due to host or build aarch64-linux.
+          bb.packages.ghc928
         else
           bb.packages.ghc924Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -287,6 +292,11 @@ in {
         if stdenv.buildPlatform.isAarch32 then
           bb.packages.ghc928
         else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
+          bb.packages.ghc928
+        else if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isLinux then
+          # For unknown reasons, compiling with a bindist GHC causes the final
+          # GHC's rpaths to contain the boot compiler on aarch64-linux / GHC 9.6.*.
+          # Note: Unclear if this is due to host or build aarch64-linux.
           bb.packages.ghc928
         else
           bb.packages.ghc924Binary;
@@ -306,6 +316,11 @@ in {
           bb.packages.ghc928
         else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
           bb.packages.ghc928
+        else if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isLinux then
+          # For unknown reasons, compiling with a bindist GHC causes the final
+          # GHC's rpaths to contain the boot compiler on aarch64-linux / GHC 9.6.*.
+          # Note: Unclear if this is due to host or build aarch64-linux.
+          bb.packages.ghc928
         else
           bb.packages.ghc924Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -323,6 +338,11 @@ in {
         if stdenv.buildPlatform.isAarch32 then
           bb.packages.ghc928
         else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
+          bb.packages.ghc928
+        else if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isLinux then
+          # For unknown reasons, compiling with a bindist GHC causes the final
+          # GHC's rpaths to contain the boot compiler on aarch64-linux / GHC 9.6.*.
+          # Note: Unclear if this is due to host or build aarch64-linux.
           bb.packages.ghc928
         else
           bb.packages.ghc924Binary;


### PR DESCRIPTION
## Description of changes

Fix a regression reported in #339272. See the commit message for details.

I'm not sure about which approach to take to update the compiler. I see the following possibilities:

* Change to `ghc928`.
* Add a `ghc928Binary` and use that instead (maybe even for other platforms?)

I chose the first approach here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (binfmt emulation)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
