### PR TITLE
tlclient: init at 4.17.0

### DIFF
--- a/pkgs/by-name/tl/tlclient/package.nix
+++ b/pkgs/by-name/tl/tlclient/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  alsa-lib,
+  libX11,
+  pcsclite,
+  testers,
+}:
+
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    version = "4.17.0";
+    buildNum = "3543";
+  in
+  {
+    pname = "tlclient";
+    version = "${version}-${buildNum}";
+
+    src = fetchurl {
+      url = "https://www.cendio.com/downloads/clients/tl-${finalAttrs.version}-client-linux-dynamic-x86_64.tar.gz";
+      hash = "sha256-7pl97xGNFwSDpWMpBvkz/bfMsWquVsJVGB+feWJvRQY=";
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+    ];
+
+    buildInputs = [
+      alsa-lib
+      libX11
+      pcsclite
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      cp -R lib "$out/"
+      cp -R lib/tlclient/share "$out/"
+
+      install -Dm644 "lib/tlclient/EULA.txt" "$out/share/licenses/tlclient/EULA.txt"
+      install -m644 "lib/tlclient/open_source_licenses.txt" "$out/share/licenses/tlclient/open_source_licenses.txt"
+      substituteInPlace "$out/share/applications/thinlinc-client.desktop" \
+        --replace-fail "/opt/thinlinc/bin/" ""
+
+      install -Dm644 "etc/tlclient.conf" "$out/etc/tlclient.conf"
+      install -Dm755 bin/tlclient* -t "$out/bin"
+      install -Dm644 "lib/tlclient/thinlinc_128.png" "$out/share/icons/hicolor/128x128/apps/thinlinc-client.png"
+
+      runHook postInstall
+    '';
+
+    passthru.tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      version = "${version} build ${buildNum}";
+    };
+
+    meta = {
+      description = "Linux remote desktop client built on open source technology";
+      license = {
+        fullName = "Cendio End User License Agreement 3.2";
+        url = "https://www.cendio.com/thinlinc/docs/legal/eula";
+        free = false;
+      };
+      homepage = "https://www.cendio.com/";
+      changelog = "https://www.cendio.com/thinlinc/docs/relnotes/${version}/";
+      maintainers = with lib.maintainers; [ felixalbrigtsen ];
+      platforms = with lib.platforms; linux ++ darwin ++ windows;
+      broken = !(stdenv.isLinux && stdenv.isx86_64);
+      mainProgram = "tlclient";
+    };
+  }
+)


### PR DESCRIPTION
## Description of changes

Adds a new package, `tlclient`, the client application for [ThinLinc](https://www.cendio.com/).

Heavily based on https://github.com/NixOS/nixpkgs/pull/293173.

[Since then](https://github.com/NixOS/nixpkgs/pull/342516/commits/b442b82e700534c2e58aa93a0cfdeb1099014086), I have
  - Updated to 4.17.0
  - Fixed the review comments (pkgs/by-name, nixfmt, with lib, etc.)
  - Used the included .desktop file and icon
  - Expanded the meta section

Solves https://github.com/NixOS/nixpkgs/issues/105399 (and https://discourse.nixos.org/t/installing-thinlinc-dynamically-linked-executable/51048).

If @Noah1989 and/or @SCOTT-HAMILTON wants to co-maintain, that's also great.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
