### PR TITLE
open-web-calendar: init at 1.41, add module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1494,6 +1494,7 @@
   ./services/web-apps/onlyoffice.nix
   ./services/web-apps/openvscode-server.nix
   ./services/web-apps/mediagoblin.nix
+  ./services/web-apps/open-web-calendar.nix
   ./services/web-apps/mobilizon.nix
   ./services/web-apps/openwebrx.nix
   ./services/web-apps/outline.nix

--- a/nixos/modules/services/web-apps/open-web-calendar.nix
+++ b/nixos/modules/services/web-apps/open-web-calendar.nix
@@ -1,0 +1,162 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    mkDefault
+    types
+    concatMapStringsSep
+    generators
+    ;
+  cfg = config.services.open-web-calendar;
+
+  nixosSpec = calendarSettingsFormat.generate "nixos_specification.json" cfg.calendarSettings;
+  finalPackage = cfg.package.override {
+    # The calendarSettings need to be merged with the default_specification.yml
+    # in the source. This way we use upstreams default values but keep everything overridable.
+    defaultSpecificationFile = pkgs.runCommand "custom-default_specification.yml" { } ''
+      ${pkgs.yq}/bin/yq -s '.[0] * .[1]' ${cfg.package}/${cfg.package.defaultSpecificationPath} ${nixosSpec} > $out
+    '';
+  };
+
+  inherit (finalPackage) python;
+  pythonEnv = python.buildEnv.override {
+    extraLibs = [
+      (python.pkgs.toPythonModule finalPackage)
+      # Allows Gunicorn to set a meaningful process name
+      python.pkgs.gunicorn.optional-dependencies.setproctitle
+    ];
+  };
+
+  settingsFormat = pkgs.formats.keyValue { };
+  calendarSettingsFormat = pkgs.formats.json { };
+in
+{
+  options.services.open-web-calendar = {
+
+    enable = mkEnableOption "OpenWebCalendar service";
+
+    package = mkPackageOption pkgs "open-web-calendar" { };
+
+    domain = mkOption {
+      type = types.str;
+      description = "The domain under which open-web-calendar is made available";
+      example = "open-web-calendar.example.org";
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          ALLOWED_HOSTS = mkOption {
+            type = types.str;
+            readOnly = true;
+            description = ''
+              The hosts that the Open Web Calendar permits. This is required to
+              mitigate the Host Header Injection vulnerability.
+
+              We always set this to the empty list, as Nginx already checks the Host header.
+            '';
+            default = "";
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Configuration for the server. These are set as environment variables to the gunicorn/flask service.
+
+        See the documentation options in <https://open-web-calendar.quelltext.eu/host/configure/#configuring-the-server>.
+      '';
+    };
+
+    calendarSettings = mkOption {
+      type = types.submodule {
+        freeformType = calendarSettingsFormat.type;
+        options = { };
+      };
+      default = { };
+      description = ''
+        Configure the default calendar.
+
+        See the documentation options in <https://open-web-calendar.quelltext.eu/host/configure/#configuring-the-default-calendar> and <https://github.com/niccokunzmann/open-web-calendar/blob/master/open_web_calendar/default_specification.yml>.
+
+        Individual calendar instances can be further configured outside this module, by specifying the `specification_url` parameter.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = !cfg.settings ? "PORT";
+        message = ''
+          services.open-web-calendar.settings.PORT can't be set, as the service uses a unix socket.
+        '';
+      }
+    ];
+
+    systemd.sockets.open-web-calendar = {
+      before = [ "nginx.service" ];
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = "/run/open-web-calendar/socket";
+        SocketUser = "open-web-calendar";
+        SocketGroup = "open-web-calendar";
+        SocketMode = "770";
+      };
+    };
+
+    systemd.services.open-web-calendar = {
+      description = "Open Web Calendar";
+      after = [ "network.target" ];
+      environment.PYTHONPATH = "${pythonEnv}/${python.sitePackages}/";
+      serviceConfig = {
+        Type = "notify";
+        NotifyAccess = "all";
+        ExecStart = ''
+          ${pythonEnv.pkgs.gunicorn}/bin/gunicorn \
+            --name=open-web-calendar \
+            --bind='unix:///run/open-web-calendar/socket' \
+            open_web_calendar.app:app
+        '';
+        EnvironmentFile = settingsFormat.generate "open-web-calendar.env" cfg.settings;
+        ExecReload = "kill -s HUP $MAINPID";
+        KillMode = "mixed";
+        PrivateTmp = true;
+        RuntimeDirectory = "open-web-calendar";
+        User = "open-web-calendar";
+        Group = "open-web-calendar";
+      };
+    };
+
+    users.users.open-web-calendar = {
+      isSystemUser = true;
+      group = "open-web-calendar";
+    };
+
+    services.nginx = {
+      enable = true;
+      virtualHosts."${cfg.domain}" = {
+        forceSSL = mkDefault true;
+        enableACME = mkDefault true;
+        locations."/".proxyPass = "http://unix:///run/open-web-calendar/socket";
+      };
+    };
+
+    users.groups.open-web-calendar.members = [ config.services.nginx.user ];
+
+  };
+
+  meta.maintainers = with lib.maintainers; [ erictapen ];
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -749,6 +749,7 @@ in {
   openstack-image-userdata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).userdata or {};
   opentabletdriver = handleTest ./opentabletdriver.nix {};
   opentelemetry-collector = handleTest ./opentelemetry-collector.nix {};
+  open-web-calendar = handleTest ./web-apps/open-web-calendar.nix {};
   ocsinventory-agent = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./ocsinventory-agent.nix {};
   owncast = handleTest ./owncast.nix {};
   outline = handleTest ./outline.nix {};

--- a/nixos/tests/web-apps/open-web-calendar.nix
+++ b/nixos/tests/web-apps/open-web-calendar.nix
@@ -1,0 +1,51 @@
+import ../make-test-python.nix (
+  { pkgs, ... }:
+
+  let
+    certs = import ../common/acme/server/snakeoil-certs.nix;
+
+    serverDomain = certs.domain;
+  in
+  {
+    name = "open-web-calendar";
+    meta.maintainers = with pkgs.lib.maintainers; [ erictapen ];
+
+    nodes.server =
+      { pkgs, lib, ... }:
+      {
+        services.open-web-calendar = {
+          enable = true;
+          domain = serverDomain;
+          calendarSettings.title = "My custom title";
+        };
+
+        services.nginx.virtualHosts."${serverDomain}" = {
+          enableACME = lib.mkForce false;
+          sslCertificate = certs."${serverDomain}".cert;
+          sslCertificateKey = certs."${serverDomain}".key;
+        };
+
+        security.pki.certificateFiles = [ certs.ca.cert ];
+
+        networking.hosts."::1" = [ "${serverDomain}" ];
+        networking.firewall.allowedTCPPorts = [
+          80
+          443
+        ];
+      };
+
+    nodes.client =
+      { pkgs, nodes, ... }:
+      {
+        networking.hosts."${nodes.server.networking.primaryIPAddress}" = [ "${serverDomain}" ];
+
+        security.pki.certificateFiles = [ certs.ca.cert ];
+      };
+
+    testScript = ''
+      start_all()
+      server.wait_for_unit("open-web-calendar.socket")
+      server.wait_until_succeeds("curl -f https://${serverDomain}/ | grep 'My custom title'")
+    '';
+  }
+)

--- a/pkgs/by-name/op/open-web-calendar/package.nix
+++ b/pkgs/by-name/op/open-web-calendar/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  python3,
+  fetchPypi,
+  nixosTests,
+
+  defaultSpecificationFile ? null,
+}:
+
+let
+  python = python3;
+in
+python.pkgs.buildPythonApplication rec {
+  pname = "open-web-calendar";
+  version = "1.41";
+  pyproject = true;
+
+  disabled = python.pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "open_web_calendar";
+    hash = "sha256-3D1bGAioKCD1XZQVwtMVXi67VzzdJQnRLS6RF+dJNL4=";
+  };
+
+  # The Pypi tarball doesn't contain open_web_calendars/features
+  postPatch = ''
+    ln -s $PWD/features open_web_calendar/features
+  '';
+
+  postInstall = lib.optionalString (defaultSpecificationFile != null) ''
+    install -D ${defaultSpecificationFile} $out/$defaultSpecificationPath
+  '';
+
+  build-system = with python.pkgs; [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies =
+    with python.pkgs;
+    [
+      flask-caching
+      flask-allowed-hosts
+      flask
+      icalendar
+      requests
+      pyyaml
+      recurring-ical-events
+      gunicorn
+      lxml
+      beautifulsoup4
+      lxml-html-clean
+      pytz
+    ]
+    ++ requests.optional-dependencies.socks;
+
+  nativeCheckInputs = with python.pkgs; [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "open_web_calendar/test" ];
+
+  pythonImportsCheck = [ "open_web_calendar.app" ];
+
+  defaultSpecificationPath = "${python.sitePackages}/open_web_calendar/default_specification.yml";
+
+  passthru = {
+    inherit python;
+    tests = {
+      inherit (nixosTests) open-web-calendar;
+    };
+  };
+
+  meta = with lib; {
+    description = "Highly customizable web calendar that can be embedded into websites using ICal source links";
+    homepage = "https://open-web-calendar.quelltext.eu";
+    changelog =
+      let
+        v = builtins.replaceStrings [ "." ] [ "" ] version;
+      in
+      "https://open-web-calendar.quelltext.eu/changelog/#v${v}";
+    license = with licenses; [
+      gpl2Only
+      cc-by-sa-40
+      cc0
+    ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ erictapen ];
+    mainProgram = "open-web-calendar";
+  };
+}

--- a/pkgs/development/python-modules/flask-allowed-hosts/default.nix
+++ b/pkgs/development/python-modules/flask-allowed-hosts/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  flask,
+}:
+
+buildPythonPackage rec {
+  pname = "flask-allowed-hosts";
+  version = "1.1.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "flask_allowed_hosts";
+    hash = "sha256-l25bZlJkOVI+S+HtAK22ZGULP95evx2NASA9ViIax7Q=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ flask ];
+
+  pythonImportsCheck = [ "flask_allowed_hosts" ];
+
+  meta = with lib; {
+    description = "Flask extension that helps you limit access to your API endpoints";
+    homepage = "https://github.com/riad-azz/flask-allowedhosts";
+    license = licenses.mit;
+    maintainers = with maintainers; [ erictapen ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4600,6 +4600,8 @@ self: super: with self; {
 
   flask-admin = callPackage ../development/python-modules/flask-admin { };
 
+  flask-allowed-hosts = callPackage ../development/python-modules/flask-allowed-hosts { };
+
   flask-api = callPackage ../development/python-modules/flask-api { };
 
   flask-appbuilder = callPackage ../development/python-modules/flask-appbuilder { };


### PR DESCRIPTION
## Description of changes

https://open-web-calendar.quelltext.eu/

Addresses https://github.com/ngi-nix/projects/issues/2081

This is probably comparatively easy to review, as the module has little moving parts.

A demo deployment is available at https://open-web-calendar.erictapen.name/



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
