### PR TITLE
release-unfree: init

### DIFF
--- a/pkgs/top-level/release-unfree-redistributable.nix
+++ b/pkgs/top-level/release-unfree-redistributable.nix
@@ -1,21 +1,26 @@
 /*
-    Nixpkgs unfree+redistributable packages.
+  Nixpkgs unfree+redistributable packages.
 
-    This release file MUST NOT be used by <https://hydra.nixos.org>. Please
-    check with your lawyers before using this file.
+  NOTE: This file is used by the sister nix-community project.
 
-    This file is used by the sister nix-community project. Our intent is to
-    test all the code paths of nixpkgs. To contact us, send an email to
-    <admin@nix-community.org>
+  The official Hydra instance only builds and provides binary caches for free
+  packages (as in OSI-approved).
 
-    See also:
+  Some unfree packages such as MongoDB, ZeroTier, ... take a while to be
+  built. While their license is not free, they allow redistribution of
+  build artefacts.
 
-    * <https://hydra.nix-community.org/jobset/nixpkgs/unfree>
-    * <https://github.com/nix-community/infra/pull/1406>
+  The sister project nix-community will build and distribute those packages
+  for a subset of the channels to <https://nix-community.cachix.org>.
 
-    Test for example like this:
+  See also:
 
-        $ hydra-eval-jobs pkgs/top-level/release-unfree.nix -I .
+  * <https://hydra.nix-community.org/jobset/nixpkgs/unfree-redistributable>
+  * <https://github.com/nix-community/infra/pull/1406>
+
+  Test for example like this:
+
+    $ hydra-eval-jobs pkgs/top-level/release-unfree-redistributable.nix -I .
 */
 
 {

--- a/pkgs/top-level/release-unfree.nix
+++ b/pkgs/top-level/release-unfree.nix
@@ -1,5 +1,5 @@
 /*
-    Nixpkgs unfree packages.
+    Nixpkgs unfree+redistributable packages.
 
     This release file MUST NOT be used by <https://hydra.nixos.org>. Please
     check with your lawyers before using this file.
@@ -76,7 +76,11 @@ let
       lib.optionals res.success res.value
     );
 
+  # Unfree is any license not OSI-approved.
   isUnfree = pkg: lib.lists.any (l: !(l.free or true)) (lib.lists.toList (pkg.meta.license or [ ]));
+
+  # Whenever the license allows re-distribution of the binaries
+  isRedistributable = pkg: lib.lists.any (l: l.redistributable or false) (lib.lists.toList (pkg.meta.license or [ ]));
 
   isSource =
     pkg: !lib.lists.any (x: !(x.isSource)) (lib.lists.toList (pkg.meta.sourceProvenance or [ ]));
@@ -95,6 +99,7 @@ let
   cond =
     attrPath: pkg:
     (isUnfree pkg)
+    && (isRedistributable pkg)
     && (isSource pkg)
     && (canSubstituteSrc pkg)
     && (

--- a/pkgs/top-level/release-unfree.nix
+++ b/pkgs/top-level/release-unfree.nix
@@ -1,0 +1,106 @@
+/*
+    NixOS unstable packages
+
+    This release file is currently not tested on hydra.nixos.org
+    because it requires unfree software, but it is tested by
+    <https://hydra.nix-community.org/jobset/nixpkgs/unfree>.
+
+    Cf. https://github.com/nix-community/infra/pull/1406
+
+    Test for example like this:
+
+        $ hydra-eval-jobs pkgs/top-level/release-unfree.nix -I .
+*/
+
+{
+  # The platforms for which we build Nixpkgs.
+  supportedSystems ? [
+    "x86_64-linux"
+    "aarch64-linux"
+  ],
+  # Attributes passed to nixpkgs.
+  nixpkgsArgs ? {
+    config = {
+      allowAliases = false;
+      allowUnfree = true;
+      cudaSupport = true;
+      inHydra = true;
+    };
+  },
+  # We only build the full package set on infrequently releasing channels.
+  full ? false,
+}:
+
+let
+  release-lib = import ./release-lib.nix {
+    inherit supportedSystems nixpkgsArgs;
+  };
+
+  inherit (release-lib)
+    lib
+    mapTestOn
+    pkgs
+    ;
+
+  # similar to release-lib.packagePlatforms, but also includes some condition for which package to pick
+  packagesWith =
+    prefix: cond:
+    lib.mapAttrs (
+      name: value:
+      let
+        attrPath = "${prefix}.${name}";
+        res = builtins.tryEval (
+          if lib.isDerivation value then
+            lib.optionals (cond attrPath value) (
+              # logic copied from release-lib packagePlatforms
+              value.meta.hydraPlatforms
+                or (lib.subtractLists (value.meta.badPlatforms or [ ]) (value.meta.platforms or [ "x86_64-linux" ]))
+            )
+          else if
+            value.recurseForDerivations or false
+            || value.recurseForRelease or false
+            || value.__recurseIntoDerivationForReleaseJobs or false
+          then
+            # Recurse
+            packagesWith attrPath cond value
+          else
+            [ ]
+        );
+      in
+      lib.optionals res.success res.value
+    );
+
+  isUnfree = pkg: lib.lists.any (l: !(l.free or true)) (lib.lists.toList (pkg.meta.license or [ ]));
+
+  isSource =
+    pkg: !lib.lists.any (x: !(x.isSource)) (lib.lists.toList (pkg.meta.sourceProvenance or [ ]));
+
+  isNotLinuxKernel =
+    attrPath: !(lib.hasPrefix "linuxKernel" attrPath || lib.hasPrefix "linuxPackages" attrPath);
+
+  # This is handled by release-cuda.nix
+  isNotCudaPackage = attrPath: !(lib.hasPrefix "cuda" attrPath);
+
+  canSubstituteSrc =
+    pkg:
+    # requireFile don't allow using substituters and are therefor skipped
+    pkg.src.allowSubstitutes or true;
+
+  cond =
+    attrPath: pkg:
+    (isUnfree pkg)
+    && (isSource pkg)
+    && (canSubstituteSrc pkg)
+    && (
+      if full then
+        true
+      else
+        # By default we also filter for these things
+        (isNotCudaPackage attrPath) && (isNotLinuxKernel attrPath)
+    );
+
+  packages = packagesWith "" cond pkgs;
+
+  jobs = mapTestOn packages;
+in
+jobs

--- a/pkgs/top-level/release-unfree.nix
+++ b/pkgs/top-level/release-unfree.nix
@@ -1,5 +1,5 @@
 /*
-    NixOS unstable packages
+    Nixpkgs unfree packages
 
     This release file is currently not tested on hydra.nixos.org
     because it requires unfree software, but it is tested by
@@ -91,12 +91,12 @@ let
     (isUnfree pkg)
     && (isSource pkg)
     && (canSubstituteSrc pkg)
+    && (isNotCudaPackage attrPath)
     && (
-      if full then
-        true
-      else
-        # By default we also filter for these things
-        (isNotCudaPackage attrPath) && (isNotLinuxKernel attrPath)
+      full
+      ||
+        # We only build these heavy packages on releases
+        (isNotLinuxKernel attrPath)
     );
 
   packages = packagesWith "" cond pkgs;

--- a/pkgs/top-level/release-unfree.nix
+++ b/pkgs/top-level/release-unfree.nix
@@ -1,11 +1,17 @@
 /*
-    Nixpkgs unfree packages
+    Nixpkgs unfree packages.
 
-    This release file is currently not tested on hydra.nixos.org
-    because it requires unfree software, but it is tested by
-    <https://hydra.nix-community.org/jobset/nixpkgs/unfree>.
+    This release file MUST NOT be used by <https://hydra.nixos.org>. Please
+    check with your lawyers before using this file.
 
-    Cf. https://github.com/nix-community/infra/pull/1406
+    This file is used by the sister nix-community project. Our intent is to
+    test all the code paths of nixpkgs. To contact us, send an email to
+    <admin@nix-community.org>
+
+    See also:
+
+    * <https://hydra.nix-community.org/jobset/nixpkgs/unfree>
+    * <https://github.com/nix-community/infra/pull/1406>
 
     Test for example like this:
 
@@ -48,7 +54,7 @@ let
     lib.mapAttrs (
       name: value:
       let
-        attrPath = "${prefix}.${name}";
+        attrPath = if prefix == "" then name else "${prefix}.${name}";
         res = builtins.tryEval (
           if lib.isDerivation value then
             lib.optionals (cond attrPath value) (
@@ -91,12 +97,11 @@ let
     (isUnfree pkg)
     && (isSource pkg)
     && (canSubstituteSrc pkg)
-    && (isNotCudaPackage attrPath)
     && (
       full
       ||
         # We only build these heavy packages on releases
-        (isNotLinuxKernel attrPath)
+        ((isNotCudaPackage attrPath) && (isNotLinuxKernel attrPath))
     );
 
   packages = packagesWith "" cond pkgs;


### PR DESCRIPTION
## Description of changes

Due to the NixOS project's current policies, there is a whole set of nixpkgs packages whose code is currently untested by the main hydra.nixos.org.

At <https://github.com/nix-community/infra/pull/1406> we started testing those packages, so we can get feedback on what breaks.

The motivation to adding this file to nixpkgs instead of maintaining <https://github.com/numtide/nixpkgs-unfree> is that it makes it easier to keep it in sync with the rest of the nixpkgs code base.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
