### PR TITLE
python312Packages.python-calamine: add missing dependency libiconv

### DIFF
--- a/pkgs/development/python-modules/python-calamine/default.nix
+++ b/pkgs/development/python-modules/python-calamine/default.nix
@@ -1,22 +1,25 @@
 {
   lib,
   buildPythonPackage,
-  cargo,
   fetchFromGitHub,
-  poetry-core,
-  pytestCheckHook,
-  pythonOlder,
-  rustc,
-  packaging,
   rustPlatform,
+
+  # build-system
+  cargo,
+  poetry-core,
+  rustc,
+
+  # dependencies
+  packaging,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "python-calamine";
   version = "0.2.3";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "dimastbk";

--- a/pkgs/development/python-modules/python-calamine/default.nix
+++ b/pkgs/development/python-modules/python-calamine/default.nix
@@ -4,6 +4,9 @@
   fetchFromGitHub,
   rustPlatform,
 
+  # buildInputs
+  libiconv,
+
   # build-system
   cargo,
   poetry-core,
@@ -38,6 +41,8 @@ buildPythonPackage rec {
   postPatch = ''
     ln -s ${./Cargo.lock} Cargo.lock
   '';
+
+  buildInputs = [ libiconv ];
 
   build-system = [
     cargo


### PR DESCRIPTION
## Description of changes

Fix the package on darwin.
It was failing with:
```
Compiling pyo3-file v0.8.1 (https://github.com/dimastbk/pyo3-file?rev=6da7c16902dde695a7b88fd83ce78ef4406e9bb7#6da7c169)
error: linking with `/nix/store/8c3v3rdzvi5364x9m959ijyy6iamqf5f-clang-wrapper-16.0.6/bin/cc` failed: exit status: 1
  |
  = note: env -u IPHONEOS_DEPLOYMENT_TARGET -u TVOS_DEPLOYMENT_TARGET -u XROS_DEPLOYMENT_TARGET LC_ALL="C" PATH="/nix/store/936pxmssyhsdamkagi1ir7cxz0ldfkql-rustc-1.80.1/lib/rustlib>
  = note: ld: library not found for -liconv
          clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```

- **python312Packages.python-calamine: clean**
- **python312Packages.python-calamine: add missing dependency libiconv**

cc @fabaff

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
