### PR TITLE
tigerbeetle: 0.15.3 -> 0.16.2, add darwin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15316,6 +15316,12 @@
     githubId = 5047052;
     name = "Niclas Hirschfeld";
   };
+  nwjsmith = {
+    email = "nate@theinternate.com";
+    github = "nwjsmith";
+    githubId = 1348;
+    name = "Nate Smith";
+  };
   nyadiia = {
     email = "nyadiia@pm.me";
     github = "nyadiia";

--- a/pkgs/by-name/ti/tigerbeetle/package.nix
+++ b/pkgs/by-name/ti/tigerbeetle/package.nix
@@ -1,26 +1,26 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, zig_0_11
+, zig_0_13
 , testers
 , tigerbeetle
 , nix-update-script
 }:
 let
-  # Read [these comments](pkgs/development/compilers/zig/hook.nix#L12-L30) on the default Zig flags, and the associated links. tigerbeetle stopped exposing the `-Doptimize` build flag, so we can't use the default Nixpkgs zig hook as-is. tigerbeetle only exposes a boolean `-Drelease` flag which we'll add in the tigerbeetle derivation in this file.
-  custom_zig_hook = zig_0_11.hook.overrideAttrs (previousAttrs: {
-    zig_default_flags = builtins.filter (flag: builtins.match "-Doptimize.*" flag == null) previousAttrs.zig_default_flags;
+  # Read [these comments](pkgs/development/compilers/zig/hook.nix#L12-L30) on the default Zig flags, and the associated links. tigerbeetle stopped exposing the `-Doptimize` and `-Dcpu` build flags, so we can't use the default Nixpkgs zig hook as-is. tigerbeetle only exposes a boolean `-Drelease` flag which we'll add in the tigerbeetle derivation in this file.
+  custom_zig_hook = zig_0_13.hook.overrideAttrs (previousAttrs: {
+    zig_default_flags = builtins.filter (flag: builtins.match "-D(optimize|cpu).*" flag == null) previousAttrs.zig_default_flags;
   });
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "tigerbeetle";
-  version = "0.15.3";
+  version = "0.16.2";
 
   src = fetchFromGitHub {
     owner = "tigerbeetle";
     repo = "tigerbeetle";
     rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-3+uCMoOnyvI//ltEaqTIXytUxxgJrfMnFly11WCh66Q=";
+    hash = "sha256-5cGEoUsY9580kHiJP0yvDmHpc6TCgwOvZyIa1vwocJo=";
   };
 
   env.TIGERBEETLE_RELEASE = finalAttrs.version;
@@ -28,8 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ custom_zig_hook ];
 
   zigBuildFlags = [
-    "-Drelease"
-    "-Dgit-commit=0000000000000000000000000000000000000000"
+    "-Drelease=true"
+    "-Dgit-commit=c26a2ee1c401ddf225eaa242b14bab19ecb60fe2"
+    "-Dconfig-release=${finalAttrs.version}"
+    "-Dconfig-release-client-min=0.15.3"
   ];
 
   passthru = {

--- a/pkgs/by-name/ti/tigerbeetle/package.nix
+++ b/pkgs/by-name/ti/tigerbeetle/package.nix
@@ -46,8 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://tigerbeetle.com/";
     description = "Financial accounting database designed to be distributed and fast";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ danielsidhion ];
-    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ danielsidhion nwjsmith ];
     mainProgram = "tigerbeetle";
   };
 })


### PR DESCRIPTION
## Description of changes

Bump TigerBeetle to latest version and start building it for Darwin.

[TigerBeetle CHANGELOG](https://github.com/tigerbeetle/tigerbeetle/blob/main/CHANGELOG.md)

I've also added myself as a maintainer, as I am primarily using TigerBeetle on `aarch64-darwin`, and [@DanielSidhion mentioned previously that he'd like maintainers to test new releases](https://github.com/NixOS/nixpkgs/pull/297607#issuecomment-2033447239). I'd be happy to.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
