### PR TITLE
ocamlPackages.hpack: 0.11.0 → 0.13.0

### DIFF
--- a/pkgs/development/ocaml-modules/h2/default.nix
+++ b/pkgs/development/ocaml-modules/h2/default.nix
@@ -5,7 +5,7 @@
 , faraday
 , base64
 , psq
-, httpaf
+, httpun-types
 , alcotest
 , yojson
 , hex
@@ -34,7 +34,7 @@ buildDunePackage rec {
     base64
     psq
     hpack
-    httpaf
+    httpun-types
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/hpack/default.nix
+++ b/pkgs/development/ocaml-modules/hpack/default.nix
@@ -7,11 +7,11 @@
 
 buildDunePackage rec {
   pname = "hpack";
-  version = "0.11.0";
+  version = "0.13.0";
 
   src = fetchurl {
     url = "https://github.com/anmonteiro/ocaml-h2/releases/download/${version}/h2-${version}.tbz";
-    hash = "sha256-GdXwazlgDurjzy7ekLpuMkCii8W+F/jl/IBv/WTHgFM=";
+    hash = "sha256-DYm28XgXUpTnogciO+gdW4P8Mbl1Sb7DTwQyo7KoBw8=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/httpun/types.nix
+++ b/pkgs/development/ocaml-modules/httpun/types.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, faraday
+}:
+
+buildDunePackage rec {
+  pname = "httpun-types";
+  version = "0.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/anmonteiro/httpun/releases/download/${version}/httpun-${version}.tbz";
+    hash = "sha256-os4n70yFro4cEAjR49Xok9ayEbk0WGod0pQvfbaHvSw=";
+  };
+
+  propagatedBuildInputs = [ faraday ];
+
+  meta = {
+    description = "Common HTTP/1.x types";
+    homepage = "https://github.com/anmonteiro/httpun";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/paf/default.nix
+++ b/pkgs/development/ocaml-modules/paf/default.nix
@@ -19,6 +19,7 @@
 , uri
 , alcotest-lwt
 , cstruct
+, httpaf
 }:
 
 buildDunePackage rec {
@@ -43,6 +44,7 @@ buildDunePackage rec {
     tls
     cstruct
     tcpip
+    httpaf
   ];
 
   doCheck = true;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -689,6 +689,8 @@ let
 
     httpaf-lwt-unix = callPackage ../development/ocaml-modules/httpaf/lwt-unix.nix { };
 
+    httpun-types = callPackage ../development/ocaml-modules/httpun/types.nix { };
+
     hxd = callPackage ../development/ocaml-modules/hxd { };
 
     ### I ###


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/anmonteiro/ocaml-h2/0.13.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
