### PR TITLE
taler-depolymerization: init at 0-unstable-2024-06-17

### DIFF
--- a/pkgs/by-name/ta/taler-depolymerization/package.nix
+++ b/pkgs/by-name/ta/taler-depolymerization/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchgit,
+  stdenv,
+  darwin,
+}:
+rustPlatform.buildRustPackage {
+  pname = "taler-depolymerization";
+  version = "0-unstable-2024-06-17";
+
+  src = fetchgit {
+    url = "https://git.taler.net/depolymerization.git/";
+    rev = "a0d27ac3bba22d4934ca9f7b244b0d9e45bb484f";
+    hash = "sha256-HmQ/DPq/O6aODWms/bSsCVgBF7z246xxfYxiHrAkgYw=";
+  };
+
+  cargoHash = "sha256-NgoLCTHhEs45cnx21bU2ko3oWxePSzKgUpnCGqhjvTs=";
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  postPatch = ''
+    # fix missing expression in test docs
+    substituteInPlace common/src/status.rs \
+      --replace-fail '          -> Requested' '()        -> Requested'
+  '';
+
+  postInstall = ''
+    mkdir -p $doc/share/doc $out/share/examples
+
+    cp -R docs $doc/share/doc/taler-depolymerization
+    cp docs/*.conf $out/share/examples
+  '';
+
+  buildInputs = lib.optionals stdenv.isDarwin (
+    with darwin.apple_sdk.frameworks;
+    [
+      CoreFoundation
+      Security
+      SystemConfiguration
+    ]
+  );
+
+  meta = {
+    description = "Wire gateway for Bitcoin/Ethereum";
+    homepage = "https://git.taler.net/depolymerization.git/";
+    license = lib.licenses.agpl3Only;
+    maintainers = [
+      # maintained by the team working on NGI-supported software, no group for this yet
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Taler [depolymerization](https://git.taler.net/depolymerization.git/about/) is an implementation of the Taler wire gateway over the Bitcoin and Ethereum blockchains.

Packaged under the [Summer of Nix](https://github.com/ngi-nix/summer-of-nix) effort.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
