### PR TITLE
doc/by-name: 2 small manual transition improvements

### DIFF
--- a/pkgs/by-name/README.md
+++ b/pkgs/by-name/README.md
@@ -92,7 +92,7 @@ though this is not required and must not be expected.
 
 Note that definitions in `all-packages.nix` with custom arguments should not be removed.
 That is a backwards-incompatible change because it changes the `.override` interface.
-Such packages may still be moved to `pkgs/by-name` however, while keeping the definition in `all-packages.nix`.
+Such packages may still be moved to `pkgs/by-name` however, in order to avoid the slightly superficial choice of directory / category in which the `default.nix` file was placed, but please keep the definition in `all-packages.nix` using `callPackage`.
 See also [changing implicit attribute defaults](#changing-implicit-attribute-defaults).
 
 ## Limitations

--- a/pkgs/by-name/README.md
+++ b/pkgs/by-name/README.md
@@ -90,10 +90,28 @@ if package maintainers would like to use this feature, they are welcome to migra
 To lessen PR traffic, they're encouraged to also perform some more general maintenance on the package in the same PR,
 though this is not required and must not be expected.
 
-Note that definitions in `all-packages.nix` with custom arguments should not be removed.
+Note that `callPackage` definitions in `all-packages.nix` with custom arguments should not be removed.
 That is a backwards-incompatible change because it changes the `.override` interface.
 Such packages may still be moved to `pkgs/by-name` however, in order to avoid the slightly superficial choice of directory / category in which the `default.nix` file was placed, but please keep the definition in `all-packages.nix` using `callPackage`.
 See also [changing implicit attribute defaults](#changing-implicit-attribute-defaults).
+
+Definitions like the following however, _can_ be transitioned:
+
+```nix
+# all-packages.nix
+fooWithBaz = foo.override {
+  bar = baz;
+};
+# turned into pkgs/by-name/fo/fooWithBaz/package.nix with:
+{
+  foo,
+  baz,
+}:
+
+foo.override {
+  bar = baz;
+}
+```
 
 ## Limitations
 

--- a/pkgs/by-name/la/lammps-mpi/package.nix
+++ b/pkgs/by-name/la/lammps-mpi/package.nix
@@ -1,0 +1,13 @@
+{
+  lammps,
+  mpi,
+  lowPrio,
+}:
+
+lowPrio (
+  lammps.override {
+    extraBuildInputs = [
+      mpi
+    ];
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36556,12 +36556,6 @@ with pkgs;
 
   dl-poly-classic-mpi = callPackage ../applications/science/molecular-dynamics/dl-poly-classic { };
 
-  lammps-mpi = lowPrio (lammps.override {
-    extraBuildInputs = [
-      mpi
-    ];
-  });
-
   gromacs = callPackage ../applications/science/molecular-dynamics/gromacs {
     singlePrec = true;
     fftw = fftwSinglePrec;


### PR DESCRIPTION
Related:

- https://github.com/NixOS/nixpkgs/pull/254632
- https://github.com/NixOS/nixpkgs/pull/342532#pullrequestreview-2310249146

## Description of changes

- **doc/by-name: explain motivation for transition when custom args are used**
- **doc/by-name: explain better `callPackage` and `xWithY=x.override` transition**

## Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
