### PR TITLE
mir: 2.17.2 -> 2.18.2

### DIFF
--- a/pkgs/by-name/mi/miracle-wm/package.nix
+++ b/pkgs/by-name/mi/miracle-wm/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "miracle-wm";
-  version = "0.3.5";
+  version = "0.3.6";
 
   src = fetchFromGitHub {
     owner = "mattkae";
     repo = "miracle-wm";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-2OoMkD4ChNXzqqzdOvzYRL0UYU7Uecm5yTXCvG45jCI=";
+    hash = "sha256-fK/g6DhcxJMvxujZDZXs1yXRu2FGZQKmhxw7/czAQiY=";
   };
 
   patches = [

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -192,9 +192,7 @@ stdenv.mkDerivation (finalAttrs: {
       #   does not know about preferred terminal
       "mir-shell"
     ];
-  } // lib.optionalAttrs (!pinned) {
-    updateScript = ./update.sh;
-  };
+  } // lib.optionalAttrs (!pinned) { updateScript = ./update.sh; };
 
   meta = {
     description = "Display server and Wayland compositor developed by Canonical";
@@ -206,22 +204,23 @@ stdenv.mkDerivation (finalAttrs: {
       OPNA2608
     ];
     platforms = lib.platforms.linux;
-    pkgConfigModules = [
-      "miral"
-      "mircommon"
-      "mircore"
-      "miroil"
-      "mirplatform"
-      "mir-renderer-gl-dev"
-      "mirrenderer"
-      "mirserver"
-      "mirtest"
-      "mirwayland"
-    ] ++ lib.optionals (lib.strings.versionOlder version "2.17.0") [
-      "mircookie"
-    ] ++ lib.optionals (lib.strings.versionAtLeast version "2.17.0") [
-      "mircommon-internal"
-      "mirserver-internal"
-    ];
+    pkgConfigModules =
+      [
+        "miral"
+        "mircommon"
+        "mircore"
+        "miroil"
+        "mirplatform"
+        "mir-renderer-gl-dev"
+        "mirrenderer"
+        "mirserver"
+        "mirtest"
+        "mirwayland"
+      ]
+      ++ lib.optionals (lib.strings.versionOlder version "2.17.0") [ "mircookie" ]
+      ++ lib.optionals (lib.strings.versionAtLeast version "2.17.0") [
+        "mircommon-internal"
+        "mirserver-internal"
+      ];
   };
 })

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  nixosTests,
   testers,
   cmake,
   pkg-config,
@@ -185,7 +186,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    } // lib.optionalAttrs (!pinned) { inherit (nixosTests) miriway miracle-wm; };
     providedSessions = lib.optionals (lib.strings.versionOlder version "2.16.0") [
       # More of an example than a fully functioning shell, some notes for the adventurous:
       # - ~/.config/miral-shell.config is one possible user config location,

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,8 +5,8 @@ let
 in
 {
   mir = common {
-    version = "2.17.2";
-    hash = "sha256-OwOGt3X7+UchksyPf/sodit2PHpSlpP2S3gkCPcdzfE=";
+    version = "2.18.0";
+    hash = "sha256-Sy7sDlOP34M9zyNorX0loP21B/dd/7Zew8wcuEcjjUY=";
   };
 
   mir_2_15 = common {

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,8 +5,8 @@ let
 in
 {
   mir = common {
-    version = "2.18.0";
-    hash = "sha256-Sy7sDlOP34M9zyNorX0loP21B/dd/7Zew8wcuEcjjUY=";
+    version = "2.18.2";
+    hash = "sha256-Yko5ws8dUazPziXzM77Zg4p1taC0mbjAcpOKJR0dJ5M=";
   };
 
   mir_2_15 = common {


### PR DESCRIPTION
## Description of changes

- `nixfmt` the common file
- update the unpinned `mir` to 2.18.2
- add Miriway and Miracle WM's VM tests as tests for Mir, so I don't need to manually invoke OfBorg for them all the time

~~Draft because it's brand new, and `miracle-wm` is not compatible with it yet: https://github.com/miracle-wm-org/miracle-wm/issues/243~~
Addressed by new release, included in PR: https://github.com/miracle-wm-org/miracle-wm/releases/tag/v0.3.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
