### PR TITLE
klevernotes: init at 1.0.0

### DIFF
--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -63,6 +63,7 @@
       kirigami-addons = self.callPackage ./misc/kirigami-addons {};
       kio-extras-kf5 = self.callPackage ./misc/kio-extras-kf5 {};
       kio-fuse = self.callPackage ./misc/kio-fuse {};
+      klevernotes = self.callPackage ./misc/klevernotes {};
       ktextaddons = self.callPackage ./misc/ktextaddons {};
       kunifiedpush = self.callPackage ./misc/kunifiedpush {};
       kup = self.callPackage ./misc/kup {};

--- a/pkgs/kde/misc/klevernotes/default.nix
+++ b/pkgs/kde/misc/klevernotes/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  mkKdeDerivation,
+  fetchurl,
+  qtsvg,
+  qtwebengine,
+}:
+mkKdeDerivation rec {
+  pname = "klevernotes";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/klevernotes/${version}/klevernotes-${version}.tar.xz";
+    hash = "sha256-9nXOaa2/DyJO3nXGbnvPaYjXFrVoAgx52th67l5geOU=";
+  };
+
+  extraBuildInputs = [
+    qtsvg
+    qtwebengine
+  ];
+
+  meta.license = with lib.licenses; [
+    bsd3
+    cc-by-sa-40
+    cc0
+    # TODO: add FSFAP license
+    gpl2Plus
+    gpl3Only
+    gpl3Plus
+    lgpl2Only
+    lgpl2Plus
+    lgpl21Only
+    lgpl21Plus
+    lgpl3Only
+    lgpl3Plus
+    mit
+  ];
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This add KleverNotes, a new note-taking and management application using markdown. The derivation is mostly copied from [Marknote’s one](https://github.com/NixOS/nixpkgs/blob/master/pkgs/kde/misc/marknote/default.nix), as they are very similar. Let me know if there is anything more I can do.

Homepage: https://apps.kde.org/klevernotes/

Closes #342618 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
