### PR TITLE
nixos/wayland: add gtk portal to all applicable compositors

### DIFF
--- a/nixos/modules/programs/wayland/cardboard.nix
+++ b/nixos/modules/programs/wayland/cardboard.nix
@@ -19,6 +19,6 @@ in
       # To make a cardboard session available for certain DMs like SDDM
       services.displayManager.sessionPackages = [ cfg.package ];
     }
-    (import ./wayland-session.nix { inherit lib; })
+    (import ./wayland-session.nix { inherit lib pkgs; })
   ]);
 }

--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -70,7 +70,7 @@ in
     }
 
     (import ./wayland-session.nix {
-      inherit lib;
+      inherit lib pkgs;
       enableXWayland = cfg.xwayland.enable;
       enableWlrPortal = lib.mkDefault false; # Hyprland has its own portal, wlr is not needed
     })

--- a/nixos/modules/programs/wayland/labwc.nix
+++ b/nixos/modules/programs/wayland/labwc.nix
@@ -20,6 +20,6 @@ in
       # To make a labwc session available for certain DMs like SDDM
       services.displayManager.sessionPackages = [ cfg.package ];
     }
-    (import ./wayland-session.nix { inherit lib; })
+    (import ./wayland-session.nix { inherit lib pkgs; })
   ]);
 }

--- a/nixos/modules/programs/wayland/miracle-wm.nix
+++ b/nixos/modules/programs/wayland/miracle-wm.nix
@@ -30,11 +30,12 @@ in
       }
 
       (import ./wayland-session.nix {
-        inherit lib;
+        inherit lib pkgs;
         # Hardcoded path in Mir, not really possible to disable
         enableXWayland = true;
         # No portal support yet: https://github.com/mattkae/miracle-wm/issues/164
         enableWlrPortal = false;
+        enableGtkPortal = false;
       })
     ]
   );

--- a/nixos/modules/programs/wayland/river.nix
+++ b/nixos/modules/programs/wayland/river.nix
@@ -56,7 +56,7 @@ in
     }
 
     (import ./wayland-session.nix {
-      inherit lib;
+      inherit lib pkgs;
       enableXWayland = cfg.xwayland.enable;
     })
   ]);

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -148,7 +148,7 @@ in
     }
 
     (import ./wayland-session.nix {
-      inherit lib;
+      inherit lib pkgs;
       enableXWayland = cfg.xwayland.enable;
     })
   ]);

--- a/nixos/modules/programs/wayland/wayfire.nix
+++ b/nixos/modules/programs/wayland/wayfire.nix
@@ -63,7 +63,7 @@ in
           };
         }
         (import ./wayland-session.nix {
-          inherit lib;
+          inherit lib pkgs;
           enableXWayland = cfg.xwayland.enable;
         })
       ]

--- a/nixos/modules/programs/wayland/wayland-session.nix
+++ b/nixos/modules/programs/wayland/wayland-session.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  pkgs,
   enableXWayland ? true,
   enableWlrPortal ? true,
+  enableGtkPortal ? true,
 }:
 
 {
@@ -18,6 +20,9 @@
   services.graphical-desktop.enable = true;
 
   xdg.portal.wlr.enable = enableWlrPortal;
+  xdg.portal.extraPortals = lib.mkIf enableGtkPortal [
+    pkgs.xdg-desktop-portal-gtk
+  ];
 
   # Window manager only sessions (unlike DEs) don't handle XDG
   # autostart files, so force them to run the service


### PR DESCRIPTION
## Description of changes

Most standalone wayland compositors lack a sufficient xdg-desktop-portal implementation. More often than not, their portal contains only screen capture protocols but completely lacks file picker functionality (see: [archwiki/xdg_desktop_portal](https://wiki.archlinux.org/title/XDG_Desktop_Portal#List_of_backends_and_interfaces)).

Most of the nixos modules used `lib.mkDefault [ "wlr" "gtk" ];` as the solution to this, but never actually provided the gtk portal. This PR adds the gtk portal as an entry in the common `wayland-session.nix` file, enabling support for all compatible compositors.

PS: if this constitutes a release change let me know !

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
