### PR TITLE
nixos/pam: option to disable fprint if laptop lid is closed

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -267,6 +267,15 @@ let
         '';
       };
 
+      fprintAuthSkipLidClose = lib.mkOption {
+        default = config.services.fprintd.lid.authSkipLidClose;
+        defaultText = lib.literalExpression "config.services.fprintd.authSkipLidClose";
+        type = lib.types.bool;
+        description = ''
+          If set, fprint will not be used if laptop lid closed.
+        '';
+      };
+
       oathAuth = lib.mkOption {
         default = config.security.pam.oath.enable;
         defaultText = lib.literalExpression "config.security.pam.oath.enable";
@@ -708,6 +717,7 @@ let
           (let dp9ik = config.security.pam.dp9ik; in { name = "p9"; enable = dp9ik.enable; control = dp9ik.control; modulePath = "${pkgs.pam_dp9ik}/lib/security/pam_p9.so"; args = [
             dp9ik.authserver
           ]; })
+          (let lid = pkgs.writeShellScript "lid.sh" "${pkgs.gnugrep}/bin/grep -q closed ${config.services.fprintd.lid.path} && exit 1; true"; in { name = "fprintd-lid"; enable = cfg.fprintAuthSkipLidClose; control = "[success=ignore default=1]"; modulePath = "${pkgs.linux-pam}/lib/security/pam_exec.so"; args = ["quiet" "${lid}"]; })
           { name = "fprintd"; enable = cfg.fprintAuth; control = "sufficient"; modulePath = "${config.services.fprintd.package}/lib/security/pam_fprintd.so"; }
         ] ++
           # Modules in this block require having the password set in PAM_AUTHTOK.

--- a/nixos/modules/services/security/fprintd.nix
+++ b/nixos/modules/services/security/fprintd.nix
@@ -38,6 +38,24 @@ in
           '';
         };
       };
+
+      lid = {
+        authSkipLidClose = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Disable fprint auth when laptop with built-in fingerprint reader has lid closed. Useful for docked laptops.
+          '';
+        };
+        path = lib.mkOption {
+          type = lib.types.str;
+          default = "/proc/acpi/button/lid/LID/state";
+          example = "/proc/acpi/button/lid/LID/state";
+          description = ''
+            Path to lid state file.
+          '';
+        };
+      };
     };
   };
 


### PR DESCRIPTION
## Description of changes

This configuration option allows you to optionally skip fprintd for PAM authentication if your laptop lid is closed. In all other scenarios, this option will be ignored.

The current behavior of fprintd before this configuration is especially annoying when you put your laptop in clamshell mode and can't access the built-in fingerprint reader and try to run a `sudo` command. Essentially, `sudo` will hang for >10 seconds until the timeout duration passes.

### Relevant links:

- Original StackExchange response outlining how to do this: https://unix.stackexchange.com/a/743941
- My implementation on my Dell XPS 13: https://github.com/heywoodlh/nixos-configs/blob/7572bf890a4db62ba74ec788e4374a1be1543d22/nixos/hosts/xps-13/configuration.nix#L75

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
