### PR TITLE
nix-serve: unstable-2018-03-20 → unstable-2024-09-17

### DIFF
--- a/pkgs/tools/package-management/nix-serve/default.nix
+++ b/pkgs/tools/package-management/nix-serve/default.nix
@@ -6,11 +6,12 @@
 , perl
 , makeWrapper
 , nixosTests
+, fetchpatch
 }:
 
 let
-  rev = "e4675e38ab54942e351c7686e40fabec822120b9";
-  sha256 = "1wm24p6pkxl1d7hrvf4ph6mwzawvqi22c60z9xzndn5xfyr4v0yr";
+  rev = "77ffa33d83d2c7c6551c5e420e938e92d72fec24";
+  sha256 = "sha256-MJRdVO2pt7wjOu5Hk0eVeNbk5bK5+Uo/Gh9XfO4OlMY=";
 in
 
 stdenv.mkDerivation {
@@ -22,6 +23,14 @@ stdenv.mkDerivation {
     repo = "nix-serve";
     inherit rev sha256;
   };
+
+  patches = [
+    # Part of https://github.com/edolstra/nix-serve/pull/61
+    (fetchpatch {
+      url = "https://github.com/edolstra/nix-serve/commit/9e434fff4486afeb3cc3f631f6dc56492b204704.patch";
+      sha256 = "sha256-TxQ6q6UApTKsYIMdr/RyrkKSA3k47stV63bTbxchNTU=";
+    })
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/package-management/nix-serve/nix-command.patch
+++ b/pkgs/tools/package-management/nix-serve/nix-command.patch
@@ -1,0 +1,40 @@
+From 9e434fff4486afeb3cc3f631f6dc56492b204704 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Wed, 31 Jul 2024 23:53:31 +0200
+Subject: [PATCH] add extra-experimental-features for nix-command
+
+fixes https://github.com/NixOS/nixpkgs/pull/331230
+---
+ nix-serve.psgi | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/nix-serve.psgi b/nix-serve.psgi
+index 928fa3b..65a8680 100644
+--- a/nix-serve.psgi
++++ b/nix-serve.psgi
+@@ -64,7 +64,7 @@ my $app = sub {
+         return [404, ['Content-Type' => 'text/plain'], ["Incorrect NAR hash. Maybe the path has been recreated.\n"]]
+             unless $narHash eq "sha256:$expectedNarHash";
+         my $fh = new IO::Handle;
+-        open $fh, "-|", "nix", "dump-path", "--", $storePath;
++        open $fh, "-|", "nix", "--extra-experimental-features", "nix-command", "dump-path", "--", $storePath;
+         return [200, ['Content-Type' => 'text/plain', 'Content-Length' => $narSize], $fh];
+     }
+ 
+@@ -75,14 +75,14 @@ my $app = sub {
+         return [404, ['Content-Type' => 'text/plain'], ["No such path.\n"]] unless $storePath;
+         my ($deriver, $narHash, $time, $narSize, $refs) = $store->queryPathInfo($storePath, 1) or die;
+         my $fh = new IO::Handle;
+-        open $fh, "-|", "nix", "dump-path", "--", $storePath;
++        open $fh, "-|", "nix", "--extra-experimental-features", "nix-command", "dump-path", "--", $storePath;
+         return [200, ['Content-Type' => 'text/plain', 'Content-Length' => $narSize], $fh];
+     }
+ 
+     elsif ($path =~ /^\/log\/([0-9a-z]+-[0-9a-zA-Z\+\-\.\_\?\=]+)/) {
+         my $storePath = "$Nix::Config::storeDir/$1";
+         my $fh = new IO::Handle;
+-        open $fh, "-|", "nix", "log", $storePath;
++        open $fh, "-|", "nix", "--extra-experimental-features", "nix-command", "log", $storePath;
+         return [200, ['Content-Type' => 'text/plain' ], $fh];
+     }
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38044,9 +38044,7 @@ with pkgs;
 
   nixpkgs-review = callPackage ../tools/package-management/nixpkgs-review { };
 
-  nix-serve = callPackage ../tools/package-management/nix-serve {
-    nix = nixVersions.nix_2_18;
-  };
+  nix-serve = callPackage ../tools/package-management/nix-serve { };
 
   nix-serve-ng = haskell.lib.compose.justStaticExecutables haskellPackages.nix-serve-ng;
 


### PR DESCRIPTION
## Description of changes

Draft while upstream decides way forward

https://github.com/edolstra/nix-serve/pull/60

Fixes broken nixosTests.nix-serve after

https://github.com/NixOS/nixpkgs/pull/335342

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
