### PR TITLE
haskellPackages.gi-gtk: Re-enable parallel building

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -1076,6 +1076,9 @@ benchmark component.
 `disableLibraryProfiling drv`
 : Sets the `enableLibraryProfiling` argument to `false` for `drv`.
 
+`disableParallelBuilding drv`
+: Sets the `enableParallelBuilding` argument to `false` for `drv`.
+
 #### Library functions in the Haskell package sets {#haskell-package-set-lib-functions}
 
 Some library functions depend on packages from the Haskell package sets. Thus they are

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2458,9 +2458,7 @@ self: super: {
   # See: https://gitlab.haskell.org/ghc/ghc/-/issues/17188
   #
   # Overwrite the build cores
-  raaz = overrideCabal (drv: {
-    enableParallelBuilding = false;
-  }) super.raaz;
+  raaz = disableParallelBuilding super.raaz;
 
   # https://github.com/andreymulik/sdp/issues/3
   sdp = disableLibraryProfiling super.sdp;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -54,9 +54,6 @@ self: super: {
   unix = null;
   xhtml = null;
 
-  # https://gitlab.haskell.org/ghc/ghc/-/issues/23392
-  gi-gtk = disableParallelBuilding super.gi-gtk;
-
   #
   # Version upgrades
   #

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -5,7 +5,6 @@ with haskellLib;
 let
   inherit (pkgs) lib;
 
-  disableParallelBuilding = haskellLib.overrideCabal (drv: { enableParallelBuilding = false; });
 in
 
 self: super: {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -3,7 +3,6 @@
 let
   inherit (pkgs) lib;
 
-  disableParallelBuilding = haskellLib.overrideCabal (drv: { enableParallelBuilding = false; });
 in
 
 self: super: {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -52,6 +52,4 @@ self: super: {
   unix = null;
   xhtml = null;
 
-  # https://gitlab.haskell.org/ghc/ghc/-/issues/23392
-  gi-gtk = disableParallelBuilding super.gi-gtk;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -15,8 +15,6 @@ let
       builtins.throw "Check if '${msg}' was resolved in ${pkg.pname} ${pkg.version} and update or remove this";
   jailbreakForCurrentVersion = p: v: checkAgainAfter p v "bad bounds" (doJailbreak p);
 
-  # Workaround for a ghc-9.6 issue: https://gitlab.haskell.org/ghc/ghc/-/issues/23392
-  disableParallelBuilding = overrideCabal (drv: { enableParallelBuilding = false; });
 in
 
 self: super: {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -107,9 +107,6 @@ self: super: {
     package-version             # doctest <0.21, tasty-hedgehog <1.4
   ;
 
-  # Avoid triggering an issue in ghc-9.6.2
-  gi-gtk = disableParallelBuilding super.gi-gtk;
-
   # Pending text-2.0 support https://github.com/gtk2hs/gtk2hs/issues/327
   gtk = doJailbreak super.gtk;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -145,7 +145,4 @@ self: super: {
     sha256 = "sha256-umjwgdSKebJdRrXjwHhsi8HBqotx1vFibY9ttLkyT/0=";
   }) super.reflex;
 
-  # https://gitlab.haskell.org/ghc/ghc/-/issues/23392
-  gi-gtk = disableParallelBuilding super.gi-gtk;
-
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -5,7 +5,6 @@ with haskellLib;
 let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
-  disableParallelBuilding = haskellLib.overrideCabal (drv: { enableParallelBuilding = false; });
 in
 
 self: super: {

--- a/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
@@ -2,12 +2,6 @@
 
 with haskellLib;
 
-let
-  disableParallelBuilding = overrideCabal (drv: {
-    enableParallelBuilding = false;
-  });
-in
-
 # cabal2nix doesn't properly add dependencies conditional on arch(javascript)
 
 (self: super: {

--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -184,6 +184,13 @@ rec {
   markBrokenVersion = version: drv: assert drv.version == version; markBroken drv;
   markUnbroken = overrideCabal (drv: { broken = false; });
 
+  /* disableParallelBuilding drops the -j<n> option from the GHC
+     command line for the given package. This can be useful in rare
+     situations where parallel building of a package causes GHC to
+     fail for some reason.
+   */
+  disableParallelBuilding = overrideCabal (drv: { enableParallelBuilding = false; });
+
   enableLibraryProfiling = overrideCabal (drv: { enableLibraryProfiling = true; });
   disableLibraryProfiling = overrideCabal (drv: { enableLibraryProfiling = false; });
 

--- a/pkgs/development/haskell-modules/lib/default.nix
+++ b/pkgs/development/haskell-modules/lib/default.nix
@@ -176,6 +176,8 @@ rec {
   markBrokenVersion = compose.markBrokenVersion;
   markUnbroken = compose.markUnbroken;
 
+  disableParallelBuilding = compose.disableParallelBuilding;
+
   enableLibraryProfiling = compose.enableLibraryProfiling;
   disableLibraryProfiling = compose.disableLibraryProfiling;
 


### PR DESCRIPTION
This is for merging into the `haskell-updates` branch (PR #339272).

1. Moves `disableParallelBuilding` function into `pkgs.haskell.lib`.
2. Removes application of `disableParallelBuilding` to `gi-gtk`. Not because the [GHC bug](https://gitlab.haskell.org/ghc/ghc/-/issues/23392) is fixed, but because a [workaround](https://github.com/haskell-gi/haskell-gi/commit/5d36c122e0b261bc3362e084cd857328b255a675) was added to [haskell-gi 0.26.10](https://hackage.haskell.org/package/haskell-gi-0.26.10/changelog) so that it won't generate code which triggers the failure.

Tested building (`x86_64-linux`) of:
 - [x] `haskellPackages.gi-gtk` (still takes about 15 minutes to build though)
 - [x] `haskellPackages.raaz` (derivation unchanged)
 - [x] `haskell.packages.ghc98.gi-gtk`
 - [x] `haskell.packages.ghc910.gi-gtk`
 - [ ] `pkgsCross.ghcjs.haskellPackages.reflex-dom`
