### PR TITLE
lltex-ls-plus: init at 17.0.1; vscode-extensions.ltex-plus.vscode-ltex-plus: init at 14.0.2

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2921,6 +2921,37 @@ let
         };
       };
 
+      ltex-plus.vscode-ltex-plus = buildVscodeMarketplaceExtension rec {
+        mktplcRef = {
+          name = "vscode-ltex-plus";
+          publisher = "ltex-plus";
+          version = "14.0.2";
+        };
+
+        vsix = fetchurl {
+          name = "${mktplcRef.publisher}-${mktplcRef.name}.zip";
+          url = "https://github.com/ltex-plus/vscode-ltex-plus/releases/download/${mktplcRef.version}/vscode-ltex-plus-${mktplcRef.version}-offline-linux-x64.vsix";
+          sha256 = "sha256-M5/ka65LTYRVSrq9EDbsjHdvK61GLiZd0anCDoSyo8c=";
+        };
+
+        nativeBuildInputs = [
+          jq
+          moreutils
+        ];
+
+        buildInputs = [ jdk ];
+
+        postInstall = ''
+          cd "$out/$installPrefix"
+          jq '.contributes.configuration.properties."ltex.java.path".default = "${jdk}"' package.json | sponge package.json
+        '';
+
+        meta = {
+          license = lib.licenses.mpl20;
+          maintainers = [ lib.maintainers.pwoelfel ];
+        };
+      };
+
       lucperkins.vrl-vscode = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "lucperkins";

--- a/pkgs/by-name/lt/ltex-ls-plus/package.nix
+++ b/pkgs/by-name/lt/ltex-ls-plus/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeBinaryWrapper,
+  jre_headless,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "ltex-ls-plus";
+  version = "17.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/ltex-plus/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
+    sha256 = "sha256-S4d9yL4hgpdhqp6Vx87FUFqdUyj3k97QsJsGFyrDVDg=";
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -rfv bin/ lib/ $out
+    rm -fv $out/bin/.lsp-cli.json $out/bin/*.bat
+    wrapProgram $out/bin/ltex-ls-plus --set JAVA_HOME "${jre_headless}"
+    wrapProgram $out/bin/ltex-cli-plus --set JAVA_HOME "${jre_headless}"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://ltex-plus.github.io/ltex-plus/";
+    description = "Grammar/Spell Checker Using LanguageTool with Support for LaTeX, Markdown, and Others";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ pwoelfel ];
+    platforms = jre_headless.meta.platforms;
+  };
+}

--- a/pkgs/by-name/lt/ltex-ls-plus/package.nix
+++ b/pkgs/by-name/lt/ltex-ls-plus/package.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://ltex-plus.github.io/ltex-plus/";
-    description = "Grammar/Spell Checker Using LanguageTool with Support for LaTeX, Markdown, and Others";
+    description = "Grammar and spell checker using LanguageTool with support for LaTeX, Markdown, and more";
     license = licenses.mpl20;
     maintainers = with maintainers; [ pwoelfel ];
     platforms = jre_headless.meta.platforms;

--- a/pkgs/by-name/lt/ltex-ls-plus/package.nix
+++ b/pkgs/by-name/lt/ltex-ls-plus/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   version = "17.0.1";
 
   src = fetchurl {
-    url = "https://github.com/ltex-plus/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
+    url = "https://github.com/ltex-plus/ltex-ls-plus/releases/download/${version}/ltex-ls-plus-${version}.tar.gz";
     sha256 = "sha256-S4d9yL4hgpdhqp6Vx87FUFqdUyj3k97QsJsGFyrDVDg=";
   };
 


### PR DESCRIPTION
## Description of changes
This adds `ltex-ls-plus` and `vscode-extensions.ltex-plus.vscode-ltex-plus`, see https://ltex-plus.github.io/ltex-plus/ and https://github.com/ltex-plus/vscode-ltex-plus
It is a fork of `ltex-ls` (see https://github.com/valentjn/vscode-ltex) which seems to be unmaintained.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
