### PR TITLE
nix-serve: 0.2-e4675e38 -> 0-unstable-2024-09-18 (switch to nix-commu…

### DIFF
--- a/pkgs/tools/package-management/nix-serve/default.nix
+++ b/pkgs/tools/package-management/nix-serve/default.nix
@@ -8,19 +8,15 @@
 , nixosTests
 }:
 
-let
-  rev = "e4675e38ab54942e351c7686e40fabec822120b9";
-  sha256 = "1wm24p6pkxl1d7hrvf4ph6mwzawvqi22c60z9xzndn5xfyr4v0yr";
-in
-
 stdenv.mkDerivation {
   pname = "nix-serve";
-  version = "0.2-${lib.substring 0 7 rev}";
+  version = "0-unstable-2024-09-18";
 
   src = fetchFromGitHub {
-    owner = "edolstra";
+    owner = "nix-community";
     repo = "nix-serve";
-    inherit rev sha256;
+    rev = "f2529a143bc6a41471e0374a983211552223aba8";
+    sha256 = "sha256-5fxrCEjx2ej0uvqDSFdQPD1LIpJ6jmbenjsX5SFiuuQ=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -41,9 +37,12 @@ stdenv.mkDerivation {
   };
 
   meta = with lib; {
-    homepage = "https://github.com/edolstra/nix-serve";
+    homepage = "https://github.com/nix-community/nix-serve";
     description = "Utility for sharing a Nix store as a binary cache";
-    maintainers = [ maintainers.eelco ];
+    maintainers = [
+      maintainers.eelco
+      maintainers.mic92
+    ];
     license = licenses.lgpl21;
     platforms = nix.meta.platforms;
     mainProgram = "nix-serve";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38020,9 +38020,7 @@ with pkgs;
 
   nixpkgs-review = callPackage ../tools/package-management/nixpkgs-review { };
 
-  nix-serve = callPackage ../tools/package-management/nix-serve {
-    nix = nixVersions.nix_2_18;
-  };
+  nix-serve = callPackage ../tools/package-management/nix-serve { };
 
   nix-serve-ng = haskell.lib.compose.justStaticExecutables haskellPackages.nix-serve-ng;
 


### PR DESCRIPTION
…nity fork)

nix 2.24 support

Diff: https://github.com/nix-community/nix-serve/compare/e4675e38ab54942e351c7686e40fabec822120b9...f2529a143bc6a41471e0374a983211552223aba8

## Description of changes

This repository is a fork of https://github.com/edolstra/nix-serve/ to apply outstanding patches needed to work with the latest version of nix. We may consider archiving this fork again if upstream becomes active again. The original author of the fork is also welcome to join this fork instead to have shared maintainance over the project.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
