### PR TITLE
haskellPackages: Assorted build fixes

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1860,6 +1860,9 @@ self: super: {
   # 2024-03-02: vty <5.39 - https://github.com/reflex-frp/reflex-ghci/pull/33
   reflex-ghci = assert super.reflex-ghci.version == "0.2.0.1"; doJailbreak super.reflex-ghci;
 
+  # 2024-09-18: transformers <0.5  https://github.com/reflex-frp/reflex-gloss/issues/6
+  reflex-gloss = assert super.reflex-gloss.version == "0.2"; doJailbreak super.reflex-gloss;
+
   # Due to tests restricting base in 0.8.0.0 release
   http-media = doJailbreak super.http-media;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1863,6 +1863,9 @@ self: super: {
   # 2024-09-18: transformers <0.5  https://github.com/reflex-frp/reflex-gloss/issues/6
   reflex-gloss = assert super.reflex-gloss.version == "0.2"; doJailbreak super.reflex-gloss;
 
+  # 2024-09-18: primitive <0.8  https://gitlab.com/Kritzefitz/reflex-gi-gtk/-/merge_requests/20
+  reflex-gi-gtk = assert super.reflex-gi-gtk.version == "0.2.0.1"; doJailbreak super.reflex-gi-gtk;
+
   # Due to tests restricting base in 0.8.0.0 release
   http-media = doJailbreak super.http-media;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1919,6 +1919,9 @@ self: super: {
   # https://github.com/Gabriella439/Haskell-Pipes-HTTP-Library/pull/17
   pipes-http = doJailbreak super.pipes-http;
 
+  # 2024-09-18: transformers <0.6  https://github.com/Gabriella439/Haskell-Pipes-Extras-Library/pull/19
+  pipes-extras = assert super.pipes-extras.version == "1.0.15"; doJailbreak super.pipes-extras;
+
   moto-postgresql = appendPatches [
     # https://gitlab.com/k0001/moto/-/merge_requests/3
     (fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1915,10 +1915,6 @@ self: super: {
     sha256 = "sha256-kFV6CcwKdMq+qSgyc+eIApnaycq5A++pEEVr2A9xvts=";
   }) super.pipes-aeson;
 
-  # Needs bytestring 0.11
-  # https://github.com/Gabriella439/Haskell-Pipes-HTTP-Library/pull/17
-  pipes-http = doJailbreak super.pipes-http;
-
   # 2024-09-18: transformers <0.6  https://github.com/Gabriella439/Haskell-Pipes-Extras-Library/pull/19
   pipes-extras = assert super.pipes-extras.version == "1.0.15"; doJailbreak super.pipes-extras;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1997,6 +1997,14 @@ self: super: {
   # Test suite fails, upstream not reachable for simple fix (not responsive on github)
   vivid-osc = dontCheck super.vivid-osc;
   vivid-supercollider = dontCheck super.vivid-supercollider;
+  vivid = overrideCabal (drv: assert drv.version == "0.5.2.0"; {
+    # 2024-10-18: Some library dependency must have stopped
+    # re-exporting 'void', so now it needs an extra import line.
+    # Fixed in 0.5.2.1.
+    postPatch = ''
+      sed -i '/) where/a import Control.Monad (void)' Vivid/GlobalState.hs
+    '';
+  }) super.vivid;
 
   # Test suite does not compile.
   feed = dontCheck super.feed;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2225,9 +2225,15 @@ self: super: {
   # https://github.com/merijn/paramtree/issues/4
   paramtree = dontCheck super.paramtree;
 
-  # Too strict version bounds on haskell-gi
-  # https://github.com/owickstrom/gi-gtk-declarative/issues/100
-  gi-gtk-declarative = doJailbreak super.gi-gtk-declarative;
+  # 2024-09-18: Make compatible with haskell-gi 0.26.10
+  # https://github.com/owickstrom/gi-gtk-declarative/pull/118
+  gi-gtk-declarative = overrideCabal (drv: assert drv.version == "0.7.1"; {
+    jailbreak = true;
+    postPatch = ''
+      sed -i '1 i {-# LANGUAGE FlexibleContexts #-}' \
+        src/GI/Gtk/Declarative/Widget/Conversions.hs
+    '';
+  }) super.gi-gtk-declarative;
   gi-gtk-declarative-app-simple = doJailbreak super.gi-gtk-declarative-app-simple;
 
   gi-gtk_4 = self.gi-gtk_4_0_9;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -118,6 +118,8 @@ self: super: {
   hashable_1_4_7_0 = doJailbreak super.hashable_1_4_7_0; # relax bounds for QuickCheck, tasty, and tasty-quickcheck
   hashable_1_5_0_0 = doJailbreak super.hashable_1_5_0_0; # relax bounds for QuickCheck, tasty, and tasty-quickcheck
 
+  broadcast-chan = doJailbreak super.broadcast-chan; # base <4.19  https://github.com/merijn/broadcast-chan/pull/19
+
   #
   # Test suite issues
   #

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -118,6 +118,7 @@ self: super: {
   string-random = doJailbreak super.string-random; # text >=1.2.2.1 && <2.1
   inflections = doJailbreak super.inflections; # text >=0.2 && <2.1
   universe-some = doJailbreak super.universe-some; # th-abstraction < 0.7
+  broadcast-chan = doJailbreak super.broadcast-chan; # base <4.19  https://github.com/merijn/broadcast-chan/pull/19
 
   #
   # Test suite issues

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -4566,7 +4566,6 @@ broken-packages:
   - pipes-cereal # failure in job https://hydra.nixos.org/build/233195413 at 2023-09-02
   - pipes-core # failure in job https://hydra.nixos.org/build/233213024 at 2023-09-02
   - pipes-errors # failure in job https://hydra.nixos.org/build/233214912 at 2023-09-02
-  - pipes-extras # failure in job https://hydra.nixos.org/build/252732291 at 2024-03-16
   - pipes-interleave # failure in job https://hydra.nixos.org/build/233247428 at 2023-09-02
   - pipes-io # failure in job https://hydra.nixos.org/build/233243253 at 2023-09-02
   - pipes-kafka # failure in job https://hydra.nixos.org/build/252727228 at 2024-03-16

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1224,7 +1224,6 @@ broken-packages:
   - dead-code-detection # failure in job https://hydra.nixos.org/build/233205957 at 2023-09-02
   - Deadpan-DDP # failure in job https://hydra.nixos.org/build/233221990 at 2023-09-02
   - dead-simple-json # failure in job https://hydra.nixos.org/build/233204301 at 2023-09-02
-  - dear-imgui # failure in job https://hydra.nixos.org/build/233238246 at 2023-09-02
   - debugger-hs # failure in job https://hydra.nixos.org/build/233206302 at 2023-09-02
   - debug-me # failure in job https://hydra.nixos.org/build/233213991 at 2023-09-02
   - debug-trace-file # failure in job https://hydra.nixos.org/build/233231840 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -6496,7 +6496,6 @@ broken-packages:
   - visibility # failure in job https://hydra.nixos.org/build/233206672 at 2023-09-02
   - visual-prof # failure in job https://hydra.nixos.org/build/233250080 at 2023-09-02
   - vitrea # failure in job https://hydra.nixos.org/build/233252038 at 2023-09-02
-  - vivid # failure in job https://hydra.nixos.org/build/252716916 at 2024-03-16
   - vk-aws-route53 # failure in job https://hydra.nixos.org/build/233250126 at 2023-09-02
   - VKHS # failure in job https://hydra.nixos.org/build/233246557 at 2023-09-02
   - vowpal-utils # failure in job https://hydra.nixos.org/build/233251505 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5029,7 +5029,6 @@ broken-packages:
   - reflex-gloss # failure in job https://hydra.nixos.org/build/234457448 at 2023-09-13
   - reflex-jsx # failure in job https://hydra.nixos.org/build/233207137 at 2023-09-02
   - reflex-orphans # failure in job https://hydra.nixos.org/build/233249128 at 2023-09-02
-  - reflex-sdl2 # failure in job https://hydra.nixos.org/build/233233947 at 2023-09-02
   - reflex-test-host # failure in job https://hydra.nixos.org/build/233220665 at 2023-09-02
   - reflex-transformers # failure in job https://hydra.nixos.org/build/233243647 at 2023-09-02
   - ref-mtl # failure in job https://hydra.nixos.org/build/233260152 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5025,7 +5025,6 @@ broken-packages:
   - reflex-external-ref # failure in job https://hydra.nixos.org/build/233215834 at 2023-09-02
   - reflex-gadt-api # failure in job https://hydra.nixos.org/build/260124380 at 2024-05-19
   - reflex-gi-gtk # failure in job https://hydra.nixos.org/build/253683412 at 2024-03-31
-  - reflex-gloss # failure in job https://hydra.nixos.org/build/234457448 at 2023-09-13
   - reflex-jsx # failure in job https://hydra.nixos.org/build/233207137 at 2023-09-02
   - reflex-orphans # failure in job https://hydra.nixos.org/build/233249128 at 2023-09-02
   - reflex-test-host # failure in job https://hydra.nixos.org/build/233220665 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -2051,7 +2051,6 @@ broken-packages:
   - gi-gio-hs-list-model # failure in job https://hydra.nixos.org/build/233241640 at 2023-09-02
   - gi-gstapp # failure in job https://hydra.nixos.org/build/253686159 at 2024-03-31
   - gi-gsttag # failure in job https://hydra.nixos.org/build/233197576 at 2023-09-02
-  - gi-gtk-declarative # failure in job https://hydra.nixos.org/build/233217494 at 2023-09-02
   - gi-gtksheet # failure in job https://hydra.nixos.org/build/233211386 at 2023-09-02
   - gi-gtksource # failure in job https://hydra.nixos.org/build/233215342 at 2023-09-02
   - gi-ibus # failure in job https://hydra.nixos.org/build/233220272 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5024,7 +5024,6 @@ broken-packages:
   - reflex-dom-svg # failure in job https://hydra.nixos.org/build/233193544 at 2023-09-02
   - reflex-external-ref # failure in job https://hydra.nixos.org/build/233215834 at 2023-09-02
   - reflex-gadt-api # failure in job https://hydra.nixos.org/build/260124380 at 2024-05-19
-  - reflex-gi-gtk # failure in job https://hydra.nixos.org/build/253683412 at 2024-03-31
   - reflex-jsx # failure in job https://hydra.nixos.org/build/233207137 at 2023-09-02
   - reflex-orphans # failure in job https://hydra.nixos.org/build/233249128 at 2023-09-02
   - reflex-test-host # failure in job https://hydra.nixos.org/build/233220665 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -732,6 +732,7 @@ dont-distribute-packages:
  - cabal-cargs
  - cabal-fix
  - cabal-query
+ - cabal-scaffold
  - cabal-test
  - cabal2arch
  - cabalmdvrpm
@@ -964,14 +965,14 @@ dont-distribute-packages:
  - copilot-cbmc
  - copilot-frp-sketch
  - copilot-language
- - copilot-language_3_20
+ - copilot-language_4_0
  - copilot-libraries
- - copilot-libraries_3_20
+ - copilot-libraries_4_0
  - copilot-sbv
  - copilot-theorem
- - copilot-theorem_3_20
+ - copilot-theorem_4_0
  - copilot-verifier
- - copilot_3_20
+ - copilot_4_0
  - corenlp-parser
  - coroutine-enumerator
  - coroutine-iteratee
@@ -988,7 +989,7 @@ dont-distribute-packages:
  - cqrs-test
  - cqrs-testkit
  - crackNum
- - crackNum_3_12
+ - crackNum_3_14
  - craft
  - craftwerk-cairo
  - craftwerk-gtk
@@ -1162,7 +1163,7 @@ dont-distribute-packages:
  - distribution-plot
  - dixi
  - dl-fedora
- - dl-fedora_1_1
+ - dl-fedora_1_2
  - dmenu-pkill
  - dmenu-pmount
  - dmenu-search
@@ -1499,7 +1500,6 @@ dont-distribute-packages:
  - gi-cairo-again
  - gi-ges
  - gi-gstpbutils
- - gi-gtk-declarative-app-simple
  - git-config
  - git-fmt
  - git-gpush
@@ -1509,6 +1509,7 @@ dont-distribute-packages:
  - gitdo
  - github-data
  - github-webhook-handler-snap
+ - github-workflow-commands
  - gitlib-cross
  - gitlib-s3
  - gitson
@@ -1793,6 +1794,7 @@ dont-distribute-packages:
  - gtk2hs-cast-gtksourceview2
  - gtkimageview
  - gtkrsync
+ - gtvm-hs
  - guarded-rewriting
  - guess-combinator
  - h3spec
@@ -2436,7 +2438,6 @@ dont-distribute-packages:
  - keera-hails-reactivelenses
  - keera-posture
  - keid-resource-gltf
- - keid-ui-dearimgui
  - kerry
  - kevin
  - key-vault
@@ -2459,6 +2460,7 @@ dont-distribute-packages:
  - kubernetes-client
  - kure-your-boilerplate
  - kurita
+ - kvitable_1_1_0_1
  - laborantin-hs
  - labsat
  - labyrinth
@@ -3543,7 +3545,6 @@ dont-distribute-packages:
  - serv
  - serv-wai
  - servant-aeson-generics-typescript
- - servant-auth-client_0_4_2_0
  - servant-auth-hmac
  - servant-auth-token
  - servant-auth-token-acid
@@ -3807,7 +3808,7 @@ dont-distribute-packages:
  - sydtest-webdriver-screenshot_0_1_0_0
  - sydtest-webdriver-yesod
  - sydtest-yesod
- - sydtest_0_17_0_0
+ - sydtest_0_18_0_0
  - sylvia
  - symantic-atom
  - symantic-http-demo
@@ -4008,6 +4009,7 @@ dont-distribute-packages:
  - ukrainian-phonetics-basic
  - unagi-bloomfilter
  - unbound
+ - unbound-generics-unify
  - unbound-kind-generics
  - unfoldable-restricted
  - uni-events
@@ -4166,7 +4168,7 @@ dont-distribute-packages:
  - werewolf-slack
  - wgpu-hs
  - what4
- - what4_1_6
+ - what4_1_6_2
  - wheb-mongo
  - wheb-redis
  - wheb-strapped

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1389,6 +1389,7 @@ self: super: builtins.intersectAttrs super {
       gi-adwaita
       sdl2-ttf
       sdl2
+      dear-imgui
       ;
 
     webkit2gtk3-javascriptcore = lib.pipe super.webkit2gtk3-javascriptcore [


### PR DESCRIPTION
This is for merging into the `haskell-updates` branch (PR #339272).

Tested the build with:
```
nix build --impure --expr 'let pkgs = (import ./. { system = "x86_64-linux"; });
in pkgs.haskellPackages.ghcWithHoogle (ps: with ps; [
  gi-gtk-declarative
  gi-gtk-declarative-app-simple
  reflex-gloss
  reflex-gi-gtk
  reflex-sdl2
  pipes-extras
  pipes-http
  vivid
  dear-imgui
])'
```

Upstream PRs:
- owickstrom/gi-gtk-declarative#118
- Gabriella439/Haskell-Pipes-Extras-Library#19
- Gabriella439/Haskell-Pipes-HTTP-Library#17
- merijn/broadcast-chan#19
