### PR TITLE
rek2: fix bugs caused by upstream changes

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/stable/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/stable/versions.nix
@@ -8,7 +8,7 @@
   etcdVersion = "v3.5.13-k3s1";
   pauseVersion = "3.6";
   ccmVersion = "v1.29.3-build20240515";
-  dockerizedVersion = "v1.30.4-dev.877838a0-dirty";
+  dockerizedVersion = "v1.30.4-rke2r1";
   golangVersion = "go1.22.5";
   eol = "2025-06-28";
 }

--- a/pkgs/applications/networking/cluster/rke2/update-script.sh
+++ b/pkgs/applications/networking/cluster/rke2/update-script.sh
@@ -29,7 +29,7 @@ curl --silent --fail --output ${VERSIONS_SCRIPT} \
         https://raw.githubusercontent.com/rancher/rke2/${RKE2_COMMIT}/scripts/version.sh
 
 set +eu
-DRONE_TAG=${LATEST_TAG_NAME} source ${VERSIONS_SCRIPT}
+GITHUB_ACTION_TAG=${LATEST_TAG_NAME} source ${VERSIONS_SCRIPT}
 set -eu
 
 KUBERNETES_CYCLES=$(echo ${KUBERNETES_VERSION} | grep -Eo "[0-9]+\.[0-9]+")
@@ -50,7 +50,7 @@ cat << EOF > "${WORKDIR}/${CHANNEL_NAME}/versions.nix"
   etcdVersion = "${ETCD_VERSION}";
   pauseVersion = "${PAUSE_VERSION}";
   ccmVersion = "${CCM_VERSION}";
-  dockerizedVersion = "${DOCKERIZED_VERSION}";
+  dockerizedVersion = "${LATEST_TAG_NAME/+/-}";
   golangVersion = "${VERSION_GOLANG}";
   eol = "${KUBERNETES_EOL}";
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix a bug caused by [the change of upstream `scripts/version.sh`](https://github.com/rancher/rke2/pull/6062/files#diff-d9002f82f23cc9b3c1545ec7d5ddfc3911aec8ba24d4e3d21c73f40355da2a16) (#342593).

In the current version, we use `LATEST_TAG_NAME` to calculate `dockerizedVersion` directly, instead of relying on the upstream `scripts/version.sh`.

Since other fields are [hard-coded in the upstream `scripts/version.sh`](https://github.com/rancher/rke2/blob/b8dfafaa9650050f85d1f44b7f3956b62120d40e/scripts/version.sh#L34-L39), there is no similar risk.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
