### PR TITLE
wpa_supplicant: add patch to fix ext_passwords_file bug

### DIFF
--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -8,6 +8,8 @@ let
     maintainers = [ oddlama rnhmjoj ];
   };
 
+  naughtyPassphrase = ''!,./;'[]\-=<>?:"{}|_+@$%^&*()`~ # ceci n'est pas un commentaire'';
+
   runConnectionTest = name: extraConfig: runTest {
     name = "wpa_supplicant-${name}";
     inherit meta;
@@ -27,7 +29,7 @@ let
               ssid = "nixos-test-sae";
               authentication = {
                 mode = "wpa3-sae";
-                saePasswords = [ { password = "reproducibility"; } ];
+                saePasswords = [ { password = naughtyPassphrase; } ];
               };
               bssid = "02:00:00:00:00:00";
             };
@@ -36,8 +38,8 @@ let
               authentication = {
                 mode = "wpa3-sae-transition";
                 saeAddToMacAllow = true;
-                saePasswordsFile = pkgs.writeText "password" "reproducibility";
-                wpaPasswordFile = pkgs.writeText "password" "reproducibility";
+                saePasswordsFile = pkgs.writeText "password" naughtyPassphrase;
+                wpaPasswordFile = pkgs.writeText "password" naughtyPassphrase;
               };
               bssid = "02:00:00:00:00:01";
             };
@@ -45,7 +47,7 @@ let
               ssid = "nixos-test-wpa2";
               authentication = {
                 mode = "wpa2-sha256";
-                wpaPassword = "reproducibility";
+                wpaPassword = naughtyPassphrase;
               };
               bssid = "02:00:00:00:00:02";
             };
@@ -65,7 +67,7 @@ let
 
           # secrets
           secretsFile = pkgs.writeText "wpa-secrets" ''
-            psk_nixos_test=reproducibility
+            psk_nixos_test=${naughtyPassphrase}
           '';
         }
         extraConfig

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
       hash = "sha256-X6mBbj7BkW66aYeSCiI3JKBJv10etLQxaTRfRgwsFmM=";
       revert = true;
     })
+    ./unsurprising-ext-password.patch
   ];
 
   # TODO: Patch epoll so that the dbus actually responds

--- a/pkgs/os-specific/linux/wpa_supplicant/unsurprising-ext-password.patch
+++ b/pkgs/os-specific/linux/wpa_supplicant/unsurprising-ext-password.patch
@@ -1,0 +1,66 @@
+From e5ac0dd1af48e085bb824082ef3b64afba673ded Mon Sep 17 00:00:00 2001
+From: rnhmjoj <rnhmjoj@inventati.org>
+Date: Wed, 18 Sep 2024 13:43:44 +0200
+Subject: [PATCH] ext_password_file: do not use wpa_config_get_line
+To: hostap@lists.infradead.org
+
+The file-based backed of the ext_password framework uses
+`wpa_config_get_line` to read the passwords line-by-line from a file.
+This function is meant to parse a single line from the
+wpa_supplicant.conf file, so it handles whitespace, quotes and other
+characters specially.
+
+Its behavior, however, it's not compatible with the rest of the
+ext_password framework implementation. For example, if a passphrase
+contains a `#` character it must be quoted to prevent parsing the
+remaining characters as an inline comment, but the code handling the
+external password in `wpa_supplicant_get_psk` does not handle quotes.
+The result is that either it will hash the enclosing quotes, producing a
+wrong PSK, or if the passphrase is long enough, fail the length check.
+As a consequence, some passphrases are impossible to input correctly.
+
+To solve this and other issues, this patch changes the behaviour of the
+`ext_password_file_get` function (which was not documented in details,
+at least w.r.t. special characters) to simply treat all characters
+literally: including trailing whitespaces (except CR and LF), `#` for
+inline comments, etc. Empty lines and full-line comments are still
+supported.
+
+Signed-off-by: Michele Guerini Rocco <rnhmjoj@inventati.org>
+---
+ src/utils/ext_password_file.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/src/utils/ext_password_file.c b/src/utils/ext_password_file.c
+index 4bb0095f3..f631ff15c 100644
+--- a/src/utils/ext_password_file.c
++++ b/src/utils/ext_password_file.c
+@@ -9,7 +9,6 @@
+ #include "includes.h"
+ 
+ #include "utils/common.h"
+-#include "utils/config.h"
+ #include "ext_password_i.h"
+ 
+ 
+@@ -97,7 +96,16 @@ static struct wpabuf * ext_password_file_get(void *ctx, const char *name)
+ 
+ 	wpa_printf(MSG_DEBUG, "EXT PW FILE: get(%s)", name);
+ 
+-	while (wpa_config_get_line(buf, sizeof(buf), f, &line, &pos)) {
++	while ((pos = fgets(buf, sizeof(buf), f))) {
++		line++;
++
++		/* Strip newline characters */
++		pos[strcspn(pos, "\r\n")] = 0;
++
++		/* Skip comments and empty lines */
++		if (*pos == '#' || *pos == '\0')
++		  continue;
++
+ 		char *sep = os_strchr(pos, '=');
+ 
+ 		if (!sep) {
+-- 
+2.44.1
+


### PR DESCRIPTION
## Description of changes

This fixes inconsistent behaviour in ext_passwords_file that makes impossible to input passphrases containing certain characters.

Fix #342140

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested with `wpa_supplicant.tests`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
