### PR TITLE
nixos/wireplumber: Add alsaDisableSuspension option

### DIFF
--- a/nixos/modules/services/desktops/pipewire/wireplumber.nix
+++ b/nixos/modules/services/desktops/pipewire/wireplumber.nix
@@ -4,7 +4,7 @@ let
   inherit (builtins) concatMap;
   inherit (lib) maintainers;
   inherit (lib.attrsets) attrByPath mapAttrsToList;
-  inherit (lib.lists) flatten optional;
+  inherit (lib.lists) flatten optional optionals;
   inherit (lib.modules) mkIf;
   inherit (lib.options) literalExpression mkOption;
   inherit (lib.strings) concatStringsSep makeSearchPath;
@@ -200,6 +200,26 @@ in
           [wiki-filter-chain]: https://docs.pipewire.org/page_module_filter_chain.html
         '';
       };
+
+      alsaDisableSuspension = mkOption {
+        type = bool;
+        default = false;
+        description = ''
+          Disable the suspension of ALSA devices when they are not in use.
+
+          On some setups, one may get audio delay or audible pop/crack when starting playback,
+          or noise when no audio is playing.
+          This is caused by node suspension when inactive.
+          Disabling suspension can solve these issues.
+
+          Note that this only disables suspension for ALSA devices, not for Bluetooth devices.
+
+          See also:
+          - [Arch wiki PipeWire page - node suspension section][arch-wiki-pipewire-node-suspension]
+
+          [arch-wiki-pipewire-node-suspension]: https://wiki.archlinux.org/title/PipeWire#Noticeable_audio_delay_or_audible_pop/crack_when_starting_playback
+        '';
+      };
     };
   };
 
@@ -215,6 +235,20 @@ in
         }
       '';
 
+      alsaDisableSuspensionConfigPkg = mapConfigToFiles {
+        "51-disable-suspension" = {
+          "monitor.alsa.rules" = [
+            {
+              matches = [
+                { "node.name" = "~alsa_input.*"; } # Matches all sources
+                { "node.name" = "~alsa_output.*"; } # Matches all sinks
+              ];
+              actions.update-props."session.suspend-timeout-seconds" = 0;
+            }
+          ];
+        };
+      };
+
       extraConfigPkg = pkgs.buildEnv {
         name = "wireplumber-extra-config";
         paths = mapConfigToFiles cfg.extraConfig;
@@ -229,7 +263,8 @@ in
 
       configPackages = cfg.configPackages
         ++ [ extraConfigPkg extraScriptsPkg ]
-        ++ optional (!pwUsedForAudio) pwNotForAudioConfigPkg;
+        ++ optional (!pwUsedForAudio) pwNotForAudioConfigPkg
+        ++ optionals cfg.alsaDisableSuspension alsaDisableSuspensionConfigPkg;
 
       configs = pkgs.buildEnv {
         name = "wireplumber-configs";


### PR DESCRIPTION
This is useful in scenarios described in the option description (beeping/cracking/popping sounds when not playing or when starting playback).

It did take me a bit of time to figure out the appropriate syntax to get this working on my own configuration via `extraConfig`, and it ended up being somewhat verbose, so I did find myself regretting that this wasn't simply an option made available as part of the module.

I have tested this module on my own setup and that does generate the appropriate files and solve the beeping sound.

## Description of changes

Adds an `alsaDisableSuspension` option to the wireplumber module, that disables suspension as described [here](https://wiki.archlinux.org/title/PipeWire#Noticeable_audio_delay_or_audible_pop/crack_when_starting_playback).

Alternatively we could also choose to make that an int or null, and give full access to parametrize `suspend-timeout-seconds`, but at first glance it doesn't look like that's worth the added description complexity for how many people are going to want to use it that way.

@K900 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
