### PR TITLE
cypress: add support for aarch64 on darwin

### DIFF
--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -12,6 +12,7 @@
 , unzip
 , wrapGAppsHook3
 , xorg
+, darwin
 }:
 
 let
@@ -24,6 +25,10 @@ let
       platform = "linux-arm64";
       checksum = "sha256-rB0ak6jYnJMb0aHDLAyhaGoOFK4FXDLEOeofNdW/Wk8=";
     };
+    aarch64-darwin = {
+      platform = "darwin-arm64";
+      checksum = "sha256-L2rhtB/DIK7Qum2YNoWVBn4mf+DA3rbcBUfZEEa/C8c=";
+    };
   };
   inherit (stdenv.hostPlatform) system;
   binary = availableBinaries.${system} or (throw "cypress: No binaries available for system ${system}");
@@ -35,27 +40,37 @@ in stdenv.mkDerivation rec {
   src = fetchzip {
     url = "https://cdn.cypress.io/desktop/${version}/${platform}/cypress.zip";
     sha256 = checksum;
+    stripRoot = !stdenv.isDarwin;
   };
 
   # don't remove runtime deps
   dontPatchELF = true;
 
-  nativeBuildInputs = [ autoPatchelfHook (wrapGAppsHook3.override { makeWrapper = makeShellWrapper; }) unzip makeShellWrapper];
+  nativeBuildInputs = [ unzip makeShellWrapper ]
+    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook (wrapGAppsHook3.override { makeWrapper = makeShellWrapper; }) ];
 
-  buildInputs = with xorg; [
+  buildInputs = lib.optionals stdenv.isLinux (with xorg; [
     libXScrnSaver
     libXdamage
     libXtst
     libxshmfence
-  ] ++ [
     nss
     gtk2
     alsa-lib
     gtk3
     mesa # for libgbm
-  ];
+  ]) ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    Cocoa
+    CoreServices
+    CoreMedia
+    CoreAudio
+    AudioToolbox
+    AVFoundation
+    Foundation
+    ApplicationServices
+  ]);
 
-  runtimeDependencies = [ (lib.getLib udev) ];
+  runtimeDependencies = lib.optional stdenv.isLinux (lib.getLib udev);
 
   installPhase = ''
     runHook preInstall
@@ -68,11 +83,15 @@ in stdenv.mkDerivation rec {
     printf '{"version":"%b"}' $version > $out/bin/resources/app/package.json
     # Cypress now looks for binary_state.json in bin
     echo '{"verified": true}' > $out/binary_state.json
-    ln -s $out/opt/cypress/Cypress $out/bin/cypress
+    ${if stdenv.isDarwin then ''
+      ln -s $out/opt/cypress/Cypress.app/Contents/MacOS/Cypress $out/bin/cypress
+    '' else ''
+      ln -s $out/opt/cypress/Cypress $out/bin/cypress
+    ''}
     runHook postInstall
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString (!stdenv.isDarwin) ''
     # exit with 1 after 25.05
     makeWrapper $out/opt/cypress/Cypress $out/bin/Cypress \
       --run 'echo "Warning: Use the lowercase cypress executable instead of the capitalized one."'


### PR DESCRIPTION
## Description of changes

This adds support for cypress on aarch64 on darwin (M1 and so on). I've never packaged an application for Macos before, so I'd assume there are things here that could be improved. I also had help from Perplexity during this.

Resolves https://github.com/NixOS/nixpkgs/issues/339554

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
