### PR TITLE
brlaser: switch to more-maintained upstream, same as Fedora

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -692,6 +692,11 @@
     githubId = 209175;
     name = "Alesya Huzik";
   };
+  ahydronous = {
+    github = "ahydronous";
+    githubId = 57762816;
+    name = "Ahydronous";
+  };
   aidalgol = {
     email = "aidalgol+nixpkgs@fastmail.net";
     github = "aidalgol";

--- a/pkgs/misc/cups/drivers/brlaser/default.nix
+++ b/pkgs/misc/cups/drivers/brlaser/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "brlaser";
-  version = "6-unstable-2023-02-30";
+  version = "6.2.6";
 
   src = fetchFromGitHub {
-    owner = "pdewacht";
+    owner = "Owl-Maintain";
     repo = "brlaser";
-    rev = "2a49e3287c70c254e7e3ac9dabe9d6a07218c3fa";
-    sha256 = "sha256-1fvO9F7ifbYQHAy54mOx052XutfKXSK6iT/zj4Mhbww=";
+    rev = "0ee2128e220ab111c74205081e51020ad3d895e6";
+    sha256 = "sha256-+W84s3Nulj0kz2h1WE7/QGysVylKkN/xNqcNvrQz6D8=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
            Brother MFC-L2710DW
            Lenovo M7605D
       '';
-    homepage = "https://github.com/pdewacht/brlaser";
+    homepage = "https://github.com/Owl-Maintain/brlaser";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ StijnDW ];

--- a/pkgs/misc/cups/drivers/brlaser/default.nix
+++ b/pkgs/misc/cups/drivers/brlaser/default.nix
@@ -22,38 +22,9 @@ stdenv.mkDerivation rec {
       ''
        Although most Brother printers support a standard printer language such as PCL or PostScript, not all do. If you have a monochrome Brother laser printer (or multi-function device) and the other open source drivers don't work, this one might help.
 
-       This driver is known to work with these printers:
+       This driver is known to work with many printers in the DCP, HL and MFC series, along with a few others.
+       See the homepage for a full list.
 
-           Brother DCP-1510
-           Brother DCP-1602
-           Brother DCP-7030
-           Brother DCP-7040
-           Brother DCP-7055
-           Brother DCP-7055W
-           Brother DCP-7060D
-           Brother DCP-7065DN
-           Brother DCP-7080
-           Brother DCP-L2500D
-           Brother DCP-L2520D
-           Brother DCP-L2540DW
-           Brother HL-1110
-           Brother HL-1200
-           Brother HL-2030
-           Brother HL-2140
-           Brother HL-2220
-           Brother HL-2270DW
-           Brother HL-5030
-           Brother HL-L2300D
-           Brother HL-L2320D
-           Brother HL-L2340D
-           Brother HL-L2360D
-           Brother MFC-1910W
-           Brother MFC-7240
-           Brother MFC-7360N
-           Brother MFC-7365DN
-           Brother MFC-7840W
-           Brother MFC-L2710DW
-           Lenovo M7605D
       '';
     homepage = "https://github.com/Owl-Maintain/brlaser";
     license = licenses.gpl2Plus;

--- a/pkgs/misc/cups/drivers/brlaser/default.nix
+++ b/pkgs/misc/cups/drivers/brlaser/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Owl-Maintain/brlaser";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ StijnDW ];
+    maintainers = with maintainers; [ ahydronous ];
   };
 }


### PR DESCRIPTION
Fedora switched to a more-maintained upstream fork because it supports more printers.

See: https://packages.fedoraproject.org/pkgs/printer-driver-brlaser/printer-driver-brlaser/index.html and
https://github.com/pdewacht/brlaser/pull/92

## Description of changes
Changed upstream from https://github.com/pdewacht/brlaser to https://github.com/Owl-Maintain/brlaser".
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
