### PR TITLE
nixos/tests/sunshine: fix test

### DIFF
--- a/nixos/tests/sunshine.nix
+++ b/nixos/tests/sunshine.nix
@@ -4,6 +4,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     # test is flaky on aarch64
     broken = pkgs.stdenv.isAarch64;
     maintainers = [ lib.maintainers.devusb ];
+    timeout = 600;
   };
 
   nodes.sunshine = { config, pkgs, ... }: {
@@ -52,19 +53,22 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
     # initiate pairing from moonlight
     moonlight.execute("moonlight pair sunshine --pin 1234 >&2 & disown")
-    moonlight.wait_for_console_text("Executing request")
+    moonlight.wait_for_console_text("Executing request.*pair")
 
     # respond to pairing request from sunshine
-    sunshine.succeed("curl --insecure -u sunshine:sunshine -d '{\"pin\": \"1234\"}' https://localhost:47990/api/pin")
+    sunshine.succeed("curl --fail --insecure -u sunshine:sunshine -d '{\"pin\": \"1234\"}' https://localhost:47990/api/pin")
 
-    # close moonlight once pairing complete
-    moonlight.send_key("kp_enter")
+    # wait until pairing is complete
+    moonlight.wait_for_console_text("Executing request.*phrase=pairchallenge")
 
+    # hide icewm panel
+    sunshine.send_key("ctrl-alt-h")
     # put words on the sunshine screen for moonlight to see
-    sunshine.execute("gxmessage 'hello world' -center -font 'sans 75' >&2 & disown")
+    sunshine.execute("gxmessage ' ABC' -center -font 'consolas 100' -fg '#FFFFFF' -bg '#000000' -borderless -geometry '2000x2000' -buttons \"\" >&2 & disown")
 
     # connect to sunshine from moonlight and look for the words
     moonlight.execute("moonlight --video-decoder software stream sunshine 'Desktop' >&2 & disown")
-    moonlight.wait_for_text("hello world")
+    moonlight.wait_for_console_text("Dropping window event during flush")
+    moonlight.wait_for_text("ABC")
   '';
 })


### PR DESCRIPTION
- change text in `wait_for_console_text` to prevent sending curl with pairing response before moonlight can accept it
- remove "close moonlight" step as next window stays on top in fullscreen, previous window with pairing result does not interfere with test. Otherwise it needs OCR or some other way to only do `send_key("kp_enter")` after "Pairing complete" window is visible.
- add different ways to increase chances of successfull OCR: hide icewm panel, gxmessage window takes full screen without titlebar or buttons, black background, white foreground, consolas font,"ABC" text

## Description of changes

Fixes `nixosTests.sunshine` timing out after 1 hour:
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.sunshine.x86_64-linux
https://hydra.nixos.org/build/272715035
Error log:
```text
(finished: must succeed: curl --insecure -u sunshine:sunshine -d '{"pin": "1234"}' https://localhost:47990/api/pin, in 0.08 seconds)
moonlight: sending key 'kp_enter'
(finished: sending key 'kp_enter', in 0.01 seconds)
moonlight: waiting for hello world to appear on screen
...
moonlight # [ 2497.757190] hrtimer: interrupt took 6012496 ns
timeout reached; test terminating...
```
`curl` with pin may execute before moonlight starts accepting it, so there is never a successful pairing.
Changed `wait_for_console_text` so that does not happen, there is another `Executing` message that is shown before pairing begins, but it does not have `pair` word in it:
```text
moonlight # 00:00:05 - Qt Info: Executing request: "http://sunshine:47989/serverinfo?uniqueid=0123456789ABCDEF&uuid=6604d450bc5a442c8d6a2c863d94487e"
```

As there is a decent control over what is shown to be recognized with OCR added things to make it less flaky (removed other text on screen, changed colors, font and text).

Listed test maintainer:
@devusb 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
