### PR TITLE
niimath: init at 1.0.20240905

### DIFF
--- a/pkgs/by-name/ni/niimath/package.nix
+++ b/pkgs/by-name/ni/niimath/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  coreutils,
+  git,
+  zlib,
+}:
+
+let
+  niimathTestsSrc = fetchFromGitHub {
+    owner = "rordenlab";
+    repo = "niimath_tests";
+    rev = "e482edf54fb5bea6e08047ba731600d26925d493";
+    hash = "sha256-FC9NHogt4Cmq7/9mao12LN7du9CoXVnonkwhafIpIQo=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "niimath";
+  version = "1.0.20240905";
+
+  src = fetchFromGitHub {
+    owner = "rordenlab";
+    repo = "niimath";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-3XgB4q0HXLo9rEQBzC+2dxN81r9n8kkj2OC5d+WFmEs=";
+  };
+
+  postPatch = ''
+    cp -r ${niimathTestsSrc} niimath_tests
+    chmod -R +w niimath_tests
+    patchShebangs niimath_tests/canonical_test.sh
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    git
+  ];
+
+  buildInputs = [ zlib ];
+
+  cmakeFlags = [ "-DZLIB_IMPLEMENTATION=System" ];
+
+  doCheck = true;
+  checkPhase = ''
+    PATH=bin:$PATH ../niimath_tests/canonical_test.sh
+  '';
+  nativeCheckInputs = [ coreutils ];
+
+  meta = {
+    description = "Open-source clone of fslmaths";
+    homepage = "https://github.com/rordenlab/niimath";
+    changelog = "https://github.com/rordenlab/niimath/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    mainProgram = "niimath";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

Init `niimath`, an [open-source reimplementation](https://github.com/rordenlab/niimath) of the FSLmaths image processing CLI tool.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
