### PR TITLE
coqPackages.QuickChick: 2.0.2 → 2.0.4

### DIFF
--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -6,7 +6,7 @@ let recent = lib.versions.isGe "8.7" coq.coq-version || coq.coq-version == "dev"
   owner = "QuickChick";
   inherit version;
   defaultVersion = lib.switch [ coq.coq-version ssreflect.version ] [
-      { cases = [ (lib.versions.range "8.15" "8.19") lib.pred.true  ]; out = "2.0.2"; }
+      { cases = [ (lib.versions.range "8.15" "8.20") lib.pred.true  ]; out = "2.0.4"; }
       { cases = [ (lib.versions.range "8.13" "8.17") lib.pred.true  ]; out = "1.6.5"; }
       { cases = [ "8.13" lib.pred.true           ]; out = "1.5.0"; }
       { cases = [ "8.12" lib.pred.true           ]; out = "1.4.0"; }
@@ -18,6 +18,7 @@ let recent = lib.versions.isGe "8.7" coq.coq-version || coq.coq-version == "dev"
       { cases = [ "8.6"  lib.pred.true           ]; out = "20171102"; }
       { cases = [ "8.5"  lib.pred.true           ]; out = "20170512"; }
     ] null;
+  release."2.0.4".sha256    = "sha256-WD8B+n8gyGctHMO+M8201Ca3Uw8zCWYsOatSNGCf0/s=";
   release."2.0.2".sha256    = "sha256-xxKkwDRjB8nUiXNhein1Ppn0DP5FZ13J90xUPAnQBbs=";
   release."2.0.1".sha256    = "sha256-gJc+9Or6tbqE00920Il4pnEvokRoiADX6CxP/Q0QZaY=";
   release."1.6.5".sha256    = "sha256-rcFyRDH8UbB9KVk10P5qjtPkWs04p78VNHkCq4mXr3U=";

--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -6,9 +6,11 @@
   repo = "coq-simple-io";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = range "8.17" "8.20"; out = "1.10.0"; }
     { case = range "8.11" "8.19"; out = "1.8.0"; }
     { case = range "8.7"  "8.13"; out = "1.3.0"; }
   ] null;
+  release."1.10.0".sha256 = "sha256-67cBhLvRMWLWBL7NXK1zZTQC4PtSKu9qtesU4SqKkOw=";
   release."1.8.0".sha256 = "sha256-3ADNeXrBIpYRlfUW+LkLHUWV1w1HFrVc/TZISMuwvRY=";
   release."1.7.0".sha256 = "sha256:1a1q9x2abx71hqvjdai3n12jxzd49mhf3nqqh3ya2ssl2lj609ci";
   release."1.3.0".sha256 = "1yp7ca36jyl9kz35ghxig45x6cd0bny2bpmy058359p94wc617ax";
@@ -20,9 +22,7 @@
   doCheck = true;
   checkTarget = "test";
 
-  useDuneifVersion = v:
-    (lib.versionAtLeast v "1.8.0" || v == "dev")
-    && (lib.versionAtLeast coq.version "8.20" || coq.version == "dev");
+  useDuneifVersion = v: (lib.versionAtLeast v "1.10.0" || v == "dev");
 
   passthru.tests.HelloWorld = callPackage ./test.nix {};
 


### PR DESCRIPTION
## Description of changes

Tested: https://github.com/coq-community/coq-nix-toolbox/pull/263

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
