### PR TITLE
meson/setup-hook.sh: make build directory configurable

### DIFF
--- a/doc/hooks/meson.section.md
+++ b/doc/hooks/meson.section.md
@@ -18,6 +18,16 @@ setup hook registering ninja-based build and install phases.
 
 Controls the flags passed to `meson setup` during configure phase.
 
+#### `mesonBuildDir` {#meson-build-dir}
+
+Directory where Meson will put intermediate files.
+
+Setting this can be useful for debugging multiple Meson builds while in the same source directory, for example, when building for different platforms.
+Different values for each build will prevent build artefacts from interefering with each other.
+This setting has no tangible effect when running the build in a sandboxed derivation.
+
+The default value is `build`.
+
 #### `mesonWrapMode` {#meson-wrap-mode}
 
 Which value is passed as

--- a/pkgs/by-name/me/meson/setup-hook.sh
+++ b/pkgs/by-name/me/meson/setup-hook.sh
@@ -3,6 +3,8 @@
 mesonConfigurePhase() {
     runHook preConfigure
 
+    : ${mesonBuildDir:=build}
+
     local flagsArray=()
 
     if [ -z "${dontAddPrefix-}" ]; then
@@ -28,8 +30,8 @@ mesonConfigurePhase() {
 
     echoCmd 'mesonConfigurePhase flags' "${flagsArray[@]}"
 
-    meson setup build "${flagsArray[@]}"
-    cd build || { echoCmd 'mesonConfigurePhase' "could not cd to build"; exit 1; }
+    meson setup "$mesonBuildDir" "${flagsArray[@]}"
+    cd "$mesonBuildDir" || { echoCmd 'mesonConfigurePhase' "could not cd to $mesonBuildDir"; exit 1; }
 
     if ! [[ -v enableParallelBuilding ]]; then
         enableParallelBuilding=1


### PR DESCRIPTION
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/335818 @Ericson2314
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc