### PR TITLE
nixos/garage: fix StateDirectory check to work with multiple data_dirs

### DIFF
--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
@@ -20,7 +25,9 @@ in
       type = types.attrsOf types.str;
       description = "Extra environment variables to pass to the Garage server.";
       default = { };
-      example = { RUST_BACKTRACE = "yes"; };
+      example = {
+        RUST_BACKTRACE = "yes";
+      };
     };
 
     environmentFile = mkOption {
@@ -30,7 +37,13 @@ in
     };
 
     logLevel = mkOption {
-      type = types.enum ([ "error" "warn" "info" "debug" "trace" ]);
+      type = types.enum ([
+        "error"
+        "warn"
+        "info"
+        "debug"
+        "trace"
+      ]);
       default = "info";
       example = "debug";
       description = "Garage log level, see <https://garagehq.deuxfleurs.fr/documentation/quick-start/#launching-the-garage-server> for examples.";
@@ -49,10 +62,12 @@ in
 
           data_dir = mkOption {
             default = "/var/lib/garage/data";
-            example = [ {
-              path = "/var/lib/garage/data";
-              capacity = "2T";
-            } ];
+            example = [
+              {
+                path = "/var/lib/garage/data";
+                capacity = "2T";
+              }
+            ];
             type = with types; either path (listOf attrs);
             description = ''
               The directory in which Garage will store the data blocks of objects. This folder can be placed on an HDD.
@@ -83,7 +98,9 @@ in
       # These assertions can be removed in NixOS 24.11, when all users have been
       # warned once.
       {
-        assertion = (cfg.settings ? replication_factor || cfg.settings ? replication_mode) || lib.versionOlder cfg.package.version "1.0.0";
+        assertion =
+          (cfg.settings ? replication_factor || cfg.settings ? replication_mode)
+          || lib.versionOlder cfg.package.version "1.0.0";
         message = ''
           Garage 1.0.0 requires an explicit replication factor to be set.
           Please set replication_factor to 1 explicitly to preserve the previous behavior.
@@ -129,14 +146,25 @@ in
 
     systemd.services.garage = {
       description = "Garage Object Storage (S3 compatible)";
-      after = [ "network.target" "network-online.target" ];
-      wants = [ "network.target" "network-online.target" ];
+      after = [
+        "network.target"
+        "network-online.target"
+      ];
+      wants = [
+        "network.target"
+        "network-online.target"
+      ];
       wantedBy = [ "multi-user.target" ];
-      restartTriggers = [ configFile ] ++ (lib.optional (cfg.environmentFile != null) cfg.environmentFile);
+      restartTriggers = [
+        configFile
+      ] ++ (lib.optional (cfg.environmentFile != null) cfg.environmentFile);
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/garage server";
 
-        StateDirectory = mkIf (hasPrefix "/var/lib/garage" cfg.settings.data_dir || hasPrefix "/var/lib/garage" cfg.settings.metadata_dir) "garage";
+        StateDirectory = mkIf (
+          hasPrefix "/var/lib/garage" cfg.settings.data_dir
+          || hasPrefix "/var/lib/garage" cfg.settings.metadata_dir
+        ) "garage";
         DynamicUser = lib.mkDefault true;
         ProtectHome = true;
         NoNewPrivileges = true;

--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -11,6 +11,13 @@ let
   cfg = config.services.garage;
   toml = pkgs.formats.toml { };
   configFile = toml.generate "garage.toml" cfg.settings;
+
+  anyHasPrefix =
+    prefix: strOrList:
+    if isString strOrList then
+      hasPrefix prefix strOrList
+    else
+      any ({ path, ... }: hasPrefix prefix path) strOrList;
 in
 {
   meta = {
@@ -162,7 +169,7 @@ in
         ExecStart = "${cfg.package}/bin/garage server";
 
         StateDirectory = mkIf (
-          hasPrefix "/var/lib/garage" cfg.settings.data_dir
+          anyHasPrefix "/var/lib/garage" cfg.settings.data_dir
           || hasPrefix "/var/lib/garage" cfg.settings.metadata_dir
         ) "garage";
         DynamicUser = lib.mkDefault true;

--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -15,7 +15,7 @@ in
 {
   meta = {
     doc = ./garage.md;
-    maintainers = [ ];
+    maintainers = [ maintainers.mjm ];
   };
 
   options.services.garage = {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #342761 

Previously the option type was updated to allow for specifying multiple data_dirs, but there was a check for whether to use StateDirectory that still only worked for a single string. That check has been fixed.

Also reformatted the module with nixfmt-rfc-style and added myself as a maintainer for the module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
