### PR TITLE
picotool: 1.1.2 -> 2.0.0

### DIFF
--- a/pkgs/development/tools/picotool/default.nix
+++ b/pkgs/development/tools/picotool/default.nix
@@ -1,15 +1,23 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libusb1, pico-sdk }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libusb1, pico-sdk, mbedtls_2 }:
 
 stdenv.mkDerivation rec {
   pname = "picotool";
-  version = "1.1.2";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = pname;
     rev = version;
-    sha256 = "sha256-OcQJeiva6X2rUyh1rJ+w4O2dWxaR7MwMfbHlnWuBVb8=";
+    sha256 = "sha256-z7EFk3qxg1PoKZQpUQqjhttZ2RkhhhiMdYc9TkXzkwk=";
   };
+
+  postPatch = ''
+    # necessary for signing/hashing support. our pico-sdk does not come with
+    # it by default, and it shouldn't due to submodule size. pico-sdk uses
+    # an upstream version of mbedtls 2.x so we patch ours in directly.
+    substituteInPlace lib/CMakeLists.txt \
+      --replace-fail "''$"'{PICO_SDK_PATH}/lib/mbedtls' '${mbedtls_2.src}'
+  '';
 
   buildInputs = [ libusb1 pico-sdk ];
   nativeBuildInputs = [ cmake pkg-config ];
@@ -21,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/raspberrypi/picotool";
-    description = "Tool for interacting with a RP2040 device in BOOTSEL mode, or with a RP2040 binary";
+    description = "Tool for interacting with RP2040/RP2350 device(s) in BOOTSEL mode, or with an RP2040/RP2350 binary";
     mainProgram = "picotool";
     license = licenses.bsd3;
     maintainers = with maintainers; [ muscaln ];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Version 2.0.0 ([changelog](https://github.com/raspberrypi/picotool/releases/tag/2.0.0)) upgrade for new RP2350 support and compatibility with 2.0.0 SDK in nixpkgs.

Tested using with pico-sdk for building, and basic communication with an RP2040. Added the mbedtls library for signing/hashing support and verified it is being detected/compiled, but I don't have the ability to fully test it.

Closes #340366 (request by @holly-hacker)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
