### PR TITLE
ezminc: unstable-2019-03-12 -> unstable-2023-10-06; unbreak

### DIFF
--- a/pkgs/applications/science/biology/EZminc/default.nix
+++ b/pkgs/applications/science/biology/EZminc/default.nix
@@ -1,30 +1,60 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libminc, bicpl, itk, fftwFloat, gsl }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  perl,
+  libminc,
+  bicpl,
+  itk_5_2,
+  fftwFloat,
+  gsl,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "EZminc";
-  version = "unstable-2019-03-12";
+  version = "2.2.00-unstable-2023-10-06";
 
   src = fetchFromGitHub {
-    owner  = "BIC-MNI";
-    repo   = pname;
-    rev    = "5e3333ee356f914d34d66d33ea8df809c7f7fa51";
-    sha256 = "0wy8cppf5xpgfqvgb3mqs1cjh81n6qzkk6zxv29wvng8nar9wsy4";
+    owner = "BIC-MNI";
+    repo = "EZminc";
+    rev = "5fdf112e837000d155891e423041d7065ea13c3f";
+    hash = "sha256-0KdFIWRHnIHrau0ysGMVpg3oz01UdIvna1y2I4YEWJw=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ itk libminc bicpl fftwFloat gsl ];
+  postPatch = ''
+    patchShebangs scripts/*
+  '';
 
-  cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/cmake"
-                 "-DEZMINC_BUILD_TOOLS=TRUE"
-                 "-DEZMINC_BUILD_MRFSEG=TRUE"
-                 "-DEZMINC_BUILD_DD=TRUE" ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
-  meta = with lib; {
-    homepage = "https://github.com/BIC-MNI/${pname}";
+  buildInputs = [
+    itk_5_2
+    libminc
+    bicpl
+    fftwFloat
+    gsl
+    perl
+  ];
+
+  cmakeFlags = [
+    "-DLIBMINC_DIR=${libminc}/lib/cmake"
+    "-DEZMINC_BUILD_TOOLS=TRUE"
+    "-DEZMINC_BUILD_MRFSEG=TRUE"
+    # "-DEZMINC_BUILD_DD=TRUE" # numerous compilation issues
+  ];
+
+  doCheck = false; # test programs/data exist but no actual test harness
+
+  meta = {
+    homepage = "https://github.com/BIC-MNI/EZminc";
     description = "Collection of Perl and shell scripts for processing MINC files";
-    maintainers = with maintainers; [ bcdarwin ];
-    platforms = platforms.unix;
-    license = licenses.free;
-    broken = true;  # ITK5 compatibility issue (https://github.com/BIC-MNI/EZminc/issues/15)
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    platforms = lib.platforms.linux; # can't detect opengl on Darwin
+    license = lib.licenses.free;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Routine update; minor refactor and apply `nixfmt`; patch some script interpreter paths.

Package was previously broken since removal of ITK 4 due to ITK 5.x incompatibility. One cmake module (for diffeomorphic demons) had to be disabled since this code is still not working due to cmake conflicts and ITK 5 and recent gcc issues.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
