### PR TITLE
python312Packages.flax: 0.8.5 -> 0.9.0

### DIFF
--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
 
   # build-system
@@ -26,6 +25,7 @@
   pytest-xdist,
   pytestCheckHook,
   tensorflow,
+  treescope,
 
   # optional-dependencies
   matplotlib,
@@ -33,16 +33,14 @@
 
 buildPythonPackage rec {
   pname = "flax";
-  version = "0.8.5";
+  version = "0.9.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "flax";
     rev = "refs/tags/v${version}";
-    hash = "sha256-6WOFq0758gtNdrlWqSQBlKmWVIGe5e4PAaGrvHoGjr0=";
+    hash = "sha256-iDWuUJKO7V4QrbVsS4ALgy6fbllOC43o7W4mhjtZ9xc=";
   };
 
   build-system = [
@@ -75,6 +73,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
     tensorflow
+    treescope
   ];
 
   pytestFlagsArray = [
@@ -95,13 +94,18 @@ buildPythonPackage rec {
     "flax/nnx/examples/*"
     # See https://github.com/google/flax/issues/3232.
     "tests/jax_utils_test.py"
-    # Requires tree
+    # Too old version of tensorflow:
+    # ModuleNotFoundError: No module named 'keras.api._v2'
     "tests/tensorboard_test.py"
   ];
 
   disabledTests = [
     # ValueError: Checkpoint path should be absolute
     "test_overwrite_checkpoints0"
+    # Fixed in more recent versions of jax: https://github.com/google/flax/issues/4211
+    # TODO: Re-enable when jax>0.4.28 will be available in nixpkgs
+    "test_vmap_and_cond_passthrough" # ValueError: vmap has mapped output but out_axes is None
+    "test_vmap_and_cond_passthrough_error" # AssertionError: "at vmap.*'broadcast'.*got axis spec ...
   ];
 
   meta = {

--- a/pkgs/development/python-modules/treescope/default.nix
+++ b/pkgs/development/python-modules/treescope/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  flit-core,
+
+  # dependencies
+  numpy,
+
+  # optional-dependencies
+  ipython,
+  jax,
+  palettable,
+
+  # tests
+  absl-py,
+  jaxlib,
+  pytestCheckHook,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "treescope";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "google-deepmind";
+    repo = "treescope";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-+Hm60O9tEXIiE0av1O0BsOdMln4e1s7ijb3WNiQ74jE=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [ numpy ];
+
+  optional-dependencies = {
+    notebook = [
+      ipython
+      jax
+      palettable
+    ];
+  };
+
+  pythonImportsCheck = [ "treescope" ];
+
+  nativeCheckInputs = [
+    absl-py
+    jax
+    jaxlib
+    pytestCheckHook
+    torch
+  ];
+
+  meta = {
+    description = "An interactive HTML pretty-printer for machine learning research in IPython notebooks";
+    homepage = "https://github.com/google-deepmind/treescope";
+    changelog = "https://github.com/google-deepmind/treescope/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15773,6 +15773,8 @@ self: super: with self; {
 
   treeo = callPackage ../development/python-modules/treeo { };
 
+  treescope = callPackage ../development/python-modules/treescope { };
+
   treex = callPackage ../development/python-modules/treex { };
 
   treq = callPackage ../development/python-modules/treq { };


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/google/flax/releases/tag/v0.9.0

Also adds the [treescope](https://github.com/google-deepmind/treescope) package.

cc @ndl

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
