### PR TITLE
nixos/github-runners: Make 'enable' functional

### DIFF
--- a/nixos/modules/services/continuous-integration/github-runner/service.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/service.nix
@@ -19,7 +19,9 @@ with lib;
     ])
   );
 
-  config.systemd.services = flip mapAttrs' config.services.github-runners (name: cfg:
+  config.systemd.services =
+  let enabledRunners = filterAttrs (_: cfg: cfg.enable) config.services.github-runners;
+  in (flip mapAttrs' enabledRunners (name: cfg:
     let
       svcName = "github-runner-${name}";
       systemdDir = "github-runner/${name}";
@@ -296,5 +298,5 @@ with lib;
         cfg.serviceOverrides
       ];
     }
-  );
+  ));
 }

--- a/nixos/tests/github-runner.nix
+++ b/nixos/tests/github-runner.nix
@@ -11,6 +11,12 @@ import ./make-test-python.nix ({ pkgs, ... }:
       tokenFile = builtins.toFile "github-runner.token" "not-so-secret";
     };
 
+    services.github-runners.test-disabled = {
+      enable = false;
+      url = "https://github.com/yaxitech";
+      tokenFile = builtins.toFile "github-runner.token" "not-so-secret";
+    };
+
     systemd.services.dummy-github-com = {
       wantedBy = [ "multi-user.target" ];
       before = [ "github-runner-test.service" ];
@@ -33,5 +39,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     assert "Self-hosted runner registration" in out, "did not read runner registration header"
 
     machine.wait_until_succeeds("test -f /tmp/registration-connect")
+
+    machine.fail("systemctl list-unit-files | grep test-disabled")
   '';
 })


### PR DESCRIPTION
## Description of changes

Previously, the 'enable' attribute was ignored. Now, it isn't.

Fixes #305304

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
