### PR TITLE
nixos/installer/sd-card: add rootVolumeLabel option

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -26,7 +26,7 @@ let
       inherit (config.sdImage) storePaths;
       compressImage = config.sdImage.compressImage;
       populateImageCommands = config.sdImage.populateRootCommands;
-      volumeLabel = "NIXOS_SD";
+      volumeLabel = config.sdImage.rootVolumeLabel;
     }
     // optionalAttrs (config.sdImage.rootPartitionUUID != null) {
       uuid = config.sdImage.rootPartitionUUID;
@@ -117,6 +117,17 @@ in
       '';
     };
 
+    rootVolumeLabel = mkOption {
+      type = types.str;
+      default = "NIXOS_SD";
+      example = "NIXOS_PENDRIVE";
+      description = ''
+        Label for the NixOS root volume.
+        Usually used when creating a recovery NixOS media installation
+        that avoids conflicting with previous instalation label.
+      '';
+    };
+
     firmwareSize = mkOption {
       type = types.int;
       # As of 2019-08-18 the Raspberry pi firmware + u-boot takes ~18MiB
@@ -197,7 +208,7 @@ in
         ];
       };
       "/" = {
-        device = "/dev/disk/by-label/NIXOS_SD";
+        device = "/dev/disk/by-label/${config.sdImage.rootVolumeLabel}";
         fsType = "ext4";
       };
     };


### PR DESCRIPTION
nixos/installer/sd-card: add rootVolumeLabel option

For recovering a NixOS system, the recovery media (pendrive, SDCard) must have a different volume label than the host NixOS to avoid volume label conflict. The proposed option enables customizing the volume label for the recovery media [or anything else].