### PR TITLE
haskell.compiler.*: move bootPkgs.ghc to depsBuildBuild

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -83,8 +83,6 @@ assert stdenv.buildPlatform == stdenv.hostPlatform || stdenv.hostPlatform == std
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
 
-  inherit (bootPkgs) ghc;
-
   # TODO(@Ericson2314) Make unconditional
   targetPrefix = lib.optionalString
     (targetPlatform != hostPlatform)
@@ -427,7 +425,7 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [
     perl autoreconfHook autoconf automake m4 python3
-    ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+    bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
     bootPkgs.ghc-settings-edit
   ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
     autoSignDarwinBinariesHook
@@ -435,8 +433,11 @@ stdenv.mkDerivation (rec {
     sphinx
   ];
 
-  # Used by the STAGE0 compiler to build stage1
+  # Stage0 compiler and the tools/libs it needs to build Stage1. Stage0 is
+  # build->build, Stage1 is build->target (which may be the same as
+  # host->target)
   depsBuildBuild = [
+    bootPkgs.ghc
     buildCC
     # stage0 builds terminfo unconditionally, so we always need ncurses
     ncurses
@@ -530,7 +531,7 @@ stdenv.mkDerivation (rec {
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     platforms = lib.platforms.all;
-    inherit (ghc.meta) license;
+    inherit (bootPkgs.ghc.meta) license;
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -256,8 +256,6 @@ assert stdenv.buildPlatform == stdenv.hostPlatform;
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
 
-  inherit (bootPkgs) ghc;
-
   # TODO(@Ericson2314) Make unconditional
   targetPrefix = lib.optionalString
     (targetPlatform != hostPlatform)
@@ -544,7 +542,7 @@ stdenv.mkDerivation ({
   dontAddExtraLibs = true;
 
   nativeBuildInputs = [
-    perl ghc hadrian bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+    perl hadrian bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
     # autoconf and friends are necessary for hadrian to create the bindist
     autoconf automake m4
     # Python is used in a few scripts invoked by hadrian to generate e.g. rts headers.
@@ -559,8 +557,11 @@ stdenv.mkDerivation ({
 
   # For building runtime libs
   depsBuildTarget = toolsForTarget;
-  # Used by the STAGE0 compiler to build stage1
+  # Stage0 compiler and the tools/libs it needs to build Stage1. Stage0 is
+  # build->build, Stage1 is build->target (which may be the same as
+  # host->target)
   depsBuildBuild = [
+    bootPkgs.ghc
     buildCC
     # stage0 builds terminfo unconditionally, so we always need ncurses
     ncurses
@@ -693,7 +694,7 @@ stdenv.mkDerivation ({
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     platforms = lib.platforms.all;
-    inherit (ghc.meta) license;
+    inherit (bootPkgs.ghc.meta) license;
   };
 
   dontStrip = targetPlatform.useAndroidPrebuilt || targetPlatform.isWasm;

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -88,8 +88,6 @@ assert stdenv.buildPlatform == stdenv.hostPlatform || stdenv.hostPlatform == std
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
 
-  inherit (bootPkgs) ghc;
-
   # TODO(@Ericson2314) Make unconditional
   targetPrefix = lib.optionalString
     (targetPlatform != hostPlatform)
@@ -441,7 +439,7 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [
     perl autoconf automake m4 python3
-    ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+    bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
     bootPkgs.ghc-settings-edit
   ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
     autoSignDarwinBinariesHook
@@ -453,8 +451,11 @@ stdenv.mkDerivation (rec {
     xattr
   ];
 
-  # Used by the STAGE0 compiler to build stage1
+  # Stage0 compiler and the tools/libs it needs to build Stage1. Stage0 is
+  # build->build, Stage1 is build->target (which may be the same as
+  # host->target)
   depsBuildBuild = [
+    bootPkgs.ghc
     buildCC
     # stage0 builds terminfo unconditionally, so we always need ncurses
     ncurses
@@ -548,7 +549,7 @@ stdenv.mkDerivation (rec {
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     platforms = lib.platforms.all;
-    inherit (ghc.meta) license;
+    inherit (bootPkgs.ghc.meta) license;
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -52,7 +52,17 @@ in {
 
   package-list = callPackage ../development/haskell-modules/package-list.nix {};
 
-  # Always get boot compilers from `pkgsBuildBuild`
+  # Always get boot compilers from `pkgsBuildBuild`. The boot (stage0) compiler
+  # is used to build another compiler (stage1) that'll be used to build the
+  # final compiler (stage2) (except when building a cross-compiler). This means
+  # that stage1's host platform is the same as stage0: build. Consequently,
+  # stage0 needs to be build->build.
+  #
+  # Note that we use bb.haskell.packages.*. haskell.packages.*.ghc is similar to
+  # stdenv: The ghc comes from the previous package set, i.e. this predicate holds:
+  # `name: pkgs: pkgs.haskell.packages.${name}.ghc == pkgs.buildPackages.haskell.compiler.${name}.ghc`.
+  # This isn't problematic since pkgsBuildBuild.buildPackages is also build->build,
+  # just something to keep in mind.
   compiler = let bb = pkgsBuildBuild.haskell; in {
     ghc865Binary = callPackage ../development/compilers/ghc/8.6.5-binary.nix {
       # Should be llvmPackages_6 which has been removed from nixpkgs


### PR DESCRIPTION
The stage0 ghc is build->build since it builds the stage1 compiler which has build for its host platform (i.e. is build->target relative to the entire GHC derivation).

Also annotate a bit more around the use of pkgsBuildBuild and the boot compiler and make it more explicit where it comes from in the derivation.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
