### PR TITLE
nixos/plasma6: wrap signond

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -529,6 +529,7 @@
   ./services/desktops/pipewire/wireplumber.nix
   ./services/desktops/profile-sync-daemon.nix
   ./services/desktops/seatd.nix
+  ./services/desktops/signond.nix
   ./services/desktops/system-config-printer.nix
   ./services/desktops/system76-scheduler.nix
   ./services/desktops/telepathy.nix

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -149,6 +149,7 @@ in {
         krdp
         kaccounts-integration
         kaccounts-providers
+        kio-gdrive # google drive interface for KIO
       ] ++ lib.optionals config.services.flatpak.enable [
         # Since PackageKit Nix support is not there yet,
         # only install discover if flatpak is enabled.

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -147,6 +147,8 @@ in {
         spectacle
         ffmpegthumbs
         krdp
+        kaccounts-integration
+        kaccounts-providers
       ] ++ lib.optionals config.services.flatpak.enable [
         # Since PackageKit Nix support is not there yet,
         # only install discover if flatpak is enabled.

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -315,5 +315,14 @@ in {
       serviceConfig.Type = "oneshot";
       script = activationScript;
     };
+
+    services.signond = {
+      enable = true;
+      package = kdePackages.signond;
+      plugins = with kdePackages; [
+        signon-plugin-oauth2
+        signon-kwallet-extension
+      ];
+    };
   };
 }

--- a/nixos/modules/services/desktops/signond.nix
+++ b/nixos/modules/services/desktops/signond.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+let
+  package = config.services.signond.package.override { plugins = config.services.signond.plugins; };
+in
+{
+  options = {
+    services.signond = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to enable signond, a DBus service
+          which performs user authentication on behalf of its clients.
+        '';
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        description = ''
+          Which signond package to use.
+          Should get set by your desktop environment.
+        '';
+      };
+
+      plugins = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [];
+        description = ''
+          What plugins to use with the signon daemon.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf config.services.signond.enable {
+    services.dbus.packages = [ package ];
+    environment.systemPackages = [ (pkgs.hiPrio package) ];
+  };
+}

--- a/pkgs/development/libraries/signond/default.nix
+++ b/pkgs/development/libraries/signond/default.nix
@@ -6,38 +6,50 @@
   qtbase,
   wrapQtAppsHook,
   doxygen,
+  makeWrapper,
+  symlinkJoin,
+  plugins ? [ ],
 }:
 
-stdenv.mkDerivation {
-  pname = "signond";
-  version = "8.61-unstable-2023-11-24";
+let
+  unwrapped = stdenv.mkDerivation {
+    pname = "signond";
+    version = "8.61-unstable-2023-11-24";
 
-  # pinned to fork with Qt6 support
-  src = fetchFromGitLab {
-    owner = "nicolasfella";
-    repo = "signond";
-    rev = "c8ad98249af541514ff7a81634d3295e712f1a39";
-    hash = "sha256-0FcSVF6cPuFEU9h7JIbanoosW/B4rQhFPOq7iBaOdKw=";
+    # pinned to fork with Qt6 support
+    src = fetchFromGitLab {
+      owner = "nicolasfella";
+      repo = "signond";
+      rev = "c8ad98249af541514ff7a81634d3295e712f1a39";
+      hash = "sha256-0FcSVF6cPuFEU9h7JIbanoosW/B4rQhFPOq7iBaOdKw=";
+    };
+
+    nativeBuildInputs = [
+      qmake
+      doxygen
+      wrapQtAppsHook
+    ];
+
+    buildInputs = [ qtbase ];
+
+    preConfigure = ''
+      substituteInPlace src/signond/signond.pro \
+        --replace "/etc" "@out@/etc"
+    '';
+
+    meta = with lib; {
+      homepage = "https://gitlab.com/accounts-sso/signond";
+      description = "Signon Daemon for Qt";
+      maintainers = with maintainers; [ freezeboy ];
+      platforms = platforms.linux;
+    };
   };
-
-  nativeBuildInputs = [
-    qmake
-    doxygen
-    wrapQtAppsHook
-  ];
-
-  buildInputs = [ qtbase ];
-
-  preConfigure = ''
-    substituteInPlace src/signond/signond.pro \
-      --replace "/etc" "@out@/etc"
-  '';
-
-  meta = with lib; {
-    homepage = "https://gitlab.com/accounts-sso/signond";
-    description = "Signon Daemon for Qt";
-    maintainers = with maintainers; [ freezeboy ];
-    platforms = platforms.linux;
-  };
-}
+in
+if plugins == [ ] then
+  unwrapped
+else
+  import ./wrapper.nix {
+    inherit makeWrapper symlinkJoin plugins;
+    signond = unwrapped;
+  }
 

--- a/pkgs/development/libraries/signond/default.nix
+++ b/pkgs/development/libraries/signond/default.nix
@@ -1,4 +1,12 @@
-{ stdenv, lib, fetchFromGitLab, qmake, qtbase, wrapQtAppsHook, doxygen }:
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  qmake,
+  qtbase,
+  wrapQtAppsHook,
+  doxygen,
+}:
 
 stdenv.mkDerivation {
   pname = "signond";
@@ -32,3 +40,4 @@ stdenv.mkDerivation {
     platforms = platforms.linux;
   };
 }
+

--- a/pkgs/development/libraries/signond/wrapper.nix
+++ b/pkgs/development/libraries/signond/wrapper.nix
@@ -1,0 +1,27 @@
+{
+  makeWrapper,
+  symlinkJoin,
+  signond,
+  plugins,
+}:
+
+symlinkJoin {
+  name = "signond-with-plugins-${signond.version}";
+
+  paths = [ signond ] ++ plugins;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/signond \
+      --set SSO_PLUGINS_DIR "$out/lib/signond/" \
+      --set SSO_EXTENSIONS_DIR "$out/lib/signond/extensions/"
+
+    rm $out/share/dbus-1/services/com.google.code.AccountsSSO.SingleSignOn.service
+
+    substitute ${signond}/share/dbus-1/services/com.google.code.AccountsSSO.SingleSignOn.service $out/share/dbus-1/services/com.google.code.AccountsSSO.SingleSignOn.service \
+      --replace-fail ${signond} $out
+  '';
+
+  inherit (signond) meta;
+}

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -80,6 +80,7 @@
       krohnkite = self.callPackage ./third-party/krohnkite {};
       kzones = self.callPackage ./third-party/kzones {};
       signon-plugin-oauth2 = self.callPackage ./third-party/signon-plugin-oauth2 {};
+      signon-ui = self.callPackage ./third-party/signon-ui {};
     }
   );
 in

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -79,6 +79,7 @@
       karousel = self.callPackage ./third-party/karousel {};
       krohnkite = self.callPackage ./third-party/krohnkite {};
       kzones = self.callPackage ./third-party/kzones {};
+      signon-plugin-oauth2 = self.callPackage ./third-party/signon-plugin-oauth2 {};
     }
   );
 in

--- a/pkgs/kde/gear/kaccounts-integration/default.nix
+++ b/pkgs/kde/gear/kaccounts-integration/default.nix
@@ -1,9 +1,11 @@
 {
   mkKdeDerivation,
   intltool,
+  signon-ui,
 }:
 mkKdeDerivation {
   pname = "kaccounts-integration";
 
   propagatedNativeBuildInputs = [intltool];
+  extraBuildInputs = [signon-ui];
 }

--- a/pkgs/kde/gear/signon-kwallet-extension/default.nix
+++ b/pkgs/kde/gear/signon-kwallet-extension/default.nix
@@ -10,7 +10,5 @@ mkKdeDerivation {
   extraBuildInputs = [signond];
 
   # NB: not actually broken, just makes it install to $out instead of $signon/lib/extensions
-  # This is useless without a wrapped signond.
-  # FIXME: wrap signond with SSO_EXTENSIONS_DIR=$wrapper/lib/extensions
   extraCmakeFlags = ["-DINSTALL_BROKEN_SIGNON_EXTENSION=1"];
 }

--- a/pkgs/kde/third-party/signon-plugin-oauth2/default.nix
+++ b/pkgs/kde/third-party/signon-plugin-oauth2/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  qtbase,
+  signond,
+  wrapQtAppsHook,
+  pkg-config,
+  qmake,
+}:
+
+stdenv.mkDerivation {
+  pname = "signon-plugin-oauth2";
+  version = "0.25-unstable-2023-11-24";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = "signon-plugin-oauth2";
+    # See MR: https://gitlab.com/accounts-sso/signon-plugin-oauth2/-/merge_requests/28
+    rev = "fab698862466994a8fdc9aa335c87b4f05430ce6";
+    hash = "sha256-KCBLaqQdBkb6KfVKMmFSLOiXx3rUiEmK41Bc3mi86Ls=";
+  };
+
+  postPatch = ''
+    echo 'INSTALLS =' >>tests/tests.pro
+    echo 'INSTALLS =' >>example/example.pro
+  '';
+
+  buildInputs = [
+    qtbase
+    signond
+  ];
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    pkg-config
+    qmake
+  ];
+
+  qmakeFlags = [
+    "SIGNON_PLUGINS_DIR=${placeholder "out"}/lib/signond"
+  ];
+
+  meta = {
+    homepage = "https://gitlab.com/accounts-sso/signon-plugin-oauth2";
+    description = "Signond plugin which handles OAuth authentication";
+    maintainers = with lib.maintainers; [ marie ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/kde/third-party/signon-ui/default.nix
+++ b/pkgs/kde/third-party/signon-ui/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  qmake,
+  qtbase,
+  qtdeclarative,
+  qtwebengine,
+  wrapQtAppsHook,
+  signond,
+  pkg-config,
+  libnotify,
+  accounts-qt,
+}:
+
+stdenv.mkDerivation {
+  pname = "signon-ui";
+  version = "0.17-unstable-2024-10-16";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = "signon-ui";
+    rev = "eef943f0edf3beee8ecb85d4a9dae3656002fc24";
+    hash = "sha256-L37nypdrfg3ZGZE4uGtFoJlzNbFgTVgA36zCgzvzk6E=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    qtbase
+    qtdeclarative
+    qtwebengine
+    signond
+    libnotify
+    accounts-qt
+  ];
+
+  meta = {
+    homepage = "https://gitlab.com/accounts-sso/signon-ui";
+    description = "UI component responsible for handling the user interactions which can happen during the login process of an online account";
+    maintainers = with lib.maintainers; [ marie ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add a wrapper for signond, similar to gsignond, enable it by default with Plasma 6.
This makes Google Login and gdrive-kio work out of the box.

This causes a rebuild for some stuff, I'm not sure how much exactly. Should this go through staging?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
