### PR TITLE
nix: revert default to 2.18 for now

### DIFF
--- a/nixos/modules/installer/tools/nix-fallback-paths.nix
+++ b/nixos/modules/installer/tools/nix-fallback-paths.nix
@@ -1,8 +1,8 @@
 {
-  x86_64-linux = "/nix/store/fmfy9zigxns8f1wfb4v2arf1jmfdjpjc-nix-2.24.6";
-  i686-linux = "/nix/store/bl95c09pcihf2fdqpzjyjk4bdq0bsizm-nix-2.24.6";
-  aarch64-linux = "/nix/store/2sbzgmvas19iq3nhg8xbnd8k0khahk34-nix-2.24.6";
-  riscv64-linux = "/nix/store/7yy1x9sx83wm77mjawd953d6a6wb669q-nix-riscv64-unknown-linux-gnu-2.24.6";
-  x86_64-darwin = "/nix/store/vs6bbxkwxqr828q8rj1xlbmsbnx1ry6z-nix-2.24.6";
-  aarch64-darwin = "/nix/store/d88r5b1qv1fvz2j9qndz8sr31mqgz45x-nix-2.24.6";
+  x86_64-linux = "/nix/store/b9kk9p6ankg080wh70smhg44dyan78kn-nix-2.24.2";
+  i686-linux = "/nix/store/nin0kajw977j8hhbyamgv5mkclssr03x-nix-2.24.2";
+  aarch64-linux = "/nix/store/pghw4m535hnrwkdlm7bamxca6lbx6n7z-nix-2.24.2";
+  riscv64-linux = "/nix/store/jcva3mcba7qn4waxkmv77w2r44q7wmq0-nix-riscv64-unknown-linux-gnu-2.24.2";
+  x86_64-darwin = "/nix/store/fkvinbdryqr854hk9i9hpdcqqaqln39m-nix-2.24.2";
+  aarch64-darwin = "/nix/store/z9j3va2vs4ycl9nxxph335c3jf47l27h-nix-2.24.2";
 }

--- a/nixos/modules/installer/tools/nix-fallback-paths.nix
+++ b/nixos/modules/installer/tools/nix-fallback-paths.nix
@@ -1,8 +1,7 @@
 {
-  x86_64-linux = "/nix/store/b9kk9p6ankg080wh70smhg44dyan78kn-nix-2.24.2";
-  i686-linux = "/nix/store/nin0kajw977j8hhbyamgv5mkclssr03x-nix-2.24.2";
-  aarch64-linux = "/nix/store/pghw4m535hnrwkdlm7bamxca6lbx6n7z-nix-2.24.2";
-  riscv64-linux = "/nix/store/jcva3mcba7qn4waxkmv77w2r44q7wmq0-nix-riscv64-unknown-linux-gnu-2.24.2";
-  x86_64-darwin = "/nix/store/fkvinbdryqr854hk9i9hpdcqqaqln39m-nix-2.24.2";
-  aarch64-darwin = "/nix/store/z9j3va2vs4ycl9nxxph335c3jf47l27h-nix-2.24.2";
+  x86_64-linux = "/nix/store/f409bhlpp0xkzvdz95qr2yvfjfi8r9jc-nix-2.18.5";
+  i686-linux = "/nix/store/ra39jzrxq3bcpf55aahwv5037akvylf5-nix-2.18.5";
+  aarch64-linux = "/nix/store/xiw8a4jbnw18svgdb04hyqzg5bsjspqf-nix-2.18.5";
+  x86_64-darwin = "/nix/store/k2gzx7i90x3h2c8g6xdi1jkwbl6ic895-nix-2.18.5";
+  aarch64-darwin = "/nix/store/rqwymbndaqxma6p8s5brcl9k32n5xx54-nix-2.18.5";
 }

--- a/pkgs/development/libraries/nix-plugins/default.nix
+++ b/pkgs/development/libraries/nix-plugins/default.nix
@@ -2,21 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "nix-plugins";
-  version = "15.0.0";
+  version = "14.0.0";
 
   src = fetchFromGitHub {
     owner = "shlevy";
     repo = "nix-plugins";
     rev = version;
-    hash = "sha256-C4VqKHi6nVAHuXVhqvTRRyn0Bb619ez4LzgUWPH1cbM=";
+    hash = "sha256-RDKAuLwcZ3Pbn5JUDmGBcfD0xbM6Jud2ouXh/YKpfS8=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [
-    nix
-    boost
-  ];
+  buildInputs = [ nix boost ];
 
   meta = {
     description = "Collection of miscellaneous plugins for the nix expression language";

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -241,7 +241,7 @@ in lib.makeExtensible (self: ({
     else
       nix;
 
-  stable = addFallbackPathsCheck self.nix_2_24;
+  stable = addFallbackPathsCheck self.nix_2_18;
 } // lib.optionalAttrs config.allowAliases (
   lib.listToAttrs (map (
     minor:


### PR DESCRIPTION
## Description of changes

The segfault bug (see #335342) keeps hitting Hydra on unstable-small, so it's likely going to hit a lot of people once it rolls out widely. Let's revert for now, and investigate without time pressure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
