### PR TITLE
nushellPlugins.bash_env: init at 0.13.0

### DIFF
--- a/pkgs/shells/nushell/plugins/bash-env.nix
+++ b/pkgs/shells/nushell/plugins/bash-env.nix
@@ -1,0 +1,75 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  makeWrapper,
+  resholve,
+  nushell,
+  bash,
+  jq,
+  coreutils,
+  IOKit,
+  Foundation,
+}:
+rustPlatform.buildRustPackage {
+  pname = "nu-plugin-bash-env";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "tesujimath";
+    repo = "nu_plugin_bash_env";
+    rev = "0.13.0";
+    hash = "sha256-fWFBGeNqrJj+fT8EusS8VhxoCmncqhQUplPEHOJlqRA=";
+  };
+
+  cargoHash = "sha256-z5pl1QjNLldXuj2ZWPlMEr/IeR9Fx73ZYDisIhEFxnY=";
+  passthru.updateScript = unstableGitUpdater { };
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    IOKit
+    Foundation
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    install -Dm755 $src/scripts/bash_env.sh $out/libexec/bash_env
+  '';
+
+  postFixup = ''
+    ${resholve.phraseSolution "bash_env" {
+      scripts = [ "libexec/bash_env" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = [
+        jq
+        coreutils
+      ];
+      keep = {
+        "source" = [ "$_path" ];
+      };
+    }}
+    wrapProgram $out/bin/nu_plugin_bash_env \
+      --set NU_PLUGIN_BASH_ENV_SCRIPT $out/libexec/bash_env
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    ${nushell}/bin/nu -c "
+      plugin add --plugin-config /tmp/plugins.msgpackz $out/bin/nu_plugin_bash_env
+    "
+    ${nushell}/bin/nu -c "
+      plugin use --plugin-config /tmp/plugins.msgpackz bash_env
+      use $src/tests.nu run_bash_env_tests
+      run_bash_env_tests
+    "
+  '';
+
+  meta = {
+    description = "A Bash environment plugin for Nushell";
+    homepage = "https://github.com/tesujimath/nu_plugin_bash_env";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.misterio77 ];
+  };
+}

--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -1,6 +1,7 @@
 { lib, newScope, IOKit, CoreFoundation, Foundation, Security }:
 
 lib.makeScope newScope (self: with self; {
+  bash_env = callPackage ./bash-env.nix { inherit IOKit Foundation; };
   gstat = callPackage ./gstat.nix { inherit Security; };
   formats = callPackage ./formats.nix { inherit IOKit Foundation; };
   polars = callPackage ./polars.nix { inherit IOKit Foundation; };


### PR DESCRIPTION
## Description of changes

Add [nu_plugin_bash_env](https://github.com/tesujimath/nu_plugin_bash_env), a plugin that helps with sourcing bash environment files.

This should help with https://github.com/nix-community/home-manager/issues/4313.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
