### PR TITLE
msi-ec-kmods: init at 0-unstable-2024-09-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12683,6 +12683,12 @@
     githubId = 3044438;
     name = "Lucas Savva";
   };
+  m1dugh = {
+    email = "romain103paris@gmail.com";
+    name = "Romain LE MIERE";
+    github = "m1dugh";
+    githubId = 42266017;
+  };
   ma27 = {
     email = "maximilian@mbosch.me";
     matrix = "@ma27:nicht-so.sexy";

--- a/pkgs/os-specific/linux/msi-ec/default.nix
+++ b/pkgs/os-specific/linux/msi-ec/default.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  linuxPackages,
+  git,
+  kernel ? linuxPackages.kernel,
+}:
+stdenv.mkDerivation {
+  pname = "msi-ec-kmods";
+  version = "0-unstable-2024-09-19";
+
+  src = fetchFromGitHub {
+    owner = "BeardOverflow";
+    repo = "msi-ec";
+    rev = "94c2a45c04a07096e10d7cb1240e1a201a025dc0";
+    hash = "sha256-amJUoIf5Sl62BLyHLeam2fzN1s+APoWh2dH5QVfJhCs=";
+  };
+
+  dontMakeSourcesWritable = false;
+
+  postPatch =
+    let
+      targets = builtins.filter (v: v != "") [
+        (lib.strings.optionalString (kernel.kernelOlder "6.2") "older-kernel-patch")
+        (lib.strings.optionalString (kernel.kernelAtLeast "6.11") "6.11-kernel-patch")
+      ];
+      commands = builtins.map (target: "make ${target}") targets;
+    in
+    lib.concatStringsSep "\n" ([ "cp ${./patches/Makefile} ./Makefile" ] ++ commands);
+
+  hardeningDisable = [ "pic" ];
+
+  makeFlags = kernel.makeFlags ++ [
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies ++ [ git ];
+
+  installTargets = [ "modules_install" ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Kernel modules for MSI Embedded controller";
+    homepage = "https://github.com/BeardOverflow/msi-ec";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.m1dugh ];
+    platforms = lib.platforms.linux;
+    broken = kernel.kernelOlder "6.2";
+  };
+}

--- a/pkgs/os-specific/linux/msi-ec/patches/Makefile
+++ b/pkgs/os-specific/linux/msi-ec/patches/Makefile
@@ -1,0 +1,27 @@
+# Out of the box, the build with this Makefile only works in FHS environments,
+# such as on Ubuntu or Debian. On NixOS, you either need to open an FHS
+# environment using a Nix shell or build this from a specially crafted Nix
+# derivation.
+#
+# This file follows the conventions written down here:
+# https://docs.kernel.org/kbuild/modules.html
+# Make it possible to override the kernel src tree location from Nix derivation.
+KERNEL ?= $(shell uname -r)
+KERNELDIR ?= /lib/modules/$(KERNEL)/build/
+ccflags-y := -std=gnu11 -Wno-declaration-after-statement
+.PHONY: default
+default: modules
+# -m: Build as module.
+obj-m = msi-ec.o
+.PHONY: modules
+modules:
+	@#"M=": Module source. Special variable of the kernel's main Makefile.
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
+.PHONY: modules_install
+modules_install:
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
+6.11-kernel-patch:
+	git apply 6.11-kernel.patch
+
+older-kernel-patch:
+	git apply older-kernel.patch

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -602,6 +602,8 @@ in {
 
     nullfs = callPackage ../os-specific/linux/nullfs { };
 
+    msi-ec = callPackage ../os-specific/linux/msi-ec { };
+
   } // lib.optionalAttrs config.allowAliases {
     ati_drivers_x11 = throw "ati drivers are no longer supported by any kernel >=4.1"; # added 2021-05-18;
     hid-nintendo = throw "hid-nintendo was added in mainline kernel version 5.16"; # Added 2023-07-30


### PR DESCRIPTION
## Adds driver `msi-ec-kmods`

Adds the driver for [msi embedded controller](https://github.com/BeardOverflow/msi-ec).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of driver
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
