### PR TITLE
Revert "nixos/wireless: link config to /etc by default"

### DIFF
--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -123,13 +123,15 @@ in
     };
 
     testScript = ''
-      config_file = "/etc/static/wpa_supplicant.conf"
-
       with subtest("Daemon is running and accepting connections"):
           machine.wait_for_unit("wpa_supplicant.service")
           status = machine.wait_until_succeeds("wpa_cli status")
           assert "Failed to connect" not in status, \
                  "Failed to connect to the daemon"
+
+      # get the configuration file
+      cmdline = machine.succeed("cat /proc/$(pgrep wpa)/cmdline").split('\x00')
+      config_file = cmdline[cmdline.index("-c") + 1]
 
       with subtest("WPA2 fallbacks have been generated"):
           assert int(machine.succeed(f"grep -c sae-only {config_file}")) == 1


### PR DESCRIPTION
## Description of changes

This reverts commit 89eb93dc3ffda68535d6ee51a7825f1de31ae658.

It broke setups where /etc/wpa_supplicant.conf is configured imperatively and reloading of the service on configuration changes.

Fixes problems reported in https://github.com/NixOS/nixpkgs/pull/343019, https://github.com/NixOS/nixpkgs/pull/180872#issuecomment-2359355734

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested with `wpa_supplicant.tests`
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
