### PR TITLE
way-shell: init package and module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -21,6 +21,8 @@
 
 - Options under [networking.getaddrinfo](#opt-networking.getaddrinfo.enable) are now allowed to declaratively configure address selection and sorting behavior of `getaddrinfo` in dual-stack networks.
 
+- [way-shell](https://github.com/ldelossa/way-shell/), a GNOME-like shell for Wayland compositors. Available as [programs.way-shell](#opt-programs.way-shell.enable).
+
 - [LACT](https://github.com/ilya-zlobintsev/LACT), a GPU monitoring and configuration tool, can now be enabled through [services.lact.enable](#opt-services.lact.enable).
   Note that for LACT to work properly on AMD GPU systems, you need to enable [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -332,6 +332,7 @@
   ./programs/virt-manager.nix
   ./programs/vivid.nix
   ./programs/wavemon.nix
+  ./programs/way-shell.nix
   ./programs/wayland/cardboard.nix
   ./programs/wayland/dwl.nix
   ./programs/wayland/gtklock.nix

--- a/nixos/modules/programs/way-shell.nix
+++ b/nixos/modules/programs/way-shell.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.way-shell;
+in
+{
+  options.programs.way-shell = {
+    enable = lib.mkEnableOption "way-shell, a GNOME-like shell for Wayland compositors";
+    package = lib.mkPackageOption pkgs "way-shell" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    # Service dependencies expected by way-shell. It is not enough to simply add packages
+    # to systemPackages, because way-shell expects daemons or IPC services to be available
+    # for basic functionality.
+    networking.networkmanager.enable = true;
+    services = {
+      upower.enable = true;
+      pipewire = {
+        enable = true;
+        wireplumber.enable = true;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/wa/way-shell/link-against-pw.patch
+++ b/pkgs/by-name/wa/way-shell/link-against-pw.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index ace1b6a..f6f2ecf 100644
+--- a/Makefile
++++ b/Makefile
+@@ -12,6 +12,7 @@ DEPS := libadwaita-1 \
+ 		wireplumber-0.5 \
+ 		json-glib-1.0 \
+ 		libnm \
++		libpipewire-0.3 \
+ 		libpulse \
+ 		libpulse-simple \
+ 		libpulse-mainloop-glib \

--- a/pkgs/by-name/wa/way-shell/package.nix
+++ b/pkgs/by-name/wa/way-shell/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook4,
+  glib,
+  gtk4,
+  gtk4-layer-shell,
+  json-glib,
+  libadwaita,
+  libpulseaudio,
+  pipewire,
+  networkmanager,
+  upower,
+  wayland-protocols,
+  wayland-scanner,
+  wireplumber,
+  nix-update-script,
+}:
+let
+  pname = "way-shell";
+  version = "0.0.10";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "ldelossa";
+    repo = "way-shell";
+    tag = "v${version}";
+    hash = "sha256-x+PrgAEfG84sbvsWE2366UePKQV1YZbLojo7QrW2H2s=";
+  };
+
+  patches = [
+    # fatal error: pipewire/keys.h: No such file or directory
+    ./link-against-pw.patch
+  ];
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    glib
+    pkg-config
+    wrapGAppsHook4
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    gtk4-layer-shell
+    json-glib
+    libadwaita
+    libpulseaudio
+    networkmanager
+    pipewire
+    upower
+    wayland-protocols
+    wireplumber
+  ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    make $installFlags install-gschema
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/ldelossa/way-shell/releases/tag/v${version}";
+    description = "GNOME-like shell for wayland compositors";
+    homepage = "https://github.com/ldelossa/way-shell/";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.NotAShelf ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Adds the package and module for way-shell, a GNOME-like shell for Wayland compositors.

- **way-shell: init at 0.0.10**
- **nixos/way-shell: init**

Continuation of #329677 under the express permission of `@eclairevoyant`. I have
chosen to adapt this PR (and I will a few others) in correlation to my own
workflows. I will also be taking over the mantle of maintainer for PRs that init
new packages.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package)
    to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  (or backporting
  [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md)
  and
  [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md)
  Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
- [x] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
