### PR TITLE
xcur2png: fix cross-build

### DIFF
--- a/pkgs/tools/graphics/xcur2png/default.nix
+++ b/pkgs/tools/graphics/xcur2png/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, libpng, xorg }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libpng,
+  xorg,
+}:
 
 stdenv.mkDerivation rec {
   pname = "xcur2png";

--- a/pkgs/tools/graphics/xcur2png/default.nix
+++ b/pkgs/tools/graphics/xcur2png/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "0858wn2p14bxpv9lvaz2bz1rk6zk0g8zgxf8iy595m8fqv4q2fya";
   };
 
+  patches = [
+    # https://github.com/eworm-de/xcur2png/pull/3
+    ./malloc.diff
+  ];
+
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/tools/graphics/xcur2png/default.nix
+++ b/pkgs/tools/graphics/xcur2png/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config,
   libpng,
   xorg,
@@ -21,6 +22,12 @@ stdenv.mkDerivation rec {
   patches = [
     # https://github.com/eworm-de/xcur2png/pull/3
     ./malloc.diff
+
+    # fix byte overflows due to off-by-one error
+    (fetchpatch {
+      url = "https://github.com/eworm-de/xcur2png/commit/aa035462d950fab35d322cb87fd2f0d702251e82.patch";
+      hash = "sha256-hlmJ/bcDSl1ADs0jp+JrAgAaMzielUSRVPad+plnSZg=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/tools/graphics/xcur2png/malloc.diff
+++ b/pkgs/tools/graphics/xcur2png/malloc.diff
@@ -1,0 +1,33 @@
+--- a/xcur2png.c
++++ b/xcur2png.c
+@@ -16,7 +16,10 @@
+ /* Todo: atoi error handling */
+ /* help is -h in manual */
+
++#if HAVE_CONFIG_H
+ #include <config.h>
++#endif
++#undef malloc
+
+ #define _ATFILE_SOURCE
+ #include <stdio.h>
+@@ -34,6 +37,19 @@
+ #include <png.h>
+ #include <X11/Xcursor/Xcursor.h>
+
++
++void *malloc ();
++
++/* Allocate an N-byte block of memory from the heap.
++   If N is zero, allocate a 1-byte block.  */
++
++void* rpl_malloc (size_t n)
++{
++  if (n == 0)
++    n = 1;
++  return malloc (n);
++}
++
+ #define PNG_SETJMP_NOT_SUPPORTED 1
+ 
+ #define PROGRESS_SHARPS 50 /* total number of progress sharps */


### PR DESCRIPTION
## Description of changes

Fixes errors caused by autoconf not finding rpl_malloc. Fix implemented by following the answer [here](https://www.linuxquestions.org/questions/linux-software-2/undefined-reference-to-%60rpl_malloc%27-587256/).

```
/nix/store/vl7wj0kj6rq3lgn7czb266lbr5y26kfn-aarch64-unknown-linux-gnu-binutils-2.42/bin/aarch64-unknown-linux-gnu-ld: /build/source/xcur2png.c:230:(.text+0x91c): undefined reference to `rpl_malloc'
```

Tested with `nix build .#pkgsCross.aarch64-multiplatform.xcur2png` and `nix build >#pkgsCross.riscv64.xcur2png`.

Also add patch fixing wrong math, thanks @Artturin for the suggestion.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
