### PR TITLE
osquery: remove workaround for autoPatchelfHook problem

### DIFF
--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -14,7 +14,6 @@
 , jq
 , removeReferencesTo
 , nixosTests
-, file
 , writers
 }:
 
@@ -24,7 +23,7 @@ let
 
   opensslSrc = fetchurl info.openssl;
 
-  toolchain = import ./toolchain-bin.nix { inherit stdenv lib fetchzip file; };
+  toolchain = import ./toolchain-bin.nix { inherit stdenv lib fetchzip autoPatchelfHook; };
 
 in
 

--- a/pkgs/tools/system/osquery/toolchain-bin.nix
+++ b/pkgs/tools/system/osquery/toolchain-bin.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip, file }:
+{ stdenv, lib, fetchzip, autoPatchelfHook }:
 let
 
   version = "1.1.0";
@@ -24,22 +24,11 @@ stdenv.mkDerivation {
 
   src = fetchzip dist.${stdenv.hostPlatform.system};
 
-  nativeBuildInputs = [ file ];
+  nativeBuildInputs = [ autoPatchelfHook ];
 
   installPhase = ''
     mkdir $out
     cp -r * $out
-  '';
-
-  # autoPatchelfHook cannot be used here because of https://github.com/NixOS/nixpkgs/issues/333710
-  postFixup = ''
-    read -r interpreter < "$NIX_BINTOOLS"/nix-support/dynamic-linker
-    for file in $(find "$out"/usr/bin -type f -executable); do
-      if [[ $(file "$file") == *ELF*dynamically* ]]; then
-        patchelf --interpreter "$interpreter" "$file"
-        patchelf --set-rpath "$out/usr/lib" "$file"
-      fi
-    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes
Remove workaround for #333710.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
