### PR TITLE
xen: remove `stubdomains` #TODO note

### DIFF
--- a/pkgs/applications/virtualization/xen/generic/default.nix
+++ b/pkgs/applications/virtualization/xen/generic/default.nix
@@ -426,8 +426,6 @@ stdenv.mkDerivation (finalAttrs: {
     "xen" # Build the Xen Hypervisor.
     "tools" # Build the userspace tools, such as `xl`.
     "docs" # Build the Xen Documentation
-    # TODO: Enable the Stubdomains target. This requires another pre-fetched source: mini-os. Currently, Xen appears to build a limited version of stubdomains which does not include mini-os.
-    # "stubdom"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
## Description of changes

MiniOS stubdomains are legacy and on their way to being replaced by unikraft. There's no need to work towards them.

## Things done

- [x] No Rebuilds
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
