### PR TITLE
guitarix: correct dependencies

### DIFF
--- a/pkgs/by-name/gu/guitarix/package.nix
+++ b/pkgs/by-name/gu/guitarix/package.nix
@@ -13,6 +13,7 @@
   glib,
   glib-networking,
   glibmm,
+  gperf,
   adwaita-icon-theme,
   gsettings-desktop-schemas,
   gtk3,
@@ -21,6 +22,7 @@
   intltool,
   ladspaH,
   libjack2,
+  liblo,
   libsndfile,
   lilv,
   lrdf,
@@ -66,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     wrapGAppsHook3
   ];
 
+  # TODO: identify sets of optional dependencies and add corresponding parameters
   buildInputs = [
     avahi
     bluez
@@ -77,12 +80,14 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     glib-networking.out
     glibmm
+    gperf
     adwaita-icon-theme
     gsettings-desktop-schemas
     gtk3
     gtkmm3
     ladspaH
     libjack2
+    liblo
     libsndfile
     lilv
     lrdf
@@ -94,6 +99,12 @@ stdenv.mkDerivation (finalAttrs: {
     zita-convolver
     zita-resampler
   ];
+
+  # There are many bad shebangs which can fail builds.
+  # See https://github.com/brummer10/guitarix/issues/97
+  prePatch = ''
+    patchShebangs --build tools/**
+  '';
 
   wafConfigureFlags = [
     "--no-font-cache-update"

--- a/pkgs/by-name/gu/guitarix/package.nix
+++ b/pkgs/by-name/gu/guitarix/package.nix
@@ -40,10 +40,6 @@
   optimizationSupport ? false, # Enable support for native CPU extensions
 }:
 
-let
-  inherit (lib) optional;
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "guitarix";
   version = "0.46.0";
@@ -70,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # TODO: identify sets of optional dependencies and add corresponding parameters
   buildInputs = [
+    adwaita-icon-theme
     avahi
     bluez
     boost
@@ -81,7 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     glib-networking.out
     glibmm
     gperf
-    adwaita-icon-theme
     gsettings-desktop-schemas
     gtk3
     gtkmm3
@@ -112,41 +108,34 @@ stdenv.mkDerivation (finalAttrs: {
     "--no-desktop-update"
     "--enable-nls"
     "--install-roboto-font"
-  ] ++ optional optimizationSupport "--optimization";
+  ] ++ lib.optional optimizationSupport "--optimization";
 
   env.NIX_CFLAGS_COMPILE = toString [ "-fpermissive" ];
 
-  meta = with lib; {
+  meta = {
     description = "Virtual guitar amplifier for Linux running with JACK";
-    mainProgram = "guitarix";
-    longDescription = ''
-        guitarix is a virtual guitar amplifier for Linux running with
-      JACK (Jack Audio Connection Kit). It is free as in speech and
-      free as in beer. Its free sourcecode allows to build it for
-      other UNIX-like systems also, namely for BSD and for MacOSX.
-
-        It takes the signal from your guitar as any real amp would do:
-      as a mono-signal from your sound card. Your tone is processed by
-      a main amp and a rack-section. Both can be routed separately and
-      deliver a processed stereo-signal via JACK. You may fill the
-      rack with effects from more than 25 built-in modules spanning
-      from a simple noise-gate to brain-slashing modulation-fx like
-      flanger, phaser or auto-wah. Your signal is processed with
-      minimum latency. On any properly set-up Linux-system you do not
-      need to wait for more than 10 milli-seconds for your playing to
-      be delivered, processed by guitarix.
-
-        guitarix offers the range of sounds you would expect from a
-      full-featured universal guitar-amp. You can get crisp
-      clean-sounds, nice overdrive, fat distortion and a diversity of
-      crazy sounds never heard before.
-    '';
     homepage = "https://github.com/brummer10/guitarix";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "guitarix";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
       astsmtl
       lord-valen
     ];
-    platforms = platforms.linux;
+    longDescription = ''
+      Guitarix takes the signal from your guitar as any real amp would do: as a
+      mono-signal from your sound card. Your tone is processed by a main amp and
+      a rack-section. Both can be routed separately and deliver a processed
+      stereo-signal via JACK. You may fill the rack with effects from more than
+      25 built-in modules spanning from a simple noise-gate to brain-slashing
+      modulation-fx like flanger, phaser or auto-wah. Your signal is processed
+      with minimum latency. On a properly set-up Linux-system you do not need to
+      wait for more than 10 milliseconds for your playing to be delivered,
+      processed by guitarix.
+
+      Guitarix offers the range of sounds you would expect from a full-featured
+      universal guitar-amp. You can get crisp clean-sounds, nice overdrive, fat
+      distortion and a diversity of crazy sounds never heard before.
+    '';
   };
 })

--- a/pkgs/by-name/gu/guitarix/package.nix
+++ b/pkgs/by-name/gu/guitarix/package.nix
@@ -8,7 +8,7 @@
   curl,
   eigen,
   faust,
-  fftw,
+  fftwFloat,
   gettext,
   glib,
   glib-networking,
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     eigen
     faust
-    fftw
+    fftwFloat
     glib
     glib-networking.out
     glibmm

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12336,10 +12336,6 @@ with pkgs;
     pulseaudioSupport = false;
   };
 
-  guitarix = callPackage ../applications/audio/guitarix {
-    fftw = fftwSinglePrec;
-  };
-
   puddletag = libsForQt5.callPackage ../applications/audio/puddletag { };
 
   welle-io = qt6Packages.callPackage ../applications/radio/welle-io { };


### PR DESCRIPTION
## Description of changes

Guitarix uses pre-generated c++ files from the dsp code when faust is not available. The waf script expects particular faust versions. We're using faust `2.74.x` which is unsupported; waf therefore acts as though we don't provide faust and uses the pre-generated files. We can force it to use any faust version with `--faust` but that fails with the current version.

Guitarix should be buildable on Mac and BSDs, so I changed the platform to more accurately reflect that. At the same time, I removed redundancies in the long description as those details were already included in other `meta` fields.

Some of the dependencies listed in the Guitarix repo weren't included. I noted that adding these did cause a different build result; however, adding `gperf` caused a failure when waf tried to run the `dsp2cc` script. This is due to poor shebangs; `patchShebangs` fixed this with ease. Since these dependencies were apparently optional, this leaves future work for enumerating the optional features and corresponding dependencies in order to allow consumers to reduce closure size if that is desired.

I moved the package to `pkgs/by-name`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc