### PR TITLE
switch-to-configuration-ng: update rust-ini to support multi-line INI…

### DIFF
--- a/pkgs/by-name/sw/switch-to-configuration-ng/package.nix
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/package.nix
@@ -12,7 +12,10 @@ rustPlatform.buildRustPackage {
 
   src = ./src;
 
-  cargoLock.lockFile = ./src/Cargo.lock;
+  cargoLock = {
+    lockFile = ./src/Cargo.lock;
+    outputHashes."rust-ini-0.21.1" = "sha256-0nSBhme/g+mVsYdiq0Ash0ek9WEdvbf/b9FRxA7sauk=";
+  };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dbus ];

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/Cargo.lock
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/Cargo.lock
@@ -337,9 +337,8 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rust-ini"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d625ed57d8f49af6cfa514c42e1a71fadcff60eb0b1c517ff82fe41aa025b41"
+version = "0.21.1"
+source = "git+https://github.com/zonyitoo/rust-ini?rev=5748ae57a178216a920b88dfac1296618e967447#5748ae57a178216a920b88dfac1296618e967447"
 dependencies = [
  "cfg-if",
  "ordered-multimap",

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/Cargo.toml
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/Cargo.toml
@@ -12,7 +12,9 @@ glob = "0.3.1"
 log = "0.4.21"
 nix = { version = "0.28.0", features = ["fs", "signal"] }
 regex = "1.10.4"
-rust-ini = "0.21.0"
+rust-ini = { git = "https://github.com/zonyitoo/rust-ini", rev = "5748ae57a178216a920b88dfac1296618e967447", features = [
+  "inline-comment",
+] }
 syslog = "6.1.1"
 
 [build-dependencies]


### PR DESCRIPTION
… values

## Description of changes

Fixes #342642

This updates the rust-ini crate to point to the latest rev of that project, which adds systemd-styled multi-line INI support to the parser.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
