### PR TITLE
xmake: 2.9.4 -> 2.9.5

### DIFF
--- a/pkgs/development/tools/build-managers/xmake/default.nix
+++ b/pkgs/development/tools/build-managers/xmake/default.nix
@@ -1,48 +1,32 @@
-{ lib
-, stdenv
-, fetchurl
-, pkg-config
-, lua
-, readline
-, ncurses
-, lz4
-, tbox
-, xmake-core-sv
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  CoreServices,
 }:
-
 stdenv.mkDerivation rec {
   pname = "xmake";
-  version = "2.9.4";
-
+  version = "2.9.5";
   src = fetchurl {
     url = "https://github.com/xmake-io/xmake/releases/download/v${version}/xmake-v${version}.tar.gz";
-    hash = "sha256-deLd4r0qSKMymJuAGuZQd8RS1JH+xRep2yeoHIcTzcU=";
+    hash = "sha256-A/61eH4i+rjdQEGew9hKvTWrzZ+KGyTEiMfrVx1nJMg=";
   };
 
-  nativeBuildInputs = [
-    pkg-config
+  patches = [
+    (fetchpatch {
+      name = "xmake-fix-configure-compatibility.patch";
+      url = "https://github.com/xmake-io/xmake/commit/2a1220727a367e753b92131577ab0c2fd974bff8.patch";
+      hash = "sha256-xknlyydHvdwqTl975VQogKozT8nAp5+gPZQuRl1yXKE=";
+    })
   ];
 
-  buildInputs = [
-    lua
-    lua.pkgs.cjson
-    readline
-    ncurses
-    lz4
-    tbox
-    xmake-core-sv
-  ];
-
-  strictDeps = true;
-
-  configureFlags = [ "--external=y" ];
+  buildInputs = lib.optional stdenv.hostPlatform.isDarwin CoreServices;
 
   meta = with lib; {
     description = "Cross-platform build utility based on Lua";
     homepage = "https://xmake.io";
     license = licenses.asl20;
-    platforms = lua.meta.platforms;
     maintainers = with maintainers; [ rewine ];
   };
 }
-

--- a/pkgs/development/tools/build-managers/xmake/default.nix
+++ b/pkgs/development/tools/build-managers/xmake/default.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation rec {
     description = "Cross-platform build utility based on Lua";
     homepage = "https://xmake.io";
     license = licenses.asl20;
-    maintainers = with maintainers; [ rewine ];
+    maintainers = with maintainers; [
+      rewine
+      rennsax
+    ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18917,7 +18917,7 @@ with pkgs;
   webdis = callPackage ../development/tools/database/webdis { };
 
   xmake = callPackage ../development/tools/build-managers/xmake {
-    lua = lua5_4;
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
   xc3sprog = callPackage ../development/embedded/xc3sprog { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18916,8 +18916,8 @@ with pkgs;
 
   webdis = callPackage ../development/tools/database/webdis { };
 
-  xmake = callPackage ../development/tools/build-managers/xmake {
-    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  xmake = darwin.apple_sdk_11_0.callPackage ../development/tools/build-managers/xmake {
+    inherit (darwin.apple_sdk_11_0.frameworks) CoreServices;
   };
 
   xc3sprog = callPackage ../development/embedded/xc3sprog { };


### PR DESCRIPTION
## Description of changes

Xmake is actually broken in Nixpkgs. See #342966.

I'm surprised that this simple derivation "just works" - on my MacBook 2021 (aarch64-darwin), on my NixOS virtual machine (aarch64-linux) and on my lab's server (x86_64-linux).

However I'm not sure if the derivation is generic enough. Maybe more tests needed.

Here is the behavior of xmake:
```console
$ xmake create -l c -P ./hello
create hello ...
  [+]: xmake.lua
  [+]: src/main.c
  [+]: .gitignore
create ok!
$ cd hello
$ xmake
checking for platform ... linux
checking for architecture ... x86_64
[ 50%]: cache compiling.release src/main.c
[ 75%]: linking.release hello
[100%]: build ok, spent 1.287s
$ xmake --version
xmake v2.9.5+19800101, A cross-platform build utility based on Lua
Copyright (C) 2015-present Ruki Wang, tboox.org, xmake.io
                         _
    __  ___ __  __  __ _| | ______
    \ \/ / |  \/  |/ _  | |/ / __ \
     >  <  | \__/ | /_| |   <  ___/
    /_/\_\_|_|  |_|\__ \|_|\_\____|
                         by ruki, xmake.io

    👉  Manual: https://xmake.io/#/getting_started
    🙏  Donate: https://xmake.io/#/sponsor
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
