### PR TITLE
emacs: make trivialBuild know its elisp dependencies in another way

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/emacs-funcs.sh
+++ b/pkgs/applications/editors/emacs/build-support/emacs-funcs.sh
@@ -20,15 +20,4 @@ addEmacsVars () {
   if [ -n "${addEmacsNativeLoadPath:-}" ]; then
     addToEmacsNativeLoadPath "$1/share/emacs/native-lisp"
   fi
-
-  # Add sub paths to the Emacs load path if it is a directory
-  # containing .el files. This is necessary to build some packages,
-  # e.g., using trivialBuild.
-  for lispDir in \
-      "$1/share/emacs/site-lisp/"* \
-      "$1/share/emacs/site-lisp/elpa/"*; do
-    if [[ -d $lispDir && "$(echo "$lispDir"/*.el)" ]] ; then
-      addToEmacsLoadPath "$lispDir"
-    fi
-  done
 }

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -86,10 +86,14 @@ libBuildHelper.extendMkDerivation' stdenv.mkDerivation (finalAttrs:
     source ${./emacs-funcs.sh}
     addEmacsVars "$out"
 
+    # package-activate-all is used to activate packages.  In other builder
+    # helpers, package-initialize is used for this purpose because
+    # package-activate-all is not available before Emacs 27.
     find $out/share/emacs -type f -name '*.el' -not -name ".dir-locals.el" -print0 \
       | xargs --verbose -0 -I {} -n 1 -P $NIX_BUILD_CORES sh -c \
           "emacs \
              --batch \
+             -f package-activate-all \
              --eval '(setq native-comp-eln-load-path (cdr native-comp-eln-load-path))' \
              --eval '(setq large-file-warning-threshold nil)' \
              --eval '(setq byte-compile-error-on-warn ${if finalAttrs.turnCompilationWarningToError then "t" else "nil"})' \

--- a/pkgs/applications/editors/emacs/build-support/trivial.nix
+++ b/pkgs/applications/editors/emacs/build-support/trivial.nix
@@ -19,7 +19,7 @@ args:
       foundMakefile=1
     fi
 
-    emacs -L . --batch -f batch-byte-compile *.el
+    emacs -l package -f package-initialize -L . --batch -f batch-byte-compile *.el
 
     runHook postBuild
   '';


### PR DESCRIPTION
Previously, trivialBuild did not know how to find its elisp dependencies.  This was[1] fixed[2] by basically rewriting part of package-activate-all in bash.

I think it is better to call package-activate-all (or package-initialize if Emacs is old) directly.  It reduces maintenance burden a bit.  It also improves consistency since elpaBuild and melpaBuild already do so.

This change provides almost the same functionality as before.  It only breaks elisp packages with non-standard[^3] elisp dependencies. However, I think those non-standard ones should be fixed instead. As an example, mu4e used to be a non-standard one and was fixed[4].

This change does not cause more build failures in emacsPackages.

[1]: https://github.com/NixOS/nixpkgs/pull/82604
[2]: https://github.com/NixOS/nixpkgs/commit/bf486f784ddd969c03243dba4c93d0e8e861173e
[4]: https://github.com/NixOS/nixpkgs/pull/253438
[^3]: Non-standard elisp packages do not meet requirements of package.el, the builtin package manager of Emacs.  Usually, they are installed to $out/share/emacs/site-lisp/$pname-$version and/or miss a $pname-pkg.el file.



## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
