### PR TITLE
open-webui: 0.3.21 -> 0.3.28

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -7,19 +7,19 @@
 }:
 let
   pname = "open-webui";
-  version = "0.3.21";
+  version = "0.3.28";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     rev = "refs/tags/v${version}";
-    hash = "sha256-b+r+nEv+9IM56KkCi9tZqnEbyCX69mFhp0Be5/9lR9c=";
+    hash = "sha256-DjwHylu6ke74dxPuMDbLMrfWL9yvmh4W8QGyLzzUZVg=";
   };
 
   frontend = buildNpmPackage {
     inherit pname version src;
 
-    npmDepsHash = "sha256-LH07LzYZpVzRAvkjoTgt7LJdXZZoDMt//ZAl30z7AHw=";
+    npmDepsHash = "sha256-AWKIqijjTKJJFOzFIcSas+cAq0mZSsYGsVNpk2yQ4ZE=";
 
     # Disabling `pyodide:fetch` as it downloads packages during `buildPhase`
     # Until this is solved, running python packages from the browser will not work.
@@ -76,8 +76,10 @@ python3.pkgs.buildPythonApplication rec {
     black
     boto3
     chromadb
+    colbert-ai
     docx2txt
     duckduckgo-search
+    einops
     extract-msg
     fake-useragent
     fastapi
@@ -103,6 +105,7 @@ python3.pkgs.buildPythonApplication rec {
     psycopg2
     pydub
     pyjwt
+    pymilvus
     pymongo
     pymysql
     pypandoc

--- a/pkgs/development/python-modules/colbert-ai/default.nix
+++ b/pkgs/development/python-modules/colbert-ai/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  bitarray,
+  datasets,
+  flask,
+  python-dotenv,
+  ninja,
+  scipy,
+  tqdm,
+  transformers,
+  ujson,
+  gitpython,
+  torch,
+  faiss,
+}:
+
+buildPythonPackage rec {
+  pname = "colbert-ai";
+  version = "0.2.21";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "colbert_ai";
+    hash = "sha256-qNb9tOInLysI7Tf45QlgchYNhBXR5AWFdRiYt35iW6s=";
+  };
+
+  pythonRemoveDeps = [ "git-python" ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    bitarray
+    datasets
+    faiss
+    flask
+    gitpython
+    python-dotenv
+    ninja
+    scipy
+    torch
+    tqdm
+    transformers
+    ujson
+  ];
+
+  pythonImportsCheck = [ "colbert" ];
+
+  # There is no tests
+  doCheck = false;
+
+  meta = {
+    description = "Fast and accurate retrieval model, enabling scalable BERT-based search over large text collections in tens of milliseconds";
+    homepage = "https://github.com/stanford-futuredata/ColBERT";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      bachp
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2436,6 +2436,8 @@ self: super: with self; {
 
   colander = callPackage ../development/python-modules/colander { };
 
+  colbert-ai = callPackage ../development/python-modules/colbert-ai { };
+
   collections-extended = callPackage ../development/python-modules/collections-extended { };
 
   collidoscope = callPackage ../development/python-modules/collidoscope { };


### PR DESCRIPTION
- Diff: https://github.com/open-webui/open-webui/compare/refs/tags/v0.3.21...v0.3.28
- Changelogs: 
  - https://github.com/open-webui/open-webui/blob/refs/tags/v0.3.22/CHANGELOG.md
  - https://github.com/open-webui/open-webui/blob/refs/tags/v0.3.23/CHANGELOG.md
  - https://github.com/open-webui/open-webui/blob/refs/tags/v0.3.24/CHANGELOG.md
  - https://github.com/open-webui/open-webui/blob/refs/tags/v0.3.25/CHANGELOG.md
  - https://github.com/open-webui/open-webui/blob/refs/tags/v0.3.26/CHANGELOG.md
  - https://github.com/open-webui/open-webui/blob/refs/tags/v0.3.27/CHANGELOG.md
  - https://github.com/open-webui/open-webui/blob/refs/tags/v0.3.28/CHANGELOG.md

<details>
   
```
❯ nix build .#open-webui -L
open-webui> Running phase: unpackPhase
open-webui> unpacking source archive /nix/store/ks9z2r0vc8899l9xx6himxj6w114hhdz-source
open-webui> source root is source
open-webui> Running phase: patchPhase
open-webui> Executing npmConfigHook
open-webui> Configuring npm
open-webui> Validating consistency between /build/source/package-lock.json and /nix/store/gd0gihcj9cyd4f0hz6n721sgrgb0lila-open-webui-0.3.22-npm-deps/package-lock.json
open-webui> \Installing dependencies
open-webui> added 796 packages, and audited 797 packages in 4s
open-webui> 175 packages are looking for funding
open-webui>   run `npm fund` for details
open-webui> found 0 vulnerabilities
open-webui> patching script interpreter paths in node_modules
open-webui> node_modules/@sveltejs/kit/svelte-kit.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/acorn/bin/acorn: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/cypress/bin/cypress: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/quick-temp/node_modules/rimraf/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rimraf/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/sander/node_modules/rimraf/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/tailwindcss/node_modules/yaml/bin.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/tailwindcss/lib/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/vite/node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/vite/bin/vite.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/vitest/vitest.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/autoprefixer/bin/autoprefixer: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/browserslist/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/crc-32/bin/crc32.njs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/cssesc/bin/cssesc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/cytoscape/.github/workflows/scripts/merge_unstable_to_master.sh: interpreter directive changed from "#!/bin/bash" to "/nix/store/izpf49b74i15pcr9708s3xdwyqs4jxwl-bash-5.2p32/bin/bash"
open-webui> node_modules/cytoscape/.github/workflows/scripts/new-feature-version.sh: interpreter directive changed from "#!/bin/bash" to "/nix/store/izpf49b74i15pcr9708s3xdwyqs4jxwl-bash-5.2p32/bin/bash"
open-webui> node_modules/cytoscape/.github/workflows/scripts/pre_release_test.sh: interpreter directive changed from "#!/bin/bash" to "/nix/store/izpf49b74i15pcr9708s3xdwyqs4jxwl-bash-5.2p32/bin/bash"
open-webui> node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/eslint/bin/eslint.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/eslint-config-prettier/bin/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/i18next-parser/bin/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/is-ci/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/nanoid/bin/nanoid.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/prettier/bin/prettier.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/resolve/bin/resolve: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/sucrase/node_modules/glob/dist/esm/bin.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/sucrase/bin/sucrase: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/sucrase/bin/sucrase-node: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/svelte-check/bin/svelte-check: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/extract-zip/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/jiti/bin/jiti.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/js-yaml/bin/js-yaml.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/marked/bin/marked.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/typescript/bin/tsc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/typescript/bin/tsserver: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/update-browserslist-db/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/uuid/dist/bin/uuid: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/uvu/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/mkdirp/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rollup/dist/bin/rollup: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/vite-node/vite-node.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/encoding-sync: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/cat-async: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/encode-object-async: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/encode-object-sync: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/encode-string-async: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/encode-string-sync: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/encoding-async: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/cat-sync: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/run-tests: interpreter directive changed from "#!/bin/bash" to "/nix/store/izpf49b74i15pcr9708s3xdwyqs4jxwl-bash-5.2p32/bin/bash"
open-webui> node_modules/rw/test/wc-async: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/wc-sync: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/write-async: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/rw/test/write-sync: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/which/bin/node-which: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/sorcery/bin/sorcery: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/sshpk/bin/sshpk-conv: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/sshpk/bin/sshpk-sign: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/sshpk/bin/sshpk-verify: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/why-is-node-running/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/katex/src/fonts/generate_fonts.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/bin/python3"
open-webui> node_modules/katex/src/metrics/extract_tfms.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/bin/python3"
open-webui> node_modules/katex/src/metrics/extract_ttfs.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/bin/python3"
open-webui> node_modules/katex/src/metrics/format_json.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/bin/python3"
open-webui> node_modules/katex/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/d3-dsv/bin/dsv2dsv.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/d3-dsv/bin/dsv2json.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/d3-dsv/bin/json2dsv.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/postcss/node_modules/nanoid/bin/nanoid.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> node_modules/@cypress/request/node_modules/uuid/dist/bin/uuid: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node"
open-webui> rebuilt dependencies successfully
open-webui> patching script interpreter paths in node_modules
open-webui> Finished npmConfigHook
open-webui> Running phase: updateAutotoolsGnuConfigScriptsPhase
open-webui> Running phase: configurePhase
open-webui> no configure script, doing nothing
open-webui> Running phase: buildPhase
open-webui> Executing npmBuildHook
open-webui> > open-webui@0.3.22 build
open-webui> > vite build
open-webui> vite v5.4.6 building SSR bundle for production...
open-webui> Browserslist: caniuse-lite is outdated. Please run:
open-webui>   npx update-browserslist-db@latest
open-webui>   Why you should do it regularly: https://github.com/browserslist/update-db#readme
open-webui> 10:35:22 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/Messages.svelte:23:11 Messages has unused export property 'processing'. If it is for external reference only, please consider using `export const processing`
open-webui> 21: export let user = $_user;
open-webui> 22: export let prompt;
open-webui> 23: export let processing = "";
open-webui>                ^
open-webui> 24: export let bottomPadding = false;
open-webui> 25: export let autoScroll;
open-webui> 10:35:22 PM [vite-plugin-svelte] /build/source/src/lib/components/layout/Navbar.svelte:25:11 Navbar has unused export property 'title'. If it is for external reference only, please consider using `export const title`
open-webui> 23: const i18n = getContext("i18n");
open-webui> 24: export let initNewChat;
open-webui> 25: export let title = $WEBUI_NAME;
open-webui>                ^
open-webui> 26: export let shareEnabled = false;
open-webui> 27: export let chat;
open-webui> 10:35:23 PM [vite-plugin-svelte] /build/source/src/lib/components/layout/Help/HelpMenu.svelte:10:11 HelpMenu has unused export property 'showDocsHandler'. If it is for external reference only, please consider using `export const showDocsHandler`
open-webui>  8: import Keyboard from "$lib/components/icons/Keyboard.svelte";
open-webui>  9: const i18n = getContext("i18n");
open-webui> 10: export let showDocsHandler;
open-webui>                ^
open-webui> 11: export let showShortcutsHandler;
open-webui> 12: export let onClose = () => {
open-webui> 10:35:24 PM [vite-plugin-svelte] /build/source/src/lib/components/layout/Navbar/Menu.svelte:17:11 Menu has unused export property 'shareEnabled'. If it is for external reference only, please consider using `export const shareEnabled`
open-webui> 15: import AdjustmentsHorizontal from "$lib/components/icons/AdjustmentsHorizontal.svelte";
open-webui> 16: const i18n = getContext("i18n");
open-webui> 17: export let shareEnabled = false;
open-webui>                ^
open-webui> 18: export let shareHandler;
open-webui> 19: export let downloadHandler;
open-webui> 10:35:24 PM [vite-plugin-svelte] /build/source/src/lib/components/layout/Navbar/Menu.svelte:19:11 Menu has unused export property 'downloadHandler'. If it is for external reference only, please consider using `export const downloadHandler`
open-webui> 17: export let shareEnabled = false;
open-webui> 18: export let shareHandler;
open-webui> 19: export let downloadHandler;
open-webui>                ^
open-webui> 20: export let chat;
open-webui> 21: export let onClose = () => {
open-webui> 10:35:24 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/Settings/Chats.svelte:17:11 Chats has unused export property 'saveSettings'. If it is for external reference only, please consider using `export const saveSettings`
open-webui> 15: import { toast } from "svelte-sonner";
open-webui> 16: const i18n = getContext("i18n");
open-webui> 17: export let saveSettings;
open-webui>                ^
open-webui> 18: let importFiles;
open-webui> 19: let showArchiveConfirm = false;
open-webui> 10:35:24 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/Settings/General.svelte:9:11 General has unused export property 'getModels'. If it is for external reference only, please consider using `export const getModels`
open-webui>  7: import AdvancedParams from "./Advanced/AdvancedParams.svelte";
open-webui>  8: export let saveSettings;
open-webui>  9: export let getModels;
open-webui>                ^
open-webui> 10: let themes = ["dark", "light", "rose-pine dark", "rose-pine-dawn light", "oled-dark"];
open-webui> 11: let selectedTheme = "system";
open-webui> 10:35:24 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/Controls/Controls.svelte:10:11 Controls has unused export property 'models'. If it is for external reference only, please consider using `export const models`
open-webui>  8: import Collapsible from "$lib/components/common/Collapsible.svelte";
open-webui>  9: import { user } from "$lib/stores";
open-webui> 10: export let models = [];
open-webui>                ^
open-webui> 11: export let chatFiles = [];
open-webui> 12: export let params = {};
open-webui> 10:35:24 PM [vite-plugin-svelte] /build/source/src/lib/components/common/Drawer.svelte:6:11 Drawer has unused export property 'size'. If it is for external reference only, please consider using `export const size`
open-webui> 4: const dispatch = createEventDispatcher();
open-webui> 5: export let show = false;
open-webui> 6: export let size = "md";
open-webui>               ^
open-webui> 7: let modalElement = null;
open-webui> 8: let mounted = false;
open-webui> 10:35:24 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/MessageInput/CallOverlay.svelte:647:5 A11y: <video> elements must have a <track kind="captions">
open-webui> 645:       {:else}
open-webui> 646:         <div class="relative flex video-container w-full max-h-full pt-2 pb-4 md:py-6 px-2 h-full">
open-webui> 647:           <video
open-webui>                ^
open-webui> 648:             id="camera-feed"
open-webui> 649:             autoplay
open-webui> "default" is imported from external module "turndown" but never used in "src/routes/(app)/workspace/models/create/+page.svelte".
open-webui> "stringify" is imported from external module "postcss" but never used in "src/routes/(app)/workspace/models/create/+page.svelte".
open-webui> "roundArrow" is imported from external module "tippy.js" but never used in "src/lib/components/common/Tooltip.svelte".
open-webui> "isInputDOMNode" is imported from external module "@xyflow/system" but never used in "node_modules/@xyflow/svelte/dist/lib/utils/index.js", "node_modules/@xyflow/svelte/dist/lib/hooks/useSvelteFlow.js", "node_modules/@xyflow/svelte/dist/lib/hooks/useHandleConnections.js", "node_modules/@xyflow/svelte/dist/lib/hooks/useNodesData.js", "node_modules/@xyflow/svelte/dist/lib/components/edges/BezierEdge.svelte", "node_modules/@xyflow/svelte/dist/lib/components/edges/BezierEdgeInternal.svelte", "node_modules/@xyflow/svelte/dist/lib/components/edges/SmoothStepEdge.svelte", "node_modules/@xyflow/svelte/dist/lib/components/edges/SmoothStepEdgeInternal.svelte", "node_modules/@xyflow/svelte/dist/lib/components/edges/StraightEdge.svelte", "node_modules/@xyflow/svelte/dist/lib/components/edges/StraightEdgeInternal.svelte", "node_modules/@xyflow/svelte/dist/lib/components/edges/StepEdge.svelte", "node_modules/@xyflow/svelte/dist/lib/components/edges/StepEdgeInternal.svelte", "node_modules/@xyflow/svelte/dist/lib/components/Handle/Handle.svelte", "node_modules/@xyflow/svelte/dist/lib/plugins/NodeResizer/NodeResizer.svelte", "node_modules/@xyflow/svelte/dist/lib/plugins/NodeResizer/ResizeControl.svelte", "node_modules/@xyflow/svelte/dist/lib/store/visible-edges.js", "node_modules/@xyflow/svelte/dist/lib/store/visible-nodes.js", "node_modules/@xyflow/svelte/dist/lib/store/utils.js", "node_modules/@xyflow/svelte/dist/lib/plugins/NodeToolbar/NodeToolbar.svelte", "node_modules/@xyflow/svelte/dist/lib/hooks/useHandleEdgeSelect.js", "node_modules/@xyflow/svelte/dist/lib/plugins/Minimap/interactive.js", "node_modules/@xyflow/svelte/dist/lib/plugins/Minimap/Minimap.svelte", "node_modules/@xyflow/svelte/dist/lib/components/nodes/DefaultNode.svelte", "node_modules/@xyflow/svelte/dist/lib/components/nodes/InputNode.svelte", "node_modules/@xyflow/svelte/dist/lib/components/nodes/OutputNode.svelte", "node_modules/@xyflow/svelte/dist/lib/store/initial-store.js", "node_modules/@xyflow/svelte/dist/lib/store/index.js", "node_modules/@xyflow/svelte/dist/lib/components/ConnectionLine/ConnectionLine.svelte", "node_modules/@xyflow/svelte/dist/lib/container/Pane/Pane.svelte", "node_modules/@xyflow/svelte/dist/lib/actions/zoom/index.js", "node_modules/@xyflow/svelte/dist/lib/container/Zoom/Zoom.svelte", "node_modules/@xyflow/svelte/dist/lib/actions/drag/index.js", "node_modules/@xyflow/svelte/dist/lib/components/NodeSelection/NodeSelection.svelte", "node_modules/@xyflow/svelte/dist/lib/components/EdgeWrapper/EdgeWrapper.svelte", "node_modules/@xyflow/svelte/dist/lib/container/EdgeRenderer/MarkerDefinition/Marker.svelte", "node_modules/@xyflow/svelte/dist/lib/components/KeyHandler/KeyHandler.svelte", "node_modules/@xyflow/svelte/dist/lib/components/NodeWrapper/NodeWrapper.svelte", "node_modules/@xyflow/svelte/dist/lib/container/NodeRenderer/NodeRenderer.svelte", "node_modules/@xyflow/svelte/dist/lib/container/SvelteFlow/SvelteFlow.svelte" and "node_modules/@xyflow/svelte/dist/lib/index.js".
open-webui> ✓ 1025 modules transformed.
open-webui> vite v5.4.6 building for production...
open-webui> 10:35:30 PM [vite-plugin-svelte] /build/source/src/lib/components/layout/Navbar.svelte:25:11 Navbar has unused export property 'title'. If it is for external reference only, please consider using `export const title`
open-webui> 23: const i18n = getContext("i18n");
open-webui> 24: export let initNewChat;
open-webui> 25: export let title = $WEBUI_NAME;
open-webui>                ^
open-webui> 26: export let shareEnabled = false;
open-webui> 27: export let chat;
open-webui> 10:35:30 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/Messages.svelte:23:11 Messages has unused export property 'processing'. If it is for external reference only, please consider using `export const processing`
open-webui> 21: export let user = $_user;
open-webui> 22: export let prompt;
open-webui> 23: export let processing = "";
open-webui>                ^
open-webui> 24: export let bottomPadding = false;
open-webui> 25: export let autoScroll;
open-webui> 10:35:33 PM [vite-plugin-svelte] /build/source/src/lib/components/layout/Help/HelpMenu.svelte:10:11 HelpMenu has unused export property 'showDocsHandler'. If it is for external reference only, please consider using `export const showDocsHandler`
open-webui>  8: import Keyboard from "$lib/components/icons/Keyboard.svelte";
open-webui>  9: const i18n = getContext("i18n");
open-webui> 10: export let showDocsHandler;
open-webui>                ^
open-webui> 11: export let showShortcutsHandler;
open-webui> 12: export let onClose = () => {
open-webui> 10:35:33 PM [vite-plugin-svelte] /build/source/src/lib/components/layout/Navbar/Menu.svelte:17:11 Menu has unused export property 'shareEnabled'. If it is for external reference only, please consider using `export const shareEnabled`
open-webui> 15: import AdjustmentsHorizontal from "$lib/components/icons/AdjustmentsHorizontal.svelte";
open-webui> 16: const i18n = getContext("i18n");
open-webui> 17: export let shareEnabled = false;
open-webui>                ^
open-webui> 18: export let shareHandler;
open-webui> 19: export let downloadHandler;
open-webui> 10:35:33 PM [vite-plugin-svelte] /build/source/src/lib/components/layout/Navbar/Menu.svelte:19:11 Menu has unused export property 'downloadHandler'. If it is for external reference only, please consider using `export const downloadHandler`
open-webui> 17: export let shareEnabled = false;
open-webui> 18: export let shareHandler;
open-webui> 19: export let downloadHandler;
open-webui>                ^
open-webui> 20: export let chat;
open-webui> 21: export let onClose = () => {
open-webui> 10:35:34 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/Settings/Chats.svelte:17:11 Chats has unused export property 'saveSettings'. If it is for external reference only, please consider using `export const saveSettings`
open-webui> 15: import { toast } from "svelte-sonner";
open-webui> 16: const i18n = getContext("i18n");
open-webui> 17: export let saveSettings;
open-webui>                ^
open-webui> 18: let importFiles;
open-webui> 19: let showArchiveConfirm = false;
open-webui> 10:35:34 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/Settings/General.svelte:9:11 General has unused export property 'getModels'. If it is for external reference only, please consider using `export const getModels`
open-webui>  7: import AdvancedParams from "./Advanced/AdvancedParams.svelte";
open-webui>  8: export let saveSettings;
open-webui>  9: export let getModels;
open-webui>                ^
open-webui> 10: let themes = ["dark", "light", "rose-pine dark", "rose-pine-dawn light", "oled-dark"];
open-webui> 11: let selectedTheme = "system";
open-webui> 10:35:35 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/Controls/Controls.svelte:10:11 Controls has unused export property 'models'. If it is for external reference only, please consider using `export const models`
open-webui>  8: import Collapsible from "$lib/components/common/Collapsible.svelte";
open-webui>  9: import { user } from "$lib/stores";
open-webui> 10: export let models = [];
open-webui>                ^
open-webui> 11: export let chatFiles = [];
open-webui> 12: export let params = {};
open-webui> 10:35:35 PM [vite-plugin-svelte] /build/source/src/lib/components/chat/MessageInput/CallOverlay.svelte:647:5 A11y: <video> elements must have a <track kind="captions">
open-webui> 645:       {:else}
open-webui> 646:         <div class="relative flex video-container w-full max-h-full pt-2 pb-4 md:py-6 px-2 h-full">
open-webui> 647:           <video
open-webui>                ^
open-webui> 648:             id="camera-feed"
open-webui> 649:             autoplay
open-webui> 10:35:35 PM [vite-plugin-svelte] /build/source/src/lib/components/common/Drawer.svelte:6:11 Drawer has unused export property 'size'. If it is for external reference only, please consider using `export const size`
open-webui> 4: const dispatch = createEventDispatcher();
open-webui> 5: export let show = false;
open-webui> 6: export let size = "md";
open-webui>               ^
open-webui> 7: let modalElement = null;
open-webui> 8: let mounted = false;
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:url" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:fs" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:fs/promises" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:vm" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:path" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:crypto" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:child_process" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:path" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:url" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> 
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:url" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details. (x2)
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:fs" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:fs/promises" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:vm" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:path" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:crypto" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:child_process" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:path" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> [plugin:vite:resolve] [plugin vite:resolve] Module "node:url" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
open-webui> ✓ 3011 modules transformed.
open-webui> 
open-webui> <--- Last few GCs --->
open-webui> [709:0x308d830]    59951 ms: Scavenge (reduce) 2031.9 (2081.9) -> 2031.7 (2082.4) MB, 4.53 / 0.00 ms  (average mu = 0.307, current mu = 0.269) allocation failure;
open-webui> [709:0x308d830]    61077 ms: Mark-Compact (reduce) 2034.0 (2084.1) -> 2033.4 (2084.6) MB, 1123.54 / 0.00 ms  (average mu = 0.192, current mu = 0.072) allocation failure; scavenge might not succeed
open-webui> <--- JS stacktrace --->
open-webui> FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
open-webui> ----- Native stack trace -----
open-webui>  1: 0xab10e4 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui>  2: 0xe6dda0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui>  3: 0xe6e184 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui>  4: 0x109d847  [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui>  5: 0x10b63b9 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui>  6: 0x108f027 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui>  7: 0x108fc64 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui>  8: 0x106dfc4 v8::internal::Factory::AllocateRaw(int, v8::internal::AllocationType, v8::internal::AllocationAlignment) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui>  9: 0x105d7d4 v8::internal::FactoryBase<v8::internal::Factory>::NewFixedArray(int, v8::internal::AllocationType) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui> 10: 0x123cddf  [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui> 11: 0x123cfdd  [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui> 12: 0x14c6096 v8::internal::Runtime_GrowArrayElements(int, unsigned long*, v8::internal::Isolate*) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
open-webui> 13: 0x7fffed4d9ef6
open-webui> /nix/store/vw8fwxhf7j7b3dq28rdv4kg5p0hnnvmn-npm-build-hook/nix-support/setup-hook: line 3:   694 Aborted                 (core dumped) npm run ${npmWorkspace+--workspace=$npmWorkspace} "$npmBuildScript" $npmBuildFlags "${npmBuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"
open-webui> ERROR: `npm build` failed
open-webui> Here are a few things you can try, depending on the error:
open-webui> 1. Make sure your build script (build) exists
open-webui>   If there is none, set `dontNpmBuild = true`.
open-webui> 2. If the error being thrown is something similar to "error:0308010C:digital envelope routines::unsupported", add `NODE_OPTIONS = "--openssl-legacy-provider"` to your derivation
open-webui>   See https://github.com/webpack/webpack/issues/14532 for more information.
error: builder for '/nix/store/z5xs6kf2cpz4wcvins7c33h6fbaa1mgc-open-webui-0.3.22.drv' failed with exit code 1;
       last 50 log lines:
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:crypto" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:child_process" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:path" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:url" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > 
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:url" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details. (x2)
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:fs" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:fs/promises" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:vm" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:path" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:crypto" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:child_process" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:path" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > [plugin:vite:resolve] [plugin vite:resolve] Module "node:url" has been externalized for browser compatibility, imported by "/build/source/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
       > ✓ 3011 modules transformed.
       > 
       > <--- Last few GCs --->
       >
       > [709:0x308d830]    59951 ms: Scavenge (reduce) 2031.9 (2081.9) -> 2031.7 (2082.4) MB, 4.53 / 0.00 ms  (average mu = 0.307, current mu = 0.269) allocation failure;
       > [709:0x308d830]    61077 ms: Mark-Compact (reduce) 2034.0 (2084.1) -> 2033.4 (2084.6) MB, 1123.54 / 0.00 ms  (average mu = 0.192, current mu = 0.072) allocation failure; scavenge might not succeed
       >
       >
       > <--- JS stacktrace --->
       >
       > FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
       > ----- Native stack trace -----
       >
       >  1: 0xab10e4 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       >  2: 0xe6dda0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       >  3: 0xe6e184 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       >  4: 0x109d847  [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       >  5: 0x10b63b9 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       >  6: 0x108f027 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       >  7: 0x108fc64 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       >  8: 0x106dfc4 v8::internal::Factory::AllocateRaw(int, v8::internal::AllocationType, v8::internal::AllocationAlignment) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       >  9: 0x105d7d4 v8::internal::FactoryBase<v8::internal::Factory>::NewFixedArray(int, v8::internal::AllocationType) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       > 10: 0x123cddf  [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       > 11: 0x123cfdd  [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       > 12: 0x14c6096 v8::internal::Runtime_GrowArrayElements(int, unsigned long*, v8::internal::Isolate*) [/nix/store/w78sh036dyn14f29w8za9ni9syrmwm3q-nodejs-20.17.0/bin/node]
       > 13: 0x7fffed4d9ef6
       > /nix/store/vw8fwxhf7j7b3dq28rdv4kg5p0hnnvmn-npm-build-hook/nix-support/setup-hook: line 3:   694 Aborted                 (core dumped) npm run ${npmWorkspace+--workspace=$npmWorkspace} "$npmBuildScript" $npmBuildFlags "${npmBuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"
       >
       > ERROR: `npm build` failed
       >
       > Here are a few things you can try, depending on the error:
       > 1. Make sure your build script (build) exists
       >   If there is none, set `dontNpmBuild = true`.
       > 2. If the error being thrown is something similar to "error:0308010C:digital envelope routines::unsupported", add `NODE_OPTIONS = "--openssl-legacy-provider"` to your derivation
       >   See https://github.com/webpack/webpack/issues/14532 for more information.
       >
       For full logs, run 'nix log /nix/store/z5xs6kf2cpz4wcvins7c33h6fbaa1mgc-open-webui-0.3.22.drv'.
error: 1 dependencies of derivation '/nix/store/fvm68wx6asskv3pyzqfz2pj4a447fspc-open-webui-0.3.22.drv' failed to build
❯
```

</details>

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
