### PR TITLE
nixos/nixpkgs: fix assertion text & show def files

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -387,6 +387,9 @@ in
 
           Current value:
           ${lib.generators.toPretty { multiline = true; } cfg.config}
+
+          Defined in:
+          ${lib.concatMapStringsSep "\n" (file: "  - ${file}") opt.config.files}
         '';
       }
     ];

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -386,7 +386,7 @@ in
           `nixpkgs.config` options should be passed when creating the instance instead.
 
           Current value:
-          ${lib.generators.toPretty { multiline = true; } opt.config}
+          ${lib.generators.toPretty { multiline = true; } cfg.config}
         '';
       }
     ];

--- a/nixos/modules/misc/nixpkgs/test.nix
+++ b/nixos/modules/misc/nixpkgs/test.nix
@@ -17,6 +17,7 @@ let
     nixpkgs.buildPlatform = "aarch64-linux";
   };
   externalPkgsWithConfig = {
+    _file = "ext-pkgs-config.nix";
     nixpkgs.pkgs = pkgs;
     nixpkgs.config.allowUnfree = true;
   };
@@ -122,6 +123,9 @@ lib.recurseIntoAttrs {
           {
             allowUnfree = true;
           }
+
+          Defined in:
+            - ext-pkgs-config.nix
         ''];
     assert getErrors {
         nixpkgs.localSystem = pkgs.stdenv.hostPlatform;

--- a/nixos/modules/misc/nixpkgs/test.nix
+++ b/nixos/modules/misc/nixpkgs/test.nix
@@ -16,6 +16,10 @@ let
     nixpkgs.hostPlatform = "aarch64-linux";
     nixpkgs.buildPlatform = "aarch64-linux";
   };
+  externalPkgsWithConfig = {
+    nixpkgs.pkgs = pkgs;
+    nixpkgs.config.allowUnfree = true;
+  };
   ambiguous = {
     _file = "ambiguous.nix";
     nixpkgs.hostPlatform = "aarch64-linux";
@@ -107,6 +111,17 @@ lib.recurseIntoAttrs {
 
           For a future proof system configuration, we recommend to remove
           the legacy definitions.
+        ''];
+    assert builtins.trace (lib.head (getErrors externalPkgsWithConfig))
+      getErrors externalPkgsWithConfig ==
+        [''
+          Your system configures nixpkgs with an externally created instance.
+          `nixpkgs.config` options should be passed when creating the instance instead.
+
+          Current value:
+          {
+            allowUnfree = true;
+          }
         ''];
     assert getErrors {
         nixpkgs.localSystem = pkgs.stdenv.hostPlatform;


### PR DESCRIPTION
## Description of changes

- **nixos/nixpkgs: fix `config` assertion text**
- **nixos/nixpkgs: show definition files in `config` assertion**

The existing `opt.pkgs.isDefined -> cfg.config == {}` assertion was printing the `nixpkgs.config` _option_ instead of the _value_. This PR fixes that, and in a follow-up commit also prints the defining files.

I was tempted to use `lib.options.showDefs`, however I felt it made more sense in this instance to show the _full and final_ value in its entirety and then only list the defining files. This avoids an unnecessarily long and repetitive assertion message. Note that `showDefs` would show part of each definition, each truncated after a few lines.

The assertion in question was introduced in ce87196a00214a0062ece1c3e03a9a97f563580f (#257458 Sept 2023) by @K900 and hasn't been touched since.

cc (some) original reviewers: @roberth @khaneliman @FRidh @SuperSandro2000

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
