### PR TITLE
nrfutil: 7.11.1 -> 7.13.0

### DIFF
--- a/pkgs/by-name/nr/nrfutil/package.nix
+++ b/pkgs/by-name/nr/nrfutil/package.nix
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   inherit (source) version;
 
   src = fetchurl {
-    url = "https://developer.nordicsemi.com/.pc-tools/nrfutil/nrfutil-${platform.name}-${finalAttrs.version}.tar.gz";
+    url = "https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/packages/nrfutil/nrfutil-${platform.name}-${finalAttrs.version}.tar.gz";
     inherit (platform) hash;
   };
 

--- a/pkgs/by-name/nr/nrfutil/source.nix
+++ b/pkgs/by-name/nr/nrfutil/source.nix
@@ -1,15 +1,15 @@
 {
-  version = "7.11.1";
+  version = "7.13.0";
   x86_64-linux = {
     name = "x86_64-unknown-linux-gnu";
-    hash = "sha256-faF/iA07wWiAuxeqEZciIYlnoWe4LKCtDxD0BwIyeYw=";
+    hash = "sha256-R3OF/340xEab+0zamfwvejY16fjy/3TrzMvQaBlVxHw=";
   };
   x86_64-darwin = {
     name = "x86_64-apple-darwin";
-    hash = "sha256-EImYXMIvxPgzaGuAOWi4O6mG5S1awdGSX0HQgT1iHaI=";
+    hash = "sha256-cnZkVkTbQ/+ciITPEx2vxxZchCC54T0JOApB4HKp8e0=";
   };
   aarch64-darwin = {
     name = "aarch64-apple-darwin";
-    hash = "sha256-jgigeJRHH/c761wYGMHhtRHE59ms7obZPxiH5pKeoeQ=";
+    hash = "sha256-5VxDQ25tW+qTXHwkltpaAm4AnQvA18qGMaflYQzE2pQ=";
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Website seems to have updated the link to their package index. This should fix it.

Build command rolls off the tongue, if you'd like to test it:

```
nix build --impure --expr 'with import ./. { config.segger-jlink.acceptLicense = true; config.allowUnfree = true; }; nrfutil'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
