### PR TITLE
emacs: fix elisp native compilation errors caused by load-path

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -91,6 +91,7 @@ libBuildHelper.extendMkDerivation' stdenv.mkDerivation (finalAttrs:
           "emacs \
              --batch \
              --eval '(setq native-comp-eln-load-path (cdr native-comp-eln-load-path))' \
+             --eval '(let ((default-directory \"$out/share/emacs/site-lisp\")) (normal-top-level-add-subdirs-to-load-path))' \
              --eval '(setq large-file-warning-threshold nil)' \
              --eval '(setq byte-compile-error-on-warn ${if finalAttrs.turnCompilationWarningToError then "t" else "nil"})' \
              -f batch-native-compile {} \


### PR DESCRIPTION
If $pname-$version/foo.el requires $pname-$version/bar-dir/bar.el, previously there were native compilation errors like the below one because $pname-$version/bar-dir was not added to load-path (only $pname-$version is added).

Error: file-missing ("/nix/store/hash-emacs-sly-20240809.2119/share/emacs/site-lisp/elpa/sly-20240809.2119/contrib/sly-mrepl.el" "Cannot open load file" "No such file or directory" "sly-autodoc")

Currently, these packages are affected: haskell-tng-mode[^1], psgml[3], sly[4], ess[5], el-get[6], proof-general[7], hyperbole[8] and edts[9].

At run time, we recursively[1] add[2] $pname-$version and its subdirs to load-path.  Let's also do that at build time to fix this kind of errors.

[1]: https://github.com/NixOS/nixpkgs/blob/9625766c32942d4fdeef6cfee0d4337f75697b5f/pkgs/applications/editors/emacs/site-start.el#L18
[2]: https://github.com/NixOS/nixpkgs/blob/9625766c32942d4fdeef6cfee0d4337f75697b5f/pkgs/applications/editors/emacs/build-support/wrapper.nix#L170-L175
[3]: https://hydra.nixos.org/build/271291118/nixlog/1
[4]: https://hydra.nixos.org/build/271372072/nixlog/1
[5]: https://hydra.nixos.org/build/271284390/nixlog/1
[6]: https://hydra.nixos.org/build/271385904/nixlog/1
[7]: https://hydra.nixos.org/build/271277707/nixlog/1
[8]: https://hydra.nixos.org/build/271345526/nixlog/1
[9]: https://hydra.nixos.org/build/271290054/nixlog/1
[^1]: Errors of this kind are shadowed by other errors.

part of https://github.com/NixOS/nixpkgs/issues/335442

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
