### PR TITLE
Maintain nixos/nixpkgs modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,6 +100,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 /nixos/lib/eval-config.nix                            @infinisil
 /nixos/modules/system/activation/bootspec.nix         @grahamc @cole-h @raitobezarius
 /nixos/modules/system/activation/bootspec.cue         @grahamc @cole-h @raitobezarius
+/nixos/modules/misc/nixpkgs/read-only.nix             @roberth
 
 # NixOS integration test driver
 /nixos/lib/test-driver  @tfc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,6 +100,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 /nixos/lib/eval-config.nix                            @infinisil
 /nixos/modules/system/activation/bootspec.nix         @grahamc @cole-h @raitobezarius
 /nixos/modules/system/activation/bootspec.cue         @grahamc @cole-h @raitobezarius
+/nixos/modules/misc/nixpkgs.nix                       @roberth
 /nixos/modules/misc/nixpkgs/read-only.nix             @roberth
 
 # NixOS integration test driver

--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -37,7 +37,10 @@ let
   #       In other words, only the public interface of nixos.evalModules
   #       is experimental.
   lib.evalModules {
-    inherit prefix modules;
+    inherit prefix;
+    modules = [
+      ../modules/misc/meta.nix
+    ] ++ modules;
     class = "nixos";
     specialArgs = {
       modulesPath = builtins.toString ../modules;

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -397,4 +397,7 @@ in
 
   # needs a full nixpkgs path to import nixpkgs
   meta.buildDocsInSandbox = false;
+  meta.maintainers = [
+    lib.maintainers.roberth
+  ];
 }

--- a/nixos/modules/misc/nixpkgs/read-only.nix
+++ b/nixos/modules/misc/nixpkgs/read-only.nix
@@ -71,4 +71,7 @@ in
     nixpkgs.hostPlatform = cfg.pkgs.stdenv.hostPlatform;
     nixpkgs.buildPlatform = cfg.pkgs.stdenv.buildPlatform;
   };
+  meta.maintainers = [
+    lib.maintainers.roberth
+  ];
 }


### PR DESCRIPTION
## Description of changes

I guess I touched it last ;)
Not just that, my fingerprints are all over it, so I better confess and own up to it.

Also this sneaks in a little patch so that the unit test keeps working.

"Unit tests?" "`meta.maintainers`"? I hear you say. Yes, NixOS is as good as you want it to be. :rocket: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
