### PR TITLE
llvmPackages: unify version for all platforms but Darwin

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15422,18 +15422,12 @@ with pkgs;
   libllvm = llvmPackages.libllvm;
   llvm-manpages = llvmPackages.llvm-manpages;
 
+  # Please remove all this logic when bumping to LLVM 19 and make this
+  # a simple alias.
   llvmPackages = let
     # This returns the minimum supported version for the platform. The
     # assumption is that or any later version is good.
-    choose = platform:
-      /**/ if platform.isDarwin then 16
-      else if platform.isFreeBSD then 18
-      else if platform.isOpenBSD then 18
-      else if platform.isAndroid then 12
-      else if platform.isLinux then 18
-      else if platform.isWasm then 16
-      # For unknown systems, assume the latest version is required.
-      else 18;
+    choose = platform: if platform.isDarwin then 16 else 18;
     # We take the "max of the mins". Why? Since those are lower bounds of the
     # supported version set, this is like intersecting those sets and then
     # taking the min bound of that.


### PR DESCRIPTION
## Description of changes

Currently, every platform uses LLVM 18 except for the following exceptions:

* Darwin, on LLVM 16.
* WASM, on LLVM 16.
* Android, on LLVM 12.

As discussed with @RossComputerGuy and @alyssais on Matrix, we plan to bump both Darwin and Linux to LLVM 19 after the 24.11 branch‐off, and try to keep them in sync after that, bumping to new stable LLVM releases immediately after releases branch off.

This prepares for a 25.05 where `llvmPackages` is a simple platform‐independent alias by removing all the redundant branches and upgrading WASM and Android to LLVM 18.

I checked with @lilyinstarlight who did the previous LLVM bump for WASM and she confirmed that there should be no particular reason to keep it pinned to 16 so long as Firefox continues to compile, and I have confirmed that it does.

Android was last bumped back when the other platforms were on LLVM 7, which is pretty good evidence that these platform‐specific conditionals create unnecessary divergence and bitrot quickly. Due to the “maximum‐of‐minimums” cross‐compilation logic, it was inevitably picking LLVM 16 or 18 anyway. `pkgsCross.aarch64-android.hello` fails the exact same way as it does on `master` on all the platforms I tested (compiler-rt failing to build on `aarch64-linux` and `x86_64-linux`, and the Linux headers package expecting `gcc(1)` on `aarch64-darwin`).

I’m not entirely sure that the maximum‐of‐minimums logic is correct (should it be completely ignoring `buildPlatform` like this?), but since it will hopefully go away very soon I’ve decided not to spend more time thinking about it.

cc @rhelmot – do you expect bumping to LLVM 19 along with other platforms to be okay for FreeBSD?

Result of `nixpkgs-review` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>43 packages built:</summary>
  <ul>
    <li>adoptopenjdk-icedtea-web</li>
    <li>betterbird</li>
    <li>betterbird-unwrapped</li>
    <li>betterbird-unwrapped.debug</li>
    <li>eyewitness</li>
    <li>firefox</li>
    <li>firefox-beta</li>
    <li>firefox-beta-unwrapped</li>
    <li>firefox-beta-unwrapped.debug</li>
    <li>firefox-beta-unwrapped.symbols</li>
    <li>firefox-devedition</li>
    <li>firefox-devedition-unwrapped</li>
    <li>firefox-devedition-unwrapped.debug</li>
    <li>firefox-devedition-unwrapped.symbols</li>
    <li>firefox-esr</li>
    <li>firefox-esr-115</li>
    <li>firefox-esr-115-unwrapped</li>
    <li>firefox-esr-115-unwrapped.debug</li>
    <li>firefox-esr-115-unwrapped.symbols</li>
    <li>firefox-esr-128-unwrapped</li>
    <li>firefox-esr-128-unwrapped.debug</li>
    <li>firefox-esr-128-unwrapped.symbols</li>
    <li>firefox-mobile</li>
    <li>firefox-unwrapped</li>
    <li>firefox-unwrapped.debug</li>
    <li>firefox-unwrapped.symbols</li>
    <li>firefoxpwa</li>
    <li>floorp</li>
    <li>floorp-unwrapped</li>
    <li>floorp-unwrapped.debug</li>
    <li>librewolf</li>
    <li>librewolf-unwrapped</li>
    <li>librewolf-unwrapped.debug</li>
    <li>sitespeed-io</li>
    <li>slimerjs</li>
    <li>thunderbird (thunderbird-128)</li>
    <li>thunderbird-115</li>
    <li>thunderbird-unwrapped</li>
    <li>thunderbird-unwrapped.debug</li>
    <li>thunderbird-unwrapped.symbols</li>
    <li>thunderbirdPackages.thunderbird-115</li>
    <li>thunderbirdPackages.thunderbird-115.debug</li>
    <li>thunderbirdPackages.thunderbird-115.symbols</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
