### PR TITLE
python3Packages.skyfield: 1.45 -> 1.49, fixed tests

### DIFF
--- a/pkgs/development/python-modules/assay/default.nix
+++ b/pkgs/development/python-modules/assay/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "assay";
-  version = "unstable-2022-01-19";
+  version = "unstable-2024-05-09";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "brandon-rhodes";
     repo = pname;
-    rev = "bb62d1f7d51d798b05a88045fff3a2ff92c299c3";
-    hash = "sha256-FuAD74mFJ9F9AMgB3vPmODAlZKgPR7FQ4yn7HEBS5Rw=";
+    rev = "74617d70e77afa09f58b3169cf496679ac5d5621";
+    hash = "sha256-zYpLtcXZ16EJWKSCqxFkSz/G9PwIZEQGBrYiJKuqnc4=";
   };
 
   pythonImportsCheck = [ "assay" ];
@@ -24,6 +24,5 @@ buildPythonPackage rec {
     description = "Attempt to write a Python testing framework I can actually stand";
     license = licenses.mit;
     maintainers = with maintainers; [ zane ];
-    broken = pythonAtLeast "3.11";
   };
 }

--- a/pkgs/development/python-modules/assay/default.nix
+++ b/pkgs/development/python-modules/assay/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "assay";
-  version = "unstable-2024-05-09";
+  version = "0-unstable-2024-05-09";
   format = "setuptools";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/skyfield/default.nix
+++ b/pkgs/development/python-modules/skyfield/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "skyfield";
-  version = "1.45";
+  version = "1.49";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "skyfielders";
     repo = "python-skyfield";
     rev = version;
-    hash = "sha256-kZrXNVE+JGPGiVsd6CTwOqfciYLsD2A4pTS3FpqO+Dk=";
+    hash = "sha256-PZ63sohdfpop3nYQr2RIMjPbrL9jdfincEhw5D8NZ+Y=";
   };
 
   # Fix broken tests on "exotic" platforms.
@@ -49,9 +49,7 @@ buildPythonPackage rec {
     assay
   ];
 
-  # assay is broken on Python >= 3.11
-  # https://github.com/brandon-rhodes/assay/issues/15
-  doCheck = pythonOlder "3.11";
+  doCheck = true;
 
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
## Description of changes

Fixed tests by updating `assay` to the latest version (which now supports Python 3.12), updated skyfield to the latest 1.49.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
