### PR TITLE
home-assistant-custom-components.solax_modbus: init at 2024.09.4

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -64,6 +64,8 @@
 
   smartthinq-sensors = callPackage ./smartthinq-sensors {};
 
+  solax_modbus = callPackage ./solax_modbus {};
+
   solis-sensor = callPackage ./solis-sensor {};
 
   somweb = callPackage ./somweb {};

--- a/pkgs/servers/home-assistant/custom-components/solax_modbus/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/solax_modbus/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  pymodbus,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "wills106";
+  domain = "solax_modbus";
+  version = "2024.09.4";
+
+  src = fetchFromGitHub {
+    owner = "wills106";
+    repo = "homeassistant-solax-modbus";
+    rev = "refs/tags/${version}";
+    hash = "sha256-xWWsV57ozzEQWRfO1t4EbwD7DWiB1go+iJbTLPuufJs=";
+  };
+
+  dependencies = [ pymodbus ];
+
+  meta = {
+    changelog = "https://github.com/wills106/homeassistant-solax-modbus/releases/tag/${version}";
+    description = "SolaX Power Modbus custom_component for Home Assistant (Supports some Ginlong Solis, Growatt, Sofar Solar, TIGO TSI & Qcells Q.Volt Hyb)";
+    homepage = "https://github.com/wills106/homeassistant-solax-modbus";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ Luflosi ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Allows integrating solar inverters with Home Assistant over modbus.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
