### PR TITLE
Systemd tpm fixes

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1636,6 +1636,7 @@
   ./system/boot/systemd/sysupdate.nix
   ./system/boot/systemd/sysusers.nix
   ./system/boot/systemd/tmpfiles.nix
+  ./system/boot/systemd/tpm2.nix
   ./system/boot/systemd/user.nix
   ./system/boot/systemd/userdbd.nix
   ./system/boot/systemd/homed.nix

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -1088,6 +1088,8 @@ in
       storePaths = [
         "${config.boot.initrd.systemd.package}/bin/systemd-cryptsetup"
         "${config.boot.initrd.systemd.package}/lib/systemd/system-generators/systemd-cryptsetup-generator"
+      ] ++ lib.optionals config.boot.initrd.systemd.tpm2.enable [
+        "${config.boot.initrd.systemd.package}/lib/cryptsetup/libcryptsetup-token-systemd-tpm2.so"
       ];
 
     };

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -37,8 +37,6 @@ let
       "cryptsetup.target"
       "cryptsetup-pre.target"
       "remote-cryptsetup.target"
-    ] ++ optionals cfg.package.withTpm2Tss [
-      "tpm2.target"
     ] ++ [
       "sigpwr.target"
       "timers.target"

--- a/nixos/modules/system/boot/systemd/tpm2.nix
+++ b/nixos/modules/system/boot/systemd/tpm2.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+{
+  meta.maintainers = [ lib.maintainers.elvishjerricco ];
+
+  imports = [
+    (lib.mkRenamedOptionModule
+      [
+        "boot"
+        "initrd"
+        "systemd"
+        "enableTpm2"
+      ]
+      [
+        "boot"
+        "initrd"
+        "systemd"
+        "tpm2"
+        "enable"
+      ]
+    )
+  ];
+
+  options = {
+    systemd.tpm2.enable = lib.mkEnableOption "systemd TPM2 support" // {
+      default = config.systemd.package.withTpm2Tss;
+      defaultText = "systemd.package.withTpm2Tss";
+    };
+
+    boot.initrd.systemd.tpm2.enable = lib.mkEnableOption "systemd initrd TPM2 support" // {
+      default = config.boot.initrd.systemd.package.withTpm2Tss;
+      defaultText = "boot.initrd.systemd.package.withTpm2Tss";
+    };
+  };
+
+  # TODO: pcrphase, pcrextend, pcrfs, pcrmachine
+  config = lib.mkMerge [
+    # Stage 2
+    (
+      let
+        cfg = config.systemd;
+      in
+      lib.mkIf cfg.tpm2.enable {
+        systemd.additionalUpstreamSystemUnits = [
+          "tpm2.target"
+        ];
+      }
+    )
+
+    # Stage 1
+    (
+      let
+        cfg = config.boot.initrd.systemd;
+      in
+      lib.mkIf cfg.tpm2.enable {
+        boot.initrd.systemd.additionalUpstreamUnits = [
+          "tpm2.target"
+        ];
+
+        boot.initrd.availableKernelModules =
+          [ "tpm-tis" ]
+          ++ lib.optional (
+            !(pkgs.stdenv.hostPlatform.isRiscV64 || pkgs.stdenv.hostPlatform.isArmv7)
+          ) "tpm-crb";
+        boot.initrd.systemd.storePaths = [
+          pkgs.tpm2-tss
+        ];
+      }
+    )
+  ];
+}

--- a/nixos/modules/system/boot/systemd/tpm2.nix
+++ b/nixos/modules/system/boot/systemd/tpm2.nix
@@ -47,6 +47,8 @@
       lib.mkIf cfg.tpm2.enable {
         systemd.additionalUpstreamSystemUnits = [
           "tpm2.target"
+          "systemd-tpm2-setup-early.service"
+          "systemd-tpm2-setup.service"
         ];
       }
     )
@@ -59,6 +61,7 @@
       lib.mkIf cfg.tpm2.enable {
         boot.initrd.systemd.additionalUpstreamUnits = [
           "tpm2.target"
+          "systemd-tpm2-setup-early.service"
         ];
 
         boot.initrd.availableKernelModules =
@@ -68,6 +71,8 @@
           ) "tpm-crb";
         boot.initrd.systemd.storePaths = [
           pkgs.tpm2-tss
+          "${cfg.package}/lib/systemd/systemd-tpm2-setup"
+          "${cfg.package}/lib/systemd/system-generators/systemd-tpm2-generator"
         ];
       }
     )


### PR DESCRIPTION
## Description of changes

Turns out there's some inconsistent behavior with the TPM2. This fixes some ordering bugs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
