### PR TITLE
postgresqlPackages: some cleanup

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, openssl, zlib, readline, libkrb5, libxcrypt }:
+{ lib, stdenv, fetchFromGitHub, postgresql }:
 
 stdenv.mkDerivation rec {
   pname = "pg_auto_failover";

--- a/pkgs/servers/sql/postgresql/ext/pg_repack.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_repack.nix
@@ -4,7 +4,6 @@
 , postgresql
 , postgresqlTestHook
 , testers
-, zlib
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ postgresql gcc ];
-  buildPhase = "USE_PGXS=1 make";
+
+  makeFlags = [ "USE_PGXS=1" ];
+
   installPhase = ''
     install -D pg_similarity${postgresql.dlSuffix} -t $out/lib/
     install -D ./{pg_similarity--unpackaged--1.0.sql,pg_similarity--1.0.sql,pg_similarity.control} -t $out/share/postgresql/extension

--- a/pkgs/servers/sql/postgresql/ext/plr.nix
+++ b/pkgs/servers/sql/postgresql/ext/plr.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ R postgresql ];
-  preBuild = ''
-    export USE_PGXS=1
-  '';
+
+  makeFlags = [ "USE_PGXS=1" ];
+
   installPhase = ''
     install -D plr${postgresql.dlSuffix} -t $out/lib/
     install -D {plr--*.sql,plr.control} -t $out/share/postgresql/extension

--- a/pkgs/servers/sql/postgresql/ext/repmgr.nix
+++ b/pkgs/servers/sql/postgresql/ext/repmgr.nix
@@ -5,7 +5,6 @@
 , flex
 , curl
 , json_c
-, libxcrypt
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/servers/sql/postgresql/ext/system_stats.nix
+++ b/pkgs/servers/sql/postgresql/ext/system_stats.nix
@@ -6,7 +6,7 @@
 }:
 stdenv.mkDerivation rec {
   pname = "system_stats";
-  version = "3.0";
+  version = "3.2";
 
   buildInputs = [ postgresql ];
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "EnterpriseDB";
     repo = "system_stats";
     rev = "v${version}";
-    hash = "sha256-LuX7/LOi0rl6L/kjbjq7rr2zPcGIOYB7hdZBNJ9xqak=";
+    hash = "sha256-/xXnui0S0ZjRw7P8kMAgttHVv8T41aOhM3pM8P0OTig=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

~~Most postgres extensions are built with PGXS, postgres' build system for extension. All of them have in common, that they override the installPhase, because the pgxs Makefiles don't work correctly in nixpkgs. This PR fixes that - by patching those Makefiles and providing a setup hook to do the same for custom Makefiles in extension repos.~~ (moved to other PR to target staging)

Some more cleanups for some packages added as well. The update for system_stats is required, because the 3.0 Makefile didn't install all sql files correctly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
