### PR TITLE
vscode-extensions.ocamllabs.ocaml-platform: 1.12.2 -> 1.20.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3782,8 +3782,8 @@ let
         mktplcRef = {
           name = "ocaml-platform";
           publisher = "ocamllabs";
-          version = "1.12.2";
-          hash = "sha256-dj8UFbYgAl6dt/1MuIBawTVUbBDTTedZEcHtKZjEcew=";
+          version = "1.20.0";
+          hash = "sha256-lHTnyObWWhMIXipqdII9GYLGQDFPMFP5y/L/ai9325o=";
         };
       };
 


### PR DESCRIPTION
vscode-extensions.ocamllabs.ocaml-platform: 1.12.2 -> 1.20.0

https://github.com/ocamllabs/vscode-ocaml-platform/releases/tag/1.20.1

Note: I'm aware version 1.20.1 is out. But it hasn't been published to the marketplace.

CC @ratsclub @ulrikstrid 