### PR TITLE
vscode-extensions.usernamehw.errorlens: 3.16.0 -> 3.20.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -4921,8 +4921,8 @@ let
         mktplcRef = {
           name = "errorlens";
           publisher = "usernamehw";
-          version = "3.16.0";
-          hash = "sha256-Y3M/A5rYLkxQPRIZ0BUjhlkvixDae+wIRUsBn4tREFw=";
+          version = "3.20.0";
+          hash = "sha256-0gCT+u6rfkEcWcdzqRdc4EosROllD/Q0TIOQ4k640j0=";
         };
         meta = {
           changelog = "https://marketplace.visualstudio.com/items/usernamehw.errorlens/changelog";


### PR DESCRIPTION
vscode-extensions.usernamehw.errorlens: 3.16.0 -> 3.20.0

https://github.com/usernamehw/vscode-error-lens/releases/tag/v3.20.0

CC @imgabe