### PR TITLE
rebuilderd: init at 0.22.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -171,6 +171,8 @@
 
 - [Recyclarr](https://github.com/recyclarr/recyclarr) a TRaSH Guides synchronizer for Sonarr and Radarr. Available as [services.recyclarr](#opt-services.recyclarr.enable).
 
+- [Rebuilderd](https://github.com/kpcyrd/rebuilderd) an independent verification of binary packages - Reproducible Builds. Available as [services.rebuilderd](#opt-services.rebuilderd.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -868,6 +868,7 @@
   ./services/misc/radicle.nix
   ./services/misc/readarr.nix
   ./services/misc/realmd.nix
+  ./services/misc/rebuilderd.nix
   ./services/misc/recyclarr.nix
   ./services/misc/redlib.nix
   ./services/misc/redmine.nix

--- a/nixos/modules/services/misc/rebuilderd.nix
+++ b/nixos/modules/services/misc/rebuilderd.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkIf mkPackageOption;
+  cfg = config.services.rebuilderd;
+
+  format = pkgs.formats.toml { };
+  settings = lib.attrsets.filterAttrs (n: v: v != null) cfg.settings;
+  configFile = format.generate "rebuilderd.conf" settings;
+in
+{
+  options.services.rebuilderd = {
+    enable = mkEnableOption "rebuilderd service for independent verification of binary packages";
+    package = mkPackageOption pkgs "rebuilderd" { };
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+      };
+      default = { };
+      description = ''
+        Configuration for rebuilderd (rebuilderd.conf)
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.rebuilderd = {
+      description = "Independent verification of binary packages";
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        REBUILDERD_COOKIE_PATH = "/var/lib/rebuilderd/auth-cookie";
+      };
+      after = [
+        "network.target"
+      ];
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/rebuilderd --config ${configFile}";
+        DynamicUser = true;
+        StateDirectory = "rebuilderd";
+        WorkingDirectory = "/var/lib/rebuilderd";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -953,6 +953,7 @@ in {
   readarr = handleTest ./readarr.nix {};
   realm = handleTest ./realm.nix {};
   readeck = runTest ./readeck.nix;
+  rebuilderd = runTest ./rebuilderd.nix;
   redis = handleTest ./redis.nix {};
   redlib = handleTest ./redlib.nix {};
   redmine = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./redmine.nix {};

--- a/nixos/tests/rebuilderd.nix
+++ b/nixos/tests/rebuilderd.nix
@@ -1,0 +1,38 @@
+{ lib, ... }:
+
+{
+  name = "rebuilderd";
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        services.rebuilderd = {
+          enable = true;
+        };
+      };
+
+    machine_custom_config =
+      { pkgs, ... }:
+      {
+        services.rebuilderd = {
+          enable = true;
+          settings = {
+            http.bind_addr = "0.0.0.0:1234";
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("rebuilderd.service")
+    machine.wait_for_open_port(8484)
+
+    machine_custom_config.start()
+    machine_custom_config.wait_for_unit("rebuilderd.service")
+    machine_custom_config.wait_for_open_port(1234)
+  '';
+
+  meta.maintainers = [ lib.maintainers.drupol ];
+}

--- a/pkgs/by-name/re/rebuilderd/package.nix
+++ b/pkgs/by-name/re/rebuilderd/package.nix
@@ -15,6 +15,7 @@
   darwin,
   buildPackages,
   versionCheckHook,
+  nixosTests,
   nix-update-script,
 }:
 
@@ -108,6 +109,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
   versionCheckProgramArg = [ "--version" ];
   doInstallCheck = true;
+
+  passthru.tests = {
+    rebuilderd = nixosTests.rebuilderd;
+  };
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/re/rebuilderd/package.nix
+++ b/pkgs/by-name/re/rebuilderd/package.nix
@@ -1,0 +1,121 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  shared-mime-info,
+  installShellFiles,
+  scdoc,
+  bzip2,
+  openssl,
+  sqlite,
+  xz,
+  zstd,
+  stdenv,
+  darwin,
+  buildPackages,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rebuilderd";
+  version = "0.22.1";
+
+  src = fetchFromGitHub {
+    owner = "kpcyrd";
+    repo = "rebuilderd";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YMBq+Z9yMQRXOM3U679g2lnBZlH/h0VLjoxySxi4SCo=";
+  };
+
+  postPatch = ''
+    substituteInPlace tools/src/args.rs \
+      --replace-fail "/etc/rebuilderd-sync.conf" '${placeholder "out"}/etc/rebuilderd-sync.conf'
+
+    substituteInPlace worker/src/config.rs \
+      --replace-fail 'from("/etc/rebuilderd-worker.conf")' 'from("${placeholder "out"}/etc/rebuilderd-worker.conf")'
+
+    substituteInPlace worker/src/proc.rs \
+      --replace-fail '/bin/echo' 'echo'
+  '';
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-MjFQ5d9VWHodjj+hIsKgAIUdaiarXIi5GCS+47n5MGU=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+    scdoc
+  ];
+
+  buildInputs =
+    [
+      bzip2
+      openssl
+      shared-mime-info
+      sqlite
+      xz
+      zstd
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
+
+  postInstall =
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      mkdir -p $out/etc
+
+      # install config files
+      install -Dm 644 -t "$out/etc" contrib/confs/rebuilderd-sync.conf
+      install -Dm 640 -t "$out/etc" contrib/confs/rebuilderd-worker.conf contrib/confs/rebuilderd.conf
+
+      installShellCompletion --cmd rebuildctl \
+        --bash <(${emulator} $out/bin/rebuildctl completions bash) \
+        --fish <(${emulator} $out/bin/rebuildctl completions fish) \
+        --zsh <(${emulator} $out/bin/rebuildctl completions zsh)
+
+      for f in contrib/docs/*.scd; do
+        local page="contrib/docs/$(basename "$f" .scd)"
+        scdoc < "$f" > "$page"
+        installManPage "$page"
+      done
+    '';
+
+  checkFlags = [
+    # Failing tests
+    "--skip=decompress::tests::decompress_bzip2_compression"
+    "--skip=decompress::tests::decompress_gzip_compression"
+    "--skip=decompress::tests::decompress_xz_compression"
+    "--skip=decompress::tests::decompress_zstd_compression"
+    "--skip=decompress::tests::detect_bzip2_compression"
+    "--skip=decompress::tests::detect_gzip_compression"
+    "--skip=decompress::tests::detect_xz_compression"
+    "--skip=decompress::tests::detect_zstd_compression"
+    "--skip=proc::tests::hello_world"
+    "--skip=proc::tests::size_limit_kill"
+    "--skip=proc::tests::size_limit_no_kill"
+    "--skip=proc::tests::size_limit_no_kill_but_timeout"
+    "--skip=proc::tests::timeout"
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Independent verification of binary packages - reproducible builds";
+    homepage = "https://github.com/kpcyrd/rebuilderd";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "rebuilderd";
+  };
+})


### PR DESCRIPTION
CC: @kpcyrd (ahoi mate!)

I have disabled the failing tests, it would be nice to investigate further.

To build it: `nix build github:drupol/nixpkgs/init/rebuilderd/0-20-0#rebuilderd -L`

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
