### PR TITLE
qhexedit2: init at 0.8.9

### DIFF
--- a/pkgs/by-name/qh/qhexedit2/package.nix
+++ b/pkgs/by-name/qh/qhexedit2/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchpatch,
+  fetchFromGitHub,
+  qt6,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qhexedit2";
+  version = "0.8.9";
+
+  src = fetchFromGitHub {
+    owner = "Simsys";
+    repo = "qhexedit2";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-qg8dyXwAsTVSx85Ad7UYhr4d1aTRG9QbvC0uyOMcY8g=";
+  };
+
+  postPatch = ''
+    # Replace QPallete::Background with QPallete::Window in all files, since QPallete::Background was removed in Qt 6
+    find . -type f -exec sed -i 's/QPalette::Background/QPalette::Window/g' {} +
+  '';
+
+  nativeBuildInputs = [
+    qt6.qmake
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qttools
+    qt6.qtwayland
+  ];
+
+  qmakeFlags = [
+    "./example/qhexedit.pro"
+  ];
+
+  # A custom installPhase is needed because no [native] build input provides an installPhase hook
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp qhexedit $out/bin
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    # I would use testers.testVersion except for some reason it fails, even with my patches that add a --version flag
+    # TODO: Debug why testVersion reports a non-zero status code in the nix sandbox
+  };
+
+  meta = {
+    description = "Hex Editor for Qt";
+    homepage = "https://github.com/Simsys/qhexedit2";
+    changelog = "https://github.com/Simsys/qhexedit2/releases";
+    mainProgram = "qhexedit";
+    license = lib.licenses.lgpl21Only;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/296166

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
