### PR TITLE
heroic: 2.15.1 -> 2.15.2

### DIFF
--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, nix-update-script
 , pnpm
 , nodejs
 , makeWrapper
@@ -92,6 +93,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    inherit (finalAttrs) pnpmDeps;
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     description = "Native GOG, Epic, and Amazon Games Launcher for Linux, Windows and Mac";

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "heroic-unwrapped";
-  version = "2.15.1";
+  version = "2.15.2";
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "HeroicGamesLauncher";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-+OQRcBOf9Y34DD7FOp/3SO05mREG6or/HPiOkasHWPM=";
+    hash = "sha256-AndJqk1VAUdC4pOTRzyfhdxmzJMskGF6pUiqPs3fIy4=";
   };
 
   pnpmDeps = pnpm.fetchDeps {

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -1,16 +1,17 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, nix-update-script
-, pnpm
-, nodejs
-, makeWrapper
-, electron
-, vulkan-helper
-, gogdl
-, legendary-gl
-, nile
-, comet-gog
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  pnpm,
+  nodejs,
+  makeWrapper,
+  electron,
+  vulkan-helper,
+  gogdl,
+  legendary-gl,
+  nile,
+  comet-gog,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/games/heroic/fhsenv.nix
+++ b/pkgs/games/heroic/fhsenv.nix
@@ -1,7 +1,8 @@
-{ buildFHSEnv
-, heroic-unwrapped
-, extraPkgs ? pkgs: [ ]
-, extraLibraries ? pkgs: [ ]
+{
+  buildFHSEnv,
+  heroic-unwrapped,
+  extraPkgs ? pkgs: [ ],
+  extraLibraries ? pkgs: [ ],
 }:
 
 buildFHSEnv {
@@ -15,120 +16,131 @@ buildFHSEnv {
   # required by Electron
   unshareIpc = false;
 
-  targetPkgs = pkgs: with pkgs; [
-    heroic-unwrapped
-    gamemode
-    curl
-    gawk
-    zenity
-    plasma5Packages.kdialog
-    mangohud
-    nettools
-    opencl-headers
-    p7zip
-    perl
-    psmisc
-    python3
-    unzip
-    which
-    xorg.xrandr
-    zstd
-  ] ++ extraPkgs pkgs;
+  targetPkgs =
+    pkgs:
+    with pkgs;
+    [
+      heroic-unwrapped
+      gamemode
+      curl
+      gawk
+      zenity
+      plasma5Packages.kdialog
+      mangohud
+      nettools
+      opencl-headers
+      p7zip
+      perl
+      psmisc
+      python3
+      unzip
+      which
+      xorg.xrandr
+      zstd
+    ]
+    ++ extraPkgs pkgs;
 
-  multiPkgs = let
-    xorgDeps = pkgs: with pkgs.xorg; [
-      libpthreadstubs
-      libSM
-      libX11
-      libXaw
-      libxcb
-      libXcomposite
-      libXcursor
-      libXdmcp
-      libXext
-      libXi
-      libXinerama
-      libXmu
-      libXrandr
-      libXrender
-      libXv
-      libXxf86vm
-    ];
-    gstreamerDeps = pkgs: with pkgs.gst_all_1; [
-      gstreamer
-      gst-plugins-base
-      gst-plugins-good
-      gst-plugins-ugly
-      gst-plugins-bad
-      gst-libav
-    ];
-  in pkgs: with pkgs; [
-    alsa-lib
-    alsa-plugins
-    bash
-    cabextract
-    cairo
-    coreutils
-    cups
-    dbus
-    freealut
-    freetype
-    fribidi
-    giflib
-    glib
-    gnutls
-    gtk3
-    icu
-    lcms2
-    libevdev
-    libgcrypt
-    libGLU
-    libglvnd
-    libgpg-error
-    libgudev
-    libjpeg
-    libkrb5
-    libmpeg2
-    libogg
-    libopus
-    libpng
-    libpulseaudio
-    libselinux
-    libsndfile
-    libsoup
-    libtheora
-    libtiff
-    libunwind
-    libusb1
-    libv4l
-    libva
-    libvdpau
-    libvorbis
-    libvpx
-    libwebp
-    libxkbcommon
-    libxml2
-    mpg123
-    ncurses
-    ocl-icd
-    openal
-    openldap
-    openssl
-    pango
-    pipewire
-    samba4
-    sane-backends
-    SDL2
-    speex
-    sqlite
-    udev
-    unixODBC
-    util-linux
-    v4l-utils
-    vulkan-loader
-    wayland
-    zlib
-  ] ++ xorgDeps pkgs
+  multiPkgs =
+    let
+      xorgDeps =
+        pkgs: with pkgs.xorg; [
+          libpthreadstubs
+          libSM
+          libX11
+          libXaw
+          libxcb
+          libXcomposite
+          libXcursor
+          libXdmcp
+          libXext
+          libXi
+          libXinerama
+          libXmu
+          libXrandr
+          libXrender
+          libXv
+          libXxf86vm
+        ];
+      gstreamerDeps =
+        pkgs: with pkgs.gst_all_1; [
+          gstreamer
+          gst-plugins-base
+          gst-plugins-good
+          gst-plugins-ugly
+          gst-plugins-bad
+          gst-libav
+        ];
+    in
+    pkgs:
+    with pkgs;
+    [
+      alsa-lib
+      alsa-plugins
+      bash
+      cabextract
+      cairo
+      coreutils
+      cups
+      dbus
+      freealut
+      freetype
+      fribidi
+      giflib
+      glib
+      gnutls
+      gtk3
+      icu
+      lcms2
+      libevdev
+      libgcrypt
+      libGLU
+      libglvnd
+      libgpg-error
+      libgudev
+      libjpeg
+      libkrb5
+      libmpeg2
+      libogg
+      libopus
+      libpng
+      libpulseaudio
+      libselinux
+      libsndfile
+      libsoup
+      libtheora
+      libtiff
+      libunwind
+      libusb1
+      libv4l
+      libva
+      libvdpau
+      libvorbis
+      libvpx
+      libwebp
+      libxkbcommon
+      libxml2
+      mpg123
+      ncurses
+      ocl-icd
+      openal
+      openldap
+      openssl
+      pango
+      pipewire
+      samba4
+      sane-backends
+      SDL2
+      speex
+      sqlite
+      udev
+      unixODBC
+      util-linux
+      v4l-utils
+      vulkan-loader
+      wayland
+      zlib
+    ]
+    ++ xorgDeps pkgs
     ++ gstreamerDeps pkgs
     ++ extraLibraries pkgs;
 


### PR DESCRIPTION
## Description of changes
- Set `passthru.updateScript` on `heroic-unwrapped`.
- Update Heroic Games Launcher to latest upstream release.
- Reformat derivation Nix code to follow RFC.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
