### PR TITLE
nixos/nautilus-open-any-terminal: only set NAUTILUS_4_EXTENSION_DIR in non GNOME environment

### DIFF
--- a/nixos/modules/programs/nautilus-open-any-terminal.nix
+++ b/nixos/modules/programs/nautilus-open-any-terminal.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.programs.nautilus-open-any-terminal;
@@ -23,20 +28,28 @@ in
       nautilus-open-any-terminal
     ];
 
-    environment.sessionVariables.NAUTILUS_4_EXTENSION_DIR = "${pkgs.nautilus-python}/lib/nautilus/extensions-4";
+    environment.sessionVariables = lib.mkIf (!config.services.xserver.desktopManager.gnome.enable) {
+      NAUTILUS_4_EXTENSION_DIR = "${pkgs.nautilus-python}/lib/nautilus/extensions-4";
+    };
+
     environment.pathsToLink = [
       "/share/nautilus-python/extensions"
     ];
 
     programs.dconf = lib.optionalAttrs (cfg.terminal != null) {
       enable = true;
-      profiles.user.databases = [{
-        settings."com/github/stunkymonkey/nautilus-open-any-terminal".terminal = cfg.terminal;
-        lockAll = true;
-      }];
+      profiles.user.databases = [
+        {
+          settings."com/github/stunkymonkey/nautilus-open-any-terminal".terminal = cfg.terminal;
+          lockAll = true;
+        }
+      ];
     };
   };
   meta = {
-    maintainers = with lib.maintainers; [ stunkymonkey linsui ];
+    maintainers = with lib.maintainers; [
+      stunkymonkey
+      linsui
+    ];
   };
 }


### PR DESCRIPTION
Fixes regression after NixOS/nixpkgs#342104. Only export the env var on Non-GNOME setups, as on GNOME, it is exported by default.

https://github.com/NixOS/nixpkgs/pull/342104#issuecomment-2360197393

```
       error: The option `environment.sessionVariables.NAUTILUS_4_EXTENSION_DIR' has conflicting definition values:
       - In `/nix/var/nix/profiles/per-user/root/channels/nixos/nixos/modules/services/x11/desktop-managers/gnome.nix': "/nix/store/460y50140b7aqisrayz7sdvg
13770ms8-system-path/lib/nautilus/extensions-4"
       - In `/nix/var/nix/profiles/per-user/root/channels/nixos/nixos/modules/programs/nautilus-open-any-terminal.nix': "/nix/store/gdkjgj7yx127vdizrv37hs3z
rmyk1bzh-nautilus-python-4.0.1/lib/nautilus/extensions-4"
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```