### PR TITLE
gle: 3.1.0 → 3.1.2

### DIFF
--- a/pkgs/development/libraries/gle/default.nix
+++ b/pkgs/development/libraries/gle/default.nix
@@ -1,7 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
   libglut,
   libX11,
   libXt,
@@ -14,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gle";
-  version = "3.1.0";
+  version = "3.1.2";
 
   buildInputs = [
     libGLU
@@ -27,12 +28,15 @@ stdenv.mkDerivation rec {
     libXext
   ];
 
-  src = fetchurl {
-    urls = [
-      "mirror://sourceforge/project/gle/gle/gle-${version}/gle-${version}.tar.gz"
-      "https://www.linas.org/gle/pub/gle-${version}.tar.gz"
-      ];
-    sha256 = "09zs1di4dsssl9k322nzildvf41jwipbzhik9p43yb1bcfsp92nw";
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  src = fetchFromGitHub {
+    owner = "linas";
+    repo = "glextrusion";
+    rev = "refs/tags/${pname}-${version}";
+    sha256 = "sha256-yvCu0EOwxOMN6upeHX+C2sIz1YVjjB/320g+Mf24S6g=";
   };
 
   meta = {

--- a/pkgs/development/libraries/gle/default.nix
+++ b/pkgs/development/libraries/gle/default.nix
@@ -1,8 +1,32 @@
-{lib, stdenv, fetchurl, libglut, libX11, libXt, libXmu, libXi, libXext, libGL, libGLU}:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  libglut,
+  libX11,
+  libXt,
+  libXmu,
+  libXi,
+  libXext,
+  libGL,
+  libGLU,
+}:
+
 stdenv.mkDerivation rec {
   pname = "gle";
   version = "3.1.0";
-  buildInputs = [libGLU libGL libglut libX11 libXt libXmu libXi libXext];
+
+  buildInputs = [
+    libGLU
+    libGL
+    libglut
+    libX11
+    libXt
+    libXmu
+    libXi
+    libXext
+  ];
+
   src = fetchurl {
     urls = [
       "mirror://sourceforge/project/gle/gle/gle-${version}/gle-${version}.tar.gz"
@@ -10,10 +34,11 @@ stdenv.mkDerivation rec {
       ];
     sha256 = "09zs1di4dsssl9k322nzildvf41jwipbzhik9p43yb1bcfsp92nw";
   };
+
   meta = {
     description = "Tubing and extrusion library";
-    license = lib.licenses.gpl2 ;
-    maintainers = [lib.maintainers.raskin];
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Unbreaks build after gcc 14 update

https://hydra.nixos.org/build/273283939 (x86_64-linux)
https://hydra.nixos.org/build/273359054 (aarch64-linux)

Targetting https://github.com/NixOS/nixpkgs/pull/343421

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
