### PR TITLE
sblast: init at 0.7.0

### DIFF
--- a/pkgs/by-name/sb/sblast/package.nix
+++ b/pkgs/by-name/sb/sblast/package.nix
@@ -1,0 +1,61 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  ffmpeg,
+  lib,
+  makeBinaryWrapper,
+  nix-update-script,
+  pulseaudio,
+  testers,
+}:
+let
+  self = buildGoModule rec {
+    pname = "sblast";
+    version = "0.7.0";
+
+    src = fetchFromGitHub {
+      owner = "ugjka";
+      repo = "sblast";
+      rev = "v${version}";
+      hash = "sha256-+ZeZ2lohAngfljCa/z9yjCKvQwCMEiwzzPFrpAU8lWA=";
+    };
+
+    vendorHash = "sha256-yPwLilMiDR1aSeuk8AEmuYPsHPRWqiByGLwgkdI5t+s=";
+
+    nativeBuildInputs = [
+      makeBinaryWrapper
+    ];
+
+    postInstall = ''
+      wrapProgram $out/bin/sblast \
+          --suffix PATH : ${
+            lib.makeBinPath [
+              ffmpeg
+              pulseaudio
+            ]
+          }
+    '';
+
+    # build only the toplevel package, and not `makerel`
+    subPackages = ".";
+
+    passthru = {
+      updateScript = nix-update-script { };
+      tests.version = testers.testVersion {
+        package = self;
+        version = "v${version}";
+      };
+    };
+
+    meta = {
+      description = "Blast your Linux audio to DLNA receivers";
+      homepage = "https://github.com/ugjka/sblast";
+      # license is "MIT+NoAI": <https://github.com/ugjka/sblast/blob/main/LICENSE>
+      license = lib.licenses.unfree;
+      mainProgram = "sblast";
+      maintainers = with lib.maintainers; [ colinsane ];
+      platforms = lib.platforms.linux;
+    };
+  };
+in
+self


### PR DESCRIPTION
- project homepage: <https://github.com/ugjka/sblast>
- project license ("MIT+NoAI", which seems to map onto nixpkgs' `unfree`): <https://github.com/ugjka/sblast/blob/main/LICENSE>

## About the package

`sblast` is a CLI tool to cast your pulseaudio or pipewire system audio to any DLNA renderer, for example, your T.V.

the audio stream is pulled by the DLNA renderer from the host machine's port 9000, so one must open that in the firewall
```nix
networking.firewall.allowedTCPPorts = [ 9000 ];
```

usage is like:
```sh
$ sblast -source blast.monitor
```
then follow the prompts to select which device to cast to, and then launch a media player or some audio source, and ensure it's routed to the pulseaudio `blast` device. some devices require additional blast flags in order to understand the audio stream, such as `blast -usewav [...]`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
