### PR TITLE
kdeApplications.koi: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7053,6 +7053,13 @@
     githubId = 5918766;
     name = "Franz Thoma";
   };
+  fnune = {
+    email = "fausto.nunez@mailbox.org";
+    github = "fnune";
+    githubId = 16181067;
+    name = "Fausto Núñez Alberro";
+    keys = [ { fingerprint = "668E 01D1 B129 3F42 0A0F  933A C880 6451 94A2 D562"; } ];
+  };
   foo-dogsquared = {
     email = "foodogsquared@foodogsquared.one";
     github = "foo-dogsquared";

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -88,6 +88,7 @@ let
 
         applet-window-buttons6 = self.callPackage ./third-party/applet-window-buttons6 { };
         karousel = self.callPackage ./third-party/karousel { };
+        koi = self.callPackage ./third-party/koi { };
         krohnkite = self.callPackage ./third-party/krohnkite { };
         kzones = self.callPackage ./third-party/kzones { };
       }

--- a/pkgs/kde/third-party/koi/default.nix
+++ b/pkgs/kde/third-party/koi/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl3;
     platforms = platforms.linux;
     homepage = "https://github.com/baduhai/Koi";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ fnune ];
   };
 }

--- a/pkgs/kde/third-party/koi/default.nix
+++ b/pkgs/kde/third-party/koi/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  kconfig,
+  kcoreaddons,
+  kwidgetsaddons,
+  wrapQtAppsHook,
+}:
+stdenv.mkDerivation rec {
+  pname = "koi";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "baduhai";
+    repo = "Koi";
+    rev = version;
+    sha256 = "sha256-dhpuKIY/Xi62hzJlnVCIOF0k6uoQ3zH129fLq/r+Kmg";
+  };
+
+  # See https://github.com/baduhai/Koi/blob/master/development/Nix%20OS/dev.nix
+  sourceRoot = "source/src";
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+  buildInputs = [
+    kconfig
+    kcoreaddons
+    kwidgetsaddons
+  ];
+
+  meta = with lib; {
+    description = "Scheduling LIGHT/DARK Theme Converter for the KDE Plasma Desktop";
+    longDescription = ''
+      Koi is a program designed to provide the KDE Plasma Desktop functionality to automatically switch between light and dark themes. Koi is under semi-active development, and while it is stable enough to use daily, expect bugs. Koi is designed to be used with Plasma, and while some features may function under different desktop environments, they are unlikely to work and untested.
+
+      Features:
+
+      - Toggle between light and dark presets based on time
+      - Change Plasma style
+      - Change Qt colour scheme
+      - Change Icon theme
+      - Change GTK theme
+      - Change wallpaper
+      - Hide application to system tray
+      - Toggle between LIGHT/DARK themes by clicking mouse wheel
+    '';
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    homepage = "https://github.com/baduhai/Koi";
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
## Description of changes

![image](https://github.com/user-attachments/assets/9544e338-455b-4c10-9cfa-c6d59a72ec0d)

[Koi](https://github.com/baduhai/Koi) is a scheduling theme switcher for KDE that I have been using on Plasma 6 for the last few days. It has been working great for me, and I was originally looking for it within `nixpkgs`, but couldn't find it, so here it is.

This is the derivation I have been testing it with: https://github.com/fnune/home.nix/commit/7edb3f60a8ee767268ac2a9915f8720d745802f0

I have also been running it from my own development fork of `nixpkgs` using the same code I'm submitting here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
