### PR TITLE
tuxedo drivers module

### DIFF
--- a/nixos/modules/hardware/tuxedo-drivers.nix
+++ b/nixos/modules/hardware/tuxedo-drivers.nix
@@ -1,12 +1,18 @@
 { config, lib, pkgs, ... }:
 let
-  cfg = config.hardware.tuxedo-keyboard;
-  tuxedo-keyboard = config.boot.kernelPackages.tuxedo-keyboard;
+  cfg = config.hardware.tuxedo-drivers;
+  tuxedo-drivers = config.boot.kernelPackages.tuxedo-drivers;
 in
   {
-    options.hardware.tuxedo-keyboard = {
-      enable = lib.mkEnableOption ''
-          the tuxedo-keyboard driver.
+    imports = [
+      (mkRenamedOptionModule [ "hardware" "tuxedo-keyboard" "enable" ] [ "hardware" "tuxedo-drivers" "enable" ])
+    ];
+    options.hardware.tuxedo-drivers = {
+      enable = mkEnableOption ''
+          Driver pack for tuxedo devices including
+          - Driver for Fn-keys
+          - SysFS control of brightness/color/mode for most TUXEDO keyboards
+          - Hardware I/O driver for TUXEDO Control Center
 
           To configure the driver, pass the options to the {option}`boot.kernelParams` configuration.
           There are several parameters you can change. It's best to check at the source code description which options are supported.
@@ -26,7 +32,11 @@ in
 
     config = lib.mkIf cfg.enable
     {
-      boot.kernelModules = ["tuxedo_keyboard"];
-      boot.extraModulePackages = [ tuxedo-keyboard ];
+      boot.kernelModules = [
+        "tuxedo_keyboard"
+        "tuxedo_compatibility_check"
+        "tuxedo_io"
+      ];
+      boot.extraModulePackages = [ tuxedo-drivers ];
     };
   }

--- a/nixos/modules/hardware/tuxedo-drivers.nix
+++ b/nixos/modules/hardware/tuxedo-drivers.nix
@@ -5,10 +5,10 @@ let
 in
   {
     imports = [
-      (mkRenamedOptionModule [ "hardware" "tuxedo-keyboard" "enable" ] [ "hardware" "tuxedo-drivers" "enable" ])
+      (lib.mkRenamedOptionModule [ "hardware" "tuxedo-keyboard" "enable" ] [ "hardware" "tuxedo-drivers" "enable" ])
     ];
     options.hardware.tuxedo-drivers = {
-      enable = mkEnableOption ''
+      enable = lib.mkEnableOption ''
           Driver pack for tuxedo devices including
           - Driver for Fn-keys
           - SysFS control of brightness/color/mode for most TUXEDO keyboards

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -98,7 +98,7 @@
   ./hardware/sensor/iio.nix
   ./hardware/steam-hardware.nix
   ./hardware/system-76.nix
-  ./hardware/tuxedo-keyboard.nix
+  ./hardware/tuxedo-drivers.nix
   ./hardware/ubertooth.nix
   ./hardware/uinput.nix
   ./hardware/uni-sync.nix

--- a/nixos/modules/services/hardware/tuxedo-rs.nix
+++ b/nixos/modules/services/hardware/tuxedo-rs.nix
@@ -14,7 +14,7 @@ in
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {
-      hardware.tuxedo-keyboard.enable = true;
+      hardware.tuxedo-drivers.enable = true;
 
       systemd = {
         services.tailord = {

--- a/pkgs/os-specific/linux/tuxedo-drivers/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-drivers/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tuxedo-drivers-${kernel.version}";
-  version = "4.6.1";
+  version = "4.6.3";
 
   src = fetchFromGitLab {
     owner = "tuxedocomputers/development/packages";
     repo = "tuxedo-drivers";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-hZ4fY6TQj4YIOzFH+iZq90VPr87KIzke4N2PiJGYeEE=";
+    hash = "sha256-7AAHkbElQFKwp1pUZWkCkuMMLzhn/GNrYTSiKYumqKQ=";
   };
 
   buildInputs = [ pahole ];

--- a/pkgs/os-specific/linux/tuxedo-drivers/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-drivers/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchFromGitLab, kernel, kmod, pahole }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tuxedo-drivers-${kernel.version}";
+  version = "4.3.0";
+
+  src = fetchFromGitLab {
+    owner = "tuxedocomputers/development/packages";
+    repo = "tuxedo-drivers";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-IZ1K7n4OrhI52u7EH0ljVkKwc/uf53sMd9qpTLjvzls=";
+  };
+
+  buildInputs = [ pahole ];
+  nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  meta = {
+    broken = stdenv.isAarch64 || (lib.versionOlder kernel.version "5.5");
+    description = "Drivers for several platform devices for TUXEDO notebooks";
+    homepage = "https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers";
+    license = lib.licenses.gpl3Plus;
+    longDescription = ''
+      This driver provides support for Fn keys, brightness/color/mode for most TUXEDO
+      keyboards (except white backlight-only models) and a hardware I/O driver for
+      the TUXEDO Control center.
+    '';
+    maintainers = [ lib.maintainers.aprl ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -494,6 +494,8 @@ in {
 
     rust-out-of-tree-module = if lib.versionAtLeast kernel.version "6.7" then callPackage ../os-specific/linux/rust-out-of-tree-module { } else null;
 
+    tuxedo-drivers = if lib.versionAtLeast kernel.version "4.14" then callPackage ../os-specific/linux/tuxedo-drivers { } else null;
+
     tuxedo-keyboard = if lib.versionAtLeast kernel.version "4.14" then callPackage ../os-specific/linux/tuxedo-keyboard { } else null;
 
     jool = callPackage ../os-specific/linux/jool { };


### PR DESCRIPTION
## Description of changes

picking up where https://github.com/NixOS/nixpkgs/pull/293017 left off

## Things done

built on kernels: 6.10, 6.11

running this on my own system with `tuxedo-rs`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
