### PR TITLE
emacsPackages.zstd: init at 0-unstable-2020-06-03

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -29,6 +29,8 @@ lib.packagesFromDirectoryRecursive {
 
   tree-sitter-langs = callPackage ./manual-packages/tree-sitter-langs { final = self; };
 
+  zstd = callPackage ./manual-packages/zstd { inherit (pkgs) zstd; };
+
   # From old emacsPackages (pre emacsPackagesNg)
   cedille = callPackage ./manual-packages/cedille { inherit (pkgs) cedille; };
 

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/zstd/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/zstd/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  melpaBuild,
+  stdenv,
+  fetchFromGitHub,
+  zstd,
+}:
+
+let
+  libExt = stdenv.hostPlatform.extensions.sharedLibrary;
+in
+melpaBuild {
+  pname = "zstd";
+  version = "0-unstable-2020-06-03";
+
+  src = fetchFromGitHub {
+    owner = "syohex";
+    repo = "emacs-zstd";
+    rev = "072b264e2cbd5c05be06a1208ebccc2dab44be39";
+    hash = "sha256-p8bxefytTOSV6vIG8PAPBXfVKA2rfmWdRtVwjE42mAw=";
+  };
+
+  buildInputs = [ zstd ];
+
+  preBuild = ''
+    $CC -std=gnu99 -shared -o zstd-core${libExt} zstd-core.c -lzstd
+  '';
+
+  files = ''(:defaults "zstd-core${libExt}")'';
+
+  meta = {
+    homepage = "https://github.com/syohex/emacs-zstd";
+    description = "Zstd binding for Emacs Lisp";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ nagy ];
+  };
+}


### PR DESCRIPTION
## Description of changes

I don't know how to remove the hard coded version number in the output directory.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
