### PR TITLE
mathematica: 14.0.0 -> 14.1.0

### DIFF
--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -71,7 +71,7 @@ callPackage ./generic.nix {
     homepage = "http://www.wolfram.com/mathematica/";
     license = licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ herberteuler rafaelrc ];
+    maintainers = with maintainers; [ herberteuler rafaelrc chewblacka ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -53,8 +53,8 @@ let versions = callPackage ./versions.nix { };
 
     matchesDoc = v:
       builtins.match (if webdoc
-                      then ".*[0-9]_LINUX.sh"
-                      else ".*[0-9]_BNDL_LINUX.sh") v.src.name != null;
+                      then ".*[0-9]_LIN(UX)?.sh"
+                      else ".*_B[Nn][Dd][Ll].sh") v.src.name != null;
 
 in
 

--- a/pkgs/applications/science/math/mathematica/generic.nix
+++ b/pkgs/applications/science/math/mathematica/generic.nix
@@ -157,9 +157,15 @@ in stdenv.mkDerivation {
 
     mkdir -p "$out/lib/udev/rules.d"
 
-    # Patch MathInstaller's shebangs and udev rules dir
-    patchShebangs MathInstaller
-    substituteInPlace MathInstaller \
+    # Set name of installer file
+    if [ -f "MathInstaller" ]; then
+      INSTALLER="MathInstaller"
+    else
+      INSTALLER="WolframInstaller"
+    fi
+    # Patch Installer's shebangs and udev rules dir
+    patchShebangs $INSTALLER
+    substituteInPlace $INSTALLER \
       --replace /etc/udev/rules.d $out/lib/udev/rules.d
 
     # Remove PATH restriction, root and avahi daemon checks, and hostname call
@@ -169,13 +175,13 @@ in stdenv.mkDerivation {
       s/^\s*checkAvahiDaemon$/:/
       s/^\s*installBundledInstall$/:/
       s/`hostname`/""/
-    ' MathInstaller
+    ' $INSTALLER
 
     # NOTE: some files placed under HOME may be useful
     XDG_DATA_HOME="$out/share" HOME="$TMPDIR/home" vernierLink=y \
-      ./MathInstaller -execdir="$out/bin" -targetdir="$out/libexec/Mathematica" -auto -verbose -createdir=y
+      ./$INSTALLER -execdir="$out/bin" -targetdir="$out/libexec/Mathematica" -auto -verbose -createdir=y
 
-    # Check if MathInstaller produced any errors
+    # Check if Installer produced any errors
     errLog="$out/libexec/Mathematica/InstallErrors"
     if [ -f "$errLog" ]; then
       echo "Installation errors:"

--- a/pkgs/applications/science/math/mathematica/versions.nix
+++ b/pkgs/applications/science/math/mathematica/versions.nix
@@ -8,6 +8,20 @@
 
 let versions = [
   {
+    version = "14.1.0";
+    lang = "en";
+    language = "English";
+    sha256 = "sha256-PCpjwqA6NC+iwvYxddYBlmF5+vl76r+MoIYAL91WFns=";
+    installer = "Wolfram_14.1.0_LIN.sh";
+  }
+  {
+    version = "14.1.0";
+    lang = "en";
+    language = "English";
+    sha256 = "sha256-pnu60Pv3xo3+MAkDLiU3yTPVbbQ00diV45vSVL8B310=";
+    installer = "Wolfram_14.1.0_LIN_Bndl.sh";
+  }
+  {
     version = "14.0.0";
     lang = "en";
     language = "English";


### PR DESCRIPTION
## Description of changes

- Added myself to maintainers

14.0.0 -> 14.1.0
https://www.wolfram.com/language/quick-revision-history/#v141
- Added new 14.1 binary names and hashes to `versions.nix`
- 14.1 sees a change in the way the Mathematica downloads are named so I've modified the regex in `default.nix` to match the new filenames (as well as the old).
- Also 14.1 sees the actual install script renamed from `MathInstaller` to `WolframInstaller` so I've changed `generic.nix` to accommodate both.


Closes https://github.com/NixOS/nixpkgs/issues/343316
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
