### PR TITLE
writers: disable broken test (fsharp)

### DIFF
--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -245,30 +245,32 @@ recurseIntoAttrs {
     #  print(y[0]['test'])
     #'');
 
-    fsharp = expectSuccess (makeFSharpWriter {
-      libraries = { fetchNuGet }: [
-        (fetchNuGet { pname = "FSharp.SystemTextJson"; version = "0.17.4"; sha256 = "1bplzc9ybdqspii4q28l8gmfvzpkmgq5l1hlsiyg2h46w881lwg2"; })
-        (fetchNuGet { pname = "System.Text.Json"; version = "4.6.0"; sha256 = "0ism236hwi0k6axssfq58s1d8lihplwiz058pdvl8al71hagri39"; })
-      ];
-    } "test-writers-fsharp" ''
+    # Commented out because fails with 'error FS0039: The value or constructor 'JsonFSharpConverter' is not defined.'
 
-      #r "nuget: FSharp.SystemTextJson, 0.17.4"
-
-      module Json =
-          open System.Text.Json
-          open System.Text.Json.Serialization
-          let options = JsonSerializerOptions()
-          options.Converters.Add(JsonFSharpConverter())
-          let serialize<'a> (o: 'a) = JsonSerializer.Serialize<'a>(o, options)
-          let deserialize<'a> (str: string) = JsonSerializer.Deserialize<'a>(str, options)
-
-      type Letter = A | B
-      let a = {| Hello = Some "World"; Letter = A |}
-      if a |> Json.serialize |> Json.deserialize |> (=) a
-      then "success"
-      else "failed"
-      |> printfn "%s"
-    '');
+    # fsharp = expectSuccess (makeFSharpWriter {
+    #   libraries = { fetchNuGet }: [
+    #     (fetchNuGet { pname = "FSharp.SystemTextJson"; version = "0.17.4"; sha256 = "1bplzc9ybdqspii4q28l8gmfvzpkmgq5l1hlsiyg2h46w881lwg2"; })
+    #     (fetchNuGet { pname = "System.Text.Json"; version = "4.6.0"; sha256 = "0ism236hwi0k6axssfq58s1d8lihplwiz058pdvl8al71hagri39"; })
+    #   ];
+    # } "test-writers-fsharp" ''
+    #
+    #   #r "nuget: FSharp.SystemTextJson, 0.17.4"
+    #
+    #   module Json =
+    #       open System.Text.Json
+    #       open System.Text.Json.Serialization
+    #       let options = JsonSerializerOptions()
+    #       options.Converters.Add(JsonFSharpConverter())
+    #       let serialize<'a> (o: 'a) = JsonSerializer.Serialize<'a>(o, options)
+    #       let deserialize<'a> (str: string) = JsonSerializer.Deserialize<'a>(str, options)
+    #
+    #   type Letter = A | B
+    #   let a = {| Hello = Some "World"; Letter = A |}
+    #   if a |> Json.serialize |> Json.deserialize |> (=) a
+    #   then "success"
+    #   else "failed"
+    #   |> printfn "%s"
+    # '');
 
     #pypy2NoLibs = expectSuccess (writePyPy2 "test-writers-pypy2-no-libs" {} ''
     #  print("success")


### PR DESCRIPTION
## Description of changes

As noticed in #335969, `tests.writers.simple.fsharp` is currently broken on master. I tried to fix it, but unfortunately, I am unfamiliar with F#.

If no one can provide a solution, I propose commenting out the test to prevent it from blocking further development of the writers.

Hydra logs: https://hydra.nixos.org/build/272877892

cc @moinessim @raphaelr, since they worked on the F# writer 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
