### PR TITLE
tsukimi: init at 0.12.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13185,6 +13185,12 @@
     github = "Mephistophiles";
     githubId = 4850908;
   };
+  merrkry = {
+    email = "merrkry@tsubasa.moe";
+    name = "merrkry";
+    github = "merrkry";
+    githubId = 124278440;
+  };
   mevatron = {
     email = "mevatron@gmail.com";
     name = "mevatron";

--- a/pkgs/by-name/ts/tsukimi/package.nix
+++ b/pkgs/by-name/ts/tsukimi/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  mpv-unwrapped,
+  ffmpeg,
+  libadwaita,
+  gst_all_1,
+  openssl,
+  libepoxy,
+  wrapGAppsHook4,
+  makeDesktopItem,
+  copyDesktopItems,
+  stdenv,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "tsukimi";
+  version = "0.12.2";
+
+  src = fetchFromGitHub {
+    owner = "tsukinaha";
+    repo = "tsukimi";
+    rev = "v${version}";
+    hash = "sha256-pJ+SUNGQS/kqBdOg21GgDeZThcjnB0FhgG00qLfqxYA=";
+  };
+
+  cargoHash = "sha256-PCJiSyfEgK8inzoRmRvnAU50kLnyVhNrgLrwtBUFpIU=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+    copyDesktopItems
+  ];
+
+  buildInputs =
+    [
+      mpv-unwrapped
+      ffmpeg
+      libadwaita
+      openssl
+      libepoxy
+    ]
+    ++ (with gst_all_1; [
+      gstreamer
+      gst-plugins-base
+      gst-plugins-good
+      gst-plugins-bad
+      gst-plugins-ugly
+      gst-libav
+    ]);
+
+  doCheck = false; # tests require networking
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Tsukimi";
+      exec = "tsukimi";
+      type = "Application";
+      icon = "tsukimi";
+      categories = [ "AudioVideo" ];
+      startupWMClass = "moe.tsuna.tsukimi";
+      desktopName = "Tsukimi";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace build.rs \
+      --replace-fail 'i18n/locale' "$out/share/locale"
+
+    substituteInPlace src/main.rs \
+      --replace-fail '/usr/share/locale' "$out/share/locale"
+  '';
+
+  postInstall = ''
+    install -Dm644 moe.tsuna.tsukimi.gschema.xml -t $out/share/glib-2.0/schemas
+    glib-compile-schemas $out/share/glib-2.0/schemas
+
+    install -Dm644 resources/ui/icons/tsukimi.png -t $out/share/pixmaps
+  '';
+
+  meta = {
+    description = "Simple third-party Emby client, featured with GTK4-RS, MPV and GStreamer";
+    homepage = "https://github.com/tsukinaha/tsukimi";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      merrkry
+      aleksana
+    ];
+    mainProgram = "tsukimi";
+    platforms = lib.platforms.linux;
+    # libmpv2 crate fail to compile
+    # expected raw pointer `*const u8` found raw pointer `*const i8`
+    broken = stdenv.isAarch64;
+  };
+}


### PR DESCRIPTION
## Description of changes

Tsukimi is a simple third-party Emby client written in GTK4-RS, uses MPV as the video player, and GStreamer as the music player.

[Homepage](https://github.com/tsukinaha/tsukimi)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
