### PR TITLE
thelounge: 4.4.1 -> 4.4.3

### DIFF
--- a/pkgs/applications/networking/irc/thelounge/default.nix
+++ b/pkgs/applications/networking/irc/thelounge/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "thelounge";
     repo = "thelounge";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-csVrgsEy9HjSBXxtgNG0hcBrR9COlcadhMQrw6BWPc4=";
+    hash = "sha256-lDbyqVFjhF2etRx31ax7KiQ1QKgVhD8xkTog/E3pUlA=";
   };
 
   # Allow setting package path for the NixOS module.

--- a/pkgs/applications/networking/irc/thelounge/default.nix
+++ b/pkgs/applications/networking/irc/thelounge/default.nix
@@ -5,7 +5,7 @@
 , nodejs
 , yarn
 , fixup-yarn-lock
-, python3
+, python311
 , npmHooks
 , cctools
 , sqlite
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "thelounge";
-  version = "4.4.1";
+  version = "4.4.3";
 
   src = fetchFromGitHub {
     owner = "thelounge";
     repo = "thelounge";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-4FdNYP9VLgv/rfvT7KHCF+ABFsZvPbJjfz6IvvDkRNA=";
+    hash = "sha256-csVrgsEy9HjSBXxtgNG0hcBrR9COlcadhMQrw6BWPc4=";
   };
 
   # Allow setting package path for the NixOS module.
@@ -35,10 +35,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-MM6SgVT7Pjdu96A4eWRucEzT7uNPxBqUDgHKl8mH2C0=";
+    hash = "sha256-csVrgsEy9HjSBXxtgNG0hcBrR9COlcadhMQrw6BWPc4=";
   };
 
-  nativeBuildInputs = [ nodejs yarn fixup-yarn-lock python3 npmHooks.npmInstallHook ] ++ lib.optional stdenv.hostPlatform.isDarwin cctools;
+  # Distutils was deprecated in 3.10, and removed in 3.12. This build needs it. An alternative could be adding
+  # setuptools, but testing with that and 3.12 still fails.
+  nativeBuildInputs = [ nodejs yarn fixup-yarn-lock python311 npmHooks.npmInstallHook ] ++ lib.optional stdenv.hostPlatform.isDarwin cctools;
   buildInputs = [ sqlite ];
 
   configurePhase = ''

--- a/pkgs/applications/networking/irc/thelounge/default.nix
+++ b/pkgs/applications/networking/irc/thelounge/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Distutils was deprecated in 3.10, and removed in 3.12. This build needs it. An alternative could be adding
   # setuptools, but testing with that and 3.12 still fails.
-  nativeBuildInputs = [ nodejs yarn fixup-yarn-lock python311 npmHooks.npmInstallHook ] ++ lib.optional stdenv.hostPlatform.isDarwin cctools;
+  nativeBuildInputs = [ nodejs yarn fixup-yarn-lock python311 npmHooks.npmInstallHook ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ];
   buildInputs = [ sqlite ];
 
   configurePhase = ''


### PR DESCRIPTION
## Description of changes
Increased version to 4.4.3 which adds auto log culling.

Had to pin python to 3.11, as distutil is removed in 3.12, and setuptools to nativebuildtools didn't seem to help.

Changelog: https://github.com/thelounge/thelounge/releases/tag/v4.4.3

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

It was tested via overrides.
This is currently building and running 
https://github.com/Duckle29/NixOS-homeserver/blob/main/modules/thelounge.nix (this is pinning to 3.10, but recently also just tested with 3.11 and it works too)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
