### PR TITLE
buildNeovimPlugin: pass a derivation to luaAttr

### DIFF
--- a/pkgs/applications/editors/neovim/build-neovim-plugin.nix
+++ b/pkgs/applications/editors/neovim/build-neovim-plugin.nix
@@ -11,14 +11,15 @@ in
   # function to create vim plugin from lua packages that are already packaged in
   # luaPackages
   {
-    # the lua attribute name that matches this vim plugin. Both should be equal
-    # in the majority of cases but we make it possible to have different attribute names
-    luaAttr ? (lua.pkgs.${normalizeName attrs.pname})
+    # the lua derivation to convert into a neovim plugin
+     luaAttr ? (lua.pkgs.${normalizeName attrs.pname})
     , ...
   }@attrs:
     let
-      # warning added Sep 2024
-      originalLuaDrv = lib.warnIf (lib.typeOf luaAttr == "string") "luaAttr as string is deprecated. Pass a lua derivation directly ( e.g., `buildNeovimPlugin { luaAttr = lua.pkgs.plenary-nvim; }`)" luaAttr;
+      originalLuaDrv = if (lib.typeOf luaAttr == "string") then
+        lib.warn "luaAttr as string is deprecated since September 2024. Pass a lua derivation directly ( e.g., `buildNeovimPlugin { luaAttr = lua.pkgs.plenary-nvim; }`)" lua.pkgs.${normalizeName luaAttr}
+        else luaAttr;
+
 
       luaDrv = originalLuaDrv.overrideAttrs (oa: {
         version = attrs.version or oa.version;

--- a/pkgs/applications/editors/neovim/build-neovim-plugin.nix
+++ b/pkgs/applications/editors/neovim/build-neovim-plugin.nix
@@ -13,11 +13,12 @@ in
   {
     # the lua attribute name that matches this vim plugin. Both should be equal
     # in the majority of cases but we make it possible to have different attribute names
-    luaAttr ? (normalizeName attrs.pname)
+    luaAttr ? (lua.pkgs.${normalizeName attrs.pname})
     , ...
   }@attrs:
     let
-      originalLuaDrv = lua.pkgs.${luaAttr};
+      # warning added Sep 2024
+      originalLuaDrv = lib.warnIf (lib.typeOf luaAttr == "string") "luaAttr as string is deprecated. Pass a lua derivation directly ( e.g., `buildNeovimPlugin { luaAttr = lua.pkgs.plenary-nvim; }`)" luaAttr;
 
       luaDrv = originalLuaDrv.overrideAttrs (oa: {
         version = attrs.version or oa.version;

--- a/pkgs/applications/editors/vim/plugins/default.nix
+++ b/pkgs/applications/editors/vim/plugins/default.nix
@@ -1,7 +1,7 @@
 # TODO check that no license information gets lost
 { callPackage, config, lib, vimUtils, vim, darwin, llvmPackages
+, neovim-unwrapped
 , neovimUtils
-, luaPackages
 }:
 
 let
@@ -27,7 +27,7 @@ let
   overrides = callPackage ./overrides.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreFoundation CoreServices;
     inherit buildVimPlugin;
-    inherit llvmPackages luaPackages;
+    inherit llvmPackages;
   };
 
   aliases = if config.allowAliases then (import ./aliases.nix lib) else final: prev: {};

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -36,6 +36,7 @@
 , languagetool
 , llvmPackages
 , meson
+, neovim-unwrapped
 , nim1
 , nodePackages
 , openscad
@@ -129,10 +130,12 @@
 , # hurl dependencies
   hurl
 , # must be lua51Packages
-  luaPackages
-, luajitPackages
+  luajitPackages
 ,
 }: self: super:
+let
+  luaPackages = neovim-unwrapped.lua.pkgs;
+in
 {
   alpha-nvim = super.alpha-nvim.overrideAttrs {
     dependencies = [
@@ -915,7 +918,7 @@
     dependencies = with self; [ nvim-treesitter ];
   };
 
-  haskell-tools-nvim = neovimUtils.buildNeovimPlugin { luaAttr = "haskell-tools-nvim"; };
+  haskell-tools-nvim = neovimUtils.buildNeovimPlugin { luaAttr = luaPackages.haskell-tools-nvim; };
 
   hex-nvim = super.hex-nvim.overrideAttrs {
     postPatch = ''
@@ -1058,7 +1061,7 @@
   };
 
   lsp-progress-nvim = neovimUtils.buildNeovimPlugin {
-    luaAttr = "lsp-progress-nvim";
+    luaAttr = luaPackages.lsp-progress-nvim;
     nvimRequireCheck = "lsp-progress";
   };
 
@@ -1066,11 +1069,11 @@
     dependencies = with self; [ luaPackages.jsregexp ];
   };
 
-  lz-n = neovimUtils.buildNeovimPlugin { luaAttr = "lz-n"; };
+  lz-n = neovimUtils.buildNeovimPlugin { luaAttr = luaPackages.lz-n; };
 
-  lze = neovimUtils.buildNeovimPlugin { luaAttr = "lze"; };
+  lze = neovimUtils.buildNeovimPlugin { luaAttr = luaPackages.lze; };
 
-  lzn-auto-require = neovimUtils.buildNeovimPlugin { luaAttr = "lzn-auto-require"; };
+  lzn-auto-require = neovimUtils.buildNeovimPlugin { luaAttr = luaPackages.lzn-auto-require; };
 
   magma-nvim-goose = buildVimPlugin {
     pname = "magma-nvim-goose";
@@ -1146,7 +1149,7 @@
   };
 
   middleclass = neovimUtils.buildNeovimPlugin {
-    luaAttr = "middleclass";
+    luaAttr = luaPackages.middleclass;
     nvimRequireCheck = "middleclass";
   };
 
@@ -1506,17 +1509,17 @@
     ];
   };
 
-  rocks-nvim = neovimUtils.buildNeovimPlugin { luaAttr = "rocks-nvim"; };
+  rocks-nvim = neovimUtils.buildNeovimPlugin { luaAttr = luaPackages.rocks-nvim; };
 
-  rocks-config-nvim = neovimUtils.buildNeovimPlugin { luaAttr = "rocks-config-nvim"; };
+  rocks-config-nvim = neovimUtils.buildNeovimPlugin { luaAttr = luaPackages.rocks-config-nvim; };
 
   roslyn-nvim = super.roslyn-nvim.overrideAttrs {
     dependencies = with self; [ nvim-lspconfig ];
   };
 
-  rtp-nvim = neovimUtils.buildNeovimPlugin { luaAttr = "rtp-nvim"; };
+  rtp-nvim = neovimUtils.buildNeovimPlugin { luaAttr = luaPackages.rtp-nvim; };
 
-  rustaceanvim = neovimUtils.buildNeovimPlugin { luaAttr = "rustaceanvim"; };
+  rustaceanvim = neovimUtils.buildNeovimPlugin { luaAttr = luaPackages.rustaceanvim; };
 
   sg-nvim = super.sg-nvim.overrideAttrs (old:
     let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38519,9 +38519,7 @@ with pkgs;
 
   vimUtils = callPackage ../applications/editors/vim/plugins/vim-utils.nix { };
 
-  vimPlugins = recurseIntoAttrs (callPackage ../applications/editors/vim/plugins {
-    luaPackages = lua51Packages;
-  });
+  vimPlugins = recurseIntoAttrs (callPackage ../applications/editors/vim/plugins { });
 
   vimb-unwrapped = callPackage ../applications/networking/browsers/vimb { };
   vimb = wrapFirefox vimb-unwrapped { };


### PR DESCRIPTION
and deprecate passing a string.
Passing a string is not a typical/good nixpkgs habit. We want to give more control on
which attribute to wrap, without having to add it to the lua package set
necessarily.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
