### PR TITLE
lagrange: 1.17.6 → 1.18.1, the-foundation: 1.8.1 → 1.9.0

### DIFF
--- a/pkgs/applications/networking/browsers/lagrange/default.nix
+++ b/pkgs/applications/networking/browsers/lagrange/default.nix
@@ -1,63 +1,85 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, nix-update-script
-, cmake
-, pkg-config
-, fribidi
-, harfbuzz
-, libwebp
-, mpg123
-, SDL2
-, the-foundation
-, AppKit
-, zip
-, enableTUI ? false, ncurses, sealcurses
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  pkg-config,
+  fribidi,
+  harfbuzz,
+  libogg,
+  libwebp,
+  mpg123,
+  opusfile,
+  SDL2,
+  the-foundation,
+  AppKit,
+  zip,
+  enableTUI ? false,
+  ncurses,
+  sealcurses,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lagrange";
-  version = "1.17.6";
+  version = "1.18.1";
 
   src = fetchFromGitHub {
     owner = "skyjake";
     repo = "lagrange";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ZF2HMfEI0LpvJrnB9MN8sQQDyBl/mRsI7pt6lfN4wdU=";
+    hash = "sha256-iIUWF93RZheW4uf3zgs1jqDjQnn0nFH7GOMaLBR0w0o=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config zip ];
-
-  buildInputs = [ the-foundation ]
-    ++ lib.optionals (!enableTUI) [ fribidi harfbuzz libwebp mpg123 SDL2 ]
-    ++ lib.optionals enableTUI [ ncurses sealcurses ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin AppKit;
-
-  cmakeFlags = lib.optionals enableTUI [
-    "-DENABLE_TUI=YES"
-    "-DENABLE_MPG123=NO"
-    "-DENABLE_WEBP=NO"
-    "-DENABLE_FRIBIDI=NO"
-    "-DENABLE_HARFBUZZ=NO"
-    "-DENABLE_POPUP_MENUS=NO"
-    "-DENABLE_IDLE_SLEEP=NO"
-    "-DCMAKE_INSTALL_DATADIR=${placeholder "out"}/share"
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    zip
   ];
 
-  installPhase = lib.optionalString (stdenv.hostPlatform.isDarwin && !enableTUI) ''
-    mkdir -p $out/Applications
-    mv Lagrange.app $out/Applications
-  '';
+  buildInputs =
+    [
+      the-foundation
+      fribidi
+      harfbuzz
+      libogg
+      libwebp
+      mpg123
+      opusfile
+      SDL2
+    ]
+    ++ lib.optionals enableTUI [
+      ncurses
+      sealcurses
+    ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin AppKit;
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_TUI" enableTUI)
+    (lib.cmakeFeature "CMAKE_INSTALL_DATAROOTDIR" "${placeholder "out"}/share")
+  ];
+
+  installPhase =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications
+      mv Lagrange.app $out/Applications
+    ''
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && enableTUI) ''
+      # https://github.com/skyjake/lagrange/issues/610
+      make install
+      install -d $out/share/lagrange
+      ln -s $out/Applications/Lagrange.app/Contents/Resources/resources.lgr $out/share/lagrange/resources.lgr
+    '';
 
   passthru = {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Beautiful Gemini Client";
     homepage = "https://gmi.skyjake.fi/lagrange/";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ sikmir ];
-    platforms = platforms.unix;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ sikmir ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/development/libraries/the-foundation/default.nix
+++ b/pkgs/development/libraries/the-foundation/default.nix
@@ -1,41 +1,55 @@
-{ lib
-, stdenv
-, fetchFromGitea
-, cmake
-, pkg-config
-, curl
-, libunistring
-, openssl
-, pcre
-, zlib
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  cmake,
+  pkg-config,
+  curl,
+  libunistring,
+  openssl,
+  pcre,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "the-foundation";
-  version = "1.8.1";
+  version = "1.9.0";
 
   src = fetchFromGitea {
     domain = "git.skyjake.fi";
     owner = "skyjake";
     repo = "the_Foundation";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-gyDBK/bF+QxXMnthUfMjeUuRBZk0Xcahm7wOtLGs5kY=";
+    hash = "sha256-hrwnY8m4xW8Sr2RunwD5VB+gnYUtZxXyGoiO3N23qGM=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
-  buildInputs = [ curl libunistring openssl pcre zlib ];
+  buildInputs = [
+    curl
+    libunistring
+    openssl
+    pcre
+    zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "UNISTRING_DIR" "${libunistring}")
+  ];
 
   postFixup = ''
     substituteInPlace "$out"/lib/pkgconfig/the_Foundation.pc \
       --replace '="''${prefix}//' '="/'
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Opinionated C11 library for low-level functionality";
     homepage = "https://git.skyjake.fi/skyjake/the_Foundation";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ sikmir ];
-    platforms = platforms.unix;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ sikmir ];
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
## Description of changes
* https://github.com/skyjake/lagrange/releases/tag/v1.18.0
* https://git.skyjake.fi/skyjake/the_Foundation/src/tag/v1.9.0

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
