### PR TITLE
freecad: 0.21.2 → 1.0rc2

### DIFF
--- a/pkgs/by-name/fr/freecad/0001-NIXOS-don-t-ignore-PYTHONPATH.patch
+++ b/pkgs/by-name/fr/freecad/0001-NIXOS-don-t-ignore-PYTHONPATH.patch
@@ -1,44 +1,43 @@
-From c4f452ef6ae083ed21095313582f6d1bd775cbf3 Mon Sep 17 00:00:00 2001
-From: Andreas Rammhold <andreas@rammhold.de>
-Date: Thu, 2 Nov 2023 17:32:07 +0100
-Subject: [PATCH] NIXOS: don't ignore PYTHONPATH
+commit c534a831c2f7186ebabe4e17f1e1df6d11ebff89
+Author: Samuel Rounce <me@samuelrounce.co.uk>
+Date:   Thu Sep 5 22:17:21 2024 +0100
 
-On NixOS or rather within nixpkgs we provide the runtime Python
-packages via the PYTHONPATH environment variable. FreeCAD tries its
-best to ignore Python environment variables that are being inherited
-from the environment. For Python versions >=3.11 it also tries to
-initialize the interpreter config without any environmental data. We
-have to initialize the configuration *with* the information from the
-environment for our packaging to work.
-
-Upstream has purposely isolated the environments AFAIK and thus
-shouldn't accept this patch (as is). What they might accept (once
-support for older Python versions has been dropped) is removing the
-PYTHONPATH specific putenv calls.
+    [PATCH] NIXOS: don't ignore PYTHONPATH
+    
+    On NixOS or rather within nixpkgs we provide the runtime Python
+    packages via the PYTHONPATH environment variable. FreeCAD tries its
+    best to ignore Python environment variables that are being inherited
+    from the environment. For Python versions >=3.11 it also tries to
+    initialize the interpreter config without any environmental data. We
+    have to initialize the configuration *with* the information from the
+    environment for our packaging to work.
+    
+    Upstream has purposely isolated the environments AFAIK and thus
+    shouldn't accept this patch (as is). What they might accept (once
+    support for older Python versions has been dropped) is removing the
+    PYTHONPATH specific putenv calls.
 ---
- src/Base/Interpreter.cpp | 2 +-
+ src/Base/Interpreter.cpp | 1 +
  src/Main/MainGui.cpp     | 3 ---
- 2 files changed, 1 insertion(+), 4 deletions(-)
+ 2 files changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/src/Base/Interpreter.cpp b/src/Base/Interpreter.cpp
-index 52c47168af..9966bd0013 100644
+index 2bdc54ccff..ee4f7fc070 100644
 --- a/src/Base/Interpreter.cpp
 +++ b/src/Base/Interpreter.cpp
-@@ -554,7 +554,9 @@ void initInterpreter(int argc,char *argv[])
- {
-     PyStatus status;
+@@ -593,6 +593,7 @@ void initInterpreter(int argc, char* argv[])
      PyConfig config;
      PyConfig_InitIsolatedConfig(&config);
-+    config.isolated = 0;
+     config.isolated = 0;
 +    config.use_environment = 1;
+     config.user_site_directory = 1;
  
      status = PyConfig_SetBytesArgv(&config, argc, argv);
-     if (PyStatus_Exception(status)) {
 diff --git a/src/Main/MainGui.cpp b/src/Main/MainGui.cpp
-index 48ae847ef4..28813df383 100644
+index 36087cffd6..89d49d2cc6 100644
 --- a/src/Main/MainGui.cpp
 +++ b/src/Main/MainGui.cpp
-@@ -112,17 +112,14 @@ int main( int argc, char ** argv )
+@@ -114,10 +114,8 @@ int main(int argc, char** argv)
      // See https://forum.freecad.org/viewtopic.php?f=18&t=20600
      // See Gui::Application::runApplication()
      putenv("LC_NUMERIC=C");
@@ -49,13 +48,11 @@ index 48ae847ef4..28813df383 100644
  #elif defined(__MINGW32__)
      const char* mingw_prefix = getenv("MINGW_PREFIX");
      const char* py_home = getenv("PYTHONHOME");
-     if (!py_home && mingw_prefix)
+@@ -125,7 +123,6 @@ int main(int argc, char** argv)
          _putenv_s("PYTHONHOME", mingw_prefix);
+     }
  #else
 -    _putenv("PYTHONPATH=");
      // https://forum.freecad.org/viewtopic.php?f=4&t=18288
      // https://forum.freecad.org/viewtopic.php?f=3&t=20515
      const char* fc_py_home = getenv("FC_PYTHONHOME");
--- 
-2.42.0
-

--- a/pkgs/by-name/fr/freecad/0002-FreeCad-OndselSolver-pkgconfig.patch
+++ b/pkgs/by-name/fr/freecad/0002-FreeCad-OndselSolver-pkgconfig.patch
@@ -1,0 +1,7 @@
+--- a/src/3rdParty/OndselSolver/OndselSolver.pc.in
++++ b/src/3rdParty/OndselSolver/OndselSolver.pc.in
+@@ -3,2 +3,2 @@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_INCLUDEDIR@

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -63,13 +63,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "freecad";
-  version = "1.0rc1";
+  version = "1.0rc2";
 
   src = fetchFromGitHub {
     owner = "FreeCAD";
     repo = "FreeCAD";
     rev = finalAttrs.version;
-    hash = "sha256-CQWLYGgcz/up1SVc2V7nOX0deGBSEEs2RwbA7pr5kc4=";
+    hash = "sha256-kPmfx/C1fCYwBqh6ZOKZAVNVR9m3VryPmBKu3ksDD5E=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -9,12 +9,12 @@
 , gfortran
 , gts
 , hdf5
-, libGLU
-, libXmu
 , libf2c
+, libGLU
 , libredwg
 , libsForQt5
 , libspnav
+, libXmu
 , medfile
 , mpi
 , ninja
@@ -29,6 +29,7 @@
 , vtk
 , wrapGAppsHook3
 , xercesc
+, yaml-cpp
 , zlib
 , withWayland ? false
 }:
@@ -50,6 +51,7 @@ let
     matplotlib
     pivy
     ply
+    pybind11
     pycollada
     pyside2
     pyside2-tools
@@ -61,13 +63,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "freecad";
-  version = "0.21.2";
+  version = "1.0rc1";
 
   src = fetchFromGitHub {
     owner = "FreeCAD";
     repo = "FreeCAD";
     rev = finalAttrs.version;
-    hash = "sha256-OX4s9rbGsAhH7tLJkUJYyq2A2vCdkq/73iqYo9adogs=";
+    hash = "sha256-CQWLYGgcz/up1SVc2V7nOX0deGBSEEs2RwbA7pr5kc4=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
@@ -100,6 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
       opencascade-occt
       pivy
       ply # for openSCAD file support
+      pybind11
       pycollada
       pyside2
       pyside2-tools
@@ -116,6 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
       swig
       vtk
       xercesc
+      yaml-cpp
       zlib
     ]
     ++ lib.optionals spaceNavSupport [
@@ -125,12 +130,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
+    ./0002-FreeCad-OndselSolver-pkgconfig.patch
   ];
 
   cmakeFlags = [
     "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
     "-DBUILD_FLAT_MESH:BOOL=ON"
     "-DBUILD_QT5=ON"
+    "-DBUILD_DRAWING=ON"
+    "-DBUILD_FLAT_MESH:BOOL=ON"
+    "-DINSTALL_TO_SITEPACKAGES=OFF"
+    "-DFREECAD_USE_PYBIND11=ON"
     "-DSHIBOKEN_INCLUDE_DIR=${shiboken2}/include"
     "-DSHIBOKEN_LIBRARY=Shiboken2::libshiboken"
     (
@@ -201,7 +211,7 @@ stdenv.mkDerivation (finalAttrs: {
       right at home with FreeCAD.
     '';
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ gebner AndersonTorres ];
+    maintainers = with lib.maintainers; [ gebner AndersonTorres srounce ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
## Description of changes

Fixes #341214 

Update FreeCAD to latest 1.0 Release Candidate (includes commits for all release candidates). I've had this building for quite some time in [srounce/freecad.nix](https://github.com/srounce/freecad.nix) albeit with a slightly different slimmed down derivation. This PR ports the key changes to the existing Nixpkgs version allowing it to build 1.0RC.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
