### PR TITLE
Steam: update bootstrap

### DIFF
--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchurl {
     # use archive url so the tarball doesn't 404 on a new release
     url = "https://repo.steampowered.com/steam/archive/stable/steam_${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-sO07g3j1Qejato2LWJ2FrW3AzfMCcBz46HEw7aKxojQ=";
+    hash = "sha256-sO07g3j1Qejato2LWJ2FrW3AzfMCcBz46HEw7aKxojQ=";
   };
 
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
     sed -e 's,/usr/bin/steam,steam,g' steam.desktop > $out/share/applications/steam.desktop
   '';
 
+  passthru.updateScript = ./update-bootstrap.py;
+
   meta = with lib; {
     description = "Digital distribution platform";
     longDescription = ''

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "steam-original";
-  version = "1.0.0.74";
+  version = "1.0.0.81";
 
   src = fetchurl {
     # use archive url so the tarball doesn't 404 on a new release
     url = "https://repo.steampowered.com/steam/archive/stable/steam_${finalAttrs.version}.tar.gz";
-    hash = "sha256-sO07g3j1Qejato2LWJ2FrW3AzfMCcBz46HEw7aKxojQ=";
+    hash = "sha256-Gia5182s4J4E3Ia1EeC5kjJX9mSltsr+b+1eRtEXtPk=";
   };
 
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -1,22 +1,21 @@
 { lib, stdenv, fetchurl, runtimeShell, traceDeps ? false, bash }:
 
-let
-  traceLog = "/tmp/steam-trace-dependencies.log";
-  version = "1.0.0.74";
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "steam-original";
-  inherit version;
+  version = "1.0.0.74";
 
   src = fetchurl {
     # use archive url so the tarball doesn't 404 on a new release
-    url = "https://repo.steampowered.com/steam/archive/stable/steam_${version}.tar.gz";
+    url = "https://repo.steampowered.com/steam/archive/stable/steam_${finalAttrs.version}.tar.gz";
     sha256 = "sha256-sO07g3j1Qejato2LWJ2FrW3AzfMCcBz46HEw7aKxojQ=";
   };
 
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 
-  postInstall = ''
+  postInstall =
+  let
+   traceLog = "/tmp/steam-trace-dependencies.log";
+  in ''
     rm $out/bin/steamdeps
     ${lib.optionalString traceDeps ''
       cat > $out/bin/steamdeps <<EOF
@@ -51,4 +50,4 @@ in stdenv.mkDerivation {
     maintainers = with maintainers; [ jagajaga ];
     mainProgram = "steam";
   };
-}
+})

--- a/pkgs/games/steam/update-bootstrap.py
+++ b/pkgs/games/steam/update-bootstrap.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure --keep NIX_PATH -i python3 -p git nix-update "python3.withPackages (ps: [ ps.beautifulsoup4 ps.requests ])"
+
+import sys
+import re
+import requests
+import subprocess
+from bs4 import BeautifulSoup
+
+VERSION_PATTERN = re.compile(r'^steam_(?P<ver>(\d+\.)+)tar.gz$')
+
+found_versions = []
+response = requests.get("https://repo.steampowered.com/steam/archive/stable/")
+soup = BeautifulSoup (response.text, "html.parser")
+for a in soup.find_all("a"):
+    href = a["href"]
+    if not href.endswith(".tar.gz"):
+        continue
+
+    match = VERSION_PATTERN.match(href)
+    if match is not None:
+        version = match.groupdict()["ver"][0:-1]
+        found_versions.append(version)
+
+if len(found_versions) == 0:
+    print("Failed to find available versions!", file=sys.stderr)
+    sys.exit(1)
+
+found_versions.sort()
+subprocess.run(["nix-update", "--version", found_versions[-1], "steamPackages.steam"])
+found_versions[0]


### PR DESCRIPTION
## Description of changes
- Add updater script for Steam bootstrap.
- Update 1.0.0.74 -> 1.0.0.81

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
