### PR TITLE
fittrackee: 0.8.8 → 0.8.9

### DIFF
--- a/pkgs/by-name/fi/fittrackee/package.nix
+++ b/pkgs/by-name/fi/fittrackee/package.nix
@@ -2,6 +2,7 @@
   fetchFromGitHub,
   fetchPypi,
   lib,
+  stdenv,
   postgresql,
   postgresqlTestHook,
   python3,
@@ -27,14 +28,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "fittrackee";
-  version = "0.8.8";
+  version = "0.8.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "SamR1";
     repo = "FitTrackee";
     rev = "refs/tags/v${version}";
-    hash = "sha256-IO6M+HXAR3Gn0/71KwkaQr6sB0eCQzmnqHYgO+mzIZM=";
+    hash = "sha256-raN6Ef/Z/JbdJDMKBIaBL8nmvFwvuZFX4rfC0ZgWgKI=";
   };
 
   build-system = [
@@ -47,6 +48,8 @@ python.pkgs.buildPythonApplication rec {
     "gunicorn"
     "pyjwt"
     "pyopenssl"
+    "pytz"
+    "sqlalchemy"
   ];
 
   dependencies =
@@ -95,8 +98,10 @@ python.pkgs.buildPythonApplication rec {
     export DATABASE_TEST_URL=postgresql://$PGUSER/$PGDATABASE?host=$PGHOST
   '';
 
+  doCheck = !stdenv.isDarwin; # tests are a bit flaky on darwin
+
   preCheck = ''
-    export TMP=$(mktemp -d)
+    export TMP=$TMPDIR
   '';
 
   meta = {
@@ -104,7 +109,6 @@ python.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/SamR1/FitTrackee";
     changelog = "https://github.com/SamR1/FitTrackee/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ traxys ];
   };
 }


### PR DESCRIPTION
## Description of changes
* https://github.com/SamR1/FitTrackee/releases/tag/v0.8.9
* enable on darwin
* relax sqlalchemy (#339863) and pytz

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
