### PR TITLE
ente-cli: init at 0.2.2

### DIFF
--- a/pkgs/by-name/en/ente-cli/package.nix
+++ b/pkgs/by-name/en/ente-cli/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  buildGoModule,
+  ente-cli,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  stdenv,
+  testers,
+}:
+let
+  version = "0.2.2";
+
+  canExecute = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+in
+buildGoModule {
+  pname = "ente-cli";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "ente-io";
+    repo = "ente";
+    rev = "refs/tags/cli-v${version}";
+    hash = "sha256-ynbljYl73XwCnt3RUNmOYdrN8FX3sJ+3qDhWa8m2YJs=";
+    sparseCheckout = [ "cli" ];
+  };
+
+  modRoot = "./cli";
+
+  vendorHash = "sha256-Gg1mifMVt6Ma8yQ/t0R5nf6NXbzLZBpuZrYsW48p0mw=";
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.AppVersion=cli-v${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall =
+    ''
+      mv $out/bin/{cli,ente}
+    ''
+    # running ente results in the following errors:
+    # > mkdir /homeless-shelter: permission denied
+    # > error getting password from keyring: exec: "dbus-launch": executable file not found in $PATH
+    # fix by setting ENTE_CLI_CONFIG_PATH to $TMP and ENTE_CLI_SECRETS_PATH to a non existing path
+    # also guarding with `isLinux` because ENTE_CLI_SECRETS_PATH doesn't help on darwin:
+    # > error setting password in keyring: exit status 195
+    #
+    + lib.optionalString (stdenv.buildPlatform.isLinux && canExecute) ''
+      export ENTE_CLI_CONFIG_PATH=$TMP
+      export ENTE_CLI_SECRETS_PATH=$TMP/secrets
+
+      installShellCompletion --cmd ente \
+        --bash <($out/bin/ente completion bash) \
+        --fish <($out/bin/ente completion fish) \
+        --zsh <($out/bin/ente completion zsh)
+    '';
+
+  passthru = {
+    # only works on linux, see comment above about ENTE_CLI_SECRETS_PATH on darwin
+    tests.version = lib.optionalAttrs stdenv.isLinux (
+      testers.testVersion {
+        package = ente-cli;
+        command = ''
+          env ENTE_CLI_CONFIG_PATH=$TMP \
+              ENTE_CLI_SECRETS_PATH=$TMP/secrets \
+              ente version
+        '';
+        version = "Version cli-v${ente-cli.version}";
+      }
+    );
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "cli-(.+)"
+      ];
+    };
+  };
+
+  meta = {
+    description = "CLI client for downloading your data from Ente";
+    longDescription = ''
+      The Ente CLI is a Command Line Utility for exporting data from Ente. It also does a few more things, for example, you can use it to decrypting the export from Ente Auth.
+    '';
+    homepage = "https://github.com/ente-io/ente/tree/main/cli#readme";
+    changelog = "https://github.com/ente-io/ente/releases/tag/cli-v${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = [
+      lib.maintainers.zi3m5f
+    ];
+    mainProgram = "ente";
+  };
+}


### PR DESCRIPTION
## Description of changes

Part of: #292641

Add cli client for ente.io server, see #325659.

Export of photos works for me with official server.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
