### PR TITLE
kabeljau: replace inkscape with cairosvg for build issues

### DIFF
--- a/pkgs/games/kabeljau/default.nix
+++ b/pkgs/games/kabeljau/default.nix
@@ -1,4 +1,12 @@
-{ stdenvNoCC, lib, fetchFromGitea, just, inkscape, makeWrapper, bash, dialog }:
+{
+  dialog,
+  fetchFromGitea,
+  just,
+  lib,
+  makeWrapper,
+  python3Packages,
+  stdenvNoCC,
+}:
 
 stdenvNoCC.mkDerivation rec {
   pname = "kabeljau";
@@ -12,21 +20,29 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-RedVItgfr6vgqXHA3bOiHXDpfGuHI+sX4jCHL9G5jYk=";
   };
 
-  # Inkscape is needed in a just recipe where it is used to export the SVG icon to several different sized PNGs.
-  nativeBuildInputs = [ just inkscape makeWrapper ];
+  # `cairosvg` is needed in a `just` recipe where it is used to export the SVG icon to several different sized PNGs.
+  nativeBuildInputs = [
+    just
+    makeWrapper
+    python3Packages.cairosvg
+  ];
+
   postPatch = ''
     patchShebangs --host ${pname}
     substituteInPlace ./justfile \
-      --replace " /bin" " $out/bin" \
-      --replace " /usr" " $out"
+      --replace-quiet " /bin" " $out/bin" \
+      --replace-quiet " /usr" " $out" \
+      --replace-fail "inkscape" "cairosvg" \
+      --replace-quiet "-C -w $icon_width" "-W $icon_width" \
+      --replace-quiet "-h $icon_height" "-H $icon_height" \
+      --replace-quiet "--export-png-color-mode=RGBA_8" "-f png"
   '';
+
   installPhase = ''
     runHook preInstall
 
     just install
-    wrapProgram $out/bin/${pname} --suffix PATH : ${
-      lib.makeBinPath [ dialog ]
-    }
+    wrapProgram $out/bin/${pname} --suffix PATH : ${lib.makeBinPath [ dialog ]}
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

`kabelaju` built fine on Linux-x86 but broke when building on Darwin due to the use of `inkscape` to generate the program icons. `inkscape` uses system UI resources that aren't normally available in the sandbox.

This replaces the call to `inkscape` with `cairosvg` to generate the icons.

(A patchfile would have been cleaner, but the code kept refusing patch after patch. CR/LF pehaps?)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
