### PR TITLE
waycorner: modernize; move to by-name & format via nixfmt

### DIFF
--- a/pkgs/by-name/wa/waycorner/package.nix
+++ b/pkgs/by-name/wa/waycorner/package.nix
@@ -1,10 +1,10 @@
-{ lib
-, makeWrapper
-, rustPlatform
-, pkg-config
-, fetchFromGitHub
-, wayland
-,
+{
+  lib,
+  makeWrapper,
+  rustPlatform,
+  pkg-config,
+  fetchFromGitHub,
+  wayland,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "waycorner";

--- a/pkgs/by-name/wa/waycorner/package.nix
+++ b/pkgs/by-name/wa/waycorner/package.nix
@@ -9,33 +9,34 @@
 rustPlatform.buildRustPackage rec {
   pname = "waycorner";
   version = "0.2.3";
+
   src = fetchFromGitHub {
     owner = "AndreasBackx";
     repo = "waycorner";
-    rev = version;
+    rev = "refs/tags/${version}";
     hash = "sha256-b8juIhJ3kh+NJc8RUVVoatqjWISSW0ir/vk2Dz/428Y=";
   };
+
   cargoHash = "sha256-LGxFRGzQ8jOfxT5di3+YGqfS5KM4+Br6KlTFpPbkJyU=";
-  buildInputs = [
-    wayland
-  ];
+
   nativeBuildInputs = [
     pkg-config
     makeWrapper
   ];
+
   postFixup = ''
     # the program looks for libwayland-client.so at runtime
     wrapProgram $out/bin/waycorner \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ wayland ]}
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Hot corners for Wayland";
     mainProgram = "waycorner";
-    changelog = "https://github.com/AndreasBackx/waycorner/blob/main/CHANGELOG.md";
+    changelog = "https://github.com/AndreasBackx/waycorner/blob/${version}/CHANGELOG.md";
     homepage = "https://github.com/AndreasBackx/waycorner";
-    platforms = platforms.linux;
-    license = licenses.mit;
-    maintainers = with maintainers; [ NotAShelf ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ NotAShelf ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30375,8 +30375,6 @@ with pkgs;
 
   remontoire = callPackage ../applications/misc/remontoire { };
 
-  waycorner = callPackage ../applications/misc/waycorner { };
-
   wayshot = callPackage ../tools/misc/wayshot { };
 
   waylevel = callPackage ../tools/misc/waylevel { };


### PR DESCRIPTION
## Description of changes

Updates waycorner derivation:
- Move to by-name overlay
- Format via nixfmt-rfc-style
- Get rid of nested `with lib;
and more cleanup. See commit messages/descriptions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
