### PR TITLE
actionlint: moved to by-name and modernized derivation

### DIFF
--- a/pkgs/by-name/ac/actionlint/package.nix
+++ b/pkgs/by-name/ac/actionlint/package.nix
@@ -1,16 +1,20 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
-, installShellFiles
-, makeWrapper
-, python3Packages
-, ronn
-, shellcheck
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  makeWrapper,
+  python3Packages,
+  ronn,
+  shellcheck,
 }:
 
-buildGoModule rec {
-  pname = "actionlint";
+let
   version = "1.7.1";
+in
+buildGoModule {
+  pname = "actionlint";
+  inherit version;
 
   subPackages = [ "cmd/actionlint" ];
 
@@ -23,23 +27,36 @@ buildGoModule rec {
 
   vendorHash = "sha256-ZREtrdHUD1B1Mogidp1y/kFTK+KR4qYJj1c/M+0utPM=";
 
-  nativeBuildInputs = [ makeWrapper ronn installShellFiles ];
+  nativeBuildInputs = [
+    makeWrapper
+    ronn
+    installShellFiles
+  ];
 
   postInstall = ''
     ronn --roff man/actionlint.1.ronn
     installManPage man/actionlint.1
     wrapProgram "$out/bin/actionlint" \
-      --prefix PATH : ${lib.makeBinPath [ python3Packages.pyflakes shellcheck ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          python3Packages.pyflakes
+          shellcheck
+        ]
+      }
   '';
 
-  ldflags = [ "-s" "-w" "-X github.com/rhysd/actionlint.version=${version}" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/rhysd/actionlint.version=${version}"
+  ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://rhysd.github.io/actionlint/";
     description = "Static checker for GitHub Actions workflow files";
     changelog = "https://github.com/rhysd/actionlint/raw/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ momeemt ];
     mainProgram = "actionlint";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16948,8 +16948,6 @@ with pkgs;
 
   actiona = libsForQt5.callPackage ../applications/misc/actiona { };
 
-  actionlint = callPackage ../development/tools/analysis/actionlint { };
-
   adreaper = callPackage ../tools/security/adreaper { };
 
   aeron = callPackage ../servers/aeron { };


### PR DESCRIPTION
## Description of changes

- Removed `with lib;` (ref: https://github.com/NixOS/nixpkgs/issues/208242)
- Formatted via nixfmt-rfc-style
- Removed `rec` (ref: https://nix.dev/guides/best-practices#recursive-attribute-set-rec)
- Moved `pkgs/development/tools/analysis` to `pkgs/by-name`

I also add myself to the maintainer list of this package, as it was empty.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
