### PR TITLE
dolphin: refactor (enable thumbnails on non plasma desktops)

### DIFF
--- a/pkgs/applications/kde/dolphin.nix
+++ b/pkgs/applications/kde/dolphin.nix
@@ -1,11 +1,34 @@
 {
-  mkDerivation, lib,
-  extra-cmake-modules, kdoctools,
-  baloo, baloo-widgets, kactivities, kbookmarks, kcmutils,
-  kcompletion, kconfig, kcoreaddons, kdbusaddons,
-  kfilemetadata, ki18n, kiconthemes, kinit, kio, knewstuff, knotifications,
-  kparts, ktexteditor, kwindowsystem, phonon, solid,
-  kuserfeedback, wayland, qtwayland, qtx11extras, qtimageformats
+  mkDerivation,
+  lib,
+  extra-cmake-modules,
+  kdoctools,
+  baloo,
+  baloo-widgets,
+  kactivities,
+  kbookmarks,
+  kcmutils,
+  kcompletion,
+  kconfig,
+  kcoreaddons,
+  kdbusaddons,
+  kfilemetadata,
+  ki18n,
+  kiconthemes,
+  kinit,
+  kio,
+  knewstuff,
+  knotifications,
+  kparts,
+  ktexteditor,
+  kwindowsystem,
+  phonon,
+  solid,
+  kuserfeedback,
+  wayland,
+  qtwayland,
+  qtx11extras,
+  qtimageformats,
 }:
 
 mkDerivation {
@@ -13,20 +36,47 @@ mkDerivation {
   meta = {
     homepage = "https://apps.kde.org/dolphin/";
     description = "KDE file manager";
-    license = with lib.licenses; [ gpl2Plus fdl12Plus ];
+    license = with lib.licenses; [
+      gpl2Plus
+      fdl12Plus
+    ];
     maintainers = [ lib.maintainers.ttuegel ];
   };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
   propagatedUserEnvPkgs = [ baloo ];
   propagatedBuildInputs = [
-    baloo baloo-widgets kactivities kbookmarks kcmutils kcompletion kconfig
-    kcoreaddons kdbusaddons kfilemetadata ki18n kiconthemes
-    kinit kio knewstuff knotifications kparts ktexteditor kwindowsystem
-    phonon solid
+    baloo
+    baloo-widgets
+    kactivities
+    kbookmarks
+    kcmutils
+    kcompletion
+    kconfig
+    kcoreaddons
+    kdbusaddons
+    kfilemetadata
+    ki18n
+    kiconthemes
+    kinit
+    kio
+    knewstuff
+    knotifications
+    kparts
+    ktexteditor
+    kwindowsystem
+    phonon
+    solid
     kuserfeedback
-    wayland qtwayland
+    wayland
+    qtwayland
     qtx11extras
     qtimageformats
   ];
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 }

--- a/pkgs/applications/kde/dolphin.nix
+++ b/pkgs/applications/kde/dolphin.nix
@@ -29,6 +29,9 @@
   qtwayland,
   qtx11extras,
   qtimageformats,
+  kio-extras,
+  kdegraphics-thumbnailers,
+  ffmpegthumbs,
 }:
 
 mkDerivation {
@@ -74,6 +77,9 @@ mkDerivation {
     qtwayland
     qtx11extras
     qtimageformats
+    kio-extras
+    kdegraphics-thumbnailers
+    ffmpegthumbs
   ];
   outputs = [
     "out"


### PR DESCRIPTION
## Description of changes

I'm using dolphin on lxqt and I don't have any thumbnails.  
With the added packages, the thumbnailing now works 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
