### PR TITLE
subsurface: 5.0.10 -> 6.0.5231

### DIFF
--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -25,16 +25,17 @@
 , qtwebengine
 , libXcomposite
 , bluez
+, writeScript
 }:
 
 let
-  version = "5.0.10";
+  version = "6.0.5231";
 
   subsurfaceSrc = (fetchFromGitHub {
     owner = "Subsurface";
     repo = "subsurface";
-    rev = "v${version}";
-    hash = "sha256-KzUBhFGvocaS1VrVT2stvKrj3uVxYka+dyYZUfkIoNs=";
+    rev = "38a0050ac33566dfd34bf94cf1d7ac66034e4118";
+    hash = "sha256-6fNcBF/Ep2xs2z83ZQ09XNb/ZkhK1nUNLChV1x8qh0Y=";
     fetchSubmodules = true;
   });
 
@@ -136,7 +137,25 @@ stdenv.mkDerivation {
     "-DNO_PRINTING=OFF"
   ];
 
-  passthru = { inherit version libdc googlemaps; };
+  passthru = {
+    inherit version libdc googlemaps;
+    updateScript = writeScript "update-subsurface" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p git common-updater-scripts
+
+      set -eu -o pipefail
+      tmpdir=$(mktemp -d)
+      pushd $tmpdir
+      git clone -b current https://github.com/subsurface/subsurface.git
+      cd subsurface
+      # this returns 6.0.????-local
+      new_version=$(./scripts/get-version.sh | cut -d '-' -f 1)
+      new_rev=$(git rev-list -1 HEAD)
+      popd
+      update-source-version subsurface "$new_version" --rev="$new_rev"
+      rm -rf $tmpdir
+    '';
+  };
 
   meta = with lib; {
     description = "Divelog program";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
subsurface changed from tagged releases to nightly builds
from which a somewhat stable release is marked as a "weekly release"
which is published on subsurface-divelog.org
Currently there is no tag on the main repository pointing
to the commit that was used to create the nightly build
that was finally selected as the "weekly release".

Upstream Documentation:
- https://github.com/subsurface/subsurface/releases/tag/v4.9.4
- https://github.com/subsurface/nightly-builds/releases
- https://subsurface-divelog.org/current-release/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
