### PR TITLE
flatpak: Don't propagate $TZDIR into sandbox

### DIFF
--- a/pkgs/by-name/fl/flatpak/unset-env-vars.patch
+++ b/pkgs/by-name/fl/flatpak/unset-env-vars.patch
@@ -1,12 +1,12 @@
-diff --git a/common/flatpak-run.c b/common/flatpak-run.c
 index e3f031d4..ed131c0b 100644
 --- a/common/flatpak-run.c
 +++ b/common/flatpak-run.c
-@@ -571,6 +571,7 @@ static const ExportData default_exports[] = {
+@@ -571,6 +571,8 @@ static const ExportData default_exports[] = {
    {"XKB_CONFIG_ROOT", NULL},
    {"GIO_EXTRA_MODULES", NULL},
    {"GDK_BACKEND", NULL},
 +  {"GDK_PIXBUF_MODULE_FILE", NULL},
++  {"TZDIR", NULL},
    {"VK_ADD_DRIVER_FILES", NULL},
    {"VK_ADD_LAYER_PATH", NULL},
    {"VK_DRIVER_FILES", NULL},


### PR DESCRIPTION
## Description of changes

This fixes https://github.com/NixOS/nixpkgs/issues/238386 by not propagating the TZDIR environment variable into the Flatpak sandbox. Since the value of TZDIR on NixOS is non-standard, and the directory does not exist within the sandbox, programs inside the sandbox that will attempt to access timezone files in TZDIR will fail and then produce wrong output.  

By exclusing TZDIR programs in the Flatpak sandbox will default to the standard default directory which is /usr/share/zoneinfo and where Flatpak org.freedesktop.Platform provides it.

Tested with Kodi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
