### PR TITLE
linuxPackages.nvidia_x11: install libraries with correct sonames

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -185,20 +185,27 @@ installPhase() {
         patchelf --set-rpath "$out/lib:$libPath" "$libname"
       fi
 
-      libname_short=`echo -n "$libname" | sed 's/so\..*/so/'`
+      # Manually create the right symlinks for the libraries.
+      #
+      # We can't just use ldconfig, because it does not create libfoo.so symlinks,
+      # only libfoo.so.1.
+      # Also, the symlink chain must be libfoo.so -> libfoo.so.1 -> libfoo.so.123.45,
+      # or ldconfig will explode.
+      # See: https://github.com/bminor/glibc/blob/6f3f6c506cdaf981a4374f1f12863b98ac7fea1a/elf/ldconfig.c#L854-L877
 
-      if [[ "$libname" != "$libname_short" ]]; then
-        ln -srnf "$libname" "$libname_short"
-      fi
+      libbase=$(basename "$libname")
+      libdir=$(dirname "$libname")
+      soname=$(patchelf --print-soname "$libname")
+      unversioned=${libbase/\.so\.[0-9\.]*/.so}
 
-      if [[ $libname_short =~ libEGL.so || $libname_short =~ libEGL_nvidia.so || $libname_short =~ libGLX.so || $libname_short =~ libGLX_nvidia.so ]]; then
-          major=0
-      else
-          major=1
-      fi
+      if [[ -n "$soname" ]]; then
+        if [[ "$soname" != "$libbase" ]]; then
+          ln -s "$libbase" "$libdir/$soname"
+        fi
 
-      if [[ "$libname" != "$libname_short.$major" ]]; then
-        ln -srnf "$libname" "$libname_short.$major"
+        if [[ "$soname" != "$unversioned" ]]; then
+          ln -s "$soname" "$libdir/$unversioned"
+        fi
       fi
     done
 


### PR DESCRIPTION
## Description of changes

Use the real soname from the library to determine where to link it,
and use a symlink structure that does not make ldconfig explode.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
