### PR TITLE
emscripten: 3.1.64 -> 3.1.73

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -1,53 +1,61 @@
 { lib, stdenv, cmake, python3, fetchFromGitHub, emscripten,
   gtest, lit, nodejs, filecheck
 }:
-
-stdenv.mkDerivation rec {
-  pname = "binaryen";
-  version = "118";
-
-  src = fetchFromGitHub {
+let
+  testsuite = fetchFromGitHub {
     owner = "WebAssembly";
-    repo = "binaryen";
-    rev = "version_${version}";
-    hash = "sha256-akMW3S2/qUyLK8F77EtnaXPDXvIMpkGfNB2jOD6hQho=";
+    repo = "testsuite";
+    rev = "e05365077e13a1d86ffe77acfb1a835b7aa78422";
+    hash = "sha256-yvZ5AZTPUA6nsD3xpFC0VLthiu2CxVto66RTXBXXeJM=";
   };
+in
+  stdenv.mkDerivation rec {
+    pname = "binaryen";
+    version = "119";
 
-  nativeBuildInputs = [ cmake python3 ];
+    src = fetchFromGitHub {
+      owner = "WebAssembly";
+      repo = "binaryen";
+      rev = "version_${version}";
+      hash = "sha256-JYXtN3CW4qm/nnjGRvv3GxQ0x9O9wHtNYQLqHIYTTOA=";
+    };
 
-  preConfigure = ''
-    if [ $doCheck -eq 1 ]; then
-      sed -i '/googletest/d' third_party/CMakeLists.txt
-    else
-      cmakeFlagsArray=($cmakeFlagsArray -DBUILD_TESTS=0)
-    fi
-  '';
+    nativeBuildInputs = [ cmake python3 ];
 
-  nativeCheckInputs = [ gtest lit nodejs filecheck ];
-  checkPhase = ''
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib python3 ../check.py $tests
-  '';
+    preConfigure = ''
+      if [ $doCheck -eq 1 ]; then
+        sed -i '/googletest/d' third_party/CMakeLists.txt
+        rmdir test/spec/testsuite
+        ln -s ${testsuite} test/spec/testsuite
+      else
+        cmakeFlagsArray=($cmakeFlagsArray -DBUILD_TESTS=0)
+      fi
+    '';
 
-  tests = [
-    "version" "wasm-opt" "wasm-dis"
-    "crash" "dylink" "ctor-eval"
-    "wasm-metadce" "wasm-reduce" "spec"
-    "lld" "wasm2js" "validator"
-    "example" "unit"
-    # "binaryenjs" "binaryenjs_wasm" # not building this
-    "lit" "gtest"
-  ];
-  doCheck = stdenv.hostPlatform.isLinux;
+    nativeCheckInputs = [ gtest lit nodejs filecheck ];
+    checkPhase = ''
+      LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib python3 ../check.py $tests
+    '';
 
-  meta = with lib; {
-    homepage = "https://github.com/WebAssembly/binaryen";
-    description = "Compiler infrastructure and toolchain library for WebAssembly, in C++";
-    platforms = platforms.all;
-    maintainers = with maintainers; [ asppsa willcohen ];
-    license = licenses.asl20;
-  };
+    tests = [
+      "version" "wasm-opt" "wasm-dis"
+      "crash" "dylink" "ctor-eval"
+      "wasm-metadce" "wasm-reduce" "spec"
+      "lld" "wasm2js" "validator"
+      "example" "unit"
+      # "binaryenjs" "binaryenjs_wasm" # not building this
+      "lit" "gtest"
+    ];
+    doCheck = stdenv.isLinux;
 
-  passthru.tests = {
-    inherit emscripten;
-  };
-}
+    meta = with lib; {
+      homepage = "https://github.com/WebAssembly/binaryen";
+      description = "Compiler infrastructure and toolchain library for WebAssembly, in C++";
+      platforms = platforms.all;
+      maintainers = with maintainers; [ asppsa willcohen ];
+      license = licenses.asl20;
+    };
+    passthru.tests = {
+      inherit emscripten;
+    };
+  }

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "emscripten";
-  version = "3.1.64";
+  version = "3.1.73";
 
   llvmEnv = symlinkJoin {
     name = "emscripten-llvm-${version}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     name = "emscripten-node-modules-${version}";
     inherit pname version src;
 
-    npmDepsHash = "sha256-2dsIuB6P+Z3wflIsn6QaZvjHeHHGzsFAI3GcP3SfiP4=";
+    npmDepsHash = "sha256-bqxUlxpIH1IAx9RbnaMq4dZW8fy+M/Q02Q7VrW/AKNQ=";
 
     dontBuild = true;
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "emscripten-core";
     repo = "emscripten";
-    hash = "sha256-AbO1b4pxZ7I6n1dRzxhLC7DnXIUnaCK9SbLy96Qxqr0=";
+    hash = "sha256-QlC2k2rhF3/Pz+knnrlBDV8AfHHBSlGr7b9Ae6TNsxY=";
     rev = version;
   };
 
@@ -50,6 +50,9 @@ stdenv.mkDerivation rec {
     runHook preBuild
 
     patchShebangs .
+
+    # emscripten 3.1.67 requires LLVM tip-of-tree instead of LLVM 18
+    sed -i -e "s/EXPECTED_LLVM_VERSION = 20/EXPECTED_LLVM_VERSION = 19/g" tools/shared.py
 
     # fixes cmake support
     sed -i -e "s/print \('emcc (Emscript.*\)/sys.stderr.write(\1); sys.stderr.flush()/g" emcc.py


### PR DESCRIPTION
## Description of changes

Supersedes #340130, embedding that commit as a pre-requisite.

To avoid breakage noted there, also bumps emscripten to latest release.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
