### PR TITLE
xen: patch with XSA-462

### DIFF
--- a/pkgs/applications/virtualization/xen/4.17/default.nix
+++ b/pkgs/applications/virtualization/xen/4.17/default.nix
@@ -16,6 +16,7 @@ let
     with upstreamPatches;
     [
       QUBES_REPRODUCIBLE_BUILDS
+      XSA_462
     ]
   );
 in

--- a/pkgs/applications/virtualization/xen/4.18/default.nix
+++ b/pkgs/applications/virtualization/xen/4.18/default.nix
@@ -16,6 +16,7 @@ let
     with upstreamPatches;
     [
       QUBES_REPRODUCIBLE_BUILDS
+      XSA_462
     ]
   );
 in

--- a/pkgs/applications/virtualization/xen/4.19/default.nix
+++ b/pkgs/applications/virtualization/xen/4.19/default.nix
@@ -18,6 +18,7 @@ let
       QUBES_REPRODUCIBLE_BUILDS
       XSA_460
       XSA_461
+      XSA_462
     ]
   );
 in

--- a/pkgs/applications/virtualization/xen/generic/patches.nix
+++ b/pkgs/applications/virtualization/xen/generic/patches.nix
@@ -134,4 +134,26 @@ in
     cve = [ "CVE-2024-31146" ];
     hash = "sha256-JQWoqf47hy9WXNkVC/LgmjUhkxN0SBF6w8PF4aFZxhM=";
   };
+  # Xen Security Advisory #462: (4.16.6 - 4.19.0)
+  "XSA_462" = xsaPatch {
+    id = "462";
+    title = "x86: Deadlock in vlapic_error()";
+    description = ''
+      In x86's APIC (Advanced Programmable Interrupt Controller) architecture,
+      error conditions are reported in a status register.  Furthermore, the OS
+      can opt to receive an interrupt when a new error occurs.
+
+      It is possible to configure the error interrupt with an illegal vector,
+      which generates an error when an error interrupt is raised.
+
+      This case causes Xen to recurse through vlapic_error().  The recursion
+      itself is bounded; errors accumulate in the the status register and only
+      generate an interrupt when a new status bit becomes set.
+
+      However, the lock protecting this state in Xen will try to be taken
+      recursively, and deadlock.
+    '';
+    cve = [ "CVE-2024-45817" ];
+    hash = "sha256-01lzjaT2f69UfEdTUCkm92DDOmd+Mo8sNPZsHJfgJEM=";
+  };
 }


### PR DESCRIPTION
## Description of changes

- Patches Xen with XSA 462.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Tested, as applicable:
  - XTF PoC test, if available, passes.
  - Nothing seems to immediately explode.
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - **Note:** This is only important if the XSA affects the Xen development libraries.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc