### PR TITLE
[staging] perl540: fix build in stage1, add C locale patch

### DIFF
--- a/pkgs/development/interpreters/perl/fix-build-with-only-C-locale-5.40.0.patch
+++ b/pkgs/development/interpreters/perl/fix-build-with-only-C-locale-5.40.0.patch
@@ -1,0 +1,57 @@
+From bd0ab509f890a6638bd5033ef58526f8c74f7e4b Mon Sep 17 00:00:00 2001
+From: Andrei Horodniceanu <a.horodniceanu@proton.me>
+Date: Wed, 4 Sep 2024 12:46:44 +0300
+Subject: [PATCH] locale.c: Fix compilation on platforms with only a C locale
+
+Signed-off-by: Andrei Horodniceanu <a.horodniceanu@proton.me>
+---
+ AUTHORS  |  1 +
+ locale.c | 16 ++++++++++++++++
+ 2 files changed, 17 insertions(+)
+
+diff --git a/AUTHORS b/AUTHORS
+index b2e0bf2043a9..b196b93bda13 100644
+--- a/AUTHORS
++++ b/AUTHORS
+@@ -103,6 +103,7 @@ Andreas König                  <a.koenig@mind.de>
+ Andreas Marienborg             <andreas.marienborg@gmail.com>
+ Andreas Schwab                 <schwab@suse.de>
+ Andreas Voegele                <andreas@andreasvoegele.com>
++Andrei Horodniceanu            <a.horodniceanu@proton.me>
+ Andrei Yelistratov             <andrew@sundale.net>
+ Andrej Borsenkow               <Andrej.Borsenkow@mow.siemens.ru>
+ Andrew Bettison                <andrewb@zip.com.au>
+diff --git a/locale.c b/locale.c
+index 168b94914318..d764b4b3c11e 100644
+--- a/locale.c
++++ b/locale.c
+@@ -8963,6 +8963,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
+      * categories into our internal indices. */
+     if (map_LC_ALL_position_to_index[0] == LC_ALL_INDEX_) {
+ 
++#    ifdef PERL_LC_ALL_CATEGORY_POSITIONS_INIT
+         /* Use this array, initialized by a config.h constant */
+         int lc_all_category_positions[] = PERL_LC_ALL_CATEGORY_POSITIONS_INIT;
+         STATIC_ASSERT_STMT(   C_ARRAY_LENGTH(lc_all_category_positions)
+@@ -8975,6 +8976,21 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
+             map_LC_ALL_position_to_index[i] =
+                               get_category_index(lc_all_category_positions[i]);
+         }
++#    else
++        /* It is possible for both PERL_LC_ALL_USES_NAME_VALUE_PAIRS and
++         * PERL_LC_ALL_CATEGORY_POSITIONS_INIT not to be defined, e.g. on
++         * systems with only a C locale during ./Configure.  Assume that this
++         * can only happen as part of some sort of bootstrapping so allow
++         * compilation to succeed by ignoring correctness.
++         */
++        for (unsigned int i = 0;
++             i < C_ARRAY_LENGTH(map_LC_ALL_position_to_index);
++             i++)
++        {
++            map_LC_ALL_position_to_index[i] = 0;
++        }
++#    endif
++
+     }
+ 
+     LOCALE_UNLOCK;

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -67,6 +67,9 @@ stdenv.mkDerivation (rec {
     ++ lib.optional ((lib.versions.majorMinor version) == "5.38") ./no-sys-dirs-5.38.0.patch
     ++ lib.optional ((lib.versions.majorMinor version) == "5.40") ./no-sys-dirs-5.40.0.patch
 
+    # Fix compilation on platforms with only a C locale: https://github.com/Perl/perl5/pull/22569
+    ++ lib.optional (version == "5.40.0") ./fix-build-with-only-C-locale-5.40.0.patch
+
     ++ lib.optional stdenv.hostPlatform.isSunOS ./ld-shared.patch
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ ./cpp-precomp.patch ./sw_vers.patch ]
     ++ lib.optional (crossCompiling && (lib.versionAtLeast version "5.40.0")) ./cross540.patch

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -308,8 +308,7 @@ in
       # This is not an issue for the final stdenv, because this perl
       # won't be included in the final stdenv and won't be exported to
       # top-level pkgs as an override either.
-      # FIXME: Pinning this stage to 538 as 540 doesn't build in stage1 atm
-      perl = super.perl538.override { enableThreading = false; enableCrypt = false; };
+      perl = super.perl.override { enableThreading = false; enableCrypt = false; };
     };
 
     # `gettext` comes with obsolete config.sub/config.guess that don't recognize LoongArch64.


### PR DESCRIPTION
## Description of changes

This PR fixes building `perl540` in bootstrap-stage-1 by adding https://github.com/Perl/perl5/pull/22569 from upstream, it also re-adds `perl540` which was replaced by `perl538` in 384f9f83363bce439aba5b345dcdc43e0ac95533

Same patch used by Gentoo:
https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-lang/perl?id=3d29aec46e21a2ce66b39dc08ea8b559943520d2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
