### PR TITLE
libedgetpu: init at 0-unstable-2024-03-14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7188,6 +7188,11 @@
     githubId = 13279982;
     name = "freezeboy";
   };
+  frenetic00 = {
+    github = "frenetic00";
+    githubId = 50942055;
+    name = "frenetic00";
+  };
   Fresheyeball = {
     email = "fresheyeball@gmail.com";
     github = "Fresheyeball";

--- a/pkgs/by-name/li/libedgetpu/package.nix
+++ b/pkgs/by-name/li/libedgetpu/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libusb1,
+  abseil-cpp,
+  flatbuffers,
+  fetchpatch,
+  xxd,
+}:
+let
+  # Tensorflow 2.16.1 requires Flatbuffers 23.5.26
+  # Compile as a shared library
+  flatbuffers_23_5_26 = flatbuffers.overrideAttrs (oldAttrs: rec {
+    version = "23.5.26";
+    cmakeFlags = (oldAttrs.cmakeFlags or [ ]) ++ [ "-DFLATBUFFERS_BUILD_SHAREDLIB=ON" ];
+    NIX_CXXSTDLIB_COMPILE = "-std=c++17";
+    configureFlags = (oldAttrs.configureFlags or [ ]) ++ [ "--enable-shared" ];
+    src = fetchFromGitHub {
+      owner = "google";
+      repo = "flatbuffers";
+      rev = "v${version}";
+      hash = "sha256-e+dNPNbCHYDXUS/W+hMqf/37fhVgEGzId6rhP3cToTE=";
+    };
+  });
+in
+stdenv.mkDerivation {
+  pname = "libedgetpu";
+  version = "0-unstable-2024-03-14";
+
+  src = fetchFromGitHub {
+    owner = "google-coral";
+    repo = "libedgetpu";
+    rev = "e35aed18fea2e2d25d98352e5a5bd357c170bd4d";
+    hash = "sha256-SabiFG/EgspiCFpg8XQs6RjFhrPPUfhILPmYQQA1E2w=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-makefile-to-compile-with-latest-tensorflow.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/google-coral/libedgetpu/pull/66.patch";
+      hash = "sha256-mMODpQmikfXtsQvtgh26cy97EiykYNLngSjidOBt/3I=";
+    })
+  ];
+
+  makeFlags = [
+    "-f"
+    "makefile_build/Makefile"
+    "libedgetpu"
+  ];
+
+  buildInputs = [
+    abseil-cpp
+    libusb1
+    flatbuffers_23_5_26
+  ];
+
+  nativeBuildInputs = [ xxd ];
+
+  NIX_CXXSTDLIB_COMPILE = "-std=c++17";
+
+  TFROOT = fetchFromGitHub {
+    owner = "tensorflow";
+    repo = "tensorflow";
+    rev = "v2.16.1";
+    hash = "sha256-UPvK5Kc/FNVJq3FchN5IIBBObvcHtAPVv0ARzWzA35M=";
+  };
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 out/direct/k8/libedgetpu.so.1.0 -t $out/lib
+    ln -s $out/lib/libedgetpu.so.1.0 $out/lib/libedgetpu.so.1
+    install -Dm444 debian/edgetpu-accelerator.rules $out/lib/udev/rules.d/99-edgetpu-accelerator.rules
+    install -Dm444 tflite/public/*.h -t $out/include
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/google-coral/libedgetpu";
+    description = "Userspace level runtime driver for Coral devices";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ frenetic00 ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds package for [libedgetpu](https://github.com/google-coral/libedgetpu) which is the user space driver for Coral devices.
Fixes #188719 

The package is based on derivations that have been posted in issue #188719
The derivation applies a [patch](https://github.com/google-coral/libedgetpu/pull/66) to the Makefile which allows the library to be built with newer versions of Tensorflow and Flatbuffers.

This as been tested and works with [Frigate 0.13.2](https://github.com/NixOS/nixpkgs/blob/nixos-24.05/nixos/modules/services/video/frigate.nix)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.


For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
