### PR TITLE
treewide: tmpfiles.rules -> tmpfiles.settings

### DIFF
--- a/nixos/modules/programs/ccache.nix
+++ b/nixos/modules/programs/ccache.nix
@@ -33,7 +33,11 @@ in {
   config = lib.mkMerge [
     # host configuration
     (lib.mkIf cfg.enable {
-      systemd.tmpfiles.rules = [ "d ${cfg.cacheDir} 0770 ${cfg.owner} ${cfg.group} -" ];
+      systemd.tmpfiles.settings."10-ccache".${cfg.cacheDir}.d = {
+        user = cfg.owner;
+        inherit (cfg) group;
+        mode = "0770";
+      };
 
       # "nix-ccache --show-stats" and "nix-ccache --clear"
       security.wrappers.nix-ccache = {

--- a/nixos/modules/programs/nncp.nix
+++ b/nixos/modules/programs/nncp.nix
@@ -63,10 +63,18 @@ in {
       log = lib.mkDefault "/var/spool/nncp/log";
     };
 
-    systemd.tmpfiles.rules = [
-      "d ${programCfg.settings.spool} 0770 root ${programCfg.group}"
-      "f ${programCfg.settings.log} 0770 root ${programCfg.group}"
-    ];
+    systemd.tmpfiles.settings."10-nncp" = {
+      ${programCfg.settings.spool}.d = {
+        user = "root";
+        inherit (programCfg) group;
+        mode = "0770";
+      };
+      ${programCfg.settings.log}.f = {
+        user = "root";
+        inherit (programCfg) group;
+        mode = "0770";
+      };
+    };
 
     systemd.services.nncp-config = {
       path = [ pkg ];

--- a/nixos/modules/programs/singularity.nix
+++ b/nixos/modules/programs/singularity.nix
@@ -112,8 +112,12 @@ in
       group = "root";
       source = "${cfg.packageOverriden}/libexec/${cfg.packageOverriden.projectName}/bin/starter-suid.orig";
     };
-    systemd.tmpfiles.rules = lib.mkIf cfg.enableExternalLocalStateDir [
-      "d /var/lib/${cfg.packageOverriden.projectName}/mnt/session 0770 root root -"
-    ];
+    systemd.tmpfiles.settings."10-singularity" = lib.mkIf cfg.enableExternalLocalStateDir {
+      "/var/lib/${cfg.packageOverriden.projectName}/mnt/session".d = {
+        user = "root";
+        group = "root";
+        mode = "0770";
+      };
+    };
   };
 }

--- a/nixos/modules/services/audio/slimserver.nix
+++ b/nixos/modules/services/audio/slimserver.nix
@@ -37,9 +37,10 @@ in {
 
   config = mkIf cfg.enable {
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - slimserver slimserver - -"
-    ];
+    systemd.tmpfiles.settings."10-slimserver".${cfg.dataDir}.d = {
+      user = "slimserver";
+      group = "slimserver";
+    };
 
     systemd.services.slimserver = {
       after = [ "network.target" ];

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -252,11 +252,24 @@ in
         cfg.sshAccess;
     };
     users.groups.btrbk = { };
-    systemd.tmpfiles.rules = [
-      "d /var/lib/btrbk 0750 btrbk btrbk"
-      "d /var/lib/btrbk/.ssh 0700 btrbk btrbk"
-      "f /var/lib/btrbk/.ssh/config 0700 btrbk btrbk - StrictHostKeyChecking=accept-new"
-    ];
+    systemd.tmpfiles.settings."10-btrbk" = {
+      "/var/lib/btrbk".d = {
+        user = "btrbk";
+        group = "btrbk";
+        mode = "0750";
+      };
+      "/var/lib/btrbk/.ssh".d = {
+        user = "btrbk";
+        group = "btrbk";
+        mode = "0700";
+      };
+      "/var/lib/btrbk/.ssh/config".f = {
+        user = "btrbk";
+        group = "btrbk";
+        mode = "0700";
+        argument = "StrictHostKeyChecking=accept-new";
+      };
+    };
     environment.etc = mapAttrs'
       (
         name: instance: {

--- a/nixos/modules/services/backup/duplicity.nix
+++ b/nixos/modules/services/backup/duplicity.nix
@@ -197,7 +197,11 @@ in
         startAt = cfg.frequency;
       };
 
-      tmpfiles.rules = optional (localTarget != null) "d ${localTarget} 0700 root root -";
+      tmpfiles.settings."10-duplicity".${localTarget}.d = {
+        user = "root";
+        group = "root";
+        mode = "0700";
+      };
     };
 
     assertions = singleton {

--- a/nixos/modules/services/backup/postgresql-backup.nix
+++ b/nixos/modules/services/backup/postgresql-backup.nix
@@ -156,9 +156,10 @@ in {
       ];
     }
     (lib.mkIf cfg.enable {
-      systemd.tmpfiles.rules = [
-        "d '${cfg.location}' 0700 postgres - - -"
-      ];
+      systemd.tmpfiles.settings."10-postgresql-backup".${cfg.location}.d = {
+        user = "postgres";
+        mode = "0700";
+      };
     })
     (lib.mkIf (cfg.enable && cfg.backupAll) {
       systemd.services.postgresqlBackup =

--- a/nixos/modules/services/cluster/hadoop/yarn.nix
+++ b/nixos/modules/services/cluster/hadoop/yarn.nix
@@ -141,9 +141,9 @@ in
     (mkIf cfg.yarn.nodemanager.enable {
       # Needed because yarn hardcodes /bin/bash in container start scripts
       # These scripts can't be patched, they are generated at runtime
-      systemd.tmpfiles.rules = [
-        (mkIf cfg.yarn.nodemanager.addBinBash "L /bin/bash - - - - /run/current-system/sw/bin/bash")
-      ];
+      systemd.tmpfiles.settings."10-yarn" = mkIf cfg.yarn.nodemanager.addBinBash {
+        "/bin/bash".L.argument = "/run/current-system/sw/bin/bash";
+      };
 
       systemd.services.yarn-nodemanager = {
         description = "Hadoop YARN NodeManager";

--- a/nixos/modules/services/databases/firebird.nix
+++ b/nixos/modules/services/databases/firebird.nix
@@ -82,10 +82,16 @@ in
 
     environment.systemPackages = [cfg.package];
 
-    systemd.tmpfiles.rules = [
-      "d '${dataDir}' 0700 ${cfg.user} - - -"
-      "d '${systemDir}' 0700 ${cfg.user} - - -"
-    ];
+    systemd.tmpfiles.settings."10-firebird" = {
+      ${dataDir}.d = {
+        inherit (cfg) user;
+        mode = "0700";
+      };
+      ${systemDir}.d = {
+        inherit (cfg) user;
+        mode = "0700";
+      };
+    };
 
     systemd.services.firebird =
       { description = "Firebird Super-Server";

--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -175,9 +175,11 @@ in
       users.groups.scanner.gid = config.ids.gids.scanner;
       networking.firewall.allowedUDPPorts = lib.mkIf config.hardware.sane.openFirewall [ 8612 ];
 
-      systemd.tmpfiles.rules = [
-        "d /var/lock/sane 0770 root scanner - -"
-      ];
+      systemd.tmpfiles.settings."10-sane"."/var/lock/sane".d = {
+        user = "root";
+        group = "scanner";
+        mode = "0770";
+      };
     })
 
     (lib.mkIf config.services.saned.enable {

--- a/nixos/modules/services/hardware/tcsd.nix
+++ b/nixos/modules/services/hardware/tcsd.nix
@@ -127,10 +127,10 @@ in
       ACTION=="add", KERNEL=="tpm[0-9]*", TAG+="systemd"
     '';
 
-    systemd.tmpfiles.rules = [
-      # Initialise the state directory
-      "d ${cfg.stateDir} 0770 ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-tcsd".${cfg.stateDir}.d = {
+      inherit (cfg) user group;
+      mode = "0770";
+    };
 
     systemd.services.tcsd = {
       description = "Manager for Trusted Computing resources";

--- a/nixos/modules/services/hardware/vdr.nix
+++ b/nixos/modules/services/hardware/vdr.nix
@@ -50,10 +50,15 @@ in
 
   config = mkIf cfg.enable {
 
-    systemd.tmpfiles.rules = [
-      "d ${cfg.videoDir} 0755 ${cfg.user} ${cfg.group} -"
-      "Z ${cfg.videoDir} - ${cfg.user} ${cfg.group} -"
-    ];
+    systemd.tmpfiles.settings."10-vdr".${cfg.videoDir} = {
+      d = {
+        inherit (cfg) user group;
+        mode = "0755";
+      };
+      Z = {
+        inherit (cfg) user group;
+      };
+    };
 
     systemd.services.vdr = {
       description = "VDR";

--- a/nixos/modules/services/logging/graylog.nix
+++ b/nixos/modules/services/logging/graylog.nix
@@ -138,9 +138,9 @@ in
     };
     users.groups = lib.mkIf (cfg.user == "graylog") { graylog = {}; };
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.messageJournalDir}' - ${cfg.user} - - -"
-    ];
+    systemd.tmpfiles.settings."10-graylog".${cfg.messageJournalDir}.d = {
+      inherit (cfg) user;
+    };
 
     systemd.services.graylog = {
       description = "Graylog Server";

--- a/nixos/modules/services/logging/heartbeat.nix
+++ b/nixos/modules/services/logging/heartbeat.nix
@@ -55,9 +55,10 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.stateDir}' - nobody nogroup - -"
-    ];
+    systemd.tmpfiles.settings."10-heartbeat".${cfg.stateDir}.d = {
+      user = "nobody";
+      group = "nogroup";
+    };
 
     systemd.services.heartbeat = with pkgs; {
       description = "heartbeat log shipper";

--- a/nixos/modules/services/mail/nullmailer.nix
+++ b/nixos/modules/services/mail/nullmailer.nix
@@ -207,12 +207,17 @@
       groups.${cfg.group} = { };
     };
 
-    systemd.tmpfiles.rules = [
-      "d /var/spool/nullmailer - ${cfg.user} ${cfg.group} - -"
-      "d /var/spool/nullmailer/failed 770 ${cfg.user} ${cfg.group} - -"
-      "d /var/spool/nullmailer/queue 770 ${cfg.user} ${cfg.group} - -"
-      "d /var/spool/nullmailer/tmp 770 ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-nullmailer" = let
+      defaultConfig = {
+        inherit (cfg) user group;
+        mode = "0770";
+      };
+    in {
+      "/var/spool/nullmailer".d = defaultConfig;
+      "/var/spool/nullmailer/failed".d = defaultConfig;
+      "/var/spool/nullmailer/queue".d = defaultConfig;
+      "/var/spool/nullmailer/tmp".d = defaultConfig;
+    };
 
     systemd.services.nullmailer = {
       description = "nullmailer";

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -102,9 +102,9 @@ in {
 
     environment.systemPackages = [ pkgs.opendkim ];
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.keyPath}' - ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-opendkim".${cfg.keyPath}.d = {
+      inherit (cfg) user group;
+    };
 
     systemd.services.opendkim = {
       description = "OpenDKIM signing and verification daemon";

--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -105,11 +105,22 @@ in {
     services.mail.sendmailSetuidWrapper = lib.mkIf cfg.setSendmail
       (security.wrappers.smtpctl // { program = "sendmail"; });
 
-    systemd.tmpfiles.rules = [
-      "d /var/spool/smtpd 711 root - - -"
-      "d /var/spool/smtpd/offline 770 root smtpq - -"
-      "d /var/spool/smtpd/purge 700 smtpq root - -"
-    ];
+    systemd.tmpfiles.settings."10-opensmtpd" = {
+      "/var/spool/smtpd".d = {
+        user = "root";
+        mode = "0711";
+      };
+      "/var/spool/smtpd/offline" = {
+        user = "root";
+        group = "smtpq";
+        mode = "0770";
+      };
+      "/var/spool/smtpd/purge" = {
+        user = "smtpq";
+        group = "root";
+        mode = "0700";
+      };
+    };
 
     systemd.services.opensmtpd = let
       procEnv = pkgs.buildEnv {

--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -179,7 +179,12 @@ in {
     };
     users.groups.apache-kafka = {};
 
-    systemd.tmpfiles.rules = map (logDir: "d '${logDir}' 0700 apache-kafka - - -") cfg.settings."log.dirs";
+    systemd.tmpfiles.settings."10-apache-kafka" = lib.genAttrs (_: {
+      d = {
+        user = "apache-kafka";
+        mode = "0700";
+      };
+    }) cfg.settings."log.dirs";
 
     systemd.services.apache-kafka = {
       description = "Apache Kafka Daemon";

--- a/nixos/modules/services/misc/etebase-server.nix
+++ b/nixos/modules/services/misc/etebase-server.nix
@@ -172,11 +172,17 @@ in
       '')
     ];
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - ${cfg.user} ${config.users.users.${cfg.user}.group} - -"
-    ] ++ lib.optionals (cfg.unixSocket != null) [
-      "d '${builtins.dirOf cfg.unixSocket}' - ${cfg.user} ${config.users.users.${cfg.user}.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-etebase-server" = {
+      ${cfg.dataDir}.d = {
+        inherit (cfg) user;
+        inherit (config.users.users.${cfg.user}) group;
+      };
+    } // (lib.optionalAttrs (cfg.unixSocket != null) {
+      ${builtins.dirOf cfg.unixSocket}.d = {
+        inherit (cfg) user;
+        inherit (config.users.users.${cfg.user}) group;
+      };
+    });
 
     systemd.services.etebase-server = {
       description = "An Etebase (EteSync 2.0) server";

--- a/nixos/modules/services/misc/gollum.nix
+++ b/nixos/modules/services/misc/gollum.nix
@@ -132,7 +132,9 @@ in
 
     users.groups."${cfg.group}" = { };
 
-    systemd.tmpfiles.rules = [ "d '${cfg.stateDir}' - ${cfg.user} ${cfg.group} - -" ];
+    systemd.tmpfiles.settings."10-gollum".${cfg.stateDir}.d = {
+      inherit (cfg) user group;
+    };
 
     systemd.services.gollum = {
       description = "Gollum wiki";

--- a/nixos/modules/services/misc/jackett.nix
+++ b/nixos/modules/services/misc/jackett.nix
@@ -45,9 +45,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-jackett".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+      mode = "0700";
+    };
 
     systemd.services.jackett = {
       description = "Jackett";

--- a/nixos/modules/services/misc/moonraker.nix
+++ b/nixos/modules/services/misc/moonraker.nix
@@ -151,9 +151,14 @@ in {
       fullConfig = lib.recursiveUpdate cfg.settings forcedConfig;
     in format.generate "moonraker.cfg" fullConfig;
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.stateDir}' - ${cfg.user} ${cfg.group} - -"
-    ] ++ lib.optional (cfg.configDir != null) "d '${cfg.configDir}' - ${cfg.user} ${cfg.group} - -";
+    systemd.tmpfiles.settings."10-moonraker" = {
+      ${cfg.stateDir}.d = {
+        inherit (cfg) user group;
+      };
+      ${cfg.configDir}.d = {
+        inherit (cfg) user group;
+      };
+    };
 
     systemd.services.moonraker = {
       description = "Moonraker, an API web server for Klipper";

--- a/nixos/modules/services/misc/nzbhydra2.nix
+++ b/nixos/modules/services/misc/nzbhydra2.nix
@@ -23,8 +23,11 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.tmpfiles.rules =
-      [ "d '${cfg.dataDir}' 0700 nzbhydra2 nzbhydra2 - -" ];
+    systemd.tmpfiles.settings."10-nzbhydra2".${cfg.dataDir}.d = {
+      user = "nzbhydra2";
+      group = "nzbhydra2";
+      mode = "0700";
+    };
 
     systemd.services.nzbhydra2 = {
       description = "NZBHydra2";

--- a/nixos/modules/services/misc/octoprint.nix
+++ b/nixos/modules/services/misc/octoprint.nix
@@ -101,12 +101,14 @@ in
       octoprint.gid = config.ids.gids.octoprint;
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.stateDir}' - ${cfg.user} ${cfg.group} - -"
+    systemd.tmpfiles.settings."10-octoprint" = {
+      ${cfg.stateDir}.d = {
+        inherit (cfg) user group;
+      };
       # this will allow octoprint access to raspberry specific hardware to check for throttling
       # read-only will not work: "VCHI initialization failed" error
-      "a /dev/vchiq - - - - u:octoprint:rw"
-    ];
+      "/dev/vchiq".a.argument = "u:octoprint:rw";
+    };
 
     systemd.services.octoprint = {
       description = "OctoPrint, web interface for 3D printers";

--- a/nixos/modules/services/misc/ombi.nix
+++ b/nixos/modules/services/misc/ombi.nix
@@ -45,9 +45,10 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-ombi".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+      mode = "0700";
+    };
 
     systemd.services.ombi = {
       description = "Ombi";

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -327,28 +327,33 @@ in
     };
 
     # create symlinks for the basic directory layout the redmine package expects
-    systemd.tmpfiles.rules = [
-      "d '${cfg.stateDir}' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/cache' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/config' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/files' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/log' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/plugins' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/public' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/public/plugin_assets' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/public/themes' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/tmp' 0750 ${cfg.user} ${cfg.group} - -"
+    systemd.tmpfiles.settings."10-redmine" = let
+      defaultConfig = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+    in {
+      "${cfg.stateDir}" = defaultConfig;
+      "${cfg.stateDir}/cache" = defaultConfig;
+      "${cfg.stateDir}/config" = defaultConfig;
+      "${cfg.stateDir}/files" = defaultConfig;
+      "${cfg.stateDir}/log" = defaultConfig;
+      "${cfg.stateDir}/plugins" = defaultConfig;
+      "${cfg.stateDir}/public" = defaultConfig;
+      "${cfg.stateDir}/public/plugin_assets" = defaultConfig;
+      "${cfg.stateDir}/public/themes" = defaultConfig;
+      "${cfg.stateDir}/tmp" = defaultConfig;
 
-      "d /run/redmine - - - - -"
-      "d /run/redmine/public - - - - -"
-      "L+ /run/redmine/config - - - - ${cfg.stateDir}/config"
-      "L+ /run/redmine/files - - - - ${cfg.stateDir}/files"
-      "L+ /run/redmine/log - - - - ${cfg.stateDir}/log"
-      "L+ /run/redmine/plugins - - - - ${cfg.stateDir}/plugins"
-      "L+ /run/redmine/public/plugin_assets - - - - ${cfg.stateDir}/public/plugin_assets"
-      "L+ /run/redmine/public/themes - - - - ${cfg.stateDir}/public/themes"
-      "L+ /run/redmine/tmp - - - - ${cfg.stateDir}/tmp"
-    ];
+      "/run/redmine".d = { };
+      "/run/redmine/public".d = { };
+      "/run/redmine/config"."L+".argument = "${cfg.stateDir}/config";
+      "/run/redmine/files"."L+".argument = "${cfg.stateDir}/files";
+      "/run/redmine/log"."L+".argument = "${cfg.stateDir}/log";
+      "/run/redmine/plugins"."L+".argument = "${cfg.stateDir}/plugins";
+      "/run/redmine/public/plugin_assets"."L+".argument = "${cfg.stateDir}/public/plugin_assets";
+      "/run/redmine/public/themes"."L+".argument = "${cfg.stateDir}/public/themes";
+      "/run/redmine/tmp"."L+".argument = "${cfg.stateDir}/tmp";
+    };
 
     systemd.services.redmine = {
       after = [ "network.target" ] ++ optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";

--- a/nixos/modules/services/misc/soft-serve.nix
+++ b/nixos/modules/services/misc/soft-serve.nix
@@ -43,10 +43,8 @@ in
 
   config = mkIf cfg.enable {
 
-    systemd.tmpfiles.rules = [
-      # The config file has to be inside the state dir
-      "L+ ${stateDir}/config.yaml - - - - ${configFile}"
-    ];
+    # The config file has to be inside the state dir
+    systemd.tmpfiles.settings."10-softserve".${stateDir}."L+".argument = configFile;
 
     systemd.services.soft-serve = {
       description = "Soft Serve git server";

--- a/nixos/modules/services/misc/sonarr.nix
+++ b/nixos/modules/services/misc/sonarr.nix
@@ -41,9 +41,10 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-sonarr".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+      mode = "0700";
+    };
 
     systemd.services.sonarr = {
       description = "Sonarr";

--- a/nixos/modules/services/misc/tautulli.nix
+++ b/nixos/modules/services/misc/tautulli.nix
@@ -55,9 +55,9 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-tautulli".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+    };
 
     systemd.services.tautulli = {
       description = "Tautulli Plex Monitor";

--- a/nixos/modules/services/misc/zookeeper.nix
+++ b/nixos/modules/services/misc/zookeeper.nix
@@ -118,10 +118,16 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages = [cfg.package];
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0700 zookeeper - - -"
-      "Z '${cfg.dataDir}' 0700 zookeeper - - -"
-    ];
+    systemd.tmpfiles.settings."10-zookeeper".${cfg.dataDir} = {
+      d = {
+        user = "zookeeper";
+        mode = "0700";
+      };
+      Z = {
+        user = "zookeeper";
+        mode = "0700";
+      };
+    };
 
     systemd.services.zookeeper = {
       description = "Zookeeper Daemon";

--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -128,9 +128,7 @@ in {
       '') cfg.include}
     '';
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - ${cfg.user} - - -"
-    ];
+    systemd.tmpfiles.settings."10-collectd".${cfg.dataDir}.d.user = cfg.user;
 
     systemd.services.collectd = {
       description = "Collectd Monitoring Agent";

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -139,10 +139,18 @@ in
 
     users.groups.aria2.gid = config.ids.gids.aria2;
 
-    systemd.tmpfiles.rules = [
-      "d '${homeDir}' 0770 aria2 aria2 - -"
-      "d '${config.services.aria2.settings.dir}' 0770 aria2 aria2 - -"
-    ];
+    systemd.tmpfiles.settings."10-aria2" = {
+      ${homeDir}.d = {
+        user = "aria2";
+        group = "aria2";
+        mode = "0770";
+      };
+      ${config.services.aria2.settings.dir}.d = {
+        user = "aria2";
+        group = "aria2";
+        mode = "0770";
+      };
+    };
 
     systemd.services.aria2 = {
       description = "aria2 Service";

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -298,7 +298,10 @@ in
       wantedBy = [ "sockets.target" ];
     };
 
-    systemd.tmpfiles.rules = [ "d /run/avahi-daemon - avahi avahi -" ];
+    systemd.tmpfiles.settings."10-avahi-daemon"."/run/avahi-daemon".d = {
+      user = "avahi";
+      group = "avahi";
+    };
 
     systemd.services.avahi-daemon = {
       description = "Avahi mDNS/DNS-SD Stack";

--- a/nixos/modules/services/networking/bee.nix
+++ b/nixos/modules/services/networking/bee.nix
@@ -80,9 +80,10 @@ in {
 
     systemd.packages = [ cfg.package ]; # include the upstream bee.service file
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.settings.data-dir}' 0750 ${cfg.user} ${cfg.group}"
-    ];
+    systemd.tmpfiles.settings."10-bee".${cfg.settings.data-dir}.d = {
+      inherit (cfg) user group;
+      mode = "0750";
+    };
 
     systemd.services.bee = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/networking/coturn.nix
+++ b/nixos/modules/services/networking/coturn.nix
@@ -358,8 +358,10 @@ in {
           Restart = "on-abort";
         };
       };
-    systemd.tmpfiles.rules = [
-      "d  /run/coturn 0700 turnserver turnserver - -"
-    ];
+    systemd.tmpfiles.settings."10-coturn"."/run/coturn".d = {
+      user = "turnserver";
+      group = "turnserver";
+      mode = "0700";
+    };
   }]));
 }

--- a/nixos/modules/services/networking/ntopng.nix
+++ b/nixos/modules/services/networking/ntopng.nix
@@ -138,7 +138,11 @@ in
     # nice to have manual page and ntopng command in PATH
     environment.systemPackages = [ pkgs.ntopng ];
 
-    systemd.tmpfiles.rules = [ "d /var/lib/ntopng 0700 ntopng ntopng -" ];
+    systemd.tmpfiles.settings."10-ntopng"."/var/lib/ntopng".d = {
+      user = "ntopng";
+      group = "ntopng";
+      mode = "0700";
+    };
 
     systemd.services.ntopng = {
       description = "Ntopng Network Monitor";

--- a/nixos/modules/services/networking/quassel.nix
+++ b/nixos/modules/services/networking/quassel.nix
@@ -103,9 +103,7 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - ${user} - - -"
-    ];
+    systemd.tmpfiles.settings."10-quassel".${cfg.dataDir}.d.user = user;
 
     systemd.services.quassel =
       { description = "Quassel IRC client daemon";

--- a/nixos/modules/services/networking/teamspeak3.nix
+++ b/nixos/modules/services/networking/teamspeak3.nix
@@ -139,9 +139,9 @@ in
       gid = config.ids.gids.teamspeak;
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.logPath}' - ${user} ${group} - -"
-    ];
+    systemd.tmpfiles.settings."10-teamspeak3".${cfg.logPath}.d = {
+      inherit user group;
+    };
 
     networking.firewall = mkIf cfg.openFirewall {
       allowedTCPPorts = [ cfg.fileTransferPort ] ++ (map (port:

--- a/nixos/modules/services/networking/wasabibackend.nix
+++ b/nixos/modules/services/networking/wasabibackend.nix
@@ -112,9 +112,10 @@ in {
 
   config = mkIf cfg.enable {
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0770 '${cfg.user}' '${cfg.group}' - -"
-    ];
+    systemd.tmpfiles.settings."10-wasabibackend".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+      mode = "0770";
+    };
 
     systemd.services.wasabibackend = {
       description = "wasabibackend server";

--- a/nixos/modules/services/torrent/peerflix.nix
+++ b/nixos/modules/services/torrent/peerflix.nix
@@ -41,9 +41,9 @@ in {
   ###### implementation
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.stateDir}' - peerflix - - -"
-    ];
+    systemd.tmpfiles.settings."10-peerflix".${cfg.stateDir}.d = {
+      user = "peerflix";
+    };
 
     systemd.services.peerflix = {
       description = "Peerflix Daemon";

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -1112,10 +1112,16 @@ in {
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d ${uploadDir}  0700 ${cfg.user} ${cfg.group} - -"
-      "Z ${uploadDir} ~0700 ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-akkoma".${uploadDir} = {
+      d = {
+        inherit (cfg) user group;
+        mode = "0700";
+      };
+      Z = {
+        inherit (cfg) user group;
+        mode = "~0700";
+      };
+    };
 
     environment.systemPackages = mkIf (cfg.installWrapper) [ userWrapper ];
 

--- a/nixos/modules/services/web-apps/atlassian/confluence.nix
+++ b/nixos/modules/services/web-apps/atlassian/confluence.nix
@@ -163,16 +163,16 @@ in
 
     users.groups.${cfg.group} = {};
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.home}' - ${cfg.user} - - -"
-      "d /run/confluence - - - - -"
+    systemd.tmpfiles.settings."10-confluence" = {
+      ${cfg.home}.d.user = cfg.user;
+      "/run/confluence".d = { };
 
-      "L+ /run/confluence/home - - - - ${cfg.home}"
-      "L+ /run/confluence/logs - - - - ${cfg.home}/logs"
-      "L+ /run/confluence/temp - - - - ${cfg.home}/temp"
-      "L+ /run/confluence/work - - - - ${cfg.home}/work"
-      "L+ /run/confluence/server.xml - - - - ${cfg.home}/server.xml"
-    ];
+      "/run/confluence/home"."L+".argument = cfg.home;
+      "/run/confluence/logs"."L+".argument = "${cfg.home}/logs";
+      "/run/confluence/temp"."L+".argument = "${cfg.home}/temp";
+      "/run/confluence/work"."L+".argument = "${cfg.home}/work";
+      "/run/confluence/server.xml"."L+".argument = "${cfg.home}/server.xml";
+    };
 
     systemd.services.confluence = {
       description = "Atlassian Confluence";

--- a/nixos/modules/services/web-apps/cloudlog.nix
+++ b/nixos/modules/services/web-apps/cloudlog.nix
@@ -480,17 +480,21 @@ in
           };
         };
       };
-      tmpfiles.rules = let
-        group = config.services.nginx.group;
-      in [
-        "d ${cfg.dataDir}                0750 ${cfg.user} ${group} - -"
-        "d ${cfg.dataDir}/updates        0750 ${cfg.user} ${group} - -"
-        "d ${cfg.dataDir}/uploads        0750 ${cfg.user} ${group} - -"
-        "d ${cfg.dataDir}/backup         0750 ${cfg.user} ${group} - -"
-        "d ${cfg.dataDir}/logbook        0750 ${cfg.user} ${group} - -"
-        "d ${cfg.dataDir}/assets/json    0750 ${cfg.user} ${group} - -"
-        "d ${cfg.dataDir}/assets/qslcard 0750 ${cfg.user} ${group} - -"
-      ];
+      tmpfiles.settings."10-cloudlog" = let
+        defaultConfig = {
+          inherit (cfg) user;
+          inherit (config.services.nginx.group) group;
+          mode = "0750";
+        };
+      in {
+        ${cfg.dataDir}.d = defaultConfig;
+        "${cfg.dataDir}/updates".d = defaultConfig;
+        "${cfg.dataDir}/uploads".d = defaultConfig;
+        "${cfg.dataDir}/backup".d = defaultConfig;
+        "${cfg.dataDir}/logbook".d = defaultConfig;
+        "${cfg.dataDir}/assets/json".d = defaultConfig;
+        "${cfg.dataDir}/assets/qslcard".d = defaultConfig;
+      };
     };
 
     users.users."${cfg.user}" = {

--- a/nixos/modules/services/web-apps/dolibarr.nix
+++ b/nixos/modules/services/web-apps/dolibarr.nix
@@ -226,12 +226,24 @@ in
       dolibarr_mailing_limit_sendbyweb = false;
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.stateDir}' 0750 ${cfg.user} ${cfg.group}"
-      "d '${cfg.stateDir}/documents' 0750 ${cfg.user} ${cfg.group}"
-      "f '${cfg.stateDir}/conf.php' 0660 ${cfg.user} ${cfg.group}"
-      "L '${cfg.stateDir}/install.forced.php' - ${cfg.user} ${cfg.group} - ${mkConfigFile "install.forced.php" install}"
-    ];
+    systemd.tmpfiles.settings."10-dolibarr" = {
+      ${cfg.stateDir}.d = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+      "${cfg.stateDir}/documents".d = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+      "${cfg.stateDir}/conf.php".f = {
+        inherit (cfg) user group;
+        mode = "0660";
+      };
+      "${cfg.stateDir}/install.forced.php".L = {
+        inherit (cfg) user group;
+        argument = mkConfigFile "install.forced.php" install;
+      };
+    };
 
     services.mysql = mkIf cfg.database.createLocally {
       enable = mkDefault true;

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -389,9 +389,11 @@ in
     };
 
     users.groups.jitsi-meet = { };
-    systemd.tmpfiles.rules = [
-      "d '/var/lib/jitsi-meet' 0750 root jitsi-meet - -"
-    ];
+    systemd.tmpfiles.settings."10-jitsi-meet"."/var/lib/jitsi-meet".d = {
+      user = "root";
+      group = "jitsi-meet";
+      mode = "0750";
+    };
 
     systemd.services.jitsi-meet-init-secrets = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/kavita.nix
+++ b/nixos/modules/services/web-apps/kavita.nix
@@ -86,10 +86,16 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}'        0750 ${cfg.user} ${cfg.user} - -"
-      "d '${cfg.dataDir}/config' 0750 ${cfg.user} ${cfg.user} - -"
-    ];
+    systemd.tmpfiles.settings."10-kavita" = {
+      ${cfg.dataDir}.d = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+      "${cfg.dataDir}/config".d = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+    };
 
     users = {
       users.${cfg.user} = {

--- a/nixos/modules/services/web-apps/limesurvey.nix
+++ b/nixos/modules/services/web-apps/limesurvey.nix
@@ -330,15 +330,37 @@ in
       } ];
     };
 
-    systemd.tmpfiles.rules = [
-      "d ${stateDir} 0750 ${user} ${group} - -"
-      "d ${stateDir}/tmp 0750 ${user} ${group} - -"
-      "d ${stateDir}/tmp/assets 0750 ${user} ${group} - -"
-      "d ${stateDir}/tmp/runtime 0750 ${user} ${group} - -"
-      "d ${stateDir}/tmp/upload 0750 ${user} ${group} - -"
-      "d ${stateDir}/credentials 0700 ${user} ${group} - -"
-      "C ${stateDir}/upload 0750 ${user} ${group} - ${cfg.package}/share/limesurvey/upload"
-    ];
+    systemd.tmpfiles.settings."10-limesurvey" = {
+      ${stateDir}.d = {
+        inherit user group;
+        mode = "0750";
+      };
+      "${stateDir}/tmp".d = {
+        inherit user group;
+        mode = "0750";
+      };
+      "${stateDir}/tmp/assets".d = {
+        inherit user group;
+        mode = "0750";
+      };
+      "${stateDir}/tmp/runtime".d = {
+        inherit user group;
+        mode = "0750";
+      };
+      "${stateDir}/tmp/upload".d = {
+        inherit user group;
+        mode = "0750";
+      };
+      "${stateDir}/credentials".d = {
+        inherit user group;
+        mode = "0700";
+      };
+      "${stateDir}/upload".C = {
+        inherit user group;
+        mode = "0750";
+        argument = "${cfg.package}/share/limesurvey/upload";
+      };
+    };
 
     systemd.services.limesurvey-init = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/mediawiki.nix
+++ b/nixos/modules/services/web-apps/mediawiki.nix
@@ -589,13 +589,24 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${stateDir}' 0750 ${user} ${group} - -"
-      "d '${cacheDir}' 0750 ${user} ${group} - -"
-    ] ++ optionals (cfg.uploadsDir != null) [
-      "d '${cfg.uploadsDir}' 0750 ${user} ${group} - -"
-      "Z '${cfg.uploadsDir}' 0750 ${user} ${group} - -"
-    ];
+    systemd.tmpfiles.settings."10-mediawiki" = {
+      ${stateDir}.d = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+      ${cacheDir}.d = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+      ${cfg.uploadsDir}.d = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+      ${cfg.uploadsDir}.Z = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+    };
 
     systemd.services.mediawiki-init = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -911,14 +911,20 @@ in {
         };
       };
 
-      systemd.tmpfiles.rules = map (dir: "d ${dir} 0750 nextcloud nextcloud - -") [
+      systemd.tmpfiles.settings."10-nextcloud" = lib.genAttrs [
         "${cfg.home}"
         "${datadir}/config"
         "${datadir}/data"
         "${cfg.home}/store-apps"
-      ] ++ [
-        "L+ ${datadir}/config/override.config.php - - - - ${overrideConfig}"
-      ];
+      ] (dir: {
+        ${dir}.d = {
+          user = "nextcloud";
+          group = "nextcloud";
+          mode = "0750";
+        };
+      }) // {
+        "${datadir}/config/override.config.php"."L+".argument = overrideConfig;
+      };
 
       systemd.services = {
         # When upgrading the Nextcloud package, Nextcloud can report errors such as

--- a/nixos/modules/services/web-apps/pixelfed.nix
+++ b/nixos/modules/services/web-apps/pixelfed.nix
@@ -435,11 +435,17 @@ in {
       '';
     };
 
-    systemd.tmpfiles.rules = [
+    systemd.tmpfiles.settings."10-pixelfed" = {
       # Cache must live across multiple systemd units runtimes.
-      "d ${cfg.runtimeDir}/                         0700 ${user} ${group} - -"
-      "d ${cfg.runtimeDir}/cache                    0700 ${user} ${group} - -"
-    ];
+      ${cfg.runtimeDir}.d = {
+        inherit user group;
+        mode = "0700";
+      };
+      "${cfg.runtimeDir}/cache".d = {
+        inherit user group;
+        mode = "0700";
+      };
+    };
 
     # Enable NGINX to access our phpfpm-socket.
     users.users."${config.services.nginx.user}".extraGroups = [ cfg.group ];

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -224,7 +224,10 @@ in {
           };
         };
 
-        tmpfiles.rules = [ "d '${cfg.dataDir}' 0775 ${cfg.user} ${cfg.group} -" ];
+        tmpfiles.settings."10-rutorrent".${cfg.dataDir}.d = {
+          inherit (cfg) user group;
+          mode = "0775";
+        };
       };
 
       users.groups."${cfg.group}" = {};

--- a/nixos/modules/services/web-apps/trilium.nix
+++ b/nixos/modules/services/web-apps/trilium.nix
@@ -124,10 +124,14 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d  ${cfg.dataDir}            0750 trilium trilium - -"
-      "L+ ${cfg.dataDir}/config.ini -    -       -       - ${configIni}"
-    ];
+    systemd.tmpfiles.settings."10-trilium" = {
+      "${cfg.dataDir}".d = {
+        user = "trilium";
+        group = "trilium";
+        mode = "0750";
+      };
+      "${cfg.dataDir}/config.ini"."L+".argument = configIni;
+    };
 
   }
 

--- a/nixos/modules/services/web-apps/weblate.nix
+++ b/nixos/modules/services/web-apps/weblate.nix
@@ -203,7 +203,7 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    systemd.tmpfiles.rules = [ "L+ ${settingsDir} - - - - ${settings_py}" ];
+    systemd.tmpfiles.settings."10-weblate".${settingsDir}."L+".argument = settings_py;
 
     services.nginx = {
       enable = true;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1373,9 +1373,7 @@ in
     boot.kernelModules = optional (versionAtLeast config.boot.kernelPackages.kernel.version "4.17") "tls";
 
     # do not delete the default temp directories created upon nginx startup
-    systemd.tmpfiles.rules = [
-      "X /tmp/systemd-private-%b-nginx.service-*/tmp/nginx_*"
-    ];
+    systemd.tmpfiles.settings."10-nginx"."/tmp/systemd-private-%b-nginx.service-*/tmp/nginx_*".X = { };
 
     services.logrotate.settings.nginx = mapAttrs (_: mkDefault) {
       files = "/var/log/nginx/*.log";

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -140,7 +140,11 @@ in {
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [ "d '${cfg.dataDir}' 0700 traefik traefik - -" ];
+    systemd.tmpfiles.settings."10-traefik".${cfg.dataDir}.d = {
+      user = "traefik";
+      group = "traefik";
+      mode = "0700";
+    };
 
     systemd.services.traefik = {
       description = "Traefik web server";

--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -187,9 +187,12 @@ in {
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = optional (cfg.runDir != "/run/uwsgi") ''
-      d ${cfg.runDir} 775 ${cfg.user} ${cfg.group}
-    '';
+    systemd.tmpfiles.settings."10-uwsgi" = mkIf (cfg.runDir != "/run/uwsgi") {
+      ${cfg.runDir}.d ={
+        inherit (cfg) user group;
+        mode = "0775";
+      };
+    };
 
     systemd.services.uwsgi = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -436,10 +436,18 @@ in
         };
       };
 
-    systemd.tmpfiles.rules = [
-      "d /run/keys 0750 root ${toString config.ids.gids.keys}"
-      "z /run/keys 0750 root ${toString config.ids.gids.keys}"
-    ];
+    systemd.tmpfiles.settings."10-filesystems"."/run/keys" = {
+      d = {
+        user = "root";
+        group = toString config.ids.gids.keys;
+        mode = "0750";
+      };
+      z = {
+        user = "root";
+        group = toString config.ids.gids.keys;
+        mode = "0750";
+      };
+    };
 
     # Sync mount options with systemd's src/core/mount-setup.c: mount_table.
     boot.specialFileSystems = {

--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -308,7 +308,11 @@ in
     # Note: the following options are also declared in virtualisation.lxc, but
     # the latter can't be simply enabled to reuse the formers, because it
     # does a bunch of unrelated things.
-    systemd.tmpfiles.rules = [ "d /var/lib/lxc/rootfs 0755 root root -" ];
+    systemd.tmpfiles.settings."10-incus"."/var/lib/lxc/rootfs".d = {
+      user = "root";
+      group = "root";
+      mode = "0755";
+    };
 
     security.apparmor = {
       packages = [ cfg.lxcPackage ];

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -524,13 +524,13 @@ in
     # https://libvirt.org/daemons.html#monolithic-systemd-integration
     systemd.sockets.libvirtd.wantedBy = [ "sockets.target" ];
 
-    systemd.tmpfiles.rules = let
+    systemd.tmpfiles.settings."10-libvirtd"."/var/lib/qemu/vhost-user"."L+".argument = let
       vhostUserCollection = pkgs.buildEnv {
         name = "vhost-user";
         paths = cfg.qemu.vhostUserPackages;
         pathsToLink = [ "/share/qemu/vhost-user" ];
       };
-    in [ "L+ /var/lib/qemu/vhost-user - - - - ${vhostUserCollection}/share/qemu/vhost-user" ];
+    in "${vhostUserCollection}/share/qemu/vhost-user";
 
     security.polkit = {
       enable = true;

--- a/nixos/modules/virtualisation/lxc.nix
+++ b/nixos/modules/virtualisation/lxc.nix
@@ -75,7 +75,11 @@ in
     environment.etc."lxc/default.conf".text = cfg.defaultConfig;
     environment.etc."lxc/lxc-net".text = cfg.bridgeConfig;
     environment.pathsToLink = [ "/share/lxc" ];
-    systemd.tmpfiles.rules = [ "d /var/lib/lxc/rootfs 0755 root root -" ];
+    systemd.tmpfiles.settings."10-lxc"."/var/lib/lxc/rootfs".d = {
+      user = "root";
+      group = "root";
+      mode = "0755";
+    };
 
     security.apparmor.packages = [ cfg.package ];
     security.apparmor.policies = {

--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -148,7 +148,11 @@ in {
     # Note: the following options are also declared in virtualisation.lxc, but
     # the latter can't be simply enabled to reuse the formers, because it
     # does a bunch of unrelated things.
-    systemd.tmpfiles.rules = [ "d /var/lib/lxc/rootfs 0755 root root -" ];
+    systemd.tmpfiles.settings."10-lxd"."/var/lib/lxc/rootfs".d = {
+      user = "root";
+      group = "root";
+      mode = "0755";
+    };
 
     security.apparmor = {
       packages = [ cfg.lxcPackage ];

--- a/nixos/modules/virtualisation/waydroid.nix
+++ b/nixos/modules/virtualisation/waydroid.nix
@@ -62,9 +62,12 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d /var/lib/misc 0755 root root -" # for dnsmasq.leases
-    ];
+    # for dnsmasq.leases
+    systemd.tmpfiles.settings."10-waydroid"."/var/lib/misc".d = {
+      user = "root";
+      group = "root";
+      mode = "0755";
+    };
 
     services.dbus.packages = with pkgs; [ waydroid ];
   };

--- a/nixos/modules/virtualisation/xe-guest-utilities.nix
+++ b/nixos/modules/virtualisation/xe-guest-utilities.nix
@@ -9,7 +9,7 @@ in {
   };
   config = lib.mkIf cfg.enable {
     services.udev.packages = [ pkgs.xe-guest-utilities ];
-    systemd.tmpfiles.rules = [ "d /run/xenstored 0755 - - -" ];
+    systemd.tmpfiles.settings."10-xe-guest-utilities"."/run/xenstored".d.mode = "0755";
 
     systemd.services.xe-daemon = {
       description = "xen daemon file";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR rewrites the tmpfile rules to use the structured attrs variant of the tmpfiles option, for a chunk of nixos modules. The change should not have any functional effect.

Continuation #280373 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
