### PR TITLE
Revert "nixos/profiles/base: install vim w/nix-syntax plugin"

### DIFF
--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -19,13 +19,7 @@
     pkgs.cryptsetup # needed for dm-crypt volumes
 
     # Some text editors.
-    (pkgs.vim.customize {
-      name = "vim";
-      vimrcConfig.packages.default = {
-        start = [ pkgs.vimPlugins.vim-nix ];
-      };
-      vimrcConfig.customRC = "syntax on";
-    })
+    pkgs.vim
 
     # Some networking tools.
     pkgs.fuse


### PR DESCRIPTION
Adding custom plugins causes the `vim` command to be a wrapper script running `vim -u ...`, which makes it not load the default ~/.vimrc. (This is analogous to #177375 about neovim.)

As of Vim 9, the syntax-highlighting portion of the nix plugin is upstream; the full plugin is only needed for indentation etc. (see also e261eb152ba8aa72a139a15e9856495ba348f8af). So, using regular pkgs.vim works around this behavior/bug and causes any ~/.vimrc to get loaded, without regressing the syntax highlighting support that motivated the change being reverted here.

This reverts commit 0b5a0cbc69f18f2a123bf4ae0751ee718ef04e53.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
