### PR TITLE
hydrus: use the native test runner

### DIFF
--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -83,43 +83,9 @@ python3Packages.buildPythonPackage rec {
   ];
 
   nativeCheckInputs = with python3Packages; [
-    nose
     mock
     httmock
   ];
-
-  # most tests are failing, presumably because we are not using test.py
-  checkPhase = ''
-    runHook preCheck
-
-    nosetests $src/hydrus/test  \
-      -e TestClientAPI \
-      -e TestClientConstants \
-      -e TestClientDaemons \
-      -e TestClientData \
-      -e TestClientDB \
-      -e TestClientDBDuplicates \
-      -e TestClientDBTags \
-      -e TestClientImageHandling \
-      -e TestClientImportOptions \
-      -e TestClientListBoxes \
-      -e TestClientMigration \
-      -e TestClientNetworking \
-      -e TestClientTags \
-      -e TestClientThreading \
-      -e TestDialogs \
-      -e TestFunctions \
-      -e TestHydrusNetwork \
-      -e TestHydrusNATPunch \
-      -e TestHydrusSerialisable \
-      -e TestHydrusServer \
-      -e TestHydrusSessions \
-      -e TestServer \
-      -e TestClientMetadataMigration \
-      -e TestClientFileStorage \
-
-    runHook postCheck
-  '';
 
   outputs = [ "out" "doc" ];
 
@@ -140,6 +106,7 @@ python3Packages.buildPythonPackage rec {
     mkdir -p $out/bin
     install -m0755 hydrus_server.py $out/bin/hydrus-server
     install -m0755 hydrus_client.py $out/bin/hydrus-client
+    install -m0755 hydrus_test.py $out/bin/hydrus-test
 
     # desktop item
     mkdir -p "$out/share/icons/hicolor/scalable/apps"
@@ -152,6 +119,16 @@ python3Packages.buildPythonPackage rec {
     ln -s ${swftools}/bin/swfrender $out/${python3Packages.python.sitePackages}/bin/swfrender_linux
   '' + ''
     runHook postInstall
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    export QT_QPA_PLATFORM=offscreen
+    export HOME=$(mktemp -d)
+    $out/bin/hydrus-test
+
+    runHook postCheck
   '';
 
   dontWrapQtApps = true;


### PR DESCRIPTION
## Description of changes

This eliminates a nose dependency and lets us actually run all the tests. Even though it throws up exceptions about the missing SWF tools, I have verified that the tests are actually getting run properly (i.e., if you adjust an assertion to compare against bogus values, the build does fail).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
