### PR TITLE
WIP: xen: wrap the XSA descriptions inside <details>

### DIFF
--- a/pkgs/applications/virtualization/xen/generic/default.nix
+++ b/pkgs/applications/virtualization/xen/generic/default.nix
@@ -691,10 +691,16 @@ stdenv.mkDerivation (finalAttrs: {
           # Finally, we write a notice explaining which vulnerabilities this Xen is NOT vulnerable to.
           # This will hopefully give users the peace of mind that their Xen is secure, without needing
           # to search the source code for the XSA patches.
-          + lib.strings.optionalString (writeAdvisoryDescription != [ ]) (
-            "\n\nThis Xen (${version}) has been patched against the following known security vulnerabilities:\n"
-            + lib.strings.removeSuffix "\n" (lib.strings.concatLines writeAdvisoryDescription)
-          );
+          + lib.strings.optionalString (writeAdvisoryDescription != [ ]) ''
+
+
+            <details>
+              <summary>This Xen (${version}) has been patched against the following known security vulnerabilities:</summary>
+
+            ${builtins.concatStringsSep "\n" writeAdvisoryDescription}
+
+            </details>
+          '';
 
         homepage = "https://xenproject.org/";
         downloadPage = "https://downloads.xenproject.org/release/xen/${version}/";

--- a/pkgs/applications/virtualization/xen/generic/default.nix
+++ b/pkgs/applications/virtualization/xen/generic/default.nix
@@ -272,9 +272,9 @@ let
   #  * [CVE-1999-00003](https://www.cve.org/CVERecord?id=CVE-1999-00003)
   writeAdvisoryDescription =
     if (lib.lists.remove null (retrievePatchAttributes [ "xsa" ]) != [ ]) then
-      lib.lists.zipListsWith (a: b: a + b)
-        (lib.lists.zipListsWith (a: b: a + "**" + b + ".**\n  >")
-          (lib.lists.zipListsWith (a: b: "* [Xen Security Advisory #" + a + "](" + b + "): ")
+      lib.lists.zipListsWith (header: description: header + description) # The full patch description item (the header created below + patch.meta.longDescription)
+        (lib.lists.zipListsWith (item: title: item + "**${title}.**\n  >") # The full `header` (item + XSA title)
+          (lib.lists.zipListsWith (number: link: "* [Xen Security Advisory #${number}](${link}): ") # The `item` (number + link + formatting)
             (lib.lists.remove null (retrievePatchAttributes [ "xsa" ]))
             (
               lib.lists.remove null (retrievePatchAttributes [


### PR DESCRIPTION
## Description of changes

This will avoid cluttering the `meta.longDescription` further if there are multiple XSAs being applied. (this will be the case when XSA-462 is applied to 4.19, which is already patched against 460 and 461)

## Things done

- [x] No rebuilds.
- [x] Tested the full description as described in the Xen README.md
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
