### PR TITLE
git-upstream: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/gi/git-upstream/package.nix
+++ b/pkgs/by-name/gi/git-upstream/package.nix
@@ -5,7 +5,7 @@
   nix-update-script,
 }: let
   pname = "git-upstream";
-  version = "1.1.0";
+  version = "1.2.0";
 in
   rustPlatform.buildRustPackage {
     inherit pname version;
@@ -14,17 +14,17 @@ in
       owner = "9999years";
       repo = pname;
       rev = "refs/tags/v${version}";
-      hash = "sha256-Pq0Z1WwrTP7dCwk6V/E0zu9sLLWr3kNuT3aJRZuRzhI=";
+      hash = "sha256-GnsqZSztDLXMO4T16nfcOKMKXap88CJzJ5nObzGwhMA=";
     };
 
-    cargoHash = "sha256-jNpleFrOvt1m2TXTeBXfhTSjWNpCknNoKooF2xsO46w=";
+    cargoHash = "sha256-a12C/fpeo0ZJ0MFQlKHVZER9dVrXF95YI1i8MwCTCJo=";
 
-    meta = with lib; {
+    meta = {
       homepage = "https://github.com/9999years/git-upstream";
       changelog = "https://github.com/9999years/git-upstream/releases/tag/v${version}";
       description = "Shortcut for `git push --set-upstream`";
-      license = [licenses.mit];
-      maintainers = [maintainers._9999years];
+      license = [lib.licenses.mit];
+      maintainers = [lib.maintainers._9999years];
       mainProgram = "git-upstream";
     };
 


### PR DESCRIPTION
## Description of changes

Adds support for a `~/.config/git-upstream/config.toml` configuration file.

See: https://github.com/9999years/git-upstream/releases/tag/v1.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
