### PR TITLE
renpy: 8.2.1 -> 8.3.1

### DIFF
--- a/pkgs/by-name/re/renpy/package.nix
+++ b/pkgs/by-name/re/renpy/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python3,
+  python311,
   pkg-config,
   SDL2,
   libpng,
@@ -22,8 +22,8 @@ let
   # base_version is of the form major.minor.patch
   # vc_version is of the form YYMMDDCC
   # version corresponds to the tag on GitHub
-  base_version = "8.2.1";
-  vc_version = "24030407";
+  base_version = "8.3.1";
+  vc_version = "24090601";
   version = "${base_version}.${vc_version}";
 in
 stdenv.mkDerivation {
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     owner = "renpy";
     repo = "renpy";
     rev = version;
-    hash = "sha256-07Hj8mJGR0+Pn1DQ+sK5YQ3x3CTMsZ5h5yEoz44b2TM=";
+    hash = "sha256-k8mcDzaFngRF3Xl9cinUFU0T9sjxNIVrECUguARJVZ4=";
   };
 
   nativeBuildInputs = [
@@ -42,8 +42,8 @@ stdenv.mkDerivation {
     makeWrapper
     # Ren'Py currently does not compile on Cython 3.x.
     # See https://github.com/renpy/renpy/issues/5359
-    python3.pkgs.cython_0
-    python3.pkgs.setuptools
+    python311.pkgs.cython_0
+    python311.pkgs.setuptools
   ];
 
   buildInputs =
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
       zlib
       harfbuzz
     ]
-    ++ (with python3.pkgs; [
+    ++ (with python311.pkgs; [
       python
       pygame-sdl2
       tkinter
@@ -100,13 +100,13 @@ stdenv.mkDerivation {
     EOF
   '';
 
-  buildPhase = with python3.pkgs; ''
+  buildPhase = with python311.pkgs; ''
     runHook preBuild
     ${python.pythonOnBuildForHost.interpreter} module/setup.py build --parallel=$NIX_BUILD_CORES
     runHook postBuild
   '';
 
-  installPhase = with python3.pkgs; ''
+  installPhase = with python311.pkgs; ''
     runHook preInstall
 
     ${python.pythonOnBuildForHost.interpreter} module/setup.py install_lib -d $out/${python.sitePackages}
@@ -120,7 +120,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  env.NIX_CFLAGS_COMPILE = with python3.pkgs; "-I${pygame-sdl2}/include/${python.libPrefix}";
+  env.NIX_CFLAGS_COMPILE = with python311.pkgs; "-I${pygame-sdl2}/include/${python.libPrefix}";
 
   meta = {
     description = "Visual Novel Engine";

--- a/pkgs/development/python-modules/pygame-sdl2/default.nix
+++ b/pkgs/development/python-modules/pygame-sdl2/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage {
 
   src = fetchurl {
     url = "https://www.renpy.org/dl/${renpy_version}/pygame_sdl2-${version}+renpy${renpy_version}.tar.gz";
-    hash = "sha256-Zib39NyQ1pGVCWPrK5/Tl3dAylUlmKZKxU8pf+OpAdY=";
+    hash = "sha256-bcTrdXWLTCnZQ/fP5crKIPoqJiyz+o6s0PzRChV7TQE=";
   };
 
   # force rebuild of headers needed for install


### PR DESCRIPTION
## Description of changes
Updated renpy from 8.2.1 to 8.3.1. 
Bumped pygame-sdl2's hash. 
Downgrade python3 to python311 due to import error of `gui7` See: https://github.com/renpy/renpy/issues/5682

Fixes #343570 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
