### PR TITLE
superhtml: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16331,6 +16331,12 @@
     githubId = 29493551;
     name = "Josh Peters";
   };
+  petertriho = {
+    email = "mail@petertriho.com";
+    github = "petertriho";
+    githubId = 7420227;
+    name = "Peter Tri Ho";
+  };
   peterwilli = {
     email = "peter@codebuffet.co";
     github = "peterwilli";

--- a/pkgs/by-name/su/superhtml/deps.nix
+++ b/pkgs/by-name/su/superhtml/deps.nix
@@ -1,0 +1,61 @@
+{
+  linkFarm,
+  fetchzip,
+  fetchgit,
+}:
+linkFarm "zig-packages" [
+  {
+    name = "1220b9ce6dc0e1fbcd9e7b406ab164344f81774351495f860a90729187c3c058ef4f";
+    path = fetchgit {
+      url = "https://github.com/kristoff-it/zig-lsp-kit";
+      rev = "b4bf61d7fbf9cf7cfdb6f01b211947d2de3e42fd";
+      hash = "sha256-6mlnPTLBXZQwWXstV+h1PAKtMq8RGcJM2dRJ8NqqqtU=";
+    };
+  }
+  {
+    name = "1220102cb2c669d82184fb1dc5380193d37d68b54e8d75b76b2d155b9af7d7e2e76d";
+    path = fetchzip {
+      url = "https://github.com/ziglibs/diffz/archive/ef45c00d655e5e40faf35afbbde81a1fa5ed7ffb.tar.gz";
+      hash = "sha256-5/3W0Xt9RjsvCb8Q4cdaM8dkJP7CdFro14JJLCuqASo=";
+    };
+  }
+  {
+    name = "12209cde192558f8b3dc098ac2330fc2a14fdd211c5433afd33085af75caa9183147";
+    path = fetchgit {
+      url = "https://github.com/ziglibs/known-folders.git";
+      rev = "0ad514dcfb7525e32ae349b9acc0a53976f3a9fa";
+      hash = "sha256-X+XkFj56MkYxxN9LUisjnkfCxUfnbkzBWHy9pwg5M+g=";
+    };
+  }
+  {
+    name = "122014e78d7c69d93595993b3231f3141368e22634b332b0b91a2fb73a8570f147a5";
+    path = fetchgit {
+      url = "https://github.com/kristoff-it/scripty";
+      rev = "df8c11380f9e9bec34809f2242fb116d27cf39d6";
+      hash = "sha256-qVm8pIfT1mHL1zanqYdFm/6AVH8poXKqLtz4+2j+F/A=";
+    };
+  }
+  {
+    name = "1220f2d8402bb7bbc4786b9c0aad73910929ea209cbd3b063842371d68abfed33c1e";
+    path = fetchgit {
+      url = "https://github.com/kristoff-it/zig-afl-kit";
+      rev = "f003bfe714f2964c90939fdc940d5993190a66ec";
+      hash = "sha256-tJ6Ln1SY4WjFZXUWQmgggsUfkd59QgmIpgdInMuv4PI=";
+    };
+  }
+  {
+    name = "1220010a1edd8631b2644476517024992f8e57f453bdb68668720bb590d168faf7c8";
+    path = fetchgit {
+      url = "https://github.com/allyourcodebase/AFLplusplus";
+      rev = "032984eabf5a35af386a3d0e542df7686da339c1";
+      hash = "sha256-KB3QnKAQQ+5CKvJVrhMveMGpF3NTrlwpIyLHVIB96hs=";
+    };
+  }
+  {
+    name = "12200966011c3dd6979d6aa88fe23061fdc6da1f584a6fb1f7682053a0b01e409dbc";
+    path = fetchzip {
+      url = "https://github.com/AFLplusplus/AFLplusplus/archive/v4.21c.tar.gz";
+      hash = "sha256-DKwPRxSO+JEJYWLldnfrAYqzwqukNzrbo4R5FzJqzzg=";
+    };
+  }
+]

--- a/pkgs/by-name/su/superhtml/package.nix
+++ b/pkgs/by-name/su/superhtml/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  callPackage,
+  fetchFromGitHub,
+  stdenv,
+  zig,
+}:
+stdenv.mkDerivation rec {
+  pname = "superhtml";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "kristoff-it";
+    repo = "superhtml";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-E4IVDYps6K+SdemkfwtTjOE+Rdu8m4Itfd3Kv0XO7qk=";
+  };
+
+  nativeBuildInputs = [
+    zig.hook
+  ];
+
+  postPatch = ''
+    ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
+  '';
+
+  meta = with lib; {
+    description = "HTML Language Server and Templating Language Library";
+    homepage = "https://github.com/kristoff-it/superhtml";
+    license = licenses.mit;
+    mainProgram = "superhtml";
+    maintainers = with maintainers; [ petertriho ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [superhtml](https://github.com/kristoff-it/superhtml) https://github.com/NixOS/nixpkgs/issues/340482

I don't use zig and have never packaged any zig projects before so I'm not sure if this the correct way to do things.

`zon2nix` doesn't work with `superhtml` so I just manually made the `deps.nix` file.

@matdibu @callumio 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
