### PR TITLE
gnu-efi: backport patch to fix memory corruption in rEFInd

### DIFF
--- a/pkgs/development/libraries/gnu-efi/default.nix
+++ b/pkgs/development/libraries/gnu-efi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPackages, fetchFromGitHub, pciutils
+{ lib, stdenv, buildPackages, fetchFromGitHub, fetchpatch, pciutils
 , gitUpdater, fwupd-efi, ipxe, refind, syslinux }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,18 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-xtiKglLXm9m4li/8tqbOsyM6ThwGhyu/g4kw5sC4URY=";
   };
+
+  patches = [
+    # Backport patch fixing memory corruption in rEFInd
+    (fetchpatch {
+      url = "https://github.com/ncroxon/gnu-efi/commit/f5bb548df572c992fe3389a586bec3a19b092c18.diff";
+      hash = "sha256-lImlcFUWKwm3u5srFkZa0QOQzUcpNfqPXOpVlh7d390=";
+    })
+    (fetchpatch {
+      url = "https://github.com/ncroxon/gnu-efi/commit/6b9dae0bef0fab82230a6672eaadd38d739e3e1e.diff";
+      hash = "sha256-1CRD8EY/RGdi7zEQ8NZ+OjA74xZrvNnAkUG8JkJ8/Y4=";
+    })
+  ];
 
   buildInputs = [ pciutils ];
 


### PR DESCRIPTION
## Description of changes

Still need to do some more testing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
