### PR TITLE
emacsPackages: fix build for a few hundred packages

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/elpa2nix.el
+++ b/pkgs/applications/editors/emacs/build-support/elpa2nix.el
@@ -31,3 +31,12 @@ The file can either be a tar file or an Emacs Lisp file."
 
 ;; Allow installing package tarfiles larger than 10MB
 (setq large-file-warning-threshold nil)
+
+(let ((flag (getenv "turnCompilationWarningToError")))
+  (when (and flag
+             (not (string-empty-p flag)))
+    (setq byte-compile-error-on-warn t)))
+
+(let ((flag (getenv "ignoreCompilationError")))
+  (when (string-empty-p flag)
+    (setq byte-compile-debug t)))

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -64,6 +64,8 @@ libBuildHelper.extendMkDerivation' stdenv.mkDerivation (finalAttrs:
 
   setupHook = args.setupHook or setupHook;
 
+  inherit turnCompilationWarningToError ignoreCompilationError;
+
   meta = {
     broken = false;
     platforms = emacs.meta.platforms;
@@ -75,8 +77,6 @@ libBuildHelper.extendMkDerivation' stdenv.mkDerivation (finalAttrs:
 // optionalAttrs (emacs.withNativeCompilation or false) {
 
   addEmacsNativeLoadPath = args.addEmacsNativeLoadPath or true;
-
-  inherit turnCompilationWarningToError ignoreCompilationError;
 
   postInstall = ''
     # Besides adding the output directory to the native load path, make sure

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
@@ -4,6 +4,14 @@ self: super:
 
 let
   libExt = pkgs.stdenv.hostPlatform.extensions.sharedLibrary;
+  inherit (import ./lib-override-helper.nix pkgs lib)
+    addPackageRequires
+    addPackageRequiresIfOlder
+    ignoreCompilationError
+    ignoreCompilationErrorIfOlder
+    mkHome
+    mkHomeIfOlder
+    ;
 in
 {
   cl-lib = null; # builtin
@@ -54,6 +62,64 @@ in
     }
   );
 
+  # native-compiler-error-empty-byte in old versions
+  ada-ref-man = ignoreCompilationErrorIfOlder super.ada-ref-man "2020.1.0.20201129.190419";
+
+  # elisp error in old versions
+  ampc = ignoreCompilationErrorIfOlder super.ampc "0.2.0.20240220.181558";
+
+  auctex = mkHome super.auctex;
+
+  auctex-cont-latexmk = mkHome super.auctex-cont-latexmk;
+
+  auctex-label-numbers = mkHome super.auctex-label-numbers;
+
+  # missing optional dependencies https://codeberg.org/rahguzar/consult-hoogle/issues/4
+  consult-hoogle = addPackageRequiresIfOlder super.consult-hoogle [ self.consult ] "0.2.2";
+
+  # missing optional dependencies https://github.com/jacksonrayhamilton/context-coloring/issues/10
+  context-coloring = addPackageRequires super.context-coloring [ self.js2-mode ];
+
+  cpio-mode = ignoreCompilationError super.cpio-mode; # elisp error
+
+  # fixed in https://git.savannah.gnu.org/cgit/emacs/elpa.git/commit/?h=externals/dbus-codegen&id=cfc46758c6252a602eea3dbc179f8094ea2a1a85
+  dbus-codegen = ignoreCompilationErrorIfOlder super.dbus-codegen "0.1.0.20201127.221326"; # elisp error
+
+  ebdb = super.ebdb.overrideAttrs (
+    finalAttrs: previousAttrs:
+    let
+      applyOrgRoamMissingPatch = lib.versionOlder finalAttrs.version "0.8.22.0.20240205.070828";
+    in
+    {
+      dontUnpack = !applyOrgRoamMissingPatch;
+      patches =
+        if applyOrgRoamMissingPatch then
+          previousAttrs.patches or [ ]
+          ++ [
+            (pkgs.fetchpatch {
+              name = "fix-comilation-error-about-missing-org-roam.patch";
+              url = "https://github.com/girzel/ebdb/commit/058f30a996eb9074feac8f94db4eb49e85ae08f1.patch";
+              hash = "sha256-UI72N3lCgro6bG75sWnbw9truREToQHEzZ1TeQAIMjo=";
+            })
+          ]
+        else
+          previousAttrs.patches or null;
+      preBuild =
+        if applyOrgRoamMissingPatch then
+          previousAttrs.preBuild or ""
+          + "\n"
+          + ''
+            pushd ..
+            local content_directory=$ename-$version
+            src=$PWD/$content_directory.tar
+            tar --create --verbose --file=$src $content_directory
+            popd
+          ''
+        else
+          previousAttrs.preBuild or null;
+    }
+  );
+
   eglot = super.eglot.overrideAttrs (
     finalAttrs: previousAttrs: {
       postInstall =
@@ -99,6 +165,29 @@ in
     };
   });
 
+  notes-mode = (mkHome super.notes-mode).overrideAttrs (old: {
+    dontUnpack = false;
+    buildInputs = old.buildInputs or [ ] ++ [ pkgs.perl ];
+    nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ pkgs.perl ];
+    preInstall =
+      old.preInstall or ""
+      + "\n"
+      + ''
+        patchShebangs --build mkconfig
+        pushd ..
+        local content_directory=$ename-$version
+        src=$PWD/$content_directory.tar
+        tar --create --verbose --file=$src $content_directory
+        popd
+      '';
+    postFixup =
+      old.postFixup or ""
+      + "\n"
+      + ''
+        patchShebangs --host --update $out/share/emacs/site-lisp/elpa/$ename-$version/mkconfig
+      '';
+  });
+
   plz = super.plz.overrideAttrs (old: {
     dontUnpack = false;
     postPatch =
@@ -117,9 +206,21 @@ in
       '';
   });
 
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=32185
+  poke = addPackageRequires super.poke [ self.poke-mode ];
+
   pq = super.pq.overrideAttrs (old: {
     buildInputs = old.buildInputs or [ ] ++ [ pkgs.postgresql ];
   });
+
+  preview-auto = mkHome super.preview-auto;
+
+  preview-tailor = mkHome super.preview-tailor;
+
+  # native-ice https://github.com/mattiase/relint/issues/15
+  relint = ignoreCompilationError super.relint;
+
+  shen-mode = ignoreCompilationErrorIfOlder super.shen-mode "0.1.0.20221221.82050"; # elisp error
 
   # native compilation for tests/seq-tests.el never ends
   # delete tests/seq-tests.el to workaround this
@@ -135,6 +236,26 @@ in
         tar --create --verbose --file=$src $content_directory
       '';
   });
+
+  # https://github.com/alphapapa/taxy.el/issues/3
+  taxy = super.taxy.overrideAttrs (old: {
+    dontUnpack = false;
+    postUnpack =
+      old.postUnpack or ""
+      + "\n"
+      + ''
+        local content_directory=$ename-$version
+        rm --verbose --recursive $content_directory/examples
+        src=$PWD/$content_directory.tar
+        tar --create --verbose --file=$src $content_directory
+      '';
+  });
+
+  tex-parens = mkHomeIfOlder super.tex-parens "0.4.0.20240630.70456";
+
+  timerfunctions = ignoreCompilationErrorIfOlder super.timerfunctions "1.4.2.0.20201129.225252";
+
+  wisitoken-grammar-mode = ignoreCompilationError super.wisitoken-grammar-mode; # elisp error
 
   xeft = super.xeft.overrideAttrs (old: {
     dontUnpack = false;
@@ -153,4 +274,7 @@ in
         rm $outd/xapian-lite.cc $outd/emacs-module.h $outd/emacs-module-prelude.h $outd/demo.gif $outd/Makefile
       '';
   });
+
+  # native-ice https://github.com/mattiase/xr/issues/9
+  xr = ignoreCompilationError super.xr;
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
@@ -217,6 +217,8 @@ in
 
   preview-tailor = mkHome super.preview-tailor;
 
+  psgml = ignoreCompilationError super.psgml; # elisp error
+
   # native-ice https://github.com/mattiase/relint/issues/15
   relint = ignoreCompilationError super.relint;
 

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-packages.nix
@@ -26,7 +26,7 @@ formats commits for you.
 
 self: let
 
-  inherit (import ./lib-override-helper.nix pkgs)
+  inherit (import ./lib-override-helper.nix pkgs lib)
     markBroken
     ;
 

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -26,7 +26,7 @@ formats commits for you.
 
 self: let
 
-  inherit (import ./lib-override-helper.nix pkgs)
+  inherit (import ./lib-override-helper.nix pkgs lib)
     markBroken
     ;
 

--- a/pkgs/applications/editors/emacs/elisp-packages/lib-override-helper.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/lib-override-helper.nix
@@ -1,6 +1,27 @@
-pkgs:
+pkgs: lib:
 
 rec {
+  addPackageRequires =
+    pkg: packageRequires: addPackageRequiresWhen pkg packageRequires (finalAttrs: previousAttrs: true);
+
+  addPackageRequiresIfOlder =
+    pkg: packageRequires: version:
+    addPackageRequiresWhen pkg packageRequires (
+      finalAttrs: previousAttrs: lib.versionOlder finalAttrs.version version
+    );
+
+  addPackageRequiresWhen =
+    pkg: packageRequires: predicate:
+    pkg.overrideAttrs (
+      finalAttrs: previousAttrs: {
+        packageRequires =
+          if predicate finalAttrs previousAttrs then
+            previousAttrs.packageRequires or [ ] ++ packageRequires
+          else
+            previousAttrs.packageRequires or null;
+      }
+    );
+
   buildWithGit =
     pkg:
     pkg.overrideAttrs (previousAttrs: {
@@ -18,6 +39,34 @@ rec {
 
   fix-rtags = pkg: dontConfigure (externalSrc pkg pkgs.rtags);
 
+  fixRequireHelmCore =
+    pkg:
+    pkg.overrideAttrs (previousAttrs: {
+      postPatch =
+        previousAttrs.postPatch or ""
+        + "\n"
+        + ''
+          substituteInPlace $ename.el \
+            --replace-fail "(require 'helm)" "(require 'helm-core)"
+        '';
+    });
+
+  ignoreCompilationError = pkg: ignoreCompilationErrorWhen pkg (finalAttrs: previousAttrs: true);
+
+  ignoreCompilationErrorIfOlder =
+    pkg: version:
+    ignoreCompilationErrorWhen pkg (
+      finalAttrs: previousAttrs: lib.versionOlder finalAttrs.version version
+    );
+
+  ignoreCompilationErrorWhen =
+    pkg: predicate:
+    pkg.overrideAttrs (
+      finalAttrs: previousAttrs: {
+        ignoreCompilationError = predicate finalAttrs previousAttrs;
+      }
+    );
+
   markBroken =
     pkg:
     pkg.overrideAttrs (previousAttrs: {
@@ -26,13 +75,24 @@ rec {
       };
     });
 
-  mkHome =
-    pkg:
-    pkg.overrideAttrs (previousAttrs: {
-      preInstall =
-        ''
-          HOME=$(mktemp -d)
-        ''
-        + previousAttrs.preInstall or "";
-    });
+  mkHome = pkg: mkHomeWhen pkg (finalAttrs: previousAttrs: true);
+
+  mkHomeIfOlder =
+    pkg: version:
+    mkHomeWhen pkg (finalAttrs: previousAttrs: lib.versionOlder finalAttrs.version version);
+
+  mkHomeWhen =
+    pkg: predicate:
+    pkg.overrideAttrs (
+      finalAttrs: previousAttrs: {
+        preInstall =
+          if predicate finalAttrs previousAttrs then
+            ''
+              HOME=$(mktemp -d)
+            ''
+            + previousAttrs.preInstall or ""
+          else
+            previousAttrs.preInstall or null;
+      }
+    );
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/acm-terminal/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/acm-terminal/package.nix
@@ -23,8 +23,6 @@ melpaBuild {
     popon
   ];
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/acm/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/acm/package.nix
@@ -15,8 +15,6 @@ melpaBuild {
 
   files = ''("acm/*.el" "acm/icons")'';
 
-  ignoreCompilationError = false;
-
   meta = {
     description = "Asynchronous Completion Menu";
     homepage = "https://github.com/manateelazycat/lsp-bridge";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/agda2-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/agda2-mode/package.nix
@@ -8,8 +8,6 @@ melpaBuild {
 
   files = ''("src/data/emacs-mode/*.el")'';
 
-  ignoreCompilationError = false;
-
   meta = {
     inherit (Agda.meta) homepage license;
     description = "Agda2-mode for Emacs extracted from Agda package";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/cask/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/cask/package.nix
@@ -46,8 +46,6 @@ melpaBuild (finalAttrs: {
     shut-up
   ];
 
-  ignoreCompilationError = false;
-
   strictDeps = true;
 
   # use melpaVersion so that it works for unstable releases too

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/codeium/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/codeium/default.nix
@@ -25,8 +25,6 @@ melpaBuild {
     })
   ];
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = gitUpdater { };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/color-theme-solarized/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/color-theme-solarized/package.nix
@@ -16,6 +16,9 @@ melpaBuild {
     hash = "sha256-7E8r56dzfD06tsQEnqU5mWSbwz9x9QPbzken2J/fhlg=";
   };
 
+  # https://github.com/NixOS/nixpkgs/issues/335408
+  ignoreCompilationError = true;
+
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/consult-gh/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/consult-gh/default.nix
@@ -30,8 +30,6 @@ melpaBuild {
 
   propagatedUserEnvPkgs = [ gh ];
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/control-lock/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/control-lock/package.nix
@@ -13,8 +13,6 @@ melpaBuild {
     hash = "sha256-JCrmS3FSGDHSR+eAR0X/uO0nAgd3TUmFxwEVH5+KV+4=";
   };
 
-  ignoreCompilationError = false;
-
   meta = {
     homepage = "https://www.emacswiki.org/emacs/control-lock.el";
     description = "Like caps-lock, but for your control key";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/package.nix
@@ -30,8 +30,6 @@ melpaBuild {
 
   propagatedUserEnvPkgs = [ nodejs ];
 
-  ignoreCompilationError = false;
-
   meta = {
     description = "Unofficial copilot plugin for Emacs";
     homepage = "https://github.com/copilot-emacs/copilot.el";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ebuild-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ebuild-mode/package.nix
@@ -13,8 +13,6 @@ melpaBuild rec {
     hash = "sha256-GFEDWT88Boz/DxEcmFgf7u2NOoMjAN05yRiYwoYtvXc=";
   };
 
-  ignoreCompilationError = false;
-
   meta = {
     homepage = "https://gitweb.gentoo.org/proj/ebuild-mode.git/";
     description = "Major modes for Gentoo package files";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/package.nix
@@ -21,8 +21,6 @@ melpaBuild {
 
   files = ''(:defaults "msg")'';
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elisp-ffi/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elisp-ffi/package.nix
@@ -29,8 +29,6 @@ melpaBuild {
     make CXX=$CXX
   '';
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-conflict/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-conflict/package.nix
@@ -16,8 +16,6 @@ melpaBuild {
     hash = "sha256-DIGvnotSQYIgHxGxtyCALHd8ZbrfkmdvjLXlkcqQ6v4=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/evil-markdown/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/evil-markdown/package.nix
@@ -23,8 +23,6 @@ melpaBuild {
     markdown-mode
   ];
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/font-lock-plus/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/font-lock-plus/package.nix
@@ -17,8 +17,6 @@ melpaBuild {
     hash = "sha256-er+knxqAejgKAtOnhqHfsGN286biHFdeMIUlbW7JyYw=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/git-undo/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/git-undo/package.nix
@@ -16,8 +16,6 @@ melpaBuild {
     hash = "sha256-xwVCAdxnIRHrFNWvtlM3u6CShsUiGgl1CiBTsp2x7IM=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/gn-mode-from-sources/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/gn-mode-from-sources/package.nix
@@ -18,8 +18,6 @@ melpaBuild {
       --replace-fail ";;; gn-mode.el - " ";;; gn-mode.el --- "
   '';
 
-  ignoreCompilationError = false;
-
   meta = {
     inherit (gn.meta) homepage license;
     maintainers = with lib.maintainers; [ rennsax ];

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/grid/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/grid/package.nix
@@ -16,8 +16,6 @@ melpaBuild {
     hash = "sha256-3QDw4W3FbFvb2zpkDHAo9BJKxs3LaehyvUVJPKqS9RE=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/helm-words/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/helm-words/package.nix
@@ -22,8 +22,6 @@ melpaBuild {
     helm
   ];
 
-  ignoreCompilationError = false;
-
   meta = {
     homepage = "https://github.com/emacsmirror/helm-words";
     description = "Helm extension for looking up words in dictionaries and thesauri";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/hsc3-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/hsc3-mode/package.nix
@@ -16,8 +16,6 @@ melpaBuild {
 
   packageRequires = [ haskell-mode ];
 
-  ignoreCompilationError = false;
-
   meta = {
     inherit (hsc3.meta) homepage license;
     description = "Emacs mode for hsc3";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/icicles/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/icicles/package.nix
@@ -16,8 +16,6 @@ melpaBuild {
     hash = "sha256-Xbt0D9EgmvN1hDTeLbdxq1ARHObj8M4GfH2sbFILRTI=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/idris2-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/idris2-mode/package.nix
@@ -24,8 +24,6 @@ melpaBuild {
     prop-menu
   ];
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = gitUpdater { };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/isearch-plus/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/isearch-plus/package.nix
@@ -17,8 +17,6 @@ melpaBuild {
     hash = "sha256-h/jkIWjkLFbtBp9F+lhA3CulYy2XaeloLmexR0CDm3E=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/isearch-prop/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/isearch-prop/package.nix
@@ -16,8 +16,6 @@ melpaBuild {
     hash = "sha256-Xli7TxBenl5cDMJv3Qz7ZELFpvJKStMploLpf9a+uoA=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/jam-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/jam-mode/package.nix
@@ -27,8 +27,6 @@ melpaBuild rec {
     mv tmp.el jam-mode.el
   '';
 
-  ignoreCompilationError = false;
-
   meta = {
     description = "Emacs major mode for editing Jam files";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/llvm-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/llvm-mode/package.nix
@@ -9,8 +9,6 @@ melpaBuild {
      "llvm/utils/emacs/README")
   '';
 
-  ignoreCompilationError = false;
-
   meta = {
     inherit (llvmPackages.llvm.meta) homepage license;
     description = "Major mode for the LLVM assembler language";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lsp-bridge/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lsp-bridge/default.nix
@@ -86,8 +86,6 @@ melpaBuild {
 
   __darwinAllowLocalNetworking = true;
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/package.nix
@@ -24,8 +24,6 @@ melpaBuild {
   # to compile lspce.el, it needs lspce-module.so
   files = ''(:defaults "${lib.getLib lspce-module}/lib/lspce-module.*")'';
 
-  ignoreCompilationError = false;
-
   passthru = {
     inherit lspce-module;
     updateScript = nix-update-script {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/mu4e/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/mu4e/package.nix
@@ -26,8 +26,6 @@ elpaBuild {
     tar --create --verbose --file=$src $content_directory
   '';
 
-  ignoreCompilationError = false;
-
   meta = removeAttrs mu.meta [ "mainProgram" ] // {
     description = "Full-featured e-mail client";
     maintainers = mu.meta.maintainers ++ (with lib.maintainers; [ linj ]);

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/notdeft/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/notdeft/package.nix
@@ -59,8 +59,6 @@ melpaBuild {
     install -D --target-directory=$out/bin notdeft-xapian
   '';
 
-  ignoreCompilationError = false;
-
   passthru = {
     updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
   };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ott-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ott-mode/package.nix
@@ -15,8 +15,6 @@ melpaBuild {
     popd
   '';
 
-  ignoreCompilationError = false;
-
   meta = {
     description = "Emacs ott mode (from ott sources)";
     inherit (ott.meta) homepage license;

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/pod-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/pod-mode/package.nix
@@ -26,8 +26,6 @@ melpaBuild {
     install -Dm644 -t ''${!outputDoc}/share/doc/pod-mode/ ChangeLog README
   '';
 
-  ignoreCompilationError = false;
-
   meta = {
     homepage = "https://metacpan.org/dist/pod-mode";
     description = "Major mode for editing .pod-files";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/prisma-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/prisma-mode/package.nix
@@ -22,8 +22,6 @@ melpaBuild {
     hash = "sha256-DJJfjbu27Gi7Nzsa1cdi8nIQowKH8ZxgQBwfXLB0Q/I=";
   };
 
-  ignoreCompilationError = false;
-
   meta = {
     description = "Major mode for Prisma Schema Language";
     license = lib.licenses.gpl2Only;

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/prolog-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/prolog-mode/package.nix
@@ -19,8 +19,6 @@ melpaBuild {
       --replace-fail ";; prolog.el ---" ";;; prolog.el ---"
   '';
 
-  ignoreCompilationError = false;
-
   meta = {
     homepage = "https://bruda.ca/emacs/prolog_mode_for_emacs/";
     description = "Prolog mode for Emacs";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/rect-mark/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/rect-mark/package.nix
@@ -19,8 +19,6 @@ melpaBuild {
     hash = "sha256-/8T1VTYkKUxlNWXuuS54S5jpl4UxJBbgSuWc17a/VyM=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = gitUpdater { };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/session-management-for-emacs/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/session-management-for-emacs/package.nix
@@ -14,6 +14,9 @@ melpaBuild rec {
     hash = "sha256-lc6NIX+lx97qCs5JqG7x0iVE6ki09Gy7DEQuPW2c+7s=";
   };
 
+  # https://github.com/NixOS/nixpkgs/issues/335421
+  ignoreCompilationError = true;
+
   meta = {
     /*
       installation: add to your ~/.emacs

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/sunrise-commander/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/sunrise-commander/package.nix
@@ -17,8 +17,6 @@ melpaBuild {
     hash = "sha256-D36qiRi5OTZrBtJ/bD/javAWizZ8NLlC/YP4rdLCSsw=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/sv-kalender/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/sv-kalender/package.nix
@@ -13,8 +13,6 @@ melpaBuild {
     hash = "sha256-VXz3pO6N94XM8FzLSAoYrj3NEh4wp0UiuG6ad8M7nVU=";
   };
 
-  ignoreCompilationError = false;
-
   meta = {
     homepage = "https://www.emacswiki.org/emacs/sv-kalender.el";
     description = "Swedish calendar for Emacs";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/texpresso/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/texpresso/default.nix
@@ -10,8 +10,6 @@ melpaBuild {
 
   files = ''("emacs/*.el")'';
 
-  ignoreCompilationError = false;
-
   meta = {
     inherit (texpresso.meta) homepage license;
     description = "Emacs mode for TeXpresso";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tree-sitter-langs/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tree-sitter-langs/default.nix
@@ -44,8 +44,6 @@ melpaStablePackages.tree-sitter-langs.overrideAttrs(old: {
           fi
         '') plugins);
 
-  ignoreCompilationError = false;
-
   passthru = old.passthru or {} // {
     inherit plugins;
     withPlugins = fn: final.tree-sitter-langs.override { plugins = fn tree-sitter-grammars; };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/package.nix
@@ -42,8 +42,6 @@ in melpaBuild {
 
   files = ''("core/*.el" "${tsc-dyn}/lib/*")'';
 
-  ignoreCompilationError = false;
-
   passthru = {
     inherit tsc-dyn;
     updateScript = nix-update-script { attrPath = "emacsPackages.tsc.tsc-dyn"; };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/urweb-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/urweb-mode/package.nix
@@ -20,8 +20,6 @@ melpaBuild {
 
   dontConfigure = true;
 
-  ignoreCompilationError = false;
-
   meta = {
     description = "Major mode for editing Ur/Web";
     inherit (urweb.meta) license homepage;

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/voicemacs/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/voicemacs/package.nix
@@ -49,8 +49,6 @@ melpaBuild {
     el-patch
   ];
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wat-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wat-mode/package.nix
@@ -16,8 +16,6 @@ melpaBuild {
     hash = "sha256-jV5V3TRY+D3cPSz3yFwVWn9yInhGOYIaUTPEhsOBxto=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/yes-no/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/yes-no/package.nix
@@ -13,8 +13,6 @@ melpaBuild {
     hash = "sha256-ceCOBFfixmGVB3kaSvOv1YZThC2pleYnS8gXhLrjhA8=";
   };
 
-  ignoreCompilationError = false;
-
   meta = {
     homepage = "https://www.emacswiki.org/emacs/yes-no.el";
     description = "Specify use of `y-or-n-p' or `yes-or-no-p' on a case-by-case basis";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/youtube-dl/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/youtube-dl/package.nix
@@ -16,8 +16,6 @@ melpaBuild {
     hash = "sha256-Etl95rcoRACDPjcTPQqYK2L+w8OZbOrTrRT0JadMdH4=";
   };
 
-  ignoreCompilationError = false;
-
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -30,7 +30,7 @@ in
 
 { lib, pkgs }: variant: self:
 let
-  inherit (import ./lib-override-helper.nix pkgs)
+  inherit (import ./lib-override-helper.nix pkgs lib)
     buildWithGit
     dontConfigure
     externalSrc

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -31,11 +31,16 @@ in
 { lib, pkgs }: variant: self:
 let
   inherit (import ./lib-override-helper.nix pkgs lib)
+    addPackageRequires
+    addPackageRequiresIfOlder
     buildWithGit
     dontConfigure
     externalSrc
     fix-rtags
+    fixRequireHelmCore
+    ignoreCompilationError
     markBroken
+    mkHome
     ;
 
   generateMelpa = lib.makeOverridable ({ archiveJson ? defaultArchive
@@ -131,7 +136,7 @@ let
 
       } // {
         # Expects bash to be at /bin/bash
-        ac-rtags = fix-rtags super.ac-rtags;
+        ac-rtags = ignoreCompilationError (fix-rtags super.ac-rtags); # elisp error
 
         age = super.age.overrideAttrs (attrs: {
           postPatch = attrs.postPatch or "" + ''
@@ -144,7 +149,8 @@ let
           inherit (self.melpaPackages) powerline;
         };
 
-        auto-complete-clang-async = super.auto-complete-clang-async.overrideAttrs (old: {
+        # https://github.com/Golevka/emacs-clang-complete-async/issues/90
+        auto-complete-clang-async = (addPackageRequires super.auto-complete-clang-async [ self.auto-complete ]).overrideAttrs (old: {
           buildInputs = old.buildInputs ++ [ pkgs.llvmPackages.llvm ];
           CFLAGS = "-I${pkgs.llvmPackages.libclang.lib}/include";
           LDFLAGS = "-L${pkgs.llvmPackages.libclang.lib}/lib";
@@ -157,7 +163,7 @@ let
         # upstream issue: missing package version
         cmake-mode = dontConfigure super.cmake-mode;
 
-        company-rtags = fix-rtags super.company-rtags;
+        company-rtags = ignoreCompilationError (fix-rtags super.company-rtags); # elisp error
 
         easy-kill-extras = super.easy-kill-extras.override {
           inherit (self.melpaPackages) easy-kill;
@@ -226,7 +232,7 @@ let
           inherit (self.melpaPackages) ess ctable popup;
         };
 
-        flycheck-rtags = fix-rtags super.flycheck-rtags;
+        flycheck-rtags = ignoreCompilationError (fix-rtags super.flycheck-rtags); # elisp error
 
         pdf-tools = super.pdf-tools.overrideAttrs (old: {
           # Temporary work around for:
@@ -313,7 +319,7 @@ let
           HOME = "/tmp";
         });
 
-        ivy-rtags = fix-rtags super.ivy-rtags;
+        ivy-rtags = ignoreCompilationError (fix-rtags super.ivy-rtags); # elisp error
 
         jinx = super.jinx.overrideAttrs (old: let
           libExt = pkgs.stdenv.hostPlatform.extensions.sharedLibrary;
@@ -392,7 +398,7 @@ let
 
         magit-tbdiff = buildWithGit super.magit-tbdiff;
 
-        magit-topgit = buildWithGit super.magit-topgit;
+        magit-topgit = ignoreCompilationError (buildWithGit super.magit-topgit); # elisp error
 
         magit-vcsh = buildWithGit super.magit-vcsh;
 
@@ -406,7 +412,7 @@ let
 
         magit-gitflow = buildWithGit super.magit-gitflow;
 
-        magithub = buildWithGit super.magithub;
+        magithub = ignoreCompilationError (buildWithGit super.magithub); # elisp error
 
         magit-svn = buildWithGit super.magit-svn;
 
@@ -426,9 +432,7 @@ let
 
         jist = buildWithGit super.jist;
 
-        mandoku = buildWithGit super.mandoku;
-
-        mandoku-tls = buildWithGit super.mandoku-tls;
+        mandoku = addPackageRequires super.mandoku [ self.git ]; # upstream is archived
 
         magit-p4 = buildWithGit super.magit-p4;
 
@@ -465,7 +469,8 @@ let
         });
 
         # upstream issue: missing file header
-        mhc = super.mhc.override {
+        # elisp error
+        mhc = (ignoreCompilationError super.mhc).override {
           inherit (self.melpaPackages) calfw;
         };
 
@@ -482,7 +487,7 @@ let
           '';
         });
 
-        rtags = dontConfigure (externalSrc super.rtags pkgs.rtags);
+        rtags = ignoreCompilationError (dontConfigure (externalSrc super.rtags pkgs.rtags)); # elisp error
 
         rtags-xref = dontConfigure super.rtags;
 
@@ -496,12 +501,21 @@ let
           '';
         });
 
-        shm = super.shm.overrideAttrs (attrs: {
-          propagatedUserEnvPkgs = [ pkgs.haskellPackages.structured-haskell-mode ];
-        });
+        # https://github.com/projectional-haskell/structured-haskell-mode/issues/165
+        shm =
+          (addPackageRequires super.shm [
+            self.haskell-mode
+            self.hindent
+          ]).overrideAttrs
+            (attrs: {
+              propagatedUserEnvPkgs = attrs.propagatedUserEnvPkgs or [ ] ++ [
+                pkgs.haskellPackages.structured-haskell-mode
+              ];
+            });
 
         # Telega has a server portion for it's network protocol
-        telega = super.telega.overrideAttrs (old: {
+        # elisp error
+        telega = (ignoreCompilationError super.telega).overrideAttrs (old: {
           buildInputs = old.buildInputs ++ [ pkgs.tdlib ];
           nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.pkg-config ];
 
@@ -640,7 +654,7 @@ let
           ];
         });
 
-        helm-rtags = fix-rtags super.helm-rtags;
+        helm-rtags = ignoreCompilationError (fix-rtags super.helm-rtags); # elisp error
 
         # tries to write to $HOME
         php-auto-yasnippets = super.php-auto-yasnippets.overrideAttrs (attrs: {
@@ -718,6 +732,809 @@ let
             '';
           })
           else super.osx-dictionary;
+
+        abgaben = addPackageRequires (mkHome super.abgaben) [ self.mu4e ];
+
+        # https://github.com/afroisalreadyinu/abl-mode/issues/9
+        abl-mode = addPackageRequires super.abl-mode [ self.f ];
+
+        ac-php-core = super.ac-php-core.overrideAttrs (old: {
+          # empty file causing native-compiler-error-empty-byte
+          preBuild =
+            ''
+              rm --verbose ac-php-comm-tags-data.el
+            ''
+            + old.preBuild or "";
+        });
+
+        # Optimizer error: too much on the stack
+        ack-menu = ignoreCompilationError super.ack-menu;
+
+        # https://github.com/gongo/airplay-el/issues/2
+        airplay = addPackageRequires super.airplay [ self.request-deferred ];
+
+        # https://github.com/melpa/melpa/pull/9185
+        alectryon = super.alectryon.overrideAttrs (old: {
+          preBuild =
+            old.preBuild or ""
+            + "\n"
+            + ''
+              rm --recursive --verbose etc/elisp/screenshot
+            '';
+        });
+
+        # https://github.com/gergelypolonkai/alert-termux/issues/2
+        alert-termux = addPackageRequires super.alert-termux [ self.alert ];
+
+        # https://github.com/magnars/angular-snippets.el/issues/7
+        angular-snippets = addPackageRequires super.angular-snippets [ self.yasnippet ];
+
+        # https://github.com/ragone/asx/pull/3
+        asx = addPackageRequires super.asx [ self.request ];
+
+        auctex-cluttex = mkHome super.auctex-cluttex;
+
+        auctex-latexmk = mkHome super.auctex-latexmk;
+
+        auto-indent-mode = ignoreCompilationError super.auto-indent-mode; # elisp error
+
+        # missing optional dependencies
+        auto-complete-auctex = addPackageRequires (mkHome super.auto-complete-auctex) [ self.auctex ];
+
+        # depends on distel which is not on any ELPA https://github.com/massemanet/distel/issues/21
+        auto-complete-distel = ignoreCompilationError super.auto-complete-distel;
+
+        aws-ec2 = ignoreCompilationError super.aws-ec2; # elisp error
+
+        badger-theme = ignoreCompilationError super.badger-theme; # elisp error
+
+        # https://github.com/BinaryAnalysisPlatform/bap-mode/pull/4
+        bap-mode = fixRequireHelmCore (addPackageRequires super.bap-mode [ self.helm-core ]);
+
+        # try to open non-existent ~/.emacs.d/.blog_minimal.config during compilation
+        blog-minimal = ignoreCompilationError super.blog-minimal;
+
+        boa-mode = ignoreCompilationError super.boa-mode; # elisp error
+
+        # missing optional dependencies
+        boogie-friends = addPackageRequires super.boogie-friends [ self.lsp-mode ];
+
+        # https://github.com/melpa/melpa/pull/9181
+        bpr = super.bpr.overrideAttrs (old: {
+          preBuild =
+            old.preBuild or ""
+            + "\n"
+            + ''
+              rm --verbose --force test-bpr.el
+            '';
+        });
+
+        bts = ignoreCompilationError super.bts; # elisp error
+
+        bts-github = ignoreCompilationError super.bts-github; # elisp error
+
+        buffer-buttons = ignoreCompilationError super.buffer-buttons; # elisp error
+
+        # https://github.com/kiwanami/emacs-calfw/pull/106
+        calfw-cal = addPackageRequires super.calfw-cal [ self.calfw ];
+
+        # https://github.com/kiwanami/emacs-calfw/pull/106
+        calfw-gcal = addPackageRequires super.calfw-gcal [ self.calfw ];
+
+        # https://github.com/kiwanami/emacs-calfw/pull/106
+        calfw-howm = addPackageRequires super.calfw-howm [
+          self.calfw
+          self.howm
+        ];
+
+        # https://github.com/kiwanami/emacs-calfw/pull/106
+        calfw-ical = addPackageRequires super.calfw-ical [ self.calfw ];
+
+        # https://github.com/kiwanami/emacs-calfw/pull/106
+        calfw-org = addPackageRequires super.calfw-org [ self.calfw ];
+
+        cardano-tx = ignoreCompilationError super.cardano-tx; # elisp error
+
+        cardano-wallet = ignoreCompilationError super.cardano-wallet; # elisp error
+
+        # elisp error and missing optional dependencies
+        cask-package-toolset = ignoreCompilationError super.cask-package-toolset;
+
+        # missing optional dependencies
+        chee = addPackageRequires super.chee [ self.helm ];
+
+        cheerilee = ignoreCompilationError super.cheerilee; # elisp error
+
+        # elisp error and missing optional dependencies
+        # one optional dependency spark is removed in https://github.com/melpa/melpa/pull/9151
+        chronometrist = ignoreCompilationError super.chronometrist;
+
+        # https://github.com/melpa/melpa/pull/9184
+        chronometrist-key-values = super.chronometrist-key-values.overrideAttrs (old: {
+          recipe = ''
+            (chronometrist-key-values :fetcher git :url ""
+             :files (:defaults "elisp/chronometrist-key-values.*"))
+          '';
+        });
+
+        # https://github.com/atilaneves/cmake-ide/issues/176
+        cmake-ide = addPackageRequires super.cmake-ide [ self.dash ];
+
+        code-review = ignoreCompilationError super.code-review; # elisp error
+
+        codesearch = super.codesearch.overrideAttrs (
+          finalAttrs: previousAttrs: {
+            patches =
+              if lib.versionOlder finalAttrs.version "20240827.805" then
+                previousAttrs.patches or [ ]
+                ++ [
+                  (pkgs.fetchpatch {
+                    name = "remove-unused-dash.patch";
+                    url = "https://github.com/abingham/emacs-codesearch/commit/bd24a152ab6ea9f69443ae8e5b7351bb2f990fb6.patch";
+                    hash = "sha256-cCHY8Ak2fHuuhymjSF7w2MLPDJa84mBUdKg27mB9yto=";
+                  })
+                ]
+              else
+                previousAttrs.patches or null;
+          }
+        );
+
+        # https://github.com/hying-caritas/comint-intercept/issues/2
+        comint-intercept = addPackageRequires super.comint-intercept [ self.vterm ];
+
+        company-auctex = mkHome super.company-auctex;
+
+        # depends on distel which is not on any ELPA https://github.com/massemanet/distel/issues/21
+        company-distel = ignoreCompilationError super.company-distel;
+
+        # qmltypes-table.el causing native-compiler-error-empty-byte
+        company-qml = ignoreCompilationError super.company-qml;
+
+        # https://github.com/neuromage/ycm.el/issues/6
+        company-ycm = ignoreCompilationError (addPackageRequires super.company-ycm [ self.company ]);
+
+        composable = ignoreCompilationError super.composable; # elisp error
+
+        # missing optional dependencies
+        conda = addPackageRequires super.conda [ self.projectile ];
+
+        counsel-gtags = ignoreCompilationError super.counsel-gtags; # elisp error
+
+        # https://github.com/fuxialexander/counsel-notmuch/issues/3
+        counsel-notmuch = addPackageRequires super.counsel-notmuch [ self.counsel ];
+
+        # needs dbus during compilation
+        counsel-spotify = ignoreCompilationError super.counsel-spotify;
+
+        creole = ignoreCompilationError super.creole; # elisp error
+
+        cssh = ignoreCompilationError super.cssh; # elisp error
+
+        dap-mode = super.dap-mode.overrideAttrs (old: {
+          # empty file causing native-compiler-error-empty-byte
+          preBuild =
+            ''
+              rm --verbose dapui.el
+            ''
+            + old.preBuild or "";
+        });
+
+        db-pg = ignoreCompilationError super.db-pg; # elisp error
+
+        describe-number = ignoreCompilationError super.describe-number; # elisp error
+
+        # missing optional dependencies: text-translator, not on any ELPA
+        dic-lookup-w3m = ignoreCompilationError super.dic-lookup-w3m;
+
+        # https://github.com/nlamirault/dionysos/issues/17
+        dionysos = addPackageRequires super.dionysos [ self.f ];
+
+        # https://github.com/emacsorphanage/dired-k/issues/48
+        # missing optional dependencies
+        dired-k = addPackageRequires super.dired-k [ self.direx ];
+
+        # depends on distel which is not on any ELPA https://github.com/massemanet/distel/issues/21
+        distel-completion-lib = ignoreCompilationError super.distel-completion-lib;
+
+        django-mode = ignoreCompilationError super.django-mode; # elisp error
+
+        # elisp error and missing optional dependencies
+        drupal-mode = ignoreCompilationError super.drupal-mode;
+
+        e2wm-pkgex4pl = ignoreCompilationError super.e2wm-pkgex4pl; # elisp error
+
+        ecb = ignoreCompilationError super.ecb; # elisp error
+
+        # Optimizer error: too much on the stack
+        edit-color-stamp = ignoreCompilationError super.edit-color-stamp;
+
+        edts = ignoreCompilationError (mkHome super.edts); # elisp error
+
+        eimp = super.eimp.overrideAttrs (old: {
+          postPatch =
+            old.postPatch or ""
+            + "\n"
+            + ''
+              substituteInPlace eimp.el --replace-fail \
+                '(defcustom eimp-mogrify-program "mogrify"' \
+                '(defcustom eimp-mogrify-program "${pkgs.imagemagick}/bin/mogrify"'
+            '';
+        });
+
+        ein = ignoreCompilationError super.ein; # elisp error
+
+        # missing optional dependencies
+        ejc-sql = addPackageRequires super.ejc-sql [
+          self.auto-complete
+          self.company
+        ];
+
+        # missing optional dependencies
+        ekg = addPackageRequires super.ekg [ self.denote ];
+
+        elisp-sandbox = ignoreCompilationError super.elisp-sandbox; # elisp error
+
+        elnode = ignoreCompilationError super.elnode; # elisp error
+
+        elscreen = super.elscreen.overrideAttrs (old: {
+          patches = old.patches or [ ] ++ [
+            (pkgs.fetchpatch {
+              name = "do-not-require-unneeded-wl.patch";
+              url = "https://github.com/knu/elscreen/pull/34/commits/2ffbeb11418d1b98809909c389e7010666d511fd.patch";
+              hash = "sha256-7JoDGtFECZEkB3xmMBXZcx6oStkEV06soiqOkDevWtM=";
+            })
+          ];
+        });
+
+        el-secretario-mu4e = addPackageRequires super.el-secretario-mu4e [ self.mu4e ];
+
+        embark-vc = buildWithGit super.embark-vc;
+
+        # https://github.com/nubank/emidje/issues/23
+        emidje = addPackageRequires super.emidje [ self.pkg-info ];
+
+        # depends on later-do which is not on any ELPA
+        emms-player-simple-mpv = ignoreCompilationError super.emms-player-simple-mpv;
+        emms-player-mpv-jp-radios = ignoreCompilationError super.emms-player-mpv-jp-radios;
+
+        enotify = ignoreCompilationError super.enotify; # elisp error
+
+        # https://github.com/leathekd/ercn/issues/6
+        ercn = addPackageRequires super.ercn [ self.dash ];
+
+        # missing optional dependencies
+        eval-in-repl = addPackageRequires super.eval-in-repl (
+          with self;
+          [
+            alchemist
+            cider
+            elm-mode
+            erlang
+            geiser
+            hy-mode
+            elixir-mode
+            js-comint
+            lua-mode
+            tuareg
+            racket-mode
+            inf-ruby
+            slime
+            sly
+            sml-mode
+          ]
+        );
+
+        # elisp error and missing dependencies
+        evalator = ignoreCompilationError super.evalator;
+
+        evalator-clojure = ignoreCompilationError super.evalator-clojure; # elisp error
+
+        # https://github.com/PythonNut/evil-easymotion/issues/74
+        evil-easymotion = addPackageRequires super.evil-easymotion [ self.evil ];
+
+        evil-mu4e = addPackageRequires super.evil-mu4e [ self.mu4e ];
+
+        # https://github.com/VanLaser/evil-nl-break-undo/issues/2
+        evil-nl-break-undo = addPackageRequiresIfOlder super.evil-nl-break-undo [
+          self.evil
+        ] "20240921.953";
+
+        evil-python-movement = ignoreCompilationError super.evil-python-movement; # elisp error
+
+        evil-tex = mkHome super.evil-tex;
+
+        # Error: Bytecode overflow
+        ewal-doom-themes = ignoreCompilationError super.ewal-doom-themes;
+
+        # https://github.com/agzam/exwm-edit/issues/32
+        exwm-edit = addPackageRequires super.exwm-edit [ self.exwm ];
+
+        # https://github.com/syl20bnr/flymake-elixir/issues/4
+        flymake-elixir = addPackageRequires super.flymake-elixir [ self.flymake-easy ];
+
+        flyparens = ignoreCompilationError super.flyparens; # elisp error
+
+        fold-dwim-org = ignoreCompilationError super.fold-dwim-org; # elisp error
+
+        # https://github.com/melpa/melpa/pull/9182
+        frontside-javascript = super.frontside-javascript.overrideAttrs (old: {
+          preBuild =
+            old.preBuild or ""
+            + "\n"
+            + ''
+              rm --verbose packages/javascript/test-suppport.el
+            '';
+        });
+
+        fxrd-mode = ignoreCompilationError super.fxrd-mode; # elisp error
+
+        # missing optional dependencies
+        gap-mode = addPackageRequires super.gap-mode [
+          self.company
+          self.flycheck
+        ];
+
+        gh-notify = buildWithGit super.gh-notify;
+
+        # https://github.com/nlamirault/emacs-gitlab/issues/68
+        gitlab = addPackageRequires super.gitlab [ self.f ];
+
+        # TODO report to upstream
+        global-tags = addPackageRequires super.global-tags [ self.s ];
+
+        go = ignoreCompilationError super.go; # elisp error
+
+        graphene = ignoreCompilationError super.graphene; # elisp error
+
+        greader = ignoreCompilationError super.greader; # elisp error
+
+        # TODO report to upstream
+        guix = addPackageRequires super.guix [ self.geiser-guile ];
+
+        # missing optional dependencies
+        gumshoe = addPackageRequires super.gumshoe [ self.perspective ];
+
+        helm-chrome-control = super.helm-chrome-control.overrideAttrs (old: {
+          patches = old.patches or [ ] ++ [
+            (pkgs.fetchpatch {
+              name = "require-helm-core-instead-of-helm.patch";
+              url = "https://github.com/xuchunyang/helm-chrome-control/pull/2/commits/7765cd2483adef5cfa6cf77f52259ad6e1dd0daf.patch";
+              hash = "sha256-tF+IaICbveYJvd3Tjx52YBBztpjifZdCA4O+Z2r1M3s=";
+            })
+          ];
+        });
+
+        # https://github.com/xuchunyang/helm-chrome-history/issues/3
+        helm-chrome-history = fixRequireHelmCore super.helm-chrome-history;
+
+        helm-cider = ignoreCompilationError super.helm-cider; # elisp error
+
+        helm-ext = ignoreCompilationError super.helm-ext; # elisp error
+
+        # https://github.com/iory/emacs-helm-ghs/issues/1
+        helm-ghs = addPackageRequires super.helm-ghs [ self.helm-ghq ];
+
+        # https://github.com/maio/helm-git/issues/7
+        helm-git = addPackageRequires super.helm-git [
+          self.helm
+          self.magit
+        ];
+
+        # TODO report to upstream
+        helm-flycheck = fixRequireHelmCore super.helm-flycheck;
+
+        # https://github.com/yasuyk/helm-git-grep/issues/54
+        helm-git-grep = addPackageRequires super.helm-git-grep [ self.helm ];
+
+        # https://github.com/yasuyk/helm-go-package/issues/8
+        helm-go-package = fixRequireHelmCore super.helm-go-package;
+
+        # https://github.com/torgeir/helm-js-codemod.el/pull/1
+        helm-js-codemod = fixRequireHelmCore super.helm-js-codemod;
+
+        helm-kythe = ignoreCompilationError super.helm-kythe; # elisp error
+
+        # https://github.com/emacs-jp/helm-migemo/issues/8
+        helm-migemo = addPackageRequiresIfOlder super.helm-migemo [ self.helm ] "20240921.1550";
+
+        helm-mu = addPackageRequires super.helm-mu [ self.mu4e ];
+
+        # https://github.com/xuchunyang/helm-osx-app/pull/1
+        helm-osx-app = addPackageRequires super.helm-osx-app [ self.helm ];
+
+        # https://github.com/cosmicexplorer/helm-rg/issues/36
+        helm-rg = ignoreCompilationError super.helm-rg; # elisp error
+
+        # https://github.com/yasuyk/helm-spaces/issues/1
+        helm-spaces = fixRequireHelmCore super.helm-spaces;
+
+        hideshow-org = ignoreCompilationError super.hideshow-org; # elisp error
+
+        # https://github.com/purcell/hippie-expand-slime/issues/2
+        hippie-expand-slime = addPackageRequires super.hippie-expand-slime [ self.slime ];
+
+        hyperbole = ignoreCompilationError (addPackageRequires (mkHome super.hyperbole) [ self.el-mock ]); # elisp error
+
+        # needs non-existent "browser database directory" during compilation
+        # TODO report to upsteam about missing dependency websocket
+        ibrowse = ignoreCompilationError (addPackageRequires super.ibrowse [ self.websocket ]);
+
+        # elisp error and missing optional dependencies
+        identica-mode = ignoreCompilationError super.identica-mode;
+
+        # missing optional dependencies
+        idris-mode = addPackageRequires super.idris-mode [ self.flycheck ];
+
+        imbot = ignoreCompilationError super.imbot; # elisp error
+
+        indium = mkHome super.indium;
+
+        # TODO report to upsteam
+        inlineR = addPackageRequires super.inlineR [ self.ess ];
+
+        # https://github.com/duelinmarkers/insfactor.el/issues/7
+        insfactor = addPackageRequires super.insfactor [ self.cider ];
+
+        # https://github.com/wandersoncferreira/ivy-clojuredocs/issues/5
+        ivy-clojuredocs = addPackageRequires super.ivy-clojuredocs [ self.parseedn ];
+
+        # TODO report to upstream
+        jack-connect = addPackageRequires super.jack-connect [ self.dash ];
+
+        jdee = ignoreCompilationError super.jdee; # elisp error
+
+        # https://github.com/fred-o/jekyll-modes/issues/6
+        jekyll-modes = addPackageRequires super.jekyll-modes [ self.poly-markdown ];
+
+        jss = ignoreCompilationError super.jss; # elisp error
+
+        # missing optional dependencies: vterm or eat
+        julia-snail = addPackageRequires super.julia-snail [ self.eat ];
+
+        kite = ignoreCompilationError super.kite; # elisp error
+
+        # missing optional dependencies
+        laas = addPackageRequires super.laas [ self.math-symbol-lists ];
+
+        latex-change-env = mkHome super.latex-change-env;
+
+        latex-extra = mkHome super.latex-extra;
+
+        latex-table-wizard = mkHome super.latex-table-wizard;
+
+        leaf-defaults = ignoreCompilationError super.leaf-defaults; # elisp error
+
+        # https://github.com/abo-abo/lispy/pull/683
+        # missing optional dependencies
+        lispy = addPackageRequires (mkHome super.lispy) [ self.indium ];
+
+        # missing optional dependencies
+        magik-mode = addPackageRequires super.magik-mode [
+          self.auto-complete
+          self.flycheck
+        ];
+
+        # missing optional dependencies
+        magnatune = addPackageRequires super.magnatune [ self.helm ];
+
+        major-mode-icons = ignoreCompilationError super.major-mode-icons; # elisp error
+
+        malinka = ignoreCompilationError super.malinka; # elisp error
+
+        mastodon = ignoreCompilationError super.mastodon; # elisp error
+
+        # https://github.com/org2blog/org2blog/issues/339
+        metaweblog = addPackageRequires super.metaweblog [ self.xml-rpc ];
+
+        mu-cite = ignoreCompilationError super.mu-cite; # elisp error
+
+        mu4e-alert = addPackageRequires super.mu4e-alert [ self.mu4e ];
+
+        mu4e-column-faces = addPackageRequires super.mu4e-column-faces [ self.mu4e ];
+
+        mu4e-conversation = addPackageRequires super.mu4e-conversation [ self.mu4e ];
+
+        mu4e-jump-to-list = addPackageRequires super.mu4e-jump-to-list [ self.mu4e ];
+
+        mu4e-marker-icons = addPackageRequires super.mu4e-marker-icons [ self.mu4e ];
+
+        mu4e-overview = addPackageRequires super.mu4e-overview [ self.mu4e ];
+
+        mu4e-query-fragments = addPackageRequires super.mu4e-query-fragments [ self.mu4e ];
+
+        mu4e-views = addPackageRequires super.mu4e-views [ self.mu4e ];
+
+        # https://github.com/magnars/multifiles.el/issues/9
+        multifiles = addPackageRequires super.multifiles [ self.dash ];
+
+        # missing optional dependencies
+        mykie = addPackageRequires super.mykie [ self.helm ];
+
+        myrddin-mode = ignoreCompilationError super.myrddin-mode; # elisp error
+
+        nand2tetris = super.nand2tetris.overrideAttrs (old: {
+          patches = old.patches or [ ] ++ [
+            (pkgs.fetchpatch {
+              name = "remove-unneeded-require.patch";
+              url = "https://github.com/CestDiego/nand2tetris.el/pull/16/commits/d06705bf52f3cf41f55498d88fe15a1064bc2cfa.patch";
+              hash = "sha256-8OJXN9MuwBbL0afus53WroIxtIzHY7Bryv5ZGcS/inI=";
+            })
+          ];
+        });
+
+        # elisp error and missing dependency spamfilter which is not on any ELPA
+        navi2ch = ignoreCompilationError super.navi2ch;
+
+        navorski = super.navorski.overrideAttrs (old: {
+          patches = old.patches or [ ] ++ [
+            (pkgs.fetchpatch {
+              name = "stop-using-assoc.patch";
+              url = "https://github.com/roman/navorski.el/pull/12/commits/b7b6c331898cae239c176346ac87c8551b1e0c72.patch";
+              hash = "sha256-CZxOSGuJXATonHMSLGCzO4kOlQqRAOcNNq0i4Qh21y8=";
+            })
+          ];
+        });
+
+        # empty tools/ncl-mode-keywords.el causing native-compiler-error-empty-byte
+        ncl-mode = ignoreCompilationError super.ncl-mode;
+
+        # missing optional dependencies
+        netease-cloud-music = addPackageRequires super.netease-cloud-music [ self.async ];
+
+        nim-mode = ignoreCompilationError super.nim-mode; # elisp error
+
+        noctilux-theme = ignoreCompilationError super.noctilux-theme; # elisp error
+
+        # https://github.com/nicferrier/emacs-noflet/issues/12
+        noflet = ignoreCompilationError super.noflet; # elisp error
+
+        norns = ignoreCompilationError super.norns; # elisp error
+
+        # missing optional dependencies
+        nu-mode = addPackageRequires super.nu-mode [ self.evil ];
+
+        # try to open non-existent ~/.emacs.d/.chatgpt-shell.el during compilation
+        ob-chatgpt-shell = ignoreCompilationError super.ob-chatgpt-shell;
+
+        org-change = ignoreCompilationError super.org-change; # elisp error
+
+        org-edit-latex = mkHome super.org-edit-latex;
+
+        org-gnome = ignoreCompilationError super.org-gnome; # elisp error
+
+        org-gtd = ignoreCompilationError super.org-gtd; # elisp error
+
+        # needs newer org than the Eamcs 29.4 builtin one
+        org-link-beautify = addPackageRequires super.org-link-beautify [ self.org ];
+
+        # TODO report to upstream
+        org-kindle = addPackageRequires super.org-kindle [ self.dash ];
+
+        org-special-block-extras = ignoreCompilationError super.org-special-block-extras; # elisp error
+
+        org-trello = ignoreCompilationError super.org-trello; # elisp error
+
+        # Optimizer error: too much on the stack
+        orgnav = ignoreCompilationError super.orgnav;
+
+        org-noter = super.org-noter.overrideAttrs (
+          finalAttrs: previousAttrs: {
+            patches =
+              if lib.versionOlder finalAttrs.version "20240915.344" then
+                previousAttrs.patches or [ ]
+                ++ [
+                  (pkgs.fetchpatch {
+                    name = "catch-error-for-optional-dep-org-roam.patch";
+                    url = "https://github.com/org-noter/org-noter/commit/761c551ecc88fec57e840d346c6af5f5b94591d5.patch";
+                    hash = "sha256-Diw9DgjANDWu6CBMOlRaihQLOzeAr7VcJPZT579dpYU=";
+                  })
+                ]
+              else
+                previousAttrs.patches or null;
+          }
+        );
+
+        org-noter-pdftools = mkHome super.org-noter-pdftools;
+
+        # elisp error and missing optional dependencies
+        org-ref = ignoreCompilationError super.org-ref;
+
+        # missing optional dependencies
+        org-roam-bibtex = addPackageRequires super.org-roam-bibtex [
+          self.helm-bibtex
+          self.ivy-bibtex
+        ];
+
+        org-pdftools = mkHome super.org-pdftools;
+
+        org-projectile = super.org-projectile.overrideAttrs (
+          finalAttrs: previousAttrs: {
+            # https://github.com/melpa/melpa/pull/9150
+            preBuild =
+              if lib.versionOlder finalAttrs.version "20240901.2041" then
+                ''
+                  rm --verbose org-projectile-helm.el
+                ''
+                + previousAttrs.preBuild or ""
+              else
+                previousAttrs.preBuild or null;
+          }
+        );
+
+        # https://github.com/colonelpanic8/org-project-capture/issues/66
+        org-projectile-helm = addPackageRequires super.org-projectile-helm [ self.helm-org ];
+
+        # https://github.com/DarwinAwardWinner/mac-pseudo-daemon/issues/9
+        osx-pseudo-daemon = addPackageRequiresIfOlder super.osx-pseudo-daemon [ self.mac-pseudo-daemon ] "20240922.2024";
+
+        # missing optional dependencies
+        outlook = addPackageRequires super.outlook [ self.mu4e ];
+
+        pastery = ignoreCompilationError super.pastery; # elisp error
+
+        pgdevenv = ignoreCompilationError super.pgdevenv; # elisp error
+
+        pinot = ignoreCompilationError super.pinot; # elisp error
+
+        # https://github.com/polymode/poly-R/issues/41
+        poly-R = addPackageRequires super.poly-R [ self.ess ];
+
+        # missing optional dependencies: direx e2wm yaol, yaol not on any ELPA
+        pophint = ignoreCompilationError super.pophint;
+
+        portage-navi = ignoreCompilationError super.portage-navi; # elisp error
+
+        preview-dvisvgm = mkHome super.preview-dvisvgm;
+
+        # https://github.com/micdahl/projectile-trailblazer/issues/4
+        projectile-trailblazer = addPackageRequires super.projectile-trailblazer [ self.projectile-rails ];
+
+        projmake-mode = ignoreCompilationError super.projmake-mode; # elisp error
+
+        # https://github.com/tumashu/pyim-basedict/issues/4
+        pyim-basedict = addPackageRequires super.pyim-basedict [ self.pyim ];
+
+        # TODO report to upstream
+        realgud-lldb = super.realgud-lldb.overrideAttrs (old: {
+          preBuild =
+            old.preBuild or ""
+            + "\n"
+            + ''
+              rm --verbose cask-install.el
+            '';
+        });
+
+        # empty .yas-compiled-snippets.el causing native-compiler-error-empty-byte
+        requirejs = ignoreCompilationError super.requirejs;
+
+        rhtml-mode = ignoreCompilationError super.rhtml-mode; # elisp error
+
+        roguel-ike = ignoreCompilationError super.roguel-ike; # elisp error
+
+        rpm-spec-mode = ignoreCompilationError super.rpm-spec-mode; # elisp error
+
+        # https://github.com/emacsfodder/emacs-theme-sakura/issues/1
+        sakura-theme = addPackageRequiresIfOlder super.sakura-theme [ self.autothemer ] "20240921.1028";
+
+        scad-preview = ignoreCompilationError super.scad-preview; # elisp error
+
+        # https://github.com/wanderlust/semi/pull/29
+        # missing optional dependencies
+        semi = addPackageRequires super.semi [ self.bbdb-vcard ];
+
+        shadchen = ignoreCompilationError super.shadchen; # elisp error
+
+        # missing optional dependencies and one of them (mew) is not on any ELPA
+        shimbun = ignoreCompilationError (
+          addPackageRequires super.shimbun [
+            self.apel
+            self.flim
+            self.w3m
+          ]
+        );
+
+        slack = mkHome super.slack;
+
+        # https://github.com/ffevotte/slurm.el/issues/14
+        slurm-mode = addPackageRequires super.slurm-mode [
+          self.dash
+          self.s
+        ];
+
+        smart-tabs-mode = ignoreCompilationError super.smart-tabs-mode; # elisp error
+
+        # needs network during compilation
+        # https://github.com/md-arif-shaikh/soccer/issues/14
+        soccer = ignoreCompilationError (addPackageRequires super.soccer [ self.s ]);
+
+        # elisp error and missing optional dependencies
+        soundklaus = ignoreCompilationError super.soundklaus;
+
+        # missing optional dependencies
+        sparql-mode = addPackageRequires super.sparql-mode [ self.company ];
+
+        speechd-el = ignoreCompilationError super.speechd-el; # elisp error
+
+        spu = ignoreCompilationError super.spu; # elisp error
+
+        # missing optional dependencies
+        ssh-tunnels = addPackageRequires super.ssh-tunnels [ self.helm ];
+
+        # https://github.com/brianc/jade-mode/issues/73
+        stylus-mode = addPackageRequires super.stylus-mode [ self.sws-mode ];
+
+        # missing optional dependencies
+        suggest = addPackageRequires super.suggest [ self.shut-up ];
+
+        symex = ignoreCompilationError super.symex; # elisp error
+
+        term-alert = mkHome super.term-alert;
+
+        # https://github.com/colonelpanic8/term-manager/issues/9
+        term-manager = addPackageRequires super.term-manager [ self.eat ];
+
+        texfrag = mkHome super.texfrag;
+
+        # https://github.com/Dspil/text-categories/issues/3
+        text-categories = addPackageRequiresIfOlder super.text-categories [ self.dash ] "20240921.824";
+
+        timp = ignoreCompilationError super.timp; # elisp error
+
+        tommyh-theme = ignoreCompilationError super.tommyh-theme; # elisp error
+
+        tramp-hdfs = ignoreCompilationError super.tramp-hdfs; # elisp error
+
+        universal-emotions-emoticons = ignoreCompilationError super.universal-emotions-emoticons; # elisp error
+
+        use-package-el-get = addPackageRequires super.use-package-el-get [ self.el-get ];
+
+        vala-mode = ignoreCompilationError super.vala-mode; # elisp error
+
+        # needs network during compilation
+        wandbox = ignoreCompilationError super.wandbox; # needs network
+
+        # optional dependency spamfilter is not on any ELPA
+        wanderlust = ignoreCompilationError (addPackageRequires super.wanderlust [ self.shimbun ]);
+
+        # https://github.com/nicklanasa/xcode-mode/issues/28
+        xcode-mode = addPackageRequires super.xcode-mode [ self.hydra ];
+
+        weechat = ignoreCompilationError super.weechat; # elisp error
+
+        weechat-alert = ignoreCompilationError super.weechat-alert; # elisp error
+
+        weibo = ignoreCompilationError super.weibo; # elisp error
+
+        xenops = mkHome super.xenops;
+
+        # missing optional dependencies
+        xmlunicode = addPackageRequires super.xmlunicode [ self.helm ];
+
+        # https://github.com/canatella/xwwp/issues/18
+        xwwp-follow-link-ivy = addPackageRequires super.xwwp-follow-link-ivy [ self.ivy ];
+
+        # https://github.com/canatella/xwwp/issues/19
+        xwwp-follow-link-helm = addPackageRequires super.xwwp-follow-link-helm [ self.helm ];
+
+        yara-mode = ignoreCompilationError super.yara-mode; # elisp error
+
+        # https://github.com/leanprover-community/yasnippet-lean/issues/6
+        yasnippet-lean = addPackageRequires super.yasnippet-lean [ self.lean-mode ];
+
+        yasnippet-snippets = mkHome super.yasnippet-snippets;
+
+        yatex = ignoreCompilationError super.yatex; # elisp error
+
+        # elisp error and incomplete recipe
+        ycm = ignoreCompilationError (
+          addPackageRequires super.ycm [
+            self.flycheck
+            self.f
+          ]
+        );
+
+        # missing optional dependencies
+        zotxt = addPackageRequires super.zotxt [ self.org-noter ];
       };
 
     in lib.mapAttrs (n: v: if lib.hasAttr n overrides then overrides.${n} else v) super);

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -39,6 +39,7 @@ let
     fix-rtags
     fixRequireHelmCore
     ignoreCompilationError
+    ignoreCompilationErrorIfOlder
     markBroken
     mkHome
     ;
@@ -732,6 +733,9 @@ let
             '';
           })
           else super.osx-dictionary;
+
+        # https://github.com/skeeto/at-el/issues/9
+        "@" = ignoreCompilationErrorIfOlder super."@" "20240923.1318";
 
         abgaben = addPackageRequires (mkHome super.abgaben) [ self.mu4e ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
@@ -1,8 +1,25 @@
-pkgs:
+pkgs: lib:
 
 self: super:
 
+let
+  inherit (import ./lib-override-helper.nix pkgs lib)
+    addPackageRequires
+    ;
+in
 {
+  # missing optional dependencies
+  haskell-tng-mode = addPackageRequires super.haskell-tng-mode (
+    with self;
+    [
+      s
+      company
+      projectile
+      smartparens
+      yasnippet
+    ]
+  );
+
   p4-16-mode = super.p4-16-mode.overrideAttrs {
     # workaround https://github.com/NixOS/nixpkgs/issues/301795
     prePatch = ''

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-packages.nix
@@ -19,6 +19,10 @@
 self:
 let
 
+  inherit (import ./lib-override-helper.nix pkgs lib)
+    addPackageRequires
+    ;
+
   generateNongnu = lib.makeOverridable (
     {
       generated ? ./nongnu-devel-generated.nix,
@@ -39,9 +43,15 @@ let
 
       super = imported;
 
-      commonOverrides = import ./nongnu-common-overrides.nix pkgs;
+      commonOverrides = import ./nongnu-common-overrides.nix pkgs lib;
 
-      overrides = self: super: { };
+      overrides = self: super: {
+        # missing optional dependencies
+        haskell-tng-mode = addPackageRequires super.haskell-tng-mode [
+          self.shut-up
+          self.lsp-mode
+        ];
+      };
 
     in
     let

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
@@ -29,7 +29,7 @@ self: let
 
     super = imported;
 
-    commonOverrides = import ./nongnu-common-overrides.nix pkgs;
+    commonOverrides = import ./nongnu-common-overrides.nix pkgs lib;
 
     overrides = self: super: { };
 


### PR DESCRIPTION
## Description of changes

This PR fixes almost all build failures introduced by https://github.com/NixOS/nixpkgs/pull/343388.

The only remaining build failure is `org-xlatex`, which fails for good reason: `Error: error ("Your Emacs was not built with Xwidget support")`.

It is better to review this PR one commit at a time.

Future work:
- resolve TODOs
- work with upstreams to solve compilation errors hidden by `ignoreCompilationError`

This PR is the final part of https://github.com/NixOS/nixpkgs/issues/335442.  Closes #335442.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
