### PR TITLE
amazon-image: Support UEFI boot on x86

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -189,3 +189,6 @@ ce21e97a1f20dee15da85c084f9d1148d84f853b
 
 # percona: apply nixfmt
 8d14fa2886fec877690c6d28cfcdba4503dbbcea
+
+# nixos/amazon-image: reformat with nixfmt
+e657cb00615089d77a86f69264fa161649502f1d

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -215,6 +215,12 @@
 
 - `androidenv.androidPkgs_9_0` has been removed, and replaced with `androidenv.androidPkgs` for a more complete Android SDK including support for Android 9 and later.
 
+- The Amazon disk images (AMIs) have been changed to use a GPT instead of MBR partition table. This change is necessary as we aim to move to a `repart` based image builder in the near future.
+  If you are booted with an old AMI and want to in-place upgrade to 24.11 you **MUST** set `system.stateVersion = "24.05";` or lower in your configuration. This will ensure that the old MBR
+  partition table is used and we do not try to install EFI Bootloader entries on your system which will fail. Note that by default `/etc/nixos/configuration.nix` on our AMIs did not set
+  `system.stateVersion` so you will need to add this line to your configuration manually if you use the on-image configuration. On 24.11 we do now ship with `system.stateVersion = "24.11";` set
+  to avoid these kind of issues in the future.  The AMI boot-mode has also been changed from `legacy-bios` to `uefi-preferred` to ensure that the system boots in UEFI mode if possible.
+
 - `grafana` has been updated to version 11.1. This version doesn't support setting `http_addr` to a hostname anymore, an IP address is expected.
 
 - `deno` has been updated to v2 which has breaking changes. Upstream will be abandoning v1 soon but for now you can use `deno_1` if you are yet to migrate (will be removed prior to cutting a final 24.11 release).

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -1,12 +1,23 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
-  inherit (lib) mkOption optionalString types versionAtLeast;
+  inherit (lib)
+    mkOption
+    optionalString
+    types
+    versionAtLeast
+    ;
   inherit (lib.options) literalExpression;
   cfg = config.amazonImage;
   amiBootMode = if config.ec2.efi then "uefi" else "legacy-bios";
 
-in {
+in
+{
 
   imports = [ ../../../modules/virtualisation/amazon-image.nix ];
 
@@ -14,11 +25,11 @@ in {
   # experience, which prior to 4.15 was 255.
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
   config.boot.kernelParams =
-    let timeout =
-      if versionAtLeast config.boot.kernelPackages.kernel.version "4.15"
-      then "4294967295"
-      else  "255";
-    in [ "nvme_core.io_timeout=${timeout}" ];
+    let
+      timeout =
+        if versionAtLeast config.boot.kernelPackages.kernel.version "4.15" then "4294967295" else "255";
+    in
+    [ "nvme_core.io_timeout=${timeout}" ];
 
   options.amazonImage = {
     name = mkOption {
@@ -34,7 +45,7 @@ in {
           }
         ]
       '';
-      default = [];
+      default = [ ];
       description = ''
         This option lists files to be copied to fixed locations in the
         generated image. Glob patterns work.
@@ -49,15 +60,19 @@ in {
     };
 
     format = mkOption {
-      type = types.enum [ "raw" "qcow2" "vpc" ];
+      type = types.enum [
+        "raw"
+        "qcow2"
+        "vpc"
+      ];
       default = "vpc";
       description = "The image format to output";
     };
   };
 
-  config.system.build.amazonImage = let
-    configFile = pkgs.writeText "configuration.nix"
-      ''
+  config.system.build.amazonImage =
+    let
+      configFile = pkgs.writeText "configuration.nix" ''
         { modulesPath, ... }: {
           imports = [ "''${modulesPath}/virtualisation/amazon-image.nix" ];
           ${optionalString config.ec2.efi ''
@@ -70,91 +85,102 @@ in {
         }
       '';
 
-    zfsBuilder = import ../../../lib/make-multi-disk-zfs-image.nix {
-      inherit lib config configFile pkgs;
-      inherit (cfg) contents format name;
+      zfsBuilder = import ../../../lib/make-multi-disk-zfs-image.nix {
+        inherit
+          lib
+          config
+          configFile
+          pkgs
+          ;
+        inherit (cfg) contents format name;
 
-      includeChannel = true;
+        includeChannel = true;
 
-      bootSize = 1000; # 1G is the minimum EBS volume
+        bootSize = 1000; # 1G is the minimum EBS volume
 
-      rootSize = cfg.sizeMB;
-      rootPoolProperties = {
-        ashift = 12;
-        autoexpand = "on";
+        rootSize = cfg.sizeMB;
+        rootPoolProperties = {
+          ashift = 12;
+          autoexpand = "on";
+        };
+
+        datasets = config.ec2.zfs.datasets;
+
+        postVM = ''
+           extension=''${rootDiskImage##*.}
+           friendlyName=$out/${cfg.name}
+           rootDisk="$friendlyName.root.$extension"
+           bootDisk="$friendlyName.boot.$extension"
+           mv "$rootDiskImage" "$rootDisk"
+           mv "$bootDiskImage" "$bootDisk"
+
+           mkdir -p $out/nix-support
+           echo "file ${cfg.format} $bootDisk" >> $out/nix-support/hydra-build-products
+           echo "file ${cfg.format} $rootDisk" >> $out/nix-support/hydra-build-products
+
+          ${pkgs.jq}/bin/jq -n \
+            --arg system_label ${lib.escapeShellArg config.system.nixos.label} \
+            --arg system ${lib.escapeShellArg pkgs.stdenv.hostPlatform.system} \
+            --arg root_logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$rootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
+            --arg boot_logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$bootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
+            --arg boot_mode "${amiBootMode}" \
+            --arg root "$rootDisk" \
+            --arg boot "$bootDisk" \
+           '{}
+             | .label = $system_label
+             | .boot_mode = $boot_mode
+             | .system = $system
+             | .disks.boot.logical_bytes = $boot_logical_bytes
+             | .disks.boot.file = $boot
+             | .disks.root.logical_bytes = $root_logical_bytes
+             | .disks.root.file = $root
+             ' > $out/nix-support/image-info.json
+        '';
       };
 
-      datasets = config.ec2.zfs.datasets;
+      extBuilder = import ../../../lib/make-disk-image.nix {
+        inherit
+          lib
+          config
+          configFile
+          pkgs
+          ;
 
-      postVM = ''
-        extension=''${rootDiskImage##*.}
-        friendlyName=$out/${cfg.name}
-        rootDisk="$friendlyName.root.$extension"
-        bootDisk="$friendlyName.boot.$extension"
-        mv "$rootDiskImage" "$rootDisk"
-        mv "$bootDiskImage" "$bootDisk"
+        inherit (cfg) contents format name;
 
-        mkdir -p $out/nix-support
-        echo "file ${cfg.format} $bootDisk" >> $out/nix-support/hydra-build-products
-        echo "file ${cfg.format} $rootDisk" >> $out/nix-support/hydra-build-products
+        fsType = "ext4";
+        partitionTableType = if config.ec2.efi then "efi" else "legacy+gpt";
 
-       ${pkgs.jq}/bin/jq -n \
-         --arg system_label ${lib.escapeShellArg config.system.nixos.label} \
-         --arg system ${lib.escapeShellArg pkgs.stdenv.hostPlatform.system} \
-         --arg root_logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$rootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
-         --arg boot_logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$bootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
-         --arg boot_mode "${amiBootMode}" \
-         --arg root "$rootDisk" \
-         --arg boot "$bootDisk" \
-        '{}
-          | .label = $system_label
-          | .boot_mode = $boot_mode
-          | .system = $system
-          | .disks.boot.logical_bytes = $boot_logical_bytes
-          | .disks.boot.file = $boot
-          | .disks.root.logical_bytes = $root_logical_bytes
-          | .disks.root.file = $root
-          ' > $out/nix-support/image-info.json
-      '';
-    };
+        diskSize = cfg.sizeMB;
 
-    extBuilder = import ../../../lib/make-disk-image.nix {
-      inherit lib config configFile pkgs;
+        postVM = ''
+           extension=''${diskImage##*.}
+           friendlyName=$out/${cfg.name}.$extension
+           mv "$diskImage" "$friendlyName"
+           diskImage=$friendlyName
 
-      inherit (cfg) contents format name;
+           mkdir -p $out/nix-support
+           echo "file ${cfg.format} $diskImage" >> $out/nix-support/hydra-build-products
 
-      fsType = "ext4";
-      partitionTableType = if config.ec2.efi then "efi" else "legacy+gpt";
-
-      diskSize = cfg.sizeMB;
-
-      postVM = ''
-        extension=''${diskImage##*.}
-        friendlyName=$out/${cfg.name}.$extension
-        mv "$diskImage" "$friendlyName"
-        diskImage=$friendlyName
-
-        mkdir -p $out/nix-support
-        echo "file ${cfg.format} $diskImage" >> $out/nix-support/hydra-build-products
-
-       ${pkgs.jq}/bin/jq -n \
-         --arg system_label ${lib.escapeShellArg config.system.nixos.label} \
-         --arg system ${lib.escapeShellArg pkgs.stdenv.hostPlatform.system} \
-         --arg logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$diskImage" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
-         --arg boot_mode "${amiBootMode}" \
-         --arg file "$diskImage" \
-          '{}
-          | .label = $system_label
-          | .boot_mode = $boot_mode
-          | .system = $system
-          | .logical_bytes = $logical_bytes
-          | .file = $file
-          | .disks.root.logical_bytes = $logical_bytes
-          | .disks.root.file = $file
-          ' > $out/nix-support/image-info.json
-      '';
-    };
-  in if config.ec2.zfs.enable then zfsBuilder else extBuilder;
+          ${pkgs.jq}/bin/jq -n \
+            --arg system_label ${lib.escapeShellArg config.system.nixos.label} \
+            --arg system ${lib.escapeShellArg pkgs.stdenv.hostPlatform.system} \
+            --arg logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$diskImage" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
+            --arg boot_mode "${amiBootMode}" \
+            --arg file "$diskImage" \
+             '{}
+             | .label = $system_label
+             | .boot_mode = $boot_mode
+             | .system = $system
+             | .logical_bytes = $logical_bytes
+             | .file = $file
+             | .disks.root.logical_bytes = $logical_bytes
+             | .disks.root.file = $file
+             ' > $out/nix-support/image-info.json
+        '';
+      };
+    in
+    if config.ec2.zfs.enable then zfsBuilder else extBuilder;
 
   meta.maintainers = with lib.maintainers; [ arianvp ];
 }

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -14,7 +14,7 @@ let
     ;
   inherit (lib.options) literalExpression;
   cfg = config.amazonImage;
-  amiBootMode = if config.ec2.efi then "uefi" else "legacy-bios";
+  amiBootMode = if config.ec2.efi then "uefi" else "uefi-preferred";
 
 in
 {
@@ -149,7 +149,7 @@ in
         inherit (cfg) contents format name;
 
         fsType = "ext4";
-        partitionTableType = if config.ec2.efi then "efi" else "legacy+gpt";
+        partitionTableType = if config.ec2.efi then "efi" else "hybrid";
 
         diskSize = cfg.sizeMB;
 

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -75,6 +75,7 @@ in
       configFile = pkgs.writeText "configuration.nix" ''
         { modulesPath, ... }: {
           imports = [ "''${modulesPath}/virtualisation/amazon-image.nix" ];
+          system.stateVersion = "${config.system.stateVersion}";
           ${optionalString config.ec2.efi ''
             ec2.efi = true;
           ''}

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -4,13 +4,18 @@
 # also to reconfigure instances. However, we can't rename it because
 # existing "configuration.nix" files on EC2 instances refer to it.)
 
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   inherit (lib) mkDefault mkIf;
   cfg = config.ec2;
-in
 
+in
 {
   imports = [
     ../profiles/headless.nix
@@ -45,18 +50,22 @@ in
 
     boot.zfs.devNodes = mkIf cfg.zfs.enable "/dev/";
 
-    boot.extraModulePackages = [
-      config.boot.kernelPackages.ena
-    ];
+    boot.extraModulePackages = [ config.boot.kernelPackages.ena ];
     boot.initrd.kernelModules = [ "xen-blkfront" ];
     boot.initrd.availableKernelModules = [ "nvme" ];
-    boot.kernelParams = [ "console=ttyS0,115200n8" "random.trust_cpu=on" ];
+    boot.kernelParams = [
+      "console=ttyS0,115200n8"
+      "random.trust_cpu=on"
+    ];
 
     # Prevent the nouveau kernel module from being loaded, as it
     # interferes with the nvidia/nvidia-uvm modules needed for CUDA.
     # Also blacklist xen_fbfront to prevent a 30 second delay during
     # boot.
-    boot.blacklistedKernelModules = [ "nouveau" "xen_fbfront" ];
+    boot.blacklistedKernelModules = [
+      "nouveau"
+      "xen_fbfront"
+    ];
 
     boot.loader.grub.device = if cfg.efi then "nodev" else "/dev/xvda";
     boot.loader.grub.efiSupport = cfg.efi;
@@ -71,7 +80,7 @@ in
     systemd.services.fetch-ec2-metadata = {
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
-      after = ["network-online.target"];
+      after = [ "network-online.target" ];
       path = [ pkgs.curl ];
       script = builtins.readFile ./ec2-metadata-fetcher.sh;
       serviceConfig.Type = "oneshot";

--- a/nixos/modules/virtualisation/amazon-options.nix
+++ b/nixos/modules/virtualisation/amazon-options.nix
@@ -1,7 +1,13 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit (lib) literalExpression types;
-in {
+in
+{
   options = {
     ec2 = {
       zfs = {
@@ -22,23 +28,25 @@ in {
             on an existing system.
           '';
 
-          default = {};
+          default = { };
 
-          type = types.attrsOf (types.submodule {
-            options = {
-              mount = lib.mkOption {
-                description = "Where to mount this dataset.";
-                type = types.nullOr types.str;
-                default = null;
-              };
+          type = types.attrsOf (
+            types.submodule {
+              options = {
+                mount = lib.mkOption {
+                  description = "Where to mount this dataset.";
+                  type = types.nullOr types.str;
+                  default = null;
+                };
 
-              properties = lib.mkOption {
-                description = "Properties to set on this dataset.";
-                type = types.attrsOf types.str;
-                default = {};
+                properties = lib.mkOption {
+                  description = "Properties to set on this dataset.";
+                  type = types.attrsOf types.str;
+                  default = { };
+                };
               };
-            };
-          });
+            }
+          );
         };
       };
       efi = lib.mkOption {
@@ -61,13 +69,16 @@ in {
   config = lib.mkIf config.ec2.zfs.enable {
     networking.hostId = lib.mkDefault "00000000";
 
-    fileSystems = let
-      mountable = lib.filterAttrs (_: value: ((value.mount or null) != null)) config.ec2.zfs.datasets;
-    in lib.mapAttrs'
-      (dataset: opts: lib.nameValuePair opts.mount {
-        device = dataset;
-        fsType = "zfs";
-      })
-      mountable;
+    fileSystems =
+      let
+        mountable = lib.filterAttrs (_: value: ((value.mount or null) != null)) config.ec2.zfs.datasets;
+      in
+      lib.mapAttrs' (
+        dataset: opts:
+        lib.nameValuePair opts.mount {
+          device = dataset;
+          fsType = "zfs";
+        }
+      ) mountable;
   };
 }

--- a/nixos/modules/virtualisation/amazon-options.nix
+++ b/nixos/modules/virtualisation/amazon-options.nix
@@ -54,7 +54,7 @@ in
         defaultText = literalExpression "pkgs.stdenv.hostPlatform.isAarch64";
         internal = true;
         description = ''
-          Whether the EC2 instance is using EFI.
+          Whether the EC2 instance **only** supports EFI.
         '';
       };
       hvm = lib.mkOption {


### PR DESCRIPTION
## Description of changes

Changes the amazon image to always use a GPT instead of MBR partition table

Nitro-enabled EC2 instances all support UEFI.
Some x86 instances on AWS don't support UEFI (like the free-tier T2).
We change the image to a hybrid image and change the
AMI type to "uefi-preferred". This way machines that
support UEFI will boot into UEFI.

Making this as a first move to help us migrate to repart-based image builder
which only supports GPT Partition Tables but is a lot more maintainable.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
