### PR TITLE
thumbdrives: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/applications/system/thumbdrives/default.nix
+++ b/pkgs/applications/system/thumbdrives/default.nix
@@ -56,7 +56,10 @@ python3.pkgs.buildPythonApplication rec {
     description = "USB mass storage emulator for Linux handhelds";
     homepage = "https://sr.ht/~martijnbraam/thumbdrives/";
     license = licenses.mit;
-    maintainers = with maintainers; [ chuangzhu ];
+    maintainers = with maintainers; [
+      chuangzhu
+      Luflosi
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/th/thumbdrives/package.nix
+++ b/pkgs/by-name/th/thumbdrives/package.nix
@@ -1,16 +1,17 @@
-{ lib
-, python3
-, fetchFromSourcehut
-, gtk3
-, libhandy_0
-, gobject-introspection
-, meson
-, pkg-config
-, ninja
-, gettext
-, glib
-, desktop-file-utils
-, wrapGAppsHook3
+{
+  lib,
+  python3,
+  fetchFromSourcehut,
+  gtk3,
+  libhandy_0,
+  gobject-introspection,
+  meson,
+  pkg-config,
+  ninja,
+  gettext,
+  glib,
+  desktop-file-utils,
+  wrapGAppsHook3,
 }:
 
 python3.pkgs.buildPythonApplication rec {

--- a/pkgs/by-name/th/thumbdrives/package.nix
+++ b/pkgs/by-name/th/thumbdrives/package.nix
@@ -16,7 +16,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "thumbdrives";
-  version = "0.3.1";
+  version = "0.3.2";
 
   format = "other";
 
@@ -24,7 +24,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "~martijnbraam";
     repo = pname;
     rev = version;
-    sha256 = "sha256-CPZKswbvsG61A6J512FOCKAntoJ0sUb2s+MKb0rO+Xw=";
+    hash = "sha256-Mh3NSEYscnzw6kjR9m0XbTygj07cIQwdyLcdLpfKi3Y=";
   };
 
   postPatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12948,8 +12948,6 @@ with pkgs;
 
   threema-desktop = callPackage ../applications/networking/instant-messengers/threema-desktop { };
 
-  thumbdrives = callPackage ../applications/system/thumbdrives { };
-
   tidy-viewer = callPackage ../tools/text/tidy-viewer { };
 
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };


### PR DESCRIPTION
## Description of changes
https://git.sr.ht/~martijnbraam/thumbdrives/refs/0.3.2

Also:
- Add myself as a maintainer
- Move the package to `pkgs/by-name`
- Format with nixfmt-rfc-style

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
