### PR TITLE
harlequin: init at 1.24.1

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  harlequin,
+  testers,
+  nix-update-script,
+  versionCheckHook,
+  withPostgresAdapter ? true,
+  withBigQueryAdapter ? true,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "harlequin";
+  version = "1.24.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tconbeer";
+    repo = "harlequin";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-3Rb47zkWsC6RJhk1btQc/kwxpFFWVnxY2PJooHB7IzQ=";
+  };
+
+  build-system = with python3Packages; [
+    poetry-core
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      textual
+      textual-fastdatatable
+      textual-textarea
+      click
+      rich-click
+      duckdb
+      sqlfmt
+      platformdirs
+      importlib-metadata
+      tomlkit
+      questionary
+      numpy
+      packaging
+    ]
+    ++ lib.optionals withPostgresAdapter [ harlequin-postgres ]
+    ++ lib.optionals withBigQueryAdapter [ harlequin-bigquery ];
+
+  pythonRelaxDeps = [
+    "textual"
+  ];
+
+  pythonImportsCheck = [
+    "harlequin"
+    "harlequin_duckdb"
+    "harlequin_sqlite"
+    "harlequin_vscode"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = harlequin;
+    };
+  };
+
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+
+  meta = {
+    description = "The SQL IDE for Your Terminal";
+    homepage = "https://harlequin.sh";
+    mainProgram = "harlequin";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pcboy ];
+    platforms = lib.platforms.unix;
+    changelog = "https://github.com/tconbeer/harlequin/releases/tag/v${version}";
+  };
+}

--- a/pkgs/development/python-modules/harlequin-bigquery/default.nix
+++ b/pkgs/development/python-modules/harlequin-bigquery/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  google-cloud-bigquery,
+  google-cloud-bigquery-storage,
+}:
+
+buildPythonPackage rec {
+  pname = "harlequin-bigquery";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "harlequin_bigquery";
+    inherit version;
+    hash = "sha256-uIPYhK4R6N7pqsKY2GozkG76WI+gru2unsK5BxO4+/Y=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    google-cloud-bigquery
+    google-cloud-bigquery-storage
+  ];
+
+  # To prevent circular dependency
+  # as harlequin-bigquery requires harlequin which requires harlequin-bigquery
+  doCheck = false;
+  pythonRemoveDeps = [
+    "harlequin"
+  ];
+
+  meta = {
+    description = "A Harlequin adapter for Google BigQuery";
+    homepage = "https://pypi.org/project/harlequin-bigquery/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pcboy ];
+  };
+}

--- a/pkgs/development/python-modules/harlequin-postgres/default.nix
+++ b/pkgs/development/python-modules/harlequin-postgres/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  psycopg,
+}:
+
+buildPythonPackage rec {
+  pname = "harlequin-postgres";
+  version = "0.4.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "harlequin_postgres";
+    inherit version;
+    hash = "sha256-1y8S3z6ZTt+PZg75aB/bKnEPdAtqjZ2IqyBtUBk8IFA=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    psycopg
+    psycopg.pool
+  ];
+
+  # To prevent circular dependency
+  # as harlequin-postgres requires harlequin which requires harlequin-postgres
+  doCheck = false;
+  pythonRemoveDeps = [
+    "harlequin"
+  ];
+
+  meta = {
+    description = "A Harlequin adapter for Postgres";
+    homepage = "https://pypi.org/project/harlequin-postgres/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pcboy ];
+  };
+}

--- a/pkgs/development/python-modules/sqlfmt/default.nix
+++ b/pkgs/development/python-modules/sqlfmt/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  fetchFromGitHub,
+  importlib-metadata,
+  black,
+  poetry-core,
+  click,
+  jinja2,
+  platformdirs,
+  tomli,
+  tqdm,
+  gitpython,
+}:
+
+buildPythonPackage rec {
+  pname = "sqlfmt";
+  version = "0.23.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tconbeer";
+    repo = "sqlfmt";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-g2ycfpsBFMh16pYVzCmde0mhQhhvAhH25i3LJTcG7Ac=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    click
+    importlib-metadata
+    jinja2
+    platformdirs
+    tomli
+    tqdm
+  ];
+
+  optional-dependencies = {
+    jinjafmt = [
+      black
+    ];
+    sqlfmt_primer = [
+      gitpython
+    ];
+  };
+
+  pythonRelaxDeps = [
+    "platformdirs"
+  ];
+
+  pythonImportsCheck = [
+    "sqlfmt"
+  ];
+
+  meta = {
+    description = "Sqlfmt formats your dbt SQL files so you don't have to";
+    homepage = "https://github.com/tconbeer/sqlfmt";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ pcboy ];
+    mainProgram = "sqlfmt";
+  };
+}

--- a/pkgs/development/python-modules/textual-fastdatatable/default.nix
+++ b/pkgs/development/python-modules/textual-fastdatatable/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  pyarrow,
+  pytz,
+  textual,
+  tzdata,
+  polars,
+}:
+
+buildPythonPackage rec {
+  pname = "textual-fastdatatable";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "textual_fastdatatable";
+    inherit version;
+    hash = "sha256-AS3SiwetCHkCMu8H81xbp5QvN/2GCvMlWgU4qZKvBRU=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    pyarrow
+    pytz
+    textual
+    tzdata
+  ];
+
+  optional-dependencies = {
+    polars = [
+      polars
+    ];
+  };
+
+  pythonImportsCheck = [
+    "textual_fastdatatable"
+  ];
+
+  meta = {
+    description = "A performance-focused reimplementation of Textual's DataTable widget, with a pluggable data storage backend";
+    homepage = "https://pypi.org/project/textual-fastdatatable/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pcboy ];
+  };
+}

--- a/pkgs/development/python-modules/textual-textarea/default.nix
+++ b/pkgs/development/python-modules/textual-textarea/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  pyperclip,
+  textual,
+}:
+
+buildPythonPackage rec {
+  pname = "textual-textarea";
+  version = "0.14.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "textual_textarea";
+    inherit version;
+    hash = "sha256-AJU7BBoev6pBrLhvbfF4I7l+E8YnO5jCD5OIsNf6NW0=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    pyperclip
+    textual
+  ];
+
+  pythonImportsCheck = [
+    "textual_textarea"
+  ];
+
+  meta = {
+    description = "A text area (multi-line input) with syntax highlighting for Textual";
+    homepage = "https://pypi.org/project/textual-textarea/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pcboy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5562,6 +5562,10 @@ self: super: with self; {
 
   hap-python = callPackage ../development/python-modules/hap-python { };
 
+  harlequin-bigquery = callPackage ../development/python-modules/harlequin-bigquery { };
+
+  harlequin-postgres = callPackage ../development/python-modules/harlequin-postgres { };
+
   hass-client = callPackage ../development/python-modules/hass-client { };
 
   hass-nabucasa = callPackage ../development/python-modules/hass-nabucasa { };
@@ -14852,6 +14856,8 @@ self: super: with self; {
 
   sqlbag = callPackage ../development/python-modules/sqlbag { };
 
+  sqlfmt = callPackage ../development/python-modules/sqlfmt { };
+
   sqlglot = callPackage ../development/python-modules/sqlglot { };
 
   sqlite-anyio = callPackage ../development/python-modules/sqlite-anyio { };
@@ -15447,9 +15453,13 @@ self: super: with self; {
 
   textual-dev = callPackage ../development/python-modules/textual-dev { };
 
+  textual-fastdatatable = callPackage ../development/python-modules/textual-fastdatatable { };
+
   textual-slider = callPackage ../development/python-modules/textual-slider { };
 
   textual-universal-directorytree = callPackage ../development/python-modules/textual-universal-directorytree { };
+
+  textual-textarea = callPackage ../development/python-modules/textual-textarea { };
 
   testbook = callPackage ../development/python-modules/testbook { };
 


### PR DESCRIPTION
## Description of changes

Following package request:
https://github.com/NixOS/nixpkgs/issues/280605

Harlequin is a SQL IDE in your terminal. It's a python CLI app.

## Things done

Harlequin supports a lot of different adapters today.
This PR only supports duckdb, sqlite, postgres, and bigquery. More can be added but this is quite some work. So would prefer to first make sure if it's necessary or not for first merging.

This is also the first time I had to make a python package with optional dependencies (`passthru.optional-dependencies`). I'm not sure if what I did is correct and I could not find much guidelines about it. :thinking: 

I also had to remove the `harlequin` dep from `harlequin-postgres` and `harlequin-bigquery` to prevent circular dependencies.

I tested it on my machine (NixOS x86_64-linux) and harlequin seems to work successfully.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


