### PR TITLE
softether: format and move to new pkgs/by-name structure

### DIFF
--- a/pkgs/by-name/so/softether/package.nix
+++ b/pkgs/by-name/so/softether/package.nix
@@ -1,6 +1,13 @@
-{ lib, stdenv, fetchurl
-, openssl, readline, ncurses, zlib
-, dataDir ? "/var/lib/softether" }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  openssl,
+  readline,
+  ncurses,
+  zlib,
+  dataDir ? "/var/lib/softether",
+}:
 
 stdenv.mkDerivation rec {
   pname = "softether";
@@ -12,7 +19,12 @@ stdenv.mkDerivation rec {
     sha256 = "0d8zahi9lkv72jh8yj66pwrsi4451vk113d3khzrzgbic6s2i0g6";
   };
 
-  buildInputs = [ openssl readline ncurses zlib ];
+  buildInputs = [
+    openssl
+    readline
+    ncurses
+    zlib
+  ];
 
   preConfigure = ''
     ./configure

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25133,8 +25133,6 @@ with pkgs;
 
   oidentd = callPackage ../servers/identd/oidentd { };
 
-  softether = callPackage ../servers/softether { };
-
   qboot = pkgsi686Linux.callPackage ../applications/virtualization/qboot { };
 
   rust-hypervisor-firmware = callPackage ../applications/virtualization/rust-hypervisor-firmware { };


### PR DESCRIPTION
format softether with nixpkgs#nixfmt-rfc-style and move it to new pkgs/by-name structure