### PR TITLE
haskell.compiler.*: don't declare stage0 ghc as dep to stdenv

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -158,12 +158,12 @@ let
       tools = {
         "cc" = cc;
         "c++" = cc;
-        as = cc.bintools.bintools;
+        as = cc.bintools;
 
-        ar = cc.bintools.bintools;
-        ranlib = cc.bintools.bintools;
-        nm = cc.bintools.bintools;
-        readelf = cc.bintools.bintools;
+        ar = cc.bintools;
+        ranlib = cc.bintools;
+        nm = cc.bintools;
+        readelf = cc.bintools;
         objdump = cc.bintools;
 
         ld = cc.bintools;

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -316,6 +316,8 @@ stdenv.mkDerivation (rec {
     for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
       export "''${env#TARGET_}=''${!env}"
     done
+    # Stage0 (build->build) which builds stage 1
+    export GHC="${bootPkgs.ghc}/bin/ghc"
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
     export CC="${toolPath "cc" targetCC}"
@@ -433,11 +435,13 @@ stdenv.mkDerivation (rec {
     sphinx
   ];
 
-  # Stage0 compiler and the tools/libs it needs to build Stage1. Stage0 is
-  # build->build, Stage1 is build->target (which may be the same as
-  # host->target)
+  # Everything the stage0 compiler needs to build stage1: CC, bintools, extra libs.
+  # See also GHC, {CC,LD,AR}_STAGE0 in preConfigure.
   depsBuildBuild = [
-    bootPkgs.ghc
+    # N.B. We do not declare bootPkgs.ghc in any of the stdenv.mkDerivation
+    # dependency lists to prevent the bintools setup hook from adding ghc's
+    # lib directory to the linker flags. Instead we tell configure about it
+    # via the GHC environment variable.
     buildCC
     # stage0 builds terminfo unconditionally, so we always need ncurses
     ncurses

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -164,6 +164,7 @@ let
         ranlib = cc.bintools.bintools;
         nm = cc.bintools.bintools;
         readelf = cc.bintools.bintools;
+        objdump = cc.bintools;
 
         ld = cc.bintools;
         "ld.gold" = cc.bintools;
@@ -330,6 +331,7 @@ stdenv.mkDerivation (rec {
     export RANLIB="${toolPath "ranlib" targetCC}"
     export READELF="${toolPath "readelf" targetCC}"
     export STRIP="${toolPath "strip" targetCC}"
+    export OBJDUMP="${toolPath "objdump" targetCC}"
   '' + lib.optionalString (stdenv.targetPlatform.linker == "cctools") ''
     export OTOOL="${toolPath "otool" targetCC}"
     export INSTALL_NAME_TOOL="${toolPath "install_name_tool" targetCC}"

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -403,6 +403,9 @@ stdenv.mkDerivation ({
     export CC_STAGE0="$CC_FOR_BUILD"
     export LD_STAGE0="$LD_FOR_BUILD"
     export AR_STAGE0="$AR_FOR_BUILD"
+
+    # Stage0 (build->build) which builds stage 1
+    export GHC="${bootPkgs.ghc}/bin/ghc"
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
     export CC="${toolPath "cc" targetCC}"
@@ -557,11 +560,13 @@ stdenv.mkDerivation ({
 
   # For building runtime libs
   depsBuildTarget = toolsForTarget;
-  # Stage0 compiler and the tools/libs it needs to build Stage1. Stage0 is
-  # build->build, Stage1 is build->target (which may be the same as
-  # host->target)
+  # Everything the stage0 compiler needs to build stage1: CC, bintools, extra libs.
+  # See also GHC, {CC,LD,AR}_STAGE0 in preConfigure.
   depsBuildBuild = [
-    bootPkgs.ghc
+    # N.B. We do not declare bootPkgs.ghc in any of the stdenv.mkDerivation
+    # dependency lists to prevent the bintools setup hook from adding ghc's
+    # lib directory to the linker flags. Instead we tell configure about it
+    # via the GHC environment variable.
     buildCC
     # stage0 builds terminfo unconditionally, so we always need ncurses
     ncurses

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -312,6 +312,7 @@ let
         ranlib = cc.bintools.bintools;
         nm = cc.bintools.bintools;
         readelf = cc.bintools.bintools;
+        objdump = cc.bintools;
 
         ld = cc.bintools;
         "ld.gold" = cc.bintools;
@@ -418,6 +419,7 @@ stdenv.mkDerivation ({
     export RANLIB="${toolPath "ranlib" targetCC}"
     export READELF="${toolPath "readelf" targetCC}"
     export STRIP="${toolPath "strip" targetCC}"
+    export OBJDUMP="${toolPath "objdump" targetCC}"
   '' + lib.optionalString (stdenv.targetPlatform.linker == "cctools") ''
     export OTOOL="${toolPath "otool" targetCC}"
     export INSTALL_NAME_TOOL="${toolPath "install_name_tool" targetCC}"

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -306,12 +306,12 @@ let
       tools = {
         "cc" = cc;
         "c++" = cc;
-        as = cc.bintools.bintools;
+        as = cc.bintools;
 
-        ar = cc.bintools.bintools;
-        ranlib = cc.bintools.bintools;
-        nm = cc.bintools.bintools;
-        readelf = cc.bintools.bintools;
+        ar = cc.bintools;
+        ranlib = cc.bintools;
+        nm = cc.bintools;
+        readelf = cc.bintools;
         objdump = cc.bintools;
 
         ld = cc.bintools;

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -317,6 +317,8 @@ stdenv.mkDerivation (rec {
     for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
       export "''${env#TARGET_}=''${!env}"
     done
+    # Stage0 (build->build) which builds stage 1
+    export GHC="${bootPkgs.ghc}/bin/ghc"
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
     export CC="${toolPath "cc" targetCC}"
@@ -451,11 +453,13 @@ stdenv.mkDerivation (rec {
     xattr
   ];
 
-  # Stage0 compiler and the tools/libs it needs to build Stage1. Stage0 is
-  # build->build, Stage1 is build->target (which may be the same as
-  # host->target)
+  # Everything the stage0 compiler needs to build stage1: CC, bintools, extra libs.
+  # See also GHC, {CC,LD,AR}_STAGE0 in preConfigure.
   depsBuildBuild = [
-    bootPkgs.ghc
+    # N.B. We do not declare bootPkgs.ghc in any of the stdenv.mkDerivation
+    # dependency lists to prevent the bintools setup hook from adding ghc's
+    # lib directory to the linker flags. Instead we tell configure about it
+    # via the GHC environment variable.
     buildCC
     # stage0 builds terminfo unconditionally, so we always need ncurses
     ncurses

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -161,12 +161,12 @@ let
       tools = {
         "cc" = cc;
         "c++" = cc;
-        as = cc.bintools.bintools;
+        as = cc.bintools;
 
-        ar = cc.bintools.bintools;
-        ranlib = cc.bintools.bintools;
-        nm = cc.bintools.bintools;
-        readelf = cc.bintools.bintools;
+        ar = cc.bintools;
+        ranlib = cc.bintools;
+        nm = cc.bintools;
+        readelf = cc.bintools;
         objdump = cc.bintools;
 
         ld = cc.bintools;

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -167,6 +167,7 @@ let
         ranlib = cc.bintools.bintools;
         nm = cc.bintools.bintools;
         readelf = cc.bintools.bintools;
+        objdump = cc.bintools;
 
         ld = cc.bintools;
         "ld.gold" = cc.bintools;
@@ -331,6 +332,7 @@ stdenv.mkDerivation (rec {
     export RANLIB="${toolPath "ranlib" targetCC}"
     export READELF="${toolPath "readelf" targetCC}"
     export STRIP="${toolPath "strip" targetCC}"
+    export OBJDUMP="${toolPath "objdump" targetCC}"
   '' + lib.optionalString (stdenv.targetPlatform.linker == "cctools") ''
     export OTOOL="${toolPath "otool" targetCC}"
     export INSTALL_NAME_TOOL="${toolPath "install_name_tool" targetCC}"

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -280,11 +280,6 @@ in {
           bb.packages.ghc928
         else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
           bb.packages.ghc928
-        else if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isLinux then
-          # For unknown reasons, compiling with a bindist GHC causes the final
-          # GHC's rpaths to contain the boot compiler on aarch64-linux / GHC 9.6.*.
-          # Note: Unclear if this is due to host or build aarch64-linux.
-          bb.packages.ghc928
         else
           bb.packages.ghc924Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -302,11 +297,6 @@ in {
         if stdenv.buildPlatform.isAarch32 then
           bb.packages.ghc928
         else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
-          bb.packages.ghc928
-        else if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isLinux then
-          # For unknown reasons, compiling with a bindist GHC causes the final
-          # GHC's rpaths to contain the boot compiler on aarch64-linux / GHC 9.6.*.
-          # Note: Unclear if this is due to host or build aarch64-linux.
           bb.packages.ghc928
         else
           bb.packages.ghc924Binary;
@@ -326,11 +316,6 @@ in {
           bb.packages.ghc928
         else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
           bb.packages.ghc928
-        else if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isLinux then
-          # For unknown reasons, compiling with a bindist GHC causes the final
-          # GHC's rpaths to contain the boot compiler on aarch64-linux / GHC 9.6.*.
-          # Note: Unclear if this is due to host or build aarch64-linux.
-          bb.packages.ghc928
         else
           bb.packages.ghc924Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -348,11 +333,6 @@ in {
         if stdenv.buildPlatform.isAarch32 then
           bb.packages.ghc928
         else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
-          bb.packages.ghc928
-        else if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isLinux then
-          # For unknown reasons, compiling with a bindist GHC causes the final
-          # GHC's rpaths to contain the boot compiler on aarch64-linux / GHC 9.6.*.
-          # Note: Unclear if this is due to host or build aarch64-linux.
           bb.packages.ghc928
         else
           bb.packages.ghc924Binary;


### PR DESCRIPTION
Some GHC bindists have a normal `$out/lib` directory which contains symlinks to all core libs. Because it is a normal lib directory, the bintools setup hook will pick up on it and cause ld to pass the appropriate -L and -rpath flags. We do not want this to happen, especially in the case of the stage2 compiler. Not only will the final ghc have an unnecessary reference (and thus increased closure size) to the binary ghc, but the extra libraries in the rpath mess with the rts and cause e.g. segfaults in GHCi.

Unfortunately, there is no way to prevent this. It is a fundamental flaw in the cc and bintools wrappers that they do not actually distinguish between the roles of dependencies (build, host, target). Instead the mangleVar* function will translate the dependencies split up by roles into platforms. This means that the wrappers can't distinguish between depsBuildBuild and depsHostTarget (== buildInputs) when natively compiling. As long as we are natively compiling the wrappers will put the stage0 ghc (be it in depsBuildBuild, nativeBuildInputs etc.) into the linker flags of the final ghc.

The solution is to sidestep the issue. We just had ghc in depsBuildBuild to have it added to PATH. GHC itself will pass the appropriate linker flags if necessary. To avoid the setup hooks picking up on the GHC libraries we just don't put it into depsBuildBuild or any other dependency list. Since the GHC build system accepts the GHC binary via an absolute path, we don't even need to add the stage0 GHC to PATH.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
