### PR TITLE
wooting-udev-rules: add rules for Wooting 80HE

### DIFF
--- a/pkgs/os-specific/linux/wooting-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/wooting-udev-rules/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "wooting-udev-rules";
-  version = "unstable-2023-03-31";
+  version = "unstable-2024-09-23";
 
   # Source: https://help.wooting.io/en/article/wootility-configuring-device-access-for-wootility-under-linux-udev-rules-r6lb2o/
   src = [ ./wooting.rules ];

--- a/pkgs/os-specific/linux/wooting-udev-rules/wooting.rules
+++ b/pkgs/os-specific/linux/wooting-udev-rules/wooting.rules
@@ -94,3 +94,9 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="31e3", ATTRS{idProduct}=="1312", MODE:="0660
 
 # Wooting 60HE (ARM) update mode
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", ATTRS{idProduct}=="131f", MODE:="0660", GROUP="input"
+
+# Wooting 80HE
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", ATTRS{idProduct}=="1402", MODE:="0660", GROUP="input"
+
+# Wooting 80HE update mode
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", ATTRS{idProduct}=="140f", MODE:="0660", GROUP="input"


### PR DESCRIPTION
## Description of changes

Adds udev rules for the newly released [Wooting 80HE](https://wooting.io/wooting-80he) keyboard. I don't know much about the "gamepad mode", I'd welcome suggestions on whether it is applicable to 80HE and how to acquire the relevant IDs for these alternative modes.

Here's the relevant dmesg snippet (plugging in the keyboard in the default mode):

```
[  730.321286] usb 1-3.1: new high-speed USB device number 14 using xhci_hcd
[  730.488413] usb 1-3.1: New USB device found, idVendor=31e3, idProduct=1402, bcdDevice= 2.30
[  730.488419] usb 1-3.1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[  730.488421] usb 1-3.1: Product: Wooting 80HE
[  730.488422] usb 1-3.1: Manufacturer: Wooting
[  730.488424] usb 1-3.1: SerialNumber: A02B2431W08T00100S02H03975
[  730.540930] hid-generic 0003:31E3:1402.0010: hiddev97,hidraw1: USB HID v1.11 Device [Wooting Wooting 80HE] on usb-0000:0d:00.0-3.1/input0
[  730.552559] input: Wooting Wooting 80HE as /devices/pci0000:00/0000:00:02.1/0000:03:00.0/0000:04:08.0/0000:07:00.0/0000:08:0c.0/0000:0d:00.0/usb1/1-3/1-3.1/1-3.1:1.1/0003:31E3:1402.0011/input/input26
[  730.628119] hid-generic 0003:31E3:1402.0011: input,hidraw2: USB HID v1.11 Keyboard [Wooting Wooting 80HE] on usb-0000:0d:00.0-3.1/input1
[  730.638601] hid-generic 0003:31E3:1402.0012: hiddev98,hidraw3: USB HID v1.11 Device [Wooting Wooting 80HE] on usb-0000:0d:00.0-3.1/input2
[  730.650562] input: Wooting Wooting 80HE System Control as /devices/pci0000:00/0000:00:02.1/0000:03:00.0/0000:04:08.0/0000:07:00.0/0000:08:0c.0/0000:0d:00.0/usb1/1-3/1-3.1/1-3.1:1.3/0003:31E3:1402.0013/input/input27
[  730.702456] input: Wooting Wooting 80HE Consumer Control as /devices/pci0000:00/0000:00:02.1/0000:03:00.0/0000:04:08.0/0000:07:00.0/0000:08:0c.0/0000:0d:00.0/usb1/1-3/1-3.1/1-3.1:1.3/0003:31E3:1402.0013/input/input28
[  730.702557] input: Wooting Wooting 80HE Mouse as /devices/pci0000:00/0000:00:02.1/0000:03:00.0/0000:04:08.0/0000:07:00.0/0000:08:0c.0/0000:0d:00.0/usb1/1-3/1-3.1/1-3.1:1.3/0003:31E3:1402.0013/input/input29
[  730.702654] hid-generic 0003:31E3:1402.0013: input,hidraw4: USB HID v1.11 Mouse [Wooting Wooting 80HE] on usb-0000:0d:00.0-3.1/input3
[  730.713550] hid-generic 0003:31E3:1402.0014: hiddev99,hidraw5: USB HID v1.11 Device [Wooting Wooting 80HE] on usb-0000:0d:00.0-3.1/input4

```

Additionally: should we use the `uaccess` tag instead of the `input` group? I don't know much about udev, but [that seems to be the recommended course of action nowadays](https://www.reddit.com/r/linuxquestions/comments/bh4ex1/is_adding_a_user_to_input_group_secure/), and it has a few usages in nixpkgs already.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
