### PR TITLE
aerospace: init at 0.14.2-Beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -907,6 +907,12 @@
     githubId = 49609151;
     name = "Popa Ioan Alexandru";
   };
+  alexandru0-dev = {
+    email = "alexandru.italia32+nixpkgs@gmail.com";
+    github = "alexandru0-dev";
+    githubId = 45104896;
+    name = "Alexandru Nechita";
+  };
   alexarice = {
     email = "alexrice999@hotmail.co.uk";
     github = "alexarice";

--- a/pkgs/by-name/ae/aerospace/package.nix
+++ b/pkgs/by-name/ae/aerospace/package.nix
@@ -1,0 +1,58 @@
+{
+  fetchzip,
+  gitUpdater,
+  installShellFiles,
+  lib,
+  stdenv,
+  versionCheckHook,
+}:
+
+let
+  appName = "AeroSpace.app";
+  version = "0.14.2-Beta";
+in
+stdenv.mkDerivation {
+  pname = "aerospace";
+
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/nikitabobko/AeroSpace/releases/download/v${version}/AeroSpace-v${version}.zip";
+    hash = "sha256-v2D/IV9Va0zbGHEwSGt6jvDqQYqha290Lm6u+nZTS3A=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    mv ${appName} $out/Applications
+    cp -R bin $out
+    mkdir -p $out/share
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installManPage manpage/*
+    installShellCompletion --bash shell-completion/bash/aerospace
+    installShellCompletion --fish shell-completion/fish/aerospace.fish
+    installShellCompletion --zsh  shell-completion/zsh/_aerospace
+  '';
+
+  passthru.tests.can-print-version = [ versionCheckHook ];
+
+  passthru.updateScript = gitUpdater {
+    url = "https://github.com/nikitabobko/AeroSpace.git";
+    rev-prefix = "v";
+  };
+
+  meta = {
+    license = lib.licenses.mit;
+    mainProgram = "aerospace";
+    homepage = "https://github.com/nikitabobko/AeroSpace";
+    description = "i3-like tiling window manager for macOS";
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ alexandru0-dev ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Introduces [aerospace](https://github.com/nikitabobko/AeroSpace) - an i3-like tiling window manager for macOS.
As of now uses binaries as are already signed and building would result in losing accessibility permissions between updates. (see https://github.com/NixOS/nixpkgs/pull/299099#issuecomment-2029566383)

I would like some feedback about man pages and shell-completion if possible.

Closes #299099.
Reason: There wasn't really a package made and unmaintained.
## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
