### PR TITLE
postgresqlPackages: replace custom installPhase with buildPostgresqlExtension helper

### DIFF
--- a/pkgs/servers/sql/postgresql/buildPostgresqlExtension.nix
+++ b/pkgs/servers/sql/postgresql/buildPostgresqlExtension.nix
@@ -1,0 +1,129 @@
+# PostgreSQL's build system for extensions (PGXS) makes the following assumptions:
+# - All extensions will be installed in the same prefix as PostgreSQL itself.
+# - pg_config is able to return the correct paths for bindir/libdir/datadir etc.
+#
+# Both of those assumptions break with nix. Since each extension is a separate
+# derivation, we need to put all its files into a different folder. At the same
+# time, pg_config only points to the PostgreSQL derivation's paths.
+#
+# When building extensions, the paths provided by pg_config are used for two
+# purposes:
+# - To find postgres libs and headers and reference those paths via -L and -I flags.
+# - To determine the correct install directory.
+#
+# The PGXS Makefiles also support an environment variable DESTDIR, which is added as
+# a prefix to all install locations. This is primarily used for temporary installs
+# while running the test suite. Since pg_config returns absolute paths to /nix/store
+# for us, using DESTDIR will result in install locations of the form:
+#   $DESTIDR/nix/store/<postgresql-output>/...
+#
+# In multiple iterations, the following approaches have been tried to work around all
+# of this:
+# 1. For a long time, all extensions in nixpkgs just overwrote the installPhase
+#    and moved the respective files to the correct location manually. This approach
+#    is not maintainable, because whenever upstream adds a new file, we'd have to
+#    make sure the file is correctly installed as well. Additionally, it makes adding
+#    a new extension harder than it should be.
+#
+# 2. A wrapper around pg_config could just replace the returned paths with paths to
+#    $out of currently building derivation, i.e. the extension. This works for install-
+#    ation, but breaks for any of the libs and headers the extension needs from postgres
+#    itself.
+#
+# 3. A variation of 2., but make the pg_config wrapper only return the changed paths
+#    during the installPahse. During configure and build, it would return the regular
+#    paths to the PostgreSQL derivation. This works better, but not for every case.
+#    Some extensions try to be smarter and search for the "postgres" binary to deduce
+#    the necessary paths from that. Those would still need special handling.
+#
+# 4. Use the fact that DESTDIR is prepended to every installation directory - and only
+#    there, to run a replacement of all Makefiles in postgres' lib/pgxs/ folder and
+#    all Makefiles in the extension's source. "$DESTDIR/$bindir" can be replaced with
+#    "$out/bin" etc. - thus mapping the installPhase directly into the right output.
+#    This works beautifully - for the majority of cases. But it doesn't work for
+#    some extensions that use CMake. And it doesn't work for some extensions that use
+#    custom variables instead of the default "bindir" and friends.
+#
+# 5. Just set DESTDIR to the extensions's output and then clean up afterward. This will
+#    result in paths like this:
+#      /nix/store/<extension-output>/nix/store/<postgresql-output>/...
+#    Directly after the installPhase, we'll move the files in the right folder.
+#    This seems to work consistently across all extensions we have in nixpkgs right now.
+#    Of course, it would break down for any extension that doesn't support DESTDIR -
+#    but that just means PGXS is not used either, so that's OK.
+#
+# This last approach is the one we're taking in this file. To make sure the removal of the
+# nested nix/store happens immediately after the installPhase, before any other postInstall
+# hooks run, this needs to be run in an override of `mkDerivation` and not in a setup hook.
+
+{
+  lib,
+  stdenv,
+  postgresql,
+}:
+
+args:
+
+let
+  buildPostgresqlExtension = finalAttrs: prevAttrs: {
+    buildInputs = [ postgresql ] ++ prevAttrs.buildInputs or [ ];
+
+    installFlags = [
+      "DESTDIR=${placeholder "out"}"
+    ] ++ prevAttrs.installFlags or [ ];
+
+    postInstall =
+      ''
+        # DESTDIR + pg_config install the files into
+        # /nix/store/<extension>/nix/store/<postgresql>/...
+        # We'll now remove the /nix/store/<postgresql> part:
+        if [[ -d "$out${postgresql}" ]]; then
+            cp -alt "$out" "$out${postgresql}"/*
+            rm -r "$out${postgresql}"
+        fi
+
+        if [[ -d "$out${postgresql.dev}" ]]; then
+            mkdir -p "''${dev:-$out}"
+            cp -alt "''${dev:-$out}" "$out${postgresql.dev}"/*
+            rm -r "$out${postgresql.dev}"
+        fi
+
+        if [[ -d "$out${postgresql.lib}" ]]; then
+            mkdir -p "''${lib:-$out}"
+            cp -alt "''${lib:-$out}" "$out${postgresql.lib}"/*
+            rm -r "$out${postgresql.lib}"
+        fi
+
+        if [[ -d "$out${postgresql.doc}" ]]; then
+            mkdir -p "''${doc:-$out}"
+            cp -alt "''${doc:-$out}" "$out${postgresql.doc}"/*
+            rm -r "$out${postgresql.doc}"
+        fi
+
+        if [[ -d "$out${postgresql.man}" ]]; then
+            mkdir -p "''${man:-$out}"
+            cp -alt "''${man:-$out}" "$out${postgresql.man}"/*
+            rm -r "$out${postgresql.man}"
+        fi
+
+        # In some cases (postgis) parts of the install script
+        # actually work "OK", before we add DESTDIR, so some
+        # files end up in
+        # /nix/store/<extension>/nix/store/<extension>/...
+        if [[ -d "$out$out" ]]; then
+            cp -alt "$out" "$out$out"/*
+            rm -r "$out$out"
+        fi
+
+        if [[ -d "$out/nix/store" ]]; then
+            if ! rmdir "$out/nix/store" "$out/nix"; then
+              find "$out/nix"
+              nixErrorLog 'Found left-overs in $out/nix/store, make sure to move them into $out properly.'
+              exit 1
+            fi
+        fi
+      ''
+      + prevAttrs.postInstall or "";
+  };
+in
+stdenv.mkDerivation (lib.extends buildPostgresqlExtension (lib.toFunction args))

--- a/pkgs/servers/sql/postgresql/ext/age.nix
+++ b/pkgs/servers/sql/postgresql/ext/age.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, bison, fetchFromGitHub, flex, perl, postgresql }:
+{ lib, stdenv, bison, fetchFromGitHub, flex, perl, postgresql, buildPostgresqlExtension }:
 
 let
   hashes = {
@@ -11,7 +11,7 @@ let
     "12" = "sha256-JFNk17ESsIt20dwXrfBkQ5E6DbZzN/Q9eS6+WjCXGd4=";
   };
 in
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "age";
   version = "1.5.0-rc0";
 
@@ -22,19 +22,11 @@ stdenv.mkDerivation rec {
     hash = hashes.${lib.versions.major postgresql.version} or (throw "Source for Age is not available for ${postgresql.version}");
   };
 
-  buildInputs = [ postgresql ];
-
   makeFlags = [
     "BISON=${bison}/bin/bison"
     "FLEX=${flex}/bin/flex"
     "PERL=${perl}/bin/perl"
   ];
-
-  installPhase = ''
-    install -D -t $out/lib *${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
 
   passthru.tests = stdenv.mkDerivation {
     inherit version src;

--- a/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
+++ b/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, postgresql, boost182, nixosTests }:
+{ stdenv, lib, fetchFromGitHub, postgresql, boost182, nixosTests, buildPostgresqlExtension }:
 
 let
   version = "1.7.0";
@@ -20,7 +20,7 @@ let
   };
 in
 
-stdenv.mkDerivation {
+buildPostgresqlExtension {
   pname = "apache_datasketches";
   inherit version;
 
@@ -28,37 +28,12 @@ stdenv.mkDerivation {
 
   sourceRoot = main_src.name;
 
-  buildInputs = [ postgresql boost182 ];
+  buildInputs = [ boost182 ];
 
   patchPhase = ''
     runHook prePatch
     cp -r ../${cpp_src.name} .
     runHook postPatch
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    install -D -m 644 ./datasketches${postgresql.dlSuffix} -t $out/lib/
-    cat \
-      sql/datasketches_cpc_sketch.sql \
-      sql/datasketches_kll_float_sketch.sql \
-      sql/datasketches_kll_double_sketch.sql \
-      sql/datasketches_theta_sketch.sql \
-      sql/datasketches_frequent_strings_sketch.sql \
-      sql/datasketches_hll_sketch.sql \
-      sql/datasketches_aod_sketch.sql \
-      sql/datasketches_req_float_sketch.sql \
-      sql/datasketches_quantiles_double_sketch.sql \
-      > sql/datasketches--${version}.sql
-    install -D -m 644 ./datasketches.control -t $out/share/postgresql/extension
-    install -D -m 644 \
-      ./sql/datasketches--${version}.sql \
-      ./sql/datasketches--1.3.0--1.4.0.sql \
-      ./sql/datasketches--1.4.0--1.5.0.sql \
-      ./sql/datasketches--1.5.0--1.6.0.sql \
-      ./sql/datasketches--1.6.0--1.7.0.sql \
-      -t $out/share/postgresql/extension
-    runHook postInstall
   '';
 
   passthru.tests.apache_datasketches = nixosTests.apache_datasketches;

--- a/pkgs/servers/sql/postgresql/ext/citus.nix
+++ b/pkgs/servers/sql/postgresql/ext/citus.nix
@@ -4,9 +4,10 @@
 , fetchFromGitHub
 , lz4
 , postgresql
+, buildPostgresqlExtension
 }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "citus";
   version = "12.1.2";
 
@@ -20,22 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     curl
     lz4
-    postgresql
   ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -D -t $out/lib src/backend/columnar/citus_columnar${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension src/backend/columnar/build/sql/*.sql
-    install -D -t $out/share/postgresql/extension src/backend/columnar/*.control
-
-    install -D -t $out/lib src/backend/distributed/citus${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension src/backend/distributed/build/sql/*.sql
-    install -D -t $out/share/postgresql/extension src/backend/distributed/*.control
-
-    runHook postInstall
-  '';
 
   meta = with lib; {
     # "Our soft policy for Postgres version compatibility is to support Citus'

--- a/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
@@ -1,11 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, protobufc }:
+{ lib, stdenv, fetchFromGitHub, postgresql, protobufc, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "cstore_fdw";
   version = "unstable-2022-03-08";
 
   nativeBuildInputs = [ protobufc ];
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner  = "citusdata";
@@ -13,14 +12,6 @@ stdenv.mkDerivation rec {
     rev    = "90e22b62fbee6852529104fdd463f532cf7a3311";
     sha256 = "sha256-02wcCqs8A5ZOZX080fgcNJTQrYQctnlwnA8+YPaRTZc=";
   };
-
-  installPhase = ''
-    mkdir -p $out/{lib,share/postgresql/extension}
-
-    cp *.so      $out/lib
-    cp *.sql     $out/share/postgresql/extension
-    cp *.control $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     broken      = versionAtLeast postgresql.version "14";

--- a/pkgs/servers/sql/postgresql/ext/h3-pg.nix
+++ b/pkgs/servers/sql/postgresql/ext/h3-pg.nix
@@ -5,9 +5,10 @@
 , h3_4
 , postgresql
 , postgresqlTestExtension
+, buildPostgresqlExtension
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "h3-pg";
   version = "4.1.3";
 
@@ -32,15 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     h3_4
-    postgresql
   ];
-
-  installPhase = ''
-    install -D -t $out/lib h3/h3.so
-    install -D -t $out/share/postgresql/extension h3/h3-*.sql h3/h3.control
-    install -D -t $out/lib h3_postgis/h3_postgis.so
-    install -D -t $out/share/postgresql/extension h3_postgis/h3_postgis-*.sql h3_postgis/h3_postgis.control
-  '';
 
   passthru.tests.extension = postgresqlTestExtension {
     inherit (finalAttrs) finalPackage;

--- a/pkgs/servers/sql/postgresql/ext/hypopg.nix
+++ b/pkgs/servers/sql/postgresql/ext/hypopg.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, gitUpdater }:
+{ lib, stdenv, fetchFromGitHub, postgresql, gitUpdater, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "hypopg";
   version = "1.4.1";
 
@@ -10,14 +10,6 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-88uKPSnITRZ2VkelI56jZ9GWazG/Rn39QlyHKJKSKMM=";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    install -D -t $out/lib *${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.control
-    install -D -t $out/share/postgresql/extension *.sql
-  '';
 
   passthru = {
     updateScript = gitUpdater {

--- a/pkgs/servers/sql/postgresql/ext/jsonb_deep_sum.nix
+++ b/pkgs/servers/sql/postgresql/ext/jsonb_deep_sum.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "jsonb_deep_sum";
   version = "unstable-2021-12-24";
 
@@ -10,16 +10,6 @@ stdenv.mkDerivation rec {
     rev = "d9c69aa6b7da860e5522a9426467e67cb787980c";
     sha256 = "sha256-W1wNILAwTAjFPezq+grdRMA59KEnMZDz69n9xQUqdc0=";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    mkdir -p $out/{lib,share/postgresql/extension}
-
-    cp *${postgresql.dlSuffix} $out/lib
-    cp *.sql     $out/share/postgresql/extension
-    cp *.control $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "PostgreSQL extension to easily add jsonb numeric";

--- a/pkgs/servers/sql/postgresql/ext/lantern.nix
+++ b/pkgs/servers/sql/postgresql/ext/lantern.nix
@@ -5,9 +5,10 @@
 , openssl
 , postgresql
 , postgresqlTestExtension
+, buildPostgresqlExtension
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "postgresql-lantern";
   version = "0.4.1";
 
@@ -29,18 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     openssl
-    postgresql
   ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -D -t $out/lib lantern${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension lantern-*.sql
-    install -D -t $out/share/postgresql/extension lantern.control
-
-    runHook postInstall
-  '';
 
   cmakeFlags = [
     "-DBUILD_FOR_DISTRIBUTING=ON"

--- a/pkgs/servers/sql/postgresql/ext/periods.nix
+++ b/pkgs/servers/sql/postgresql/ext/periods.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "periods";
   version = "1.2.2";
 
@@ -10,14 +10,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-ezt+MtDqPM8OmJCD6oQTS644l+XHZoxuivq0PUIXOY8=";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    install -D -t $out/lib *${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
 
   meta = with lib; {
     description = "PostgreSQL extension implementing SQL standard functionality for PERIODs and SYSTEM VERSIONING";

--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_auto_failover";
   version = "2.1";
 
@@ -11,14 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-OIWykfFbVskrkPG/zSmZtZjc+W956KSfIzK7f5QOqpI=";
   };
 
-  buildInputs = postgresql.buildInputs ++ [ postgresql ];
-
-  installPhase = ''
-    install -D -t $out/bin src/bin/pg_autoctl/pg_autoctl
-    install -D -t $out/lib src/monitor/pgautofailover.so
-    install -D -t $out/share/postgresql/extension src/monitor/*.sql
-    install -D -t $out/share/postgresql/extension src/monitor/pgautofailover.control
-  '';
+  buildInputs = postgresql.buildInputs;
 
   meta = with lib; {
     description = "PostgreSQL extension and service for automated failover and high-availability";

--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, postgresql }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_bigm";
   version = "1.2-20200228";
 
@@ -19,15 +19,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ postgresql ];
-
   makeFlags = [ "USE_PGXS=1" ];
-
-  installPhase = ''
-    install -D -t $out/lib pg_bigm${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
 
   meta = with lib; {
     description = "Text similarity measurement and index searching based on bigrams";

--- a/pkgs/servers/sql/postgresql/ext/pg_cron.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_cron.nix
@@ -1,10 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_cron";
   version = "1.6.4";
-
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner  = "citusdata";
@@ -12,14 +10,6 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     hash   = "sha256-t1DpFkPiSfdoGG2NgNT7g1lkvSooZoRoUrix6cBID40=";
   };
-
-  installPhase = ''
-    mkdir -p $out/{lib,share/postgresql/extension}
-
-    cp *${postgresql.dlSuffix} $out/lib
-    cp *.sql     $out/share/postgresql/extension
-    cp *.control $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "Run Cron jobs through PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitLab, postgresql }:
+{ lib, stdenv, fetchFromGitLab, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_ed25519";
   version = "0.2";
   src = fetchFromGitLab {
@@ -9,17 +9,6 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "16w3qx3wj81bzfhydl2pjhn8b1jak6h7ja9wq1kc626g0siggqi0";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    mkdir -p $out/bin    # For buildEnv to setup proper symlinks. See #22653
-    mkdir -p $out/{lib,share/postgresql/extension}
-
-    cp *.so      $out/lib
-    cp *.sql     $out/share/postgresql/extension
-    cp *.control $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "PostgreSQL extension for signing and verifying ed25519 signatures";

--- a/pkgs/servers/sql/postgresql/ext/pg_embedding.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_embedding.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_embedding";
   version = "0.3.6";
 
@@ -10,14 +10,6 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-NTBxsQB8mR7e/CWwkCEyDiYhi3Nxl/aKgRBwqc0THcI=";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    install -D -t $out/lib *.so
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
 
   meta = with lib; {
     description = "PostgreSQL extension implementing the HNSW algorithm for vector similarity search";

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
 let
   source = {
@@ -28,7 +28,7 @@ let
     };
   }.${lib.versions.major postgresql.version} or (throw "Source for pg_hint_plan is not available for ${postgresql.version}");
 in
-stdenv.mkDerivation {
+buildPostgresqlExtension {
   pname = "pg_hint_plan";
   inherit (source) version;
 
@@ -42,14 +42,6 @@ stdenv.mkDerivation {
   postPatch = lib.optionalString (lib.versionOlder postgresql.version "14") ''
     # https://github.com/ossc-db/pg_hint_plan/commit/e9e564ad59b8bd4a03e0f13b95b5122712e573e6
     substituteInPlace Makefile --replace "LDFLAGS+=-Wl,--build-id" ""
-  '';
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    install -D -t $out/lib pg_hint_plan${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
   '';
 
   meta = with lib; {

--- a/pkgs/servers/sql/postgresql/ext/pg_hll.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hll.nix
@@ -1,10 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_hll";
   version = "2.18";
-
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner  = "citusdata";
@@ -12,12 +10,6 @@ stdenv.mkDerivation rec {
     rev    = "refs/tags/v${version}";
     hash   = "sha256-Latdxph1Ura8yKEokEjalJ+/GY+pAKOT3GXjuLprj6c=";
   };
-
-  installPhase = ''
-    install -D -t $out/lib hll${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
- '';
 
   meta = with lib; {
     description = "HyperLogLog for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_ivm";
   version = "1.9";
 
@@ -10,14 +10,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-Qcie7sbXcMbQkMoFIYBfttmvlYooESdSk2DyebHKPlk=";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    install -D -t $out/lib pg_ivm${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
 
   meta = with lib; {
     description = "Materialized views with IVM (Incremental View Maintenance) for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/pg_libversion.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_libversion.nix
@@ -5,9 +5,10 @@
 , pkg-config
 , postgresql
 , libversion
+, buildPostgresqlExtension
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "pg_libversion";
   version = "2.0.1";
 
@@ -23,19 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    postgresql
     libversion
   ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -D -t $out/lib libversion${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-
-    runHook postInstall
-  '';
 
   passthru.updateScript = gitUpdater { };
 

--- a/pkgs/servers/sql/postgresql/ext/pg_net.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_net.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, curl, postgresql }:
+{ lib, stdenv, fetchFromGitHub, curl, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_net";
   version = "0.8.0";
 
-  buildInputs = [ curl postgresql ];
+  buildInputs = [ curl ];
 
   src = fetchFromGitHub {
     owner  = "supabase";
@@ -14,14 +14,6 @@ stdenv.mkDerivation rec {
   };
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
-
-  installPhase = ''
-    mkdir -p $out/{lib,share/postgresql/extension}
-
-    cp *${postgresql.dlSuffix} $out/lib
-    cp sql/*.sql $out/share/postgresql/extension
-    cp *.control $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "Async networking for Postgres";

--- a/pkgs/servers/sql/postgresql/ext/pg_partman.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_partman.nix
@@ -1,10 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_partman";
   version = "5.1.0";
-
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner  = "pgpartman";
@@ -12,15 +10,6 @@ stdenv.mkDerivation rec {
     rev    = "refs/tags/v${version}";
     sha256 = "sha256-GrVOJ5ywZMyqyDroYDLdKkXDdIJSDGhDfveO/ZvrmYs=";
   };
-
-  installPhase = ''
-    mkdir -p $out/{lib,share/postgresql/extension}
-
-    cp src/*${postgresql.dlSuffix} $out/lib
-    cp updates/*     $out/share/postgresql/extension
-    cp -r sql/*      $out/share/postgresql/extension
-    cp *.control     $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "Partition management extension for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/pg_rational.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_rational.nix
@@ -2,9 +2,10 @@
 , fetchFromGitHub
 , lib
 , postgresql
+, buildPostgresqlExtension
 }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_rational";
   version = "0.0.2";
 
@@ -14,20 +15,6 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "sha256-Sp5wuX2nP3KGyWw7MFa11rI1CPIKIWBt8nvBSsASIEw=";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/{lib,share/postgresql/extension}
-
-    cp *${postgresql.dlSuffix} $out/lib
-    cp *.sql     $out/share/postgresql/extension
-    cp *.control $out/share/postgresql/extension
-
-    runHook postInstall
-  '';
 
   meta = with lib; {
     description = "Precise fractional arithmetic for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
@@ -1,10 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_relusage";
   version = "0.0.1";
-
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner  = "adept";
@@ -12,12 +10,6 @@ stdenv.mkDerivation rec {
     rev    = "refs/tags/${version}";
     sha256 = "8hJNjQ9MaBk3J9a73l+yQMwMW/F2N8vr5PO2o+5GvYs=";
   };
-
-  installPhase = ''
-    install -D -t $out/lib *${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
 
   meta = with lib; {
     description = "pg_relusage extension for PostgreSQL: discover and log the relations used in your statements";

--- a/pkgs/servers/sql/postgresql/ext/pg_repack.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_repack.nix
@@ -4,13 +4,14 @@
 , postgresql
 , postgresqlTestExtension
 , testers
+, buildPostgresqlExtension
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "pg_repack";
   version = "1.5.0";
 
-  buildInputs = postgresql.buildInputs ++ [ postgresql ];
+  buildInputs = postgresql.buildInputs;
 
   src = fetchFromGitHub {
     owner = "reorg";
@@ -18,12 +19,6 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "ver_${finalAttrs.version}";
     sha256 = "sha256-do80phyMxwcRIkYyUt9z02z7byNQhK+pbSaCUmzG+4c=";
   };
-
-  installPhase = ''
-    install -D bin/pg_repack -t $out/bin/
-    install -D lib/pg_repack${postgresql.dlSuffix} -t $out/lib/
-    install -D lib/{pg_repack--${finalAttrs.version}.sql,pg_repack.control} -t $out/share/postgresql/extension
-  '';
 
   passthru.tests = {
     version = testers.testVersion {

--- a/pkgs/servers/sql/postgresql/ext/pg_roaringbitmap.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_roaringbitmap.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, postgresqlTestHook }:
+{ lib, stdenv, fetchFromGitHub, postgresql, postgresqlTestHook, buildPostgresqlExtension }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "pg_roaringbitmap";
   version = "0.5.4";
 
@@ -10,16 +10,6 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-E6vqawnsRsAIajGDgJcTUWV1H8GFFboTjhmVfemUGbs=";
   };
-
-  buildInputs = [
-    postgresql
-  ];
-
-  installPhase = ''
-    install -D -t $out/lib roaringbitmap${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension roaringbitmap-*.sql
-    install -D -t $out/share/postgresql/extension roaringbitmap.control
-  '';
 
   meta = with lib; {
     description = "RoaringBitmap extension for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
 with {
   "12" = {
@@ -27,11 +27,9 @@ with {
   };
 }."${lib.versions.major postgresql.version}" or (throw "pg_safeupdate: version specification for pg ${postgresql.version} missing.");
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg-safeupdate";
   inherit version;
-
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner  = "eradman";
@@ -39,10 +37,6 @@ stdenv.mkDerivation rec {
     rev    = version;
     inherit sha256;
   };
-
-  installPhase = ''
-    install -D safeupdate${postgresql.dlSuffix} -t $out/lib
-  '';
 
   meta = with lib; {
     description = "Simple extension to PostgreSQL that requires criteria for UPDATE and DELETE";

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, postgresql, unstableGitUpdater }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, postgresql, unstableGitUpdater, buildPostgresqlExtension }:
 
-stdenv.mkDerivation {
+buildPostgresqlExtension {
   pname = "pg_similarity";
   version = "1.0-unstable-2021-01-12";
 
@@ -21,14 +21,7 @@ stdenv.mkDerivation {
     })
   ];
 
-  buildInputs = [ postgresql ];
-
   makeFlags = [ "USE_PGXS=1" ];
-
-  installPhase = ''
-    install -D pg_similarity${postgresql.dlSuffix} -t $out/lib/
-    install -D ./{pg_similarity--unpackaged--1.0.sql,pg_similarity--1.0.sql,pg_similarity.control} -t $out/share/postgresql/extension
-  '';
 
   passthru.updateScript = unstableGitUpdater {};
 

--- a/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, postgresqlTestExtension }:
+{ lib, stdenv, fetchFromGitHub, postgresql, postgresqlTestExtension, buildPostgresqlExtension }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "pg_squeeze";
   version = "1.7.0";
 
@@ -10,20 +10,6 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "REL${builtins.replaceStrings ["."] ["_"] finalAttrs.version}";
     hash = "sha256-Kh1wSOvV5Rd1CG/na3yzbWzvaR8SJ6wmTZOnM+lbgik=";
   };
-
-  buildInputs = [
-    postgresql
-  ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -D -t $out/lib pg_squeeze${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension pg_squeeze-*.sql
-    install -D -t $out/share/postgresql/extension pg_squeeze.control
-
-    runHook postInstall
-  '';
 
   passthru.tests.extension = postgresqlTestExtension {
     inherit (finalAttrs) finalPackage;

--- a/pkgs/servers/sql/postgresql/ext/pg_topn.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_topn.nix
@@ -1,10 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_topn";
   version = "2.7.0";
-
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner  = "citusdata";
@@ -12,14 +10,6 @@ stdenv.mkDerivation rec {
     rev    = "refs/tags/v${version}";
     sha256 = "sha256-lP6Iil/BUv4ga+co+oBpKv1FBqFuBGfNjueEolM6png=";
   };
-
-  installPhase = ''
-    mkdir -p $out/{lib,share/postgresql/extension}
-
-    cp *${postgresql.dlSuffix} $out/lib
-    cp *.sql     $out/share/postgresql/extension
-    cp *.control $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "Efficient querying of 'top values' for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
@@ -2,13 +2,12 @@
 , stdenv
 , fetchFromGitHub
 , postgresql
+, buildPostgresqlExtension
 }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pg_uuidv7";
   version = "1.5.0";
-
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner = "fboulnois";
@@ -16,11 +15,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-oVyRtjl3KsD3j96qvQb8bFLMhoWO81OudOL4wVXrjzI=";
   };
-
-  installPhase = ''
-      install -D -t $out/lib pg_uuidv7${postgresql.dlSuffix}
-      install -D {sql/pg_uuidv7--${lib.versions.majorMinor version}.sql,pg_uuidv7.control} -t $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "Tiny Postgres extension to create version 7 UUIDs";

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, libkrb5, openssl, postgresql }:
+{ lib, stdenv, fetchFromGitHub, libkrb5, openssl, postgresql, buildPostgresqlExtension }:
 
 let
   source = {
@@ -28,7 +28,7 @@ let
     };
   }.${lib.versions.major postgresql.version} or (throw "Source for pgaudit is not available for ${postgresql.version}");
 in
-stdenv.mkDerivation {
+buildPostgresqlExtension {
   pname = "pgaudit";
   inherit (source) version;
 
@@ -39,15 +39,9 @@ stdenv.mkDerivation {
     hash = source.hash;
   };
 
-  buildInputs = [ libkrb5 openssl postgresql ];
+  buildInputs = [ libkrb5 openssl ];
 
   makeFlags = [ "USE_PGXS=1" ];
-
-  installPhase = ''
-    install -D -t $out/lib pgaudit${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
 
   meta = with lib; {
     description = "Open Source PostgreSQL Audit Logging";

--- a/pkgs/servers/sql/postgresql/ext/pgjwt.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgjwt.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, unstableGitUpdater, nixosTests, postgresqlTestExtension }:
+{ lib, stdenv, fetchFromGitHub, postgresql, unstableGitUpdater, nixosTests, postgresqlTestExtension, buildPostgresqlExtension }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "pgjwt";
   version = "0-unstable-2023-03-02";
 
@@ -10,12 +10,6 @@ stdenv.mkDerivation (finalAttrs: {
     rev    = "f3d82fd30151e754e19ce5d6a06c71c20689ce3d";
     sha256 = "sha256-nDZEDf5+sFc1HDcG2eBNQj+kGcdAYRXJseKi9oww+JU=";
   };
-
-  dontBuild = true;
-  installPhase = ''
-    mkdir -p $out/share/postgresql/extension
-    cp pg*sql *.control $out/share/postgresql/extension
-  '';
 
   passthru.updateScript = unstableGitUpdater { };
 

--- a/pkgs/servers/sql/postgresql/ext/pgmq.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgmq.nix
@@ -3,9 +3,10 @@
   stdenv,
   fetchFromGitHub,
   postgresql,
+  buildPostgresqlExtension,
 }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pgmq";
   version = "1.4.4";
 
@@ -19,17 +20,6 @@ stdenv.mkDerivation rec {
   sourceRoot = "${src.name}/pgmq-extension";
 
   dontConfigure = true;
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -D -t $out/share/postgresql/extension sql/*.sql
-    install -D -t $out/share/postgresql/extension *.control
-
-    runHook postInstall
-  '';
 
   meta = {
     description = "Lightweight message queue like AWS SQS and RSMQ but on Postgres";

--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, groonga }:
+{ lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, groonga, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pgroonga";
   version = "3.2.3";
 
@@ -10,22 +10,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ postgresql msgpack-c groonga ];
+  buildInputs = [ msgpack-c groonga ];
 
   makeFlags = [
     "HAVE_MSGPACK=1"
     "MSGPACK_PACKAGE_NAME=msgpack-c"
   ];
-
-  installPhase = ''
-    install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
-    install -D pgroonga.control -t $out/share/postgresql/extension
-    install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
-
-    install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
-    install -D pgroonga_database.control -t $out/share/postgresql/extension
-    install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "PostgreSQL extension to use Groonga as the index";

--- a/pkgs/servers/sql/postgresql/ext/pgrouting.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgrouting.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, perl, cmake, boost }:
+{ lib, stdenv, fetchFromGitHub, postgresql, perl, cmake, boost, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pgrouting";
   version = "3.6.3";
 
   nativeBuildInputs = [ cmake perl ];
-  buildInputs = [ postgresql boost ];
+  buildInputs = [ boost ];
 
   src = fetchFromGitHub {
     owner  = "pgRouting";
@@ -13,12 +13,6 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     hash   = "sha256-VCoapUM7Vh4W1DUE/gWQ9YIRLbw63XlOWsgajJW+XNU=";
   };
-
-  installPhase = ''
-    install -D lib/*.so                        -t $out/lib
-    install -D sql/pgrouting--${version}.sql   -t $out/share/postgresql/extension
-    install -D sql/common/pgrouting.control    -t $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "PostgreSQL/PostGIS extension that provides geospatial routing functionality";

--- a/pkgs/servers/sql/postgresql/ext/pgsodium.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgsodium.nix
@@ -4,9 +4,10 @@
 , libsodium
 , postgresql
 , postgresqlTestExtension
+, buildPostgresqlExtension
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "pgsodium";
   version = "3.1.9";
 
@@ -19,20 +20,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libsodium
-    postgresql
   ];
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D -t $out/lib pgsodium${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension sql/pgsodium-*.sql
-    install -D -t $out/share/postgresql/extension pgsodium.control
-
+  postInstall = ''
     install -D -t $out/share/pgsodium/getkey_scripts getkey_scripts/*
     ln -s $out/share/pgsodium/getkey_scripts/pgsodium_getkey_urandom.sh $out/share/postgresql/extension/pgsodium_getkey
-
-    runHook postInstall
   '';
 
   passthru.tests.extension = postgresqlTestExtension {

--- a/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, curl, postgresql }:
+{ lib, stdenv, fetchFromGitHub, curl, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pgsql-http";
   version = "1.6.0";
 
@@ -11,13 +11,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-CPHfx7vhWfxkXsoKTzyFuTt47BPMvzi/pi1leGcuD60=";
   };
 
-  buildInputs = [ curl postgresql ];
-
-  installPhase = ''
-    install -D -t $out/lib *${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
+  buildInputs = [ curl ];
 
   meta = with lib; {
     description = "HTTP client for PostgreSQL, retrieve a web page from inside the database";

--- a/pkgs/servers/sql/postgresql/ext/pgtap.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgtap.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, buildPostgresqlExtension
 , fetchFromGitHub
 , perl
 , perlPackages
@@ -8,7 +9,7 @@
 , which
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "pgtap";
   version = "1.3.3";
 
@@ -20,10 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [ postgresql perl perlPackages.TAPParserSourceHandlerpgTAP which ];
-
-  installPhase = ''
-    install -D {sql/pgtap--${finalAttrs.version}.sql,pgtap.control} -t $out/share/postgresql/extension
-  '';
 
   passthru.tests.extension = stdenv.mkDerivation {
     name = "pgtap-test";

--- a/pkgs/servers/sql/postgresql/ext/pgvector.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvector.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "pgvector";
   version = "0.6.2";
 
@@ -10,14 +10,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-r+TpFJg6WrMn0L2B7RpmSRvw3XxpHzMRtpFWDCzLvgs=";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    install -D -t $out/lib vector${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension sql/vector-*.sql
-    install -D -t $out/share/postgresql/extension vector.control
-  '';
 
   meta = with lib; {
     description = "Open-source vector similarity search for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
+++ b/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, postgresqlTestExtension }:
+{ lib, stdenv, fetchFromGitHub, postgresql, postgresqlTestExtension, buildPostgresqlExtension }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "plpgsql-check";
   version = "2.7.5";
 
@@ -10,14 +10,6 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-CD/G/wX6o+mC6gowlpFe1DdJWyh3cB9wxSsW2GXrENE=";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    install -D -t $out/lib *${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
 
   passthru.tests.extension = postgresqlTestExtension {
     inherit (finalAttrs) finalPackage;

--- a/pkgs/servers/sql/postgresql/ext/plr.nix
+++ b/pkgs/servers/sql/postgresql/ext/plr.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, R, postgresql }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, R, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "plr";
   version = "8.4.7";
 
@@ -12,14 +12,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ R postgresql ];
+  buildInputs = [ R ];
 
   makeFlags = [ "USE_PGXS=1" ];
-
-  installPhase = ''
-    install -D plr${postgresql.dlSuffix} -t $out/lib/
-    install -D {plr--*.sql,plr.control} -t $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "PL/R - R Procedural Language for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/plv8/default.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8/default.nix
@@ -5,6 +5,7 @@
 , perl
 , postgresql
 , jitSupport
+, buildPostgresqlExtension
 # For test
 , runCommand
 , coreutils
@@ -13,7 +14,7 @@
 
 let
   libv8 = nodejs_20.libv8;
-in stdenv.mkDerivation (finalAttrs: {
+in buildPostgresqlExtension (finalAttrs: {
   pname = "plv8";
   version = "3.2.3";
 
@@ -36,7 +37,6 @@ in stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libv8
-    postgresql
   ];
 
   buildFlags = [ "all" ];
@@ -48,24 +48,11 @@ in stdenv.mkDerivation (finalAttrs: {
     "V8_OUTDIR=${libv8}/lib"
   ];
 
-  installFlags = [
-    # PGXS only supports installing to postgresql prefix so we need to redirect this
-    "DESTDIR=${placeholder "out"}"
-  ];
-
   # No configure script.
   dontConfigure = true;
 
   postPatch = ''
     patchShebangs ./generate_upgrade.sh
-  '';
-
-  postInstall = ''
-    # Move the redirected to proper directory.
-    # There appear to be no references to the install directories
-    # so changing them does not cause issues.
-    mv "$out/nix/store"/*/* "$out"
-    rmdir "$out/nix/store"/* "$out/nix/store" "$out/nix"
   '';
 
   passthru = {

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -21,12 +21,13 @@
   nixosTests,
   jitSupport,
   llvm,
+  buildPostgresqlExtension,
 }:
 
 let
   gdal = gdalMinimal;
 in
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "postgis";
   version = "3.5.0";
 
@@ -42,7 +43,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libxml2
-    postgresql
     geos
     proj
     gdal
@@ -68,20 +68,18 @@ stdenv.mkDerivation rec {
   # postgis config directory assumes /include /lib from the same root for json-c library
   env.NIX_LDFLAGS = "-L${lib.getLib json_c}/lib";
 
+  setOutputFlags = false;
   preConfigure = ''
     sed -i 's@/usr/bin/file@${file}/bin/file@' configure
-    configureFlags="--datadir=$out/share/postgresql --datarootdir=$out/share/postgresql --bindir=$out/bin --docdir=$doc/share/doc/${pname} --with-gdalconfig=${gdal}/bin/gdal-config --with-jsondir=${json_c.dev} --disable-extension-upgrades-install"
-
-    makeFlags="PERL=${perl}/bin/perl datadir=$out/share/postgresql pkglibdir=$out/lib bindir=$out/bin docdir=$doc/share/doc/${pname}"
   '';
+
+  configureFlags = [
+    "--with-gdalconfig=${gdal}/bin/gdal-config"
+    "--with-jsondir=${json_c.dev}"
+    "--disable-extension-upgrades-install"
+  ];
+
   postConfigure = ''
-    sed -i "s|@mkdir -p \$(DESTDIR)\$(PGSQL_BINDIR)||g ;
-            s|\$(DESTDIR)\$(PGSQL_BINDIR)|$prefix/bin|g
-            " \
-        "raster/loader/Makefile";
-    sed -i "s|\$(DESTDIR)\$(PGSQL_BINDIR)|$prefix/bin|g
-            " \
-        "raster/scripts/python/Makefile";
     mkdir -p $out/bin
 
     # postgis' build system assumes it is being installed to the same place as postgresql, and looks
@@ -89,12 +87,13 @@ stdenv.mkDerivation rec {
     ln -s ${postgresql}/bin/postgres $out/bin/postgres
   '';
 
+  makeFlags = [
+    "PERL=${perl}/bin/perl"
+  ];
+
   doCheck = stdenv.hostPlatform.isLinux;
 
   preCheck = ''
-    substituteInPlace regress/run_test.pl --replace-fail "/share/contrib/postgis" "$out/share/postgresql/contrib/postgis"
-    substituteInPlace regress/Makefile --replace-fail 's,\$$libdir,$(REGRESS_INSTALLDIR)/lib,g' "s,\\$\$libdir,$PWD/regress/00-regress-install$out/lib,g" \
-      --replace-fail '$(REGRESS_INSTALLDIR)/share/contrib/postgis/*.sql' "$PWD/regress/00-regress-install$out/share/postgresql/contrib/postgis/*.sql"
     substituteInPlace doc/postgis-out.xml --replace-fail "http://docbook.org/xml/5.0/dtd/docbook.dtd" "${docbook5}/xml/dtd/docbook/docbookx.dtd"
     # The test suite hardcodes it to use /tmp.
     export PGIS_REG_TMPDIR="$TMPDIR/pgis_reg"

--- a/pkgs/servers/sql/postgresql/ext/repmgr.nix
+++ b/pkgs/servers/sql/postgresql/ext/repmgr.nix
@@ -5,9 +5,10 @@
 , flex
 , curl
 , json_c
+, buildPostgresqlExtension
 }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "repmgr";
   version = "5.4.1";
 
@@ -20,16 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ flex ];
 
-  buildInputs = postgresql.buildInputs ++ [ postgresql curl json_c ];
-
-  installPhase = ''
-    mkdir -p $out/{bin,lib,share/postgresql/extension}
-
-    cp repmgr{,d} $out/bin
-    cp *${postgresql.dlSuffix} $out/lib
-    cp *.sql      $out/share/postgresql/extension
-    cp *.control  $out/share/postgresql/extension
-  '';
+  buildInputs = postgresql.buildInputs ++ [ curl json_c ];
 
   meta = with lib; {
     homepage = "https://repmgr.org/";

--- a/pkgs/servers/sql/postgresql/ext/rum.nix
+++ b/pkgs/servers/sql/postgresql/ext/rum.nix
@@ -4,9 +4,10 @@
   fetchFromGitHub,
   postgresql,
   postgresqlTestHook,
+  buildPostgresqlExtension,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPostgresqlExtension (finalAttrs: {
   pname = "rum";
   version = "1.3.14";
 
@@ -17,15 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-VsfpxQqRBu9bIAP+TfMRXd+B3hSjuhU2NsutocNiCt8=";
   };
 
-  buildInputs = [ postgresql ];
-
   makeFlags = [ "USE_PGXS=1" ];
-
-  installPhase = ''
-    install -D -t $out/lib *${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.control
-    install -D -t $out/share/postgresql/extension *.sql
-  '';
 
   passthru.tests.extension = stdenv.mkDerivation {
     inherit (finalAttrs) version;

--- a/pkgs/servers/sql/postgresql/ext/smlar.nix
+++ b/pkgs/servers/sql/postgresql/ext/smlar.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchgit, postgresql }:
+{ lib, stdenv, fetchgit, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "smlar-unstable";
   version = "2021-11-08";
 
@@ -10,15 +10,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-AC6w7uYw0OW70pQpWbK1A3rkCnMvTJzTCAdFiY3rO7A=";
   };
 
-  buildInputs = [ postgresql ];
-
   makeFlags = [ "USE_PGXS=1" ];
-
-  installPhase = ''
-    install -D -t $out/lib *.so
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
-  '';
 
   meta = with lib; {
     description = "Compute similary of any one-dimensional arrays";

--- a/pkgs/servers/sql/postgresql/ext/system_stats.nix
+++ b/pkgs/servers/sql/postgresql/ext/system_stats.nix
@@ -3,12 +3,11 @@
   lib,
   stdenv,
   postgresql,
+  buildPostgresqlExtension,
 }:
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "system_stats";
   version = "3.2";
-
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner = "EnterpriseDB";
@@ -16,18 +15,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-/xXnui0S0ZjRw7P8kMAgttHVv8T41aOhM3pM8P0OTig=";
   };
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/{lib,share/postgresql/extension}
-
-    cp *${postgresql.dlSuffix} $out/lib
-    cp *.sql     $out/share/postgresql/extension
-    cp *.control $out/share/postgresql/extension
-
-    runHook postInstall
-  '';
 
   meta = with lib; {
     description = "A Postgres extension for exposing system metrics such as CPU, memory and disk information";

--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, freetds, unstableGitUpdater }:
+{ lib, stdenv, fetchFromGitHub, postgresql, freetds, unstableGitUpdater, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "tds_fdw";
   version = "2.0.4";
 
-  buildInputs = [ postgresql freetds ];
+  buildInputs = [ freetds ];
 
   src = fetchFromGitHub {
     owner  = "tds-fdw";
@@ -12,13 +12,6 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     hash   = "sha256-ruelOHueaHx1royLPvDM8Abd1rQD62R4KXgtHY9qqTw=";
   };
-
-  installPhase = ''
-    version="$(sed -En "s,^default_version *= *'([^']*)'.*,\1,p" tds_fdw.control)"
-    install -D tds_fdw${postgresql.dlSuffix} -t $out/lib
-    install -D sql/tds_fdw.sql    "$out/share/postgresql/extension/tds_fdw--$version.sql"
-    install -D tds_fdw.control -t $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "PostgreSQL foreign data wrapper to connect to TDS databases (Sybase and Microsoft SQL Server)";

--- a/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
+++ b/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
@@ -1,10 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "temporal_tables";
   version = "1.2.2";
-
-  buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner  = "arkhipov";
@@ -12,12 +10,6 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "sha256-7+DCSPAPhsokWDq/5IXNhd7jY6FfzxxUjlsg/VJeD3k=";
   };
-
-  installPhase = ''
-    install -D -t $out/lib temporal_tables${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension *.sql
-    install -D -t $out/share/postgresql/extension *.control
- '';
 
   meta = with lib; {
     description = "Temporal Tables PostgreSQL Extension";

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, cmake, postgresql, openssl, libkrb5, nixosTests, enableUnfree ? true }:
+{ lib, stdenv, fetchFromGitHub, cmake, postgresql, openssl, libkrb5, nixosTests, enableUnfree ? true, buildPostgresqlExtension }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "timescaledb${lib.optionalString (!enableUnfree) "-apache"}";
   version = "2.14.2";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ postgresql openssl libkrb5 ];
+  buildInputs = [ openssl libkrb5 ];
 
   src = fetchFromGitHub {
     owner = "timescale";

--- a/pkgs/servers/sql/postgresql/ext/tsearch_extras.nix
+++ b/pkgs/servers/sql/postgresql/ext/tsearch_extras.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, postgresql }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPostgresqlExtension }:
 
-stdenv.mkDerivation {
+buildPostgresqlExtension {
   pname = "tsearch-extras";
   version = "0.4";
 
@@ -10,13 +10,6 @@ stdenv.mkDerivation {
     rev    = "84e78f00931c4ef261d98197d6b5d94fc141f742"; # no release tag?
     sha256 = "18j0saqblg3jhrz38splk173xjwdf32c67ymm18m8n5y94h8d2ba";
   };
-
-  buildInputs = [ postgresql ];
-
-  installPhase = ''
-    install -D tsearch_extras${postgresql.dlSuffix} -t $out/lib/
-    install -D ./{tsearch_extras--1.0.sql,tsearch_extras.control} -t $out/share/postgresql/extension
-  '';
 
   meta = with lib; {
     description = "Provides a few PostgreSQL functions for a lower-level data full text search";

--- a/pkgs/servers/sql/postgresql/ext/tsja.nix
+++ b/pkgs/servers/sql/postgresql/ext/tsja.nix
@@ -2,7 +2,6 @@
 , fetchzip
 , nixosTests
 , stdenv
-
 , mecab
 , postgresql
 }:

--- a/pkgs/servers/sql/postgresql/ext/wal2json.nix
+++ b/pkgs/servers/sql/postgresql/ext/wal2json.nix
@@ -4,9 +4,10 @@
   callPackage,
   fetchFromGitHub,
   postgresql,
+  buildPostgresqlExtension,
 }:
 
-stdenv.mkDerivation rec {
+buildPostgresqlExtension rec {
   pname = "wal2json";
   version = "2.6";
 
@@ -17,14 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-+QoACPCKiFfuT2lJfSUmgfzC5MXf75KpSoc2PzPxKyM=";
   };
 
-  buildInputs = [ postgresql ];
-
   makeFlags = [ "USE_PGXS=1" ];
-
-  installPhase = ''
-    install -D -t $out/lib *${postgresql.dlSuffix}
-    install -D -t $out/share/postgresql/extension sql/*.sql
-  '';
 
   passthru.tests.wal2json = lib.recurseIntoAttrs (
     callPackage ../../../../../nixos/tests/postgresql-wal2json.nix {

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -289,6 +289,7 @@ let
               '';
               installPhase = "touch $out";
             } // extraArgs);
+          buildPostgresqlExtension = newSuper.callPackage ./buildPostgresqlExtension.nix {};
         };
         newSelf = self // scope;
         newSuper = { callPackage = newScope (scope // this.pkgs); };


### PR DESCRIPTION
## Description of changes

Most postgres extensions are built with PGXS, postgres' build system for extension. All of them have in common, that they override the installPhase, because the pgxs Makefiles don't work correctly in nixpkgs out of the box. This PR fixes that - by providing the `DESTDIR` option, which all those Makefiles support. However, this will be added to the full paths which are returned by pg_config and will temporarily result in paths installed as `$out/nix/store/..-postgresql-.../<proper-path`. To deal with that, a postInstall hook cleans up and moves the files back to `$out/` directly without the additional `nix/store/...`.

This works nicely - I was able to build all extension like this without any custom installPhases anymore. Even more, I was able to significantly simplify the `postgis` derivation with that.

The current approach has two downsides, from what I can tell:
- `postInstall` doesn't work as expected, because at this time the files are still in `$out/nix/store/.../` instead of `$out`. The postInstall hook registered via setup hook will always run **after** the `postInstall` hook in the derivation.
- All packages having `postgresql` in their build dependencies will get this setup hook and thus the `DESTDIR` setting automatically, not only the extensions in `postgresql/ext`. While this is good thing for those which use PGXS - there might some other packages that just happen to have postgresql as a dependency without it's build system. Setting `DESTDIR` could have unintended effects, **if** they happen to use that differently.

One way to solve both of this would me to create a wrapper around `mkDerivation` specifically for postgresql extensions - and then prepend the `postInstall` hook code to the derivation-provided `postInstall` code. This would always run first, making `postInstall` work normally again. This wrapper would have to be used explicitly - and all postgresql extensions would do so. Other packages would not be affected.

Before I go that way, I would like to have some feedback on the general approach here and whether is anything that I might have missed or is not working currently. Since `postgis` is changed / simplified the most, I'd welcome a review of some of the postgis maintainers: @NixOS/geospatial @MarcWeber 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (all extensions, each on a supported postgresql version)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (all extensions, each on a supported postgresql version)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
