### PR TITLE
abseil-cpp: fix cross-compile to Windows

### DIFF
--- a/pkgs/development/libraries/abseil-cpp/202301.nix
+++ b/pkgs/development/libraries/abseil-cpp/202301.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , cmake
 , gtest
+, windows
 , static ? stdenv.hostPlatform.isStatic
 , cxxStandard ? null
 }:
@@ -36,7 +37,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ gtest ];
+  buildInputs = [
+    gtest
+  ] ++ lib.optionals stdenv.hostPlatform.isWindows [ windows.mingw_w64_pthreads ];
 
   meta = with lib; {
     description = "Open-source collection of C++ code designed to augment the C++ standard library";

--- a/pkgs/development/libraries/abseil-cpp/202401.nix
+++ b/pkgs/development/libraries/abseil-cpp/202401.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , cmake
 , gtest
+, windows
 , static ? stdenv.hostPlatform.isStatic
 , cxxStandard ? null
 }:
@@ -30,7 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ gtest ];
+  buildInputs = [
+    gtest
+  ] ++ lib.optionals stdenv.hostPlatform.isWindows [ windows.mingw_w64_pthreads ];
 
   meta = {
     description = "Open-source collection of C++ code designed to augment the C++ standard library";

--- a/pkgs/development/libraries/abseil-cpp/202407.nix
+++ b/pkgs/development/libraries/abseil-cpp/202407.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , cmake
 , gtest
+, windows
 , static ? stdenv.hostPlatform.isStatic
 , cxxStandard ? null
 }:
@@ -30,7 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ gtest ];
+  buildInputs = [
+    gtest
+  ] ++ lib.optionals stdenv.hostPlatform.isWindows [ windows.mingw_w64_pthreads ];
 
   meta = {
     description = "Open-source collection of C++ code designed to augment the C++ standard library";


### PR DESCRIPTION
## Description of changes

This adds a build input to include windows pthreads when the host platform is windows.

There are two basic ways to allow cross compiling to windows -- this method allows the abseil code to run `#include <pthread.h>`.

An alternative (not used here) approach would be to rely on the `_WIN32` precompiler directive. The abseil code is designed to not import pthread.h when that symbol is defined. However, this definition is not currently preserved from the mingw compiler. It's not clear what fix would enable this approach.

## Things done

These builds now work:

    $ nix build .#legacyPackages.x86_64-linux.pkgsCross.mingwW64.abseil-cpp_202301
    $ nix build .#legacyPackages.x86_64-linux.pkgsCross.mingwW64.abseil-cpp_202401
    $ nix build .#legacyPackages.x86_64-linux.pkgsCross.mingwW64.abseil-cpp_202407
    
Coincidentally, this also enables:

    $ nix build -L .#legacyPackages.x86_64-linux.pkgsCross.mingwW64.protobuf

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
