### PR TITLE
idris2Packages.pack: init at 2024-02-07

### DIFF
--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -4,5 +4,7 @@
   idris2Api = callPackage ./idris2-api.nix { };
   idris2Lsp = callPackage ./idris2-lsp.nix { };
 
+  pack = callPackage ./pack.nix { };
+
   buildIdris = callPackage ./build-idris.nix { };
 }

--- a/pkgs/development/compilers/idris2/pack.nix
+++ b/pkgs/development/compilers/idris2/pack.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  idris2Packages,
+  fetchFromGitHub,
+}:
+let
+  inherit (idris2Packages) idris2Api buildIdris;
+  toml = buildIdris {
+    ipkgName = "toml";
+    version = "2022-05-05";
+    src = fetchFromGitHub {
+      owner = "cuddlefishie";
+      repo = "toml-idr";
+      rev = "b4f5a4bd874fa32f20d02311a62a1910dc48123f";
+      hash = "sha256-+bqfCE6m0aJ+S65urT+zQLuZUtUkC1qcuSsefML/fAE=";
+    };
+    idrisLibraries = [ ];
+  };
+  filepath = buildIdris {
+    ipkgName = "filepath";
+    version = "2023-12-04";
+    src = fetchFromGitHub {
+      owner = "stefan-hoeck";
+      repo = "idris2-filepath";
+      rev = "eac02d51b631633f32330c788bcebeb24221fa09";
+      hash = "sha256-noylxQvT2h50H0xmAiwe/cI6vz5gkbOhSD7mXuhJGfU=";
+    };
+    idrisLibraries = [ ];
+  };
+  packPkg = buildIdris {
+    ipkgName = "pack";
+    version = "2024-02-07";
+    src = fetchFromGitHub {
+      owner = "stefan-hoeck";
+      repo = "idris2-pack";
+      rev = "305123401a28a57b02f750c589c35af628b2a5eb";
+      hash = "sha256-IPAkwe6fEYWT3mpyKKkUPU0qFJX9gGIM1f7OeNWyB9w=";
+    };
+    idrisLibraries = [
+      idris2Api
+      toml
+      filepath
+    ];
+
+    meta = {
+      description = "An Idris2 Package Manager with Curated Package Collections";
+      mainProgram = "pack";
+      homepage = "https://github.com/stefan-hoeck/idris2-pack";
+      license = lib.licenses.bsd3;
+      maintainers = with lib.maintainers; [ mattpolzin ];
+      inherit (idris2Packages.idris2.meta) platforms;
+    };
+  };
+in
+packPkg.executable


### PR DESCRIPTION
## Description of changes
Pack is the most popular package manager for Idris2. I’ve mostly focused on making it easier to package Idris2 programs as Nix derivations but there is definitely demand for using nixpkgs to install Pack and then using Pack to build Idris2 projects. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>idris2Packages.pack</li>
  </ul>
</details>

----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>idris2Packages.pack</li>
  </ul>
</details>

----

Result of `nixpkgs-review pr 344109` run on aarch64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>idris2Packages.pack</li>
  </ul>
</details>

----

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
