### PR TITLE
ocamlPackages.mlbdd: init at 0.7.2

### DIFF
--- a/pkgs/development/ocaml-modules/mlbdd/default.nix
+++ b/pkgs/development/ocaml-modules/mlbdd/default.nix
@@ -19,17 +19,8 @@ buildDunePackage {
   };
 
   checkInputs = [ ounit ];
-  nativeCheckInputs = [ ];
-  buildInputs = [ ];
-  nativeBuildInputs = [ ];
-  propagatedBuildInputs = [ ];
 
   doCheck = true;
-
-  outputs = [
-    "out"
-    "dev"
-  ];
 
   meta = {
     homepage = "https://github.com/arlencox/mlbdd";

--- a/pkgs/development/ocaml-modules/mlbdd/default.nix
+++ b/pkgs/development/ocaml-modules/mlbdd/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  ounit,
+}:
+
+buildDunePackage {
+  pname = "mlbdd";
+  version = "0.7.2";
+
+  minimalOCamlVersion = "4.04";
+
+  src = fetchFromGitHub {
+    owner = "arlencox";
+    repo = "mlbdd";
+    rev = "v0.7.2";
+    hash = "sha256-GRkaUL8LQDdQx9mPvlJIXatgRfen/zKt+nGLiH7Mfvs=";
+  };
+
+  checkInputs = [ ounit ];
+  nativeCheckInputs = [ ];
+  buildInputs = [ ];
+  nativeBuildInputs = [ ];
+  propagatedBuildInputs = [ ];
+
+  doCheck = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  meta = {
+    homepage = "https://github.com/arlencox/mlbdd";
+    description = "A not-quite-so-simple Binary Decision Diagrams implementation for OCaml";
+    maintainers = with lib.maintainers; [ katrinafyi ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1177,6 +1177,8 @@ let
 
     mirage-vnetif = callPackage ../development/ocaml-modules/mirage-vnetif { };
 
+    mlbdd = callPackage ../development/ocaml-modules/mlbdd { };
+
     mldoc =  callPackage ../development/ocaml-modules/mldoc { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
new ocaml package, a library for working with binary decision diagrams. https://github.com/arlencox/mlbdd

> The mlbdd library provides a simple, easy-to-use, easy-to-extend implementation of binary decision diagrams (BDDs) in OCaml. It is well tested and well documented. The library itself has no dependencies and is thus easy to include in applications that might, for example, be compiled with js_of_ocaml or other tools that rely on pure OCaml. It is also easier to integrate with existing projects due to its lack of dependencies.

built package size is 880KB.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
