### PR TITLE
Extend rust `import-cargo-lock` tests to include `[workspace.lints]`

### DIFF
--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate.toml
@@ -11,3 +11,6 @@ keywords = [
 [dependencies]
 foo = { workspace = true, features = ["cat"] }
 bar = "1.0.0"
+
+[lints]
+workspace = true

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want.toml
@@ -12,8 +12,11 @@ keywords = [
 bar = "1.0.0"
 
 [dependencies.foo]
+version = "1.0.0"
 features = [
     "cat",
     "meow",
 ]
-version = "1.0.0"
+
+[lints.clippy]
+semicolon_if_nothing_returned = "warn"

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/workspace.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/workspace.toml
@@ -3,3 +3,6 @@ version = "1.0.0"
 
 [workspace.dependencies]
 foo = { version = "1.0.0", features = ["meow"] }
+
+[workspace.lints.clippy]
+semicolon_if_nothing_returned = "warn"


### PR DESCRIPTION
## Description of changes

I did some sanity checking since I'm looking into some nix build issues in one of my projects. Since I did the checks in nixpkgs directly, I figured that I might as well upstream the extension to the existing tests.

## Things done

- [x] ran `nix-build -A pkgs.tests.importCargoLock.gitDependencyWorkspaceInheritance` ✅
