### PR TITLE
gcc: backport patch to fix libhwy on aarch64

### DIFF
--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -76,6 +76,13 @@ in
 
 ## 2. Patches relevant to gcc>=12 on specific platforms ####################################
 
+### aarch64
+
+++ optionals stdenv.targetPlatform.isAarch64 [
+  # Fixes libhwy
+  ./tree-optimization-116274-overzealous-SLP-vectorization.patch
+]
+
 ### Musl+Go+gcc12
 
 # backport fixes to build gccgo with musl libc

--- a/pkgs/development/compilers/gcc/patches/tree-optimization-116274-overzealous-SLP-vectorization.patch
+++ b/pkgs/development/compilers/gcc/patches/tree-optimization-116274-overzealous-SLP-vectorization.patch
@@ -1,0 +1,74 @@
+From d5d4f3bae5a9478dc2189e53da933175a6d7b197 Mon Sep 17 00:00:00 2001
+From: Richard Biener <rguenther@suse.de>
+Date: Thu, 8 Aug 2024 11:36:43 +0200
+Subject: [PATCH] tree-optimization/116274 - overzealous SLP vectorization
+
+The following tries to address that the vectorizer fails to have
+precise knowledge of argument and return calling conventions and
+views some accesses as loads and stores that are not.
+This is mainly important when doing basic-block vectorization as
+otherwise loop indexing would force such arguments to memory.
+
+On x86 the reduction in the number of apparent loads and stores
+often dominates cost analysis so the following tries to mitigate
+this aggressively by adjusting only the scalar load and store
+cost, reducing them to the cost of a simple scalar statement,
+but not touching the vector access cost which would be much
+harder to estimate.  Thereby we error on the side of not performing
+basic-block vectorization.
+
+	PR tree-optimization/116274
+	* tree-vect-slp.cc (vect_bb_slp_scalar_cost): Cost scalar loads
+	and stores as simple scalar stmts when they access a non-global,
+	not address-taken variable that doesn't have BLKmode assigned.
+
+	* gcc.target/i386/pr116274-2.c: New testcase.
+
+(cherry picked from commit b8ea13ebf1211714503fd72f25c04376483bfa53)
+---
+ gcc/testsuite/gcc.target/i386/pr116274-2.c |  9 +++++++++
+ gcc/tree-vect-slp.cc                       | 12 +++++++++++-
+ 2 files changed, 20 insertions(+), 1 deletion(-)
+ create mode 100644 gcc/testsuite/gcc.target/i386/pr116274-2.c
+
+diff --git a/gcc/testsuite/gcc.target/i386/pr116274-2.c b/gcc/testsuite/gcc.target/i386/pr116274-2.c
+new file mode 100644
+index 000000000000..d5811344b935
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/i386/pr116274-2.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* { dg-options "-O2 -fdump-tree-slp2-optimized" } */
++
++struct a { long x,y; };
++long test(struct a a) { return a.x+a.y; }
++
++/* { dg-final { scan-tree-dump-not "basic block part vectorized" "slp2" } } */
++/* { dg-final { scan-assembler-times "addl|leaq" 1 } } */
++/* { dg-final { scan-assembler-not "padd" } } */
+diff --git a/gcc/tree-vect-slp.cc b/gcc/tree-vect-slp.cc
+index 0795605ec527..d0635b7a146c 100644
+--- a/gcc/tree-vect-slp.cc
++++ b/gcc/tree-vect-slp.cc
+@@ -7102,7 +7102,17 @@ next_lane:
+       vect_cost_for_stmt kind;
+       if (STMT_VINFO_DATA_REF (orig_stmt_info))
+ 	{
+-	  if (DR_IS_READ (STMT_VINFO_DATA_REF (orig_stmt_info)))
++	  data_reference_p dr = STMT_VINFO_DATA_REF (orig_stmt_info);
++	  tree base = get_base_address (DR_REF (dr));
++	  /* When the scalar access is to a non-global not address-taken
++	     decl that is not BLKmode assume we can access it with a single
++	     non-load/store instruction.  */
++	  if (DECL_P (base)
++	      && !is_global_var (base)
++	      && !TREE_ADDRESSABLE (base)
++	      && DECL_MODE (base) != BLKmode)
++	    kind = scalar_stmt;
++	  else if (DR_IS_READ (STMT_VINFO_DATA_REF (orig_stmt_info)))
+ 	    kind = scalar_load;
+ 	  else
+ 	    kind = scalar_store;
+-- 
+2.43.5
+


### PR DESCRIPTION
## Description of changes

On staging we should make this unconditional, and possibly apply the fix for libaom as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
