### PR TITLE
docs: update the CUDA section with how to use the `nvidia-container-toolkit`

### DIFF
--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -149,3 +149,104 @@ All new projects should use the CUDA redistributables available in [`cudaPackage
 | Find libraries | `buildPhase` or `patchelf` | Missing dependency on a `lib` or `static` output | Add the missing dependency | The `lib` or `static` output typically contain the libraries |
 
 In the scenario you are unable to run the resulting binary: this is arguably the most complicated as it could be any combination of the previous reasons. This type of failure typically occurs when a library attempts to load or open a library it depends on that it does not declare in its `DT_NEEDED` section. As a first step, ensure that dependencies are patched with [`autoAddDriverRunpath`](https://search.nixos.org/packages?channel=unstable&type=packages&query=autoAddDriverRunpath). Failing that, try running the application with [`nixGL`](https://github.com/guibou/nixGL) or a similar wrapper tool. If that works, it likely means that the application is attempting to load a library that is not in the `RPATH` or `RUNPATH` of the binary.
+
+## Running Docker or Podman containers with CUDA support {#running-docker-or-podman-containers-with-cuda-support}
+
+It is possible to run Docker or Podman containers with CUDA support. The recommended mechanism to perform this task is to use the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/index.html).
+
+The NVIDIA Container Toolkit can be enabled in NixOS like follows:
+
+```nix
+{
+  hardware.nvidia-container-toolkit.enable = true;
+}
+```
+
+This will automatically enable a service that generates a CDI specification (located at `/var/run/cdi/nvidia-container-toolkit.json`) based on the auto-detected hardware of your machine. You can check this service by running:
+
+```ShellSession
+$ systemctl status nvidia-container-toolkit-cdi-generator.service
+```
+
+::: {.note}
+Depending on what settings you had already enabled in your system, you might need to restart your machine in order for the NVIDIA Container Toolkit to generate a valid CDI specification for your machine.
+:::
+
+Once that a valid CDI specification has been generated for your machine on boot time, both Podman and Docker (> 25) will use this spec if you provide them with the `--device` flag:
+
+```ShellSession
+$ podman run --rm -it --device=nvidia.com/gpu=all ubuntu:latest nvidia-smi -L
+GPU 0: NVIDIA GeForce RTX 4090 (UUID: <REDACTED>)
+GPU 1: NVIDIA GeForce RTX 2080 SUPER (UUID: <REDACTED>)
+```
+
+```ShellSession
+$ docker run --rm -it --device=nvidia.com/gpu=all ubuntu:latest nvidia-smi -L
+GPU 0: NVIDIA GeForce RTX 4090 (UUID: <REDACTED>)
+GPU 1: NVIDIA GeForce RTX 2080 SUPER (UUID: <REDACTED>)
+```
+
+You can check all the identifiers that have been generated for your auto-detected hardware by checking the contents of the `/var/run/cdi/nvidia-container-toolkit.json` file:
+
+```ShellSession
+$ nix run nixpkgs#jq -- -r '.devices[].name' < /var/run/cdi/nvidia-container-toolkit.json
+0
+1
+all
+```
+
+### Specifying what devices to expose to the container {#specifying-what-devices-to-expose-to-the-container}
+
+You can choose what devices are exposed to your containers by using the identifier on the generated CDI specification. Like follows:
+
+```ShellSession
+$ podman run --rm -it --device=nvidia.com/gpu=0 ubuntu:latest nvidia-smi -L
+GPU 0: NVIDIA GeForce RTX 4090 (UUID: <REDACTED>)
+```
+
+You can repeat the `--device` argument as many times as necessary if you have multiple GPU's and you want to pick up which ones to expose to the container:
+
+```ShellSession
+$ podman run --rm -it --device=nvidia.com/gpu=0 --device=nvidia.com/gpu=1 ubuntu:latest nvidia-smi -L
+GPU 0: NVIDIA GeForce RTX 4090 (UUID: <REDACTED>)
+GPU 1: NVIDIA GeForce RTX 2080 SUPER (UUID: <REDACTED>)
+```
+
+::: {.note}
+By default, the NVIDIA Container Toolkit will use the GPU index to identify specific devices. You can change the way to identify what devices to expose by using the `hardware.nvidia-container-toolkit.device-name-strategy` NixOS attribute.
+:::
+
+### Using docker-compose {#using-docker-compose}
+
+It's possible to expose GPU's to a `docker-compose` environment as well. With a `docker-compose.yaml` file like follows:
+
+```yaml
+services:
+  some-service:
+    image: ubuntu:latest
+    command: sleep infinity
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: cdi
+            device_ids:
+            - nvidia.com/gpu=all
+```
+
+In the same manner, you can pick specific devices that will be exposed to the container:
+
+```yaml
+services:
+  some-service:
+    image: ubuntu:latest
+    command: sleep infinity
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: cdi
+            device_ids:
+            - nvidia.com/gpu=0
+            - nvidia.com/gpu=1
+```


### PR DESCRIPTION
Depends on: https://github.com/NixOS/nixpkgs/pull/344174

This part of the manual explains how to use the
`nvidia-container-toolkit` in order to expose GPU's both for Docker and Podman, as well as for a `docker-compose` environment.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
