### PR TITLE
yudit: init at 3.1.0

### DIFF
--- a/pkgs/by-name/yu/yudit/package.nix
+++ b/pkgs/by-name/yu/yudit/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  xorg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yudit";
+  version = "3.1.0";
+
+  src = fetchurl {
+    url = "https://www.yudit.org/download/yudit-${finalAttrs.version}.tar.gz";
+    hash = "sha256-oYgjTWEnNXaE9Sw9bGpLnY9avQ99tnJWa/RE73p85Vc=";
+  };
+
+  buildInputs = [
+    xorg.libX11
+  ];
+
+  meta = {
+    description = "Free Unicode plain-text editor for Unix-like systems";
+    homepage = "https://www.yudit.org/";
+    changelog = "https://www.yudit.org/download/CHANGELOG.TXT";
+    mainProgram = "yudit";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    # Might work on Darwin but currently fails, and upstream doesn't officially
+    # supports it.
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
