### PR TITLE
Libpsl: don't depend on python3

### DIFF
--- a/pkgs/by-name/li/libpsl/package.nix
+++ b/pkgs/by-name/li/libpsl/package.nix
@@ -1,17 +1,19 @@
-{ lib, stdenv
-, fetchurl
-, autoreconfHook
-, docbook_xsl
-, docbook_xml_dtd_43
-, gtk-doc
-, lzip
-, libidn2
-, libunistring
-, libxslt
-, pkg-config
-, python3
-, buildPackages
-, publicsuffix-list
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoreconfHook,
+  docbook_xsl,
+  docbook_xml_dtd_43,
+  gtk-doc,
+  lzip,
+  libidn2,
+  libunistring,
+  libxslt,
+  pkg-config,
+  python3,
+  buildPackages,
+  publicsuffix-list,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +25,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-mp9qjG7bplDPnqVUdc0XLdKEhzFoBOnHMgLZdXLNOi0=";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/li/libpsl/package.nix
+++ b/pkgs/by-name/li/libpsl/package.nix
@@ -23,9 +23,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-mp9qjG7bplDPnqVUdc0XLdKEhzFoBOnHMgLZdXLNOi0=";
   };
 
-  outputs = [ "out" "dev" ]
-    # bin/psl-make-dafsa brings a large runtime closure through python3
-    ++ lib.optional (!stdenv.hostPlatform.isStatic) "bin";
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -41,15 +39,11 @@ stdenv.mkDerivation rec {
     libidn2
     libunistring
     libxslt
-  ] ++ lib.optional (!stdenv.hostPlatform.isStatic) python3;
+  ];
 
   propagatedBuildInputs = [
     publicsuffix-list
   ];
-
-  postPatch = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-    patchShebangs src/psl-make-dafsa
-  '';
 
   preAutoreconf = ''
     gtkdocize

--- a/pkgs/by-name/ps/psl-make-dafsa/package.nix
+++ b/pkgs/by-name/ps/psl-make-dafsa/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  libpsl,
+  lzip,
+  python3,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "psl-make-dafsa";
+  version = "0.21.5";
+
+  inherit (libpsl) src;
+
+  buildInputs = [ python3 ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  installPhase = ''
+    install -m755 -D src/psl-make-dafsa $out/bin/psl-make-dafsa
+    install -m644 -D src/psl-make-dafsa.1 $out/share/man/man1/psl-make-dafsa.1
+  '';
+
+  nativeBuildInputs = [ lzip ];
+
+  meta = with lib; {
+    description = "Generate a compact and optimized DAFSA from a Public Suffix List";
+    homepage = "https://rockdaboot.github.io/libpsl/";
+    changelog = "https://raw.githubusercontent.com/rockdaboot/libpsl/libpsl-${version}/NEWS";
+    license = licenses.mit;
+    maintainers = [ maintainers.c0bw3b ];
+    mainProgram = "psl";
+    platforms = platforms.unix ++ platforms.windows;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21718,8 +21718,6 @@ with pkgs;
 
   libpseudo = callPackage ../development/libraries/libpseudo { };
 
-  libpsl = callPackage ../development/libraries/libpsl { };
-
   libpst = callPackage ../development/libraries/libpst { };
 
   libptytty = callPackage ../development/libraries/libptytty { };


### PR DESCRIPTION
## Description of changes

Currently libpsl -> libcurl depends on python3. This means nix also depends on python.
Which is a hefty dependency.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
