### PR TITLE
lib.types: attrsWith named placeholder

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1877,6 +1877,44 @@ runTests {
     expected = [ [ "_module" "args" ] [ "foo" ] [ "foo" "<name>" "bar" ] [ "foo" "bar" ] ];
   };
 
+  testAttrsWithName = {
+    expr = let
+      eval =  evalModules {
+        modules = [
+          {
+            options = {
+              foo = lib.mkOption {
+                type = lib.types.attrsWith {
+                  placeholder = "MyCustomPlaceholder";
+                  elemType = lib.types.submodule {
+                    options.bar = lib.mkOption {
+                      type = lib.types.int;
+                      default = 42;
+                    };
+                  };
+                };
+              };
+            };
+          }
+        ];
+      };
+      opt = eval.options.foo;
+    in
+      (opt.type.getSubOptions opt.loc).bar.loc;
+    expected = [
+      "foo"
+      "<MyCustomPlaceholder>"
+      "bar"
+    ];
+  };
+
+  testShowOptionWithPlaceholder = {
+    # <name>, *, should not be escaped. It is used as a placeholder by convention.
+    # Other symbols should be escaped. `{}`
+    expr = lib.showOption ["<name>" "<myName>" "*" "{foo}"];
+    expected = "<name>.<myName>.*.\"{foo}\"";
+  };
+
   testCartesianProductOfEmptySet = {
     expr = cartesianProduct {};
     expected = [ {} ];

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -391,6 +391,10 @@ checkConfigError 'The option `mergedLazyNonLazy'\'' in `.*'\'' is already declar
 checkConfigOutput '^11$' config.lazyResult ./lazy-attrsWith.nix
 checkConfigError 'infinite recursion encountered' config.nonLazyResult ./lazy-attrsWith.nix
 
+# AttrsWith placeholder tests
+checkConfigOutput '^"mergedName.<id>.nested"$' config.result ./name-merge-attrsWith-1.nix
+checkConfigError 'The option .mergedName. in .*\.nix. is already declared in .*\.nix' config.mergedName ./name-merge-attrsWith-2.nix
+
 # Even with multiple assignments, a type error should be thrown if any of them aren't valid
 checkConfigError 'A definition for option .* is not of type .*' \
   config.value ./declare-int-unsigned-value.nix ./define-value-list.nix ./define-value-int-positive.nix

--- a/lib/tests/modules/name-merge-attrsWith-1.nix
+++ b/lib/tests/modules/name-merge-attrsWith-1.nix
@@ -1,0 +1,51 @@
+{ lib, ... }:
+let
+  inherit (lib) types mkOption;
+in
+{
+  imports = [
+    # Module A
+    (
+      { ... }:
+      {
+        options.mergedName = mkOption {
+          default = { };
+          type = types.attrsWith {
+            placeholder = "id"; # <- This is beeing tested
+            elemType = types.submodule {
+              options.nested = mkOption {
+                type = types.int;
+                default = 1;
+              };
+            };
+          };
+        };
+      }
+    )
+    # Module B
+    (
+      { ... }:
+      {
+        # defines the default placeholder "name"
+        # type merging should resolve to "id"
+        options.mergedName = mkOption {
+          type = types.attrsOf (types.submodule { });
+        };
+      }
+    )
+
+    # Output
+    (
+      {
+        options,
+        ...
+      }:
+      {
+        options.result = mkOption {
+          default = lib.concatStringsSep "." (options.mergedName.type.getSubOptions options.mergedName.loc)
+          .nested.loc;
+        };
+      }
+    )
+  ];
+}

--- a/lib/tests/modules/name-merge-attrsWith-2.nix
+++ b/lib/tests/modules/name-merge-attrsWith-2.nix
@@ -1,0 +1,38 @@
+{ lib, ... }:
+let
+  inherit (lib) types mkOption;
+in
+{
+  imports = [
+    # Module A
+    (
+      { ... }:
+      {
+        options.mergedName = mkOption {
+          default = { };
+          type = types.attrsWith {
+            placeholder = "id"; # <- this is beeing tested
+            elemType = types.submodule {
+              options.nested = mkOption {
+                type = types.int;
+                default = 1;
+              };
+            };
+          };
+        };
+      }
+    )
+    # Module B
+    (
+      { ... }:
+      {
+        options.mergedName = mkOption {
+          type = types.attrsWith {
+            placeholder = "other"; # <- define placeholder = "other" (conflict)
+            elemType = types.submodule { };
+          };
+        };
+      }
+    )
+  ];
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -608,17 +608,27 @@ rec {
               lhs.lazy
             else
               null;
+          placeholder =
+            if lhs.placeholder == rhs.placeholder then
+              lhs.placeholder
+            else if lhs.placeholder == "name" then
+              rhs.placeholder
+            else if rhs.placeholder == "name" then
+              lhs.placeholder
+            else
+              null;
         in
-        if elemType == null || lazy == null then
+        if elemType == null || lazy == null || placeholder == null then
           null
         else
           {
-            inherit elemType lazy;
+            inherit elemType lazy placeholder;
           };
     in
     {
       elemType,
       lazy ? false,
+      placeholder ? "name",
     }:
     mkOptionType {
       name = if lazy then "lazyAttrsOf" else "attrsOf";
@@ -645,16 +655,16 @@ rec {
           (pushPositions defs)))
       );
       emptyValue = { value = {}; };
-      getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["<name>"]);
+      getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["<${placeholder}>"]);
       getSubModules = elemType.getSubModules;
-      substSubModules = m: attrsWith { elemType = elemType.substSubModules m; inherit lazy; };
+      substSubModules = m: attrsWith { elemType = elemType.substSubModules m; inherit lazy placeholder; };
       functor = defaultFunctor "attrsWith" // {
         wrappedDeprecationMessage = { loc }: lib.warn ''
           The deprecated `type.functor.wrapped` attribute of the option `${showOption loc}` is accessed, use `type.nestedTypes.elemType` instead.
         '' elemType;
         payload = {
           # Important!: Add new function attributes here in case of future changes
-          inherit elemType lazy;
+          inherit elemType lazy placeholder;
         };
         inherit binOp;
       };

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -399,7 +399,7 @@ Composed types are types that take a type as parameter. `listOf
     returned instead for the same `mkIf false` definition.
     :::
 
-`types.attrsWith` { *`elemType`*, *`lazy`* ? false }
+`types.attrsWith` { *`elemType`*, *`lazy`* ? false, *`placeholder`* ? "name" }
 
 :   An attribute set of where all the values are of *`elemType`* type.
 
@@ -411,10 +411,18 @@ Composed types are types that take a type as parameter. `listOf
     `lazy`
     : Determines whether the attribute set is lazily evaluated. See: `types.lazyAttrsOf`
 
+    `placeholder` (`String`, default: `name` )
+    : Placeholder string in documentation for the attribute names.
+      The default value `name` results in the placeholder `<name>`
+
     **Behavior**
 
     - `attrsWith { elemType = t; }` is equivalent to `attrsOf t`
     - `attrsWith { lazy = true; elemType = t; }` is equivalent to `lazyAttrsOf t`
+    - `attrsWith { placeholder = "id"; elemType = t; }`
+
+      Displays the option as `foo.<id>` in the manual.
+
 
 `types.uniq` *`t`*
 


### PR DESCRIPTION
## Description of changes

- Set `placeholder`="name" to configure the `<name>` placeholder for the docs. This is particularly useful when `"<name>"` doesn't make sense or when dealing with nested attrsOf submodule. Which would yield `"<name>.<name>"`

Usage example
```nix
mkOption {
  type = types.attrsWith {
    elemType = types.str;
    placeholder = "userName";
  };
  default = "root";
}
```

## Context

- Closes https://github.com/NixOS/nixpkgs/issues/295872
- Closes #193311

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
