### PR TITLE
python312Packages.arviz: disable tests on darwin (segfault)

### DIFF
--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
@@ -103,6 +104,9 @@ buildPythonPackage rec {
     "test_plot_kde_2d"
     "test_plot_pair"
   ];
+
+  # Tests segfault on darwin
+  doCheck = !stdenv.isDarwin;
 
   pythonImportsCheck = [ "arviz" ];
 


### PR DESCRIPTION
## Description of changes

Tests seem to be flaky and segfault on darwin. This PR disables them on this platform.

```
============================= test session starts ==============================
platform darwin -- Python 3.12.5, pytest-8.3.2, pluggy-1.5.0
rootdir: /private/tmp/nix-build-python3.12-arviz-0.19.0.drv-1/source
configfile: pytest.ini
collecting ... Fatal Python error: Aborted

Current thread 0x0000000206d04f40 (most recent call first):
  File "/nix/store/pwa6q0gi7g07v2ig6hm6zmccjii1ajk8-python3.12-matplotlib-3.9.1/lib/python3.12/site-packages/matplotlib/backend_bases.py", line 2681 in create_with_canvas
  File "/nix/store/pwa6q0gi7g07v2ig6hm6zmccjii1ajk8-python3.12-matplotlib-3.9.1/lib/python3.12/site-packages/matplotlib/backend_bases.py", line 1797 in new_manager
  File "/nix/store/pwa6q0gi7g07v2ig6hm6zmccjii1ajk8-python3.12-matplotlib-3.9.1/lib/python3.12/site-packages/matplotlib/backend_bases.py", line 3512 in new_figure_manager_given_figure
  File "/nix/store/pwa6q0gi7g07v2ig6hm6zmccjii1ajk8-python3.12-matplotlib-3.9.1/lib/python3.12/site-packages/matplotlib/backend_bases.py", line 3507 in new_figure_manager
  File "/nix/store/pwa6q0gi7g07v2ig6hm6zmccjii1ajk8-python3.12-matplotlib-3.9.1/lib/python3.12/site-packages/matplotlib/pyplot.py", line 550 in new_figure_manager
  File "/nix/store/pwa6q0gi7g07v2ig6hm6zmccjii1ajk8-python3.12-matplotlib-3.9.1/lib/python3.12/site-packages/matplotlib/pyplot.py", line 1027 in figure
  File "/nix/store/pwa6q0gi7g07v2ig6hm6zmccjii1ajk8-python3.12-matplotlib-3.9.1/lib/python3.12/site-packages/matplotlib/pyplot.py", line 1759 in subplots
  File "/private/tmp/nix-build-python3.12-arviz-0.19.0.drv-1/source/arviz/tests/base_tests/test_plots_matplotlib.py", line 139 in <module>
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/assertion/rewrite.py", line 174 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "<frozen importlib._bootstrap>", line 1387 in _gcd_import
  File "/nix/store/9pj4rzx5pbynkkxq1srzwjhywmcfxws3-python3-3.12.5/lib/python3.12/importlib/__init__.py", line 90 in import_module
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/pathlib.py", line 582 in import_path
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/python.py", line 493 in importtestmodule
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/python.py", line 546 in _getobj
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/python.py", line 284 in obj
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/python.py", line 562 in _register_setup_module_fixture
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/python.py", line 549 in collect
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/runner.py", line 389 in collect
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/runner.py", line 341 in from_call
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/runner.py", line 391 in pytest_make_collect_report
  File "/nix/store/vcs120dii7848kk9vwz1xicab89lv16b-python3.12-pluggy-1.5.0/lib/python3.12/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/nix/store/vcs120dii7848kk9vwz1xicab89lv16b-python3.12-pluggy-1.5.0/lib/python3.12/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/nix/store/vcs120dii7848kk9vwz1xicab89lv16b-python3.12-pluggy-1.5.0/lib/python3.12/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/runner.py", line 567 in collect_one_node
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/main.py", line 835 in _collect_one_node
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/main.py", line 970 in genitems
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/main.py", line 975 in genitems
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/main.py", line 809 in perform_collect
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/main.py", line 347 in pytest_collection
  File "/nix/store/vcs120dii7848kk9vwz1xicab89lv16b-python3.12-pluggy-1.5.0/lib/python3.12/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/nix/store/vcs120dii7848kk9vwz1xicab89lv16b-python3.12-pluggy-1.5.0/lib/python3.12/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/nix/store/vcs120dii7848kk9vwz1xicab89lv16b-python3.12-pluggy-1.5.0/lib/python3.12/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/main.py", line 336 in _main
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/main.py", line 283 in wrap_session
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/main.py", line 330 in pytest_cmdline_main
  File "/nix/store/vcs120dii7848kk9vwz1xicab89lv16b-python3.12-pluggy-1.5.0/lib/python3.12/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/nix/store/vcs120dii7848kk9vwz1xicab89lv16b-python3.12-pluggy-1.5.0/lib/python3.12/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/nix/store/vcs120dii7848kk9vwz1xicab89lv16b-python3.12-pluggy-1.5.0/lib/python3.12/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/config/__init__.py", line 175 in main
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/_pytest/config/__init__.py", line 201 in console_main
  File "/nix/store/x4ssmgpp6xbn96zg8xg83g0zb7gb530l-python3.12-pytest-8.3.2/lib/python3.12/site-packages/pytest/__main__.py", line 9 in <module>
  File "<frozen runpy>", line 88 in _run_code
  File "<frozen runpy>", line 198 in _run_module_as_main

Extension modules: numpy.core._multiarray_umath, numpy.core._multiarray_tests, numpy.linalg._umath_linalg, numpy.fft._pocketfft_internal, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._mt19937, numpy.random.mtrand, numpy.random._philox, numpy.random._pcg64, numpy.random._sfc64, numpy.random._generator, PIL._imaging, kiwisolver._cext, pandas._libs.tslibs.ccalendar, pandas._libs.tslibs.np_datetime, pandas._libs.tslibs.dtypes, pandas._libs.tslibs.base, pandas._libs.tslibs.nattype, pandas._libs.tslibs.timezones, pandas._libs.tslibs.fields, pandas._libs.tslibs.timedeltas, pandas._libs.tslibs.tzconversion, pandas._libs.tslibs.timestamps, pandas._libs.properties, pandas._libs.tslibs.offsets, pandas._libs.tslibs.strptime, pandas._libs.tslibs.parsing, pandas._libs.tslibs.conversion, pandas._libs.tslibs.period, pandas._libs.tslibs.vectorized, pandas._libs.ops_dispatch, pandas._libs.missing, pandas._libs.hashtable, pandas._libs.algos, pandas._libs.interval, pandas._libs.lib, pandas._libs.ops, pandas._libs.hashing, pandas._libs.arrays, pandas._libs.tslib, pandas._libs.sparse, pandas._libs.internals, pandas._libs.indexing, pandas._libs.index, pandas._libs.writers, pandas._libs.join, pandas._libs.window.aggregations, pandas.>
/nix/store/6ny63k9fl8x9hm0z2hvlbrkv7jh8x4lc-pytest-check-hook/nix-support/setup-hook: line 53: 42980 Abort trap: 6           /nix/store/9pj4rzx5pbynkkxq1srzwjhywmcfxws3-python3-3.12.5/bin/python3.12 -m pytest -k "not test_plot_ppc_transposed and not test_plot_separation and not test_plot_trace_legend and not test_cov and not test_plot_kde and not test_plot_kde_2d and not test_plot_pair" arviz/tests/base_tests/
```

cc @OmnipotentEntity 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
