### PR TITLE
ollama: fix rocm build

### DIFF
--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -157,6 +157,9 @@ goBuild {
     # this also disables necessary patches contained in `ollama/llm/patches/`
     # those patches are applied in `postPatch`
     ./disable-git.patch
+
+    # we provide our own deps at runtime
+    ./skip-rocm-cp.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ol/ollama/skip-rocm-cp.patch
+++ b/pkgs/by-name/ol/ollama/skip-rocm-cp.patch
@@ -1,0 +1,14 @@
+diff --git a/llm/generate/gen_linux.sh b/llm/generate/gen_linux.sh
+index 48d08fd0..e50f7b36 100755
+--- a/llm/generate/gen_linux.sh
++++ b/llm/generate/gen_linux.sh
+@@ -284,9 +284,6 @@ if [ -z "${OLLAMA_SKIP_ROCM_GENERATE}" -a -d "${ROCM_PATH}" ]; then
+     mkdir -p "${ROCM_DIST_DIR}"
+     for dep in $(ldd "${BUILD_DIR}/bin/ollama_llama_server" | grep "=>" | cut -f2 -d= | cut -f2 -d' ' | grep -v "${GOARCH}/rocm${ROCM_VARIANT}" | grep -e rocm -e amdgpu -e libtinfo -e libnuma -e libelf ); do
+         cp -a "${dep}"* "${ROCM_DIST_DIR}"
+-        if [ $(readlink -f "${dep}") != "${dep}" ] ; then
+-            cp $(readlink -f "${dep}") "${ROCM_DIST_DIR}"
+-        fi
+     done
+     install
+     dist


### PR DESCRIPTION
## Description of changes

upstream added this extra cp, but it fails because it has already copied over the required symlinks. since we provide our own runtime anyway, i'm not sure what value this has regardless.

from hydra:
```
+ for dep in $(ldd "${BUILD_DIR}/bin/ollama_llama_server" | grep "=>" | cut -f2 -d= | cut -f2 -d' ' | grep -v "${GOARCH}/rocm${ROCM_VARIANT}" | grep -e rocm -e amdgpu -e libtinfo -e libnuma -e libelf)
+ cp -a /nix/store/d7wl4hnydqbqc2j1qg29sybpc614wkz8-rocm-path/lib/libhipblas.so.2 /nix/store/d7wl4hnydqbqc2j1qg29sybpc614wkz8-rocm-path/lib/libhipblas.so.2.0 ../../dist/linux-amd64//../linux-amd64-rocm/lib/ollama
++ readlink -f /nix/store/d7wl4hnydqbqc2j1qg29sybpc614wkz8-rocm-path/lib/libhipblas.so.2
+ '[' /nix/store/2c04lrnax0x0jcdrdins3wykm1lb1360-hipblas-6.0.2/lib/libhipblas.so.2.0 '!=' /nix/store/d7wl4hnydqbqc2j1qg29sybpc614wkz8-rocm-path/lib/libhipblas.so.2 ']'
++ readlink -f /nix/store/d7wl4hnydqbqc2j1qg29sybpc614wkz8-rocm-path/lib/libhipblas.so.2
+ cp /nix/store/2c04lrnax0x0jcdrdins3wykm1lb1360-hipblas-6.0.2/lib/libhipblas.so.2.0 ../../dist/linux-amd64//../linux-amd64-rocm/lib/ollama
cp: '/nix/store/2c04lrnax0x0jcdrdins3wykm1lb1360-hipblas-6.0.2/lib/libhipblas.so.2.0' and '../../dist/linux-amd64//../linux-amd64-rocm/lib/ollama/libhipblas.so.2.0' are the same file
```

Closes #344182
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
