### PR TITLE
gcc13: apply default errors from gcc14

### DIFF
--- a/pkgs/development/compilers/gcc/all.nix
+++ b/pkgs/development/compilers/gcc/all.nix
@@ -8,7 +8,7 @@
 , threadsCross
 , noSysDirs
 , lowPrio
-, wrapCC
+, wrapCCWith
 }@args:
 
 let
@@ -17,22 +17,33 @@ let
     let
       atLeast = lib.versionAtLeast majorMinorVersion;
       attrName = "gcc${lib.replaceStrings ["."] [""] majorMinorVersion}";
-      pkg = lowPrio (wrapCC (callPackage ./default.nix ({
-        inherit noSysDirs;
-        inherit majorMinorVersion;
-        reproducibleBuild = true;
-        profiledCompiler = false;
-        libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then args.libcCross else null;
-        threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else { };
-        isl = if       stdenv.hostPlatform.isDarwin then null
-              else if    atLeast "9"   then isl_0_20
-              else    /* atLeast "7" */     isl_0_17;
-      } // lib.optionalAttrs (!(atLeast "9")) {
-        # gcc 10 is too strict to cross compile gcc <= 8
-        stdenv = if (stdenv.targetPlatform != stdenv.buildPlatform) && stdenv.cc.isGNU then gcc9Stdenv else stdenv;
-      })));
+      pkg = lowPrio (wrapCCWith {
+        cc = callPackage ./default.nix ({
+          inherit noSysDirs;
+          inherit majorMinorVersion;
+          reproducibleBuild = true;
+          profiledCompiler = false;
+          libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then args.libcCross else null;
+          threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else { };
+          isl = if       stdenv.hostPlatform.isDarwin then null
+                else if    atLeast "9"   then isl_0_20
+                else    /* atLeast "7" */     isl_0_17;
+        } // lib.optionalAttrs (!(atLeast "9")) {
+          # gcc 10 is too strict to cross compile gcc <= 8
+          stdenv = if (stdenv.targetPlatform != stdenv.buildPlatform) && stdenv.cc.isGNU then gcc9Stdenv else stdenv;
+        });
+        # In preparation for GCC 14 becoming the default,
+        # backport the new default errors to GCC 13.
+        nixSupport.cc-cflags = lib.optionals (atLeast "13") [
+          "-Werror=implicit-int"
+          "-Werror=implicit-function-declaration"
+          "-Werror=declaration-missing-parameter-type"
+          "-Werror=return-mismatch"
+          "-Werror=int-conversion"
+          "-Werror=incompatible-pointer-types"
+        ];
+      });
     in
       lib.nameValuePair attrName pkg;
 in
 lib.listToAttrs (map gccForMajorMinorVersion versions.allMajorVersions)
-


### PR DESCRIPTION
## Description of changes

**This is for after branch-off.**

We wanted to update GCC to 14.  We were okay with fixing all the new errors, but ultimately it had to be rolled back due to stability issues.

We don't know at what point in the 25.05 release cycle the next release will come out, so let's get ready by taking care of the new errors in advance.  Once GCC 14 is the default, this should be reverted.

Source: https://gcc.gnu.org/gcc-14/porting_to.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
