### PR TITLE
nixos/influxdb2: wait until service is ready

### DIFF
--- a/nixos/modules/services/databases/influxdb2.nix
+++ b/nixos/modules/services/databases/influxdb2.nix
@@ -67,16 +67,16 @@ let
     inherit (cfg.provision) organizations users;
   });
 
-  provisioningScript = pkgs.writeShellScript "post-start-provision" ''
-    set -euo pipefail
-    export INFLUX_HOST="http://"${escapeShellArg (
+  influxHost = "http://${escapeShellArg (
       if ! hasAttr "http-bind-address" cfg.settings
         || hasInfix "0.0.0.0" cfg.settings.http-bind-address
       then "localhost:8086"
       else cfg.settings.http-bind-address
-    )}
+    )}";
 
-    # Wait for the influxdb server to come online
+  waitUntilServiceIsReady = pkgs.writeShellScript "wait-until-service-is-ready" ''
+    set -euo pipefail
+    export INFLUX_HOST=${influxHost}
     count=0
     while ! influx ping &>/dev/null; do
       if [ "$count" -eq 300 ]; then
@@ -92,6 +92,11 @@ let
       sleep 0.1
       count=$((count++))
     done
+  '';
+
+  provisioningScript = pkgs.writeShellScript "post-start-provision" ''
+    set -euo pipefail
+    export INFLUX_HOST=${influxHost}
 
     # Do the initial database setup. Pass /dev/null as configs-path to
     # avoid saving the token as the active config.
@@ -447,11 +452,13 @@ in
           "admin-token:${cfg.provision.initialSetup.tokenFile}"
         ];
 
-        ExecStartPost = mkIf cfg.provision.enable (
+        ExecStartPost = [
+          waitUntilServiceIsReady
+        ] ++ (lib.optionals cfg.provision.enable (
           [provisioningScript] ++
           # Only the restarter runs with elevated privileges
           optional anyAuthDefined "+${restarterScript}"
-        );
+        ));
       };
 
       path = [


### PR DESCRIPTION
## Description of changes

Factor out part of the provisioning script into a
wait-until-service-is-ready script, and put it unconditionally in
front of ExecStartPost=, so that services that depend on influxdb2 are
not started until influxdb2 responds to requests.

Fixes https://github.com/NixOS/nixpkgs/issues/317017 ("Scrutiny tries to start before influxdb has started")

(I found that nixosTests.influxdb2 is flaky, see
https://github.com/NixOS/nixpkgs/issues/344229, but with enough retries it
passes. I don't think this PR can negatively affect that situation.)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
