### PR TITLE
nexusmods-app: add a warning about its experimental state

### DIFF
--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -9,8 +9,28 @@
   lib,
   runCommand,
   pname ? "nexusmods-app",
+  iKnowItsExperimental ? false,
 }:
-buildDotnetModule (finalAttrs: {
+let
+  # TODO: Remove this warning once upstream stabilises
+  warningText = ''
+    `${pname}` is currently in an unstable and experimental state.
+    In particular, you will usually need to wipe its config & reset any modded games whenever this package updates.
+    This can normally be done by running `NexusMods.App uninstall-app` before updating.
+
+    See the upstream FAQ for more detail:
+    https://nexus-mods.github.io/NexusMods.App/users/faq/#why-do-i-have-to-uninstall-everything-to-update-the-app
+
+    Note: You can silence this warning by overriding the package:
+    pkgs.${pname}.override {
+      iKnowItsExperimental = true;
+    }
+  '';
+
+  # Use a wrapper to avoid unnecessary indentation changes when we eventually remove the warning
+  withWarning = fn: arg: lib.warnIfNot iKnowItsExperimental warningText (fn arg);
+in
+withWarning buildDotnetModule (finalAttrs: {
   inherit pname;
   version = "0.4.1";
 


### PR DESCRIPTION
## Description of changes

Users need to be aware that the app is experimental.

In particular, they must take manual action to wipe any state before updating the package, e.g. using `NexusMods.App uninstall-app`. If this is not done, the updated app will crash while attempting to read the old database.

See earlier discussion https://github.com/NixOS/nixpkgs/pull/331150#issuecomment-2348856295
And upstream's FAQ: https://nexus-mods.github.io/NexusMods.App/users/faq/#why-do-i-have-to-uninstall-everything-to-update-the-app

This PR adds a temporary warning when evaluating `nexusmods-app` that informs end-users of the above.
```
$ nix-build -A nexusmods-app
trace: evaluation warning: `nexusmods-app` is currently in an unstable and experimental state.
In particular, you will usually need to wipe its config & reset any modded games whenever this package updates.
This can normally be done by running `NexusMods.App uninstall-app` before updating.

See the upstream FAQ for more detail:
https://nexus-mods.github.io/NexusMods.App/users/faq/#why-do-i-have-to-uninstall-everything-to-update-the-app

Note: You can silence this warning by overriding the package:
pkgs.nexusmods-app.override {
  iKnowItsExperimental = true;
}
```

The warning can be silenced by overriding the package:
```nix
pkgs.nexusmods-app.override {
  iKnowItsExperimental = true;
}
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
