### PR TITLE
ocamlPackages.piaf: 0.1.0 → 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/eio-ssl/default.nix
+++ b/pkgs/development/ocaml-modules/eio-ssl/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, eio
+, ssl
+}:
+
+buildDunePackage rec {
+  pname = "eio-ssl";
+  version = "0.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/anmonteiro/eio-ssl/releases/download/${version}/eio-ssl-${version}.tbz";
+    hash = "sha256-m4CiUQtXVSMfLthbDsAftpiOsr24I5IGiU1vv7Rz8go=";
+  };
+
+  propagatedBuildInputs = [ eio ssl ];
+
+  meta = {
+    homepage = "https://github.com/anmonteiro/eio-ssl";
+    description = "OpenSSL binding to EIO";
+    license = lib.licenses.lgpl21;
+  };
+}

--- a/pkgs/development/ocaml-modules/h2/eio.nix
+++ b/pkgs/development/ocaml-modules/h2/eio.nix
@@ -1,0 +1,18 @@
+{ buildDunePackage
+, h2
+, eio
+, gluten-eio
+}:
+
+buildDunePackage {
+  pname = "h2-eio";
+
+  inherit (h2) src version;
+
+  propagatedBuildInputs = [ eio gluten-eio h2 ];
+
+  meta = h2.meta // {
+    description = "EIO support for h2";
+  };
+}
+

--- a/pkgs/development/ocaml-modules/httpun-ws/default.nix
+++ b/pkgs/development/ocaml-modules/httpun-ws/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchurl
+, buildDunePackage
+, angstrom
+, base64
+, bigstringaf
+, faraday
+, gluten
+, httpun
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "httpun-ws";
+  version = "0.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/anmonteiro/httpun-ws/releases/download/${version}/httpun-ws-${version}.tbz";
+    hash = "sha256-6uDNLg61tPyctthitxFqbw/IUDsuQ5BGvw5vTLLCl/0=";
+  };
+
+  propagatedBuildInputs = [
+    angstrom
+    base64
+    bigstringaf
+    faraday
+    gluten
+    httpun
+  ];
+
+  doCheck = true;
+  checkInputs = [ alcotest ];
+
+  meta = {
+    description = "Websocket implementation for httpun";
+    license = lib.licenses.bsd3;
+    homepage = "https://github.com/anmonteiro/httpun-ws";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/httpun/default.nix
+++ b/pkgs/development/ocaml-modules/httpun/default.nix
@@ -1,0 +1,22 @@
+{ buildDunePackage
+, httpun-types
+, angstrom
+, bigstringaf
+, faraday
+, alcotest
+}:
+
+buildDunePackage {
+  pname = "httpun";
+
+  inherit (httpun-types) src version;
+
+  propagatedBuildInputs = [ angstrom bigstringaf faraday httpun-types ];
+
+  doCheck = true;
+  checkInputs = [ alcotest ];
+
+  meta = httpun-types.meta // {
+    description = "A high-performance, memory-efficient, and scalable HTTP library for OCaml";
+  };
+}

--- a/pkgs/development/ocaml-modules/httpun/eio.nix
+++ b/pkgs/development/ocaml-modules/httpun/eio.nix
@@ -1,0 +1,16 @@
+{ buildDunePackage
+, httpun
+, gluten-eio
+}:
+
+buildDunePackage {
+  pname = "httpun-eio";
+
+  inherit (httpun) src version;
+
+  propagatedBuildInputs = [ gluten-eio httpun ];
+
+  meta = httpun.meta // {
+    description = "EIO support for httpun";
+  };
+}

--- a/pkgs/development/ocaml-modules/piaf/default.nix
+++ b/pkgs/development/ocaml-modules/piaf/default.nix
@@ -1,52 +1,57 @@
-{ alcotest-lwt
+{ alcotest
 , buildDunePackage
-, ocaml
-, bigarray-compat
-, dune-site
 , fetchurl
-, gluten-lwt-unix
+, eio-ssl
+, faraday
+, h2-eio
+, httpun-eio
+, httpun-ws
+, ipaddr
+, ke
 , lib
 , logs
 , magic-mime
-, mrmime
-, psq
-, rresult
+, pecu
+, prettym
+, unstrctrd
 , uri
+, uutf
+, dune-site
+, eio_main
 }:
-
-lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
-  "piaf is not available for OCaml ${ocaml.version}"
 
 buildDunePackage rec {
   pname = "piaf";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchurl {
     url = "https://github.com/anmonteiro/piaf/releases/download/${version}/piaf-${version}.tbz";
-    hash = "sha256-AMO+ptGox33Bi7u/H0SaeCU88XORrRU3UbLof3EwcmU=";
+    hash = "sha256-B/qQCaUvrqrm2GEW51AH9SebGFx7x8laq5RV8hBzcPs=";
   };
 
-  postPatch = ''
-    substituteInPlace ./vendor/dune --replace "mrmime.prettym" "prettym"
-  '';
-
   propagatedBuildInputs = [
-    bigarray-compat
+    eio-ssl
+    faraday
+    h2-eio
+    httpun-eio
+    httpun-ws
+    ipaddr
     logs
     magic-mime
-    mrmime
-    psq
-    rresult
+    pecu
+    prettym
+    unstrctrd
     uri
-    gluten-lwt-unix
+    uutf
   ];
 
-  nativeCheckInputs = [
-    alcotest-lwt
-    dune-site
-  ];
-  # Check fails with OpenSSL 3
+  # Some test cases fail
   doCheck = false;
+  checkInputs = [
+    alcotest
+    dune-site
+    eio_main
+  ];
 
   meta = {
     description = "HTTP library with HTTP/2 support written entirely in OCaml";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -660,6 +660,8 @@ let
 
     h2 = callPackage ../development/ocaml-modules/h2 { };
 
+    h2-eio = callPackage ../development/ocaml-modules/h2/eio.nix { };
+
     hack_parallel = callPackage ../development/ocaml-modules/hack_parallel { };
 
     hacl-star = callPackage ../development/ocaml-modules/hacl-star { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -691,6 +691,8 @@ let
 
     httpaf-lwt-unix = callPackage ../development/ocaml-modules/httpaf/lwt-unix.nix { };
 
+    httpun = callPackage ../development/ocaml-modules/httpun { };
+
     httpun-types = callPackage ../development/ocaml-modules/httpun/types.nix { };
 
     hxd = callPackage ../development/ocaml-modules/hxd { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -693,6 +693,8 @@ let
 
     httpun = callPackage ../development/ocaml-modules/httpun { };
 
+    httpun-eio = callPackage ../development/ocaml-modules/httpun/eio.nix { };
+
     httpun-types = callPackage ../development/ocaml-modules/httpun/types.nix { };
 
     hxd = callPackage ../development/ocaml-modules/hxd { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -444,6 +444,8 @@ let
     eio_main = callPackage ../development/ocaml-modules/eio/main.nix { };
     eio_posix = callPackage ../development/ocaml-modules/eio/posix.nix { };
 
+    eio-ssl = callPackage ../development/ocaml-modules/eio-ssl { };
+
     either = callPackage ../development/ocaml-modules/either { };
 
     elina = callPackage ../development/ocaml-modules/elina { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -697,6 +697,8 @@ let
 
     httpun-types = callPackage ../development/ocaml-modules/httpun/types.nix { };
 
+    httpun-ws = callPackage ../development/ocaml-modules/httpun-ws { };
+
     hxd = callPackage ../development/ocaml-modules/hxd { };
 
     ### I ###


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/anmonteiro/piaf/refs/tags/0.2.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
