### PR TITLE
pinentry-kwallet: init at 3.03, kwalletcli: autoformat

### DIFF
--- a/pkgs/by-name/pi/pinentry-kwallet/package.nix
+++ b/pkgs/by-name/pi/pinentry-kwallet/package.nix
@@ -1,0 +1,29 @@
+{ stdenv, kwalletcli }:
+stdenv.mkDerivation {
+  pname = "pinentry-kwallet";
+  version = kwalletcli.version;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s ${kwalletcli}/bin/pinentry-kwallet $out/bin/pinentry-kwallet
+  '';
+
+  dontUnpack = true;
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontCheck = true;
+  dontFixup = true;
+
+  meta = {
+    description = "Pinentry program for GnuPG that uses KWallet to store passphrases";
+    longDescription = ''
+      pinentry-kwallet is a pinentry program for GnuPG that uses KWallet to store passphrases.
+      This allows automatically unlocking GnuPG keys on login. This package is a thin wrapper
+      that symlinks to the pinentry-kwallet binary in the kwalletcli package to make it compatible
+      with the `programs.gnupg.agent.pinentryPackage` option in NixOS.
+    '';
+    mainProgram = "pinentry-kwallet";
+    inherit (kwalletcli.meta) homepage license maintainers;
+  };
+}


### PR DESCRIPTION
pinentry-kwallet is a pinentry program for GnuPG that uses KWallet to store passphrases. This allows automatically unlocking GnuPG keys on login. This package is a thin wrapper that symlinks to the pinentry-kwallet binary in the kwalletcli package to make it compatible with the `programs.gnupg.agent.pinentryPackage` option in NixOS.

## Description of changes

Add a small wrapper package that exposes the `pinentry-kwallet` program in such a way that it can be passed to `programs.gnupg.agent.pinentryPackage`.

I'm already using [this exact package](https://github.com/iFreilicht/.dotfiles/blob/master/.dotfiles/nixos/packages/pinentry-kwallet.nix) in [my own configuration](https://github.com/iFreilicht/.dotfiles/blob/101f1308c9623e94e71628eb9bbdcb44c3d9f305/.dotfiles/nixos/source/configuration.nix#L81C1-L84C7) and it works exactly as intended.

Because this is basically just a special case of kwalletcli, I decided to use this opportunity to autoformat that. I also tried moving it to `by-name` but that's not possible because it is called with `libsForQt5.callPackage`.

@peterhoeg because you're listed as the sole maintainer of kwalletcli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
