### PR TITLE
python3Packages.flash-attn: init at 2.6.3

### DIFF
--- a/pkgs/development/python-modules/flash-attn/default.nix
+++ b/pkgs/development/python-modules/flash-attn/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  einops,
+  ninja,
+  setuptools,
+  torch,
+  transformers,
+  triton,
+  cudaPackages,
+  config,
+  cudaSupport ? config.cudaSupport,
+  which,
+  git,
+  psutil
+}:
+
+let
+  cutlass = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "cutlass";
+    rev = "refs/tags/v3.5.0";
+    sha256 = "sha256-D/s7eYsa5l/mfx73tE4mnFcTQdYqGmXa9d9TCryw4e4=";
+  };
+in
+
+buildPythonPackage rec {
+  pname = "flash-attn";
+  version = "2.6.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Dao-AILab";
+    repo = "flash-attention";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-9AmmoUlyh4x0CuasZeXML7N3TETmG0vhHMm8cirsblk=";
+  };
+
+  build-system = [
+    ninja
+    setuptools
+    torch
+    psutil
+  ];
+
+  nativeBuildInputs = [ which git ];
+
+  buildInputs = (
+    lib.optionals cudaSupport (
+      with cudaPackages;
+      [
+        cuda_cudart # cuda_runtime.h, -lcudart
+        cuda_cccl
+        libcusparse # cusparse.h
+        libcusolver # cusolverDn.h
+        cuda_nvcc
+        libcublas
+        cutlass
+      ]
+    )
+  );
+
+  dependencies = [
+    einops
+    torch
+    triton
+  ];
+
+  env = {
+    FLASHATTENTION_FORCE_BUILD = "TRUE";
+  } // lib.optionalAttrs cudaSupport { CUDA_HOME = "${lib.getDev cudaPackages.cuda_nvcc}"; };
+
+  # pytest tests not enabled due to nvidia GPU dependency
+  pythonImportsCheck = [ "flash_attn" ];
+
+  meta = with lib; {
+    description = "Fast and Memory-Efficient Exact Attention with IO-Awareness";
+    homepage = "https://github.com/Dao-AILab/flash-attention";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cfhammill ];
+    # The package requires CUDA or ROCm, the ROCm build hasn't
+    # been completed or tested, so broken if not using cuda.
+    broken = !cudaSupport;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4454,6 +4454,8 @@ self: super: with self; {
 
   flashtext = callPackage ../development/python-modules/flashtext { };
 
+  flash-attn = callPackage ../development/python-modules/flash-attn { };
+
   flask-admin = callPackage ../development/python-modules/flask-admin { };
 
   flask-api = callPackage ../development/python-modules/flask-api { };


### PR DESCRIPTION
## Description of changes

Adds the flash-attn package. Similar to https://github.com/NixOS/nixpkgs/pull/341195, only cuda has been tested (84 F, 300P S, 200K S; yes it has 500 thousand tests). The 84 failures are numerical and likely just numerical instability. (This was tested with the triton fix from https://github.com/NixOS/nixpkgs/pull/344259).

This can be used as an optional dependency for vllm and likely other packages as well.

cc @SomeoneSerge @samuela @natsukium 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
