### PR TITLE
teams: create the Xen Project Team and rename instances of `Xen` to `Xen Project`.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17467,6 +17467,12 @@
     githubId = 5653911;
     name = "Rampoina";
   };
+  rane = {
+    email = "rane+nix@junkyard.systems";
+    github = "digitalrane";
+    githubId = 1829286;
+    name = "Rane";
+  };
   ranfdev = {
     email = "ranfdev@gmail.com";
     name = "Lorenzo Miglietta";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8357,6 +8357,12 @@
     githubId = 287769;
     name = "Sergii Paryzhskyi";
   };
+  hehongbo = {
+    name = "Hongbo";
+    github = "hehongbo";
+    githubId = 665472;
+    matrix = "@hehongbo:matrix.org";
+  };
   heijligen = {
     email = "src@posteo.de";
     github = "heijligen";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1022,6 +1022,19 @@ with lib.maintainers;
     shortName = "WDZ GmbH";
   };
 
+  xen = {
+    members = [
+      hehongbo
+      lach
+      rane
+      sigmasquadron
+    ];
+    scope = "Maintain the Xen Project Hypervisor and the related tooling ecosystem.";
+    shortName = "Xen Project Hypervisor";
+    enableFeatureFreezePing = true;
+    githubTeams = [ "xen-project" ];
+  };
+
   xfce = {
     members = [
       bobby285271

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -49,13 +49,13 @@
 - Support for mounting filesystems from block devices protected with [dm-verity](https://docs.kernel.org/admin-guide/device-mapper/verity.html)
   was added through the `boot.initrd.systemd.dmVerity` option.
 
-- The [Xen Hypervisor](https://xenproject.org) is once again available as a virtualisation option under [`virtualisation.xen`](#opt-virtualisation.xen.enable).
+- The [Xen Project Hypervisor](https://xenproject.org) is once again available as a virtualisation option under [`virtualisation.xen`](#opt-virtualisation.xen.enable).
   - This release includes Xen [4.17.5](https://wiki.xenproject.org/wiki/Xen_Project_4.17_Release_Notes), [4.18.3](https://wiki.xenproject.org/wiki/Xen_Project_4.18_Release_Notes) and [4.19.0](https://wiki.xenproject.org/wiki/Xen_Project_4.19_Release_Notes), as well as support for booting the hypervisor on EFI systems.
   ::: {.warning}
-    Booting into Xen through a legacy BIOS bootloader or with the legacy script-based Stage 1 initrd have been **deprecated**. Only EFI booting and the new systemd-based Stage 1 initrd are supported.
+    Booting into the Xen Project Hypervisor through a legacy BIOS bootloader or with the legacy script-based Stage 1 initrd have been **deprecated**. Only EFI booting and the new systemd-based Stage 1 initrd are supported.
   :::
   - There are two flavours of Xen available by default: `xen`, which includes all built-in components, and `xen-slim`, which replaces the built-in components with their Nixpkgs equivalents.
-    - The `qemu-xen-traditional` component has been deprecated by upstream Xen, and is no longer available in any of the Xen packages.
+    - The `qemu-xen-traditional` component has been deprecated by the upstream Xen Project, and is no longer available in any of the Xen Project Hypervisor packages.
   - The OCaml-based Xen Store can now be configured using  [`virtualisation.xen.store.settings`](#opt-virtualisation.xen.store.settings).
   - The `virtualisation.xen.bridge` options have been deprecated in this release cycle. Users who need network bridges are encouraged to set up their own networking configurations.
 

--- a/nixos/modules/virtualisation/xe-guest-utilities.nix
+++ b/nixos/modules/virtualisation/xe-guest-utilities.nix
@@ -4,7 +4,7 @@ let
 in {
   options = {
     services.xe-guest-utilities = {
-      enable = lib.mkEnableOption "the Xen guest utilities daemon";
+      enable = lib.mkEnableOption "the XenServer guest utilities daemon";
     };
   };
   config = lib.mkIf cfg.enable {

--- a/nixos/modules/virtualisation/xen-boot-builder.sh
+++ b/nixos/modules/virtualisation/xen-boot-builder.sh
@@ -5,7 +5,7 @@
 [[ $# -ne 1 ]] && echo -e "\e[1;31merror:\e[0m xenBootBuilder must be called with exactly one verbosity argument. See the \e[1;34mvirtualisation.xen.efi.bootBuilderVerbosity\e[0m option." && exit 1
 case "$1" in
     "quiet") true ;;
-    "default" | "info") echo -n "Installing Xen Hypervisor boot entries..." ;;
+    "default" | "info") echo -n "Installing Xen Project Hypervisor boot entries..." ;;
     "debug") echo -e "\e[1;34mxenBootBuilder:\e[0m called with the '$1' flag" ;;
     *)
         echo -e "\e[1;31merror:\e[0m xenBootBuilder was called with an invalid argument. See the \e[1;34mvirtualisation.xen.efi.bootBuilderVerbosity\e[0m option."
@@ -150,7 +150,7 @@ else
     esac
     if [ "$1" = "info" ]; then
         if [[ ${#preGenerations[@]} == "${#postGenerations[@]}" ]]; then
-            echo -e "\e[1;33mNo Change:\e[0m Xen Hypervisor boot entries were refreshed, but their contents are identical."
+            echo -e "\e[1;33mNo Change:\e[0m Xen Project Hypervisor boot entries were refreshed, but their contents are identical."
         else
             echo -e "\e[1;32mSuccess:\e[0m Changed the following boot entries:"
             # We briefly unset errexit and pipefail here, as GNU diff has no option to not fail when files differ.

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -1,4 +1,4 @@
-# Xen hypervisor (Dom0) support.
+# Xen Project Hypervisor (Dom0) support.
 
 {
   config,
@@ -123,7 +123,7 @@ in
 
   options.virtualisation.xen = {
 
-    enable = lib.options.mkEnableOption "the Xen Hypervisor, a virtualisation technology defined as a *type-1 hypervisor*, which allows multiple virtual machines, known as *domains*, to run concurrently on the physical machine. NixOS runs as the privileged *Domain 0*. This option requires a reboot into a Xen kernel to take effect";
+    enable = lib.options.mkEnableOption "the Xen Project Hypervisor, a virtualisation technology defined as a *type-1 hypervisor*, which allows multiple virtual machines, known as *domains*, to run concurrently on the physical machine. NixOS runs as the privileged *Domain 0*. This option requires a reboot into a Xen kernel to take effect";
 
     debug = lib.options.mkEnableOption "Xen debug features for Domain 0. This option enables some hidden debugging tests and features, and should not be used in production";
 
@@ -141,7 +141,7 @@ in
       defaultText = lib.options.literalExpression "pkgs.xen";
       example = lib.options.literalExpression "pkgs.xen-slim";
       description = ''
-        The package used for Xen Hypervisor.
+        The package used for Xen Project Hypervisor.
       '';
       relatedPackages = [
         "xen"
@@ -207,7 +207,7 @@ in
 
           - `quiet` supresses all messages.
 
-          - `default` adds a simple "Installing Xen Hypervisor boot entries...done." message to the script.
+          - `default` adds a simple "Installing Xen Project Hypervisor boot entries...done." message to the script.
 
           - `info` is the same as `default`, but it also prints a diff with information on which generations were altered.
             - This option adds two extra dependencies to the script: `diffutils` and `bat`.

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -870,5 +870,5 @@ in
       };
     };
   };
-  meta.maintainers = with lib.maintainers; [ sigmasquadron ];
+  meta.maintainers = lib.teams.xen.members;
 }

--- a/pkgs/applications/virtualization/xen/README.md
+++ b/pkgs/applications/virtualization/xen/README.md
@@ -15,11 +15,11 @@
   </a>
 </p>
 
-# Xen Hypervisor <a href="https://xenproject.org/"><img src="https://downloads.xenproject.org/Branding/Mascots/Xen-Fu-Panda-2000px.png" width="48px" align="top" alt="Xen Fu Panda"></a>
+# Xen Project Hypervisor <a href="https://xenproject.org/"><img src="https://downloads.xenproject.org/Branding/Mascots/Xen-Fu-Panda-2000px.png" width="48px" align="top" alt="Xen Fu Panda"></a>
 
-This directory includes the build recipes for the [Xen Hypervisor](https://xenproject.org/).
+This directory includes the build recipes for the [Xen Project Hypervisor](https://xenproject.org/).
 
-Some other notable packages that compose the Xen Ecosystem include:
+Some other notable packages that compose the Xen Project Ecosystem include:
 
 - `ocamlPackages.xenstore`: Mirage's `oxenstore` implementation.
 - `ocamlPackages.vchan`: Mirage's `xen-vchan` implementation.

--- a/pkgs/applications/virtualization/xen/generic/default.nix
+++ b/pkgs/applications/virtualization/xen/generic/default.nix
@@ -647,7 +647,7 @@ stdenv.mkDerivation (finalAttrs: {
 
         # Short description for Xen.
         description =
-          "Xen Hypervisor"
+          "Xen Project Hypervisor"
           # The "and related components" addition is automatically hidden if said components aren't being built.
           + lib.strings.optionalString (prefetchedSources != { }) " and related components"
           # To alter the description inside the paranthesis, edit ./packages.nix.
@@ -681,18 +681,18 @@ stdenv.mkDerivation (finalAttrs: {
                 # Originally, this was a call for the complicated withPrefetchedSources. Since there aren't
                 # that many optional components, we just use lib.strings.optionalString, because it's simpler.
                 # Optional components that aren't being built are automatically hidden.
-                + lib.strings.optionalString withEFI "\n* `xen.efi`: Xen's [EFI binary](https://xenbits.xenproject.org/docs/${branch}-testing/misc/efi.html), available on the `boot` output of this package."
+                + lib.strings.optionalString withEFI "\n* `xen.efi`: The Xen Project's [EFI binary](https://xenbits.xenproject.org/docs/${branch}-testing/misc/efi.html), available on the `boot` output of this package."
                 + lib.strings.optionalString withFlask "\n* `xsm-flask`: The [FLASK Xen Security Module](https://wiki.xenproject.org/wiki/Xen_Security_Modules_:_XSM-FLASK). The `xenpolicy-${version}` file is available on the `boot` output of this package."
-                + lib.strings.optionalString withInternalQEMU "\n* `qemu-xen`: Xen's mirror of [QEMU](https://www.qemu.org/)."
-                + lib.strings.optionalString withInternalSeaBIOS "\n* `seabios-xen`: Xen's mirror of [SeaBIOS](https://www.seabios.org/SeaBIOS)."
-                + lib.strings.optionalString withInternalOVMF "\n* `ovmf-xen`: Xen's mirror of [OVMF](https://github.com/tianocore/tianocore.github.io/wiki/OVMF)."
-                + lib.strings.optionalString withInternalIPXE "\n* `ipxe-xen`: Xen's pinned version of [iPXE](https://ipxe.org/)."
+                + lib.strings.optionalString withInternalQEMU "\n* `qemu-xen`: The Xen Project's mirror of [QEMU](https://www.qemu.org/)."
+                + lib.strings.optionalString withInternalSeaBIOS "\n* `seabios-xen`: The Xen Project's mirror of [SeaBIOS](https://www.seabios.org/SeaBIOS)."
+                + lib.strings.optionalString withInternalOVMF "\n* `ovmf-xen`: The Xen Project's mirror of [OVMF](https://github.com/tianocore/tianocore.github.io/wiki/OVMF)."
+                + lib.strings.optionalString withInternalIPXE "\n* `ipxe-xen`: The Xen Project's pinned version of [iPXE](https://ipxe.org/)."
               )
           # Finally, we write a notice explaining which vulnerabilities this Xen is NOT vulnerable to.
           # This will hopefully give users the peace of mind that their Xen is secure, without needing
           # to search the source code for the XSA patches.
           + lib.strings.optionalString (writeAdvisoryDescription != [ ]) (
-            "\n\nThis Xen (${version}) has been patched against the following known security vulnerabilities:\n"
+            "\n\nThis Xen Project Hypervisor (${version}) has been patched against the following known security vulnerabilities:\n"
             + lib.strings.removeSuffix "\n" (lib.strings.concatLines writeAdvisoryDescription)
           );
 
@@ -712,8 +712,8 @@ stdenv.mkDerivation (finalAttrs: {
         ];
 
         # This automatically removes maintainers from EOL versions of Xen, so we aren't bothered about versions we don't explictly support.
-        knownVulnerabilities = lib.lists.optional (lib.strings.versionOlder version minSupportedVersion) "Xen ${version} is no longer supported by the Xen Security Team. See https://xenbits.xenproject.org/docs/unstable/support-matrix.html";
         maintainers = lib.lists.optionals (lib.strings.versionAtLeast version minSupportedVersion) lib.teams.xen.members;
+        knownVulnerabilities = lib.lists.optional (lib.strings.versionOlder version minSupportedVersion) "The Xen Project Hypervisor version ${version} is no longer supported by the Xen Project Security Team. See https://xenbits.xenproject.org/docs/unstable/support-matrix.html";
 
         mainProgram = "xl";
 

--- a/pkgs/applications/virtualization/xen/generic/default.nix
+++ b/pkgs/applications/virtualization/xen/generic/default.nix
@@ -712,10 +712,8 @@ stdenv.mkDerivation (finalAttrs: {
         ];
 
         # This automatically removes maintainers from EOL versions of Xen, so we aren't bothered about versions we don't explictly support.
-        maintainers = lib.lists.optionals (lib.strings.versionAtLeast version minSupportedVersion) (
-          with lib.maintainers; [ sigmasquadron ]
-        );
         knownVulnerabilities = lib.lists.optional (lib.strings.versionOlder version minSupportedVersion) "Xen ${version} is no longer supported by the Xen Security Team. See https://xenbits.xenproject.org/docs/unstable/support-matrix.html";
+        maintainers = lib.lists.optionals (lib.strings.versionAtLeast version minSupportedVersion) lib.teams.xen.members;
 
         mainProgram = "xl";
 

--- a/pkgs/applications/virtualization/xen/packages.nix
+++ b/pkgs/applications/virtualization/xen/packages.nix
@@ -2,13 +2,13 @@
 let
   standard = {
     meta = {
-      description = "Standard Xen";
+      description = "Standard";
       longDescription = ''
-        Standard version of Xen. Uses forks of QEMU, SeaBIOS, OVMF and iPXE provided
-        by the Xen Project. This provides the vanilla Xen experince, but wastes space
-        and build time. A typical NixOS setup that runs lots of VMs will usually need
-        to build two different versions of QEMU when using this Xen derivation (one
-        fork and upstream).
+        Standard version of the Xen Project Hypervisor. Uses forks of QEMU, SeaBIOS,
+        OVMF and iPXE provided by the Xen Project. This provides the vanilla Xen
+        experience, but wastes space and build time. A typical NixOS setup that runs
+        lots of VMs will usually need to build two different versions of QEMU when using
+        this Xen derivation (one fork and upstream).
       '';
     };
   };
@@ -16,11 +16,11 @@ let
     meta = {
       description = "Without Internal Components";
       longDescription = ''
-        Slimmed-down version of Xen that reuses nixpkgs packages as much as possible.
-        Instead of using the Xen forks for various internal components, this version uses
-        `seabios`, `ovmf` and `ipxe` from nixpkgs. These components may ocasionally get
-        out of sync with the hypervisor itself, but this builds faster and uses less space
-        than the default derivation.
+        Slimmed-down version of the Xen Project Hypervisor that reuses nixpkgs packages
+        as much as possible. Instead of using the Xen Project forks for various internal
+        components, this version uses `seabios`, `ovmf` and `ipxe` from Nixpkgs. These
+        components may ocasionally get out of sync with the hypervisor itself, but this
+        builds faster and uses less space than the default derivation.
       '';
     };
   };

--- a/pkgs/by-name/xe/xen-guest-agent/package.nix
+++ b/pkgs/by-name/xe/xen-guest-agent/package.nix
@@ -45,9 +45,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://gitlab.com/xen-project/xen-guest-agent";
     license = lib.licenses.agpl3Only;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      matdibu
-      sigmasquadron
-    ];
+    maintainers = lib.teams.xen.members;
+    mainProgram = "xen-guest-agent";
   };
 }

--- a/pkgs/by-name/xt/xtf/package.nix
+++ b/pkgs/by-name/xt/xtf/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation {
     description = "Xen Test Framework and Suite for creating microkernel-based tests";
     homepage = "https://xenbits.xenproject.org/docs/xtf/index.html";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ sigmasquadron ];
+    maintainers = lib.teams.xen.members;
     mainProgram = "xtf-runner";
     platforms = lib.lists.intersectLists lib.platforms.linux lib.platforms.x86_64;
   };

--- a/pkgs/development/ocaml-modules/vchan/default.nix
+++ b/pkgs/development/ocaml-modules/vchan/default.nix
@@ -32,6 +32,6 @@ buildDunePackage rec {
     description = "Xen Vchan implementation";
     homepage = "https://github.com/mirage/ocaml-vchan";
     license = licenses.isc;
-    maintainers = [ maintainers.sternenseemann ];
+    maintainers = teams.xen.members ++ [ maintainers.sternenseemann ];
   };
 }

--- a/pkgs/development/ocaml-modules/xenstore/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore/default.nix
@@ -25,10 +25,7 @@ buildDunePackage rec {
   meta = with lib; {
     description = "Xenstore protocol in pure OCaml";
     license = licenses.lgpl21Only;
-    maintainers = with maintainers; [
-      sternenseemann
-      sigmasquadron
-    ];
+    maintainers = teams.xen.members ++ [ maintainers.sternenseemann ];
     homepage = "https://github.com/mirage/ocaml-xenstore";
   };
 }

--- a/pkgs/development/ocaml-modules/xenstore_transport/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore_transport/default.nix
@@ -23,5 +23,6 @@ buildDunePackage rec {
     description = "Low-level libraries for connecting to a xenstore service on a xen host";
     license = licenses.lgpl21Only;
     homepage = "https://github.com/xapi-project/ocaml-xenstore-clients";
+    maintainers = teams.xen.members;
   };
 }


### PR DESCRIPTION
## Description of changes

- Creates the Xen Project Hypervisor Team, with **4** members who will maintain the Xen Project's ecosystem on Nixpkgs.

- Renames instances of "Xen" to "Xen Project" to comply with the Linux Foundation's and the Cloud Software Group's copyright agreements.

## Things done

- All parties have agreed to joining the team:
  - [x] Fernando Rodrigues
  - [x] HeHongBo
  - [x] Rane
  - [x] Yaroslav Bolyukin 
- Miscellaneous distro-wide changes:
  - [ ] The team page on the nixos.org website is up.
  - [x] A `6.topic: xen` label has been created.
  - [x] The `NixOS with Xen Project Hypervisor` matrix room has been created.
    - [x] The room's icon has been added to `nixos-artwork`. (Rename group to `Xen Project`)
    - [x] The room has been adopted by the `nixos.org` homeserver and space. (`#xen:nixos.org` is fine, like the option name is, as the room is clearly described as "Xen Project Hypervisor"-related.)
- All XPH-related packages are being maintained by the team:
  - [x] `xen` (pkgs/applications/virtualisation/xen)
    - Inherited by `qemu_xen`
  - [x] `xen-guest-agent`
  - [x] `xtf`
  - [x] `virtualisation.xen` (xen-dom0.nix)
  - [x] `virtualisation.xen.guest` (xen-domU.nix)
  - OCaml Packages:
    - [x] `ocamlPackages.xenstore`
    - [x] `ocamlPackages.xenstore_transport`
    - Inherited by `ocamlPackages.xenstore-tool`
    - [x] `ocamlPackages.vchan`
- [x] We have announced the creation of the team on Discourse and made an open invite for more maintainers/users.
- [x] The legal issues have been resolved.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## E-mails

<details>
<summary><b>A Proposal for the Xen Maintenance Team for Nixpkgs</b></summary>

> Hello everyone!
>
> I'm Fernando, known as SigmaSquadron on GitHub/Matrix, and as you already know,
> I've been doing my best to revive Xen on NixOS. There is still much work to be
> done to fully integrate Xen with Nix's declarative nature, but I'm confident
> that we can achieve first-class Xen support by banding together as a team.
>
> Matei has been working on the DomU aspects of Xen, and I am currently preparing
> an accompanying module for the guest tools. Since the guest tools depend on the
> main Xen package, I believe we'd both benefit from tightly integrating these
> workflows, thereby making sure a Dom0 update doesn't break DomU tools, and
> vice-versa.
>
> Yaroslav has been working on the Lanzaboote boot builder for Dom0 Xen and
> hassingle-handedly packaged a POC Qubes dom0 on Nix. While the Qubes utilities
> are a bit out of scope for the Xen team, they'll certainly benefit from
> reliably-maintained dependencies. Maybe in the future we'll even be making a
> Qubes team!
>
> William, as the previous de facto Xen maintainer, your input will always be
> invaluable. I ask you to reconsider leaving and join us again, as you won't be
> maintaining the packages alone this time.
>
> I've also CC-ed other reviewers to the module PR; consider this an invitation to
> join the team as well! Although you're not currently listed as maintainers in
> Nixpkgs, you're familiar with the contribution process, and I hope you'll step
> up to help us co-maintain the Xen ecosystem. Since we're all together in the
> same team, none of us will be overwhelmed with Xen work, and we'll be able to
> more easily review each others' PRs to avoid regressions, as OfBorg will be
> notifying the whole team.
>
> If you're unaware, Nixpkgs has teams defined in maintainers/team-list.nix that
> include the purpose of the team and the list of members. Remember that
> maintaining a package doesn't mean rewriting it from scratch every time. Opening
> issues if other members of the team forget an update, testing PRs or fixing code
> quality/modernisation issues is already an immense help.
>
> The ultimate goal of the team is to distribute the maintainership responsibility
> and improve Xen's reliability on Nixpkgs. That said, now that the Constitution
> Draft has been published, I was also hoping to ask the Steering Committee for a
> @nixos.org email specifically meant to receive embargoed XSAs. We had trouble
> patching Xen in the last few XSA releases, as upstream Xen forgot to make the
> patches public in a timely manner. Being a part of the pre-disclosure list means
> that this is no longer an issue, as we can prepare vendored patches and merge
> them in minutes after the embargo ends, not days. Having a whole team behind Xen
> would officialise NixOS's position as a distributor of the Hypervisor.
>
> Thank you for reading, and I hope you will all accept this invitation to start a
> Xen team. If you do, please include any non-email contact information you use
> for interacting with NixOS, such as a Matrix/NixOS Discourse handle, in your
> reply.
>
> Appreciatively yours,<br>
> Fernando Rodrigues.
>
> E3CD E225 47C6 2DB6 6CCD BC06 CC3A E2EA 0000 0000
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc