### PR TITLE
python3Packages.ultralytics_thop: init at 2.0.8

### DIFF
--- a/pkgs/development/python-modules/ultralytics_thop/default.nix
+++ b/pkgs/development/python-modules/ultralytics_thop/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, torch
+, pythonOlder
+, setuptools
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "ultralytics_thop";
+  version = "2.0.8";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fd098468a5a50609c28906c557240c0d1603175c5420843de5ebefd7c83376ab";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    torch
+  ];
+
+  pythonImportsCheck = [ "thop" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Profile PyTorch models for FLOPs and parameters.";
+    homepage = "https://github.com/ultralytics/thop";
+    licenses = with licenses; [ agpl3 ];
+    maintainers = with maintainers; [ ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16843,6 +16843,10 @@ self: super: with self; {
 
   ultraheat-api = callPackage ../development/python-modules/ultraheat-api { };
 
+  ultralytics_thop = callPackage ../development/python-modules/ultralytics_thop {
+    inherit (self) pythonOlder setuptools wheel buildPythonPackage fetchPypi numpy torch;
+  };
+
   umalqurra = callPackage ../development/python-modules/umalqurra { };
 
   umap-learn = callPackage ../development/python-modules/umap-learn { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16844,7 +16844,8 @@ self: super: with self; {
   ultraheat-api = callPackage ../development/python-modules/ultraheat-api { };
 
   ultralytics_thop = callPackage ../development/python-modules/ultralytics_thop {
-    inherit (self) pythonOlder setuptools wheel buildPythonPackage fetchPypi numpy torch;
+    inherit (self) pythonOlder setuptools wheel buildPythonPackage fetchPypi
+      numpy torch;
   };
 
   umalqurra = callPackage ../development/python-modules/umalqurra { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16843,10 +16843,7 @@ self: super: with self; {
 
   ultraheat-api = callPackage ../development/python-modules/ultraheat-api { };
 
-  ultralytics_thop = callPackage ../development/python-modules/ultralytics_thop {
-    inherit (self) pythonOlder setuptools wheel buildPythonPackage fetchPypi
-      numpy torch;
-  };
+  ultralytics_thop = callPackage ../development/python-modules/ultralytics_thop { };
 
   umalqurra = callPackage ../development/python-modules/umalqurra { };
 


### PR DESCRIPTION
## Description of changes

Add ultralytics-thop: Profile PyTorch models for FLOPs and parameters, helping to evaluate computational efficiency and memory usage.

GH: https://github.com/ultralytics/thop/tree/main

This is one of the requirements to build https://github.com/ultralytics/ultralytics, done as a prerequisite for https://github.com/NixOS/nixpkgs/issues/342313.

https://github.com/ultralytics/thop/tree/main

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
