### PR TITLE
nixos/systemd-boot: Simpler windows dual booting

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -522,6 +522,8 @@
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.
 
+- The new `boot.loader.systemd-boot.windows` option makes setting up dual-booting with Windows on a different drive easier
+
 - Linux 4.19 has been removed because it will reach its end of life within the lifespan of 24.11
 
 - Unprivileged access to the kernel syslog via `dmesg` is now restricted by default. Users wanting to keep an

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
@@ -10,16 +15,19 @@ let
   # We check the source code in a derivation that does not depend on the
   # system configuration so that most users don't have to redo the check and require
   # the necessary dependencies.
-  checkedSource = pkgs.runCommand "systemd-boot" {
-    preferLocalBuild = true;
-  } ''
-    install -m755 -D ${./systemd-boot-builder.py} $out
-    ${lib.getExe pkgs.buildPackages.mypy} \
-      --no-implicit-optional \
-      --disallow-untyped-calls \
-      --disallow-untyped-defs \
-      $out
-  '';
+  checkedSource =
+    pkgs.runCommand "systemd-boot"
+      {
+        preferLocalBuild = true;
+      }
+      ''
+        install -m755 -D ${./systemd-boot-builder.py} $out
+        ${lib.getExe pkgs.buildPackages.mypy} \
+          --no-implicit-optional \
+          --disallow-untyped-calls \
+          --disallow-untyped-defs \
+          $out
+      '';
 
   systemdBootBuilder = pkgs.substituteAll rec {
     name = "systemd-boot";
@@ -44,13 +52,17 @@ let
 
     configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
 
-    inherit (cfg) consoleMode graceful editor rebootForBitlocker;
+    inherit (cfg)
+      consoleMode
+      graceful
+      editor
+      rebootForBitlocker
+      ;
 
     inherit (efi) efiSysMountPoint canTouchEfiVariables;
 
-    bootMountPoint = if cfg.xbootldrMountPoint != null
-      then cfg.xbootldrMountPoint
-      else efi.efiSysMountPoint;
+    bootMountPoint =
+      if cfg.xbootldrMountPoint != null then cfg.xbootldrMountPoint else efi.efiSysMountPoint;
 
     nixosDir = "/EFI/nixos";
 
@@ -66,23 +78,27 @@ let
         exit 1
       }
       ${pkgs.util-linuxMinimal}/bin/findmnt ${efiSysMountPoint} > /dev/null || fail efiSysMountPoint ${efiSysMountPoint}
-      ${lib.optionalString
-        (cfg.xbootldrMountPoint != null)
-        "${pkgs.util-linuxMinimal}/bin/findmnt ${cfg.xbootldrMountPoint} > /dev/null || fail xbootldrMountPoint ${cfg.xbootldrMountPoint}"}
+      ${lib.optionalString (cfg.xbootldrMountPoint != null)
+        "${pkgs.util-linuxMinimal}/bin/findmnt ${cfg.xbootldrMountPoint} > /dev/null || fail xbootldrMountPoint ${cfg.xbootldrMountPoint}"
+      }
     '';
 
     copyExtraFiles = pkgs.writeShellScript "copy-extra-files" ''
       empty_file=$(${pkgs.coreutils}/bin/mktemp)
 
-      ${concatStrings (mapAttrsToList (n: v: ''
-        ${pkgs.coreutils}/bin/install -Dp "${v}" "${bootMountPoint}/"${escapeShellArg n}
-        ${pkgs.coreutils}/bin/install -D $empty_file "${bootMountPoint}/${nixosDir}/.extra-files/"${escapeShellArg n}
-      '') cfg.extraFiles)}
+      ${concatStrings (
+        mapAttrsToList (n: v: ''
+          ${pkgs.coreutils}/bin/install -Dp "${v}" "${bootMountPoint}/"${escapeShellArg n}
+          ${pkgs.coreutils}/bin/install -D $empty_file "${bootMountPoint}/${nixosDir}/.extra-files/"${escapeShellArg n}
+        '') cfg.extraFiles
+      )}
 
-      ${concatStrings (mapAttrsToList (n: v: ''
-        ${pkgs.coreutils}/bin/install -Dp "${pkgs.writeText n v}" "${bootMountPoint}/loader/entries/"${escapeShellArg n}
-        ${pkgs.coreutils}/bin/install -D $empty_file "${bootMountPoint}/${nixosDir}/.extra-files/loader/entries/"${escapeShellArg n}
-      '') cfg.extraEntries)}
+      ${concatStrings (
+        mapAttrsToList (n: v: ''
+          ${pkgs.coreutils}/bin/install -Dp "${pkgs.writeText n v}" "${bootMountPoint}/loader/entries/"${escapeShellArg n}
+          ${pkgs.coreutils}/bin/install -D $empty_file "${bootMountPoint}/${nixosDir}/.extra-files/loader/entries/"${escapeShellArg n}
+        '') cfg.extraEntries
+      )}
     '';
   };
 
@@ -91,23 +107,61 @@ let
     ${systemdBootBuilder}/bin/systemd-boot "$@"
     ${cfg.extraInstallCommands}
   '';
-in {
+in
+{
 
   meta.maintainers = with lib.maintainers; [ julienmalka ];
 
-  imports =
-    [ (mkRenamedOptionModule [ "boot" "loader" "gummiboot" "enable" ] [ "boot" "loader" "systemd-boot" "enable" ])
-      (lib.mkChangedOptionModule
-        [ "boot" "loader" "systemd-boot" "memtest86" "entryFilename" ]
-        [ "boot" "loader" "systemd-boot" "memtest86" "sortKey" ]
-        (config: lib.strings.removeSuffix ".conf" config.boot.loader.systemd-boot.memtest86.entryFilename)
-      )
-      (lib.mkChangedOptionModule
-        [ "boot" "loader" "systemd-boot" "netbootxyz" "entryFilename" ]
-        [ "boot" "loader" "systemd-boot" "netbootxyz" "sortKey" ]
-        (config: lib.strings.removeSuffix ".conf" config.boot.loader.systemd-boot.netbootxyz.entryFilename)
-      )
-    ];
+  imports = [
+    (mkRenamedOptionModule
+      [
+        "boot"
+        "loader"
+        "gummiboot"
+        "enable"
+      ]
+      [
+        "boot"
+        "loader"
+        "systemd-boot"
+        "enable"
+      ]
+    )
+    (lib.mkChangedOptionModule
+      [
+        "boot"
+        "loader"
+        "systemd-boot"
+        "memtest86"
+        "entryFilename"
+      ]
+      [
+        "boot"
+        "loader"
+        "systemd-boot"
+        "memtest86"
+        "sortKey"
+      ]
+      (config: lib.strings.removeSuffix ".conf" config.boot.loader.systemd-boot.memtest86.entryFilename)
+    )
+    (lib.mkChangedOptionModule
+      [
+        "boot"
+        "loader"
+        "systemd-boot"
+        "netbootxyz"
+        "entryFilename"
+      ]
+      [
+        "boot"
+        "loader"
+        "systemd-boot"
+        "netbootxyz"
+        "sortKey"
+      ]
+      (config: lib.strings.removeSuffix ".conf" config.boot.loader.systemd-boot.netbootxyz.entryFilename)
+    )
+  ];
 
   options.boot.loader.systemd-boot = {
     enable = mkOption {
@@ -218,7 +272,15 @@ in {
     consoleMode = mkOption {
       default = "keep";
 
-      type = types.enum [ "0" "1" "2" "5" "auto" "max" "keep" ];
+      type = types.enum [
+        "0"
+        "1"
+        "2"
+        "5"
+        "auto"
+        "max"
+        "keep"
+      ];
 
       description = ''
         The resolution of the console. The following values are valid:
@@ -283,7 +345,7 @@ in {
 
     extraEntries = mkOption {
       type = types.attrsOf types.lines;
-      default = {};
+      default = { };
       example = literalExpression ''
         { "memtest86.conf" = '''
           title Memtest86+
@@ -306,7 +368,7 @@ in {
 
     extraFiles = mkOption {
       type = types.attrsOf types.path;
-      default = {};
+      default = { };
       example = literalExpression ''
         { "efi/memtest86/memtest.efi" = "''${pkgs.memtest86plus}/memtest.efi"; }
       '';
@@ -352,37 +414,42 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = (hasPrefix "/" efi.efiSysMountPoint);
-        message = "The ESP mount point '${toString efi.efiSysMountPoint}' must be an absolute path";
-      }
-      {
-        assertion = cfg.xbootldrMountPoint == null || (hasPrefix "/" cfg.xbootldrMountPoint);
-        message = "The XBOOTLDR mount point '${toString cfg.xbootldrMountPoint}' must be an absolute path";
-      }
-      {
-        assertion = cfg.xbootldrMountPoint != efi.efiSysMountPoint;
-        message = "The XBOOTLDR mount point '${toString cfg.xbootldrMountPoint}' cannot be the same as the ESP mount point '${toString efi.efiSysMountPoint}'";
-      }
-      {
-        assertion = (config.boot.kernelPackages.kernel.features or { efiBootStub = true; }) ? efiBootStub;
-        message = "This kernel does not support the EFI boot stub";
-      }
-      {
-        assertion = cfg.installDeviceTree -> config.hardware.deviceTree.enable -> config.hardware.deviceTree.name != null;
-        message = "Cannot install devicetree without 'config.hardware.deviceTree.enable' enabled and 'config.hardware.deviceTree.name' set";
-      }
-    ] ++ concatMap (filename: [
-      {
-        assertion = !(hasInfix "/" filename);
-        message = "boot.loader.systemd-boot.extraEntries.${lib.strings.escapeNixIdentifier filename} is invalid: entries within folders are not supported";
-      }
-      {
-        assertion = hasSuffix ".conf" filename;
-        message = "boot.loader.systemd-boot.extraEntries.${lib.strings.escapeNixIdentifier filename} is invalid: entries must have a .conf file extension";
-      }
-    ]) (builtins.attrNames cfg.extraEntries)
+    assertions =
+      [
+        {
+          assertion = (hasPrefix "/" efi.efiSysMountPoint);
+          message = "The ESP mount point '${toString efi.efiSysMountPoint}' must be an absolute path";
+        }
+        {
+          assertion = cfg.xbootldrMountPoint == null || (hasPrefix "/" cfg.xbootldrMountPoint);
+          message = "The XBOOTLDR mount point '${toString cfg.xbootldrMountPoint}' must be an absolute path";
+        }
+        {
+          assertion = cfg.xbootldrMountPoint != efi.efiSysMountPoint;
+          message = "The XBOOTLDR mount point '${toString cfg.xbootldrMountPoint}' cannot be the same as the ESP mount point '${toString efi.efiSysMountPoint}'";
+        }
+        {
+          assertion = (config.boot.kernelPackages.kernel.features or { efiBootStub = true; }) ? efiBootStub;
+          message = "This kernel does not support the EFI boot stub";
+        }
+        {
+          assertion =
+            cfg.installDeviceTree
+            -> config.hardware.deviceTree.enable
+            -> config.hardware.deviceTree.name != null;
+          message = "Cannot install devicetree without 'config.hardware.deviceTree.enable' enabled and 'config.hardware.deviceTree.name' set";
+        }
+      ]
+      ++ concatMap (filename: [
+        {
+          assertion = !(hasInfix "/" filename);
+          message = "boot.loader.systemd-boot.extraEntries.${lib.strings.escapeNixIdentifier filename} is invalid: entries within folders are not supported";
+        }
+        {
+          assertion = hasSuffix ".conf" filename;
+          message = "boot.loader.systemd-boot.extraEntries.${lib.strings.escapeNixIdentifier filename} is invalid: entries must have a .conf file extension";
+        }
+      ]) (builtins.attrNames cfg.extraEntries)
       ++ concatMap (filename: [
         {
           assertion = !(hasPrefix "/" filename);

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -339,6 +339,21 @@ in
     '';
   };
 
+  edk2-uefi-shell = makeTest {
+    name = "systemd-boot-edk2-uefi-shell";
+    meta.maintainers = with pkgs.lib.maintainers; [ iFreilicht ];
+
+    nodes.machine = { ... }: {
+      imports = [ common ];
+      boot.loader.systemd-boot.edk2-uefi-shell.enable = true;
+    };
+
+    testScript = ''
+      machine.succeed("test -e /boot/loader/entries/edk2-uefi-shell.conf")
+      machine.succeed("test -e /boot/efi/edk2-uefi-shell/shell.efi")
+    '';
+  };
+
   memtestSortKey = makeTest {
     name = "systemd-boot-memtest-sortkey";
     meta.maintainers = with pkgs.lib.maintainers; [ julienmalka ];


### PR DESCRIPTION
## Description of changes

When installing NixOS on a machine with Windows, the "easiest" solution
to dual-boot is re-using the existing EFI System Partition (ESP),
which allows systemd-boot to detect Windows automatically.

However, if there are multiple ESPs, maybe even on multiple disks,
systemd-boot is unable to detect the other OSes, and you either have to
use Grub and os-prober, or do a tedious manual configuration as
described in the wiki:
https://wiki.nixos.org/w/index.php?title=Dual_Booting_NixOS_and_Windows&redirect=no#EFI_with_multiple_disks

This commit automates and documents this properly so only a single line
like

```nix
boot.loader.systemd-boot.windows."Windows 10".efiDeviceHandle = "HD0c2";
```

is required.

In the future, we might want to try automatically detecting this
during installation, but finding the correct device handle while the
kernel is running is tricky.

This is not something we can rely on systemd-boot to fix, [the issue about this](https://github.com/systemd/systemd/issues/3252) has been open for years.

---

In addition, this PR also adds an option to add a boot-entry for edk2-uefi-shell, which is required to find the correct value for `efiDeviceHandle` and is generally useful for debugging and tinkering.

I also took the liberty of autoformatting, which was done in a separate commit to make review easier.

I'm uncertain if this change is significant enough to warrant a release-note.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
