### PR TITLE
.github/labeler.yml: label Xen-related pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -380,6 +380,17 @@
       - any-glob-to-any-file:
         - pkgs/applications/editors/vscode/**/*
 
+"6.topic: xen":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/virtualisation/xen*
+        - pkgs/applications/virtualization/xen/**
+        - pkgs/by-name/xe/xen-guest-agent/*
+        - pkgs/by-name/xt/xtf/*
+        - pkgs/development/ocaml-modules/xen*/*
+        - pkgs/development/ocaml-modules/vchan/*
+
 "6.topic: xfce":
   - any:
     - changed-files:


### PR DESCRIPTION
## Description of changes

To celebrate the new Xen topic and the Xen Team, let's use a labeler so I won't have to manually tag ~120 issues like I just did.

Some things must still be labeled manually (notably, qemu_xen and specific kernel changes), but these PRs should be pretty infrequent.

## Things done

- [x] The `labeler.yml` syntax is valid.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
