### PR TITLE
fahclient: 8.3.7 -> 8.3.18

### DIFF
--- a/pkgs/applications/science/misc/foldingathome/client.nix
+++ b/pkgs/applications/science/misc/foldingathome/client.nix
@@ -13,13 +13,13 @@
 , extraPkgs ? [ ]
 }:
 let
-  version = "8.3.7";
+  version = "8.3.18";
 
   cbangSrc = fetchFromGitHub {
     owner = "cauldrondevelopmentllc";
     repo = "cbang";
     rev = "bastet-v${version}";
-    sha256 = "sha256-acAImItdkgo6PBFL6Vu/caIdcnvp/3VEW2lgVDgKy9g=";
+    sha256 = "sha256-BQNomjz6Bhod3FOC5iICwt1rPrZgIxGQ08yspSvAnJc=";
   };
 
   fah-client = stdenv.mkDerivation {
@@ -30,7 +30,7 @@ let
       owner = "FoldingAtHome";
       repo = "fah-client-bastet";
       rev = "v${version}";
-      sha256 = "sha256-d+LY/R4TAko+2e2W76KEBQ8fXj0hzzmBOm+c4tksXMA=";
+      sha256 = "sha256-lqpC1fAMFb8iX02daVre/pE0c7DkwswlFigJS3ZGEjM=";
     };
 
     nativeBuildInputs = [ scons re2 libevent git ];


### PR DESCRIPTION
Update fah-client from version 8.3.7 to 8.3.18. No other changes

## Description of changes

<!--
Updated folding at home client to version 3.18. Changelog here:
https://github.com/FoldingAtHome/fah-client-bastet/blob/master/CHANGELOG.md
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ X] x86_64-linux

  - [NixOS test(s)] - None 
  - <!--


To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
