### PR TITLE
treewide: replace `stdenv.is` in non nix files

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -160,6 +160,9 @@ ad815aebfbfe1415ff6436521d545029c803c3fb
 # nixos/nvidia: apply nixfmt-rfc-style (#313440)
 fbdcdde04a7caa007e825a8b822c75fab9adb2d6
 
+# treewide: reformat files which need reformatting after (#341407)
+e0464e47880a69896f0fb1810f00e0de469f770a
+
 # step-cli: format package.nix with nixfmt (#331629)
 fc7a83f8b62e90de5679e993d4d49ca014ea013d
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -637,7 +637,7 @@ Names of files and directories should be in lowercase, with dashes between words
 
   ```nix
   {
-    buildInputs = lib.optional stdenv.isDarwin iconv;
+    buildInputs = lib.optional stdenv.hostPlatform.isDarwin iconv;
   }
   ```
 
@@ -645,7 +645,7 @@ Names of files and directories should be in lowercase, with dashes between words
 
   ```nix
   {
-    buildInputs = if stdenv.isDarwin then [ iconv ] else null;
+    buildInputs = if stdenv.hostPlatform.isDarwin then [ iconv ] else null;
   }
   ```
 

--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -349,8 +349,8 @@ let
     nodePackages.prettier
   ];
 
-  inputs = basePackages ++ lib.optionals stdenv.isLinux [ inotify-tools ]
-    ++ lib.optionals stdenv.isDarwin
+  inputs = basePackages ++ lib.optionals stdenv.hostPlatform.isLinux [ inotify-tools ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin
     (with darwin.apple_sdk.frameworks; [ CoreFoundation CoreServices ]);
 
   # define shell startup command

--- a/doc/languages-frameworks/emscripten.section.md
+++ b/doc/languages-frameworks/emscripten.section.md
@@ -84,7 +84,7 @@ One advantage is that when `pkgs.zlib` is updated, it will automatically update 
     echo "================= /testing zlib using node ================="
   '';
 
-  postPatch = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+  postPatch = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
     substituteInPlace configure \
       --replace-fail '/usr/bin/libtool' 'ar' \
       --replace-fail 'AR="libtool"' 'AR="ar"' \

--- a/doc/languages-frameworks/perl.section.md
+++ b/doc/languages-frameworks/perl.section.md
@@ -125,8 +125,8 @@ On Darwin, if a script has too many `-Idir` flags in its first line (its “sheb
       hash = "sha256-vOhB/FwQMC8PPvdnjDvxRpU6jAZcC6GMQfc0AH4uwKg=";
     };
 
-    nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.isDarwin ''
+    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
+    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
       shortenPerlShebang $out/bin/exiftool
     '';
   };

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1306,7 +1306,7 @@ for example:
   ] ++ lib.optionals (pythonAtLeast "3.8") [
     # broken due to python3.8 async changes
     "async"
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
     # can fail when building with other packages
     "socket"
   ];

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1306,7 +1306,7 @@ for example:
   ] ++ lib.optionals (pythonAtLeast "3.8") [
     # broken due to python3.8 async changes
     "async"
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # can fail when building with other packages
     "socket"
   ];

--- a/doc/stdenv/platform-notes.chapter.md
+++ b/doc/stdenv/platform-notes.chapter.md
@@ -22,7 +22,7 @@ Some common issues when packaging software for Darwin:
   stdenv.mkDerivation {
     name = "libfoo-1.2.3";
     # ...
-    makeFlags = lib.optional stdenv.isDarwin "LDFLAGS=-Wl,-install_name,$(out)/lib/libfoo.dylib";
+    makeFlags = lib.optional stdenv.hostPlatform.isDarwin "LDFLAGS=-Wl,-install_name,$(out)/lib/libfoo.dylib";
   }
   ```
 

--- a/pkgs/applications/networking/browsers/brave/update.sh
+++ b/pkgs/applications/networking/browsers/brave/update.sh
@@ -23,7 +23,7 @@ cat > $SCRIPT_DIR/default.nix << EOF
 
 callPackage ./make-brave.nix (removeAttrs args [ "callPackage" ])
   (
-    if stdenv.isAarch64 then
+    if stdenv.hostPlatform.isAarch64 then
       rec {
         pname = "brave";
         version = "${latestVersionAarch64}";
@@ -31,7 +31,7 @@ callPackage ./make-brave.nix (removeAttrs args [ "callPackage" ])
         hash = "${hashAarch64}";
         platform = "aarch64-linux";
       }
-    else if stdenv.isx86_64 then
+    else if stdenv.hostPlatform.isx86_64 then
       rec {
         pname = "brave";
         version = "${latestVersionAmd64}";


### PR DESCRIPTION
Cont https://github.com/NixOS/nixpkgs/pull/341407

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
