### PR TITLE
sogo: 5.10.0 -> 5.11.0

### DIFF
--- a/pkgs/servers/web-apps/sogo/default.nix
+++ b/pkgs/servers/web-apps/sogo/default.nix
@@ -5,14 +5,14 @@
 , libwbxml }:
 gnustep.stdenv.mkDerivation rec {
   pname = "sogo";
-  version = "5.10.0";
+  version = "5.11.0";
 
   # always update the sope package as well, when updating sogo
   src = fetchFromGitHub {
     owner = "Alinto";
     repo = pname;
     rev = "SOGo-${version}";
-    hash = "sha256-ZmpOI1zk/TkRNFmwTXugVb9IvxYSP4LgNrApSytdI7s=";
+    hash = "sha256-2/0OaCAQkdnDPGOVERZs2Oz+bCpQN3MTLzp2pz0WB08=";
   };
 
   nativeBuildInputs = [ gnustep.make makeWrapper python3 pkg-config ];
@@ -77,7 +77,7 @@ gnustep.stdenv.mkDerivation rec {
     license = with licenses; [ gpl2Only lgpl21Only ];
     homepage = "https://sogo.nu/";
     platforms = platforms.linux;
-    maintainers = [ ];
+    maintainers = with maintainers; [ jceb ];
   };
 }
 


### PR DESCRIPTION
## Description of changes

Update Sogo to versoin 5.11.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
