### PR TITLE
inputplumber: init at 0.39.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20513,6 +20513,12 @@
     githubId = 18403034;
     name = "Shaddy";
   };
+  shadowapex = {
+    email = "shadowapex@gmail.com";
+    github = "ShadowApex";
+    githubId = 376460;
+    name = "William Edwards";
+  };
   shadowrz = {
     email = "shadowrz+nixpkgs@disroot.org";
     matrix = "@shadowrz:nixos.dev";

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -50,6 +50,8 @@
 
 - [nvidia-gpu](https://github.com/utkuozdemir/nvidia_gpu_exporter), a Prometheus exporter that scrapes `nvidia-smi` for GPU metrics. Available as [services.prometheus.exporters.nvidia-gpu](#opt-services.prometheus.exporters.nvidia-gpu.enable).
 
+- [InputPlumber](https://github.com/ShadowBlip/InputPlumber/), an open source input router and remapper daemon for Linux. Available as [services.inputplumber](#opt-services.inputplumber.enable).
+
 - [Buffyboard](https://gitlab.postmarketos.org/postmarketOS/buffybox/-/tree/master/buffyboard), a framebuffer on-screen keyboard. Available as [services.buffyboard](option.html#opt-services.buffyboard).
 
 - [KanBoard](https://github.com/kanboard/kanboard), a project management tool that focuses on the Kanban methodology. Available as [services.kanboard](#opt-services.kanboard.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -604,6 +604,7 @@
   ./services/hardware/handheld-daemon.nix
   ./services/hardware/hddfancontrol.nix
   ./services/hardware/illum.nix
+  ./services/hardware/inputplumber.nix
   ./services/hardware/interception-tools.nix
   ./services/hardware/iptsd.nix
   ./services/hardware/irqbalance.nix

--- a/nixos/modules/services/hardware/inputplumber.nix
+++ b/nixos/modules/services/hardware/inputplumber.nix
@@ -1,0 +1,37 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.inputplumber;
+in
+{
+  options.services.inputplumber = {
+    enable = lib.mkEnableOption "InputPlumber";
+    package = lib.mkPackageOption pkgs "inputplumber" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.inputplumber = {
+      description = "InputPlumber Service";
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        XDG_DATA_DIRS = "/run/current-system/sw/share";
+      };
+      restartIfChanged = true;
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package}";
+        Restart = "on-failure";
+        RestartSec = "5";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ shadowapex ];
+}

--- a/pkgs/by-name/in/inputplumber/package.nix
+++ b/pkgs/by-name/in/inputplumber/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  udev,
+  libiio,
+  libevdev,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "inputplumber";
+  version = "0.39.2";
+
+  src = fetchFromGitHub {
+    owner = "ShadowBlip";
+    repo = "InputPlumber";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Glq7iJ1AHy99AGXYg5P3wAd3kAMJnt5P2vZzyn7qBY4=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-pcbW/Od5f+hFCrVpH2yioq+qCmlZ1m3TbUc6rBkYCEs=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    udev
+    libevdev
+    libiio
+  ];
+
+  postInstall = ''
+    cp -r rootfs/usr/* $out/
+  '';
+
+  meta = {
+    description = "Open source input router and remapper daemon for Linux";
+    homepage = "https://github.com/ShadowBlip/InputPlumber";
+    license = lib.licenses.gpl3Plus;
+    changelog = "https://github.com/ShadowBlip/InputPlumber/releases/tag/v${version}";
+    maintainers = with lib.maintainers; [ shadowapex ];
+    mainProgram = "inputplumber";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds a derivation to run [InputPlumber](https://github.com/ShadowBlip/InputPlumber/) on NixOS.

InputPlumber is an open source input routing and remapping daemon for Linux. It can combine multiple input devices together into a single emulated gamepad, support gaming handhelds like the ROG Ally and Legion Go, and remap and route input to other virtual input devices.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
