### PR TITLE
python312Packages.autobahn: 23.6.2 -> 24.4.2

### DIFF
--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   attrs,
   argon2-cffi,
   base58,
@@ -28,7 +28,7 @@
   pygobject3,
   pyopenssl,
   qrcode,
-  pytest-asyncio_0_21,
+  pytest-asyncio,
   python-snappy,
   pytestCheckHook,
   pythonOlder,
@@ -50,20 +50,17 @@
 
 buildPythonPackage rec {
   pname = "autobahn";
-  version = "23.6.2";
+  version = "24.4.2";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-7JQhxSohAzZNHvBGgDbmAZ7oT3FyHoazb+Ga1pZsEYE=";
+  src = fetchFromGitHub {
+    owner = "crossbario";
+    repo = "autobahn-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-aeTE4a37zr83KZ+v947XikzFrHAhkZ4mj4tXdkQnB84=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "pytest>=2.8.6,<3.3.0" "pytest"
-  '';
 
   build-system = [ setuptools ];
 
@@ -77,7 +74,7 @@ buildPythonPackage rec {
   nativeCheckInputs =
     [
       mock
-      pytest-asyncio_0_21
+      pytest-asyncio
       pytestCheckHook
     ]
     ++ optional-dependencies.scram ++ optional-dependencies.serialization ++ optional-dependencies.xbr;
@@ -87,7 +84,10 @@ buildPythonPackage rec {
     export USE_ASYNCIO=1
   '';
 
-  pytestFlagsArray = [ "--pyargs autobahn" ];
+  pytestFlagsArray = [
+    "--ignore=./autobahn/twisted"
+    "./autobahn"
+  ];
 
   pythonImportsCheck = [ "autobahn" ];
 
@@ -141,6 +141,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
+    changelog = "https://github.com/crossbario/autobahn-python/blob/${src.rev}/docs/changelog.rst";
     description = "WebSocket and WAMP in Python for Twisted and asyncio";
     homepage = "https://crossbar.io/autobahn";
     license = licenses.mit;

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -58,6 +58,10 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
+  pythonRelaxDeps = [
+    "spake2"
+  ];
+
   dependencies = [
     attrs
     autobahn

--- a/pkgs/development/python-modules/spake2/default.nix
+++ b/pkgs/development/python-modules/spake2/default.nix
@@ -1,35 +1,28 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   fetchpatch2,
   setuptools,
-  hkdf,
+  cryptography,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "spake2";
-  version = "0.8";
+  version = "0.9";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "c17a614b29ee4126206e22181f70a406c618d3c6c62ca6d6779bce95e9c926f4";
+  src = fetchFromGitHub {
+    owner = "warner";
+    repo = "python-spake2";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-WPMGH1OzG+5O+2lNl2sv06/dNardY+BHYDS290Z36vQ=";
   };
 
-  patches = [
-    # https://github.com/warner/python-spake2/pull/16
-    (fetchpatch2 {
-      name = "python312-compat.patch";
-      url = "https://github.com/warner/python-spake2/commit/1b04d33106b105207c97c64b2589c45790720b0b.patch";
-      hash = "sha256-OoBz0lN17VyVGg6UfT+Zj9M1faFTNpPIhxrwCgUwMc8=";
-    })
-  ];
+  build-system = [ setuptools ];
 
-  nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = [ hkdf ];
+  dependencies = [ cryptography ];
 
   pythonImportsCheck = [ "spake2" ];
 


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/crossbario/autobahn-python/compare/refs/tags/v23.6.2...v24.4.2

Changelog: https://github.com/crossbario/autobahn-python/blob/refs/tags/v24.4.2/docs/changelog.rst
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
