### PR TITLE
linux/common-config: enable Intel TDX guest support

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -769,6 +769,10 @@ let
       # Shadow stacks
       X86_USER_SHADOW_STACK = whenAtLeast "6.6" yes;
 
+      # Enable support for Intel Trust Domain Extensions (TDX)
+      INTEL_TDX_GUEST = whenAtLeast "5.19" yes;
+      TDX_GUEST_DRIVER = whenAtLeast "6.2" module;
+
       # Mitigate straight line speculation at the cost of some file size
       SLS = whenBetween "5.17" "6.9" yes;
       MITIGATION_SLS = whenAtLeast "6.9" yes;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Intel Trust Domain Extensions (TDX) is a VM-based trusted execution environment which attempts to isolate confidential guest VMs from the host, similar to AMD SEV-SNP. Like AMD SEV-SNP it requires guest modifications (also referred to as "enlightenments") to operate in the TEE. Initial support for running Linux in a TDX guest environment was merged [in 5.19][1]. The guest driver used for generating attestation reports was merged [in 6.2][2].

Enable both of these options on supported kernel versions. This matches other distros such as [Arch Linux][3], [Debian][4], [Fedora][5], [openSUSE][6], and [Ubuntu][7].

[1]: https://lore.kernel.org/lkml/Yot1IAqHoRBlwe0w@zn.tnic/
[2]: https://lore.kernel.org/lkml/20221212191525.553266-1-dave.hansen@linux.intel.com/
[3]: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/blob/ac5ceec882898aa46353794a7c8b645b9ec5ae19/config#L409
[4]: https://salsa.debian.org/kernel-team/linux/-/blob/3fdc0bdcafb4e49c232dcea1144dbdfab21eef20/debian/config/amd64/config#L13
[5]: https://src.fedoraproject.org/rpms/kernel/blob/28b3da71f8a3bbd4947adeeba223527776e01927/f/kernel-x86_64-fedora.config#_3170
[6]: https://github.com/SUSE/kernel-source/blob/994cc2d44d4db48977fa33715fd833105fa23555/config/x86_64/default#L403
[7]: https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble/tree/debian.master/config/annotations#n6660

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
