### PR TITLE
spike: 1.1.0 -> 1.1.0-unstable-2024-09-21

### DIFF
--- a/pkgs/applications/virtualization/spike/default.nix
+++ b/pkgs/applications/virtualization/spike/default.nix
@@ -1,30 +1,21 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, dtc, pkgsCross }:
+{ lib, stdenv, fetchFromGitHub, dtc, pkgsCross }:
 
 stdenv.mkDerivation rec {
   pname = "spike";
-  version = "1.1.0";
+  version = "1.1.0-unstable-2024-09-21";
 
   src = fetchFromGitHub {
     owner = "riscv";
     repo = "riscv-isa-sim";
-    rev = "v${version}";
-    sha256 = "sha256-4D2Fezej0ioOOupw3kgMT5VLs+/jXQjwvek6v0AVMzI=";
+    rev = "de5094a1a901d77ff44f89b38e00fefa15d4018e";
+    sha256 = "sha256-mAgR2VzDgeuIdmPEgrb+MaA89BnWfmNanOVidqn0cgc=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fesvr-fix-compilation-with-gcc-13.patch";
-      url = "https://github.com/riscv-software-src/riscv-isa-sim/commit/0a7bb5403d0290cea8b2356179d92e4c61ffd51d.patch";
-      hash = "sha256-JUMTbGawvLkoOWKkruzLzUFQytVR3wqTlGu/eegRFEE=";
-    })
-  ];
 
   nativeBuildInputs = [ dtc ];
   enableParallelBuilding = true;
 
   postPatch = ''
     patchShebangs scripts/*.sh
-    patchShebangs tests/ebreak.py
   '';
 
   doCheck = true;


### PR DESCRIPTION
## Description of changes

Bump from 1.1.0 since 2021-12-17 to newest master branch 2024-09-21 as spike didn't have release for nearly 3 years, but we still need some bug fixes and future implementation.

Specifically, @eastonman reported a bug today that the current version of the `spike-dasm` binary in nix master would wrongly output a DASM result:

```console
$ nix-shell -p spike                                         
[nix-shell:~]$ spike-dasm
DASM(0xb72023)
sw      s11, -32(a4)
DASM(0x00b72023)
sw      a1, 0(a4)
```

And bump to the newest master, we will get:

```console
[nix-shell:~]$ spike-dasm
DASM(0xb72023)
sw      a1, 0(a4)
DASM(0x00b72023)           
sw      a1, 0(a4)
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
