### PR TITLE
pychess: init at 1.0.5

### DIFF
--- a/pkgs/by-name/py/pychess/package.nix
+++ b/pkgs/by-name/py/pychess/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  pkg-config,
+  gobject-introspection,
+  wrapGAppsHook3,
+  gtk3,
+  gst_all_1,
+  gtksourceview,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pychess";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "pychess";
+    repo = "pychess";
+    rev = "${version}";
+    hash = "sha256-hxc+vYvCeiM0+oOu1peI9qkZg5PeIsDMCiydJQAuzOk=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    gobject-introspection
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtk3
+    gst_all_1.gst-plugins-base
+    gtksourceview
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    pycairo
+    sqlalchemy
+    pexpect
+    psutil
+    websockets
+    ptyprocess
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+    export PYTHONPATH=./lib:$PYTHONPATH
+    python pgn2ecodb.py
+    python create_theme_preview.py
+  '';
+
+  postInstall = ''
+    cp -r $out/share/pychess/* $out/lib/python*/
+  '';
+
+  # No tests available.
+  doCheck = false;
+
+  meta = {
+    description = "Advanced GTK chess client written in Python";
+    homepage = "https://pychess.github.io/";
+    mainProgram = "pychess";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ lgbishop ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

PyChess is an advanced GTK chess client originally developed for GNOME. The goal of the project is to provide a free and feature-rich chess client for Linux following the GNOME Human Interface Guidelines.

### Some notes:

- All functionality has been tested and seems to be in fully working order (on x86_64 Linux at least). This includes sound, graphics, engines, online play, saved games, and chess databases.
  - This is despite the (seemingly benign) error message thrown immediately upon running the program:
`ERROR: gst_player requires pygobject to be installed.`

- The `preBuild` commands are required when using the source (tagged or otherwise). One could alternatively use the release `url = "https://github.com/pychess/${pname}/releases/download/${version}/${pname}-${version}.tar.gz"` (via `fetchurl`) which contains some pre-built assets.
  - Both methods require manual copying/moving/symlinking of some assets as accomplished in `postInstall`.

- Compatible chess engines like Stockfish can optionally be installed independently and used in the game (provided they are on $PATH, or alternatively imported manually in-game).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
