### PR TITLE
NixOS `apply` script

### DIFF
--- a/nixos/doc/manual/administration/rollback.section.md
+++ b/nixos/doc/manual/administration/rollback.section.md
@@ -12,7 +12,7 @@ system has booted, you can make the selected configuration the default
 for subsequent boots:
 
 ```ShellSession
-# /run/current-system/bin/switch-to-configuration boot
+# /run/current-system/bin/apply boot
 ```
 
 Second, you can switch to the previous configuration in a running
@@ -25,11 +25,11 @@ system:
 This is equivalent to running:
 
 ```ShellSession
-# /nix/var/nix/profiles/system-N-link/bin/switch-to-configuration switch
+# /nix/var/nix/profiles/system-N-link/bin/apply switch
 ```
 
-where `N` is the number of the NixOS system configuration. To get a
-list of the available configurations, do:
+where `N` is the number of the NixOS system configuration to roll back to.
+To get a list of the available configurations, run:
 
 ```ShellSession
 $ ls -l /nix/var/nix/profiles/system-*-link

--- a/nixos/doc/manual/development/non-switchable-systems.section.md
+++ b/nixos/doc/manual/development/non-switchable-systems.section.md
@@ -16,6 +16,6 @@ profile:
 The most notable deviation of this profile from a standard NixOS configuration
 is that after building it, you cannot switch *to* the configuration anymore.
 The profile sets `config.system.switch.enable = false;`, which excludes
-`switch-to-configuration`, the central script called by `nixos-rebuild`, from
+`apply` and `switch-to-configuration`, the central scripts called by `nixos-rebuild`, from
 your system. Removing this script makes the image lighter and slightly more
 secure.

--- a/nixos/doc/manual/development/what-happens-during-a-system-switch.chapter.md
+++ b/nixos/doc/manual/development/what-happens-during-a-system-switch.chapter.md
@@ -5,8 +5,8 @@ This chapter explains some of the internals of this command to make it simpler
 for new module developers to configure their units correctly and to make it
 easier to understand what is happening and why for curious administrators.
 
-`nixos-rebuild`, like many deployment solutions, calls `switch-to-configuration`
-which resides in a NixOS system at `$out/bin/switch-to-configuration`. The
+`nixos-rebuild`, like many deployment solutions, calls `apply` (or for NixOS older than 24.11, `switch-to-configuration`)
+which resides in a NixOS system at `$out/bin/apply`. The
 script is called with the action that is to be performed like `switch`, `test`,
 `boot`. There is also the `dry-activate` action which does not really perform
 the actions but rather prints what it would do if you called it with `test`.

--- a/nixos/doc/manual/installation/installing-from-other-distro.section.md
+++ b/nixos/doc/manual/installation/installing-from-other-distro.section.md
@@ -247,7 +247,7 @@ The first steps to all these are the same:
 
     ```ShellSession
     $ sudo mv -v /boot /boot.bak &&
-    sudo /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+    sudo /nix/var/nix/profiles/system/bin/apply boot
     ```
 
     Cross your fingers, reboot, hopefully you should get a NixOS prompt!

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -50,6 +50,16 @@
   If you experience any issues, please report them.
   The original Perl script is deprecated and is planned for removal in the 25.05 release. It will remain accessible until then by setting `system.switch.enableNg` to `false`.
 
+- Built NixOS configurations now have a `$toplevel/bin/apply` script.
+  Unlike `switch-to-configuration`, it is capable of performing a complete `switch` operation.
+  If you call `switch-to-configuration` directly, you are recommended to use `apply` instead, and remove your call to `nix-env --profile /nix/var/nix/profiles/system --set $toplevel` or similar.
+  It will run the switch operation as a systemd unit if available, as `nixos-rebuild switch` would.
+
+  Benefits include:
+  - The `apply` script reduces the roundtrips required when performing a remote deployment with `nixos-rebuild switch --target-host HOST`.
+  - Developers and power users can now update NixOS in a single call.
+  - Alternative NixOS deployment methods have feature parity with `nixos-rebuild`, and NixOS can evolve all of its switching logic in one place.
+
 - Support for mounting filesystems from block devices protected with [dm-verity](https://docs.kernel.org/admin-guide/device-mapper/verity.html)
   was added through the `boot.initrd.systemd.dmVerity` option.
 

--- a/nixos/lib/testing/nixos-test-base.nix
+++ b/nixos/lib/testing/nixos-test-base.nix
@@ -23,7 +23,7 @@ in
       };
     }
     ({ config, ... }: {
-      # Don't pull in switch-to-configuration by default, except when specialisations or early boot shenanigans are involved.
+      # Don't pull in apply and switch-to-configuration by default, except when specialisations or early boot shenanigans are involved.
       # This is mostly a Hydra optimization, so we don't rebuild all the tests every time switch-to-configuration-ng changes.
       key = "no-switch-to-configuration";
       system.switch.enable = mkDefault (config.isSpecialisation || config.specialisation != {} || config.virtualisation.installBootLoader);

--- a/nixos/modules/system/activation/apply/apply.sh
+++ b/nixos/modules/system/activation/apply/apply.sh
@@ -28,6 +28,23 @@ die() {
     exit 1
 }
 
+usage() {
+    log "NixOS apply invocation error: $*"
+cat >&2 <<EOF
+Usage: apply [switch|boot|test|dry-activate] [OPTIONS]
+Subcommands:
+    switch        make the configuration the boot default and activate it
+    boot          make the configuration the boot default
+    test          activate the configuration, but don\'t make it the boot default
+    dry-activate  show what would be done if this configuration were activated
+Options:
+    --install-bootloader    install the bootloader
+    --profile PROFILE       use PROFILE as the target profile (if applicable)
+    --specialisation NAME   use the specialisation NAME
+EOF
+}
+
+
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in

--- a/nixos/modules/system/activation/apply/apply.sh
+++ b/nixos/modules/system/activation/apply/apply.sh
@@ -1,0 +1,146 @@
+#!@bash@
+
+
+# This is the NixOS apply script, typically located at
+#
+# ${config.system.build.toplevel}/bin/apply
+#
+# This script is responsible for managing the profile link and calling the
+# appropriate scripts for its subcommands, such as switch, boot, and test.
+
+
+set -euo pipefail
+
+toplevel=@toplevel@
+
+subcommand=
+
+installBootloader=
+specialisation=
+profile=/nix/var/nix/profiles/system
+
+log() {
+    echo "$@" >&2
+}
+
+die() {
+    log "NixOS apply error: $*"
+    exit 1
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            switch|boot|test|dry-activate)
+                subcommand="$1"
+                ;;
+            --install-bootloader)
+                installBootloader=1
+                ;;
+            --profile)
+                if [[ $# -lt 2 ]]; then
+                    die "missing argument for --profile"
+                fi
+                profile="$2"
+                shift
+                ;;
+            # --rollback is not an `apply` responsibility, and it should be
+            # implemented by the caller of `apply` instead.
+            --specialisation)
+                if [[ $# -lt 2 ]]; then
+                    die "missing argument for --specialisation"
+                fi
+                specialisation="$2"
+                shift
+                ;;
+            *)
+                if [[ -n "$subcommand" ]]; then
+                    die "unexpected argument or flag: $1"
+                else
+                    die "unexpected subcommand or flag: $1"
+                fi
+                ;;
+        esac
+        shift
+    done
+
+    if [ -z "$subcommand" ]; then
+        die "no subcommand specified"
+    fi
+}
+
+main() {
+    local cmd activity
+
+    case "$subcommand" in
+        boot|switch)
+            nix-env -p "$profile" --set "$toplevel"
+            ;;
+    esac
+
+    # Using systemd-run here to protect against PTY failures/network
+    # disconnections during rebuild.
+    # See: https://github.com/NixOS/nixpkgs/issues/39118
+    cmd=(
+        "systemd-run"
+        "-E" "LOCALE_ARCHIVE" # Will be set to new value early in switch-to-configuration script, but interpreter starts out with old value
+        "-E" "NIXOS_INSTALL_BOOTLOADER=$installBootloader"
+        "--collect"
+        "--no-ask-password"
+        "--pipe"
+        "--quiet"
+        "--same-dir"
+        "--service-type=exec"
+        "--unit=nixos-rebuild-switch-to-configuration"
+        "--wait"
+    )
+    # Check if we have a working systemd-run. In chroot environments we may have
+    # a non-working systemd, so we fallback to not using systemd-run.
+    if ! "${cmd[@]}" true; then
+        log "Skipping systemd-run to switch configuration since it is not working in target host."
+        cmd=(
+            "env"
+            "-i"
+            "LOCALE_ARCHIVE=${LOCALE_ARCHIVE:-}"
+            "NIXOS_INSTALL_BOOTLOADER=$installBootloader"
+        )
+    fi
+    if [[ -z "$specialisation" ]]; then
+        cmd+=("$toplevel/bin/switch-to-configuration")
+    else
+        cmd+=("$toplevel/specialisation/$specialisation/bin/switch-to-configuration")
+
+        if ! [[ -f "${cmd[-1]}" ]]; then
+            log "error: specialisation not found: $specialisation"
+            exit 1
+        fi
+    fi
+
+    if ! "${cmd[@]}" "$subcommand"; then
+        case "$subcommand" in
+            switch)
+                activity="switching to the new configuration"
+                ;;
+            boot)
+                activity="switching the boot entry to the new configuration"
+                ;;
+            test)
+                activity="switching to the new configuration (in test mode)"
+                ;;
+            dry-activate)
+                activity="switching to the new configuration (in dry-activate mode)"
+                ;;
+            *)  # Should never happen
+                activity="running $subcommand"
+                ;;
+        esac
+        log "warning: error(s) occurred while $activity"
+        exit 1
+    fi
+}
+
+if ! type test_run_tests &>/dev/null; then
+    # We're not loaded into the test.sh, so we run main.
+    parse_args "$@"
+    main
+fi

--- a/nixos/modules/system/activation/apply/checks.nix
+++ b/nixos/modules/system/activation/apply/checks.nix
@@ -1,0 +1,51 @@
+# Run:
+#   nix-build -A nixosTests.apply
+#
+# These are not all tests. See also nixosTests.
+
+{
+  lib,
+  stdenvNoCC,
+  testers,
+  ...
+}:
+
+let
+  fileset = lib.fileset.unions [
+    ./test.sh
+    ./apply.sh
+  ];
+in
+
+{
+  unitTests = stdenvNoCC.mkDerivation {
+    name = "nixos-apply-unit-tests";
+    src = lib.fileset.toSource {
+      root = ./.;
+      inherit fileset;
+    };
+    dontBuild = true;
+    checkPhase = ''
+      ./test.sh
+    '';
+    installPhase = ''
+      touch $out
+    '';
+  };
+
+  shellcheck =
+    (testers.shellcheck {
+      src = lib.fileset.toSource {
+        # This makes the error messages include the full path
+        root = ../../../../..;
+        inherit fileset;
+      };
+    }).overrideAttrs
+      {
+        postUnpack = ''
+          for f in $(find . -type f); do
+            substituteInPlace $f --replace @bash@ /usr/bin/bash
+          done
+        '';
+      };
+}

--- a/nixos/modules/system/activation/apply/test.sh
+++ b/nixos/modules/system/activation/apply/test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2317 disable=SC2031
+# False positives:
+# SC2317: Unreachable code: TEST_*
+# SC2031: <variable> was modified in a subshell. That change might be lost.
+#         We have a lot of that, and that's expected.
+
+# This is a unit test script for the NixOS apply script.
+# It can be run quickly with the following command:
+#
+#     ./test.sh
+#
+# Alternatively, run the following to run all tests and checks
+#
+#     TODO
+#
+
+set -euo pipefail
+# set -x
+
+apply="${BASH_SOURCE[0]%/*}/apply.sh"
+# source_apply() {
+
+run_parse_args() {
+  bash -c "source $apply;"' parse_args "$@"' -- "$@"
+}
+
+TEST_parse_args_none() {
+  if errout="$(run_parse_args 2>&1)"; then
+    test_fail "apply without arguments should fail"
+  elif [[ $? -ne 1 ]]; then
+    test_fail "apply without arguments should exit with code 1"
+  fi
+  grep -F "no subcommand specified" <<<"$errout" >/dev/null
+}
+
+TEST_parse_args_switch() {
+  (
+    # shellcheck source=nixos/modules/system/activation/apply/apply.sh
+    source "$apply";
+    parse_args switch;
+    [[ $subcommand == switch ]]
+    [[ $specialisation == "" ]]
+    [[ $profile == "" ]]
+  )
+}
+
+TEST_parse_args_boot() {
+  (
+    # shellcheck source=nixos/modules/system/activation/apply/apply.sh
+    source "$apply";
+    parse_args boot;
+    [[ $subcommand == boot ]]
+    [[ $specialisation == "" ]]
+    [[ $profile == "" ]]
+  )
+}
+
+TEST_parse_args_test() {
+  (
+    # shellcheck source=nixos/modules/system/activation/apply/apply.sh
+    source "$apply";
+    parse_args test;
+    [[ $subcommand == test ]]
+    [[ $specialisation == "" ]]
+    [[ $profile == "" ]]
+  )
+}
+
+TEST_parse_args_dry_activate() {
+  (
+    # shellcheck source=nixos/modules/system/activation/apply/apply.sh
+    source "$apply";
+    parse_args dry-activate;
+    [[ $subcommand == dry-activate ]]
+    [[ $specialisation == "" ]]
+    [[ $profile == "" ]]
+  )
+}
+
+TEST_parse_args_unknown() {
+  if errout="$(run_parse_args foo 2>&1)"; then
+    test_fail "apply with unknown subcommand should fail"
+  fi
+  grep -F "unexpected argument or flag: foo" <<<"$errout" >/dev/null
+}
+
+TEST_parse_args_switch_specialisation_no_arg() {
+  if errout="$(run_parse_args switch --specialisation 2>&1)"; then
+    test_fail "apply with --specialisation without argument should fail"
+  fi
+  grep -F "missing argument for --specialisation" <<<"$errout" >/dev/null
+}
+
+TEST_parse_args_switch_specialisation() {
+  (
+    # shellcheck source=nixos/modules/system/activation/apply/apply.sh
+    source "$apply";
+    parse_args switch --specialisation low-power;
+    [[ $subcommand == switch ]]
+    [[ $specialisation == low-power ]]
+    [[ $profile == "" ]]
+  )
+}
+
+TEST_parse_args_switch_profile() {
+  (
+    # shellcheck source=nixos/modules/system/activation/apply/apply.sh
+    source "$apply";
+    parse_args switch --profile /nix/var/nix/profiles/system;
+    [[ $subcommand == switch ]]
+    [[ $specialisation == "" ]]
+    [[ $profile == /nix/var/nix/profiles/system ]]
+  )
+}
+
+
+
+# Support code
+
+test_fail() {
+  echo "TEST FAILURE: $*" >&2
+  exit 1
+}
+
+test_print_trace() {
+  local frame=${1:0}
+  local caller
+  # shellcheck disable=SC2207 disable=SC2086
+  while caller=( $(caller $frame) ); do
+    echo "  in ${caller[1]} at ${caller[2]}:${caller[0]}"
+    frame=$((frame+1));
+  done
+}
+test_on_err() {
+  echo "ERROR running: ${BASH_COMMAND}" >&2
+  test_print_trace 1 >&2
+}
+
+test_init() {
+  trap 'test_on_err' ERR
+}
+
+test_find() {
+  declare -F | grep -o 'TEST_.*' | sort
+}
+
+test_run_tests() {
+  local status=0
+  for test in $(test_find); do
+    set +e
+    (
+      set -eEuo pipefail
+      trap 'test_on_err' ERR
+      $test
+    )
+    r=$?
+    set -e
+    if [[ $r == 0 ]]; then
+      echo "ok: $test"
+    else
+      echo "TEST FAIL: $test"; status=1;
+    fi
+  done
+  if [[ $status == 0 ]]; then
+    echo "All good"
+  else
+    echo
+    echo "TEST SUITE FAILED"
+  fi
+  exit $status
+}
+
+# Main
+test_init
+test_run_tests

--- a/nixos/modules/system/activation/specialisation.nix
+++ b/nixos/modules/system/activation/specialisation.nix
@@ -42,7 +42,7 @@ in
         (e.g. `fewJobsManyCores`) at runtime, run:
 
         ```
-        sudo /run/current-system/specialisation/fewJobsManyCores/bin/switch-to-configuration test
+        sudo /run/current-system/specialisation/fewJobsManyCores/bin/apply test
         ```
       '';
       type = types.attrsOf (types.submodule (

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -80,12 +80,9 @@ if ("@localeArchive@" ne "") {
 
 if (!defined($action) || ($action ne "switch" && $action ne "boot" && $action ne "test" && $action ne "dry-activate")) {
     print STDERR <<"EOF";
+error: Unknown action $action
 Usage: $0 [switch|boot|test|dry-activate]
-
-switch:       make the configuration the boot default and activate now
-boot:         make the configuration the boot default
-test:         activate the configuration, but don\'t make it the boot default
-dry-activate: show what would be done if this configuration were activated
+Consider calling `apply` instead of `switch-to-configuration`.
 EOF
     exit(1);
 }

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -49,8 +49,8 @@ let
   # Putting it all together.  This builds a store path containing
   # symlinks to the various parts of the built configuration (the
   # kernel, systemd units, init scripts, etc.) as well as a script
-  # `switch-to-configuration' that activates the configuration and
-  # makes it bootable. See `activatable-system.nix`.
+  # `bin/apply` that activates the configuration and
+  # makes it bootable. See `activatable-system.nix` and `switchable-system.nix`.
   baseSystem = pkgs.stdenvNoCC.mkDerivation ({
     name = "nixos-system-${config.system.name}-${config.system.nixos.label}";
     preferLocalBuild = true;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -705,6 +705,11 @@ in {
   nixos-rebuild-install-bootloader = handleTestOn ["x86_64-linux"] ./nixos-rebuild-install-bootloader.nix {};
   nixos-rebuild-specialisations = runTestOn ["x86_64-linux"] ./nixos-rebuild-specialisations.nix;
   nixos-rebuild-target-host = runTest ./nixos-rebuild-target-host.nix;
+  nixos-rebuild-target-host-legacy = runTest {
+    name = mkForce "nixos-rebuild-target-host-legacy";
+    imports = [ ./nixos-rebuild-target-host.nix ];
+    extraBaseModules = { system.apply.enable = false; };
+  };
   nixpkgs = pkgs.callPackage ../modules/misc/nixpkgs/test.nix { inherit evalMinimalConfig; };
   nixseparatedebuginfod = handleTest ./nixseparatedebuginfod.nix {};
   node-red = handleTest ./node-red.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -704,6 +704,11 @@ in {
   nixos-generate-config = handleTest ./nixos-generate-config.nix {};
   nixos-rebuild-install-bootloader = handleTestOn ["x86_64-linux"] ./nixos-rebuild-install-bootloader.nix {};
   nixos-rebuild-specialisations = runTestOn ["x86_64-linux"] ./nixos-rebuild-specialisations.nix;
+  nixos-rebuild-specialisations-legacy = runTestOn ["x86_64-linux"] {
+    name = mkForce "nixos-rebuild-specialisations-legacy";
+    imports = [ ./nixos-rebuild-specialisations.nix ];
+    extraBaseModules = { system.apply.enable = false; };
+  };
   nixos-rebuild-target-host = runTest ./nixos-rebuild-target-host.nix;
   nixos-rebuild-target-host-legacy = runTest {
     name = mkForce "nixos-rebuild-target-host-legacy";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -129,6 +129,7 @@ in {
   apfs = runTest ./apfs.nix;
   appliance-repart-image = runTest ./appliance-repart-image.nix;
   appliance-repart-image-verity-store = runTest ./appliance-repart-image-verity-store.nix;
+  apply = pkgs.callPackage ../modules/system/activation/apply/checks.nix { };
   apparmor = handleTest ./apparmor.nix {};
   archi = handleTest ./archi.nix {};
   aria2 = handleTest ./aria2.nix {};

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -940,10 +940,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
 fn usage(argv0: &str) -> ! {
     eprintln!(
         r#"Usage: {} [switch|boot|test|dry-activate]
-switch:       make the configuration the boot default and activate now
-boot:         make the configuration the boot default
-test:         activate the configuration, but don't make it the boot default
-dry-activate: show what would be done if this configuration were activated
+Consider calling `apply` instead of `switch-to-configuration`.
 "#,
         argv0
     );

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -220,9 +220,9 @@ buildHostCmd() {
     if [ -z "$buildHost" ]; then
         runCmd "$@"
     elif [ -n "$remoteNix" ]; then
-        runCmd ssh $SSHOPTS "$buildHost" "${c[@]}" env PATH="$remoteNix":'$PATH' "$@"
+        runCmd ssh $SSHOPTS "$buildHost" "${c[@]}" env PATH="$remoteNix":'$PATH' "${@@Q}"
     else
-        runCmd ssh $SSHOPTS "$buildHost" "${c[@]}" "$@"
+        runCmd ssh $SSHOPTS "$buildHost" "${c[@]}" "${@@Q}"
     fi
 }
 
@@ -237,7 +237,7 @@ targetHostCmd() {
     if [ -z "$targetHost" ]; then
         runCmd "${c[@]}" "$@"
     else
-        runCmd ssh $SSHOPTS "$targetHost" "${c[@]}" "$@"
+        runCmd ssh $SSHOPTS "$targetHost" "${c[@]}" "${@@Q}"
     fi
 }
 


### PR DESCRIPTION
## Description of changes

As proposed in https://github.com/NixOS/nixpkgs/issues/266290:

Introduce an "apply" script to NixOS, aimed at improving deployment processes for developers and power users. The script reduces SSH roundtrips and sudo invocations by refactoring deployment logic, moving systemd-run logic out of nixos-rebuild, and simplifying the management of the profile and actions on the target host. This change addresses limitations in nixos-rebuild and offers a more efficient backend for deployment tools

Observations and deviations from the original proposal:

- > initiating the installation of the bootloader
  
  This is already done by `switch-to-configuration`, and that's ok.
  
- > The new apply script will be called and packaged in multiple ways:
  > 
  >     * The `nixos-rebuild` package: For applying configurations that pre-date the toplevel/bin/apply script
  
  I have avoided this, to keep the new code path simple, devoid of conditional `ssh` calls.
  The equivalent code in `nixos-rebuild` is ok to go stale, because it is only needed for old releases anyway. We can remove that in, say, early 2026, when everyone has had more than enough time to migrate away from the unsupported releases.

- > `system.build.apply` [...] very optional

  Not done yet, and that's ok.

- > **Interface**
- > - Extra parameter that allows `pathToConfig` to be specified

  Unnecessarily complicated, and very low value once `apply` can be assumed to exist in, e.g. in January

- > - Extra: default action [...] TBD [...] should be postponed

  Not needed in this PR; feature creep; postponing



TODO:

- [x] update documentation about `switch-to-configuration switch` to reflect reality (of even before this PR), and/or point to `apply` instead.
- [x] release note

## Context

- Closes https://github.com/NixOS/nixpkgs/issues/266290
- Closes  #82851
- Closes https://github.com/NixOS/nixpkgs/issues/258974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
