### PR TITLE
python312Packages.{ncclient, sshtunnel,docker}: fix missing dependency after paramiko changes

### DIFF
--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -14,7 +14,7 @@
   requests,
   urllib3,
 
-  # optional-dependenices
+  # optional-dependencies
   paramiko,
   pynacl,  # optional in paramiko, required here
   websocket-client,
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    ssh = [ paramiko ];
+    ssh = [ paramiko paramiko.optional-dependencies.ed25519 ];
     tls = [];
     websockets = [ websocket-client ];
   };

--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -16,7 +16,6 @@
 
   # optional-dependencies
   paramiko,
-  pynacl,  # optional in paramiko, required here
   websocket-client,
 
   # tests
@@ -58,10 +57,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    paramiko
-    pynacl
-    websocket-client
-  ];
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pytestFlagsArray = [ "tests/unit" ];
 

--- a/pkgs/development/python-modules/ncclient/default.nix
+++ b/pkgs/development/python-modules/ncclient/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     paramiko
     lxml
     six
-  ];
+  ] ++ paramiko.optional-dependencies.ed25519;
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/sshtunnel/default.nix
+++ b/pkgs/development/python-modules/sshtunnel/default.nix
@@ -5,19 +5,22 @@
   paramiko,
   pytestCheckHook,
   mock,
+  setuptools,
 }:
 
 buildPythonPackage rec {
-  version = "0.4.0";
-  format = "setuptools";
   pname = "sshtunnel";
+  version = "0.4.0";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-58sOp3Tbgb+RhE2yLecqQKro97D5u5ug9mbUdO9r+fw=";
   };
 
-  propagatedBuildInputs = [ paramiko ];
+  build-system = [ setuptools ];
+
+  dependencies = [ paramiko ] ++ paramiko.optional-dependencies.ed25519;
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
## Description of changes

The two packages are broken since at least https://github.com/SuperSandro2000/nixpkgs/commit/a97420b26d3302913e5393e1cd888a069bd46089

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
