### PR TITLE
kubectl-node-shell: enable for all unix platforms

### DIFF
--- a/pkgs/applications/networking/cluster/kubectl-node-shell/default.nix
+++ b/pkgs/applications/networking/cluster/kubectl-node-shell/default.nix
@@ -28,6 +28,6 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/kvaps/kubectl-node-shell";
     license = licenses.asl20;
     maintainers = with maintainers; [ jocelynthode ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
`kubectl-node-shell` is just a shell script, so there's no reason to restrict it for just linux