### PR TITLE
mangl: init at 1.1.5-unstable-2024-07-10

### DIFF
--- a/pkgs/by-name/ma/mangl/package.nix
+++ b/pkgs/by-name/ma/mangl/package.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  glfw,
+  freetype,
+  pkg-config,
+  bzip2,
+  zlib,
+}:
+
+stdenv.mkDerivation {
+  pname = "mangl";
+  version = "1.1.5-unstable-2024-07-10";
+  src = fetchFromGitHub {
+    owner = "zigalenarcic";
+    repo = "mangl";
+    rev = "9d369fb0b9637969bbdfaafca73832fe8a31445b";
+    hash = "sha256-22JnflZtlkjI3wr6UHweb77pOk9cMwF+c6KORutCSDM=";
+  };
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    freetype
+    glfw
+    bzip2
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0555 mangl -t $out/bin
+    install -Dm0444 mangl.1 -t $out/man/man1
+    install -Dm0444 art/mangl.svg -t $out/share/icons/hicolor/scalable/apps
+    install -Dm0444 mangl.desktop -t $out/share/applications
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/zigalenarcic/mangl";
+    description = "A graphical man page viewer based on the mandoc library";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ nrabulinski ];
+    platforms = platforms.linux;
+    mainProgram = "mangl";
+  };
+}


### PR DESCRIPTION
## Description of changes

[Mangl](https://github.com/zigalenarcic/mangl) is a graphical man page viewer based on the mandoc library

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
