### PR TITLE
caido: 0.40 -> 0.41

### DIFF
--- a/pkgs/by-name/ca/caido/package.nix
+++ b/pkgs/by-name/ca/caido/package.nix
@@ -15,14 +15,14 @@ let
     "cli"
     "desktop"
   ];
-  version = "0.40.0";
+  version = "0.41.0";
   cli = fetchurl {
-    url = "https://storage.googleapis.com/caido-releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
-    hash = "sha256-G8sg+3Cp9QkSiiZ810z4jCfGvEJUFLorKT0JmHrO6Ao=";
+    url = "https://caido.download/releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
+    hash = "sha256-aQhax0efp5L3JNqGsOWsoO6z5pVVc/rxlz+5mvZoPNU=";
   };
   desktop = fetchurl {
-    url = "https://storage.googleapis.com/caido-releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
-    hash = "sha256-iNhitCNc221pYwcG+07GvP+bnTdtQGFjsloQ5Pth2l0=";
+    url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
+    hash = "sha256-DgXxOOWaLJG1h1nB+mkw77APh06WiJo9V9ZFCiWeha8=";
   };
   appimageContents = appimageTools.extractType2 {
     inherit pname version;


### PR DESCRIPTION
## Description of changes

We are moving away from gcp soon and onto our custom domain.
That domain is the officially supported way of downloading caido binaries.
See https://docs.caido.io/concepts/internals/download.html

I am not a nix person so it might require additional work, please let me know. 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
