### PR TITLE
{buildFHSEnvBubblewrap,buildFHSEnvChroot}: add `nativeBuildInputs`

### DIFF
--- a/pkgs/applications/audio/cider/default.nix
+++ b/pkgs/applications/audio/cider/default.nix
@@ -9,10 +9,11 @@ appimageTools.wrapType2 rec {
     sha256 = "sha256-NwoV1eeAN0u9VXWpu5mANXhmgqe8u3h7BlsREP1f/pI=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands =
     let contents = appimageTools.extract { inherit pname version src; };
     in ''
-      source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/${pname} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
 

--- a/pkgs/applications/blockchains/framesh/default.nix
+++ b/pkgs/applications/blockchains/framesh/default.nix
@@ -14,13 +14,12 @@ let
 in
 appimageTools.wrapType2 {
   inherit pname version src;
+  nativeBuildInputs = [ makeWrapper ];
 
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/frame.desktop $out/share/applications/frame.desktop
     install -m 444 -D ${appimageContents}/frame.png \
       $out/share/icons/hicolor/512x512/apps/frame.png
-
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram "$out/bin/${pname}" \
        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations}}"
 

--- a/pkgs/applications/blockchains/ledger-live-desktop/default.nix
+++ b/pkgs/applications/blockchains/ledger-live-desktop/default.nix
@@ -16,13 +16,14 @@ in
 appimageTools.wrapType2 rec {
   inherit pname version src;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/ledger-live-desktop.desktop $out/share/applications/ledger-live-desktop.desktop
     install -m 444 -D ${appimageContents}/ledger-live-desktop.png $out/share/icons/hicolor/1024x1024/apps/ledger-live-desktop.png
     ${imagemagick}/bin/convert ${appimageContents}/ledger-live-desktop.png -resize 512x512 ledger-live-desktop_512.png
     install -m 444 -D ledger-live-desktop_512.png $out/share/icons/hicolor/512x512/apps/ledger-live-desktop.png
 
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram "$out/bin/${pname}" \
        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime}}"
 

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -44,13 +44,13 @@ let
 
   linux = appimageTools.wrapType2 rec {
     inherit pname version src meta;
+    nativeBuildInputs = [ makeWrapper ];
 
     profile = ''
       export LC_ALL=C.UTF-8
     '';
 
     extraInstallCommands = ''
-      source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/${pname} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations}}"
       install -Dm444 ${appimageContents}/@joplinapp-desktop.desktop -t $out/share/applications

--- a/pkgs/applications/misc/notable/default.nix
+++ b/pkgs/applications/misc/notable/default.nix
@@ -22,6 +22,8 @@ appimageTools.wrapType2 rec {
     export LC_ALL=C.UTF-8
   '';
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraPkgs = pkgs: [ pkgs.at-spi2-atk pkgs.at-spi2-core ];
 
   extraInstallCommands = ''
@@ -30,7 +32,6 @@ appimageTools.wrapType2 rec {
       $out/share/icons/hicolor/1024x1024/apps/notable.png
     substituteInPlace $out/share/applications/notable.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram "$out/bin/${pname}" \
       --add-flags "--disable-seccomp-filter-sandbox"
   '';

--- a/pkgs/applications/misc/zettlr/generic.nix
+++ b/pkgs/applications/misc/zettlr/generic.nix
@@ -26,8 +26,9 @@ appimageTools.wrapType2 rec {
     pkgs.pandoc
   ];
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands = ''
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/zettlr \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
     install -m 444 -D ${appimageContents}/Zettlr.desktop $out/share/applications/Zettlr.desktop

--- a/pkgs/applications/networking/cluster/lens/linux.nix
+++ b/pkgs/applications/networking/cluster/lens/linux.nix
@@ -9,9 +9,10 @@ in
 appimageTools.wrapType2 {
   inherit pname version src meta;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands =
     ''
-      source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/${pname} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
       install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop

--- a/pkgs/applications/video/losslesscut-bin/build-from-appimage.nix
+++ b/pkgs/applications/video/losslesscut-bin/build-from-appimage.nix
@@ -22,6 +22,8 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   profile = ''
     export LC_ALL=C.UTF-8
   '';
@@ -38,7 +40,6 @@ appimageTools.wrapType2 {
     cp ${extracted}/losslesscut.desktop $out/share/applications
     substituteInPlace $out/share/applications/losslesscut.desktop \
       --replace AppRun losslesscut
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram "$out/bin/losslesscut" \
       --add-flags "--disable-seccomp-filter-sandbox"
   '';

--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -12,6 +12,7 @@
 , targetPkgs ? pkgs: []
 , multiPkgs ? pkgs: []
 , multiArch ? false # Whether to include 32bit packages
+, nativeBuildInputs ? []
 , extraBuildCommands ? ""
 , extraBuildCommandsMulti ? ""
 , extraOutputsToInstall ? []
@@ -257,6 +258,7 @@ let
   '';
 
 in runCommandLocal "${name}-fhs" {
+  inherit nativeBuildInputs;
   passthru = {
     inherit args baseTargetPaths targetPaths baseMultiPaths ldconfig isMultiBuild;
   };

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -10,6 +10,7 @@
 }:
 
 { runScript ? "bash"
+, nativeBuildInputs ? []
 , extraInstallCommands ? ""
 , meta ? {}
 , passthru ? {}
@@ -270,7 +271,7 @@ let
 
   bin = writeShellScript "${name}-bwrap" (bwrapCmd { initArgs = ''"$@"''; });
 in runCommandLocal name (nameAttrs // {
-  inherit meta;
+  inherit nativeBuildInputs meta;
 
   passthru = passthru // {
     env = runCommandLocal "${name}-shell-env" {

--- a/pkgs/build-support/build-fhsenv-chroot/default.nix
+++ b/pkgs/build-support/build-fhsenv-chroot/default.nix
@@ -2,7 +2,7 @@
 
 let buildFHSEnv = callPackage ./env.nix { }; in
 
-args@{ name, version ? null, runScript ? "bash", extraInstallCommands ? "", meta ? {}, passthru ? {}, ... }:
+args@{ name, version ? null, runScript ? "bash", nativeBuildInputs ? [], extraInstallCommands ? "", meta ? {}, passthru ? {}, ... }:
 
 let
   env = buildFHSEnv (removeAttrs args [ "version" "runScript" "extraInstallCommands" "meta" "passthru" ]);
@@ -28,7 +28,7 @@ let
   nameAndVersion = name + versionStr;
 
 in runCommandLocal nameAndVersion {
-  inherit meta;
+  inherit nativeBuildInputs meta;
 
   passthru = passthru // {
     env = runCommandLocal "${name}-shell-env" {

--- a/pkgs/build-support/build-fhsenv-chroot/env.nix
+++ b/pkgs/build-support/build-fhsenv-chroot/env.nix
@@ -4,6 +4,7 @@
 , profile ? ""
 , targetPkgs ? pkgs: []
 , multiPkgs ? pkgs: []
+, nativeBuildInputs ? []
 , extraBuildCommands ? ""
 , extraBuildCommandsMulti ? ""
 , extraOutputsToInstall ? []
@@ -245,6 +246,7 @@ let
 
 in stdenv.mkDerivation {
   name         = "${name}-fhs";
+  inherit nativeBuildInputs;
   buildCommand = ''
     mkdir -p $out
     cd $out

--- a/pkgs/by-name/an/anytype/package.nix
+++ b/pkgs/by-name/an/anytype/package.nix
@@ -12,10 +12,11 @@ let
 in appimageTools.wrapType2 {
   inherit pname version src;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraPkgs = pkgs: [ pkgs.libsecret ];
 
   extraInstallCommands = ''
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/${pname} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}

--- a/pkgs/by-name/ba/bazecor/package.nix
+++ b/pkgs/by-name/ba/bazecor/package.nix
@@ -31,6 +31,8 @@ appimageTools.wrapAppImage {
   # taken from
   # https://github.com/Dygmalab/Bazecor/blob/v1.4.4/src/main/utils/udev.ts#L6
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraPkgs = pkgs: [ pkgs.glib ];
 
   # Also expose the udev rules here, so it can be used as:
@@ -38,7 +40,6 @@ appimageTools.wrapAppImage {
   # to allow non-root modifications to the keyboards.
 
   extraInstallCommands = ''
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/bazecor \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
 

--- a/pkgs/by-name/be/beekeeper-studio/package.nix
+++ b/pkgs/by-name/be/beekeeper-studio/package.nix
@@ -29,8 +29,9 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands = ''
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/${pname} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
     install -Dm444 ${appimageContents}/${pname}.desktop -t $out/share/applications/

--- a/pkgs/by-name/ca/caido/package.nix
+++ b/pkgs/by-name/ca/caido/package.nix
@@ -33,13 +33,14 @@ let
     src = desktop;
     inherit pname version;
 
+    nativeBuildInputs = [ makeWrapper ];
+
     extraPkgs = pkgs: [ pkgs.libthai ];
 
     extraInstallCommands = ''
       install -m 444 -D ${appimageContents}/caido.desktop -t $out/share/applications
       install -m 444 -D ${appimageContents}/caido.png \
         $out/share/icons/hicolor/512x512/apps/caido.png
-      source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/caido \
         --set WEBKIT_DISABLE_COMPOSITING_MODE 1
     '';

--- a/pkgs/by-name/lu/lunar-client/package.nix
+++ b/pkgs/by-name/lu/lunar-client/package.nix
@@ -13,10 +13,11 @@ appimageTools.wrapType2 rec {
     hash = "sha512-hzW7khHfWEYPtzMmedy/dXqKh7LPniqI7/0F1FtBtrlDnEIEQUq/7VUcygsVTBI6kuj8vTG5+PYcLez+cYAjqg==";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands =
     let contents = appimageTools.extract { inherit pname version src; };
     in ''
-      source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/lunarclient \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
       install -Dm444 ${contents}/lunarclient.desktop -t $out/share/applications/

--- a/pkgs/by-name/mu/muffon/package.nix
+++ b/pkgs/by-name/mu/muffon/package.nix
@@ -17,8 +17,9 @@ in
 appimageTools.wrapType2 {
   inherit pname src version;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands = ''
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/muffon \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
     install -m 444 -D ${appimageContents}/muffon.desktop -t $out/share/applications

--- a/pkgs/development/tools/altair-graphql-client/default.nix
+++ b/pkgs/development/tools/altair-graphql-client/default.nix
@@ -14,8 +14,9 @@ in
 appimageTools.wrapType2 {
   inherit src pname version;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands = ''
-    source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/${pname} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
 

--- a/pkgs/tools/misc/wootility/default.nix
+++ b/pkgs/tools/misc/wootility/default.nix
@@ -16,10 +16,11 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands =
     let contents = appimageTools.extract { inherit pname version src; };
     in ''
-      source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/wootility \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
 


### PR DESCRIPTION
`makeWrapper` is often used in these with `source "${makeWrapper}/nix-support/setup-hook"` which causes `error: makeWrapper/makeShellWrapper must be in nativeBuildInputs` on cross.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
