### PR TITLE
tdarr-server: init at 2.25.01

### DIFF
--- a/pkgs/servers/tdarr/node.nix
+++ b/pkgs/servers/tdarr/node.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, lib
+, makeBinaryWrapper
+, fetchurl
+, unzip
+, ffmpeg
+, mkvtoolnix
+, tesseract
+, handbrake
+}:
+
+let
+  binName = "Tdarr_Node";
+in
+stdenv.mkDerivation rec {
+  pname = "tdarr-node";
+  version = "2.26.01";
+  src = fetchurl {
+    # Urls can be found here https://storage.tdarr.io/versions.json
+    url = "https://storage.tdarr.io/versions/${version}/linux_x64/Tdarr_Node.zip";
+    sha256 = "sha256-GAcK5g2fh9B6ZI8fYtLjWC0PntX5lOukUO04PGqxLzw=";
+  };
+
+  buildInputs = [
+  ];
+
+  nativeBuildInputs = [
+    unzip
+    makeBinaryWrapper
+  ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./ $out
+    mkdir $out/bin
+    makeBinaryWrapper $out/${binName} $out/bin/${binName} \
+      --set ffmpegPath ${ffmpeg}/bin/ffmpeg \
+      --set handbrakePath ${handbrake}/bin/HandBrakeCLI \
+      --set mkvpropeditPath ${mkvtoolnix}/bin/mkvpropedit \
+      --set ffprobePath ${ffmpeg}/bin/ffprobe
+  '';
+
+  meta = with lib; {
+    mainProgram = binName;
+    description = "Distributed transcode automation";
+    homepage = "https://tdarr.io";
+    license = licenses.unfree; # TODO: figure out if license is redistributable
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/servers/tdarr/server.nix
+++ b/pkgs/servers/tdarr/server.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, lib
+, makeBinaryWrapper
+, fetchurl
+, unzip
+, ffmpeg
+, mkvtoolnix
+, tesseract
+, handbrake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tdarr-server";
+  version = "2.26.01";
+  src = fetchurl {
+    # Urls can be found here https://storage.tdarr.io/versions.json
+    url = "https://storage.tdarr.io/versions/${version}/linux_x64/Tdarr_Server.zip";
+    sha256 = "sha256-jIPPss22aCFydWcBE30IXBc6zDsOzc27nm4StOd4VCE=";
+  };
+
+  buildInputs = [
+    tesseract
+  ];
+
+  nativeBuildInputs = [
+    unzip
+    makeBinaryWrapper
+  ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  patchPhase = ''
+    # Remove bundled ffmpeg, since we will be using the one from nixpkgs
+    rm -rf ./node_modules/ffmpeg-static/ffmpeg
+    # rm -rf ./node_modules/@ffprobe-installer/linux-x64/ffprobe
+  '';
+
+  installPhase =
+    let
+      binName = "Tdarr_Server";
+      trayBinName = "Tdarr_Server_Tray";
+    in
+    ''
+      mkdir -p $out
+      cp -r ./ $out
+      mkdir $out/bin
+      # ln -s $out/${binName} $out/bin/${binName}
+      makeBinaryWrapper $out/${binName} $out/bin/${binName} \
+        --set ffmpegPath ${ffmpeg}/bin/ffmpeg \
+        --set handbrakePath ${handbrake}/bin/HandBrakeCLI \
+        --set mkvpropeditPath ${mkvtoolnix}/bin/mkvpropedit \
+        --set ffprobePath ${ffmpeg}/bin/ffprobe
+      # ln -s $out/${trayBinName} $out/bin/${trayBinName}
+    '';
+
+  meta = with lib; {
+    mainProgram = "Tdarr_Server";
+    description = "Distributed transcode automation";
+    homepage = "https://tdarr.io";
+    license = licenses.unfree; # TODO: figure out if license is redistributable
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24506,6 +24506,8 @@ with pkgs;
 
   prosody-filer = callPackage ../servers/xmpp/prosody-filer { };
 
+  tdarr-server = callPackage ../servers/tdarr/server.nix { };
+
   biboumi = callPackage ../servers/xmpp/biboumi { };
 
   elasticmq-server-bin = callPackage ../servers/elasticmq-server-bin {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24506,6 +24506,8 @@ with pkgs;
 
   prosody-filer = callPackage ../servers/xmpp/prosody-filer { };
 
+  tdarr-node = callPackage ../servers/tdarr/node.nix { };
+
   tdarr-server = callPackage ../servers/tdarr/server.nix { };
 
   biboumi = callPackage ../servers/xmpp/biboumi { };


### PR DESCRIPTION
## Description of changes

This pull request aims to package the tdarr server and tdarr node packages, such that one can run tdarr through nixpkgs.

Aims to close #273459

**Current state:**

The program can start on my machine, but it immediately runs into an error where it tries to make folders in the `/nix/store`, I am not sure why it chooses the nix store. This means that it is also not possible to configure it to my knowledge.

The relevant native build inputs has been added according to [the documentation](https://docs.tdarr.io/docs/installation/windows-linux-macos#configs)

**TODO before draft is finished**

- [ ] figure out correct license
- [ ] Be able to set appsDir to a mutable directory

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
