### PR TITLE
edex-ui: init to 2.2.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23142,6 +23142,12 @@
     githubId = 33605526;
     name = "Yash Garg";
   };
+  yassinebenarbia = {
+    email = "yassine.bna@proton.me";
+    github = "yassinebenarbia";
+    githubId = 104306099;
+    name = "Yassine";
+  };
   yavko = {
     name = "Yavor Kolev";
     email = "yavornkolev@gmail.com";

--- a/pkgs/by-name/ed/edex-ui/package.nix
+++ b/pkgs/by-name/ed/edex-ui/package.nix
@@ -1,0 +1,34 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+}:
+appimageTools.wrapType2 rec {
+  pname = "edex-ui";
+  name = "eDEX-UI";
+  version = "2.2.8";
+  platform = "Linux-x86_64";
+  src = fetchurl {
+    url = "https://github.com/GitSquared/edex-ui/releases/download/v${version}/${name}-${platform}.AppImage";
+    hash = "sha256-yPKM1yHKAyygwZYLdWyj5k3EQaZDwy6vu3nGc7QC1oE=";
+  };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/${pname}.png \
+    $out/share/icons/hicolor/512x512/apps/${pname}.png
+    substituteInPlace $out/share/applications/${pname}.desktop \
+    --replace 'Exec=AppRun' 'Exec=edex-ui %U'
+  '';
+
+  meta = {
+    description = "Customizable science fiction terminal emulator with advanced monitoring & touchscreen support.";
+    mainProgram = "edex-ui";
+    changelog = "https://github.com/GitSquared/edex-ui/releases/tag${version}";
+    homepage = "https://github.com/GitSquared/edex-ui";
+    license = lib.licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ yassinebenarbia ];
+  };
+}


### PR DESCRIPTION
## Description of changes
https://www.youtube.com/watch?v=BGeY1rK19zA
https://github.com/GitSquared/edex-ui
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
