### PR TITLE
kdePackages.koi: Fix changing theme and icons

### DIFF
--- a/pkgs/kde/third-party/koi/default.nix
+++ b/pkgs/kde/third-party/koi/default.nix
@@ -7,6 +7,7 @@
   kcoreaddons,
   kwidgetsaddons,
   wrapQtAppsHook,
+  plasma-workspace,
 }:
 stdenv.mkDerivation rec {
   pname = "koi";
@@ -19,8 +20,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-dhpuKIY/Xi62hzJlnVCIOF0k6uoQ3zH129fLq/r+Kmg";
   };
 
+  patches = [
+    ./patches/0001-plasmastyle.cpp-Use-relative-path.patch
+    ./patches/0002-icons.cpp-Use-configurable-libexec-path.patch
+  ];
+  postPatch = ''
+    sed -i "s|@plasma-changeicons@|${plasma-workspace}/libexec/plasma-changeicons|g" src/icons.cpp
+  '';
   # See https://github.com/baduhai/Koi/blob/master/development/Nix%20OS/dev.nix
-  sourceRoot = "source/src";
+  sourceRoot = "source";
+  preConfigure = ''
+    cd src
+  '';
   nativeBuildInputs = [
     cmake
     wrapQtAppsHook

--- a/pkgs/kde/third-party/koi/patches/0001-plasmastyle.cpp-Use-relative-path.patch
+++ b/pkgs/kde/third-party/koi/patches/0001-plasmastyle.cpp-Use-relative-path.patch
@@ -1,0 +1,25 @@
+From ef6178446363682f969186c42443d95f98e06584 Mon Sep 17 00:00:00 2001
+From: alexyao2015 <33379584+alexyao2015@users.noreply.github.com>
+Date: Wed, 25 Sep 2024 23:17:47 -0500
+Subject: [PATCH 1/2] plasmastyle.cpp: Use relative path
+
+---
+ src/plasmastyle.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/plasmastyle.cpp b/src/plasmastyle.cpp
+index a266150..c86fd20 100644
+--- a/src/plasmastyle.cpp
++++ b/src/plasmastyle.cpp
+@@ -8,7 +8,7 @@ PlasmaStyle::PlasmaStyle()
+ void PlasmaStyle::setPlasmaStyle(QString plasmaStyle)
+ {
+     styleProcess = new QProcess;
+-    QString style = "/usr/bin/plasma-apply-desktoptheme";
++    QString style = "plasma-apply-desktoptheme";
+     QStringList styleArgs = {plasmaStyle};
+     styleProcess->start(style, styleArgs);
+     styleProcess->waitForFinished();
+-- 
+2.44.1
+

--- a/pkgs/kde/third-party/koi/patches/0001-plasmastyle.cpp-Use-relative-path.patch
+++ b/pkgs/kde/third-party/koi/patches/0001-plasmastyle.cpp-Use-relative-path.patch
@@ -9,8 +9,8 @@ Subject: [PATCH 1/2] plasmastyle.cpp: Use relative path
 
 diff --git a/src/plasmastyle.cpp b/src/plasmastyle.cpp
 index a266150..c86fd20 100644
---- a/src/plasmastyle.cpp
-+++ b/src/plasmastyle.cpp
+--- a/src/plugins/plasmastyle.cpp
++++ b/src/plugins/plasmastyle.cpp
 @@ -8,7 +8,7 @@ PlasmaStyle::PlasmaStyle()
  void PlasmaStyle::setPlasmaStyle(QString plasmaStyle)
  {

--- a/pkgs/kde/third-party/koi/patches/0002-icons.cpp-Use-configurable-libexec-path.patch
+++ b/pkgs/kde/third-party/koi/patches/0002-icons.cpp-Use-configurable-libexec-path.patch
@@ -1,0 +1,34 @@
+From 06fe9627757b94693bf9446124ba4b81a279d1d5 Mon Sep 17 00:00:00 2001
+From: alexyao2015 <33379584+alexyao2015@users.noreply.github.com>
+Date: Wed, 25 Sep 2024 23:18:21 -0500
+Subject: [PATCH 2/2] icons.cpp: Use configurable libexec path
+
+---
+ src/icons.cpp | 11 +----------
+ 1 file changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/src/icons.cpp b/src/icons.cpp
+index aa6aae9..a2564c4 100644
+--- a/src/icons.cpp
++++ b/src/icons.cpp
+@@ -9,16 +9,7 @@ void Icons::setIcons(QString iconTheme)
+ {
+     iconProcess = new QProcess;
+ 
+-    // locate plasma-changeicons program
+-    QString locateProgram = "whereis";
+-    QStringList programToLocate = {"plasma-changeicons"};
+-
+-    iconProcess->start(locateProgram, programToLocate);
+-    iconProcess->waitForFinished();
+-
+-    QString program(iconProcess->readAllStandardOutput());
+-    program.replace("plasma-changeicons: ", "");
+-    program.replace("\n", "");
++    QString program = "@plasma-changeicons@";
+ 
+     // apply the icon theme
+     QStringList arguments{iconTheme};
+-- 
+2.44.1
+


### PR DESCRIPTION
## Description of changes

Previously changing the global theme and icons would not function correctly in koi. This was caused by the path to the applications that Koi was using being incorrect. This fixes the problem by patching the path to these apps.

I've tested this by configuring Koi to change the theme or icon only and observing that the respective setting has been changed when it previously was not.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
