### PR TITLE
alt-ergo: 2.5.4 → 2.6.0

### DIFF
--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -39,7 +39,17 @@ ocamlPackages.buildDunePackage {
   inherit pname version src;
 
   nativeBuildInputs = [ ocamlPackages.menhir ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.sigtool ];
-  buildInputs = [ alt-ergo-parsers ] ++ (with ocamlPackages; [ cmdliner dune-site ppxlib ]);
+  propagatedBuildInputs = [ alt-ergo-parsers ] ++ (with ocamlPackages; [ cmdliner dune-site ppxlib ]);
+
+  outputs = [ "bin" "out" ];
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $bin ${pname}
+    mkdir -p $out/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib
+    mv $bin/lib/alt-ergo $out/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib/
+    runHook postInstall
+  '';
 
   meta = {
     description = "High-performance theorem prover and SMT solver";

--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -2,11 +2,11 @@
 
 let
   pname = "alt-ergo";
-  version = "2.5.4";
+  version = "2.6.0";
 
   src = fetchurl {
     url = "https://github.com/OCamlPro/alt-ergo/releases/download/v${version}/alt-ergo-${version}.tbz";
-    hash = "sha256-AsHok5i62vqJ5hK8XRiD8hM6JQaFv3dMxZAcVYEim6w=";
+    hash = "sha256-EmkxGvJSeKRmiSuoeMyIi6WfF39T3QPxKixiOwP8834=";
   };
 in
 
@@ -14,7 +14,17 @@ let alt-ergo-lib = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-lib";
   inherit version src;
   buildInputs = with ocamlPackages; [ ppx_blob ];
-  propagatedBuildInputs = with ocamlPackages; [ camlzip dolmen_loop dune-build-info fmt ocplib-simplex seq stdlib-shims zarith ];
+  propagatedBuildInputs = with ocamlPackages; [
+    camlzip
+    dolmen_loop
+    dune-build-info
+    fmt
+    ocplib-simplex
+    ppx_deriving
+    seq
+    stdlib-shims
+    zarith
+  ];
 }; in
 
 let alt-ergo-parsers = ocamlPackages.buildDunePackage rec {
@@ -29,7 +39,7 @@ ocamlPackages.buildDunePackage {
   inherit pname version src;
 
   nativeBuildInputs = [ ocamlPackages.menhir ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.sigtool ];
-  buildInputs = [ alt-ergo-parsers ] ++ (with ocamlPackages; [ cmdliner dune-site ]);
+  buildInputs = [ alt-ergo-parsers ] ++ (with ocamlPackages; [ cmdliner dune-site ppxlib ]);
 
   meta = {
     description = "High-performance theorem prover and SMT solver";

--- a/pkgs/development/ocaml-modules/dolmen/default.nix
+++ b/pkgs/development/ocaml-modules/dolmen/default.nix
@@ -1,22 +1,23 @@
 { lib, fetchurl, buildDunePackage
 , menhir, menhirLib
 , fmt
+, hmap
 , qcheck
 }:
 
 buildDunePackage rec {
   pname = "dolmen";
-  version = "0.9";
+  version = "0.10";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/Gbury/dolmen/releases/download/v${version}/dolmen-${version}.tbz";
-    hash = "sha256-AD21OFS6zDoz+lXtac95gXwQNppPfGvpRK8dzDZXigo=";
+    hash = "sha256-xchfd+OSTzeOjYLxZu7+QTG04EG/nN7KRnQQ8zxx+mE=";
   };
 
   nativeBuildInputs = [ menhir ];
-  propagatedBuildInputs = [ menhirLib fmt ];
+  propagatedBuildInputs = [ menhirLib fmt hmap ];
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/dolmen/loop.nix
+++ b/pkgs/development/ocaml-modules/dolmen/loop.nix
@@ -1,6 +1,7 @@
 { buildDunePackage, dolmen, dolmen_type
 , gen
 , pp_loc
+, mdx
 }:
 
 buildDunePackage {
@@ -8,6 +9,10 @@ buildDunePackage {
   inherit (dolmen) src version;
 
   propagatedBuildInputs = [ dolmen dolmen_type gen pp_loc ];
+
+  doCheck = true;
+  nativeCheckInputs = [ mdx.bin ];
+  checkInputs = [ mdx ];
 
   meta = dolmen.meta // {
     description = "Tool library for automated deduction tools";


### PR DESCRIPTION
ocamlPackages.dolmen: 0.9 → 0.10

## Description of changes

https://raw.githubusercontent.com/OCamlPro/alt-ergo/refs/tags/v2.6.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
