### PR TITLE
nixos/caddy: add options for ports and openFirewall

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -518,6 +518,8 @@
 
 - `nixosTests` now provide a working IPv6 setup for VLAN 1 by default.
 
+- `services.caddy` now supports setting `httpPort` and `httpsPort` and opening them in the firewall via `openFirewall`.
+
 - Kanidm can now be provisioned using the new [`services.kanidm.provision`] option, but requires using a patched version available via `pkgs.kanidm.withSecretProvisioning`.
 
 - Kanidm previously had an incorrect systemd service type, causing dependent units with an `after` and `requires` directive to start before `kanidm*` finished startup. The module has now been updated in line with upstream recommendations.

--- a/nixos/modules/services/web-servers/caddy/default.nix
+++ b/nixos/modules/services/web-servers/caddy/default.nix
@@ -336,6 +336,20 @@ in
         :::
       '';
     };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to enable opening the specified http(s) ports in the firewall.
+        Any port set to `null` will not be opened.
+
+        ::: {.note}
+        If you use other ports for your virtual hosts, you need to open them manually.
+        :::
+      '';
+    };
   };
 
   # implementation
@@ -424,5 +438,10 @@ in
         listToAttrs certCfg;
 
     environment.etc.${etcConfigFile}.source = cfg.configFile;
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = filter (port: port != null) [ cfg.httpPort cfg.httpsPort ];
+      allowedUDPPorts = optional (cfg.httpsPort != null) cfg.httpsPort;
+    };
   };
 }

--- a/nixos/modules/services/web-servers/caddy/default.nix
+++ b/nixos/modules/services/web-servers/caddy/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, options, lib, pkgs, ... }:
 
 with lib;
 
@@ -283,6 +283,23 @@ in
       '';
     };
 
+    httpPort = mkOption {
+      default = 80;
+      type = with types; nullOr port;
+      description = ''
+        The default port to listen on for HTTP traffic.
+      '';
+    };
+
+    httpsPort = mkOption {
+      default = 443;
+      type = with types; nullOr port;
+      description = ''
+        The default port to listen on for HTTPS traffic.
+        Will also be used for HTTP/3.
+      '';
+    };
+
     enableReload = mkOption {
       default = true;
       type = types.bool;
@@ -337,6 +354,8 @@ in
     services.caddy.globalConfig = ''
       ${optionalString (cfg.email != null) "email ${cfg.email}"}
       ${optionalString (cfg.acmeCA != null) "acme_ca ${cfg.acmeCA}"}
+      ${optionalString (!elem cfg.httpPort [null options.services.caddy.httpPort.default]) "http_port ${cfg.httpPort}"}
+      ${optionalString (!elem cfg.httpsPort [null options.services.caddy.httpsPort.default]) "https_port ${cfg.httpsPort}"}
       log {
         ${cfg.logFormat}
       }


### PR DESCRIPTION
## Description of changes

Added the option `services.caddy.openFirewall`. Fixes #338015

Maybe it would be a good idea to trigger a backport for 24.05 as well?

I ran the test `nix-build -A nixosTests.caddy` in a virtual NixOS machine on my Mac and got the following error. My assumption is that this is caused by some networking issues due to the nested VMs.

```txt
error: builder for '/nix/store/1b7bgcx2xf84i3aq8abgbbrrn3mwpmsd-vm-test-run-caddy.drv' failed with exit code 1;
       last 25 log lines:
       > webserver: waiting for TCP port 80 on localhost
       > webserver # Connection to localhost (::1) 80 port [tcp/http] succeeded!
       > (finished: waiting for TCP port 80 on localhost, in 1.91 seconds)
       > subtest: config is reloaded on nixos-rebuild switch
       > webserver: must succeed: /nix/store/83r48jqiag13psakxg142mnyr8jvm9mx-nixos-system-webserver-test/specialisation/config-reload/bin/switch-to-configuration test >&2
       > webserver # [  266.468913] nixos[1038]: switching to system configuration /nix/store/k19q5gmd8f0kxdavbmsvqkw4wahbgw2j-nixos-system-webserver-test
       > webserver # [  266.556710] systemd[1]: Stopped target Local File Systems.
       > webserver # [  266.659840] systemd[1]: Stopped target Remote File Systems.
       > webserver # activating the configuration...
       > webserver # setting up /etc...
       > webserver # [  295.540848] systemd[1]: Reload requested from client PID 1038 ('.switch-to-conf') (unit backdoor.service)...
       > webserver # [  295.588781] systemd[1]: Reloading...
       > webserver # restarting sysinit-reactivation.target
       > webserver # Failed to restart sysinit-reactivation.target: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
       > webserver # Error: Failed to get unit caddy.service
       > webserver # 
       > webserver # Caused by:
       > webserver #     Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
       > webserver: output:
       > Test "config is reloaded on nixos-rebuild switch" failed with error: "command `/nix/store/83r48jqiag13psakxg142mnyr8jvm9mx-nixos-system-webserver-test/specialisation/config-reload/bin/switch-to-configuration test >&2` failed (exit code 1)"
       > cleanup
       > kill machine (pid 10)
       > qemu-kvm: terminating on signal 15 from pid 7 (/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/bin/python3.12)
       > (finished: cleanup, in 0.01 seconds)
       > kill vlan (pid 8)
       For full logs, run 'nix log /nix/store/1b7bgcx2xf84i3aq8abgbbrrn3mwpmsd-vm-test-run-caddy.drv'.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
