### PR TITLE
rPackages: compile r-torch from source

### DIFF
--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -239,6 +239,9 @@ buildPythonPackage rec {
     [
       ./pytorch_2_0_1_c10_fix.patch
       ./pytorch_2_0_1_aten_fix.patch
+      ./pytorch_2_0_1_quant_fix.patch
+      ./pytorch_2_0_1_jit_fix.patch
+      ./pytorch_2_0_1_lazy_fix.patch
 
       ./pytorch_2_0_1_kineto_fix.patch
       ./pytorch_2_0_1_fbgemmm_fix.patch

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -119,7 +119,7 @@ let
         "8.7"
         "8.9"
         "9.0"
-        "9.0a"
+        # "9.0a"
       ];
       ptx = lists.map (x: "${x}+PTX") real;
     in
@@ -214,7 +214,7 @@ in
 buildPythonPackage rec {
   pname = "torch";
   # Don't forget to update torch-bin to the same version.
-  version = "2.4.1";
+  version = "2.0.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8.0";
@@ -232,16 +232,21 @@ buildPythonPackage rec {
     repo = "pytorch";
     rev = "refs/tags/v${version}";
     fetchSubmodules = true;
-    hash = "sha256-x/zM/57syr46CP1TfGaefSjzvNm4jJbWFZGVGyzPMg8=";
+    hash = "sha256-xUj77yKz3IQ3gd/G32pI4OhL3LoN1zS7eFg0/0nZp5I=";
   };
 
   patches =
     [
+      ./pytorch_2_0_1_c10_fix.patch
+      ./pytorch_2_0_1_aten_fix.patch
+
+      ./pytorch_2_0_1_kineto_fix.patch
+      ./pytorch_2_0_1_fbgemmm_fix.patch
       # Allow setting PYTHON_LIB_REL_PATH with an environment variable.
       # https://github.com/pytorch/pytorch/pull/128419
       ./passthrough-python-lib-rel-path.patch
     ]
-    ++ lib.optionals cudaSupport [ ./fix-cmake-cuda-toolkit.patch ]
+    #++ lib.optionals cudaSupport [ ./fix-cmake-cuda-toolkit.patch ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
       # pthreadpool added support for Grand Central Dispatch in April
       # 2020. However, this relies on functionality (DISPATCH_APPLY_AUTO)
@@ -290,9 +295,9 @@ buildPythonPackage rec {
     # NOTE: Parts of pytorch rely on unmaintained FindCUDA.cmake with custom patches to support e.g.
     # newer architectures (sm_90a). We do want to delete vendored patches, but have to keep them
     # until https://github.com/pytorch/pytorch/issues/76082 is addressed
-    + lib.optionalString cudaSupport ''
-      rm cmake/Modules/FindCUDAToolkit.cmake
-    ''
+    # + lib.optionalString cudaSupport ''
+    #   rm cmake/Modules/FindCUDAToolkit.cmake
+    # ''
     # error: no member named 'aligned_alloc' in the global namespace; did you mean simply 'aligned_alloc'
     # This lib overrided aligned_alloc hence the error message. Tltr: his function is linkable but not in header.
     +

--- a/pkgs/development/python-modules/torch/pytorch_2_0_1_aten_fix.patch
+++ b/pkgs/development/python-modules/torch/pytorch_2_0_1_aten_fix.patch
@@ -1,0 +1,23 @@
+From bb0b283e5ace42b65a6180956bdff6af1b560e4c Mon Sep 17 00:00:00 2001
+From: Nikita Shulga <nshulga@meta.com>
+Date: Fri, 28 Jul 2023 07:08:59 -0700
+Subject: [PATCH] Do not force -Werror on Pooling.cpp
+
+As new versions of compilers are likely find new types of violation s as shown in https://github.com/pytorch/pytorch/issues/105728
+---
+ caffe2/CMakeLists.txt | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
+index cc6ecdc7415f6..955bc67e2299c 100644
+--- a/caffe2/CMakeLists.txt
++++ b/caffe2/CMakeLists.txt
+@@ -530,8 +530,6 @@ endif()
+ # Required workaround for LLVM 9 includes.
+ if(NOT MSVC)
+   set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_jit.cpp PROPERTIES COMPILE_FLAGS -Wno-noexcept-type)
+-  # Force -Werror on several files
+-  set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/mkldnn/Pooling.cpp PROPERTIES COMPILE_FLAGS "-Werror")
+ endif()
+ # Disable certain warnings for GCC-9.X
+ if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0.0))

--- a/pkgs/development/python-modules/torch/pytorch_2_0_1_c10_fix.patch
+++ b/pkgs/development/python-modules/torch/pytorch_2_0_1_c10_fix.patch
@@ -1,0 +1,11 @@
+diff --git a/c10/util/Registry.h b/c10/util/Registry.h
+--- a/c10/util/Registry.h
++++ b/c10/util/Registry.h
+@@ -11,2 +11,3 @@
+ #include <c10/macros/Macros.h>
+ #include <c10/util/Type.h>
++#include <stdexcept>
+
+ namespace c10 {
+
+ template <typename KeyType>

--- a/pkgs/development/python-modules/torch/pytorch_2_0_1_fbgemmm_fix.patch
+++ b/pkgs/development/python-modules/torch/pytorch_2_0_1_fbgemmm_fix.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/fbgemm/include/fbgemm/UtilsAvx2.h b/third_party/fbgemm/include/fbgemm/UtilsAvx2.h
+index a1af6078a..4fb1220eb 100644
+--- a/third_party/fbgemm/include/fbgemm/UtilsAvx2.h
++++ b/third_party/fbgemm/include/fbgemm/UtilsAvx2.h
+@@ -8,4 +8,5 @@
+ // This file defines common utilities used in code compiled with avx2/avx512
+ // flags.
+
++#include <cstdint>
+ #include <string>
+
+ namespace fbgemm {

--- a/pkgs/development/python-modules/torch/pytorch_2_0_1_jit_fix.patch
+++ b/pkgs/development/python-modules/torch/pytorch_2_0_1_jit_fix.patch
@@ -1,0 +1,17 @@
+diff --git a/torch/csrc/jit/runtime/logging.h b/torch/csrc/jit/runtime/logging.h
+--- a/torch/csrc/jit/runtime/logging.h
++++ b/torch/csrc/jit/runtime/logging.h
+@@ -11,12 +11,13 @@
+ #pragma once
+
+ #include <mutex>
+ #include <string>
+ #include <unordered_map>
+ #include <vector>
++#include <stdexcept>
+
+ #include <torch/csrc/Export.h>
+
+ namespace torch {
+ namespace jit {
+ namespace logging {

--- a/pkgs/development/python-modules/torch/pytorch_2_0_1_kineto_fix.patch
+++ b/pkgs/development/python-modules/torch/pytorch_2_0_1_kineto_fix.patch
@@ -1,0 +1,10 @@
+diff --git a/third_party/kineto/libkineto/src/SampleListener.h b/a/third_party/kineto/libkineto/src/SampleListener.h
+--- a/third_party/kineto/libkineto/src/SampleListener.h
++++ b/third_party/kineto/libkineto/src/SampleListener.h
+@@ -11,5 +11,6 @@
+ #include <assert.h>
+ #include <cmath>
+ #include <iostream>
++#include <cstdint>
+ #include <string>
+ #include <vector>

--- a/pkgs/development/python-modules/torch/pytorch_2_0_1_lazy_fix.patch
+++ b/pkgs/development/python-modules/torch/pytorch_2_0_1_lazy_fix.patch
@@ -1,0 +1,14 @@
+diff --git a/torch/csrc/lazy/core/multi_wait.h b/torch/csrc/lazy/core/multi_wait.h
+--- a/torch/csrc/lazy/core/multi_wait.h
++++ b/torch/csrc/lazy/core/multi_wait.h
+@@ -11,9 +11,10 @@
+ #include <condition_variable>
+ #include <functional>
+ #include <memory>
+ #include <mutex>
++#include <stdexcept>
+
+ #include <c10/macros/Export.h>
+
+ namespace torch {
+ namespace lazy {

--- a/pkgs/development/python-modules/torch/pytorch_2_0_1_quant_fix.patch
+++ b/pkgs/development/python-modules/torch/pytorch_2_0_1_quant_fix.patch
@@ -1,0 +1,11 @@
+diff --git a/torch/csrc/jit/passes/quantization/quantization_type.h b/torch/csrc/jit/passes/quantization/quantization_type.h
+index a1af6078a..4fb1220eb 100644
+--- a/torch/csrc/jit/passes/quantization/quantization_type.h
++++ b/torch/csrc/jit/passes/quantization/quantization_type.h
+@@ -8,4 +8,5 @
+ #pragma once
+ #include <ostream>
++#include <cstdint>
+
+ namespace torch {
+ namespace jit {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -811,13 +811,17 @@ let
     torch = [
       pkgs.cudaPackages_11_8.cuda_cudart.dev
       pkgs.cudaPackages_11_8.cuda_nvrtc.dev
-      pkgs.cudaPackages_11_8.cuda_nvrtc.lib
+      # pkgs.cudaPackages_11_8.cuda_nvrtc.lib
+      pkgs.cudaPackages_11_8.cuda_cccl.dev
       pkgs.cudaPackages_11_8.cuda_nvtx.dev
       pkgs.cudaPackages_11_8.cuda_nvcc # no lib or dev?
       pkgs.cudaPackages_11_8.libcusparse.dev
       pkgs.cudaPackages_11_8.libcusolver.dev
       pkgs.cudaPackages_11_8.libcublas.dev
+      pkgs.cudaPackages_11_8.libcurand.dev
+      pkgs.cudaPackages_11_8.libcufft.lib
       pkgs.cudaPackages_11_8.cudnn.dev
+
       # pkgs.python3Packages.torchWithCuda.dev # pulled in by setting env var TORCH_PATH in torch override
     ];
   };
@@ -1843,7 +1847,7 @@ let
 
     torch =
       let
-        libtorch_hack_2_0_1 = pkgs.python3Packages.torch.override
+        libtorch_hack_2_0_1 = pkgs.python311Packages.torch.override
           {
             # protobuf = pkgs.python3Packages.protobuf.override {
             #   protobuf = pkgs.protobuf.override {
@@ -1874,7 +1878,13 @@ let
             # };
             cudaSupport = true;
             rocmSupport = false;
-            cudaPackages = pkgs.cudaPackages_11_8;
+            cudaPackages = pkgs.cudaPackages_11_8.overrideScope (cu-fi: _: {
+              # CuDNN 9 is not supported:
+              # https://github.com/cupy/cupy/issues/8215
+              cudnn = cu-fi.cudnn_8_9;
+            });
+
+            # cudaPackages = pkgs.cudaPackages_11_8;
             effectiveMagma = pkgs.magma-cuda-static.override {
               cudaPackages = pkgs.cudaPackages_11_8;
             };

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1841,7 +1841,47 @@ let
       '';
     });
 
-    torch = old.torch.overrideAttrs (attrs: {
+    torch =
+      let
+        libtorch_hack_2_0_1 = pkgs.python3Packages.torch.override
+          {
+            # protobuf = pkgs.python3Packages.protobuf.override {
+            #   protobuf = pkgs.protobuf.override {
+            #     stdenv = pkgs.gcc13Stdenv;
+            #     abseil-cpp = pkgs.abseil-cpp.override {
+            #       stdenv = pkgs.gcc13Stdenv;
+            #     };
+            #     gtest = pkgs.gtest.override {
+            #       stdenv = pkgs.gcc13Stdenv;
+            #     };
+            #   };
+            # };
+            # tensorboard = pkgs.python3Packages.tensorboard.override {
+
+            #   protobuf = pkgs.python3Packages.protobuf.override {
+            #                   # stdenv = pkgs.gcc13Stdenv;
+
+            #     protobuf = pkgs.protobuf.override {
+            #       stdenv = pkgs.gcc13Stdenv;
+            #       abseil-cpp = pkgs.abseil-cpp.override {
+            #         stdenv = pkgs.gcc13Stdenv;
+            #       };
+            #       gtest = pkgs.gtest.override {
+            #         stdenv = pkgs.gcc13Stdenv;
+            #       };
+            #     };
+            #   };
+            # };
+            cudaSupport = true;
+            rocmSupport = false;
+            cudaPackages = pkgs.cudaPackages_11_8;
+            effectiveMagma = pkgs.magma-cuda-static.override {
+              cudaPackages = pkgs.cudaPackages_11_8;
+            };
+            #stdenv = pkgs.gcc11Stdenv;
+          };
+      in
+      old.torch.overrideAttrs (attrs: {
       # CRAN source is modified, and does not contain lantern source
       src = pkgs.fetchFromGitHub {
         owner = "mlverse";
@@ -1854,7 +1894,7 @@ let
         CUDA = "11.8";
         # May need libtorch 2.0.1
         # Trialled libtorch-bin, missing a header file
-        TORCH_PATH = "${pkgs.python3Packages.torchWithCuda.dev}";
+        TORCH_PATH = "${libtorch_hack_2_0_1.dev}";
       };
 #      cmakeFlags = [
 #        "-DCMAKE_C_COMPILER=${pkgs.gcc11}/bin/cc"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16606,7 +16606,8 @@ with pkgs;
 
   pythonInterpreters = callPackage ./../development/interpreters/python { };
   inherit (pythonInterpreters) python27 python39 python310 python311 python312 python313 python3Minimal pypy27 pypy310 pypy39 rustpython;
-
+  # inherit (pythonInterpreters) python27 python39 python310 python311  python313 python3Minimal pypy27 pypy310 pypy39 rustpython;
+  # python312 = pythonInterpreters.python312.override {stdenv = gcc11Stdenv;};
   # List of extensions with overrides to apply to all Python package sets.
   pythonPackagesExtensions = [ ];
 


### PR DESCRIPTION
## Description of changes

The R package `torch` provides an R interface to `libtorch`, without calling intermediate python code for speed. `torch` can be compiled with CUDA support, allowing R users to work on GPUs. Currently, `torch` is broken in master but not marked as such.

`torch` has a relatively complex setup for an R package. The R code includes an interface to a compiled library, `liblantern`, which interfaces with the API of `libtorch`. CUDA support can be compiled in. During installation, the R code is built, but if the env variable `BUILD_LANTERN` is set to `1`, `torch` will attempt to compile `liblantern` as well. Otherwise, during first use of the package, `torch` will attempt to either build or fetch binaries for `liblantern` and `libtorch`. The fetched binaries need to be patched to work with Nix and NixOS, and the default installation directory is probably in the nix store, so the binaries have to be present during the nix build.

In #271342, I succeeded in downloading the binaries during the build phase and patching them, and I was able to get work done on my local machine with GPU acceleration. I also managed to use the same PR code to run `torch` on an HPC cluster using nix-gl-host.

More recently, #328980 took another approach to downloading the binaries. When `torch` is downloaded as a precompiled binary from CRAN, rather than as source code,  `liblantern` and `libtorch` are included. The binaries still need patching, but the nix code is cleaner, as the correct versions are already bundled together.

Using precompiled binaries in Nixpkgs is not ideal, it goes against the spirit of nixpkgs, as well as duplicating `libtorch` and related CUDA libraries in the nix store. However, `torch` is packaged on CRAN, and therefore it is provided by nixpkgs. It would be a confusing user experience for one CRAN package to require an unusual installation, such as setting up an overlay. I recommend merging one of the binary solutions when they are ready.

This PR aims to compile `torch` and `liblantern` from source, making use of the exisitng CUDA libraries and `libtorch` in nixpkgs. It would make #328980 and #271342 redundant if we can succeed. This PR is a draft because `liblantern` fails to build, and I would like to work with @SomeoneSerge to fix it.

The current issues:

- [ ] `liblantern` fails to build. Build logs below.
- [ ] Nixpkgs does not provide `libtorch` version 2.0.1, which `liblantern` expects
- [ ] CMake warns that the kineto library is not found. As kineto is a monitoring library that `liblantern` does not appear to use, I have not addressed this yet.

Some surprises I encountered while getting this PR to it's current state:

- [X] `liblantern` seems to have a bug in the CMake configuration files. Fixed by substituteInPlace
- [X] The source code on CRAN has the `liblantern` source stripped out. Fixed by overriding the `src` attribute to point to the git repo.
- [X] libtorch-bin in nixpkgs was missing a header file. Fixed by switching to `torchWithCuda.dev`
- [X] CUDA v11 complains about using Gcc>11. Apparently #218265 fixes the GCC version used with CUDA, but gcc11 needed to be included as a build input.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc