### PR TITLE
teamspeak_client: update pluginsdk

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchzip,
   makeWrapper,
   makeDesktopItem,
   zlib,
@@ -22,7 +23,6 @@
   libredirect,
   quazip,
   which,
-  unzip,
   perl,
   llvmPackages,
 }:
@@ -83,15 +83,14 @@ stdenv.mkDerivation rec {
   };
 
   # grab the plugin sdk for the desktop icon
-  pluginsdk = fetchurl {
-    url = "http://dl.4players.de/ts/client/pluginsdk/pluginsdk_3.1.1.1.zip";
-    sha256 = "1bywmdj54glzd0kffvr27r84n4dsd0pskkbmh59mllbxvj0qwy7f";
+  pluginsdk = fetchzip {
+    url = "https://files.teamspeak-services.com/releases/sdk/3.3.1/ts_sdk_3.3.1.zip";
+    hash = "sha256-wx4pBZHpFPoNvEe4xYE80KnXGVda9XcX35ho4R8QxrQ=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     which
-    unzip
     perl # Installer script needs `shasum`
   ];
 
@@ -129,8 +128,7 @@ stdenv.mkDerivation rec {
 
       # Make a desktop item
       mkdir -p $out/share/applications/ $out/share/icons/hicolor/64x64/apps/
-      unzip ${pluginsdk}
-      cp pluginsdk/docs/client_html/images/logo.png $out/share/icons/hicolor/64x64/apps/teamspeak.png
+      cp ${pluginsdk}/doc/_static/logo.png $out/share/icons/hicolor/64x64/apps/teamspeak.png
       cp ${desktopItem}/share/applications/* $out/share/applications/
 
       # Make a symlink to the binary from bin.

--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -110,6 +110,7 @@ stdenv.mkDerivation rec {
     homepage = "https://teamspeak.com/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = {
+      # See distribution-permit.txt for a confirmation that nixpkgs is allowed to distribute TeamSpeak.
       fullName = "Teamspeak client license";
       url = "https://www.teamspeak.com/en/privacy-and-terms/";
       free = false;
@@ -119,38 +120,3 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
   };
 }
-
-/*
-License issues:
-Date: Mon, 10 Dec 2007 19:55:16 -0500
-From: TeamSpeak Sales <sales@tritoncia.com>
-To: 'Marc Weber' <marco-oweber@gmx.de>
-Subject: RE: teamspeak on nix?
-
-Yes, that would be fine.  As long as you are not renting servers or selling
-TeamSpeak then you are more than welcome to distribute it.
-
-Thank you,
-
-TeamSpeak Sales Team
-________________________________
-e-Mail: sales@tritoncia.com
-TeamSpeak: http://www.TeamSpeak.com
-Account Login: https://sales.TritonCIA.com/users
-
-
-
------Original Message-----
-From: Marc Weber [mailto:marco-oweber@gmx.de]
-Sent: Monday, December 10, 2007 5:03 PM
-To: sales@tritoncia.com
-Subject: teamspeak on nix?
-
-Hello,
-
-nix is very young software distribution system (http://nix.cs.uu.nl/)
-I'd like to ask wether you permit us to add teamspeak (server/ client?)
-
-Sincerly
-Marc Weber (small nix contributor)
-*/

--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -1,6 +1,30 @@
-{ lib, stdenv, fetchurl, makeWrapper, makeDesktopItem, zlib, glib, libpng, freetype, openssl
-, xorg, fontconfig, qtbase, qtwebengine, qtwebchannel, qtsvg, qtwebsockets, xkeyboard_config
-, alsa-lib, libpulseaudio ? null, libredirect, quazip, which, unzip, perl, llvmPackages
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  makeDesktopItem,
+  zlib,
+  glib,
+  libpng,
+  freetype,
+  openssl,
+  xorg,
+  fontconfig,
+  qtbase,
+  qtwebengine,
+  qtwebchannel,
+  qtsvg,
+  qtwebsockets,
+  xkeyboard_config,
+  alsa-lib,
+  libpulseaudio ? null,
+  libredirect,
+  quazip,
+  which,
+  unzip,
+  perl,
+  llvmPackages,
 }:
 
 let
@@ -9,12 +33,33 @@ let
 
   libDir = "lib64";
 
-  deps =
-    [ zlib glib libpng freetype xorg.libSM xorg.libICE xorg.libXrender openssl
-      xorg.libXrandr xorg.libXfixes xorg.libXcursor xorg.libXinerama
-      xorg.libxcb fontconfig xorg.libXext xorg.libX11 alsa-lib qtbase qtwebengine qtwebchannel qtsvg
-      qtwebsockets libpulseaudio quazip llvmPackages.libcxx
-    ];
+  deps = [
+    zlib
+    glib
+    libpng
+    freetype
+    xorg.libSM
+    xorg.libICE
+    xorg.libXrender
+    openssl
+    xorg.libXrandr
+    xorg.libXfixes
+    xorg.libXcursor
+    xorg.libXinerama
+    xorg.libxcb
+    fontconfig
+    xorg.libXext
+    xorg.libX11
+    alsa-lib
+    qtbase
+    qtwebengine
+    qtwebchannel
+    qtsvg
+    qtwebsockets
+    libpulseaudio
+    quazip
+    llvmPackages.libcxx
+  ];
 
   desktopItem = makeDesktopItem {
     name = "teamspeak";
@@ -54,23 +99,21 @@ stdenv.mkDerivation rec {
   # ++ exec
   # + PAGER_PATH=
   # it's looking for a dependency and didn't find it. Check the script and make sure the dep is in nativeBuildInputs.
-  unpackPhase =
-    ''
-      echo -e '\ny' | PAGER=cat sh -xe $src
-      cd TeamSpeak*
-    '';
+  unpackPhase = ''
+    echo -e '\ny' | PAGER=cat sh -xe $src
+    cd TeamSpeak*
+  '';
 
-  buildPhase =
-    ''
-      mv ts3client_linux_${arch} ts3client
-      echo "patching ts3client..."
-      patchelf --replace-needed libquazip.so ${quazip}/lib/libquazip1-qt5.so ts3client
-      patchelf \
-        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath ${lib.makeLibraryPath deps}:$(cat $NIX_CC/nix-support/orig-cc)/${libDir} \
-        --force-rpath \
-        ts3client
-    '';
+  buildPhase = ''
+    mv ts3client_linux_${arch} ts3client
+    echo "patching ts3client..."
+    patchelf --replace-needed libquazip.so ${quazip}/lib/libquazip1-qt5.so ts3client
+    patchelf \
+      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath ${lib.makeLibraryPath deps}:$(cat $NIX_CC/nix-support/orig-cc)/${libDir} \
+      --force-rpath \
+      ts3client
+  '';
 
   installPhase =
     ''
@@ -97,9 +140,10 @@ stdenv.mkDerivation rec {
       wrapProgram $out/bin/ts3client \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
         --set QT_PLUGIN_PATH "${qtbase}/${qtbase.qtPluginPrefix}" \
-    '' /* wayland is currently broken, remove when TS3 fixes that */ + ''
-        --set QT_QPA_PLATFORM xcb \
-        --set NIX_REDIRECTS /usr/share/X11/xkb=${xkeyboard_config}/share/X11/xkb
+    '' # wayland is currently broken, remove when TS3 fixes that
+    + ''
+      --set QT_QPA_PLATFORM xcb \
+      --set NIX_REDIRECTS /usr/share/X11/xkb=${xkeyboard_config}/share/X11/xkb
     '';
 
   dontStrip = true;
@@ -115,7 +159,11 @@ stdenv.mkDerivation rec {
       url = "https://www.teamspeak.com/en/privacy-and-terms/";
       free = false;
     };
-    maintainers = with maintainers; [ lhvwb lukegb atemu ];
+    maintainers = with maintainers; [
+      lhvwb
+      lukegb
+      atemu
+    ];
     mainProgram = "ts3client";
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/applications/networking/instant-messengers/teamspeak/distribution-permit.txt
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/distribution-permit.txt
@@ -1,0 +1,32 @@
+License issues:
+Date: Mon, 10 Dec 2007 19:55:16 -0500
+From: TeamSpeak Sales <sales@tritoncia.com>
+To: 'Marc Weber' <marco-oweber@gmx.de>
+Subject: RE: teamspeak on nix?
+
+Yes, that would be fine.  As long as you are not renting servers or selling
+TeamSpeak then you are more than welcome to distribute it.
+
+Thank you,
+
+TeamSpeak Sales Team
+________________________________
+e-Mail: sales@tritoncia.com
+TeamSpeak: http://www.TeamSpeak.com
+Account Login: https://sales.TritonCIA.com/users
+
+
+
+-----Original Message-----
+From: Marc Weber [mailto:marco-oweber@gmx.de]
+Sent: Monday, December 10, 2007 5:03 PM
+To: sales@tritoncia.com
+Subject: teamspeak on nix?
+
+Hello,
+
+nix is very young software distribution system (http://nix.cs.uu.nl/)
+I'd like to ask wether you permit us to add teamspeak (server/ client?)
+
+Sincerly
+Marc Weber (small nix contributor)

--- a/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
@@ -59,43 +59,9 @@ in stdenv.mkDerivation rec {
     description = "TeamSpeak voice communication server";
     homepage = "https://teamspeak.com/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    # See distribution-permit.txt for a confirmation that nixpkgs is allowed to distribute TeamSpeak.
     license = licenses.unfreeRedistributable;
     platforms = platforms.linux;
     maintainers = with maintainers; [ arobyn gerschtli ];
   };
 }
-
-/*
-License issues:
-Date: Mon, 10 Dec 2007 19:55:16 -0500
-From: TeamSpeak Sales <sales@tritoncia.com>
-To: 'Marc Weber' <marco-oweber@gmx.de>
-Subject: RE: teamspeak on nix?
-
-Yes, that would be fine.  As long as you are not renting servers or selling
-TeamSpeak then you are more than welcome to distribute it.
-
-Thank you,
-
-TeamSpeak Sales Team
-________________________________
-e-Mail: sales@tritoncia.com
-TeamSpeak: http://www.TeamSpeak.com
-Account Login: https://sales.TritonCIA.com/users
-
-
-
------Original Message-----
-From: Marc Weber [mailto:marco-oweber@gmx.de]
-Sent: Monday, December 10, 2007 5:03 PM
-To: sales@tritoncia.com
-Subject: teamspeak on nix?
-
-Hello,
-
-nix is very young software distribution system (http://nix.cs.uu.nl/)
-I'd like to ask wether you permit us to add teamspeak (server/ client?)
-
-Sincerly
-Marc Weber (small nix contributor)
-*/


### PR DESCRIPTION
## Description of changes

The old url was not reachable for me. This replaces it with the current version from teamspeak.com and updates the package for it.

In addition:
* move distribution permit email to a separate txt file
* reformat file using nixfmt

Fixes https://github.com/NixOS/nixpkgs/issues/344885

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
