### PR TITLE
playwright-driver.browsers: expose raw fontconfig file

### DIFF
--- a/pkgs/development/web/playwright/chromium.nix
+++ b/pkgs/development/web/playwright/chromium.nix
@@ -1,15 +1,10 @@
 {
   runCommand,
   makeWrapper,
-  makeFontsConf,
+  fontconfig_file,
   chromium,
   ...
 }:
-let
-  fontconfig = makeFontsConf {
-    fontDirectories = [ ];
-  };
-in
 runCommand "playwright-chromium"
   {
     nativeBuildInputs = [
@@ -25,5 +20,5 @@ runCommand "playwright-chromium"
     # as headless nixos test vms.
     makeWrapper ${chromium}/bin/chromium $out/chrome-linux/chrome \
       --set-default SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
-      --set-default FONTCONFIG_FILE ${fontconfig}
+      --set-default FONTCONFIG_FILE ${fontconfig_file}
   ''

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -217,12 +217,15 @@ let
     meta.platforms = lib.platforms.darwin;
   };
 
-  browsers-linux =
+  browsers-linux = lib.makeOverridable (
     {
       withChromium ? true,
       withFirefox ? true,
       withWebkit ? true,
       withFfmpeg ? true,
+      fontconfig_file ? makeFontsConf {
+        fontDirectories = [ ];
+      },
     }:
     let
       browsers =
@@ -242,14 +245,20 @@ let
             # TODO check platform for revisionOverrides
             "${name}-${value.revision}"
             (
-              callPackage ./${name}.nix {
-                inherit suffix system throwSystem;
-                inherit (value) revision;
-              }
+              callPackage ./${name}.nix (
+                {
+                  inherit suffix system throwSystem;
+                  inherit (value) revision;
+                }
+                // lib.optionalAttrs (name == "chromium") {
+                  inherit fontconfig_file;
+                }
+              )
             )
         ) browsers
       )
-    );
+    )
+  );
 in
 {
   playwright-core = playwright-core;


### PR DESCRIPTION
## Description of changes

we run playwright in CI with pixel-perfect snapshots (well, there is a threshold with masks) but it's very sensitive to using the correct font. Depending on which container or which machine, the generated snapshots would differ. 

So we use playwright with a "pure" font config devoid of the user. 

```
# in the flake
devShells.default = let
          fontconfig_file = pkgs.substitute {
            name = "custom-fontconfig.xml";
            src = ./fonts.xml;
              substitutions = [
                "--replace"
                "@DEJAVU@"
                pkgs.dejavu_fonts.minimal
              ];
          };

          driver = pkgs.playwright-driver;
          playwrightBrowsers = driver.browsers.override ({inherit fontconfig_file;});
    in
         mkShell {
 shellHook = ''
              export PLAYWRIGHT_BROWSERS_PATH=${playwrightBrowsers}
'';        
} 

```
I thought I would upstream that. It was not easy to override the fontconfig file just for one browser so it's overriden for all (but just chromium uses it).  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
