### PR TITLE
python3Packages.mkdocs-material-insiders: init at 9.5.40-insiders-4.53.14

### DIFF
--- a/pkgs/development/python-modules/mkdocs-material-insiders/default.nix
+++ b/pkgs/development/python-modules/mkdocs-material-insiders/default.nix
@@ -1,0 +1,103 @@
+{
+  # Evaluation
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # Build
+  hatchling,
+  hatch-requirements-txt,
+  hatch-nodejs-version,
+  trove-classifiers,
+
+  # Dependencies
+  jinja2,
+  markdown,
+  mkdocs,
+  mkdocs-material-extensions,
+  pygments,
+  pymdown-extensions,
+  babel,
+  colorama,
+  mergedeep,
+  paginate,
+  regex,
+  requests,
+
+  # Optional dependencies
+  mkdocs-minify-plugin,
+  mkdocs-redirects,
+  mkdocs-rss-plugin,
+  mkdocs-git-committers-plugin-2,
+  mkdocs-git-revision-date-localized-plugin,
+  pillow,
+  cairosvg,
+}:
+
+buildPythonPackage rec {
+  pname = "mkdocs-material";
+  version = "9.5.49-insiders-4.53.14";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "squidfunk";
+    repo = "mkdocs-material-insiders";
+    private = true;
+    rev = "refs/tags/${version}";
+    hash = "sha256-o1ptZO8hoNwDEP6G9PiTebyWUSTEOJnwxpMn9K+KcgU=";
+  };
+
+  disabled = pythonOlder "3.8";
+
+  build-system = [
+    hatchling
+    hatch-requirements-txt
+    hatch-nodejs-version
+    trove-classifiers
+  ];
+
+  dependencies = [
+    jinja2
+    markdown
+    mkdocs
+    mkdocs-material-extensions
+    pygments
+    pymdown-extensions
+    babel
+    colorama
+    mergedeep
+    paginate
+    regex
+    requests
+  ];
+
+  optional-dependencies = {
+    recommended = [
+      mkdocs-minify-plugin
+      mkdocs-redirects
+      mkdocs-rss-plugin
+    ];
+
+    git = [
+      mkdocs-git-committers-plugin-2
+      mkdocs-git-revision-date-localized-plugin
+    ];
+
+    imaging = [
+      pillow
+      cairosvg
+    ];
+  };
+
+  pythonImportsCheck = [ "material" ];
+
+  meta = {
+    changelog = "https://github.com/squidfunk/mkdocs-material-insiders/blob/${version}/CHANGELOG";
+    description = "Sponsor's edition of Material for MkDocs";
+    downloadPage = "https://github.com/squidfunk/mkdocs-material-insiders";
+    homepage = "https://squidfunk.github.io/mkdocs-material/insiders";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mahtaran ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8291,6 +8291,8 @@ self: super: with self; {
 
   mkdocs-material-extensions = callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix { };
 
+  mkdocs-material-insiders = callPackage ../development/python-modules/mkdocs-material-insiders { };
+
   mkdocs-mermaid2-plugin = callPackage ../development/python-modules/mkdocs-mermaid2-plugin { };
 
   mkdocs-minify-plugin = callPackage ../development/python-modules/mkdocs-minify-plugin { };


### PR DESCRIPTION
(Same as #343788, renamed branch in my repo. Apologies for spam.)

[Insiders version](https://squidfunk.github.io/mkdocs-material/insiders) of [Material for MkDocs](https://squidfunk.github.io/mkdocs-material)

Depends on #344615

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
