### PR TITLE
openvswitch: remove kernel, add tests

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -740,6 +740,7 @@ in {
   image-contents = handleTest ./image-contents.nix {};
   openvscode-server = handleTest ./openvscode-server.nix {};
   open-webui = runTest ./open-webui.nix;
+  openvswitch = runTest ./openvswitch.nix;
   orangefs = handleTest ./orangefs.nix {};
   os-prober = handleTestOn ["x86_64-linux"] ./os-prober.nix {};
   osquery = handleTestOn ["x86_64-linux"] ./osquery.nix {};

--- a/nixos/tests/openvswitch.nix
+++ b/nixos/tests/openvswitch.nix
@@ -1,0 +1,62 @@
+{
+  name = "openvswitch";
+
+  nodes = {
+    node1 = {
+      virtualisation.vlans = [ 1 ];
+
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+        firewall.enable = false;
+
+        vswitches.vs0 = {
+          interfaces = {
+            eth1 = { };
+          };
+        };
+
+      };
+
+      systemd.network.networks."40-vs0" = {
+        name = "vs0";
+        networkConfig.Address = "10.0.0.1/24";
+      };
+
+    };
+
+    node2 = {
+      virtualisation.vlans = [ 1 ];
+
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+        firewall.enable = false;
+
+        vswitches.vs0 = {
+          interfaces = {
+            eth1 = { };
+          };
+        };
+
+      };
+
+      systemd.network.networks."40-vs0" = {
+        name = "vs0";
+        networkConfig.Address = "10.0.0.2/24";
+      };
+    };
+  };
+
+  testScript = # python
+    ''
+      start_all()
+      node1.wait_for_unit("ovsdb.service")
+      node1.wait_for_unit("ovs-vswitchd.service")
+      node2.wait_for_unit("ovsdb.service")
+      node2.wait_for_unit("ovs-vswitchd.service")
+
+      node1.succeed("ping -c3 10.0.0.2")
+      node2.succeed("ping -c3 10.0.0.1")
+    '';
+}

--- a/pkgs/by-name/op/openvswitch/package.nix
+++ b/pkgs/by-name/op/openvswitch/package.nix
@@ -125,7 +125,14 @@ stdenv.mkDerivation rec {
       setuptools
     ]);
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      default = nixosTests.openvswitch;
+      incus = nixosTests.incus-lts.openvswitch;
+    };
+
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     changelog = "https://www.openvswitch.org/releases/NEWS-${version}.txt";

--- a/pkgs/by-name/op/openvswitch/package.nix
+++ b/pkgs/by-name/op/openvswitch/package.nix
@@ -1,39 +1,36 @@
 {
+  withDPDK ? false,
+
   lib,
   stdenv,
-  fetchFromGitHub,
+
   autoconf,
   automake,
+  dpdk,
+  fetchFromGitHub,
   installShellFiles,
   iproute2,
-  kernel ? null,
   libcap_ng,
+  libpcap,
   libtool,
+  makeWrapper,
   nix-update-script,
+  nixosTests,
+  numactl,
   openssl,
   perl,
   pkg-config,
   procps,
   python3,
-  tcpdump,
   sphinxHook,
+  tcpdump,
   util-linux,
   which,
-  makeWrapper,
-  withDPDK ? false,
-  dpdk,
-  numactl,
-  libpcap,
 }:
 
-let
-  _kernel = kernel;
-in
 stdenv.mkDerivation rec {
   pname = if withDPDK then "openvswitch-dpdk" else "openvswitch";
   version = "3.4.0";
-
-  kernel = lib.optional (_kernel != null) _kernel.dev;
 
   src = fetchFromGitHub {
     owner = "openvswitch";
@@ -84,14 +81,11 @@ stdenv.mkDerivation rec {
 
   preConfigure = "./boot.sh";
 
-  configureFlags =
-    [
-      "--localstatedir=/var"
-      "--sharedstatedir=/var"
-      "--sbindir=$(out)/bin"
-    ]
-    ++ (lib.optionals (_kernel != null) [ "--with-linux" ])
-    ++ (lib.optionals withDPDK [ "--with-dpdk=shared" ]);
+  configureFlags = [
+    "--localstatedir=/var"
+    "--sharedstatedir=/var"
+    "--sbindir=$(out)/bin"
+  ] ++ (lib.optionals withDPDK [ "--with-dpdk=shared" ]);
 
   # Leave /var out of this!
   installFlags = [


### PR DESCRIPTION
## Description of changes

- **openvswitch: remove legacy kernel module building**
 As of Linux 3.3 the openvswitch kernel module is part of the mainline kernel.

- **openvswitch: init simple bridge test and add incus test**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
