### PR TITLE
linux: allow building with ld.lld (for LTO)

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -352,7 +352,7 @@ stdenvNoCC.mkDerivation {
     ##
 
     # TODO(@sternenseemann): make a generic strip wrapper?
-    + optionalString (bintools.isGNU or false || bintools.isCCTools or false) ''
+    + optionalString (bintools.isGNU or false || bintools.isLLVM or false || bintools.isCCTools or false) ''
       wrap ${targetPrefix}strip ${./gnu-binutils-strip-wrapper.sh} \
         "${bintools_bin}/bin/${targetPrefix}strip"
     ''

--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -41,7 +41,14 @@ close ANSWERS;
 sub runConfig {
 
     # Run `make config'.
-    my $pid = open2(\*IN, \*OUT, "make -C $ENV{SRC} O=$buildRoot config SHELL=bash ARCH=$ENV{ARCH} CC=$ENV{CC} HOSTCC=$ENV{HOSTCC} HOSTCXX=$ENV{HOSTCXX} $makeFlags");
+    #
+    # We have to pass through the target toolchain, because `make config` checks them for versions. This is
+    # required to get clang LTO working, among other things.
+    my $pid = open2(\*IN, \*OUT,
+                    "make -C $ENV{SRC} O=$buildRoot config"
+                    . " SHELL=bash ARCH=$ENV{ARCH} CC=$ENV{CC} HOSTCC=$ENV{HOSTCC} HOSTCXX=$ENV{HOSTCXX}"
+                    . " LD=$ENV{LD} NM=$ENV{NM} AR=$ENV{AR} OBJCOPY=$ENV{OBJCOPY}"
+                    . " $makeFlags");
 
     # Parse the output, look for questions and then send an
     # appropriate answer.

--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -46,8 +46,7 @@ sub runConfig {
     # required to get clang LTO working, among other things.
     my $pid = open2(\*IN, \*OUT,
                     "make -C $ENV{SRC} O=$buildRoot config"
-                    . " SHELL=bash ARCH=$ENV{ARCH} CC=$ENV{CC} HOSTCC=$ENV{HOSTCC} HOSTCXX=$ENV{HOSTCXX}"
-                    . " LD=$ENV{LD} NM=$ENV{NM} AR=$ENV{AR} OBJCOPY=$ENV{OBJCOPY}"
+                    . " SHELL=bash ARCH=$ENV{ARCH} CROSS_COMPILE=$ENV{CROSS_COMPILE}"
                     . " $makeFlags");
 
     # Parse the output, look for questions and then send an

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -171,34 +171,18 @@ let
 
     buildPhase = ''
       export buildRoot="''${buildRoot:-build}"
-      export HOSTCC=$CC_FOR_BUILD
-      export HOSTCXX=$CXX_FOR_BUILD
-      export HOSTAR=$AR_FOR_BUILD
-      export HOSTLD=$LD_FOR_BUILD
-
-      # Absolute paths for tools avoid any PATH-clobbering issues.
-      export CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc
-      export LD=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}ld
-      export AR=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}ar
-      export NM=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}nm
-      export STRIP=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}strip
-      export OBJCOPY=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objcopy
-      export OBJDUMP=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objdump
-      export READELF=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}readelf
 
       # Get a basic config file for later refinement with $generateConfig.
       make $makeFlags \
           -C . O="$buildRoot" $kernelBaseConfig \
-          ARCH=$kernelArch \
-          HOSTCC=$HOSTCC HOSTCXX=$HOSTCXX HOSTAR=$HOSTAR HOSTLD=$HOSTLD \
-          CC=$CC OBJCOPY=$OBJCOPY OBJDUMP=$OBJDUMP READELF=$READELF \
-          LD=$LD AR=$AR NM=$NM STRIP=$STRIP \
+          ARCH=$kernelArch CROSS_COMPILE=${stdenv.cc.targetPrefix} \
           $makeFlags
 
       # Create the config file.
       echo "generating kernel configuration..."
       ln -s "$kernelConfigPath" "$buildRoot/kernel-config"
-      DEBUG=1 ARCH=$kernelArch KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
+      DEBUG=1 ARCH=$kernelArch CROSS_COMPILE=${stdenv.cc.targetPrefix} \
+        KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
         PREFER_BUILTIN=$preferBuiltin BUILD_ROOT="$buildRoot" SRC=. MAKE_FLAGS="$makeFlags" \
         perl -w $generateConfig
     '';

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -176,12 +176,23 @@ let
       export HOSTAR=$AR_FOR_BUILD
       export HOSTLD=$LD_FOR_BUILD
 
+      # Absolute paths for tools avoid any PATH-clobbering issues.
+      export CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc
+      export LD=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}ld
+      export AR=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}ar
+      export NM=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}nm
+      export STRIP=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}strip
+      export OBJCOPY=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objcopy
+      export OBJDUMP=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objdump
+      export READELF=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}readelf
+
       # Get a basic config file for later refinement with $generateConfig.
       make $makeFlags \
           -C . O="$buildRoot" $kernelBaseConfig \
           ARCH=$kernelArch \
           HOSTCC=$HOSTCC HOSTCXX=$HOSTCXX HOSTAR=$HOSTAR HOSTLD=$HOSTLD \
           CC=$CC OBJCOPY=$OBJCOPY OBJDUMP=$OBJDUMP READELF=$READELF \
+          LD=$LD AR=$AR NM=$NM STRIP=$STRIP \
           $makeFlags
 
       # Create the config file.

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -434,6 +434,18 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.linux-kernel kernelPat
   makeFlags = [
     "O=$(buildRoot)"
     "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
+    "LD=${if stdenv.isx86_64 && stdenv.cc.bintools.isLLVM
+          then
+            # The wrapper for ld.lld breaks linking the kernel. We use the unwrapped linker as workaround. See:
+            # https://github.com/NixOS/nixpkgs/issues/321667
+            stdenv.cc.bintools.bintools
+          else stdenv.cc}/bin/${stdenv.cc.targetPrefix}ld"
+    "AR=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}ar"
+    "NM=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}nm"
+    "STRIP=${stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip"
+    "OBJCOPY=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objcopy"
+    "OBJDUMP=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objdump"
+    "READELF=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}readelf"
     "HOSTCC=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
     "HOSTLD=${buildPackages.stdenv.cc.bintools}/bin/${buildPackages.stdenv.cc.targetPrefix}ld"
     "ARCH=${stdenv.hostPlatform.linuxArch}"

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -433,24 +433,14 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.linux-kernel kernelPat
   # Absolute paths for compilers avoid any PATH-clobbering issues.
   makeFlags = [
     "O=$(buildRoot)"
-    "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
-    "LD=${if stdenv.isx86_64 && stdenv.cc.bintools.isLLVM
-          then
-            # The wrapper for ld.lld breaks linking the kernel. We use the unwrapped linker as workaround. See:
-            # https://github.com/NixOS/nixpkgs/issues/321667
-            stdenv.cc.bintools.bintools
-          else stdenv.cc}/bin/${stdenv.cc.targetPrefix}ld"
-    "AR=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}ar"
-    "NM=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}nm"
-    "STRIP=${stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip"
-    "OBJCOPY=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objcopy"
-    "OBJDUMP=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objdump"
-    "READELF=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}readelf"
-    "HOSTCC=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
-    "HOSTLD=${buildPackages.stdenv.cc.bintools}/bin/${buildPackages.stdenv.cc.targetPrefix}ld"
     "ARCH=${stdenv.hostPlatform.linuxArch}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+  ] ++ lib.optionals (stdenv.isx86_64 && stdenv.cc.bintools.isLLVM) [
+    # The wrapper for ld.lld breaks linking the kernel. We use the
+    # unwrapped linker as workaround. See:
+    #
+    # https://github.com/NixOS/nixpkgs/issues/321667
+    "LD=${stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ld"
   ] ++ (stdenv.hostPlatform.linux-kernel.makeFlags or [])
     ++ extraMakeFlags;
 


### PR DESCRIPTION
Even when building the Linux kernel with a `stdenv` where the linker is `ld.lld` instead of binutils `ld`, the build picks up binutils `ld` for linking. This prevents features that require `ld.lld` from working, such as LTO.

Fix by being more specific about which tools we want to build with. This extends what manual-config.nix has already done for quite a while.

I've used the following to get `ld.ldd` as linker:

```nix
# clang-kernels.nix
let
  pkgs = import ./. {};
  pkgsLLVM = pkgs.pkgsLLVM;
in {
  linux_llvm = pkgsLLVM.linux_latest;
}

```

## Things left to be done

- [x] Check whether `make config` recognizes the right linker
- [x] Resolve build failure
  - `nix-build clang-kernel.nix -A linux_llvm` currently fails:

```console
# LD      arch/x86/boot/setup.elf
  /nix/store/zb769plpdp2cj3yj43zp666qsyqyw4r2-x86_64-unknown-linux-gnu-clang-wrapper-18.1.8/bin/x86_64-unknown-linux-gnu-ld -m elf_x86_64 -z noexecstack  -m e
lf_i386 -z noexecstack -T ../arch/x86/boot/setup.ld arch/x86/boot/a20.o arch/x86/boot/bioscall.o arch/x86/boot/cmdline.o arch/x86/boot/copy.o arch/x86/boot/cp
u.o arch/x86/boot/cpuflags.o arch/x86/boot/cpucheck.o arch/x86/boot/early_serial_console.o arch/x86/boot/edd.o arch/x86/boot/header.o arch/x86/boot/main.o arc
h/x86/boot/memory.o arch/x86/boot/pm.o arch/x86/boot/pmjump.o arch/x86/boot/printf.o arch/x86/boot/regs.o arch/x86/boot/string.o arch/x86/boot/tty.o arch/x86/
boot/video.o arch/x86/boot/video-mode.o arch/x86/boot/version.o arch/x86/boot/video-vga.o arch/x86/boot/video-vesa.o arch/x86/boot/video-bios.o -o arch/x86/bo
ot/setup.elf
x86_64-unknown-linux-gnu-ld: error: ../arch/x86/boot/setup.ld:15: unable to move location counter (0x204) backward to 0x1ef for section '.bstext'
make[2]: *** [../arch/x86/boot/Makefile:93: arch/x86/boot/setup.elf] Error 1
make[1]: *** [../arch/x86/Makefile:302: bzImage] Error 2
make[1]: *** Waiting for unfinished jobs....

```

- [x] Check for build regressions in GCC kernels 
- [x] Check whether LTO works
- [x] Check whether cross-compiling works

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
