### PR TITLE
ocamlPackages.lsp: 1.18.0 → 1.19.0

### DIFF
--- a/pkgs/development/ocaml-modules/linol/default.nix
+++ b/pkgs/development/ocaml-modules/linol/default.nix
@@ -12,7 +12,13 @@ rec {
     hash = "sha256-MwEisPJdzZN1VRnssotvExNMYOQdffS+Y2B8ZSUDVfo=";
   };
 
-  propagatedBuildInputs = [ yojson logs lsp ppx_yojson_conv_lib trace ];
+  propagatedBuildInputs = [
+    yojson
+    logs
+    (lsp.override { version = "1.18.0"; })
+    ppx_yojson_conv_lib
+    trace
+  ];
 
   meta = with lib; {
     description = "LSP server library";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -8,7 +8,9 @@
 , lib
 , ocaml
 , version ?
-    if lib.versionAtLeast ocaml.version "4.14" then
+    if lib.versionAtLeast ocaml.version "5.02" then
+      "1.19.0"
+    else if lib.versionAtLeast ocaml.version "4.14" then
       "1.18.0"
     else if lib.versionAtLeast ocaml.version "4.13" then
       "1.10.5"
@@ -19,6 +21,11 @@
 }:
 
 let params = {
+  "1.19.0" = {
+    name = "lsp";
+    minimalOCamlVersion = "5.02";
+    sha256 = "sha256-54PZ8af4nOG/TJFIqjSiKDaL0Um7zKQ96AtFkiHe5ew=";
+  };
   "1.18.0" = {
     name = "lsp";
     minimalOCamlVersion = "4.14";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -22,7 +22,9 @@
 , ocamlformat-rpc-lib
 , ocaml
 , version ?
-    if lib.versionAtLeast ocaml.version "4.14" then
+    if lib.versionAtLeast ocaml.version "5.02" then
+      "1.19.0"
+    else if lib.versionAtLeast ocaml.version "4.14" then
       "1.18.0"
     else if lib.versionAtLeast ocaml.version "4.13" then
       "1.10.5"


### PR DESCRIPTION
## Description of changes

Support for OCaml 5.2.

https://raw.githubusercontent.com/ocaml/ocaml-lsp/refs/tags/1.19.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
