### PR TITLE
lib/modules: Improve error when loading a flake as a module

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -354,12 +354,7 @@ let
           else if m._type == "if" || m._type == "override" then
             loadModule args fallbackFile fallbackKey { config = m; }
           else
-            throw (
-              "Could not load a value as a module, because it is of type ${lib.strings.escapeNixString m._type}"
-              + optionalString (fallbackFile != unknownModule) ", in file ${toString fallbackFile}."
-              + optionalString (m._type == "configuration") " If you do intend to import this configuration, please only import the modules that make up the configuration. You may have to create a `let` binding, file or attribute to give yourself access to the relevant modules.\nWhile loading a configuration into the module system is a very sensible idea, it can not be done cleanly in practice."
-               # Extended explanation: That's because a finalized configuration is more than just a set of modules. For instance, it has its own `specialArgs` that, by the nature of `specialArgs` can't be loaded through `imports` or the the `modules` argument. So instead, we have to ask you to extract the relevant modules and use those instead. This way, we keep the module system comparatively simple, and hopefully avoid a bad surprise down the line.
-            )
+            throw (messages.not_a_module { inherit fallbackFile; value = m; _type = m._type; expectedClass = class; })
         else if isList m then
           let defs = [{ file = fallbackFile; value = m; }]; in
           throw "Module imports can't be nested lists. Perhaps you meant to remove one level of lists? Definitions: ${showDefs defs}"
@@ -1449,6 +1444,110 @@ let
         ;
       collectModules = collectModules null;
     };
+
+  /**
+    Error messages produced by the module system.
+
+    We factor these out to improve the flow when reading the code.
+
+    Functions in `messages` that produce error messages are spelled in
+    lower_snake_case. This goes against the convention in order to make the
+    error message implementation more readable, and to visually distinguish
+    them from other functions in the module system.
+   */
+  messages = let
+    inherit (lib.strings) concatMapStringsSep escapeNixString trim;
+    /** "" or ", in file FOO" */
+    into_fallback_file_maybe = file:
+      optionalString
+        (file != null && file != unknownModule)
+        ", while trying to load a module into ${toString file}";
+
+    /** Format text with one line break between each list item. */
+    lines = concatMapStringsSep "\n" trim;
+
+    /** Format text with two line break between each list item. */
+    paragraphs = concatMapStringsSep "\n\n" trim;
+
+    /**
+      ```
+      optionalMatch
+        { foo = "Foo result";
+          bar = "Bar result";
+        } "foo"
+        ==  [ "Foo result" ]
+
+      optionalMatch { foo = "Foo"; } "baz"  ==  [ ]
+
+      optionalMatch { foo = "Foo"; } true   ==  [ ]
+      ```
+     */
+    optionalMatch = cases: value:
+      if isString value && cases?${value}
+      then [ cases.${value} ]
+      else [];
+
+    # esc = builtins.fromJSON "\"\\u001b\"";
+    esc = builtins.fromJSON "\"\\u001b\"";
+    # Bold purple for warnings
+    warn = s: "${esc}[1;35m${s}${esc}[0m";
+    # Bold green for suggestions
+    good = s: "${esc}[1;32m${s}${esc}[0m";
+    # Bold, default color for code
+    code = s: "${esc}[1m${s}${esc}[0m";
+
+  in {
+
+    /** When load a value with a (wrong) _type as a module  */
+    not_a_module = { fallbackFile, value, _type, expectedClass ? null }:
+      paragraphs (
+        [ ''
+            Expected a module, but found a value of type ${warn (escapeNixString _type)}${into_fallback_file_maybe fallbackFile}.
+            A module is typically loaded by adding it the ${code "imports = [ ... ];"} attribute of an existing module, or in the ${code "modules = [ ... ];"} argument of various functions.
+            Please make sure that each of the list items is a module, and not a different kind of value.
+          ''
+        ]
+        ++ (optionalMatch
+          {
+            "configuration" = trim ''
+              If you really mean to import this configuration, instead please only import the modules that make up the configuration.
+              You may have to create a `let` binding, file or attribute to give yourself access to the relevant modules.
+              While loading a configuration into the module system is a very sensible idea, it can not be done cleanly in practice.
+            '';
+            # ^^ Extended explanation: That's because a finalized configuration is more than just a set of modules. For instance, it has its own `specialArgs` that, by the nature of `specialArgs` can't be loaded through `imports` or the the `modules` argument. So instead, we have to ask you to extract the relevant modules and use those instead. This way, we keep the module system comparatively simple, and hopefully avoid a bad surprise down the line.
+
+            "flake" = lines
+              ([(trim ''
+                Perhaps you forgot to select an attribute name?
+                Instead of, for example,
+                    ${warn "inputs.someflake"}
+                you need to write something like
+                    ${warn "inputs.someflake"}${
+                      if expectedClass == null
+                      then good ".modules.someApp.default"
+                      else good ".modules.${expectedClass}.default"
+
+                    }
+            '')]
+            ++ optionalMatch
+              { # We'll no more than 5 custom suggestions here.
+                # Please switch to `.modules.${class}` in your Module System application.
+                "nixos" = trim ''
+                  or
+                      ${warn "inputs.someflake"}${good ".nixosModules.default"}
+                '';
+                "darwin" = trim ''
+                  or
+                      ${warn "inputs.someflake"}${good ".darwinModules.default"}
+                '';
+              }
+              expectedClass
+            );
+          }
+          _type
+        )
+      );
+  };
 
 in
 private //

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -534,9 +534,10 @@ checkConfigError 'The module .*/module-class-is-darwin.nix was imported into nix
 checkConfigError 'A submoduleWith option is declared multiple times with conflicting class values "darwin" and "nixos".' config.sub.mergeFail.config ./class-check.nix
 
 # _type check
-checkConfigError 'Could not load a value as a module, because it is of type "flake", in file .*/module-imports-_type-check.nix' config.ok.config ./module-imports-_type-check.nix
+checkConfigError 'Expected a module, but found a value of type .*"flake".*, while trying to load a module into .*/module-imports-_type-check.nix' config.ok.config ./module-imports-_type-check.nix
 checkConfigOutput '^true$' "$@" config.enable ./declare-enable.nix ./define-enable-with-top-level-mkIf.nix
-checkConfigError 'Could not load a value as a module, because it is of type "configuration", in file .*/import-configuration.nix.*please only import the modules that make up the configuration.*' config ./import-configuration.nix
+checkConfigError 'Expected a module, but found a value of type .*"configuration".*, while trying to load a module into .*/import-configuration.nix.' config ./import-configuration.nix
+checkConfigError 'please only import the modules that make up the configuration' config ./import-configuration.nix
 
 # doRename works when `warnings` does not exist.
 checkConfigOutput '^1234$' config.c.d.e ./doRename-basic.nix


### PR DESCRIPTION
## Description of changes

Loading a flake, or any other `_type`d value into the module system is an error that already had a custom error message, but it wasn't very good.

This PR
- improves the writing style and accuracy
- handles a `_type == "flake"` specially, to make a meaningful suggestion for cases like
  `imports = [ inputs.simple-nixos-mailserver ];`
- separates out the extensive error message logic from the main code
- adds formatting

New message:

Input

```nix
nix-repl> nixos { _file = "foo"; imports = [ ({ _type = "flake"; }) ]; }
```
            
![Screenshot from 2024-09-26 18-44-59](https://github.com/user-attachments/assets/b8bc51c1-c261-4708-9b5b-70ec56b20879)

(indented line overflow can't be handled well inside the Nix language)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
