### PR TITLE
music-assistant: fix evaluation of provider packages

### DIFF
--- a/pkgs/by-name/mu/music-assistant/ffmpeg.patch
+++ b/pkgs/by-name/mu/music-assistant/ffmpeg.patch
@@ -1,8 +1,8 @@
 diff --git a/music_assistant/server/helpers/audio.py b/music_assistant/server/helpers/audio.py
-index 6b7b5c8e..ec3b92d7 100644
+index 80310604..0a72bcfc 100644
 --- a/music_assistant/server/helpers/audio.py
 +++ b/music_assistant/server/helpers/audio.py
-@@ -214,7 +214,7 @@ async def crossfade_pcm_parts(
+@@ -74,7 +74,7 @@ async def crossfade_pcm_parts(
          await outfile.write(fade_out_part)
      args = [
          # generic args
@@ -11,16 +11,16 @@ index 6b7b5c8e..ec3b92d7 100644
          "-hide_banner",
          "-loglevel",
          "quiet",
-@@ -277,7 +277,7 @@ async def strip_silence(
+@@ -135,7 +135,7 @@ async def strip_silence(
+     reverse: bool = False,
  ) -> bytes:
      """Strip silence from begin or end of pcm audio using ffmpeg."""
-     fmt = ContentType.from_bit_depth(bit_depth)
 -    args = ["ffmpeg", "-hide_banner", "-loglevel", "quiet"]
 +    args = ["@ffmpeg@", "-hide_banner", "-loglevel", "quiet"]
      args += [
          "-acodec",
-         fmt.name.lower(),
-@@ -824,7 +824,7 @@ async def get_ffmpeg_stream(
+         pcm_format.content_type.name.lower(),
+@@ -812,7 +812,7 @@ async def get_file_stream(
  async def check_audio_support() -> tuple[bool, bool, str]:
      """Check if ffmpeg is present (with/without libsoxr support)."""
      # check for FFmpeg presence
@@ -29,7 +29,7 @@ index 6b7b5c8e..ec3b92d7 100644
      ffmpeg_present = returncode == 0 and "FFmpeg" in output.decode()
  
      # use globals as in-memory cache
-@@ -878,7 +878,7 @@ async def get_silence(
+@@ -866,7 +866,7 @@ async def get_silence(
          return
      # use ffmpeg for all other encodings
      args = [
@@ -38,7 +38,11 @@ index 6b7b5c8e..ec3b92d7 100644
          "-hide_banner",
          "-loglevel",
          "quiet",
-@@ -972,7 +972,7 @@ def get_ffmpeg_args(
+diff --git a/music_assistant/server/helpers/ffmpeg.py b/music_assistant/server/helpers/ffmpeg.py
+index 0aaa9dcf..88cd9cdb 100644
+--- a/music_assistant/server/helpers/ffmpeg.py
++++ b/music_assistant/server/helpers/ffmpeg.py
+@@ -200,7 +200,7 @@ def get_ffmpeg_args(
  
      # generic args
      generic_args = [
@@ -48,21 +52,21 @@ index 6b7b5c8e..ec3b92d7 100644
          "-loglevel",
          loglevel,
 diff --git a/music_assistant/server/helpers/tags.py b/music_assistant/server/helpers/tags.py
-index d17b55f6..b7b56c04 100644
+index c60ea526..162c4ab7 100644
 --- a/music_assistant/server/helpers/tags.py
 +++ b/music_assistant/server/helpers/tags.py
-@@ -380,7 +380,7 @@ async def parse_tags(
-     file_path = input_file if isinstance(input_file, str) else "-"
- 
+@@ -401,7 +401,7 @@ async def parse_tags(input_file: str, file_size: int | None = None) -> AudioTags
+     Input_file may be a (local) filename or URL accessible by ffmpeg.
+     """
      args = (
 -        "ffprobe",
 +        "@ffprobe@",
          "-hide_banner",
          "-loglevel",
          "fatal",
-@@ -471,7 +471,7 @@ async def get_embedded_image(input_file: str | AsyncGenerator[bytes, None]) -> b
+@@ -462,7 +462,7 @@ async def get_embedded_image(input_file: str) -> bytes | None:
+     Input_file may be a (local) filename or URL accessible by ffmpeg.
      """
-     file_path = input_file if isinstance(input_file, str) else "-"
      args = (
 -        "ffmpeg",
 +        "@ffmpeg@",

--- a/pkgs/by-name/mu/music-assistant/frontend.nix
+++ b/pkgs/by-name/mu/music-assistant/frontend.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "music-assistant-frontend";
-  version = "2.8.12";
+  version = "2.8.13";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-QqjryLHEpsdcZkIu/QmrQ0t9u4PysnE7FTXsIWBz7tk=";
+    hash = "sha256-bbNIYVFASAdeF1c+Nrcb92wMEBhrCMI8NdQvYhGvbLI=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -24,14 +24,14 @@ in
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.2.3";
+  version = "2.2.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     rev = "refs/tags/${version}";
-    hash = "sha256-7PIyo3srKwftakDiaxvZjrzo/1I9LGUwG+QGfIU5pRA=";
+    hash = "sha256-BEbcIq+qtJ1OffT2we6qajzvDYDu09rMcmJF1F06xZQ=";
   };
 
   patches = [
@@ -91,8 +91,14 @@ python.pkgs.buildPythonApplication rec {
     pytest-cov-stub
     pytestCheckHook
     syrupy
+    pytest-timeout
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
+
+  pytestFlagsArray = [
+    # blocks in setup
+    "--deselect=tests/server/providers/jellyfin/test_init.py::test_initial_sync"
+  ];
 
   pythonImportsCheck = [ "music_assistant" ];
 

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -3,11 +3,11 @@
 {
   version = "2.2.3";
   providers = {
-    airplay = [
+    airplay = ps: [
     ];
-    apple_music = [
+    apple_music = ps: [
     ]; # missing pywidevine
-    builtin = [
+    builtin = ps: [
     ];
     chromecast = ps: with ps; [
       pychromecast
@@ -18,11 +18,11 @@
     dlna = ps: with ps; [
       async-upnp-client
     ];
-    fanarttv = [
+    fanarttv = ps: [
     ];
-    filesystem_local = [
+    filesystem_local = ps: [
     ];
-    filesystem_smb = [
+    filesystem_smb = ps: [
     ];
     fully_kiosk = ps: with ps; [
       python-fullykiosk
@@ -30,12 +30,12 @@
     hass = ps: with ps; [
       hass-client
     ];
-    hass_players = [
+    hass_players = ps: [
     ];
     jellyfin = ps: with ps; [
       aiojellyfin
     ];
-    musicbrainz = [
+    musicbrainz = ps: [
     ];
     opensubsonic = ps: with ps; [
       py-opensonic
@@ -43,7 +43,7 @@
     plex = ps: with ps; [
       plexapi
     ];
-    qobuz = [
+    qobuz = ps: [
     ];
     radiobrowser = ps: with ps; [
       radios
@@ -60,23 +60,23 @@
       soco
       sonos-websocket
     ];
-    soundcloud = [
+    soundcloud = ps: [
     ]; # missing soundcloudpy
     spotify = ps: with ps; [
       pkce
     ];
-    template_player_provider = [
+    template_player_provider = ps: [
     ];
-    test = [
+    test = ps: [
     ];
-    theaudiodb = [
+    theaudiodb = ps: [
     ];
     tidal = ps: with ps; [
       tidalapi
     ];
-    tunein = [
+    tunein = ps: [
     ];
-    ugp = [
+    ugp = ps: [
     ];
     ytmusic = ps: with ps; [
       yt-dlp

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,7 +1,7 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.2.3";
+  version = "2.2.6";
   providers = {
     airplay = ps: [
     ];

--- a/pkgs/by-name/mu/music-assistant/update-providers.py
+++ b/pkgs/by-name/mu/music-assistant/update-providers.py
@@ -24,7 +24,7 @@ TEMPLATE = """# Do not edit manually, run ./update-providers.py
   version = "{{ version }}";
   providers = {
 {%- for provider in providers | sort(attribute='domain') %}
-    {{ provider.domain }} = {% if provider.available %}ps: with ps; {% endif %}[
+    {{ provider.domain }} = {% if provider.available %}ps: with ps;{% else %}ps:{% endif %} [
 {%- for requirement in provider.available | sort %}
       {{ requirement }}
 {%- endfor %}


### PR DESCRIPTION
When provider packages have no dependencies we still need to make them a function, as to have a generic interface to transform these attributes into python packages of the passed package set.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
