### PR TITLE
amiberry: create desktop file

### DIFF
--- a/pkgs/by-name/am/amiberry/package.nix
+++ b/pkgs/by-name/am/amiberry/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  copyDesktopItems,
   makeWrapper,
   flac,
   libmpeg2,
@@ -13,6 +14,7 @@
   SDL2,
   SDL2_image,
   SDL2_ttf,
+  makeDesktopItem,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    copyDesktopItems
     makeWrapper
   ];
 
@@ -61,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
     cp amiberry $out/bin/
     cp -r abr data $out/
+    install -Dm444 data/amiberry.png $out/share/icons/hicolor/256x256/apps/amiberry.png
     wrapProgram $out/bin/amiberry \
       --set-default AMIBERRY_DATA_DIR $out \
       --run 'AMIBERRY_HOME_DIR="$HOME/.amiberry"' \
@@ -79,6 +83,20 @@ stdenv.mkDerivation (finalAttrs: {
         $AMIBERRY_HOME_DIR/harddrives'
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "amiberry";
+      desktopName = "Amiberry";
+      exec = "amiberry";
+      comment = "Amiga emulator";
+      icon = "amiberry";
+      categories = [
+        "System"
+        "Emulator"
+      ];
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/BlitterStudio/amiberry";


### PR DESCRIPTION
## Description of changes

This adds a desktop icon for Amiberry to the common desktop environments using the [makeDesktopItem](https://nixos.org/manual/nixpkgs/stable/#trivial-builder-makeDesktopItem) builder and the `copyDesktopItems` hook.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
