### PR TITLE
drogon: 1.9.4 → 1.9.7

### DIFF
--- a/pkgs/development/libraries/drogon/default.nix
+++ b/pkgs/development/libraries/drogon/default.nix
@@ -9,21 +9,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "drogon";
-  version = "1.9.4";
+  version = "1.9.7";
 
   src = fetchFromGitHub {
     owner = "drogonframework";
     repo = "drogon";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-P6blu3EIBzmK1zikFPiV+tvFLfiQhK+cRdClQOhcBSU=";
+    hash = "sha256-YmN02OvCllxADAIicWKaTevrbAsP/ZbnhBd/hjqqz7A=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
-    "-DBUILD_TESTING=${if finalAttrs.finalPackage.doInstallCheck then "ON" else "OFF"}"
-    "-DBUILD_EXAMPLES=OFF"
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doInstallCheck)
+    (lib.cmakeBool "BUILD_EXAMPLES" false)
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/drogon/fix_find_package.patch
+++ b/pkgs/development/libraries/drogon/fix_find_package.patch
@@ -1,13 +1,13 @@
-diff --git a/test.sh b/test.sh
-index f017b9a..027031e 100755
---- a/test.sh
-+++ b/test.sh
-@@ -135,7 +135,7 @@ if [ $os = "windows" ]; then
-   conan install $src_dir -s compiler="Visual Studio" -s compiler.version=16 -sbuild_type=Debug -g cmake_paths
-   cmake_gen="$cmake_gen -DCMAKE_TOOLCHAIN_FILE=conan_paths.cmake -DCMAKE_INSTALL_PREFIX=$src_dir/install"
- fi
--cmake .. $cmake_gen
-+cmake .. $cmake_gen -DDrogon_DIR=$out/lib/cmake/Drogon -DTrantor_DIR=$out/lib/cmake/Trantor
+diff --git i/test.sh w/test.sh
+index 4796ff11..a6627fec 100755
+--- i/test.sh
++++ w/test.sh
+@@ -148,7 +148,7 @@ function do_drogon_ctl_test()
+                               -DCMAKE_POLICY_DEFAULT_CMP0091=NEW \
+                               -DCMAKE_CXX_STANDARD=17"
+     fi
+-    cmake .. $cmake_gen
++    cmake .. $cmake_gen -DDrogon_DIR=$out/lib/cmake/Drogon -DTrantor_DIR=$out/lib/cmake/Trantor
  
- if [ $? -ne 0 ]; then
-     echo "Failed to run CMake for example project"
+     if [ $? -ne 0 ]; then
+         echo "Failed to run CMake for example project"


### PR DESCRIPTION
## Description of changes
[Changelog](https://github.com/drogonframework/drogon/releases)

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
