### PR TITLE
Revert "python3Packages.proton-vpn-network-manager: 0.5.2 -> 0.6.3"

### DIFF
--- a/pkgs/applications/networking/protonvpn-gui/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui/default.nix
@@ -16,6 +16,8 @@
   proton-vpn-killswitch-network-manager,
   proton-vpn-logger,
   proton-vpn-network-manager,
+  proton-vpn-network-manager-openvpn,
+  proton-vpn-network-manager-wireguard,
   proton-vpn-session,
   pycairo,
   pygobject3,
@@ -65,6 +67,8 @@ buildPythonApplication rec {
     proton-vpn-killswitch-network-manager
     proton-vpn-logger
     proton-vpn-network-manager
+    proton-vpn-network-manager-openvpn
+    proton-vpn-network-manager-wireguard
     proton-vpn-session
     pycairo
     pygobject3

--- a/pkgs/development/python-modules/proton-vpn-network-manager-openvpn/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-network-manager-openvpn/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  gobject-introspection,
+  setuptools,
+  proton-core,
+  proton-vpn-network-manager,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "proton-vpn-network-manager-openvpn";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-network-manager-openvpn";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-eDBcpuz37crfAFX6oysB4FCkSmVLyfLJ0R2L0cZgjRo=";
+  };
+
+  nativeBuildInputs = [
+    # Solves Namespace NM not available
+    gobject-introspection
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    proton-core
+    proton-vpn-network-manager
+  ];
+
+  pythonImportsCheck = [ "proton.vpn.backend.linux.networkmanager.protocol" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  meta = {
+    description = "Adds support for the OpenVPN protocol using NetworkManager";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-network-manager-openvpn";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ sebtm ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-network-manager-wireguard/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-network-manager-wireguard/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  gobject-introspection,
+  setuptools,
+  proton-core,
+  proton-vpn-killswitch-network-manager-wireguard,
+  proton-vpn-network-manager,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "proton-vpn-network-manager-wireguard";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "python-proton-vpn-network-manager-wireguard";
+    rev = "v${version}";
+    hash = "sha256-DZXixcm2VwXhbN4buABlkybDgXIg/mbeUVHOpdoj0Kw=";
+  };
+
+  nativeBuildInputs = [
+    # Solves Namespace NM not available
+    gobject-introspection
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    proton-core
+    proton-vpn-killswitch-network-manager-wireguard
+    proton-vpn-network-manager
+  ];
+
+  preCheck = ''
+    # Needed for Permission denied: '/homeless-shelter'
+    export HOME=$(mktemp -d)
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  meta = {
+    description = "Adds support for the Wireguard protocol using NetworkManager";
+    homepage = "https://github.com/ProtonVPN/python-proton-vpn-network-manager-wireguard";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ sebtm ];
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-network-manager/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-network-manager/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "proton-vpn-network-manager";
-  version = "0.6.3";
+  version = "0.5.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "python-proton-vpn-network-manager";
     rev = "refs/tags/v${version}";
-    hash = "sha256-fbA3kvhU3l20+7irThiTk/fDe60yR4aWxhE3Ol2K7ow=";
+    hash = "sha256-hTJE9sUjPMsE9d0fIA/OhoasumtfsWuFwn0aTm10PN4=";
   };
 
   nativeBuildInputs = [
@@ -53,11 +53,6 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytest-asyncio
   ];
-
-  preCheck = ''
-    # Needed for Permission denied: '/homeless-shelter'
-    export HOME=$(mktemp -d)
-  '';
 
   meta = {
     description = "Provides the necessary functionality for other ProtonVPN components to interact with NetworkManager";

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -400,8 +400,6 @@ mapAliases ({
   prometheus_client = prometheus-client; # added 2021-06-10
   prompt_toolkit = prompt-toolkit; # added 2021-07-22
   protonup = protonup-ng; # Added 2022-11-06
-  proton-vpn-network-manager-openvpn = throw "proton-vpn-network-manager-openvpn functionality was integrated in the proton-vpn-network-manager module"; # added 2024-09-20
-  proton-vpn-network-manager-wireguard = throw "proton-vpn-network-manager-wireguard functionality was integrated in the proton-vpn-network-manager module"; # added 2024-09-20
   proxy_tools = proxy-tools; # added 2023-11-05
   pur = throw "pur has been renamed to pkgs.pur"; # added 2021-11-08
   pushbullet = pushbullet-py;  # Added 2022-10-15

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10678,6 +10678,10 @@ self: super: with self; {
 
   proton-vpn-network-manager = callPackage ../development/python-modules/proton-vpn-network-manager { };
 
+  proton-vpn-network-manager-openvpn = callPackage ../development/python-modules/proton-vpn-network-manager-openvpn { };
+
+  proton-vpn-network-manager-wireguard = callPackage ../development/python-modules/proton-vpn-network-manager-wireguard { };
+
   proton-vpn-session = callPackage ../development/python-modules/proton-vpn-session { };
 
   protonup-ng = callPackage ../development/python-modules/protonup-ng { };


### PR DESCRIPTION
Reverts NixOS/nixpkgs#343208

This update breaks the current version of ProtonVPN and as a result, should only merged again only in the same commit as the ProtonVPN version bump.

The latest version of ProtonVPN is not fully working, so until the Proton dev team is finalizing the architecture rework, this shouldn't be merged. More details can be found here: https://github.com/NixOS/nixpkgs/pull/343204