### PR TITLE
Revert "python3Packages.proton-core: 0.2.0 -> 0.3.3"

### DIFF
--- a/pkgs/development/python-modules/proton-core/default.nix
+++ b/pkgs/development/python-modules/proton-core/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "proton-core";
-  version = "0.3.3";
+  version = "0.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "python-proton-core";
     rev = "refs/tags/v${version}";
-    hash = "sha256-2Drlai/PYzi1z1CtDYfNhol2wamb/HNrvUhj0XsiyHg=";
+    hash = "sha256-IiKmtgcCSe2q3qaNuUSaC/D/vSQzVq7w8VN2Xq81+tQ=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#343131

This update breaks the current version of ProtonVPN and as a result, should only merged again only in the same commit as the ProtonVPN version bump.

The latest version of ProtonVPN is not fully working, so until the Proton dev team is finalizing the architecture rework, this shouldn't be merged. More details can be found here: https://github.com/NixOS/nixpkgs/pull/343204