### PR TITLE
nixos/snapper: use more precise type definition

### DIFF
--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -35,7 +35,13 @@ let
     descriptionClass = "conjunction";
   };
 
-  intOrSafeStr = lib.types.either lib.types.ints.unsigned safeStr;
+  intOrNumberOrRange = lib.types.either lib.types.ints.unsigned (
+    lib.types.strMatching "[[:digit:]]+(\-[[:digit:]]+)?"
+    // {
+      description = "string containing either a number or a range";
+      descriptionClass = "conjunction";
+    }
+  );
 
   configOptions = {
     SUBVOLUME = lib.mkOption {
@@ -95,7 +101,7 @@ let
     };
 
     TIMELINE_LIMIT_HOURLY = lib.mkOption {
-      type = intOrSafeStr;
+      type = intOrNumberOrRange;
       default = 10;
       description = ''
         Limits for timeline cleanup.
@@ -103,7 +109,7 @@ let
     };
 
     TIMELINE_LIMIT_DAILY = lib.mkOption {
-      type = intOrSafeStr;
+      type = intOrNumberOrRange;
       default = 10;
       description = ''
         Limits for timeline cleanup.
@@ -111,7 +117,7 @@ let
     };
 
     TIMELINE_LIMIT_WEEKLY = lib.mkOption {
-      type = intOrSafeStr;
+      type = intOrNumberOrRange;
       default = 0;
       description = ''
         Limits for timeline cleanup.
@@ -119,7 +125,7 @@ let
     };
 
     TIMELINE_LIMIT_MONTHLY = lib.mkOption {
-      type = intOrSafeStr;
+      type = intOrNumberOrRange;
       default = 10;
       description = ''
         Limits for timeline cleanup.
@@ -127,7 +133,7 @@ let
     };
 
     TIMELINE_LIMIT_QUARTERLY = lib.mkOption {
-      type = intOrSafeStr;
+      type = intOrNumberOrRange;
       default = 0;
       description = ''
         Limits for timeline cleanup.
@@ -135,7 +141,7 @@ let
     };
 
     TIMELINE_LIMIT_YEARLY = lib.mkOption {
-      type = intOrSafeStr;
+      type = intOrNumberOrRange;
       default = 10;
       description = ''
         Limits for timeline cleanup.


### PR DESCRIPTION
## Description of changes

Define a more restrictive type definition for the `TIMELINE_LIMIT_*` options to better document what is and isn't valid configuration.

Came up in https://github.com/NixOS/nixpkgs/pull/327418.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
