### PR TITLE
[24.05] emacs: do not allow webkitgtk on Emacs >= 30

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -88,7 +88,7 @@
 , withWebP ? lib.versionAtLeast version "29"
 , withX ? !(stdenv.isDarwin || noGui || withPgtk)
 , withXinput2 ? withX && lib.versionAtLeast version "29"
-, withXwidgets ? !stdenv.isDarwin && !noGui && (withGTK3 || withPgtk)
+, withXwidgets ? !stdenv.hostPlatform.isDarwin && !noGui && (withGTK3 || withPgtk) && (lib.versionOlder version "30") # XXX: upstream bug 66068 precludes newer versions of webkit2gtk (https://lists.gnu.org/archive/html/bug-gnu-emacs/2024-09/msg00695.html)
 , withSmallJaDic ? false
 , withCompressInstall ? true
 


### PR DESCRIPTION
An incompatibility with newer versions of webkit2gtk was revealed
upstream (https://lists.gnu.org/archive/html/bug-gnu-emacs/2024-09/msg00695.html).

(cherry picked from commit a755ead8efa1716cf72cdbe552835270281d65a6)

Backport of https://github.com/NixOS/nixpkgs/pull/344631