### PR TITLE
llm-ollama: init at 0.8.1

### DIFF
--- a/pkgs/by-name/ll/llm-ollama/package.nix
+++ b/pkgs/by-name/ll/llm-ollama/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "llm-ollama";
+  version = "0.8.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "taketwo";
+    repo = "llm-ollama";
+    tag = version;
+    hash = "sha256-9AgHX2FJRXSKZOLt7JR/9Fg4i2HGNQY2vSsJa4+2BGQ=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    # Follows the reasoning from https://github.com/NixOS/nixpkgs/pull/327800#discussion_r1681586659 about including llm in build-system
+    llm
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    ollama
+    pydantic
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  # These tests try to access the filesystem and fail
+  disabledTests = [
+    "test_registered_model"
+    "test_registered_chat_models"
+    "test_registered_embedding_models"
+    "test_registered_models_when_ollama_is_down"
+  ];
+
+  pythonImportCheck = [
+    "llm_ollama"
+  ];
+
+  meta = {
+    description = "LLM plugin providing access to Ollama models using HTTP API";
+    homepage = "https://github.com/taketwo/llm-ollama";
+    changelog = "https://github.com/taketwo/llm-ollama/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ erethon ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This is a plugin for the already packaged `llm` software. [Homepage](https://github.com/taketwo/llm-ollama) of the project.

#268955 and #327800 are PRs that add similar plugins.

Output of running `llm plugins` after building this package:
```
[nix-shell:~/Code/Nix/nixpkgs]$ llm plugins
[
  {
    "name": "llm-ollama",
    "hooks": [
      "register_commands",
      "register_models"
    ],
    "version": "0.5.0"
  }
]
```
Something to note, as mentioned [here](https://github.com/NixOS/nixpkgs/pull/327800#discussion_r1681586659) this is meant to be a plugin for `python3Packages.llm`, so I'm intentionally not including `python3Packages.llm` as a dependency. This results in an import failure if one tries to load this file on it's own without `python3Packages.llm`, but that's to be expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
