### PR TITLE
spotube: add aarch64 support

### DIFF
--- a/pkgs/by-name/sp/spotube/package.nix
+++ b/pkgs/by-name/sp/spotube/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  system,
 
   autoPatchelfHook,
   dpkg,
@@ -77,12 +76,13 @@ let
     '';
   };
 
-  arch = if system == "x86_64-linux" then "x86_64" else "aarch64";
+  arch = if stdenv.isAarch64 then "aarch64" else "x86_64";
   hash =
-    if system == "x86_64-linux" then
-      "sha256-R/yHXx29T/7NNc1L1AmevzXp1k98qnmvOEd3cfSlJuA="
+    if stdenv.isAarch64 then
+      "sha256-s7wrt/7whAvaF0m15bxqhd6g8I7E+tRYLJYrHpTaiwc="
+
     else
-      "sha256-s7wrt/7whAvaF0m15bxqhd6g8I7E+tRYLJYrHpTaiwc=";
+      "sha256-R/yHXx29T/7NNc1L1AmevzXp1k98qnmvOEd3cfSlJuA=";
 
   linux = stdenv.mkDerivation {
     inherit pname version meta;

--- a/pkgs/by-name/sp/spotube/package.nix
+++ b/pkgs/by-name/sp/spotube/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  system,
 
   autoPatchelfHook,
   dpkg,
@@ -38,6 +39,7 @@ let
     maintainers = with lib.maintainers; [ tomasajt ];
     platforms = [
       "x86_64-linux"
+      "aarch64-linux"
       "x86_64-darwin"
       "aarch64-darwin"
     ];
@@ -75,12 +77,19 @@ let
     '';
   };
 
+  arch = if system == "x86_64-linux" then "x86_64" else "aarch64";
+  hash =
+    if system == "x86_64-linux" then
+      "sha256-R/yHXx29T/7NNc1L1AmevzXp1k98qnmvOEd3cfSlJuA="
+    else
+      "sha256-s7wrt/7whAvaF0m15bxqhd6g8I7E+tRYLJYrHpTaiwc=";
+
   linux = stdenv.mkDerivation {
     inherit pname version meta;
 
     src = fetchArtifact {
-      filename = "Spotube-linux-x86_64.deb";
-      hash = "sha256-R/yHXx29T/7NNc1L1AmevzXp1k98qnmvOEd3cfSlJuA=";
+      filename = "Spotube-linux-${arch}.deb";
+      inherit hash;
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/sp/spotube/package.nix
+++ b/pkgs/by-name/sp/spotube/package.nix
@@ -80,7 +80,6 @@ let
   hash =
     if stdenv.isAarch64 then
       "sha256-s7wrt/7whAvaF0m15bxqhd6g8I7E+tRYLJYrHpTaiwc="
-
     else
       "sha256-R/yHXx29T/7NNc1L1AmevzXp1k98qnmvOEd3cfSlJuA=";
 


### PR DESCRIPTION
## Description of changes

Added aarch64-linux support for spotube. 

## Things done

Made the package fetching for Linux more flexible and arch independent.

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
