### PR TITLE
nixos/upower: update percentage defaults

### DIFF
--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -85,7 +85,7 @@ in
 
       percentageLow = lib.mkOption {
         type = lib.types.ints.unsigned;
-        default = 10;
+        default = 20;
         description = ''
           When `usePercentageForPolicy` is
           `true`, the levels at which UPower will consider the
@@ -103,7 +103,7 @@ in
 
       percentageCritical = lib.mkOption {
         type = lib.types.ints.unsigned;
-        default = 3;
+        default = 5;
         description = ''
           When `usePercentageForPolicy` is
           `true`, the levels at which UPower will consider the


### PR DESCRIPTION
## Description of changes

Current defaults were added in aecfea098e17eaf5cd4a80fab440e0e29b12420c, which were in turn based on upstream:
https://gitlab.freedesktop.org/upower/upower/-/blob/28bd86c181e2510ef6a1dc7cfa26f97803698a79/etc/UPower.conf.

Current upstream config:
https://gitlab.freedesktop.org/upower/upower/-/blob/94c91f93f133e23da25a9a7be57db745a30dc5f1/etc/UPower.conf

<details><summary>diff</summary>

```diff
--- /tmp/old-UPower.conf	2024-09-25 16:57:49.073614746 +0100
+++ /tmp/new-UPower.conf	2024-09-25 16:57:52.676666351 +0100
@@ -59,16 +59,16 @@
 # will be used.
 #
 # Defaults:
-# PercentageLow=10
-# PercentageCritical=3
-# PercentageAction=2
-PercentageLow=10
-PercentageCritical=3
-PercentageAction=2
+# PercentageLow=20.0
+# PercentageCritical=5.0
+# PercentageAction=2.0
+PercentageLow=20.0
+PercentageCritical=5.0
+PercentageAction=2.0
 
-# When UsePercentageForPolicy is false, the time remaining at which UPower
-# will consider the battery low, critical, or take action for the critical
-# battery level.
+# When UsePercentageForPolicy is false, the time remaining in seconds at
+# which UPower will consider the battery low, critical, or take action for
+# the critical battery level.
 #
 # If any value is invalid, or not in descending order, the defaults
 # will be used.
@@ -81,6 +81,13 @@
 TimeCritical=300
 TimeAction=120
 
+# Enable the risky CriticalPowerAction-Suspend
+# This option is not recommended, but it is here for users who
+# want to enable the riscky CriticalPowerAction, such as "Suspend"
+# to fulfil their needs.
+# Default is false
+AllowRiskyCriticalPowerAction=false
+
 # The action to take when "TimeAction" or "PercentageAction" above has been
 # reached for the batteries (UPS or laptop batteries) supplying the computer
 #
@@ -88,7 +95,10 @@
 # PowerOff
 # Hibernate
 # HybridSleep
+# Suspend (AllowRiskyCriticalPowerAction should be true to use this option but risky)
+# Ignore (AllowRiskyCriticalPowerAction should be true to use this option but risky)
 #
+# If Suspend isn't available or AllowRiskyCriticalPowerAction=false, HybridSleep will be used
 # If HybridSleep isn't available, Hibernate will be used
 # If Hibernate isn't available, PowerOff will be used
 CriticalPowerAction=HybridSleep
```
</details>

The rest of the changes are already in #341086.

## Things done

Updated option defaults.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
