### PR TITLE
neovimUtils: make installing queries in treesitter grammars optional

### DIFF
--- a/pkgs/applications/editors/neovim/to-nvim-treesitter-grammar.sh
+++ b/pkgs/applications/editors/neovim/to-nvim-treesitter-grammar.sh
@@ -1,0 +1,36 @@
+echo "Sourcing to-nvim-treesitter-grammar.sh"
+
+toNvimTreesitterGrammar() {
+    echo "Executing toNvimTreesitterGrammar"
+
+    mkdir -p "$out/parser"
+    ln -s "$origGrammar/parser" "$out/parser/$grammarName.so"
+
+    if [ "$installQueries" != 1 ]; then
+        echo "Installing queries is disabled: installQueries=$installQueries"
+        return
+    fi
+
+    echo "Installing queries for $grammarName"
+
+    mkdir -p "$out/queries/$grammarName"
+    if [ -d "$origGrammar/queries/$grammarName" ]; then
+        echo "Moving queries from neovim queries dir"
+        for file in "$origGrammar/queries/$grammarName/"*; do
+            ln -s "$file" "$out/queries/$grammarName/$(basename "$file")"
+        done
+    else
+        if [ -d "$origGrammar/queries" ]; then
+            echo "Moving queries from standard queries dir"
+
+            for file in "$origGrammar/queries/"*; do
+                ln -s "$file" "$out/queries/$grammarName/$(basename "$file")"
+            done
+        else
+            echo "Missing queries for $grammarName"
+        fi
+    fi
+}
+
+echo "Using toNvimTreesitterGrammar"
+preDistPhases+=" toNvimTreesitterGrammar"

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -1,6 +1,9 @@
 { lib
+, stdenv
+, makeSetupHook
 , callPackage
 , vimUtils
+, vimPlugins
 , nodejs
 , neovim-unwrapped
 , bundlerEnv
@@ -8,7 +11,6 @@
 , lua
 , python3Packages
 , wrapNeovimUnstable
-, runCommand
 }:
 let
   inherit (vimUtils) toVimPlugin;
@@ -215,35 +217,49 @@ let
         (lib.removePrefix "tree-sitter-")
         (lib.replaceStrings [ "-" ] [ "_" ])
       ];
+
+      nvimGrammars = lib.mapAttrsToList (name: value: value.origGrammar) vimPlugins.nvim-treesitter.grammarPlugins;
+      isNvimGrammar = x: builtins.elem x nvimGrammars;
+
+      toNvimTreesitterGrammar = callPackage ({ }:
+        makeSetupHook {
+          name = "to-nvim-treesitter-grammar";
+        } ./to-nvim-treesitter-grammar.sh) {};
     in
 
-    toVimPlugin (runCommand "treesitter-grammar-${name}"
-      {
-        meta = {
-          platforms = lib.platforms.all;
-        } // grammar.meta;
-      }
-      ''
-        mkdir -p "$out/parser"
-        ln -s "${grammar}/parser" "$out/parser/${name}.so"
+    (toVimPlugin (stdenv.mkDerivation {
+      name = "treesitter-grammar-${name}";
 
-        mkdir -p "$out/queries/${name}"
-        if [ -d "${grammar}/queries/${name}" ]; then
-          echo "moving queries from neovim queries dir"
-          for file in "${grammar}/queries/${name}"*; do
-            ln -s "$file" "$out/queries/${name}/$(basename "$file")"
-          done
-        else
-          if [ -d "${grammar}/queries" ]; then
-            echo "moving queries from standard queries dir"
-            for file in "${grammar}/queries/"*; do
-              ln -s "$file" "$out/queries/${name}/$(basename "$file")"
-            done
-          else
-            echo "missing queries for ${name}"
-          fi
-        fi
-      '');
+      origGrammar = grammar;
+      grammarName = name;
+
+      # Queries for nvim-treesitter's (not just tree-sitter's) officially
+      # supported languages are bundled with nvim-treesitter
+      # Queries from repositories for such languages are incompatible
+      # with nvim's implementation of treesitter.
+      #
+      # We try our best effort to only include queries for niche languages
+      # (there are grammars for them in nixpkgs, but they're in
+      # `tree-sitter-grammars.tree-sitter-*`; `vimPlugins.nvim-treesitter-parsers.*`
+      # only includes officially supported languages)
+      #
+      # To use grammar for a niche language, users usually do:
+      #   packages.all.start = with final.vimPlugins; [
+      #     (pkgs.neovimUtils.grammarToPlugin pkgs.tree-sitter-grammars.tree-sitter-LANG)
+      #   ]
+      #
+      # See also https://github.com/NixOS/nixpkgs/pull/344849#issuecomment-2381447839
+      installQueries = !isNvimGrammar grammar;
+
+      dontUnpack = true;
+      __structuredAttrs = true;
+
+      nativeBuildInputs = [ toNvimTreesitterGrammar ];
+
+      meta = {
+        platforms = lib.platforms.all;
+      } // grammar.meta;
+    }));
 
   /*
     Fork of vimUtils.packDir that additionnally generates a propagated-build-inputs-file that

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -4,17 +4,9 @@ self: super:
 
 let
   inherit (neovimUtils) grammarToPlugin;
-
-  initialGeneratedGrammars = callPackage ./generated.nix {
+  generatedGrammars = callPackage ./generated.nix {
     inherit (tree-sitter) buildGrammar;
   };
-  grammarOverrides = final: prev: {
-    nix = prev.nix.overrideAttrs {
-      # workaround for https://github.com/NixOS/nixpkgs/issues/332580
-      prePatch = "rm queries/highlights.scm";
-    };
-  };
-  generatedGrammars = lib.fix (lib.extends grammarOverrides (_: initialGeneratedGrammars));
 
   generatedDerivations = lib.filterAttrs (_: lib.isDerivation) generatedGrammars;
 

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, tree-sitter, neovim, neovimUtils, runCommand }:
+{ lib, callPackage, tree-sitter, neovim, neovimUtils, runCommand, vimPlugins, tree-sitter-grammars }:
 
 self: super:
 
@@ -61,29 +61,102 @@ in
 
     grammarPlugins = lib.mapAttrs (_: grammarToPlugin) generatedDerivations;
 
-    tests.check-queries =
-      let
-        nvimWithAllGrammars = neovim.override {
-          configure.packages.all.start = [ withAllGrammars ];
-        };
-      in
-      runCommand "nvim-treesitter-check-queries"
-        {
-          nativeBuildInputs = [ nvimWithAllGrammars ];
-          CI = true;
-        }
+    tests = {
+      check-queries =
+        let
+          nvimWithAllGrammars = neovim.override {
+            configure.packages.all.start = [ withAllGrammars ];
+          };
+        in
+        runCommand "nvim-treesitter-check-queries"
+          {
+            nativeBuildInputs = [ nvimWithAllGrammars ];
+            CI = true;
+          }
+          ''
+            touch $out
+            export HOME=$(mktemp -d)
+            ln -s ${withAllGrammars}/CONTRIBUTING.md .
+
+            nvim --headless "+luafile ${withAllGrammars}/scripts/check-queries.lua" | tee log
+
+            if grep -q Warning log; then
+              echo "Error: warnings were emitted by the check"
+              exit 1
+            fi
+          '';
+
+      tree-sitter-queries-are-present-for-custom-grammars =
+        let
+          pluginsToCheck =
+            builtins.map
+            (grammar: grammarToPlugin grammar)
+            # true is here because there is `recurseForDerivations = true`
+            (lib.remove true
+              (lib.attrValues tree-sitter-grammars)
+            );
+        in
+        runCommand "nvim-treesitter-test-queries-are-present-for-custom-grammars"
+        { CI = true; }
+        ''
+          function check_grammar {
+            EXPECTED_FILES="$2/parser/$1.so `ls $2/queries/$1/*.scm`"
+
+            echo
+            echo expected files for $1:
+            echo $EXPECTED_FILES
+
+            # the derivation has only symlinks, and `find` doesn't count them as files
+            # so we cannot use `-type f`
+            for file in `find $2 -not -type d`; do
+              echo checking $file
+              # see https://stackoverflow.com/a/8063284
+              if ! echo "$EXPECTED_FILES" | grep -wqF "$file"; then
+                echo $file is unexpected, exiting
+                exit 1
+              fi
+            done
+          }
+
+          ${lib.concatLines
+            (lib.forEach
+              pluginsToCheck
+              (g: "check_grammar \"${g.grammarName}\" \"${g}\"")
+            )
+          }
+          touch $out
+        '';
+
+      no-queries-for-official-grammars =
+        let
+          pluginsToCheck =
+            # true is here because there is `recurseForDerivations = true`
+            (lib.remove true
+              (lib.attrValues vimPlugins.nvim-treesitter-parsers)
+            );
+        in
+        runCommand "nvim-treesitter-test-no-queries-for-official-grammars"
+        { CI = true; }
         ''
           touch $out
-          export HOME=$(mktemp -d)
-          ln -s ${withAllGrammars}/CONTRIBUTING.md .
 
-          nvim --headless "+luafile ${withAllGrammars}/scripts/check-queries.lua" | tee log
+          function check_grammar {
+            echo checking $1...
+            if [ -d $2/queries ]; then
+              echo Queries dir exists in $1
+              echo This is unexpected, see https://github.com/NixOS/nixpkgs/pull/344849#issuecomment-2381447839
+              exit 1
+            fi
+          }
 
-          if grep -q Warning log; then
-            echo "Error: warnings were emitted by the check"
-            exit 1
-          fi
+          ${lib.concatLines
+            (lib.forEach
+              pluginsToCheck
+              (g: "check_grammar \"${g.grammarName}\" \"${g}\"")
+            )
+          }
         '';
+    };
   };
 
   meta = with lib; (super.nvim-treesitter.meta or { }) // {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #332580 (there should be more, please point out in comments)

Nvim's implementation tree-sitter is mostly incompatible with queries in its grammars. All compatible queries are [vendored with treesitter](https://github.com/nvim-treesitter/nvim-treesitter/tree/f027762/queries). I allow copying queries at all for [this use case](https://github.com/NixOS/nixpkgs/pull/321550#issuecomment-2186207920).

This PR makes queries optional and togglable by override, like this `(neovimUtils.grammarToPlugin tree-sitter-grammars.tree-sitter-nu).overrideAttrs { installQueries = true; }` (or `vimPlugins.nvim-treesitter-parsers.markdown.overrideAttrs { installQueries = true; }`).

By default queries are not installed, because `:TSInstall` also installs only `.so` files. I also didn't want to introduce any breaking change

<details>
<summary>I tested these three use cases:</summary>

Queries are in `queries/LANG/*.scm` (https://github.com/NixOS/nixpkgs/pull/321550#issuecomment-2283363308)
```
(neovimUtils.grammarToPlugin tree-sitter-grammars.tree-sitter-nu).overrideAttrs { installQueries = true; }

$ eza --tree /nix/store/qwkg0v0nxidv1k5vh45vyfig0m91gbr6-vimplugin-treesitter-grammar-nu
/nix/store/qwkg0v0nxidv1k5vh45vyfig0m91gbr6-vimplugin-treesitter-grammar-nu
├── parser
│  └── nu.so -> /nix/store/4m6szkjbhfvlb8rhl974k53akks5v4bw-tree-sitter-nu-grammar-0.22.6/parser
└── queries
   └── nu
      ├── highlights.scm -> /nix/store/4m6szkjbhfvlb8rhl974k53akks5v4bw-tree-sitter-nu-grammar-0.22.6/queries/nu/highlights.scm
      ├── indents.scm -> /nix/store/4m6szkjbhfvlb8rhl974k53akks5v4bw-tree-sitter-nu-grammar-0.22.6/queries/nu/indents.scm
      └── injections.scm -> /nix/store/4m6szkjbhfvlb8rhl974k53akks5v4bw-tree-sitter-nu-grammar-0.22.6/queries/nu/injections.scm
```

Queries are in `queries/*.scm`
```
(neovimUtils.grammarToPlugin tree-sitter-grammars.tree-sitter-koka).overrideAttrs { installQueries = true; }

$ eza --tree /nix/store/zjd0vgkmdr8r654z70kp3i9qw25np4ap-vimplugin-treesitter-grammar-koka
/nix/store/zjd0vgkmdr8r654z70kp3i9qw25np4ap-vimplugin-treesitter-grammar-koka
├── parser
│  └── koka.so -> /nix/store/h0iigwbr000s98xm8gx2814vjzmjb1f9-tree-sitter-koka-grammar-0.22.6/parser
└── queries
   └── koka
      ├── highlights.scm -> /nix/store/h0iigwbr000s98xm8gx2814vjzmjb1f9-tree-sitter-koka-grammar-0.22.6/queries/highlights.scm
      ├── indents.scm -> /nix/store/h0iigwbr000s98xm8gx2814vjzmjb1f9-tree-sitter-koka-grammar-0.22.6/queries/indents.scm
      ├── injections.scm -> /nix/store/h0iigwbr000s98xm8gx2814vjzmjb1f9-tree-sitter-koka-grammar-0.22.6/queries/injections.scm
      └── locals.scm -> /nix/store/h0iigwbr000s98xm8gx2814vjzmjb1f9-tree-sitter-koka-grammar-0.22.6/queries/locals.scm
```

Grammar provided by `vimPlugins.nvim-treesitter-parsers`
```
vimPlugins.nvim-treesitter-parsers.markdown.overrideAttrs { installQueries = true; }

$ eza --tree /nix/store/klwvxgkcg6nfmd4278lzhcfl7hakjw1k-vimplugin-treesitter-grammar-markdown
/nix/store/klwvxgkcg6nfmd4278lzhcfl7hakjw1k-vimplugin-treesitter-grammar-markdown
├── parser
│  └── markdown.so -> /nix/store/6285wnmisgzyc32b220rc4lsqmh4in6n-markdown-grammar-0.0.0+rev=d9287a6/parser
└── queries
   └── markdown
      ├── highlights.scm -> /nix/store/6285wnmisgzyc32b220rc4lsqmh4in6n-markdown-grammar-0.0.0+rev=d9287a6/queries/highlights.scm
      └── injections.scm -> /nix/store/6285wnmisgzyc32b220rc4lsqmh4in6n-markdown-grammar-0.0.0+rev=d9287a6/queries/injections.scm
```
</details>

I would appreciate nixpkgs-review from someone, as I have limited internet, unfortunately.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

CC (everyone related to this topic) @MangoIV @BirdeeHub @teto @humemm

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
