### PR TITLE
hylafaxplus: 7.0.8 -> 7.0.9

### DIFF
--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -32,8 +32,8 @@
 let
 
   pname = "hylafaxplus";
-  version = "7.0.8";
-  hash = "sha512-6wTLVcaHpASy+2i+jeoJ1cM2aLgI5vznGrLd4NCkLHiOxlfCh/ASRaj2Nxt9ZZ5NN/deEwf9tNSZ7MkFZHVsqA==";
+  version = "7.0.9";
+  hash = "sha512-3OJwM4vFC9pzPozPobFLiNNx/Qnkl8BpNNziRUpJNBDLBxjtg/eDm3GnprS2hpt7VUoV4PCsFvp1hxhNnhlUwQ==";
 
   configSite = substituteAll {
     name = "${pname}-config.site";

--- a/pkgs/servers/hylafaxplus/libtiff-4.patch
+++ b/pkgs/servers/hylafaxplus/libtiff-4.patch
@@ -5,7 +5,7 @@ https://bugs.gentoo.org/706154
  				echo '#define TIFFSTRIPBYTECOUNTS uint32_t'
  				echo '#define TIFFVERSION TIFF_VERSION'
  				echo '#define TIFFHEADER TIFFHeader';;
--		4.[0123456])	tiff_runlen_t="uint32_t"
+-		4.[01234567])	tiff_runlen_t="uint32_t"
 +		4.[0-9])	tiff_runlen_t="uint32_t"
  				tiff_offset_t="uint64_t"
  				echo '#define TIFFSTRIPBYTECOUNTS uint64_t'


### PR DESCRIPTION
## Description of changes

Routine update, adds support for libtiff 4.7.0.

Release notes: https://hylafax.sourceforge.io/news/7.0.9.php

Note: In the meantime, [hylafaxplus got moved to `pkgs/by-name`](https://github.com/NixOS/nixpkgs/pull/340566) on `staging` branch ([has already reached `staging-next`](https://nixpk.gs/pr-tracker.html?pr=340566)).  However, git is able to merge the pull request at hand with current `staging` without complaints (I did this for the tests documented below), so that should not lead to conflicts.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More tests, tested on x86-64, with the branch as-is, and again with the branch merged with [a recent version of `staging-next`](https://github.com/NixOS/nixpkgs/tree/fd671be0176def09c0213e74dc59ef89eeeadf9d) that includes [the latest libtiff update](https://github.com/NixOS/nixpkgs/pull/340566):

- [x] `hylafaxplus` builds successfully
- [x] sending and receiving faxes works
- [x] sending to unresponsive or busy number returns the expected error
- [x] sending over a flaky line (random connection interruptions) causes automatic retries as expected

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package built:</summary>
  <ul>
    <li>hylafaxplus</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
