### PR TITLE
python312Packages.ircrobots: 0.6.0 -> 0.7.2

### DIFF
--- a/pkgs/development/python-modules/async-stagger/default.nix
+++ b/pkgs/development/python-modules/async-stagger/default.nix
@@ -1,8 +1,9 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pythonOlder,
+  setuptools,
   pytestCheckHook,
   pytest-asyncio,
   pytest-mock,
@@ -10,16 +11,19 @@
 
 buildPythonPackage rec {
   pname = "async-stagger";
-  version = "0.3.1";
-  format = "setuptools";
+  version = "0.4.0.post1";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.11";
 
-  src = fetchPypi {
-    pname = "async_stagger";
-    inherit version;
-    hash = "sha256-qp81fp79J36aUWqUvegSStXkZ+m8Zcn62qrJjpVqQ9Y=";
+  src = fetchFromGitHub {
+    owner = "twisteroidambassador";
+    repo = "async_stagger";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-uJohc3EsAKevqT0J+N0Cqop3xy0PCM5jsP6YYtx+HuQ=";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -28,8 +32,8 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # RuntimeError: Logic bug in...
-    "test_stagger_coro_gen"
+    # "OSError: [Errno 0] fileno not supported" during teardown
+    "test_create_connected_sock_normal"
   ];
 
   pythonImportsCheck = [ "async_stagger" ];

--- a/pkgs/development/python-modules/ircrobots/default.nix
+++ b/pkgs/development/python-modules/ircrobots/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "ircrobots";
-  version = "0.6.6";
+  version = "0.7.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jesopo";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-mIh3tERwHtGH9eA0AT8Lcnwp1Wn9lQhKkUjuZcOXO/c=";
+    hash = "sha256-slz4AH2Mi21N3aV+OrnoXoQsseS7arW2NuUZARQJsf0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/ircrobots/default.nix
+++ b/pkgs/development/python-modules/ircrobots/default.nix
@@ -2,21 +2,20 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
+  setuptools,
   anyio,
   asyncio-rlock,
   asyncio-throttle,
   ircstates,
   async-stagger,
   async-timeout,
-  python,
+  unittestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "ircrobots";
   version = "0.6.6";
-  format = "setuptools";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jesopo";
@@ -25,10 +24,9 @@ buildPythonPackage rec {
     hash = "sha256-mIh3tERwHtGH9eA0AT8Lcnwp1Wn9lQhKkUjuZcOXO/c=";
   };
 
-  postPatch = ''
-    # too specific pins https://github.com/jesopo/ircrobots/issues/3
-    sed -iE 's/anyio.*/anyio/' requirements.txt
-  '';
+  build-system = [ setuptools ];
+
+  pythonRelaxDeps = true;
 
   propagatedBuildInputs = [
     anyio
@@ -39,9 +37,7 @@ buildPythonPackage rec {
     async-timeout
   ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest test
-  '';
+  nativeCheckInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [ "ircrobots" ];
 

--- a/pkgs/development/python-modules/ircstates/default.nix
+++ b/pkgs/development/python-modules/ircstates/default.nix
@@ -2,36 +2,36 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
+  setuptools,
   irctokens,
   pendulum,
   freezegun,
-  python,
+  unittestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "ircstates";
-  version = "0.12.1";
-  format = "setuptools";
-  disabled = pythonOlder "3.6"; # f-strings
+  version = "0.13.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jesopo";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-F9yOY3YBacyoUzNTvPs7pxp6yNx08tiq1jWQKhGiagc=";
+    hash = "sha256-Mq9aOj6PXzPjaz3ofoPcAbur59oUWffmEg8aHt0v+0Q=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     irctokens
     pendulum
   ];
 
-  nativeCheckInputs = [ freezegun ];
-
-  checkPhase = ''
-    ${python.interpreter} -m unittest test
-  '';
+  nativeCheckInputs = [
+    freezegun
+    unittestCheckHook
+  ];
 
   pythonImportsCheck = [ "ircstates" ];
 

--- a/pkgs/development/python-modules/irctokens/default.nix
+++ b/pkgs/development/python-modules/irctokens/default.nix
@@ -3,14 +3,16 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
+  setuptools,
   pyyaml,
-  python,
+  unittestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "irctokens";
   version = "2.0.2";
-  format = "setuptools";
+  pyproject = true;
+
   disabled = pythonOlder "3.6"; # f-strings
 
   src = fetchFromGitHub {
@@ -20,10 +22,12 @@ buildPythonPackage rec {
     hash = "sha256-Y9NBqxGUkt48hnXxsmfydHkJmWWb+sRrElV8C7l9bpw=";
   };
 
-  nativeCheckInputs = [ pyyaml ];
-  checkPhase = ''
-    ${python.interpreter} -m unittest test
-  '';
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pyyaml
+    unittestCheckHook
+  ];
 
   pythonImportsCheck = [ "irctokens" ];
 


### PR DESCRIPTION
twisteroidambassador/async_stagger@v0.3.1...v0.4.0.post1
https://github.com/jesopo/ircstates/compare/v0.12.1...v0.13.0

Missing tag, broken sdist on ircrobots. Reported upstream.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
