### PR TITLE
keyd: 2.4.3 -> 2.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1016,6 +1016,12 @@
     githubId = 50754358;
     name = "Alex Winter";
   };
+  alfarel = {
+    email = "alfarelcynthesis@proton.me";
+    github = "alfarelcynthesis";
+    githubId = 104072649;
+    name = "Cynth";
+  };
   algram = {
     email = "aliasgram@gmail.com";
     github = "Algram";

--- a/pkgs/tools/inputmethods/keyd/default.nix
+++ b/pkgs/tools/inputmethods/keyd/default.nix
@@ -8,13 +8,13 @@
 }:
 
 let
-  version = "2.4.3";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "rvaiya";
     repo = "keyd";
     rev = "v" + version;
-    hash = "sha256-NhZnFIdK0yHgFR+rJm4cW+uEhuQkOpCSLwlXNQy6jas=";
+    hash = "sha256-pylfQjTnXiSzKPRJh9Jli1hhin/MIGIkZxLKxqlReVo=";
   };
 
   pypkgs = python3.pkgs;

--- a/pkgs/tools/inputmethods/keyd/default.nix
+++ b/pkgs/tools/inputmethods/keyd/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Key remapping daemon for Linux";
     license = licenses.mit;
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ alfarel ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/inputmethods/keyd/default.nix
+++ b/pkgs/tools/inputmethods/keyd/default.nix
@@ -47,10 +47,10 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace-fail /usr ""
+      --replace-fail /usr/local ""
 
-    substituteInPlace keyd.service \
-      --replace-fail /usr/bin $out/bin
+    substituteInPlace keyd.service.in \
+      --replace-fail @PREFIX@ $out
   '';
 
   installFlags = [ "DESTDIR=${placeholder "out"}" ];

--- a/pkgs/tools/inputmethods/keyd/default.nix
+++ b/pkgs/tools/inputmethods/keyd/default.nix
@@ -26,7 +26,7 @@ let
 
     postPatch = ''
       substituteInPlace scripts/${pname} \
-        --replace /bin/sh ${runtimeShell}
+        --replace-fail /bin/sh ${runtimeShell}
     '';
 
     propagatedBuildInputs = with pypkgs; [ xlib ];
@@ -47,10 +47,10 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace /usr ""
+      --replace-fail /usr ""
 
     substituteInPlace keyd.service \
-      --replace /usr/bin $out/bin
+      --replace-fail /usr/bin $out/bin
   '';
 
   installFlags = [ "DESTDIR=${placeholder "out"}" ];


### PR DESCRIPTION
## Description of changes

[Changelog](https://github.com/rvaiya/keyd/blob/master/docs/CHANGELOG.md#v250).
[Request for someone to take over maintainership](https://github.com/NixOS/nixpkgs/issues/344339#issuecomment-2377826745).

Closes: #344339 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
