### PR TITLE
wireshark: 4.2.6 -> 4.4.2

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -25,7 +25,7 @@
 , libpcap
 , libsmi
 , libssh
-, lua5
+, lua5_4
 , lz4
 , makeWrapper
 , minizip
@@ -57,7 +57,7 @@ assert withQt -> qt6 != null;
 
 stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.2.8";
+  version = "4.4.2";
 
   outputs = [ "out" "dev" ];
 
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     repo = "wireshark";
     owner = "wireshark";
     rev = "v${version}";
-    hash = "sha256-QnBETFkYoeBTQFV8g2c/dZjgCXaMtFi1MQUgmkOool8=";
+    hash = "sha256-qeMaj8kRGG1NlDb5j4M/Za2M2Ohh2qhXbzBtQGjrCSo=";
   };
 
   patches = [
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
     libpcap
     libsmi
     libssh
-    lua5
+    lua5_4
     lz4
     minizip
     nghttp2

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -44,7 +44,7 @@
 , speexdsp
 , SystemConfiguration
 , wrapGAppsHook3
-, zlib
+, zlib-ng
 , zstd
 
 , withQt ? true
@@ -118,7 +118,7 @@ stdenv.mkDerivation rec {
     snappy
     spandsp3
     speexdsp
-    zlib
+    zlib-ng
     zstd
   ] ++ lib.optionals withQt (with qt6; [
     qt5compat

--- a/pkgs/applications/networking/sniffers/wireshark/patches/lookup-dumpcap-in-path.patch
+++ b/pkgs/applications/networking/sniffers/wireshark/patches/lookup-dumpcap-in-path.patch
@@ -19,19 +19,21 @@ EDITED by esclear for wireshark 4.0
 
 EDITED by paveloom for wireshark 4.2
 
+EDITED by pabloaul for wireshark 4.4
+
 Signed-off-by: Franz Pletz <fpletz@fnordicwalking.de>
 ---
  capture/capture_sync.c | 13 ++++++++++---
  1 file changed, 10 insertions(+), 3 deletions(-)
 
 diff --git a/capture/capture_sync.c b/capture/capture_sync.c
-index 01e9510a27..e439098298 100644
+index 946dc810db..ef0b6e12cd 100644
 --- a/capture/capture_sync.c
 +++ b/capture/capture_sync.c
-@@ -225,8 +225,15 @@ init_pipe_args(int *argc) {
+@@ -243,8 +243,15 @@ init_pipe_args(int *argc) {
      char *exename;
      char **argv;
-
+ 
 -    /* Find the absolute path of the dumpcap executable. */
 -    exename = get_executable_path("dumpcap");
 +    /* NixOS patch: Look for dumpcap in PATH first, because there may be a
@@ -46,14 +48,12 @@ index 01e9510a27..e439098298 100644
      if (exename == NULL) {
          return NULL;
      }
-@@ -533,7 +540,7 @@ sync_pipe_open_command(char* const argv[], int *data_read_fd,
-         dup2(sync_pipe[PIPE_WRITE], 2);
-         ws_close(sync_pipe[PIPE_READ]);
-         ws_close(sync_pipe[PIPE_WRITE]);
+@@ -596,7 +603,7 @@ sync_pipe_open_command(char **argv, int *data_read_fd,
+         snprintf(sync_id, ARGV_NUMBER_LEN, "%d", sync_pipe[PIPE_WRITE]);
+         argv = sync_pipe_add_arg(argv, &argc, sync_id);
+ #endif
 -        execv(argv[0], argv);
 +        execvp(argv[0], argv);
-         sync_pipe_write_int_msg(2, SP_EXEC_FAILED, errno);
-
+         sync_pipe_write_int_msg(sync_pipe[PIPE_WRITE], SP_EXEC_FAILED, errno);
+ 
          /* Exit with "_exit()", so that we don't close the connection
---
-2.42.0

--- a/pkgs/by-name/cr/credslayer/package.nix
+++ b/pkgs/by-name/cr/credslayer/package.nix
@@ -55,5 +55,8 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/ShellCode33/CredSLayer";
     license = with licenses; [ gpl3Only ];
     maintainers = with maintainers; [ fab ];
+    # broken due to wireshark 4.4 bump
+    # see: https://github.com/NixOS/nixpkgs/pull/344914
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pyshark/default.nix
+++ b/pkgs/development/python-modules/pyshark/default.nix
@@ -4,6 +4,7 @@
   appdirs,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   lxml,
   packaging,
   py,
@@ -29,6 +30,14 @@ buildPythonPackage rec {
 
   # `stripLen` does not seem to work here
   patchFlags = [ "-p2" ];
+
+  patches = [
+    # fixes capture test
+    (fetchpatch {
+      url = "https://github.com/KimiNewt/pyshark/commit/7142c5bf88abcd4c65c81052a00226d6155dda42.patch";
+      hash = "sha256-Ti7cwRyYSbF4a4pEEV9FntNevkV/JVXNqACQWzoma7g=";
+    })
+  ];
 
   sourceRoot = "${src.name}/src";
 


### PR DESCRIPTION
## Description of changes
- wireshark: 
  - 4.2.6 -> 4.4.2 
  - updated git patch offsets 
  - lua implicit 5.2 -> explicit 5.4
  - zlib -> zlib-ng
- pyshark: add https://github.com/KimiNewt/pyshark/pull/670 as a patch (thank you for finding this fpletz)
- credslayer: mark as broken due to failing tests on wireshark 4.4

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
