### PR TITLE
cups: apply patches for CVE-2024-47175

### DIFF
--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchurl
+, fetchpatch
 , pkg-config
 , removeReferencesTo
 , zlib
@@ -31,6 +32,34 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "lib" "dev" "man" ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2024-47175_0.patch";
+      url = "https://github.com/OpenPrinting/cups/commit/9939a70b750edd9d05270060cc5cf62ca98cfbe5.patch";
+      hash = "sha256-Nt6/JwoaHkzFxCl1BuXOQRfki8Oquk2rIwvw7qekTQI=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-47175_1.patch";
+      url = "https://github.com/OpenPrinting/cups/commit/04bb2af4521b56c1699a2c2431c56c05a7102e69.patch";
+      hash = "sha256-ZyvVAv96pK6ldSQf5IOiIXk8xYeNJOWNHX0S5pyn6pw=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-47175_2.patch";
+      url = "https://github.com/OpenPrinting/cups/commit/e0630cd18f76340d302000f2bf6516e99602b844.patch";
+      hash = "sha256-uDUOIwkRGZo+XXheDt+HGsXujtEJ3b4o5yNWdnz5uIY=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-47175_3.patch";
+      url = "https://github.com/OpenPrinting/cups/commit/1e6ca5913eceee906038bc04cc7ccfbe2923bdfd.patch";
+      hash = "sha256-SiYUsa+DUNPua0/r/rvzzRAYra2AP49ImbyWG5RnCI0=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-47175_4.patch";
+      url = "https://github.com/OpenPrinting/cups/commit/2abe1ba8a66864aa82cd9836b37e57103b8e1a3b.patch";
+      hash = "sha256-oeZ3nNmPMkusxZhmmKOCcD/AD+QzkVE8acNXapGK/Ew=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace cups/testfile.c \


### PR DESCRIPTION
## Description of changes

Based on the information provided in https://www.openwall.com/lists/oss-security/2024/09/27/3

https://github.com/OpenPrinting/libppd/security/advisories/GHSA-7xfx-47qg-grp6
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (on top of `master`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
