### PR TITLE
nixos/postgresql: set up sandboxing

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -602,6 +602,11 @@
 
 - `iproute2` now has libbpf support.
 
+- `postgresql` is now [hardened by default](#module-services-postgres-hardening) using the common `systemd` settings for that.
+
+  If you use extensions that are not packaged in nixpkgs, please review whether it still works
+  with the current settings and adjust accordingly if needed.
+
 - `nix.channel.enable = false` no longer implies `nix.settings.nix-path = []`.
   Since Nix 2.13, a `nix-path` set in `nix.conf` cannot be overriden by the `NIX_PATH` configuration variable.
 

--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -364,6 +364,24 @@ postgresql.withJIT.pname
 
 evaluates to `"foobar"`.
 
+## Service hardening {#module-services-postgres-hardening}
+
+The service created by the [`postgresql`-module](#opt-services.postgresql.enable) uses
+several common hardening options from `systemd`, most notably:
+
+* Memory pages must not be both writable and executable (this only applies to non-JIT setups).
+* A system call filter (see {manpage}`systemd.exec(5)` for details on `@system-service`).
+* A stricter default UMask (`0027`).
+* Only sockets of type `AF_INET`/`AF_INET6`/`AF_NETLINK`/`AF_UNIX` allowed.
+* Restricted filesystem access (private `/tmp`, most of the file-system hierachy is mounted read-only, only process directories in `/proc` that are owned by the same user).
+
+The NixOS module also contains necessary adjustments for extensions from `nixpkgs`
+if these are enabled. If an extension or a postgresql feature from `nixpkgs` breaks
+with hardening, it's considered a bug.
+
+When using extensions that are not packaged in `nixpkgs`, hardening adjustments may
+become necessary.
+
 ## Notable differences to upstream {#module-services-postgres-upstream-deviation}
 
 - To avoid circular dependencies between default and -dev outputs, the output of the `pg_config` system view has been removed.

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -623,7 +623,46 @@ in
             TimeoutSec = 120;
 
             ExecStart = "${postgresql}/bin/postgres";
+
+            # Hardening
+            CapabilityBoundingSet = [ "" ];
+            DevicePolicy = "closed";
+            PrivateTmp = false; #breaks wal-receiver test
+            ProtectHome = true;
+            ProtectSystem = "strict";
+            MemoryDenyWriteExecute = true;
+            NoNewPrivileges = true;
+            LockPersonality = true;
+            PrivateDevices = true;
+            PrivateMounts = false; # breaks wal-receiver test
+            ProcSubset = "pid";
+            ProtectClock = true;
+            ProtectControlGroups = true;
+            ProtectHostname = true;
+            ProtectKernelLogs = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectProc = "invisible";
+            RemoveIPC = true;
+            RestrictAddressFamilies = [
+              "AF_INET"
+              "AF_INET6"
+              "AF_NETLINK" # used for network interface enumeration
+              "AF_UNIX"
+            ];
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            SystemCallArchitectures = "native";
+            SystemCallFilter = [
+              "@system-service"
+              "~@privileged @resources"
+            ];
+            UMask = if groupAccessAvailable then "0027" else "0077";
           }
+          (mkIf (cfg.dataDir != "/var/lib/postgresql") {
+            ReadWritePaths = [ cfg.dataDir ];
+          })
           (mkIf (cfg.dataDir == "/var/lib/postgresql/${cfg.package.psqlSchema}") {
             StateDirectory = "postgresql postgresql/${cfg.package.psqlSchema}";
             StateDirectoryMode = if groupAccessAvailable then "0750" else "0700";

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -627,14 +627,14 @@ in
             # Hardening
             CapabilityBoundingSet = [ "" ];
             DevicePolicy = "closed";
-            PrivateTmp = false; #breaks wal-receiver test
+            PrivateTmp = true;
             ProtectHome = true;
             ProtectSystem = "strict";
             MemoryDenyWriteExecute = true;
             NoNewPrivileges = true;
             LockPersonality = true;
             PrivateDevices = true;
-            PrivateMounts = false; # breaks wal-receiver test
+            PrivateMounts = true;
             ProcSubset = "pid";
             ProtectClock = true;
             ProtectControlGroups = true;

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -630,7 +630,7 @@ in
             PrivateTmp = true;
             ProtectHome = true;
             ProtectSystem = "strict";
-            MemoryDenyWriteExecute = true;
+            MemoryDenyWriteExecute = lib.mkDefault (cfg.settings.jit == "off");
             NoNewPrivileges = true;
             LockPersonality = true;
             PrivateDevices = true;

--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -126,6 +126,8 @@ let
       with subtest("Initdb works"):
           machine.succeed("sudo -u postgres initdb -D /tmp/testpostgres2")
 
+      machine.log(machine.execute("systemd-analyze security postgresql.service | grep -v ✓")[1])
+
       machine.shutdown()
     '';
 


### PR DESCRIPTION
Reduces the general exposure of the postgresql.service through systemd hardening options.

I fully expect that I've missed a number of use cases (e.g. through extensions), feedback is welcome!

Here's what `systemd-analye security postgresql.service` thinks of the remaining options:

```
machine:   NAME                                                        DESCRIPTION                                                                    EXPOSURE
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                       0.1
✗ RestrictAddressFamilies=~AF_UNIX                            Service may allocate local sockets                                                  0.1
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                               0.3
✗ PrivateNetwork=                                             Service has access to the host's network                                            0.5
✗ PrivateUsers=                                               Service has access to other users                                                   0.2
✗ PrivateTmp=                                                 Service has access to other software's temporary files                              0.2
✗ DeviceAllow=                                                Service has a device ACL with some special devices: char-rtc:r                      0.1
✗ IPAddressDeny=                                              Service does not define an IP address allow list                                    0.2

→ Overall exposure level for postgresql.service: 1.4 OK :-)
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable: (`nixosTests.postgresql`, `postgresql.tests`)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
