### PR TITLE
php83: 8.3.11 -> 8.3.12, php82: 8.2.23 -> 8.2.24, php81: 8.1.29 -> 8.1.30

### DIFF
--- a/pkgs/development/interpreters/php/8.1.nix
+++ b/pkgs/development/interpreters/php/8.1.nix
@@ -2,8 +2,8 @@
 
 let
   base = callPackage ./generic.nix ((removeAttrs _args [ "fetchpatch" ]) // {
-    version = "8.1.29";
-    hash = "sha256-h6YDEyY/L1M/GA5xknLKXkfNmITU7DyTcgGY6v+uCCc=";
+    version = "8.1.30";
+    hash = "sha256-yxYl5axJuRA3R34+d2e7BiQ0OXGuuZL0eRthivVx0j4=";
     extraPatches = [
       # Fix build with libxml2 2.12+.
       # Patch from https://github.com/php/php-src/commit/0a39890c967aa57225bb6bdf4821aff7a3a3c082

--- a/pkgs/development/interpreters/php/8.2.nix
+++ b/pkgs/development/interpreters/php/8.2.nix
@@ -2,8 +2,8 @@
 
 let
   base = callPackage ./generic.nix (_args // {
-    version = "8.2.23";
-    hash = "sha256-98kM2no8HeAfO/t7Rp1S3snrovO4MyCDYAT5wu7K4ms=";
+    version = "8.2.24";
+    hash = "sha256-TMduxkTu6X0XySv+jQ6EcU/t8pmlOLffrcBjndDcQy8=";
   });
 in
 base.withExtensions ({ all, ... }: with all; ([

--- a/pkgs/development/interpreters/php/8.3.nix
+++ b/pkgs/development/interpreters/php/8.3.nix
@@ -2,8 +2,8 @@
 
 let
   base = callPackage ./generic.nix (_args // {
-    version = "8.3.11";
-    hash = "sha256-ZkDiRVCAqJrcQdTle7BPjCv7fuxif+GZr5c7/zTX8O4=";
+    version = "8.3.12";
+    hash = "sha256-gHYzSWzNs3CokFRY24K9ZzZumKbVlyiRS3l7h+nK7L8=";
   });
 in
 base.withExtensions ({ all, ... }: with all; ([

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -705,12 +705,6 @@ in {
               url = "https://github.com/php/php-src/commit/4fe821311cafb18ca8bdf20b9d796c48a13ba552.diff?full_index=1";
               hash = "sha256-YC3I0BQi3o3+VmRu/UqpqPpaSC+ekPqzbORTHftbPvY=";
             })
-          ] ++ lib.optionals (lib.versions.majorMinor php.version == "8.2") [
-            # Fix test 'bug55639.phpt'
-            (fetchpatch {
-              url = "https://github.com/php/php-src/commit/1b52ecd78ad1a211a4a9db65975df34d2539125b.patch";
-              hash = "sha256-LVk9sfwl5D+rHzyYjfV4pAuhBjSPXj1WjTfnrzBJXhY";
-            })
           ] ++ lib.optionals (lib.versions.majorMinor php.version == "8.3" && lib.versionOlder php.version "8.3.10") [
             (fetchpatch {
               url = "https://github.com/php/php-src/commit/ecf0bb0fd12132d853969c5e9a212e5f627f2da2.diff?full_index=1";


### PR DESCRIPTION
## Description of changes

Fixes CVE-2024-8927, CVE-2024-9026 and CVE-2024-8925.

Changes:
https://www.php.net/ChangeLog-8.php#8.3.12
https://www.php.net/ChangeLog-8.php#8.2.24
https://www.php.net/ChangeLog-8.php#8.1.30

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages failed to build:</summary>
  <ul>
    <li>php81Packages.psysh</li>
    <li>php82Packages.psysh</li>
    <li>php83Extensions.couchbase</li>
    <li>php83Packages.psysh</li>
  </ul>
</details>
<details>
  <summary>590 packages built:</summary>
  <ul>
    <li>adminer</li>
    <li>adminerevo</li>
    <li>php (apacheHttpdPackages.php)</li>
    <li>bloom</li>
    <li>bookstack</li>
    <li>composer-require-checker</li>
    <li>davis</li>
    <li>easyeffects</li>
    <li>easyeffects.debug</li>
    <li>engelsystem</li>
    <li>firefly-iii</li>
    <li>firefly-iii-data-importer</li>
    <li>flarum</li>
    <li>frankenphp</li>
    <li>freshrss</li>
    <li>gnomeExtensions.easyeffects-preset-selector</li>
    <li>grocy</li>
    <li>icingaweb2</li>
    <li>ifm-web</li>
    <li>laravel</li>
    <li>librenms</li>
    <li>libsForQt5.kcachegrind</li>
    <li>lsp-plugins</li>
    <li>lsp-plugins.dev</li>
    <li>lsp-plugins.doc</li>
    <li>matomo</li>
    <li>matomo-beta</li>
    <li>matomo_5</li>
    <li>movim</li>
    <li>n98-magerun</li>
    <li>n98-magerun2</li>
    <li>nagios</li>
    <li>nextcloud-news-updater</li>
    <li>nextcloud-news-updater.dist</li>
    <li>nominatim</li>
    <li>paratest</li>
    <li>pdepend</li>
    <li>pest</li>
    <li>phel</li>
    <li>phoronix-test-suite</li>
    <li>php81</li>
    <li>php81Extensions.amqp</li>
    <li>php81Extensions.apcu</li>
    <li>php81Extensions.apcu.dev</li>
    <li>php81Extensions.ast</li>
    <li>php81Extensions.bcmath</li>
    <li>php81Extensions.bcmath.dev</li>
    <li>php81Extensions.bz2</li>
    <li>php81Extensions.bz2.dev</li>
    <li>php81Extensions.calendar</li>
    <li>php81Extensions.calendar.dev</li>
    <li>php81Extensions.couchbase</li>
    <li>php81Extensions.ctype</li>
    <li>php81Extensions.ctype.dev</li>
    <li>php81Extensions.curl</li>
    <li>php81Extensions.curl.dev</li>
    <li>php81Extensions.datadog_trace</li>
    <li>php81Extensions.dba</li>
    <li>php81Extensions.dba.dev</li>
    <li>php81Extensions.dom</li>
    <li>php81Extensions.dom.dev</li>
    <li>php81Extensions.ds</li>
    <li>php81Extensions.enchant</li>
    <li>php81Extensions.enchant.dev</li>
    <li>php81Extensions.event</li>
    <li>php81Extensions.exif</li>
    <li>php81Extensions.exif.dev</li>
    <li>php81Extensions.ffi</li>
    <li>php81Extensions.ffi.dev</li>
    <li>php81Extensions.fileinfo</li>
    <li>php81Extensions.fileinfo.dev</li>
    <li>php81Extensions.filter</li>
    <li>php81Extensions.filter.dev</li>
    <li>php81Extensions.ftp</li>
    <li>php81Extensions.ftp.dev</li>
    <li>php81Extensions.gd</li>
    <li>php81Extensions.gd.dev</li>
    <li>php81Extensions.gettext</li>
    <li>php81Extensions.gettext.dev</li>
    <li>php81Extensions.gmp</li>
    <li>php81Extensions.gmp.dev</li>
    <li>php81Extensions.gnupg</li>
    <li>php81Extensions.grpc</li>
    <li>php81Extensions.iconv</li>
    <li>php81Extensions.iconv.dev</li>
    <li>php81Extensions.igbinary</li>
    <li>php81Extensions.igbinary.dev</li>
    <li>php81Extensions.imagick</li>
    <li>php81Extensions.imap</li>
    <li>php81Extensions.imap.dev</li>
    <li>php81Extensions.inotify</li>
    <li>php81Extensions.intl</li>
    <li>php81Extensions.intl.dev</li>
    <li>php81Extensions.ldap</li>
    <li>php81Extensions.ldap.dev</li>
    <li>php81Extensions.mailparse</li>
    <li>php81Extensions.maxminddb</li>
    <li>php81Extensions.mbstring</li>
    <li>php81Extensions.mbstring.dev</li>
    <li>php81Extensions.memcache</li>
    <li>php81Extensions.memcached</li>
    <li>php81Extensions.meminfo</li>
    <li>php81Extensions.memprof</li>
    <li>php81Extensions.mongodb</li>
    <li>php81Extensions.msgpack</li>
    <li>php81Extensions.mysqli</li>
    <li>php81Extensions.mysqli.dev</li>
    <li>php81Extensions.mysqlnd</li>
    <li>php81Extensions.mysqlnd.dev</li>
    <li>php81Extensions.oci8</li>
    <li>php81Extensions.opcache</li>
    <li>php81Extensions.opcache.dev</li>
    <li>php81Extensions.openssl</li>
    <li>php81Extensions.openssl.dev</li>
    <li>php81Extensions.openswoole</li>
    <li>php81Extensions.opentelemetry</li>
    <li>php81Extensions.pcntl</li>
    <li>php81Extensions.pcntl.dev</li>
    <li>php81Extensions.pcov</li>
    <li>php81Extensions.pdlib</li>
    <li>php81Extensions.pdo</li>
    <li>php81Extensions.pdo.dev</li>
    <li>php81Extensions.pdo_dblib</li>
    <li>php81Extensions.pdo_dblib.dev</li>
    <li>php81Extensions.pdo_mysql</li>
    <li>php81Extensions.pdo_mysql.dev</li>
    <li>php81Extensions.pdo_oci</li>
    <li>php81Extensions.pdo_odbc</li>
    <li>php81Extensions.pdo_odbc.dev</li>
    <li>php81Extensions.pdo_pgsql</li>
    <li>php81Extensions.pdo_pgsql.dev</li>
    <li>php81Extensions.pdo_sqlite</li>
    <li>php81Extensions.pdo_sqlite.dev</li>
    <li>php81Extensions.pdo_sqlsrv</li>
    <li>php81Extensions.pgsql</li>
    <li>php81Extensions.pgsql.dev</li>
    <li>php81Extensions.phalcon</li>
    <li>php81Extensions.pinba</li>
    <li>php81Extensions.posix</li>
    <li>php81Extensions.posix.dev</li>
    <li>php81Extensions.protobuf</li>
    <li>php81Extensions.pspell</li>
    <li>php81Extensions.rdkafka</li>
    <li>php81Extensions.readline</li>
    <li>php81Extensions.readline.dev</li>
    <li>php81Extensions.redis</li>
    <li>php81Extensions.rrd</li>
    <li>php81Extensions.session</li>
    <li>php81Extensions.session.dev</li>
    <li>php81Extensions.shmop</li>
    <li>php81Extensions.shmop.dev</li>
    <li>php81Extensions.simplexml</li>
    <li>php81Extensions.simplexml.dev</li>
    <li>php81Extensions.smbclient</li>
    <li>php81Extensions.snmp</li>
    <li>php81Extensions.snmp.dev</li>
    <li>php81Extensions.snuffleupagus</li>
    <li>php81Extensions.soap</li>
    <li>php81Extensions.soap.dev</li>
    <li>php81Extensions.sockets</li>
    <li>php81Extensions.sockets.dev</li>
    <li>php81Extensions.sodium</li>
    <li>php81Extensions.sodium.dev</li>
    <li>php81Extensions.spx</li>
    <li>php81Extensions.sqlite3</li>
    <li>php81Extensions.sqlite3.dev</li>
    <li>php81Extensions.sqlsrv</li>
    <li>php81Extensions.ssh2</li>
    <li>php81Extensions.swoole</li>
    <li>php81Extensions.sysvmsg</li>
    <li>php81Extensions.sysvmsg.dev</li>
    <li>php81Extensions.sysvsem</li>
    <li>php81Extensions.sysvsem.dev</li>
    <li>php81Extensions.sysvshm</li>
    <li>php81Extensions.sysvshm.dev</li>
    <li>php81Extensions.tidy</li>
    <li>php81Extensions.tidy.dev</li>
    <li>php81Extensions.tokenizer</li>
    <li>php81Extensions.tokenizer.dev</li>
    <li>php81Extensions.uv</li>
    <li>php81Extensions.vld</li>
    <li>php81Extensions.xdebug</li>
    <li>php81Extensions.xml</li>
    <li>php81Extensions.xml.dev</li>
    <li>php81Extensions.xmlreader</li>
    <li>php81Extensions.xmlreader.dev</li>
    <li>php81Extensions.xmlwriter</li>
    <li>php81Extensions.xmlwriter.dev</li>
    <li>php81Extensions.xsl</li>
    <li>php81Extensions.xsl.dev</li>
    <li>php81Extensions.yaml</li>
    <li>php81Extensions.zend_test</li>
    <li>php81Extensions.zend_test.dev</li>
    <li>php81Extensions.zip</li>
    <li>php81Extensions.zip.dev</li>
    <li>php81Extensions.zlib</li>
    <li>php81Extensions.zlib.dev</li>
    <li>php81Extensions.zstd</li>
    <li>php81Packages.box (php82Packages.box ,php83Packages.box ,php84Packages.box)</li>
    <li>php81Packages.castor</li>
    <li>php81Packages.composer</li>
    <li>php81Packages.composer-local-repo-plugin</li>
    <li>php81Packages.cyclonedx-php-composer</li>
    <li>php81Packages.deployer</li>
    <li>php81Packages.grumphp</li>
    <li>php81Packages.phan</li>
    <li>php81Packages.phing</li>
    <li>php81Packages.phive</li>
    <li>php81Packages.php-codesniffer</li>
    <li>php81Packages.php-cs-fixer</li>
    <li>php81Packages.php-parallel-lint</li>
    <li>php81Packages.phpinsights</li>
    <li>php81Packages.phpmd</li>
    <li>php81Packages.phpspy</li>
    <li>php81Packages.phpstan</li>
    <li>php81Packages.psalm</li>
    <li>php82Extensions.amqp</li>
    <li>php82Extensions.apcu</li>
    <li>php82Extensions.apcu.dev</li>
    <li>php82Extensions.ast</li>
    <li>php82Extensions.bcmath</li>
    <li>php82Extensions.bcmath.dev</li>
    <li>php82Extensions.bz2</li>
    <li>php82Extensions.bz2.dev</li>
    <li>php82Extensions.calendar</li>
    <li>php82Extensions.calendar.dev</li>
    <li>php82Extensions.couchbase</li>
    <li>php82Extensions.ctype</li>
    <li>php82Extensions.ctype.dev</li>
    <li>php82Extensions.curl</li>
    <li>php82Extensions.curl.dev</li>
    <li>php82Extensions.datadog_trace</li>
    <li>php82Extensions.dba</li>
    <li>php82Extensions.dba.dev</li>
    <li>php82Extensions.dom</li>
    <li>php82Extensions.dom.dev</li>
    <li>php82Extensions.ds</li>
    <li>php82Extensions.enchant</li>
    <li>php82Extensions.enchant.dev</li>
    <li>php82Extensions.event</li>
    <li>php82Extensions.exif</li>
    <li>php82Extensions.exif.dev</li>
    <li>php82Extensions.ffi</li>
    <li>php82Extensions.ffi.dev</li>
    <li>php82Extensions.fileinfo</li>
    <li>php82Extensions.fileinfo.dev</li>
    <li>php82Extensions.filter</li>
    <li>php82Extensions.filter.dev</li>
    <li>php82Extensions.ftp</li>
    <li>php82Extensions.ftp.dev</li>
    <li>php82Extensions.gd</li>
    <li>php82Extensions.gd.dev</li>
    <li>php82Extensions.gettext</li>
    <li>php82Extensions.gettext.dev</li>
    <li>php82Extensions.gmp</li>
    <li>php82Extensions.gmp.dev</li>
    <li>php82Extensions.gnupg</li>
    <li>php82Extensions.grpc</li>
    <li>php82Extensions.iconv</li>
    <li>php82Extensions.iconv.dev</li>
    <li>php82Extensions.igbinary</li>
    <li>php82Extensions.igbinary.dev</li>
    <li>php82Extensions.imagick</li>
    <li>php82Extensions.imap</li>
    <li>php82Extensions.imap.dev</li>
    <li>php82Extensions.inotify</li>
    <li>php82Extensions.intl</li>
    <li>php82Extensions.intl.dev</li>
    <li>php82Extensions.ldap</li>
    <li>php82Extensions.ldap.dev</li>
    <li>php82Extensions.mailparse</li>
    <li>php82Extensions.maxminddb</li>
    <li>php82Extensions.mbstring</li>
    <li>php82Extensions.mbstring.dev</li>
    <li>php82Extensions.memcache</li>
    <li>php82Extensions.memcached</li>
    <li>php82Extensions.meminfo</li>
    <li>php82Extensions.memprof</li>
    <li>php82Extensions.mongodb</li>
    <li>php82Extensions.msgpack</li>
    <li>php82Extensions.mysqli</li>
    <li>php82Extensions.mysqli.dev</li>
    <li>php82Extensions.mysqlnd</li>
    <li>php82Extensions.mysqlnd.dev</li>
    <li>php82Extensions.oci8</li>
    <li>php82Extensions.opcache</li>
    <li>php82Extensions.opcache.dev</li>
    <li>php82Extensions.openssl</li>
    <li>php82Extensions.openssl.dev</li>
    <li>php82Extensions.openswoole</li>
    <li>php82Extensions.opentelemetry</li>
    <li>php82Extensions.pcntl</li>
    <li>php82Extensions.pcntl.dev</li>
    <li>php82Extensions.pcov</li>
    <li>php82Extensions.pdlib</li>
    <li>php82Extensions.pdo</li>
    <li>php82Extensions.pdo.dev</li>
    <li>php82Extensions.pdo_dblib</li>
    <li>php82Extensions.pdo_dblib.dev</li>
    <li>php82Extensions.pdo_mysql</li>
    <li>php82Extensions.pdo_mysql.dev</li>
    <li>php82Extensions.pdo_oci</li>
    <li>php82Extensions.pdo_odbc</li>
    <li>php82Extensions.pdo_odbc.dev</li>
    <li>php82Extensions.pdo_pgsql</li>
    <li>php82Extensions.pdo_pgsql.dev</li>
    <li>php82Extensions.pdo_sqlite</li>
    <li>php82Extensions.pdo_sqlite.dev</li>
    <li>php82Extensions.pdo_sqlsrv</li>
    <li>php82Extensions.pgsql</li>
    <li>php82Extensions.pgsql.dev</li>
    <li>php82Extensions.phalcon</li>
    <li>php82Extensions.pinba</li>
    <li>php82Extensions.posix</li>
    <li>php82Extensions.posix.dev</li>
    <li>php82Extensions.protobuf</li>
    <li>php82Extensions.pspell</li>
    <li>php82Extensions.rdkafka</li>
    <li>php82Extensions.readline</li>
    <li>php82Extensions.readline.dev</li>
    <li>php82Extensions.redis</li>
    <li>php82Extensions.rrd</li>
    <li>php82Extensions.session</li>
    <li>php82Extensions.session.dev</li>
    <li>php82Extensions.shmop</li>
    <li>php82Extensions.shmop.dev</li>
    <li>php82Extensions.simplexml</li>
    <li>php82Extensions.simplexml.dev</li>
    <li>php82Extensions.smbclient</li>
    <li>php82Extensions.snmp</li>
    <li>php82Extensions.snmp.dev</li>
    <li>php82Extensions.snuffleupagus</li>
    <li>php82Extensions.soap</li>
    <li>php82Extensions.soap.dev</li>
    <li>php82Extensions.sockets</li>
    <li>php82Extensions.sockets.dev</li>
    <li>php82Extensions.sodium</li>
    <li>php82Extensions.sodium.dev</li>
    <li>php82Extensions.spx</li>
    <li>php82Extensions.sqlite3</li>
    <li>php82Extensions.sqlite3.dev</li>
    <li>php82Extensions.sqlsrv</li>
    <li>php82Extensions.ssh2</li>
    <li>php82Extensions.swoole</li>
    <li>php82Extensions.sysvmsg</li>
    <li>php82Extensions.sysvmsg.dev</li>
    <li>php82Extensions.sysvsem</li>
    <li>php82Extensions.sysvsem.dev</li>
    <li>php82Extensions.sysvshm</li>
    <li>php82Extensions.sysvshm.dev</li>
    <li>php82Extensions.tidy</li>
    <li>php82Extensions.tidy.dev</li>
    <li>php82Extensions.tokenizer</li>
    <li>php82Extensions.tokenizer.dev</li>
    <li>php82Extensions.uv</li>
    <li>php82Extensions.vld</li>
    <li>php82Extensions.xdebug</li>
    <li>php82Extensions.xml</li>
    <li>php82Extensions.xml.dev</li>
    <li>php82Extensions.xmlreader</li>
    <li>php82Extensions.xmlreader.dev</li>
    <li>php82Extensions.xmlwriter</li>
    <li>php82Extensions.xmlwriter.dev</li>
    <li>php82Extensions.xsl</li>
    <li>php82Extensions.xsl.dev</li>
    <li>php82Extensions.yaml</li>
    <li>php82Extensions.zend_test</li>
    <li>php82Extensions.zend_test.dev</li>
    <li>php82Extensions.zip</li>
    <li>php82Extensions.zip.dev</li>
    <li>php82Extensions.zlib</li>
    <li>php82Extensions.zlib.dev</li>
    <li>php82Extensions.zstd</li>
    <li>php82Packages.castor</li>
    <li>php82Packages.composer</li>
    <li>php82Packages.composer-local-repo-plugin</li>
    <li>php82Packages.cyclonedx-php-composer</li>
    <li>php82Packages.deployer</li>
    <li>php82Packages.grumphp</li>
    <li>php82Packages.phan</li>
    <li>php82Packages.phing</li>
    <li>php82Packages.phive</li>
    <li>php82Packages.php-codesniffer</li>
    <li>php82Packages.php-cs-fixer</li>
    <li>php82Packages.php-parallel-lint</li>
    <li>php82Packages.phpinsights</li>
    <li>php82Packages.phpmd</li>
    <li>php82Packages.phpspy</li>
    <li>php82Packages.phpstan</li>
    <li>php82Packages.psalm</li>
    <li>php83</li>
    <li>php83Extensions.amqp</li>
    <li>php83Extensions.apcu</li>
    <li>php83Extensions.apcu.dev</li>
    <li>php83Extensions.ast</li>
    <li>php83Extensions.bcmath</li>
    <li>php83Extensions.bcmath.dev</li>
    <li>php83Extensions.bz2</li>
    <li>php83Extensions.bz2.dev</li>
    <li>php83Extensions.calendar</li>
    <li>php83Extensions.calendar.dev</li>
    <li>php83Extensions.ctype</li>
    <li>php83Extensions.ctype.dev</li>
    <li>php83Extensions.curl</li>
    <li>php83Extensions.curl.dev</li>
    <li>php83Extensions.datadog_trace</li>
    <li>php83Extensions.dba</li>
    <li>php83Extensions.dba.dev</li>
    <li>php83Extensions.dom</li>
    <li>php83Extensions.dom.dev</li>
    <li>php83Extensions.ds</li>
    <li>php83Extensions.enchant</li>
    <li>php83Extensions.enchant.dev</li>
    <li>php83Extensions.event</li>
    <li>php83Extensions.exif</li>
    <li>php83Extensions.exif.dev</li>
    <li>php83Extensions.ffi</li>
    <li>php83Extensions.ffi.dev</li>
    <li>php83Extensions.fileinfo</li>
    <li>php83Extensions.fileinfo.dev</li>
    <li>php83Extensions.filter</li>
    <li>php83Extensions.filter.dev</li>
    <li>php83Extensions.ftp</li>
    <li>php83Extensions.ftp.dev</li>
    <li>php83Extensions.gd</li>
    <li>php83Extensions.gd.dev</li>
    <li>php83Extensions.gettext</li>
    <li>php83Extensions.gettext.dev</li>
    <li>php83Extensions.gmp</li>
    <li>php83Extensions.gmp.dev</li>
    <li>php83Extensions.gnupg</li>
    <li>php83Extensions.grpc</li>
    <li>php83Extensions.iconv</li>
    <li>php83Extensions.iconv.dev</li>
    <li>php83Extensions.igbinary</li>
    <li>php83Extensions.igbinary.dev</li>
    <li>php83Extensions.imagick</li>
    <li>php83Extensions.imap</li>
    <li>php83Extensions.inotify</li>
    <li>php83Extensions.intl</li>
    <li>php83Extensions.intl.dev</li>
    <li>php83Extensions.ldap</li>
    <li>php83Extensions.ldap.dev</li>
    <li>php83Extensions.mailparse</li>
    <li>php83Extensions.maxminddb</li>
    <li>php83Extensions.mbstring</li>
    <li>php83Extensions.mbstring.dev</li>
    <li>php83Extensions.memcache</li>
    <li>php83Extensions.memcached</li>
    <li>php83Extensions.meminfo</li>
    <li>php83Extensions.memprof</li>
    <li>php83Extensions.mongodb</li>
    <li>php83Extensions.msgpack</li>
    <li>php83Extensions.mysqli</li>
    <li>php83Extensions.mysqli.dev</li>
    <li>php83Extensions.mysqlnd</li>
    <li>php83Extensions.mysqlnd.dev</li>
    <li>php83Extensions.oci8</li>
    <li>php83Extensions.opcache</li>
    <li>php83Extensions.opcache.dev</li>
    <li>php83Extensions.openssl</li>
    <li>php83Extensions.openssl.dev</li>
    <li>php83Extensions.openswoole</li>
    <li>php83Extensions.opentelemetry</li>
    <li>php83Extensions.pcntl</li>
    <li>php83Extensions.pcntl.dev</li>
    <li>php83Extensions.pcov</li>
    <li>php83Extensions.pdlib</li>
    <li>php83Extensions.pdo</li>
    <li>php83Extensions.pdo.dev</li>
    <li>php83Extensions.pdo_dblib</li>
    <li>php83Extensions.pdo_dblib.dev</li>
    <li>php83Extensions.pdo_mysql</li>
    <li>php83Extensions.pdo_mysql.dev</li>
    <li>php83Extensions.pdo_oci</li>
    <li>php83Extensions.pdo_odbc</li>
    <li>php83Extensions.pdo_odbc.dev</li>
    <li>php83Extensions.pdo_pgsql</li>
    <li>php83Extensions.pdo_pgsql.dev</li>
    <li>php83Extensions.pdo_sqlite</li>
    <li>php83Extensions.pdo_sqlite.dev</li>
    <li>php83Extensions.pdo_sqlsrv</li>
    <li>php83Extensions.pgsql</li>
    <li>php83Extensions.pgsql.dev</li>
    <li>php83Extensions.phalcon</li>
    <li>php83Extensions.pinba</li>
    <li>php83Extensions.posix</li>
    <li>php83Extensions.posix.dev</li>
    <li>php83Extensions.protobuf</li>
    <li>php83Extensions.pspell</li>
    <li>php83Extensions.rdkafka</li>
    <li>php83Extensions.readline</li>
    <li>php83Extensions.readline.dev</li>
    <li>php83Extensions.redis</li>
    <li>php83Extensions.rrd</li>
    <li>php83Extensions.session</li>
    <li>php83Extensions.session.dev</li>
    <li>php83Extensions.shmop</li>
    <li>php83Extensions.shmop.dev</li>
    <li>php83Extensions.simplexml</li>
    <li>php83Extensions.simplexml.dev</li>
    <li>php83Extensions.smbclient</li>
    <li>php83Extensions.snmp</li>
    <li>php83Extensions.snmp.dev</li>
    <li>php83Extensions.snuffleupagus</li>
    <li>php83Extensions.soap</li>
    <li>php83Extensions.soap.dev</li>
    <li>php83Extensions.sockets</li>
    <li>php83Extensions.sockets.dev</li>
    <li>php83Extensions.sodium</li>
    <li>php83Extensions.sodium.dev</li>
    <li>php83Extensions.spx</li>
    <li>php83Extensions.sqlite3</li>
    <li>php83Extensions.sqlite3.dev</li>
    <li>php83Extensions.sqlsrv</li>
    <li>php83Extensions.ssh2</li>
    <li>php83Extensions.swoole</li>
    <li>php83Extensions.sysvmsg</li>
    <li>php83Extensions.sysvmsg.dev</li>
    <li>php83Extensions.sysvsem</li>
    <li>php83Extensions.sysvsem.dev</li>
    <li>php83Extensions.sysvshm</li>
    <li>php83Extensions.sysvshm.dev</li>
    <li>php83Extensions.tidy</li>
    <li>php83Extensions.tidy.dev</li>
    <li>php83Extensions.tokenizer</li>
    <li>php83Extensions.tokenizer.dev</li>
    <li>php83Extensions.uv</li>
    <li>php83Extensions.vld</li>
    <li>php83Extensions.xdebug</li>
    <li>php83Extensions.xml</li>
    <li>php83Extensions.xml.dev</li>
    <li>php83Extensions.xmlreader</li>
    <li>php83Extensions.xmlreader.dev</li>
    <li>php83Extensions.xmlwriter</li>
    <li>php83Extensions.xmlwriter.dev</li>
    <li>php83Extensions.xsl</li>
    <li>php83Extensions.xsl.dev</li>
    <li>php83Extensions.yaml</li>
    <li>php83Extensions.zend_test</li>
    <li>php83Extensions.zend_test.dev</li>
    <li>php83Extensions.zip</li>
    <li>php83Extensions.zip.dev</li>
    <li>php83Extensions.zlib</li>
    <li>php83Extensions.zlib.dev</li>
    <li>php83Extensions.zstd</li>
    <li>php83Packages.castor</li>
    <li>php83Packages.composer</li>
    <li>php83Packages.composer-local-repo-plugin</li>
    <li>php83Packages.cyclonedx-php-composer</li>
    <li>php83Packages.deployer</li>
    <li>php83Packages.grumphp</li>
    <li>php83Packages.phan</li>
    <li>php83Packages.phing</li>
    <li>php83Packages.phive</li>
    <li>php83Packages.php-codesniffer</li>
    <li>php83Packages.php-cs-fixer</li>
    <li>php83Packages.php-parallel-lint</li>
    <li>php83Packages.phpinsights</li>
    <li>php83Packages.phpmd</li>
    <li>php83Packages.phpspy</li>
    <li>php83Packages.phpstan</li>
    <li>php83Packages.psalm</li>
    <li>phpactor</li>
    <li>phpdocumentor</li>
    <li>phpunit</li>
    <li>pixelfed</li>
    <li>pulseeffects-legacy</li>
    <li>qcachegrind</li>
    <li>roave-backward-compatibility-check</li>
    <li>robo</li>
    <li>rss-bridge-cli</li>
    <li>signaturepdf</li>
    <li>simplesamlphp</li>
    <li>snipe-it</li>
    <li>unit</li>
    <li>vimPlugins.phpactor</li>
    <li>weechat</li>
    <li>weechat-unwrapped</li>
    <li>weechat-unwrapped.guile</li>
    <li>weechat-unwrapped.lua</li>
    <li>weechat-unwrapped.man</li>
    <li>weechat-unwrapped.perl</li>
    <li>weechat-unwrapped.php</li>
    <li>weechat-unwrapped.python</li>
    <li>weechat-unwrapped.ruby</li>
    <li>weechat-unwrapped.tcl</li>
    <li>wp-cli</li>
    <li>yle-dl</li>
    <li>yle-dl.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
