### PR TITLE
gmt: adoption by the geospatial team

### DIFF
--- a/pkgs/applications/gis/gmt/dcw.nix
+++ b/pkgs/applications/gis/gmt/dcw.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       for use by GMT, the Generic Mapping Tools.
     '';
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ tviti ];
+    maintainers = lib.teams.geospatial.members ++ (with lib.maintainers; [ tviti ]);
   };
 
 }

--- a/pkgs/applications/gis/gmt/default.nix
+++ b/pkgs/applications/gis/gmt/default.nix
@@ -106,7 +106,7 @@ in stdenv.mkDerivation (finalAttrs: {
     '';
     platforms = lib.platforms.unix;
     license = lib.licenses.lgpl3Plus;
-    maintainers = with lib.maintainers; [ tviti ];
+    maintainers = lib.teams.geospatial.members ++ (with lib.maintainers; [ tviti ]);
   };
 
 })

--- a/pkgs/applications/gis/gmt/gshhg.nix
+++ b/pkgs/applications/gis/gmt/gshhg.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       Mapping Tools.
     '';
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ tviti ];
+    maintainers = lib.teams.geospatial.members ++ (with lib.maintainers; [ tviti ]);
   };
 
 }

--- a/pkgs/development/python-modules/pygmt/default.nix
+++ b/pkgs/development/python-modules/pygmt/default.nix
@@ -67,6 +67,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/GenericMappingTools/pygmt";
     license = licenses.bsd3;
     changelog = "https://github.com/GenericMappingTools/pygmt/releases/tag/v${version}";
-    maintainers = with maintainers; [ sikmir ];
+    maintainers = with maintainers; teams.geospatial.members;
   };
 }


### PR DESCRIPTION
## Description of changes

This MR does 2 things:

- it adopts gmt under the geospatial team. Is that ok for you @NixOS/geospatial and @tviti?
- it fixes its build

About the build fix, it seems to be yet another libxml2 fix. For some reason, the error was about libspatialite, but libspatialite package has already the libxml2 fix. `netcdf`  on the other hand, didn't and for some reason, that brought libxml2 without httpSupport for libspatialite too:

```
/nix/store/81xsp348yfgmaan9r5055mcdjfw7a8wc-binutils-2.42/bin/ld: /nix/store/hfb55givv2afsz93b705hkjd9y98wqam-libspatialite-5.1.0/lib/libspatialite.so.8: undefined reference to `xmlNanoHTTPCleanup@LIBXML2_2.4.30'
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/gmt.dir/build.make:108: src/gmt] Error 1
make[1]: *** [CMakeFiles/Makefile2:601: src/CMakeFiles/gmt.dir/all] Error 2

```
I don't really understand this (for me libspatialite should get its own libxml2 right?), so please have a look to my fix to ensure it is the correct one.

Another doubt I have: I decided not to patch directly netcdf derivation, but maybe we want this instead (this also fixes the build).

The build failure was discovered when updating geos (https://github.com/NixOS/nixpkgs/pull/344310)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
