### PR TITLE
[Backport release-24.05] invidious sig helper

### DIFF
--- a/nixos/modules/services/web-apps/invidious.nix
+++ b/nixos/modules/services/web-apps/invidious.nix
@@ -199,6 +199,41 @@ let
     };
   };
 
+  sigHelperConfig = lib.mkIf cfg.sig-helper.enable {
+    services.invidious.settings.signature_server = "tcp://${cfg.sig-helper.listenAddress}";
+    systemd.services.invidious-sig-helper = {
+      script = ''
+        exec ${lib.getExe cfg.sig-helper.package} --tcp "${cfg.sig-helper.listenAddress}"
+      '';
+      wantedBy = [ "multi-user.target" ];
+      before = [ "invidious.service" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      serviceConfig = {
+        User = "invidious-sig-helper";
+        DynamicUser = true;
+        Restart = "always";
+
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectSystem = true;
+        ProtectProc = "invisible";
+        ProtectHome = true;
+        PrivateDevices = true;
+        NoNewPrivileges = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        CapabilityBoundingSet = "";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" "@network-io" ];
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+      };
+    };
+  };
+
   nginxConfig = lib.mkIf cfg.nginx.enable {
     services.invidious.settings = {
       https_only = config.services.nginx.virtualHosts.${cfg.domain}.forceSSL;
@@ -392,6 +427,30 @@ in
 
       package = lib.mkPackageOptionMD pkgs "http3-ytproxy" { };
     };
+
+    sig-helper = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to enable and configure inv-sig-helper to emulate the youtube client's javascript. This is required
+          to make certain videos playable.
+
+          This will download and run completely untrusted javascript from youtube! While this service is sandboxed,
+          this may still be an issue!
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "inv-sig-helper" { };
+
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1:2999";
+        description = ''
+          The IP address/port where inv-sig-helper should listen.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
@@ -399,5 +458,6 @@ in
     localDatabaseConfig
     nginxConfig
     ytproxyConfig
+    sigHelperConfig
   ]);
 }

--- a/nixos/tests/invidious.nix
+++ b/nixos/tests/invidious.nix
@@ -37,6 +37,19 @@ import ./make-test-python.nix ({ pkgs, ... }: {
           };
           networking.hosts."127.0.0.1" = [ "invidious.example.com" ];
         };
+        nginx-sig-helper.configuration = {
+          services.invidious = {
+            nginx.enable = true;
+            domain = "invidious.example.com";
+            sig-helper.enable = true;
+            settings.log_level = "Trace";
+          };
+          services.nginx.virtualHosts."invidious.example.com" = {
+            forceSSL = false;
+            enableACME = false;
+          };
+          networking.hosts."127.0.0.1" = [ "invidious.example.com" ];
+        };
         nginx-scale.configuration = {
           services.invidious = {
             nginx.enable = true;
@@ -115,6 +128,14 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     # this should error out as no internet connectivity is available in the test
     curl_assert_status_code("http://invidious.example.com/vi/dQw4w9WgXcQ/mqdefault.jpg", 502)
     machine.succeed("journalctl -eu http3-ytproxy.service | grep -o 'dQw4w9WgXcQ'")
+
+    activate_specialisation("nginx-sig-helper")
+    machine.wait_for_unit("invidious-sig-helper.service")
+    # we can't really test the sig helper that well without internet connection...
+    # invidious does connect to the sig helper though and crashes when the sig helper is not available
+    machine.wait_for_open_port(80)
+    curl_assert_status_code("http://invidious.example.com/search", 200)
+    machine.succeed("journalctl -eu invidious.service | grep -o \"SigHelper: Using helper at 'tcp://127.0.0.1:2999'\"")
 
     postgres_tcp.wait_for_unit("postgresql.service")
     activate_specialisation("postgres-tcp")

--- a/pkgs/by-name/in/inv-sig-helper/package.nix
+++ b/pkgs/by-name/in/inv-sig-helper/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  pkg-config,
+
+  # buildInputs
+  openssl,
+  darwin,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "inv-sig-helper";
+  version = "0-unstable-2024-08-17";
+
+  src = fetchFromGitHub {
+    owner = "iv-org";
+    repo = "inv_sig_helper";
+    rev = "215d32c76e5e9e598de6e4f8542316f80dd92f57";
+    hash = "sha256-Ge0XoWrscyZSrkmtDPkAnv96IVylKZTcgGgonbFV43I=";
+  };
+
+  cargoHash = "sha256-JVpLUhNJ7/4WZwLn/zOurpP8kF5WblF3nphJh6keHG8=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
+
+  meta = {
+    description = "Rust service that decrypts YouTube signatures and manages player information";
+    homepage = "https://github.com/iv-org/inv_sig_helper";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "inv_sig_helper_rust";
+  };
+}


### PR DESCRIPTION
## Description of changes

My invidious instance recently became unusable, the only solution I found was enabling `invidious-sig-helper`, which is currently only available in unstable.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
