### PR TITLE
easyeffects: fix bug 'missing spectrum analyzer'

### DIFF
--- a/pkgs/by-name/ea/easyeffects/0001-Revert-Merge-pull-request-3340-from-violetmage-viole.patch
+++ b/pkgs/by-name/ea/easyeffects/0001-Revert-Merge-pull-request-3340-from-violetmage-viole.patch
@@ -1,0 +1,229 @@
+From a2f524ffe163e1a15dc8a4b6f21964092ec8e0a7 Mon Sep 17 00:00:00 2001
+From: Sofi <sofi+git@mailbox.org>
+Date: Sat, 28 Sep 2024 00:31:11 +0200
+Subject: [PATCH] Revert "Merge pull request #3340 from
+ violetmage/violetmage-spectrum-avsync"
+
+This reverts commit d40ff638e2f0db00579e1f30a9880b7d35f137fd, reversing
+changes made to ee0fe4a8da57ef84a39600ad02280ddc98d9de31.
+---
+ ...thub.wwmm.easyeffects.spectrum.gschema.xml |  5 --
+ data/ui/preferences_spectrum.ui               | 21 -----
+ include/spectrum.hpp                          |  5 --
+ src/preferences_spectrum.cpp                  |  7 +-
+ src/spectrum.cpp                              | 86 +++----------------
+ 5 files changed, 14 insertions(+), 110 deletions(-)
+
+diff --git a/data/schemas/com.github.wwmm.easyeffects.spectrum.gschema.xml b/data/schemas/com.github.wwmm.easyeffects.spectrum.gschema.xml
+index 340da382e..1260810f3 100644
+--- a/data/schemas/com.github.wwmm.easyeffects.spectrum.gschema.xml
++++ b/data/schemas/com.github.wwmm.easyeffects.spectrum.gschema.xml
+@@ -49,10 +49,5 @@
+             <range min="120" max="22000" />
+             <default>20000</default>
+         </key>
+-
+-        <key name="avsync-delay" type="i">
+-            <range min="0" max="1000" />
+-            <default>0</default>
+-        </key>
+     </schema>
+ </schemalist>
+\ No newline at end of file
+diff --git a/data/ui/preferences_spectrum.ui b/data/ui/preferences_spectrum.ui
+index 2eae7b8ab..97535d518 100644
+--- a/data/ui/preferences_spectrum.ui
++++ b/data/ui/preferences_spectrum.ui
+@@ -18,27 +18,6 @@
+                         </child>
+                     </object>
+                 </child>
+-
+-                <child>
+-                    <object class="AdwActionRow">
+-                        <property name="title" translatable="yes">Compensating Delay (ms)</property>
+-
+-                        <child>
+-                            <object class="GtkSpinButton" id="avsync_delay">
+-                                <property name="valign">center</property>
+-                                <property name="digits">0</property>
+-                                <property name="adjustment">
+-                                    <object class="GtkAdjustment">
+-                                        <property name="lower">0</property>
+-                                        <property name="upper">1000</property>
+-                                        <property name="step-increment">1</property>
+-                                        <property name="page-increment">10</property>
+-                                    </object>
+-                                </property>
+-                            </object>
+-                        </child>
+-                    </object>
+-                </child>
+             </object>
+         </child>
+ 
+diff --git a/include/spectrum.hpp b/include/spectrum.hpp
+index 546ceec59..af49dd9e5 100644
+--- a/include/spectrum.hpp
++++ b/include/spectrum.hpp
+@@ -65,11 +65,6 @@ class Spectrum : public PluginBase {
+ 
+   std::array<float, n_bands> real_input;
+   std::array<double, n_bands / 2U + 1U> output;
+-  
+-  std::vector<float> left_delayed_vector;
+-  std::vector<float> right_delayed_vector;
+-  std::span<float> left_delayed;
+-  std::span<float> right_delayed;
+ 
+   std::array<float, n_bands> latest_samples_mono;
+ 
+diff --git a/src/preferences_spectrum.cpp b/src/preferences_spectrum.cpp
+index 2902a8ee4..151960bef 100644
+--- a/src/preferences_spectrum.cpp
++++ b/src/preferences_spectrum.cpp
+@@ -49,7 +49,7 @@ struct _PreferencesSpectrum {
+ 
+   GtkDropDown* type;
+ 
+-  GtkSpinButton *n_points, *height, *line_width, *minimum_frequency, *maximum_frequency, *avsync_delay;
++  GtkSpinButton *n_points, *height, *line_width, *minimum_frequency, *maximum_frequency;
+ 
+   GSettings* settings;
+ 
+@@ -119,7 +119,6 @@ void preferences_spectrum_class_init(PreferencesSpectrumClass* klass) {
+   gtk_widget_class_bind_template_child(widget_class, PreferencesSpectrum, axis_color_button);
+   gtk_widget_class_bind_template_child(widget_class, PreferencesSpectrum, minimum_frequency);
+   gtk_widget_class_bind_template_child(widget_class, PreferencesSpectrum, maximum_frequency);
+-  gtk_widget_class_bind_template_child(widget_class, PreferencesSpectrum, avsync_delay);
+ 
+   gtk_widget_class_bind_template_callback(widget_class, on_spectrum_color_set);
+   gtk_widget_class_bind_template_callback(widget_class, on_spectrum_axis_color_set);
+@@ -193,9 +192,9 @@ void preferences_spectrum_init(PreferencesSpectrum* self) {
+   // spectrum section gsettings bindings
+ 
+   gsettings_bind_widgets<"show", "fill", "rounded-corners", "show-bar-border", "dynamic-y-scale", "n-points", "height",
+-                         "line-width", "minimum-frequency", "maximum-frequency", "avsync-delay">(
++                         "line-width", "minimum-frequency", "maximum-frequency">(
+       self->settings, self->show, self->fill, self->rounded_corners, self->show_bar_border, self->dynamic_y_scale,
+-      self->n_points, self->height, self->line_width, self->minimum_frequency, self->maximum_frequency, self->avsync_delay);
++      self->n_points, self->height, self->line_width, self->minimum_frequency, self->maximum_frequency);
+ 
+   ui::gsettings_bind_enum_to_combo_widget(self->settings, "type", self->type);
+ 
+diff --git a/src/spectrum.cpp b/src/spectrum.cpp
+index 28f7ff4da..1075a358f 100644
+--- a/src/spectrum.cpp
++++ b/src/spectrum.cpp
+@@ -55,30 +55,6 @@ Spectrum::Spectrum(const std::string& tag,
+ 
+   plan = fftwf_plan_dft_r2c_1d(static_cast<int>(n_bands), real_input.data(), complex_output, FFTW_ESTIMATE);
+ 
+-
+-
+-  lv2_wrapper = std::make_unique<lv2::Lv2Wrapper>("http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo");
+-
+-  package_installed = lv2_wrapper->found_plugin;
+-
+-  if (!package_installed) {
+-    util::debug(log_tag + "http://lsp-plug.in/plugins/lv2/comp_delay_x2_stereo is not installed, spectrum will not have A/V sync compensation");
+-  }
+-
+-  lv2_wrapper->set_control_port_value("mode_l", 2);
+-  lv2_wrapper->set_control_port_value("mode_r", 2);
+-
+-  lv2_wrapper->set_control_port_value("dry_l", 0.0F);
+-  lv2_wrapper->set_control_port_value("dry_r", 0.0F);
+-
+-  lv2_wrapper->set_control_port_value("wet_l", static_cast<float>(util::db_to_linear(0.0F)));
+-  lv2_wrapper->set_control_port_value("wet_r", static_cast<float>(util::db_to_linear(0.0F)));
+-
+-  lv2_wrapper->bind_key_int<"time_l", "avsync-delay">(settings);
+-  lv2_wrapper->bind_key_int<"time_r", "avsync-delay">(settings);
+-
+-
+-
+   g_signal_connect(settings, "changed::show", G_CALLBACK(+[](GSettings* settings, char* key, gpointer user_data) {
+                      auto* self = static_cast<Spectrum*>(user_data);
+ 
+@@ -106,19 +82,6 @@ Spectrum::~Spectrum() {
+ void Spectrum::setup() {
+   std::ranges::fill(real_input, 0.0F);
+   std::ranges::fill(latest_samples_mono, 0.0F);
+-
+-  left_delayed_vector.resize(n_samples, 0.0F);
+-  right_delayed_vector.resize(n_samples, 0.0F);
+-
+-  left_delayed = std::span<float>(left_delayed_vector);
+-  right_delayed = std::span<float>(right_delayed_vector);
+-
+-  lv2_wrapper->set_n_samples(n_samples);
+-
+-  if (lv2_wrapper->get_rate() != rate) {
+-    util::debug(log_tag + " creating instance of comp delay x2 stereo for spectrum A/V sync");
+-    lv2_wrapper->create_instance(rate);
+-  }
+ }
+ 
+ void Spectrum::process(std::span<float>& left_in,
+@@ -132,46 +95,19 @@ void Spectrum::process(std::span<float>& left_in,
+     return;
+   }
+ 
+-  // delay the visualization of the spectrum by the reported latency
+-  // of the output device, so that the spectrum is visually in sync
+-  // with the audio as experienced by the user. (A/V sync)
+-  if ( lv2_wrapper->found_plugin && lv2_wrapper->has_instance() ) {
+-    lv2_wrapper->connect_data_ports(left_in, right_in, left_delayed, right_delayed);
+-    lv2_wrapper->run();
++  if (n_samples < n_bands) {
++    // Drop the oldest quantum.
++    std::memmove(&latest_samples_mono[0], &latest_samples_mono[n_samples],
++        (n_bands - n_samples) * sizeof(float));
+ 
+-    // Downmix the latest n_bands samples from the delayed signal.
+-    if (n_samples < n_bands) {
+-      // Drop the oldest quantum.
+-      std::memmove(&latest_samples_mono[0], &latest_samples_mono[n_samples],
+-          (n_bands - n_samples) * sizeof(float));
+-
+-      // Copy the new quantum.
+-      for (size_t n = 0; n < n_samples; n++) {
+-        latest_samples_mono[n_bands - n_samples + n] = 0.5F * (left_delayed[n] + right_delayed[n]);
+-      }
+-    } else {
+-      // Copy the latest n_bands samples.
+-      for (size_t n = 0; n < n_bands; n++)
+-        latest_samples_mono[n] = 0.5F * (left_delayed[n_samples - n_bands + n] +
+-                                        right_delayed[n_samples - n_bands + n]);
+-    }
++    // Copy the new quantum.
++    for (size_t n = 0; n < n_samples; n++)
++      latest_samples_mono[n_bands - n_samples + n] = 0.5F * (left_in[n] + right_in[n]);
+   } else {
+-    // Downmix the latest n_bands samples from the non-delayed signal.
+-    if (n_samples < n_bands) {
+-      // Drop the oldest quantum.
+-      std::memmove(&latest_samples_mono[0], &latest_samples_mono[n_samples],
+-          (n_bands - n_samples) * sizeof(float));
+-
+-      // Copy the new quantum.
+-      for (size_t n = 0; n < n_samples; n++) {
+-        latest_samples_mono[n_bands - n_samples + n] = 0.5F * (left_in[n] + right_in[n]);
+-      }
+-    } else {
+-      // Copy the latest n_bands samples.
+-      for (size_t n = 0; n < n_bands; n++)
+-        latest_samples_mono[n] = 0.5F * (left_in[n_samples - n_bands + n] +
+-                                        right_in[n_samples - n_bands + n]);
+-    }
++    // Copy the latest n_bands samples.
++    for (size_t n = 0; n < n_bands; n++)
++      latest_samples_mono[n] = 0.5F * (left_in[n_samples - n_bands + n] +
++                                       right_in[n_samples - n_bands + n]);
+   }
+ 
+   /*
+-- 
+2.46.0
+

--- a/pkgs/by-name/ea/easyeffects/package.nix
+++ b/pkgs/by-name/ea/easyeffects/package.nix
@@ -114,6 +114,11 @@ stdenv.mkDerivation rec {
       )
     '';
 
+  patches = [
+    # Remove when lsp-plugins is >= 1.2.17. (https://github.com/wwmm/easyeffects/issues/3394)
+    ./0001-Revert-Merge-pull-request-3340-from-violetmage-viole.patch
+  ];
+
   separateDebugInfo = true;
 
   passthru = {


### PR DESCRIPTION
Due to old version of `lsp-plugins` in nixpkgs, the delay plugin is incorrectly inserting silence in the plugin output instead of the processed audio. This has been fixed in `lsp-plugins-1.2.17` but is not in nixpkgs yet.

Added a patch to revert the merge which causes issues, but the correct fix longer term will be to properly package `lsp-plugins-1.2.17`. I tried to this, but this release has also added gstreamer support to the package, but it is trying to do all sorts of odd things by writing into gstreamer's path instead of its own due to that new support.

Related issue in easyeffects: https://github.com/wwmm/easyeffects/issues/3394

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
