### PR TITLE
swim: init at 0.10.0

### DIFF
--- a/pkgs/by-name/sp/spade/package.nix
+++ b/pkgs/by-name/sp/spade/package.nix
@@ -3,6 +3,8 @@
   rustPlatform,
   fetchFromGitLab,
   stdenv,
+  _experimental-update-script-combinators,
+  nix-update-script,
   nix-update,
   writeScript,
   git,
@@ -30,16 +32,23 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  # rust + gitlab is a rare combo
-  passthru.updateScript = [
+  # TODO: somehow respect https://nixos.org/manual/nixpkgs/stable/#var-passthru-updateScript-commit
+  passthru.updateScript = _experimental-update-script-combinators.sequence [
+    # rust + gitlab + fetchgit is a rare combo
     (writeScript "update-spade" ''
       VERSION="$(
         ${lib.getExe git} ls-remote --tags --sort -version:refname ${lib.escapeShellArg src.gitRepoUrl} \
           | cut -f2 | grep ^refs/tags/v | cut -d/ -f3- | cut -c2- \
           | sort --version-sort --reverse | head -n1
       )"
-      exec ${lib.getExe nix-update} --version "$VERSION" "$@"
+      exec ${lib.getExe nix-update} spade --version "$VERSION" "$@" --commit
     '')
+    (nix-update-script {
+      extraArgs = [
+        "swim"
+        "--commit"
+      ];
+    })
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ python312 ];

--- a/pkgs/by-name/sp/spade/package.nix
+++ b/pkgs/by-name/sp/spade/package.nix
@@ -7,6 +7,7 @@
   writeScript,
   git,
   python312,
+  swim,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -43,6 +44,10 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ python312 ];
   env.NIX_CFLAGS_LINK = lib.optionalString stdenv.hostPlatform.isDarwin "-L${python312}/lib/python3.12/config-3.12-darwin -lpython3.12";
+
+  passthru.tests = {
+    inherit swim;
+  };
 
   meta = with lib; {
     description = "Better hardware description language";

--- a/pkgs/by-name/sw/swim/package.nix
+++ b/pkgs/by-name/sw/swim/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  pkg-config,
+  openssl,
+  spade,
+  stdenv,
+  darwin,
+  git,
+  _experimental-update-script-combinators,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "swim";
+  version = "0.10.0";
+
+  src = fetchFromGitLab {
+    owner = "spade-lang";
+    repo = "swim";
+    rev = "v${version}";
+    hash = "sha256-Yuq1eYjxNnmrydzPyx+UWJJlZnC9sIEP3ZEleKmkzIM=";
+  };
+
+  cargoHash = "sha256-3WcMXvxlY0I7HnR+GTxHPAN+1HQsQLymjGFMM6q18xQ=";
+
+  preConfigure = ''
+    # de-vendor spade git submodule
+    test "$version" = "${spade.version}" || {
+      >&2 echo ERROR: version mismatch between spade and swim!
+      false
+    }
+    ln -s ${spade.src} runt/spade
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs =
+    [
+      openssl
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
+
+  nativeCheckInputs = [ git ];
+
+  checkFlags = [
+    # tries to clone https://gitlab.com/spade-lang/swim-templates
+    "--skip=init::tests::git_init_then_swim_init_works"
+    "--skip=init::tests::init_board_correctly_sets_project_name"
+    "--skip=init::tests::init_board_creates_required_files"
+    "--skip=plugin::test::deny_changes_to_plugins::edits_are_denied"
+    "--skip=plugin::test::deny_changes_to_plugins::restores_work"
+  ];
+
+  passthru.updateScript = _experimental-update-script-combinators.sequence [
+    (nix-update-script { extraArgs = [ "spade" "--commit" "--use-update-script" "--update-script-args" "--argstr skip-prompt true" ]; })
+    (nix-update-script { extraArgs = [ "swim" ]; })
+  ];
+
+  meta = {
+    description = "Build tool for spade";
+    homepage = "https://gitlab.com/spade-lang/swim";
+    changelog = "https://gitlab.com/spade-lang/swim/-/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [ pbsds ];
+    mainProgram = "swim";
+  };
+}

--- a/pkgs/by-name/sw/swim/package.nix
+++ b/pkgs/by-name/sw/swim/package.nix
@@ -8,8 +8,6 @@
   stdenv,
   darwin,
   git,
-  _experimental-update-script-combinators,
-  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -56,10 +54,9 @@ rustPlatform.buildRustPackage rec {
     "--skip=plugin::test::deny_changes_to_plugins::restores_work"
   ];
 
-  passthru.updateScript = _experimental-update-script-combinators.sequence [
-    (nix-update-script { extraArgs = [ "spade" "--commit" "--use-update-script" "--update-script-args" "--argstr skip-prompt true" ]; })
-    (nix-update-script { extraArgs = [ "swim" ]; })
-  ];
+  passthru = {
+    inherit (spade) updateScript;
+  };
 
   meta = {
     description = "Build tool for spade";


### PR DESCRIPTION
## Description of changes

A build tool for [spade-lang](https://spade-lang.org/)

https://gitlab.com/spade-lang/swim

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
