### PR TITLE
agbcc: init at 0-unstable-2023-09-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7289,6 +7289,11 @@
     githubId = 134872;
     name = "Sergei Lukianov";
   };
+  FrothyMarrow = {
+    github = "FrothyMarrow";
+    githubId = 76622149;
+    name = "FrothyMarrow";
+  };
   fryuni = {
     name = "Luiz Ferraz";
     email = "luiz@lferraz.com";

--- a/pkgs/by-name/ag/agbcc/package.nix
+++ b/pkgs/by-name/ag/agbcc/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  pkgsCross,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "agbcc";
+  version = "0-unstable-2023-09-03";
+
+  src = fetchFromGitHub {
+    owner = "pret";
+    repo = "agbcc";
+    rev = "bfa92a1c98ce039a7df833beefa612fea65d3874";
+    hash = "sha256-yQ4k2gkc8TwPBxHnXvpD0hqv19QP2CAnQMiFZv9Sje0=";
+  };
+
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error"
+    "-Wno-error=format-security"
+    "-Wno-error=incompatible-pointer-types"
+  ];
+
+  nativeBuildInputs = [ pkgsCross.arm-embedded.buildPackages.binutils ];
+
+  patchPhase = ''
+    runHook prePatch
+
+    substituteInPlace libc/Makefile --replace-fail "/bin/bash" "${stdenv.shell}"
+    substituteInPlace gcc_arm/configure --replace-fail "main(){return(0);}" "int main(){return(0);}"
+
+    runHook postPatch
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -e -C gcc old
+    mv gcc/old_agbcc .
+
+    make -e -C gcc
+    mv gcc/agbcc .
+
+    cd gcc_arm
+    ./configure --target=arm-elf --host=i386-linux-gnu
+    make cc1 && cd ..
+    mv gcc_arm/cc1 agbcc_arm
+
+    make -C libgcc
+    mv libgcc/libgcc.a .
+
+    make -C libc
+    mv libc/libc.a .
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp old_agbcc $out/bin
+    cp agbcc_arm $out/bin
+    cp agbcc $out/bin
+
+    mkdir -p $out/include
+    cp -r libc/include/* $out/include
+    cp ginclude/* $out/include
+
+    mkdir -p $out/lib
+    cp libgcc.a $out/lib
+    cp libc.a $out/lib
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "GCC reworked to match games compiled for the Game Boy Advance";
+    homepage = "https://github.com/pret/agbcc";
+    license = lib.licenses.gpl2;
+    mainProgram = "agbcc";
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [
+      FrothyMarrow
+      NotAShelf
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes

GCC reworked to match games compiled for the Game Boy Advance.

https://github.com/pret/agbcc

I have permission from @NotAShelf to add them as a maintainer.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
