### PR TITLE
nixos/prometheus-restic-exporter: add option to specify repository as a file

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -331,6 +331,13 @@ in
           not reside within /tmp - it won't be visible to the systemd service.
       '';
     } {
+      assertion =
+        cfg.restic.enable -> ((cfg.restic.repository == null) != (cfg.restic.repositoryFile == null));
+      message = ''
+        Please specify either 'services.prometheus.exporters.restic.repository'
+          or 'services.prometheus.exporters.restic.repositoryFile'.
+      '';
+    } {
       assertion = cfg.snmp.enable -> (
         (cfg.snmp.configurationPath == null) != (cfg.snmp.configuration == null)
       );

--- a/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
@@ -10,6 +10,7 @@ let
     mapAttrs'
     splitString
     toUpper
+    optional
     optionalAttrs
     nameValuePair
     ;
@@ -18,11 +19,20 @@ in
   port = 9753;
   extraOpts = {
     repository = mkOption {
-      type = types.str;
+      type = with lib.types; nullOr str;
+      default = null;
       description = ''
         URI pointing to the repository to monitor.
       '';
       example = "sftp:backup@192.168.1.100:/backups/example";
+    };
+
+    repositoryFile = mkOption {
+      type = with lib.types; nullOr path;
+      default = null;
+      description = ''
+        Path to the file containing the URI for the repository to monitor.
+      '';
     };
 
     passwordFile = mkOption {
@@ -103,13 +113,21 @@ in
 
   serviceOpts = {
     script = ''
+      export RESTIC_REPOSITORY=${
+        if cfg.repositoryFile != null
+        then "$(cat $CREDENTIALS_DIRECTORY/RESTIC_REPOSITORY)"
+        else "${cfg.repository}"
+      }
       export RESTIC_PASSWORD_FILE=$CREDENTIALS_DIRECTORY/RESTIC_PASSWORD_FILE
       ${pkgs.prometheus-restic-exporter}/bin/restic-exporter.py \
         ${concatStringsSep " \\\n  " cfg.extraFlags}
     '';
     serviceConfig = {
       EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
-      LoadCredential = [ "RESTIC_PASSWORD_FILE:${cfg.passwordFile}" ];
+      LoadCredential =
+        [ "RESTIC_PASSWORD_FILE:${cfg.passwordFile}" ]
+        ++ optional (cfg.repositoryFile != null)
+          [ "RESTIC_REPOSITORY:${cfg.repositoryFile}" ];
     };
     environment =
       let
@@ -119,7 +137,6 @@ in
         toRcloneVal = v: if lib.isBool v then lib.boolToString v else v;
       in
       {
-        RESTIC_REPOSITORY = cfg.repository;
         LISTEN_ADDRESS = cfg.listenAddress;
         LISTEN_PORT = toString cfg.port;
         REFRESH_INTERVAL = toString cfg.refreshInterval;


### PR DESCRIPTION
## Description of changes

This PR adds the option to specify the backup repository as a file. The Restic service module already has this option, but it serves little purpose if this exporter module exposes it as cleartext.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Reviewed points

- [x] changes are backward compatible
- [x] removed options are declared with `mkRemovedOptionModule`
- [x] changes that are not backward compatible are documented in release notes
- [x] module tests succeed on x86_64-linux
- [x] options types are appropriate
- [x] options description is set
- [ ] options example is provided
- [x] documentation affected by the changes is updated

I omitted an example as it is an arbitrary path and the other existing nullable file options does not have one either.

### Possible improvements
I believe the module will fail if `repositoryFile` is used together with an `rcloneConfig`, because it will try to use `cfg.repository`, which is null. The Restic service module seems to have the same problem though, and it does not break backward compatibility, so I have left it as is to at least make the behavior consistent.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
