### PR TITLE
archivemount: 0.9.1 -> 1

### DIFF
--- a/pkgs/by-name/ar/archivemount/package.nix
+++ b/pkgs/by-name/ar/archivemount/package.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchurl, pkg-config, fuse, libarchive }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  fuse,
+  libarchive,
+}:
 
 stdenv.mkDerivation rec {
   pname = "archivemount";
@@ -10,7 +17,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ fuse libarchive ];
+  buildInputs = [
+    fuse
+    libarchive
+  ];
 
   meta = {
     description = "Gateway between FUSE and libarchive: allows mounting of cpio, .tar.gz, .tar.bz2 archives";

--- a/pkgs/by-name/ar/archivemount/package.nix
+++ b/pkgs/by-name/ar/archivemount/package.nix
@@ -1,19 +1,22 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromSourcehut,
+  fetchpatch,
   pkg-config,
   fuse,
   libarchive,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "archivemount";
-  version = "0.9.1";
+  version = "1";
 
-  src = fetchurl {
-    url = "https://www.cybernoia.de/software/archivemount/archivemount-${version}.tar.gz";
-    sha256 = "1cy5b6qril9c3ry6fv7ir87s8iyy5vxxmbyx90dm86fbra0vjaf5";
+  src = fetchFromSourcehut {
+    owner = "~nabijaczleweli";
+    repo = "archivemount-ng";
+    rev = finalAttrs.version;
+    hash = "sha256-xuLtbqC9iS86BKz4jG8of4id+GTlBXoohONrkmIzOpY=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -22,10 +25,35 @@ stdenv.mkDerivation rec {
     libarchive
   ];
 
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "VERSION=${finalAttrs.version}"
+  ];
+
+  dontConfigure = true;
+
+  # Fix missing standard struct stat on Darwin
+  # Already on upstream, but no new release made
+  patches = [
+    (fetchpatch {
+      name = "fix-missing-standard-struct-stat-on-darwin.patch";
+      url = "https://git.sr.ht/~nabijaczleweli/archivemount-ng/commit/53dd70f05fdb6ababe7c1ca70f0f62bcf4930b5a.patch";
+      hash = "sha256-UqoALAJoNXihop6Mem4mu+W8REOV92Zyv7pPW20Ugz8=";
+    })
+  ];
+
+  # Fix cross-compilation
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail pkg-config "$PKG_CONFIG"
+  '';
+
   meta = {
     description = "Gateway between FUSE and libarchive: allows mounting of cpio, .tar.gz, .tar.bz2 archives";
     mainProgram = "archivemount";
-    license = lib.licenses.gpl2Only;
+    license = [
+      lib.licenses.lgpl2Plus
+      lib.licenses.bsd0
+    ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3062,8 +3062,6 @@ with pkgs;
 
   archivebox = callPackage ../applications/misc/archivebox { };
 
-  archivemount = callPackage ../tools/filesystems/archivemount { };
-
   archivy = callPackage ../applications/misc/archivy { };
 
   arandr = callPackage ../tools/X11/arandr { };


### PR DESCRIPTION
## Description of changes

`archivemount` has a new upstream, [per this filed issue indicating the deprecation of the old project and why](https://github.com/cybernoid/archivemount/issues/29)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
