### PR TITLE
ceph: 18.2.4 -> 19.2.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -452,6 +452,8 @@
 
 - The `lsh` package and the `services.lshd` module have been removed as they had no maintainer in Nixpkgs and hadn’t seen an upstream release in over a decade. It is recommended to migrate to `openssh` and `services.openssh`.
 
+- `ceph` has been upgraded to v19. See the [Ceph "squid" release notes](https://docs.ceph.com/en/latest/releases/squid/#v19-2-0-squid) for details and recommended upgrade procedure.
+
 - `opencv2` and `opencv3` have been removed, as they are obsolete and
   were not used by any other package. External users are encouraged to
   migrate to OpenCV 4.

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -7,10 +7,13 @@
 , fetchpatch
 
 # Build time
+, autoconf
+, automake
 , cmake
 , ensureNewerSourcesHook
 , fmt
 , git
+, libtool
 , makeWrapper
 , nasm
 , pkg-config
@@ -22,10 +25,11 @@
 # Runtime dependencies
 , arrow-cpp
 , babeltrace
-, boost179
+, boost182  # using the version installed by ceph's `install-deps.sh`
 , bzip2
 , cryptsetup
 , cunit
+, e2fsprogs
 , doxygen
 , gperf
 , graphviz
@@ -37,17 +41,22 @@
 , libcap_ng
 , libnl
 , libxml2
+, lmdb
 , lttng-ust
 , lua
+, lvm2
 , lz4
 , oath-toolkit
 , openldap
-, python311
+, parted
+, python311 # to get an idea which Python versions are supported by Ceph, see upstream `do_cmake.sh` (see `PYBUILD=` variable)
 , rdkafka
 , rocksdb
 , snappy
+, openssh
 , sqlite
 , utf8proc
+, xfsprogs
 , zlib
 , zstd
 
@@ -247,7 +256,7 @@ let
     };
   };
 
-  boost = boost179.override {
+  boost = boost182.override {
     enablePython = true;
     inherit python;
   };
@@ -282,6 +291,9 @@ let
     virtualenv
     werkzeug
 
+    # src/cephadm/zipapp-reqs.txt
+    markupsafe
+
     # src/pybind/mgr/requirements-required.txt
     cryptography
     jsonpatch
@@ -292,54 +304,24 @@ let
   ]);
   inherit (ceph-python-env.python) sitePackages;
 
-  version = "18.2.4";
+  version = "19.2.0";
   src = fetchurl {
     url = "https://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-    hash = "sha256-EFqteP3Jo+hASXVesH6gkjDjFO7/1RN151tIf/lQ06s=";
+    hash = "sha256-30vkW1j49hFIxyxzkssSKVSq0VqiwLfDtOb62xfxadM=";
   };
 in rec {
   ceph = stdenv.mkDerivation {
     pname = "ceph";
     inherit src version;
 
-    patches = [
-      # Fixes mgr not being able to import `packaging` due to autotools >= 70.
-      # Remove once https://github.com/ceph/ceph/pull/58624 is merged, see
-      # https://github.com/NixOS/nixpkgs/pull/330226#issuecomment-2268421031
-      (fetchpatch {
-        url = "https://github.com/ceph/ceph/commit/8da2d857fa8fdfedd7aad0ca90e1780a3ed085c9.patch";
-        name = "ceph-mgr-python-fix-packaging-import.patch";
-        hash = "sha256-3Yl1X6UfTf0XCXJxgRnM/Js9sz8tS+hsqViY6gDExoI=";
-      })
-
-      # Fixes cryptesetup version parsing regex, see
-      # * https://github.com/NixOS/nixpkgs/issues/334227
-      # * https://www.mail-archive.com/ceph-users@ceph.io/msg26309.html
-      # * https://github.com/ceph/ceph/pull/58997
-      # Remove once we're on the next version of Ceph 18, when this should be in:
-      # https://github.com/ceph/ceph/pull/58997
-      (fetchpatch {
-        url = "https://github.com/ceph/ceph/commit/6ae874902b63652fa199563b6e7950cd75151304.patch";
-        name = "ceph-reef-ceph-volume-fix-set_dmcrypt_no_workqueue.patch";
-        hash = "sha256-r+7hcCz2WF/rJfgKwTatKY9unJlE8Uw3fmOyaY5jVH0=";
-      })
-      (fetchpatch {
-        url = "https://github.com/ceph/ceph/commit/607eb34b2c278566c386efcbf3018629cf08ccfd.patch";
-        name = "ceph-volume-fix-set_dmcrypt_no_workqueue-regex.patch";
-        hash = "sha256-q28Q7OIyFoMyMBCPXGA+AdNqp+9/6J/XwD4ODjx+JXY=";
-      })
-    ];
-
-    postPatch = ''
-      substituteInPlace cmake/modules/Finduring.cmake \
-        --replace-fail "liburing.a liburing" "uring"
-    '';
-
     nativeBuildInputs = [
+      autoconf # `autoreconf` is called, e.g. for `qatlib_ext`
+      automake # `aclocal` is called, e.g. for `qatlib_ext`
       cmake
       fmt
       git
       makeWrapper
+      libtool # used e.g. for `qatlib_ext`
       nasm
       pkg-config
       python
@@ -357,17 +339,23 @@ in rec {
       babeltrace
       boost
       bzip2
+      # Adding `ceph-python-env` here adds the env's `site-packages` to `PYTHONPATH` during the build.
+      # This is important, otherwise the build system may not find the Python deps and then
+      # silently skip installing ceph-volume and other Ceph python tools.
       ceph-python-env
       cryptsetup
       cunit
+      e2fsprogs # according to `debian/control` file, `ceph-volume` is supposed to use it
       gperf
       gtest
       icu
       libcap
       libnl
       libxml2
+      lmdb
       lttng-ust
       lua
+      lvm2 # according to `debian/control` file, e.g. `pvs` command used by `src/ceph-volume/ceph_volume/api/lvm.py`
       lz4
       malloc
       oath-toolkit
@@ -375,11 +363,14 @@ in rec {
       optLibatomic_ops
       optLibs3
       optYasm
+      parted # according to `debian/control` file, used by `src/ceph-volume/ceph_volume/util/disk.py`
       rdkafka
       rocksdb'
       snappy
+      openssh # according to `debian/control` file, `ssh` command used by `cephadm`
       sqlite
       utf8proc
+      xfsprogs # according to `debian/control` file, `ceph-volume` is supposed to use it
       zlib
       zstd
     ] ++ lib.optionals stdenv.hostPlatform.isLinux [
@@ -402,7 +393,11 @@ in rec {
       optLibedit
     ];
 
-    pythonPath = [ ceph-python-env "${placeholder "out"}/${ceph-python-env.sitePackages}" ];
+    # Picked up, amongst others, by `wrapPythonPrograms`.
+    pythonPath = [
+      ceph-python-env
+      "${placeholder "out"}/${ceph-python-env.sitePackages}"
+    ];
 
     # replace /sbin and /bin based paths with direct nix store paths
     # increase the `command` buffer size since 2 nix store paths cannot fit within 128 characters
@@ -413,9 +408,8 @@ in rec {
         --replace "/sbin/modprobe" "${kmod}/bin/modprobe" \
         --replace "/bin/grep" "${gnugrep}/bin/grep"
 
-      # install target needs to be in PYTHONPATH for "*.pth support" check to succeed
-      # set PYTHONPATH, so the build system doesn't silently skip installing ceph-volume and others
-      export PYTHONPATH=${ceph-python-env}/${sitePackages}:$lib/${sitePackages}:$out/${sitePackages}
+      # The install target needs to be in PYTHONPATH for "*.pth support" check to succeed
+      export PYTHONPATH=$PYTHONPATH:$lib/${sitePackages}:$out/${sitePackages}
       patchShebangs src/
     '';
 
@@ -452,6 +446,10 @@ in rec {
       "-DWITH_SYSTEM_ROCKSDB:BOOL=ON"
       "-DWITH_SYSTEM_UTF8PROC:BOOL=ON"
       "-DWITH_SYSTEM_ZSTD:BOOL=ON"
+
+      # Use our own python libraries too, see:
+      #     https://github.com/NixOS/nixpkgs/pull/344993#issuecomment-2391046329
+      "-DCEPHADM_BUNDLED_DEPENDENCIES=none"
 
       # TODO breaks with sandbox, tries to download stuff with npm
       "-DWITH_MGR_DASHBOARD_FRONTEND:BOOL=OFF"


### PR DESCRIPTION
## Description of changes

* https://ceph.io/en/news/blog/2024/v19-2-0-squid-released/
* https://docs.ceph.com/en/latest/releases/squid/#v19-2-0-squid

## TODO

* [x] Make the build work.
* [ ] The Ceph release notes currently mention an issue with iSCSI, we may not want to merge this until there are no known upstream issues.
  * I asked at https://tracker.ceph.com/issues/68215#note-12:
    > For distro packagers, can you clarify if this problem only exists for 19.1.1 to 19.2.0, or also for 18.* or older versions to 19.2.0?
    >
    > As in, should we ask iSCSI users NOT to upgrade yet?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
