### PR TITLE
CONTRIBUTING: add section on getting your PR merged

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -744,6 +744,24 @@ If ofBorg reveals the build to be broken on some platform and you don't have acc
 
 When in any doubt, please simply ask via a comment in your PR or through one of the help channels.
 
+## I received a review on my PR, how do I get it over the finish line?
+
+In the review process, the committer will have left some sort of feedback on your PR.
+They may have immediately approved of your PR or even merged it but the more likely case is that they want you to change a few things or that they require further input.
+
+A reviewer may have taken a look at the code and it looked good to them ("Diff LGTM") but they still need to be convinced of the artefact's quality.
+They might also be waiting on input from other users of the component or its listed maintainer on whether the intention of your PR makes sense for the component.
+If you know of people who could help clarify any of this, please bring the PR to their attention.
+The current state of the PR is frequently not clearly communicated, so please don't hesitate to ask about it if it's unclear to you.
+
+It's also possible for the reviewer to not be convinced that your PR is necessary or that the method you've chose to achieve your intention is the right one.
+
+Please explain your intentions and reasoning to the committer in such a case.
+There may be constraints you had to work with which they're not aware of or qualities of your approach that they didn't immediately notice.
+(If these weren't clear to the reviewer, that's a good sign you should explain them in your commit message or code comments!)
+
+There are some further pitfalls and realities which this section intends to make you aware of.
+
 ### A reviewer requested a bunch of insubstantial changes on my PR
 
 The people involved in Nixpkgs care about code quality because, once in Nixpkgs, it needs to be maintained for many years to come.
@@ -771,3 +789,36 @@ This will usually reveal how important they deem it to be and will help educate 
 
 Some committers may have stronger opinions on some things and therefore (understandably) may not want to merge your PR if you don't follow their requests.
 It is totally fine to get yourself a second or third opinion in such a case.
+
+### Committers work on a push-basis
+
+It's possible for you to get a review but nothing happens afterwards, even if you reply to review comments.
+A committer not following up on your PR does not necessarily mean they're disinterested or unresponsive, they may have simply forgotten to follow up on it or had some other circumstances preventing them from doing so.
+
+Committers typically handle many other PRs besides yours and it is not realistic for them to keep up with all of them to a degree where they could reasonably remember to follow up on all PRs that they had intended following up upon.
+If someone left an approving review on your PR and didn't merge a few days later, the most likely case is that they simply forgot.
+
+Please see it as your responsibility to actively remind reviewers of your open PRs.
+
+The easiest way to do so is to simply cause them a Github notification.
+Github notifies people involved in the PR when you add a comment to your PR, push your PR or re-request their review.
+Doing any of that will get you people's attention again.
+
+It may very well be the case that you have to do this every time you need the committer to follow up upon your PR.
+Again, this is a community project so please be mindful of people's circumstances here; be nice when requesting reviews again.
+
+It may also be the case that the committer has lost interest or isn't familiar enough with the component you're touching to be comfortable merging your PR.
+They will likely not immediately state that fact however, so please ask for clarification and don't hesitate to find yourself another committer to take a look at your PR.
+
+### Nothing helped
+
+If you followed these guidelines but still got no results or if you feel that you have been wronged in some way, please explicitly reach out to the greater community via its communication channels.
+
+The [NixOS Discourse](https://discourse.nixos.org/) is a great place to do this as it has historically been the asynchronous medium with the greatest concentration of committers and other people who are significantly involved in Nixpkgs.
+There is a dedicated discourse thread [PRs in distress](https://discourse.nixos.org/t/prs-in-distress/3604) where you can link your PR if everything else fails.
+The [Nixpkgs / NixOS contributions Matrix channel](https://matrix.to/#/#dev:nixos.org) is the best synchronous channel with the same qualities.
+
+Please reserve these for cases where you've made a serious effort in trying to get the attention of multiple active committers and provided realistic means for them to assess your PR's quality though.
+As mentioned previously, it is unfortunately perfectly normal for a PR to sit around for weeks on end due to the realities of this being a community project.
+Please don't blow up situations where progress is happening but is merely not going fast enough for your tastes.
+Honking in a traffic jam will not make you go any faster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,8 @@ This section describes in some detail how changes can be made and proposed with 
 7. Respond to review comments, potential CI failures and potential merge conflicts by updating the pull request.
    Always keep the pull request in a mergeable state.
 
+   This process is covered in more detail from the non-technical side in [I opened a PR, how do I get it merged?](#i-opened-a-pr-how-do-i-get-it-merged).
+
    The custom [OfBorg](https://github.com/NixOS/ofborg) CI system will perform various checks to help ensure code quality, whose results you can see at the bottom of the pull request.
    See [the OfBorg Readme](https://github.com/NixOS/ofborg#readme) for more details.
 
@@ -343,7 +345,7 @@ If you consider having enough knowledge and experience in a topic and would like
 
 Container system, boot system and library changes are some examples of the pull requests fitting this category.
 
-## How to merge pull requests
+## How to merge pull requests yourself
 [pr-merge]: #how-to-merge-pull-requests
 
 To streamline automated updates, leverage the nixpkgs-merge-bot by simply commenting `@NixOS/nixpkgs-merge-bot merge`. The bot will verify if the following conditions are met, refusing to merge otherwise:
@@ -353,10 +355,7 @@ To streamline automated updates, leverage the nixpkgs-merge-bot by simply commen
 
 Further, nixpkgs-merge-bot will ensure all ofBorg checks (except the Darwin-related ones) are successfully completed before merging the pull request. Should the checks still be underway, the bot patiently waits for ofBorg to finish before attempting the merge again.
 
-For other pull requests, the *Nixpkgs committers* are people who have been given
-permission to merge.
-
-It is possible for community members that have enough knowledge and experience on a special topic to contribute by merging pull requests.
+For other pull requests, please see [I opened a PR, how do I get it merged?](#i-opened-a-pr-how-do-i-get-it-merged).
 
 In case the PR is stuck waiting for the original author to apply a trivial
 change (a typo, capitalisation change, etc.) and the author allowed the members
@@ -553,6 +552,7 @@ To get a sense for what changes are considered mass rebuilds, see [previously me
   - [Commit conventions](./doc/README.md#commit-conventions) for changes to `doc`, the Nixpkgs manual.
 
 ### Writing good commit messages
+[writing-good-commit-messages]: #writing-good-commit-messages
 
 In addition to writing properly formatted commit messages, it's important to include relevant information so other developers can later understand *why* a change was made. While this information usually can be found by digging code, mailing list/Discourse archives, pull request discussions or upstream changes, it may require a lot of work.
 
@@ -651,3 +651,123 @@ Names of files and directories should be in lowercase, with dashes between words
 
   As an exception, an explicit conditional expression with null can be used when fixing a important bug without triggering a mass rebuild.
   If this is done a follow up pull request _should_ be created to change the code to `lib.optional(s)`.
+
+## I opened a PR, how do I get it merged?
+[i-opened-a-pr-how-do-i-get-it-merged]:#i-opened-a-pr-how-do-i-get-it-merged
+
+In order for your PR to be merged, someone with merge permissions on the repository ("committer") needs to review and merge it.
+Because the group of people with merge permissions is mostly a collection of independent unpaid volunteers who do this in their own free time, this can take some time to happen.
+It is entirely normal for your PR to sit around without any feedback for days, weeks or sometimes even months.
+We strive to avoid the latter cases of course but the reality of it is that this does happen quite frequently.
+Even when you get feedback, follow-up feedback may take similarly long.
+Don't be intimidated by this and kindly ask for feedback again every so often.
+If your change is good it will eventually be merged at some point.
+
+There are some things you can do to help speed up the process of your PR being merged though.
+In order to speed the process up, you need to know what needs to happen before a committer will actually hit the merge button.
+This section intends to give a little overview and insight of what happens after you create your PR.
+
+### The committer's perspective
+
+PRs have varying quality and even the best people make mistakes.
+It is the role of the committer team to assess whether any PR's changes are good changes or not.
+In order for any PR to be merged, at least one committer needs to be convinced of its quality enough to merge it.
+
+Committers typically assess three aspects of your PR:
+
+1. Whether the change's intention is necessary and desirable
+2. Whether the code quality of your changes is good
+3. Whether the artefacts produced by the code are good
+
+If you want your PR to get merged quickly and smoothly, it is in your best interest to help convince committers in these three aspects.
+
+### How to help committers assess your PR
+
+For the committer to judge your intention, it's best to explain why you've made your change.
+This does not apply to trivial changes like version updates because the intention is obvious (though linking the changelog is appreciated).
+For any more nuanced changed or even major version upgrades, it helps if you explain the background behind your change a bit.
+E.g. if you're adding a package, explain what it is and why it should be in Nixpkgs.
+This goes hand in hand with [Writing good commit messages](#writing-good-commit-messages).
+
+For the code quality assessment, you cannot do anything yourself as only the committer can do this and they already have your code to look at.
+In order to minimise the need for back and forth though, do take a look over your code changes yourself and try to put yourself into the shoes of someone who didn't just write that code.
+Would you immediately know what the code does by glancing at it?
+If not, reviewers will notice this and will ask you to clarify the code by refactoring it and/or adding a few explanations in code comments.
+Doing this preemptively can save you and the committer a lot of time.
+
+The code artefacts are the hardest for committers to assess because PRs touch all sorts of components: applications, libraries, NixOS modules, editor plugins and many many other things.
+Any individual committer can only really assess components that they themselves know how to use however and yet they must still be convinced somehow.
+There isn't a good generic solution to this but there are some ways easing the committer's job here:
+
+- Provide smoke tests that the committer can run without much research or setup.
+
+  Committers usually don't have the time or interest to learn how your component works and how they could test its functionality.
+  If you can provide a quick guide on how to use the component in a meaningful way or a ready-made command that demonstrates that the component works as expected, the committer can easily convince themselves that your change is good.
+  If it can be automated, you could even turn this smoke test into an automated NixOS test which reviewers could simply run via Nix.
+- Invite other users of the component to try it out and report their findings.
+
+  If a committer sees the testimonials of other users trying your change and it works as expected for them, that too can convince the committer of your PR's quality.
+- Describe what you have done to test your PR.
+
+  If you can convince the committer that you have done sufficient quality assurance on your changes and they trust your report, this too can convince them of your PR's quality, albeit not as strongly as the methods above.
+- Become a maintainer of the component.
+
+  This isn't something you can do on your first few PRs touching a component but listed maintainers generally receive more trust when it comes to changes to their maintained components and committers may opt to merge changes without deeper review when they see they're done by their respective maintainer.
+
+Even if you adhere to all of these recommendations, it is still quite possible for your PR to be forgotten or abandoned by any given committer.
+Please remain mindful of the fact that they are doing this on their own volition and unpaid in their free time and therefore [owe you nothing](https://mikemcquaid.com/open-source-maintainers-owe-you-nothing/).
+Causing a stink in such a situation is a surefire way to get any other potential committer to not want to look at your PR either.
+Ask them nicely whether they still intend to review your PR and find yourself another committer to look at your PR if not.
+
+### How can I get a committer to look at my PR?
+
+- Simply wait. Reviewers frequently browse open PRs and may happen to run across yours and take a look.
+- Get non-committers to review/approve. Many committers filter open PRs for low-hanging fruit that are already been reviewed.
+- [@-mention](https://github.blog/news-insights/mention-somebody-they-re-notified/) someone and ask them nicely
+- Post in one of the channels made for this purpose if there has been no activity for at least one week
+  - The current "PRs ready for review" or "PRs already reviewed" threads in the [NixOS Discourse](https://discourse.nixos.org/c/dev/14) (of course choose the one that applies to your situation)
+  - The [Nixpkgs Review Requests Matrix room](https://matrix.to/#/#review-requests:nixos.org).
+
+### CI failed or got stuck on my PR, what do I do?
+
+First ensure that the failure is actually related to your change.
+Sometimes, the CI system simply has a hiccup or the check was broken by someone else before you made your changes.
+Read through the error message; it's usually quite easy to tell whether it is caused by anything you did by checking whether it mentions the component you touched anywhere.
+If it is indeed caused by your change, obviously try to fix it.
+Don't be afraid of asking for advice if you're uncertain how to do that, others have likely fixed such issues dozens of times and can help you out.
+Your PR is unlikely to be merged if it has a known issue and it is the purpose of CI to alert you aswell as reviewers to these issues.
+
+ofBorg builds can often get stuck, particularly in PRs targeting `staging` and in builders for the Darwin platform. Reviewers will know how to handle them or when to ignore them.
+Don't worry about it.
+If there is a build failure however and it happened due to a package related to your change, you need to investigate it of course.
+If ofBorg reveals the build to be broken on some platform and you don't have access to that platform, you should set your package's `meta.broken` accordingly.
+
+When in any doubt, please simply ask via a comment in your PR or through one of the help channels.
+
+### A reviewer requested a bunch of insubstantial changes on my PR
+
+The people involved in Nixpkgs care about code quality because, once in Nixpkgs, it needs to be maintained for many years to come.
+It is therefore likely that other people will ask you to do some things in another way or adhere to some standard.
+Sometimes however, they also care a bit too much and may ask you to adhere to a personal preference of theirs.
+It's not always easy to tell which is which and whether the requests are critically important to merging the PR.
+Sometimes another reviewer may also come along with totally different opinions on some points too.
+
+It is convention to mark review comments that are not critical to the PR as nitpicks but this is not always followed.
+As the PR author, you should still take a look at these as they will often reveal best practices and unwritten rules that usually have good reasons behind them and you may want to incorporate them into your modus operandi.
+
+Please keep in mind that reviewers almost always mean well here.
+Their intent is not to denounce your code, they simply want your code to be as good as it can be.
+Through their experience, they may also take notice of a seemingly insignificant issues that have caused significant burden before.
+
+Sometimes however, they can also get a bit carried away and become too perfectionistic.
+If you feel some of the requests are unreasonable or merely a matter of personal preference, try to nicely remind the reviewers that you may not intend this code to be 100% perfect or that you have different taste in some regards and press them on whether they think that these requests are *critical* to the PR's success.
+
+While we do have a set of [official standards for the Nix community](https://github.com/NixOS/rfcs/), we don't have standards for everything and there are often multiple valid ways to achieve the same goal.
+Unless there are standards forbidding the patterns used in your code or there are serious technical, maintainability or readability issues with your code, you can insist to keep the code the way you made it and disregard the requests.
+Please communicate this clearly though; a simple "I prefer it this way and see no major issue with it" can save you a lot of arguing.
+
+If you are unsure about some change requests, please ask reviewers *why* they requested them.
+This will usually reveal how important they deem it to be and will help educate you about standards, best practices, unwritten rules aswell as preferences people have and why.
+
+Some committers may have stronger opinions on some things and therefore (understandably) may not want to merge your PR if you don't follow their requests.
+It is totally fine to get yourself a second or third opinion in such a case.


### PR DESCRIPTION
This serves as an overview of the process as we currently live it and as a guide for getting it done quickly and efficiently for people who haven't been contributing to Nixpkgs for many years.

The intention is to document how the process currently works, set expectations right, provide recommendations on getting through the process and motivate people to help us committers help them better. Win-win for everyone.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
