### PR TITLE
Filebot: replace libmediainfo with working version

### DIFF
--- a/pkgs/by-name/fi/filebot/package.nix
+++ b/pkgs/by-name/fi/filebot/package.nix
@@ -69,7 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : ${
         lib.makeBinPath [
           chromaprint
-          libmediainfo
           openjdk17
           p7zip
           unrar
@@ -78,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Expose the binary in bin to make runnable.
     ln -s $out/opt/filebot.sh $out/bin/filebot
 
-    # Delete the built-in libmediainfo so the program has to use the nixpkgs version
+    # Delete the built-in libmediainfo so the program has to use the symlinked nixpkgs version
     rm $out/opt/lib/**/libmediainfo.so
     ln -s ${libmediainfo.outPath}/lib/libmediainfo.so $out/opt/lib/Linux-aarch64/libmediainfo.so
     ln -s ${libmediainfo.outPath}/lib/libmediainfo.so $out/opt/lib/Linux-armv7l/libmediainfo.so

--- a/pkgs/by-name/fi/filebot/package.nix
+++ b/pkgs/by-name/fi/filebot/package.nix
@@ -15,10 +15,8 @@
   glib,
   genericUpdater,
   writeShellScript,
-  openjfx,
   p7zip,
   unrar,
-  zenity,
 }:
 
 let
@@ -41,7 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     autoPatchelfHook
-    zenity
   ];
 
   buildInputs = [
@@ -51,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     curlWithGnuTls
     libmms
     glib
-    zenity
   ];
 
   postPatch = ''
@@ -75,10 +71,8 @@ stdenv.mkDerivation (finalAttrs: {
           chromaprint
           libmediainfo
           openjdk17
-          openjfx
           p7zip
           unrar
-          zenity
         ]
       }
     # Expose the binary in bin to make runnable.

--- a/pkgs/by-name/fi/filebot/package.nix
+++ b/pkgs/by-name/fi/filebot/package.nix
@@ -83,6 +83,12 @@ stdenv.mkDerivation (finalAttrs: {
       }
     # Expose the binary in bin to make runnable.
     ln -s $out/opt/filebot.sh $out/bin/filebot
+
+    # Delete the built-in libmediainfo so the program has to use the nixpkgs version
+    rm $out/opt/lib/**/libmediainfo.so
+    ln -s ${libmediainfo.outPath}/lib/libmediainfo.so $out/opt/lib/Linux-aarch64/libmediainfo.so
+    ln -s ${libmediainfo.outPath}/lib/libmediainfo.so $out/opt/lib/Linux-armv7l/libmediainfo.so
+    ln -s ${libmediainfo.outPath}/lib/libmediainfo.so $out/opt/lib/Linux-x86_64/libmediainfo.so
   '';
 
   passthru.updateScript = genericUpdater {

--- a/pkgs/by-name/fi/filebot/package.nix
+++ b/pkgs/by-name/fi/filebot/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   coreutils,
+  chromaprint,
   openjdk17,
   makeWrapper,
   autoPatchelfHook,
@@ -14,6 +15,10 @@
   glib,
   genericUpdater,
   writeShellScript,
+  openjfx,
+  p7zip,
+  unrar,
+  zenity,
 }:
 
 let
@@ -36,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     autoPatchelfHook
+    zenity
   ];
 
   buildInputs = [
@@ -45,6 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     curlWithGnuTls
     libmms
     glib
+    zenity
   ];
 
   postPatch = ''
@@ -63,7 +70,17 @@ stdenv.mkDerivation (finalAttrs: {
       --replace '$FILEBOT_HOME/data/.license' '$APP_DATA/.license' \
       --replace '-jar "$FILEBOT_HOME/jar/filebot.jar"' '-Dcom.googlecode.lanterna.terminal.UnixTerminal.sttyCommand=${coreutils}/bin/stty -jar "$FILEBOT_HOME/jar/filebot.jar"'
     wrapProgram $out/opt/filebot.sh \
-      --prefix PATH : ${lib.makeBinPath [ openjdk17 ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          chromaprint
+          libmediainfo
+          openjdk17
+          openjfx
+          p7zip
+          unrar
+          zenity
+        ]
+      }
     # Expose the binary in bin to make runnable.
     ln -s $out/opt/filebot.sh $out/bin/filebot
   '';


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The included libmediainfo library fails to load as it is built on CURL_GNUTLS_3 while nixpkgs supplies CURL_GNUTLS_4. This updates the library in-place by removing the supplied version and symlinking the one in nixpkgs to the same locations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
