### PR TITLE
atlassian-plugin-sdk: init at 9.1.1

### DIFF
--- a/pkgs/by-name/at/atlassian-plugin-sdk/package.nix
+++ b/pkgs/by-name/at/atlassian-plugin-sdk/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  jdk11,
+  atlassian-plugin-sdk,
+  testers,
+  writeShellScript,
+  common-updater-scripts,
+  curl,
+  jq,
+  yq,
+}:
+
+let
+  mavenGroupIdUrl = "https://packages.atlassian.com/maven/public/com/atlassian/amps";
+
+in
+stdenv.mkDerivation rec {
+  pname = "atlassian-plugin-sdk";
+  version = "9.1.1";
+
+  src = fetchurl {
+    url = "${mavenGroupIdUrl}/atlassian-plugin-sdk/${version}/atlassian-plugin-sdk-${version}.tar.gz";
+    hash = "sha256-sEAe1eif9qXvIOu8RfZ4MWngEO5yCjU74g4Crd85J3Y=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jdk11 ];
+
+  unpackPhase = "tar -xzf $src";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r atlassian-plugin-sdk-${version}/* $out
+    rm $out/bin/*.bat
+
+    for file in "$out"/bin/*; do
+      wrapProgram $file --set JAVA_HOME "${jdk11}"
+    done
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = atlassian-plugin-sdk;
+      command = "atlas-version";
+      version = "atlassian-plugin-sdk-${version}";
+    };
+
+    updateScript = writeShellScript "update-atlassian-plugin-sdk" ''
+      set -o errexit
+      export PATH="${
+        lib.makeBinPath [
+          curl
+          jq
+          yq
+          common-updater-scripts
+        ]
+      }:$PATH"
+
+      NEW_VERSION=$(curl -s ${mavenGroupIdUrl}/atlassian-plugin-sdk/maven-metadata.xml | xq -r '.metadata.versioning.latest')
+
+      if [[ "${version}" = "$NEW_VERSION" ]]; then
+          echo "The new version same as the old version."
+          exit 0
+      fi
+
+      DOWNLOAD_URL="${mavenGroupIdUrl}/atlassian-plugin-sdk/${version}/atlassian-plugin-sdk-$NEW_VERSION.tar.gz"
+      NIX_HASH=$(nix hash to-sri sha256:$(nix-prefetch-url $DOWNLOAD_URL))
+
+      update-source-version "atlassian-plugin-sdk" "$NEW_VERSION" "$NIX_HASH" "$DOWNLOAD_URL"
+    '';
+  };
+
+  meta = with lib; {
+    description = "Atlassian Plugin SDK";
+    homepage = "https://developer.atlassian.com/server/framework/atlassian-sdk/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pathob ];
+    platforms = platforms.linux;
+    mainProgram = "atlas-mvn";
+  };
+}


### PR DESCRIPTION
## Description of changes

For work I have to deal with custom Atlassian Data Center apps (plugins) quite often. These apps are Maven projects for which an official tool exists, the "Atlassian Plugin SDK". The Atlassian Plugin SDK is basically only a Maven wrapper that comes with some "aliases" for a list of Maven commands plus some config such as the Atlassian Maven repo. Still, I think the tool is quite useful, especially for bootstrapping new plugin projects, and I've been using this package as an overlay for a while already, and now I would like to make it available as an official Nix package for other users also.

As the Atlassian Plugin SDK is based on Maven, it requires Java. The official documentation states that it still requires Java 8. However, all the Atlassian products, that also can be launched with this SDK, such as Jira, Confluence, etc. already support Java 11 for a while, and I've used the SDK with Java 11 also since I've created this package without issues. Java 17 support for Atlassian products is still quite new and in order to also be able to maintain plugins for older product versions, I would recommend to not use Java 17 yet. Going down to Java 8 would be fine for me also.

For upstreaming this package, I've added the test and update passthru scripts. However, I'm using these for the first time now, and I didn't figure out how to run them locally in a reasonable amount of time. My setup is flake based, and I now have this package in a pkgs.unstable overlay...

Also, I'm not sure whether the metadata section is already correct and complete.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
