### PR TITLE
symlinkJoin: ability to strip prefix from tree

### DIFF
--- a/pkgs/build-support/trivial-builders/test/default.nix
+++ b/pkgs/build-support/trivial-builders/test/default.nix
@@ -19,6 +19,7 @@ in
 recurseIntoAttrs {
   concat = callPackage ./concat-test.nix {};
   linkFarm = callPackage ./link-farm.nix {};
+  symlinkJoin = recurseIntoAttrs (callPackage ./symlink-join.nix {});
   overriding = callPackage ../test-overriding.nix {};
   inherit references;
   writeCBin = callPackage ./writeCBin.nix {};

--- a/pkgs/build-support/trivial-builders/test/symlink-join.nix
+++ b/pkgs/build-support/trivial-builders/test/symlink-join.nix
@@ -1,0 +1,136 @@
+{
+  symlinkJoin,
+  writeTextFile,
+  runCommand,
+  testers,
+}:
+
+let
+  inherit (testers) testEqualContents testBuildFailure;
+
+  foo = writeTextFile {
+    name = "foo";
+    text = "foo";
+    destination = "/etc/test.d/foo";
+  };
+
+  bar = writeTextFile {
+    name = "bar";
+    text = "bar";
+    destination = "/etc/test.d/bar";
+  };
+
+  baz = writeTextFile {
+    name = "baz";
+    text = "baz";
+    destination = "/var/lib/arbitrary/baz";
+  };
+
+  qux = writeTextFile {
+    name = "qux";
+    text = "qux";
+  };
+
+  emulatedSymlinkJoinFooBarStrip = runCommand "symlinkJoin-strip-foo-bar" { } ''
+    mkdir $out
+    ln -s ${foo}/etc/test.d/foo $out/
+    ln -s ${bar}/etc/test.d/bar $out/
+  '';
+in
+{
+  symlinkJoin = testEqualContents {
+    assertion = "symlinkJoin";
+    actual = symlinkJoin {
+      name = "symlinkJoin";
+      paths = [
+        foo
+        bar
+        baz
+      ];
+    };
+    expected = runCommand "symlinkJoin-foo-bar-baz" { } ''
+      mkdir -p $out/{var/lib/arbitrary,etc/test.d}
+      ln -s {${foo},${bar}}/etc/test.d/* $out/etc/test.d
+      ln -s ${baz}/var/lib/arbitrary/baz $out/var/lib/arbitrary/
+    '';
+  };
+
+  symlinkJoin-strip-paths = testEqualContents {
+    assertion = "symlinkJoin-strip-paths";
+    actual = symlinkJoin {
+      name = "symlinkJoinPrefix";
+      paths = [
+        foo
+        bar
+      ];
+      stripPrefix = "/etc/test.d";
+    };
+    expected = emulatedSymlinkJoinFooBarStrip;
+  };
+
+  symlinkJoin-strip-paths-skip-missing = testEqualContents {
+    assertion = "symlinkJoin-strip-paths-skip-missing";
+    actual = symlinkJoin {
+      name = "symlinkJoinPrefix";
+      paths = [
+        foo
+        bar
+        baz
+      ];
+      stripPrefix = "/etc/test.d";
+    };
+    expected = emulatedSymlinkJoinFooBarStrip;
+  };
+
+  symlinkJoin-strip-paths-skip-not-directories = testEqualContents {
+    assertion = "symlinkJoin-strip-paths-skip-not-directories";
+    actual = symlinkJoin {
+      name = "symlinkJoinPrefix";
+      paths = [
+        foo
+        bar
+        qux
+      ];
+      stripPrefix = "/etc/test.d";
+    };
+    expected = emulatedSymlinkJoinFooBarStrip;
+  };
+
+  symlinkJoin-fails-on-missing =
+    runCommand "symlinkJoin-fails-on-missing"
+      {
+        failed = testBuildFailure (symlinkJoin {
+          name = "symlinkJoin-fail";
+          paths = [
+            foo
+            bar
+            baz
+          ];
+          stripPrefix = "/etc/test.d";
+          failOnMissing = true;
+        });
+      }
+      ''
+        grep -e "-baz/etc/test.d: No such file or directory" $failed/testBuildFailure.log
+        touch $out
+      '';
+
+  symlinkJoin-fails-on-file =
+    runCommand "symlinkJoin-fails-on-file"
+      {
+        failed = testBuildFailure (symlinkJoin {
+          name = "symlinkJoin-fail";
+          paths = [
+            foo
+            bar
+            qux
+          ];
+          stripPrefix = "/etc/test.d";
+          failOnMissing = true;
+        });
+      }
+      ''
+        grep -e "-qux/etc/test.d: Not a directory" $failed/testBuildFailure.log
+        touch $out
+      '';
+}


### PR DESCRIPTION
Currently, symlinkJoin always joins packages at its roots. It is possible to just suffix every package with wanted path to avoid that, but this causes an error due to missing path (If there is one `packages` option, but multiple things that you want to extract from those packages)

We already have uses for similar functionality in tree, but it it always duplicated, e.g
- udev (also includes some checking/patching, but doesn't matter, patching would be better implemented as a build hook, and checking as symlinkJoin postBuild): https://github.com/NixOS/nixpkgs/blob/818089ba7383b6a8950a8b74d12744850cd46652/nixos/modules/services/hardware/udev.nix#L52-L59
- systemd: https://github.com/NixOS/nixpkgs/blob/nixos-24.05/nixos/modules/system/boot/systemd.nix#L507-L521
- tmpfiles (it is suffixing packages, and it is enough in this case. Still, stripPrefix might look better): https://github.com/NixOS/nixpkgs/blob/nixos-24.05/nixos/modules/system/boot/systemd/tmpfiles.nix#L189-L202

The patch is a little bit ugly to avoid causing mass-rebuilds, it would be nice to make it prettier during one.

Required for Qubes: https://github.com/NixOS/nixpkgs/pull/341215

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
