### PR TITLE
 python3Packages.xdis: 6.1.0 -> 6.1.1,  python3Packages.uncompyle6: 3.9.1 -> 3.9.2

### DIFF
--- a/pkgs/development/python-modules/uncompyle6/default.nix
+++ b/pkgs/development/python-modules/uncompyle6/default.nix
@@ -6,19 +6,19 @@
   spark-parser,
   xdis,
   nose,
-  pytest,
+  pytestCheckHook,
   hypothesis,
   six,
 }:
 
 buildPythonPackage rec {
   pname = "uncompyle6";
-  version = "3.9.1";
+  version = "3.9.2";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-xFHDjrPFzINOuLip5uCwzzIm5NlNCP0nbdA/6RWO2yc=";
+    hash = "sha256-b3CYD/4IpksRS2hxgy/QLYbJkDX4l2qPH4Eh2tb8pCU=";
   };
 
   propagatedBuildInputs = [
@@ -28,25 +28,19 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     nose
-    pytest
+    pytestCheckHook
     hypothesis
     six
   ];
 
-  # Tests attempt to decompile bytecode of the python version
-  # that is running the tests - this does not work for versions
-  # above 3.8, but they decompile older bytecode fine
+  # No tests are provided for versions past 3.8,
+  # as the project only targets bytecode of versions <= 3.8
   doCheck = pythonOlder "3.9";
-  # six import errors (yet it is supplied...)
-  checkPhase = ''
-    runHook preCheck
-    pytest ./pytest --ignore=pytest/test_function_call.py
-    runHook postCheck
-  '';
 
-  meta = with lib; {
-    description = "Python cross-version byte-code deparser";
-    homepage = "https://github.com/rocky/python-uncompyle6/";
-    license = licenses.gpl3;
+  meta = {
+    description = "A bytecode decompiler for Python versions 3.8 and below";
+    homepage = "https://github.com/rocky/python-uncompyle6";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ melvyn2 ];
   };
 }

--- a/pkgs/development/python-modules/xdis/default.nix
+++ b/pkgs/development/python-modules/xdis/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   click,
   fetchFromGitHub,
+  fetchpatch,
   pytestCheckHook,
   pythonOlder,
   six,
@@ -10,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "xdis";
-  version = "6.1.0";
+  version = "6.1.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -19,8 +20,21 @@ buildPythonPackage rec {
     owner = "rocky";
     repo = "python-xdis";
     rev = "refs/tags/${version}";
-    hash = "sha256-KgKTO99T2/be1sBs5rY3Oy7/Yl9WGgdG3hqqkZ7D7ZY=";
+    hash = "sha256-Fn1cyUPMrn1SEXl4sdQwJiNHaY+BbxBDz3nKZY965/0=";
   };
+
+  # Backport magics for newer newer python versions
+  # 6.1.1 only supports up to 3.12.4 while nixpkgs is already on 3.12.5+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/rocky/python-xdis/commit/fcba74a7f64c5e2879ca0779ff10f38f9229e7da.patch";
+      hash = "sha256-D7eJ97g4G6pmYL/guq0Ndf8yKTVBD2gAuUCAKwvlYbE=";
+    })
+    (fetchpatch {
+      url = "https://github.com/rocky/python-xdis/commit/b66976ff53a2c6e17a73fb7652ddd6c8054df8db.patch";
+      hash = "sha256-KO1y0nDTPmEZ+0/3Pjh+CvTdpr/p4AYZ8XdH5J+XzXo=";
+    })
+  ];
 
   propagatedBuildInputs = [
     click
@@ -41,6 +55,9 @@ buildPythonPackage rec {
 
     # Doesn't run on non-2.7 but has global-level mis-import
     "test_unit/test_dis27.py"
+
+    # Has Python 2 style prints
+    "test/decompyle/test_nested_scopes.py"
   ];
 
   disabledTests = [
@@ -50,11 +67,14 @@ buildPythonPackage rec {
     "test_basic"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python cross-version byte-code disassembler and marshal routines";
     homepage = "https://github.com/rocky/python-xdis";
     changelog = "https://github.com/rocky/python-xdis/releases/tag/${version}";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ onny ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      onny
+      melvyn2
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes
Adds support for a few extra versions in `xdis`, and `uncompyle6` is updated to keep it in sync.
Note that the new versions' bytecode are not supported in `uncompyle6`, which can be ran on up-to-date python versions, but only decompiles bytecode of versions 3.8 and below.

Also added myself as a maintainer to both derivations.

This supersedes PR #316214.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
