### PR TITLE
cdrtools: remove -fpermissive due to revert of gcc_14 as default

### DIFF
--- a/pkgs/tools/cd-dvd/cdrtools/default.nix
+++ b/pkgs/tools/cd-dvd/cdrtools/default.nix
@@ -27,10 +27,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "GMAKE_NOWARN=true" "INS_BASE=/" "INS_RBASE=/" "DESTDIR=${placeholder "out"}" ];
 
-  env = lib.optionalAttrs stdenv.cc.isGNU {
-    NIX_CFLAGS_COMPILE = "-fpermissive";
-  };
-
   enableParallelBuilding = false; # parallel building fails on some linux machines
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";


### PR DESCRIPTION
## Description of changes

Targetting: https://github.com/NixOS/nixpkgs/pull/343421

Currently fails to build with:

```
cc1: warning: command-line option '-fpermissive' is valid for C++/ObjC++ but not for C
In file included from ../include/schily/xconfig.h:55,
                 from ../include/schily/mconfig.h:57,
                 from align_test.c:2:
../incs/x86_64-linux-cc/xconfig.h:929:16: error: duplicate 'unsigned'
  929 | #define size_t unsigned                 /* To be used if size_t is not present */
      |                ^~~~~~~~
../incs/x86_64-linux-cc/xconfig.h:933:15: error: two or more data types in declaration specifiers
  933 | #define off_t long                      /* To be used if off_t is not present  */
      |               ^~~~
../incs/x86_64-linux-cc/xconfig.h:930:17: error: two or more data types in declaration specifiers
  930 | #define ssize_t int                     /* To be used if ssize_t is not present */
      |                 ^~~
../incs/x86_64-linux-cc/xconfig.h:986:16: error: two or more data types in declaration specifiers
  986 | #define u_char unsigned char                    /* To be used if u_char is not present  */
      |                ^~~~~~~~
../incs/x86_64-linux-cc/xconfig.h:986:25: error: two or more data types in declaration specifiers
  986 | #define u_char unsigned char                    /* To be used if u_char is not present  */
      |                         ^~~~
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
