### PR TITLE
input-remapper: install desktop icon, don’t mark configuration files as executable

### DIFF
--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -120,15 +120,13 @@ in
     sed -r "s#RUN\+\=\"/bin/input-remapper-control#RUN\+\=\"$out/bin/input-remapper-control#g" -i data/99-input-remapper.rules
     sed -r "s#ExecStart\=/usr/bin/input-remapper-service#ExecStart\=$out/bin/input-remapper-service#g" -i data/input-remapper.service
 
-    chmod +x data/*.desktop
-
-    install -D -t $out/share/applications/ data/*.desktop
-    install -D -t $out/share/polkit-1/actions/ data/input-remapper.policy
-    install -D data/99-input-remapper.rules $out/etc/udev/rules.d/99-input-remapper.rules
-    install -D data/input-remapper.service $out/lib/systemd/system/input-remapper.service
-    install -D data/input-remapper.policy $out/share/polkit-1/actions/input-remapper.policy
-    install -D data/inputremapper.Control.conf $out/etc/dbus-1/system.d/inputremapper.Control.conf
-    install -D -t $out/usr/share/input-remapper/ data/*
+    install -m644 -D -t $out/share/applications/ data/*.desktop
+    install -m644 -D -t $out/share/polkit-1/actions/ data/input-remapper.policy
+    install -m644 -D data/99-input-remapper.rules $out/etc/udev/rules.d/99-input-remapper.rules
+    install -m644 -D data/input-remapper.service $out/lib/systemd/system/input-remapper.service
+    install -m644 -D data/input-remapper.policy $out/share/polkit-1/actions/input-remapper.policy
+    install -m644 -D data/inputremapper.Control.conf $out/etc/dbus-1/system.d/inputremapper.Control.conf
+    install -m644 -D -t $out/usr/share/input-remapper/ data/*
 
     # Only install input-remapper prefixed binaries, we don't care about deprecated key-mapper ones
     install -m755 -D -t $out/bin/ bin/input-remapper*

--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -117,8 +117,10 @@ in
   ];
 
   postInstall = ''
-    sed -r "s#RUN\+\=\"/bin/input-remapper-control#RUN\+\=\"$out/bin/input-remapper-control#g" -i data/99-input-remapper.rules
-    sed -r "s#ExecStart\=/usr/bin/input-remapper-service#ExecStart\=$out/bin/input-remapper-service#g" -i data/input-remapper.service
+    substituteInPlace data/99-input-remapper.rules \
+      --replace-fail 'RUN+="/bin/input-remapper-control' "RUN+=\"$out/bin/input-remapper-control"
+    substituteInPlace data/input-remapper.service \
+      --replace-fail 'ExecStart=/usr/bin/input-remapper-service' "ExecStart=$out/bin/input-remapper-service"
 
     install -m644 -D -t $out/share/applications/ data/*.desktop
     install -m644 -D -t $out/share/polkit-1/actions/ data/input-remapper.policy

--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -121,6 +121,8 @@ in
       --replace-fail 'RUN+="/bin/input-remapper-control' "RUN+=\"$out/bin/input-remapper-control"
     substituteInPlace data/input-remapper.service \
       --replace-fail 'ExecStart=/usr/bin/input-remapper-service' "ExecStart=$out/bin/input-remapper-service"
+    substituteInPlace data/input-remapper-*.desktop \
+      --replace-fail 'Icon=/usr/share/input-remapper/input-remapper.svg' 'Icon=input-remapper.svg'
 
     install -m644 -D -t $out/share/applications/ data/*.desktop
     install -m644 -D -t $out/share/polkit-1/actions/ data/input-remapper.policy
@@ -128,6 +130,7 @@ in
     install -m644 -D data/input-remapper.service $out/lib/systemd/system/input-remapper.service
     install -m644 -D data/input-remapper.policy $out/share/polkit-1/actions/input-remapper.policy
     install -m644 -D data/inputremapper.Control.conf $out/etc/dbus-1/system.d/inputremapper.Control.conf
+    install -m644 -D data/input-remapper.svg $out/share/icons/hicolor/scalable/apps/input-remapper.svg
     install -m644 -D -t $out/usr/share/input-remapper/ data/*
 
     # Only install input-remapper prefixed binaries, we don't care about deprecated key-mapper ones


### PR DESCRIPTION
## Description of changes

Resolves:

- Icon is broken in desktop entry
- Warning:

    > Configuration file `/etc/systemd/system/input-remapper.service` is marked executable. Please remove executable permission bits. Proceeding anyway.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
