### PR TITLE
positron-bin: init at 2024.11.0-116

### DIFF
--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  _7zz,
+  alsa-lib,
+  systemd,
+  autoPatchelfHook,
+  blas,
+  dpkg,
+  fetchurl,
+  gtk3,
+  libglvnd,
+  libxkbcommon,
+  makeShellWrapper,
+  mesa,
+  musl,
+  nss,
+  patchelf,
+  stdenv,
+  xorg,
+}:
+let
+  pname = "positron-bin";
+  version = "2024.11.0-116";
+in
+stdenv.mkDerivation {
+  inherit version pname;
+
+  src =
+    if stdenv.isDarwin then
+      fetchurl {
+        url = "https://github.com/posit-dev/positron/releases/download/${version}/Positron-${version}.dmg";
+        hash = "sha256-5Ym42InDgFLGdZk0LYV1H0eC5WzmsYToG1KLdiGgTto=";
+      }
+    else
+      fetchurl {
+        url = "https://github.com/posit-dev/positron/releases/download/${version}/Positron-${version}.deb";
+        hash = "sha256-pE25XVYFW8WwyQ7zmox2mmXy6ZCSaXk2gSnPimg7xtU=";
+      };
+
+  buildInputs =
+    [ makeShellWrapper ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      alsa-lib
+      dpkg
+      gtk3
+      libglvnd
+      libxkbcommon
+      mesa
+      musl
+      nss
+      stdenv.cc.cc
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libxkbfile
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      blas
+      patchelf
+    ];
+
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      autoPatchelfHook
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      _7zz
+    ];
+
+  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
+    # Needed to fix the "Zygote could not fork" error.
+    (lib.getLib systemd)
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''dpkg-deb --fsys-tarfile "$src" | tar -x --no-same-owner''}
+    runHook postUnpack
+  '';
+
+  installPhase =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        runHook preInstall
+        mkdir -p "$out/Applications" "$out/bin"
+        cp -r . "$out/Applications/Positron.app"
+
+        # Positron will use the system version of BLAS if we don't provide the nix version.
+        wrapProgram "$out/Applications/Positron.app/Contents/Resources/app/bin/code" \
+          --prefix DYLD_INSERT_LIBRARIES : "${lib.makeLibraryPath [ blas ]}/libblas.dylib"
+
+        ln -s "$out/Applications/Positron.app/Contents/Resources/app/bin/code" "$out/bin/positron"
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+        mkdir -p "$out/share"
+        cp -r usr/share/pixmaps "$out/share/pixmaps"
+        cp -r usr/share/positron "$out/share/positron"
+
+        mkdir -p "$out/share/applications"
+        install -m 444 -D usr/share/applications/positron.desktop "$out/share/applications/positron.desktop"
+        substituteInPlace "$out/share/applications/positron.desktop" \
+          --replace-fail \
+          "Icon=com.visualstudio.code.oss" \
+          "Icon=$out/share/pixmaps/com.visualstudio.code.oss.png" \
+          --replace-fail \
+          "Exec=/usr/share/positron/positron %F" \
+          "Exec=$out/share/positron/.positron-wrapped %F" \
+          --replace-fail \
+          "/usr/share/positron/positron --new-window %F" \
+          "$out/share/positron/.positron-wrapped --new-window %F"
+
+        # Fix libGL.so not found errors.
+        wrapProgram "$out/share/positron/positron" \
+          --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libglvnd ]}"
+
+        mkdir -p "$out/bin"
+        ln -s "$out/share/positron/positron" "$out/bin/positron"
+        runHook postInstall
+      '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "Positron, a next-generation data science IDE";
+    homepage = "https://github.com/posit-dev/positron";
+    license = licenses.elastic20;
+    maintainers = with maintainers; [
+      b-rodrigues
+      detroyejr
+    ];
+    mainProgram = "positron";
+    platforms = [ "x86_64-linux" ] ++ platforms.darwin;
+  };
+}

--- a/pkgs/by-name/po/positron-bin/update.sh
+++ b/pkgs/by-name/po/positron-bin/update.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq git
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+positron_nix="$nixpkgs/pkgs/by-name/po/positron-bin/package.nix"
+
+current_version=$(grep -oP "version = \"\K.*\d" $positron_nix)
+new_version=$(curl -sSfL \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/posit-dev/positron/releases?per_page=1" \
+  | jq -r '.[0].name')
+
+if [[ "$new_version" == "$current_version" ]]; then
+    echo 'Positron is already up to date'
+    exit 0;
+fi
+
+# Update Darwin hash.
+current_hash=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://github.com/posit-dev/positron/releases/download/${current_version}/Positron-${current_version}.dmg" \
+    | jq -r .hash)
+
+new_hash=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://github.com/posit-dev/positron/releases/download/${new_version}/Positron-${new_version}.dmg" \
+    | jq -r .hash)
+
+sed -i "s|$current_hash|$new_hash|g" $positron_nix
+
+# Update Linux hash.
+current_hash=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://github.com/posit-dev/positron/releases/download/${current_version}/Positron-${current_version}.deb" \
+    | jq -r .hash)
+
+new_hash=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://github.com/posit-dev/positron/releases/download/${new_version}/Positron-${new_version}.deb" \
+    | jq -r .hash)
+
+sed -i "s|$current_hash|$new_hash|g" $positron_nix
+
+# Update version
+sed -i "s|$current_version|$new_version|g" $positron_nix
+
+# Attempt to build.
+export NIXPKGS_ALLOW_UNFREE=1
+
+if ! nix-build -A positron-bin "$nixpkgs"; then
+  echo "The updated positron-bin failed to build."
+  exit 1
+fi
+
+# Commit changes
+git add "$positron_nix"
+git commit -m "positron-bin: ${current_version} -> ${new_version}"


### PR DESCRIPTION
## Description of changes

[Positron](https://github.com/posit-dev/positron/): init at 2024.11.0-116.

Working installation of positron on NixOS. Will need to do some work to ensure a good experience out of the box, but the base application seems to work well and can find R/Python when installed in the right place. In my case, it found my "default" version of python + ipykernel and R installed through home-manager but YMMV.

cc @b-rodrigues I know you were working on https://github.com/NixOS/nixpkgs/pull/335078. If you've made any progress building from source after that PR, I'm happy to close and help with that. Otherwise, I could use some help testing and maybe input on the todo's in the package.nix file if you're interested.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
