### PR TITLE
gnome-pomodoro 0.24.1 -> 0.26.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8454,6 +8454,11 @@
     githubId = 15121114;
     name = "Tom Herbers";
   };
+  herschenglime = {
+    github = "Herschenglime";
+    githubId = 69494718;
+    name = "Herschenglime";
+  };
   hexa = {
     email = "hexa@darmstadt.ccc.de";
     matrix = "@hexa:lossy.network";

--- a/pkgs/by-name/gn/gnome-pomodoro/fix-schema-path.patch
+++ b/pkgs/by-name/gn/gnome-pomodoro/fix-schema-path.patch
@@ -1,29 +1,3 @@
-diff --git a/data/meson.build b/data/meson.build
-index 5e4ce69..982b3c9 100644
---- a/data/meson.build
-+++ b/data/meson.build
-@@ -31,7 +31,7 @@ i18n.merge_file(
- 
- install_data(
-   'org.gnome.pomodoro.gschema.xml',
--  install_dir: get_option('datadir') / 'glib-2.0' / 'schemas',
-+  install_dir: gschema_dir,
- )
- 
- subdir('icons')
-diff --git a/meson-post-install.sh b/meson-post-install.sh
-index bf4013a..c87fba4 100644
---- a/meson-post-install.sh
-+++ b/meson-post-install.sh
-@@ -7,7 +7,7 @@ datadir="${prefix}/$1"
- # want/need us to do the below
- if [ -z "${DESTDIR}" ]; then
-     echo "Compiling GSchema..."
--    glib-compile-schemas "${datadir}/glib-2.0/schemas"
-+    glib-compile-schemas "${datadir}/gsettings-schemas/@pname@-@version@/glib-2.0/schemas"
- 
-     echo "Updating icon cache..."
-     gtk-update-icon-cache -f -t "${datadir}/icons/hicolor"
 diff --git a/meson.build b/meson.build
 index 09857a1..a07d27c 100644
 --- a/meson.build
@@ -38,3 +12,12 @@ index 09857a1..a07d27c 100644
  plugin_libdir = get_option('prefix') / get_option('libdir') / meson.project_name() / 'plugins'
  extension_dir = get_option('prefix') / get_option('datadir') / 'gnome-shell' / 'extensions' / 'pomodoro@arun.codito.in'
  
+@@ -134,7 +135,7 @@
+ subdir('tests')
+ 
+ gnome.post_install(
+-  glib_compile_schemas: true,
++  glib_compile_schemas: false,
+   gtk_update_icon_cache: true,
+   update_desktop_database: true,
+ )

--- a/pkgs/by-name/gn/gnome-pomodoro/package.nix
+++ b/pkgs/by-name/gn/gnome-pomodoro/package.nix
@@ -83,7 +83,10 @@ stdenv.mkDerivation rec {
       This GNOME utility helps to manage time according to Pomodoro Technique.
       It intends to improve productivity and focus by taking short breaks.
     '';
-    maintainers = with maintainers; [ aleksana ];
+    maintainers = with maintainers; [
+      aleksana
+      herschenglime
+    ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/gn/gnome-pomodoro/package.nix
+++ b/pkgs/by-name/gn/gnome-pomodoro/package.nix
@@ -1,36 +1,36 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, substituteAll
-, meson
-, ninja
-, pkg-config
-, wrapGAppsHook3
-, desktop-file-utils
-, libcanberra
-, gst_all_1
-, vala
-, gtk3
-, gom
-, sqlite
-, libxml2
-, glib
-, gobject-introspection
-, json-glib
-, libpeas
-, gsettings-desktop-schemas
-, gettext
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  substituteAll,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
+  desktop-file-utils,
+  libcanberra,
+  gst_all_1,
+  vala,
+  gtk3,
+  gom,
+  sqlite,
+  libxml2,
+  glib,
+  gobject-introspection,
+  json-glib,
+  libpeas,
+  gsettings-desktop-schemas,
+  gettext,
 }:
-
 stdenv.mkDerivation rec {
   pname = "gnome-pomodoro";
-  version = "0.24.1";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    hash = "sha256-Ml3znMz1Q9593rMgfAST8k9QglxMG9ocFD7W8kaFWCw=";
+    hash = "sha256-icyS/K6H90/DWYvqJ7f7XXTTuIwLea3k+vDDEBYil6o=";
   };
 
   patches = [
@@ -41,6 +41,13 @@ stdenv.mkDerivation rec {
       inherit pname version;
     })
   ];
+
+  # Manually compile schemas for package since meson option
+  # gnome.post_install(glib_compile_schemas) used by package tries to compile in
+  # the wrong dir.
+  preFixup = ''
+    glib-compile-schemas ${glib.makeSchemaPath "$out" "${pname}-${version}"}
+  '';
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
## Description of changes
This PR brings gnome-pomodoro up to the latest published version which is compatible with both Gnome 46 and 47. Both the application portion and the extension are functional.

The fix-schema-path.patch had to be changed, as the way that schemas were compiled upstream changed after v0.24 which broke the existing build steps. I also added a preFixup patch to compile these schemas manually.

Fixes NixOS/nixpkgs#314999.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
  - *As far as I'm aware, there were not existing tests for this package and I did not add any. However, it was verified to function locally.*
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
