### PR TITLE
Bcachefs unlock generator

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1746,6 +1746,7 @@
   ./tasks/filesystems.nix
   ./tasks/filesystems/apfs.nix
   ./tasks/filesystems/bcachefs.nix
+  ./tasks/filesystems/bcachefs-unlock.nix
   ./tasks/filesystems/btrfs.nix
   ./tasks/filesystems/cifs.nix
   ./tasks/filesystems/ecryptfs.nix

--- a/nixos/modules/tasks/filesystems/bcachefs-unlock.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs-unlock.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+{
+  options.bcachefs-unlock.enable =
+    lib.mkEnableOption "unlocking bcachefs file systems with a systemd generator."
+    // {
+      default =
+        (config.boot.supportedFilesystems.bcachefs or false)
+        || (config.boot.initrd.supportedFilesystems.bcachefs or false);
+      defaultText = "boot.supportedFilesystems.bcachefs || boot.initrd.supportedFilesystems.bcachefs";
+    };
+
+  config = lib.mkIf config.bcachefs-unlock.enable {
+    boot.initrd.systemd.contents."/etc/systemd/system-generators/bcachefs-fstab-generator".source =
+      "${pkgs.bcachefs-fstab-generator}/bin/bcachefs-fstab-generator";
+
+    boot.initrd.systemd.services."bcachefs-unlock@" = {
+      overrideStrategy = "asDropin";
+      path = [
+        pkgs.bcachefs-tools
+        config.boot.initrd.systemd.package
+      ];
+      serviceConfig.ExecSearchPath = lib.makeBinPath [ pkgs.bcachefs-tools ];
+    };
+
+    systemd.generators.bcachefs-fstab-generator = "${pkgs.bcachefs-fstab-generator}/bin/bcachefs-fstab-generator";
+
+    systemd.services."bcachefs-unlock@" = {
+      overrideStrategy = "asDropin";
+      path = [
+        pkgs.bcachefs-tools
+        config.systemd.package
+      ];
+      serviceConfig.ExecSearchPath = lib.makeBinPath [ pkgs.bcachefs-tools ];
+    };
+  };
+}

--- a/pkgs/by-name/bc/bcachefs-fstab-generator/package.nix
+++ b/pkgs/by-name/bc/bcachefs-fstab-generator/package.nix
@@ -1,0 +1,24 @@
+{
+  rustPlatform,
+  pkg-config,
+  systemd,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "bcachefs-fstab-generator";
+  version = "0.1.0-unstable-2024-11-02";
+
+  src = fetchFromGitHub {
+    owner = "ElvishJerricco";
+    repo = "bcachefs-fstab-generator";
+    rev = "c98b7dd19a1ffda0e3137e417822e3d79e208f5f";
+    hash = "sha256-WeZZ96fq9aQ+OMfpj5yqk2X+qthLJGgITg9cV7VOD7o=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-W9p8EEluU0+BSz3zR1LuQ6IgVYaZtuaIfpM4BDRH0WM=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ systemd ];
+}


### PR DESCRIPTION
## Description of changes

This systemd generator creates units that unlock your encrypted bcachefs file systems, based on the `fstab` file. It parses the `fs_spec` field and orders generated units after the necessary device.

I need to write an installer test for this. The original repo has tests that prove it works but that needs to be migrated into here.

It also respects the `x-systemd.*` FS options. e.g. `x-systemd.requires` is used to order a multi-device bcachefs mount after the requisite devices.

It also uses systemd credentials named `bcachefs$(systemd-escape $mountpoint).mount`, so file systems can be unlocked via keyfile, potentially encrypted with the TPM2.

Requesting review from known bcachefs users, among others.

Closes #317901

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
