### PR TITLE
treewide: replace passthru.optional-dependencies with optional-dependencies

### DIFF
--- a/pkgs/applications/file-managers/browsr/default.nix
+++ b/pkgs/applications/file-managers/browsr/default.nix
@@ -32,9 +32,9 @@ python3.pkgs.buildPythonApplication rec {
     rich-pixels
     textual
     textual-universal-directorytree
-  ] ++ lib.attrVals extras passthru.optional-dependencies;
+  ] ++ lib.attrVals extras optional-dependencies;
 
-  passthru.optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3.pkgs; {
     all = [
       pyarrow
       textual-universal-directorytree.optional-dependencies.remote

--- a/pkgs/applications/misc/dbx/default.nix
+++ b/pkgs/applications/misc/dbx/default.nix
@@ -52,7 +52,7 @@ python.pkgs.buildPythonApplication rec {
       watchdog
     ];
 
-  passthru.optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3.pkgs; {
     aws = [ boto3 ];
     azure = [
       azure-storage-blob

--- a/pkgs/applications/misc/meerk40t/default.nix
+++ b/pkgs/applications/misc/meerk40t/default.nix
@@ -36,9 +36,9 @@ python3Packages.buildPythonApplication rec {
     setuptools
     wxpython
   ]
-  ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  passthru.optional-dependencies = with python3Packages; {
+  optional-dependencies = with python3Packages; {
     cam = [
       opencv4
     ];

--- a/pkgs/by-name/as/asciinema-automation/package.nix
+++ b/pkgs/by-name/as/asciinema-automation/package.nix
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     pexpect
   ];
 
-  passthru.optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3.pkgs; {
     dev = [
       mypy
       pytest

--- a/pkgs/by-name/co/comic-mandown/package.nix
+++ b/pkgs/by-name/co/comic-mandown/package.nix
@@ -4,8 +4,8 @@
 , withGUI ? true
 }:
 let
-  mandown' = python3Packages.mandown.overrideAttrs (prev: {
-    propagatedBuildInputs = prev.propagatedBuildInputs ++ lib.optionals withGUI prev.passthru.optional-dependencies.gui;
+  mandown' = python3Packages.mandown.overridePythonAttrs (prev: {
+    propagatedBuildInputs = prev.propagatedBuildInputs ++ lib.optionals withGUI prev.optional-dependencies.gui;
   });
   mandownApp = python3Packages.toPythonApplication mandown';
 in

--- a/pkgs/by-name/ho/homeassistant-satellite/package.nix
+++ b/pkgs/by-name/ho/homeassistant-satellite/package.nix
@@ -27,7 +27,7 @@ python3.pkgs.buildPythonApplication rec {
     aiohttp
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     pulseaudio = with python3.pkgs; [
       pasimple
       pulsectl

--- a/pkgs/by-name/ji/jinja2-cli/package.nix
+++ b/pkgs/by-name/ji/jinja2-cli/package.nix
@@ -27,11 +27,11 @@ python3.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3.pkgs; [
     jinja2
-  ] ++ lib.attrVals extras passthru.optional-dependencies;
+  ] ++ lib.attrVals extras optional-dependencies;
 
   pythonImportsCheck = [ "jinja2cli" ];
 
-  passthru.optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3.pkgs; {
     hjson = [ hjson ];
     json5 = [ json5 ];
     toml = [ toml ];

--- a/pkgs/by-name/of/offat/package.nix
+++ b/pkgs/by-name/of/offat/package.nix
@@ -33,7 +33,7 @@ python3.pkgs.buildPythonApplication rec {
     tenacity
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     api = with python3.pkgs; [
       fastapi
       uvicorn

--- a/pkgs/by-name/po/poethepoet/package.nix
+++ b/pkgs/by-name/po/poethepoet/package.nix
@@ -24,7 +24,7 @@ python3.pkgs.buildPythonApplication rec {
     tomli
   ];
 
-  passthru.optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3.pkgs; {
     poetry_plugin = [
       poetry
     ];

--- a/pkgs/by-name/st/strictdoc/package.nix
+++ b/pkgs/by-name/st/strictdoc/package.nix
@@ -45,7 +45,7 @@ python3.pkgs.buildPythonApplication rec {
     xlsxwriter
   ];
 
-  passthru.optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3.pkgs; {
     development = [
       invoke
       tox

--- a/pkgs/by-name/wy/wyoming-satellite/package.nix
+++ b/pkgs/by-name/wy/wyoming-satellite/package.nix
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication rec {
     zeroconf
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     silerovad = with python3Packages; [
       pysilero-vad
     ];

--- a/pkgs/development/python-modules/acquire/default.nix
+++ b/pkgs/development/python-modules/acquire/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     dissect-target
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     full = [
       dissect-target
       minio
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     ] ++ dissect-target.optional-dependencies.full;
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.full;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.full;
 
   pythonImportsCheck = [ "acquire" ];
 

--- a/pkgs/development/python-modules/adb-shell/default.nix
+++ b/pkgs/development/python-modules/adb-shell/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     rsa
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [
       aiofiles
       async-timeout
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     mock
     pycryptodome
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "adb_shell" ];
 

--- a/pkgs/development/python-modules/aiobotocore/default.nix
+++ b/pkgs/development/python-modules/aiobotocore/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     wrapt
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     awscli = [ awscli ];
     boto3 = [ boto3 ];
   };

--- a/pkgs/development/python-modules/aiocoap/default.nix
+++ b/pkgs/development/python-modules/aiocoap/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     oscore = [
       cbor2
       cryptography

--- a/pkgs/development/python-modules/aioftp/default.nix
+++ b/pkgs/development/python-modules/aioftp/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ siosocks ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     socks = [ siosocks ];
   };
 
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
     trustme
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # uses 127.0.0.2, which macos doesn't like

--- a/pkgs/development/python-modules/aiojobs/default.nix
+++ b/pkgs/development/python-modules/aiojobs/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = lib.optionals (pythonOlder "3.11") [ async-timeout ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aiohttp = [ aiohttp ];
   };
 
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-aiohttp
     pytest-cov-stub
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "aiojobs" ];
 

--- a/pkgs/development/python-modules/aiomisc/default.nix
+++ b/pkgs/development/python-modules/aiomisc/default.nix
@@ -45,9 +45,9 @@ buildPythonPackage rec {
     fastapi
     pytestCheckHook
     setproctitle
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aiohttp = [ aiohttp ];
     #asgi = [ aiohttp-asgi ];
     cron = [ croniter ];

--- a/pkgs/development/python-modules/aioprometheus/default.nix
+++ b/pkgs/development/python-modules/aioprometheus/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     quantile-python
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aiohttp = [ aiohttp ];
     starlette = [ starlette ];
     quart = [ quart ];
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     httpx
     fastapi
     uvicorn
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "aioprometheus" ];
 

--- a/pkgs/development/python-modules/alpha-vantage/default.nix
+++ b/pkgs/development/python-modules/alpha-vantage/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     pandas = [
       pandas
     ];
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     aioresponses
     requests-mock
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   # Starting with 3.0.0 most tests require an API key
   doCheck = false;

--- a/pkgs/development/python-modules/androidtv/default.nix
+++ b/pkgs/development/python-modules/androidtv/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pure-python-adb
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [ aiofiles ];
     inherit (adb-shell.optional-dependencies) usb;
   };
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     mock
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.async ++ passthru.optional-dependencies.usb;
+  ] ++ optional-dependencies.async ++ optional-dependencies.usb;
 
   disabledTests = [
     # Requires git but fails anyway

--- a/pkgs/development/python-modules/angr/default.nix
+++ b/pkgs/development/python-modules/angr/default.nix
@@ -91,7 +91,7 @@ buildPythonPackage rec {
     unique-log-filter
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     AngrDB = [ sqlalchemy ];
   };
 

--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     vertex = [ google-auth ];
   };
 

--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
       typing-extensions
     ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     trio = [ trio ];
   };
 
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     pytestCheckHook
     trustme
     uvloop
-  ] ++ passthru.optional-dependencies.trio;
+  ] ++ optional-dependencies.trio;
 
   pytestFlagsArray = [
     "-W"

--- a/pkgs/development/python-modules/apischema/default.nix
+++ b/pkgs/development/python-modules/apischema/default.nix
@@ -22,14 +22,14 @@ buildPythonPackage rec {
     hash = "sha256-omw6znk09r2SigPfaVrtA6dd8KeSfjaPgGfK12ty23g=";
   };
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     graphql = [ graphql-core ];
   };
 
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "apischema" ];
 

--- a/pkgs/development/python-modules/apispec/default.nix
+++ b/pkgs/development/python-modules/apispec/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ packaging ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     marshmallow = [ marshmallow ];
     yaml = [ pyyaml ];
     validation = [
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     mock
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "apispec" ];
 

--- a/pkgs/development/python-modules/arabic-reshaper/default.nix
+++ b/pkgs/development/python-modules/arabic-reshaper/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     hash = "sha256-ucSC5aTvpnlAVQcT0afVecnoN3hIZKtzUhEQ6Qg0jQM=";
   };
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     with-fonttools = [ fonttools ];
   };
 

--- a/pkgs/development/python-modules/argilla/default.nix
+++ b/pkgs/development/python-modules/argilla/default.nix
@@ -106,7 +106,7 @@ buildPythonPackage rec {
     typer
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     server =
       [
         aiofiles
@@ -178,7 +178,7 @@ buildPythonPackage rec {
     pytest-mock
     pytest-asyncio
     factory-boy
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTestPaths = [ "tests/server/datasets/test_dao.py" ];
 

--- a/pkgs/development/python-modules/argparse-manpage/default.nix
+++ b/pkgs/development/python-modules/argparse-manpage/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "argparse_manpage" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     setuptools = [ setuptools ];
   };
 

--- a/pkgs/development/python-modules/aria2p/default.nix
+++ b/pkgs/development/python-modules/aria2p/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     websocket-client
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     tui = [
       asciimatics
       pyperclip
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     responses
     psutil
     uvicorn
-  ] ++ passthru.optional-dependencies.tui;
+  ] ++ optional-dependencies.tui;
 
   disabledTests = [
     # require a running display server

--- a/pkgs/development/python-modules/avwx-engine/default.nix
+++ b/pkgs/development/python-modules/avwx-engine/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     xmltodict
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       numpy
       rapidfuzz
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
     time-machine
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "avwx" ];
 

--- a/pkgs/development/python-modules/awswrangler/default.nix
+++ b/pkgs/development/python-modules/awswrangler/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     requests-aws4auth
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     sqlserver = [ pyodbc ];
     sparql = [ sparqlwrapper ];
   };

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aio = [ aiohttp ];
   };
 
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
     trio
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   # test server needs to be available
   preCheck = ''

--- a/pkgs/development/python-modules/azure-storage-file-share/default.nix
+++ b/pkgs/development/python-modules/azure-storage-file-share/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aio = [ azure-core ] ++ azure-core.optional-dependencies.aio;
   };
 

--- a/pkgs/development/python-modules/azure-storage-queue/default.nix
+++ b/pkgs/development/python-modules/azure-storage-queue/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aio = [ azure-core ] ++ azure-core.optional-dependencies.aio;
   };
 

--- a/pkgs/development/python-modules/base2048/default.nix
+++ b/pkgs/development/python-modules/base2048/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     fuzz = [ frelatage ];
   };
 

--- a/pkgs/development/python-modules/bc-detect-secrets/default.nix
+++ b/pkgs/development/python-modules/bc-detect-secrets/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     unidiff
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     word_list = [ pyahocorasick ];
     gibberish = [ gibberish-detector ];
   };
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pkgs.gitMinimal
     pytestCheckHook
     responses
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = ''
     export HOME=$(mktemp -d);

--- a/pkgs/development/python-modules/beautifulsoup4/default.nix
+++ b/pkgs/development/python-modules/beautifulsoup4/default.nix
@@ -47,14 +47,14 @@ buildPythonPackage rec {
     soupsieve
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     html5lib = [ html5lib ];
     lxml = [ lxml ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "bs4" ];
 

--- a/pkgs/development/python-modules/betterproto/default.nix
+++ b/pkgs/development/python-modules/betterproto/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies.compiler = [
+  optional-dependencies.compiler = [
     black
     jinja2
     isort
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     pytest-mock
     pytest7CheckHook
     tomlkit
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "betterproto" ];
 

--- a/pkgs/development/python-modules/bimmer-connected/default.nix
+++ b/pkgs/development/python-modules/bimmer-connected/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     pyjwt
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     china = [ pillow ];
   };
 
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytestCheckHook
     respx
     time-machine
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [
     # presumably regressed in pytest-asyncio 0.23.0

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
       typing-extensions
     ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     colorama = [ colorama ];
     d = [ aiohttp ];
     uvloop = [ uvloop ];
@@ -71,7 +71,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     parameterized
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pytestFlagsArray = [
     "-W"

--- a/pkgs/development/python-modules/bleach/default.nix
+++ b/pkgs/development/python-modules/bleach/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     webencodings
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     css = [ tinycss2 ];
   };
 

--- a/pkgs/development/python-modules/bonsai/default.nix
+++ b/pkgs/development/python-modules/bonsai/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     openldap
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     gevent = [ gevent ];
     tornado = [ tornado ];
     trio = [ trio ];

--- a/pkgs/development/python-modules/boto3-stubs/default.nix
+++ b/pkgs/development/python-modules/boto3-stubs/default.nix
@@ -378,7 +378,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     accessanalyzer = [ mypy-boto3-accessanalyzer ];
     account = [ mypy-boto3-account ];
     acm = [ mypy-boto3-acm ];

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     "tests/integration"
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     crt = [ botocore.optional-dependencies.crt ];
   };
 

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "botocore" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     crt = [ awscrt ];
   };
 

--- a/pkgs/development/python-modules/breezy/default.nix
+++ b/pkgs/development/python-modules/breezy/default.nix
@@ -71,9 +71,15 @@ buildPythonPackage rec {
       tzlocal
       urllib3
     ]
-    ++ passthru.optional-dependencies.launchpad
-    ++ passthru.optional-dependencies.fastimport
-    ++ passthru.optional-dependencies.github;
+    ++ optional-dependencies.launchpad
+    ++ optional-dependencies.fastimport
+    ++ optional-dependencies.github;
+
+  optional-dependencies = {
+    launchpad = [ launchpadlib ];
+    fastimport = [ fastimport ];
+    github = [ pygithub ];
+  };
 
   nativeCheckInputs = [ testtools ];
 
@@ -106,11 +112,6 @@ buildPythonPackage rec {
     tests.version = testers.testVersion {
       package = breezy;
       command = "HOME=$TMPDIR brz --version";
-    };
-    optional-dependencies = {
-      launchpad = [ launchpadlib ];
-      fastimport = [ fastimport ];
-      github = [ pygithub ];
     };
   };
 

--- a/pkgs/development/python-modules/btchip-python/default.nix
+++ b/pkgs/development/python-modules/btchip-python/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     ecdsa
   ];
 
-  passthru.optional-dependencies.smartcard = [ pyscard ];
+  optional-dependencies.smartcard = [ pyscard ];
 
   # tests requires hardware
   doCheck = false;

--- a/pkgs/development/python-modules/bugsnag/default.nix
+++ b/pkgs/development/python-modules/bugsnag/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ webob ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     flask = [
       blinker
       flask

--- a/pkgs/development/python-modules/bytewax/default.nix
+++ b/pkgs/development/python-modules/bytewax/default.nix
@@ -74,7 +74,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ jsonpickle ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     kafka = [ confluent-kafka ];
   };
 
@@ -85,7 +85,7 @@ buildPythonPackage rec {
   checkInputs = [
     myst-docutils
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTestPaths = [
     # dependens on an old myst-docutils version

--- a/pkgs/development/python-modules/cachecontrol/default.nix
+++ b/pkgs/development/python-modules/cachecontrol/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     filecache = [ filelock ];
     redis = [ redis ];
   };
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
     requests
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "cachecontrol" ];
 

--- a/pkgs/development/python-modules/camel-converter/default.nix
+++ b/pkgs/development/python-modules/camel-converter/default.nix
@@ -25,14 +25,14 @@ buildPythonPackage rec {
 
   build-system = [ hatchling ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     pydantic = [ pydantic ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
     pytest-cov-stub
-  ] ++ passthru.optional-dependencies.pydantic;
+  ] ++ optional-dependencies.pydantic;
 
   pythonImportsCheck = [ "camel_converter" ];
 

--- a/pkgs/development/python-modules/canals/default.nix
+++ b/pkgs/development/python-modules/canals/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     docs = [
       mkdocs-material
       mkdocs-mermaid2-plugin
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTestPaths = [
     # Test requires internet connection to mermaid.ink

--- a/pkgs/development/python-modules/canmatrix/default.nix
+++ b/pkgs/development/python-modules/canmatrix/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     six
   ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     arxml = [ lxml ];
     fibex = [ lxml ];
     kcd = [ lxml ];
@@ -65,7 +65,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pytestFlagsArray = [
     # long_envvar_name_imports requires stable key value pair ordering

--- a/pkgs/development/python-modules/cantools/default.nix
+++ b/pkgs/development/python-modules/cantools/default.nix
@@ -42,12 +42,12 @@ buildPythonPackage rec {
     textparser
   ];
 
-  passthru.optional-dependencies.plot = [ matplotlib ];
+  optional-dependencies.plot = [ matplotlib ];
 
   nativeCheckInputs = [
     parameterized
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.plot;
+  ] ++ optional-dependencies.plot;
 
   pythonImportsCheck = [ "cantools" ];
 

--- a/pkgs/development/python-modules/cartopy/default.nix
+++ b/pkgs/development/python-modules/cartopy/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     shapely
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ows = [
       owslib
       pillow
@@ -80,7 +80,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-mpl
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   preCheck = ''
     export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf

--- a/pkgs/development/python-modules/cashews/default.nix
+++ b/pkgs/development/python-modules/cashews/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     dill = [ dill ];
     diskcache = [ diskcache ];
     redis = [ redis ];

--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     pytz
     pyyaml
     sure
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   # This is used to determine the version of cython that can be used
   CASS_DRIVER_ALLOWED_CYTHON_VERSION = cython.version;
@@ -127,7 +127,7 @@ buildPythonPackage rec {
     "test_nts_token_performance"
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cle = [ cryptography ];
     eventlet = [ eventlet ];
     gevent = [ gevent ];

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     vine
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     gcs = [ google-cloud-storage ];
     mongodb = [ pymongo ];
     msgpack = [ msgpack ];
@@ -71,7 +71,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytest-xdist
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTestPaths = [
     # test_eventlet touches network

--- a/pkgs/development/python-modules/certomancer/default.nix
+++ b/pkgs/development/python-modules/certomancer/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     tzlocal
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     requests-mocker = [ requests-mock ];
     web-api = [
       jinja2
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytz
     requests
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTests = [
     # pyhanko_certvalidator.errors.DisallowedAlgorithmError

--- a/pkgs/development/python-modules/channels-redis/default.nix
+++ b/pkgs/development/python-modules/channels-redis/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     msgpack
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cryptography = [ cryptography ];
   };
 

--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -111,7 +111,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "cherrypy" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     json = [ simplejson ];
     memcached_session = [ python-memcached ];
     routes_dispatcher = [ routes ];

--- a/pkgs/development/python-modules/clarifai/default.nix
+++ b/pkgs/development/python-modules/clarifai/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     tritonclient
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [ pycocotools ];
   };
 

--- a/pkgs/development/python-modules/clevercsv/default.nix
+++ b/pkgs/development/python-modules/clevercsv/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     packaging
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     full = [
       faust-cchardet
       pandas
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.full;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.full;
 
   pythonImportsCheck = [
     "clevercsv"

--- a/pkgs/development/python-modules/cli-helpers/default.nix
+++ b/pkgs/development/python-modules/cli-helpers/default.nix
@@ -28,14 +28,14 @@ buildPythonPackage rec {
     tabulate
   ] ++ tabulate.optional-dependencies.widechars;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     styles = [ pygments ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
     mock
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   meta = with lib; {
     description = "Python helpers for common CLI tasks";

--- a/pkgs/development/python-modules/clickhouse-connect/default.nix
+++ b/pkgs/development/python-modules/clickhouse-connect/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-dotenv
-  ] ++ passthru.optional-dependencies.sqlalchemy ++ passthru.optional-dependencies.numpy;
+  ] ++ optional-dependencies.sqlalchemy ++ optional-dependencies.numpy;
 
   # these tests require a running clickhouse instance
   disabledTestPaths = [
@@ -68,14 +68,12 @@ buildPythonPackage rec {
     "clickhouse_connect.driverc.npconv"
   ];
 
-  passthru = {
-    optional-dependencies = {
-      sqlalchemy = [ sqlalchemy ];
-      numpy = [ numpy ];
-      pandas = [ pandas ];
-      arrow = [ pyarrow ];
-      orjson = [ orjson ];
-    };
+  optional-dependencies = {
+    sqlalchemy = [ sqlalchemy ];
+    numpy = [ numpy ];
+    pandas = [ pandas ];
+    arrow = [ pyarrow ];
+    orjson = [ orjson ];
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/cloudpathlib/default.nix
+++ b/pkgs/development/python-modules/cloudpathlib/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [ cloudpathlib ];
     azure = [ azure-storage-blob ];
     gs = [ google-cloud-storage ];

--- a/pkgs/development/python-modules/cmdstanpy/default.nix
+++ b/pkgs/development/python-modules/cmdstanpy/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     stanio
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [ xarray ];
   };
 
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.all;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.all;
 
   disabledTestPaths = [
     # No need to test these when using Nix

--- a/pkgs/development/python-modules/coinmetrics-api-client/default.nix
+++ b/pkgs/development/python-modules/coinmetrics-api-client/default.nix
@@ -48,14 +48,12 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-mock
-  ] ++ passthru.optional-dependencies.pandas;
+  ] ++ optional-dependencies.pandas;
 
   pythonImportsCheck = [ "coinmetrics.api_client" ];
 
-  passthru = {
-    optional-dependencies = {
-      pandas = [ pandas ];
-    };
+  optional-dependencies = {
+    pandas = [ pandas ];
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/compressai/default.nix
+++ b/pkgs/development/python-modules/compressai/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     torchvision
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     tutorials = [
       ipywidgets
       jupyter

--- a/pkgs/development/python-modules/configargparse/default.nix
+++ b/pkgs/development/python-modules/configargparse/default.nix
@@ -22,14 +22,14 @@ buildPythonPackage rec {
     hash = "sha256-m77MY0IZ1AJkd4/Y7ltApvdF9y17Lgn92WZPYTCU9tA=";
   };
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     yaml = [ pyyaml ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
     mock
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "configargparse" ];
 

--- a/pkgs/development/python-modules/confluent-kafka/default.nix
+++ b/pkgs/development/python-modules/confluent-kafka/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ requests ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     avro = [
       avro
       fastavro
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pyflakes
     pytestCheckHook
     requests-mock
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "confluent_kafka" ];
 

--- a/pkgs/development/python-modules/connexion/default.nix
+++ b/pkgs/development/python-modules/connexion/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     werkzeug
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     flask = [
       a2wsgi
       flask
@@ -75,7 +75,7 @@ buildPythonPackage rec {
     pytest-aiohttp
     pytestCheckHook
     testfixtures
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "connexion" ];
 

--- a/pkgs/development/python-modules/construct/default.nix
+++ b/pkgs/development/python-modules/construct/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     lz4
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     extras = [
       arrow
       cloudpickle
@@ -47,7 +47,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "construct" ];
 

--- a/pkgs/development/python-modules/corner/default.nix
+++ b/pkgs/development/python-modules/corner/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
 
   dependencies = [ matplotlib ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     arviz = [ arviz ];
     docs = [
       arviz
@@ -66,7 +66,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "corner" ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ corner.passthru.optional-dependencies.test;
+  nativeCheckInputs = [ pytestCheckHook ] ++ corner.optional-dependencies.test;
 
   # matplotlib.testing.exceptions.ImageComparisonFailure: images not close
   disabledTests = [

--- a/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
+++ b/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     types-toml
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     validation = [
       jsonschema
       lxml
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     ddt
     pytestCheckHook
     xmldiff
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "cyclonedx" ];
 

--- a/pkgs/development/python-modules/dask-gateway-server/default.nix
+++ b/pkgs/development/python-modules/dask-gateway-server/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     traitlets
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     kerberos = [ pykerberos ];
     jobqueue = [ sqlalchemy ];
     local = [ sqlalchemy ];

--- a/pkgs/development/python-modules/databases/default.nix
+++ b/pkgs/development/python-modules/databases/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ sqlalchemy ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     postgresql = [ asyncpg ];
     asyncpg = [ asyncpg ];
     aiopg = [ aiopg ];

--- a/pkgs/development/python-modules/dataclass-wizard/default.nix
+++ b/pkgs/development/python-modules/dataclass-wizard/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ ] ++ lib.optionals (pythonOlder "3.9") [ typing-extensions ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     timedelta = [ pytimeparse ];
     yaml = [ pyyaml ];
   };
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-mock
-  ] ++ passthru.optional-dependencies.timedelta ++ passthru.optional-dependencies.yaml;
+  ] ++ optional-dependencies.timedelta ++ optional-dependencies.yaml;
 
   disabledTests =
     [ ]

--- a/pkgs/development/python-modules/dataproperty/default.nix
+++ b/pkgs/development/python-modules/dataproperty/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     tcolorpy
   ] ++ typepy.optional-dependencies.datetime;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     logging = [ loguru ];
   };
 

--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     tzlocal
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     calendars = [
       hijri-converter
       convertdate
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     parsel
     requests
     ruamel-yaml
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   preCheck = ''
     export HOME="$TEMPDIR"

--- a/pkgs/development/python-modules/debuglater/default.nix
+++ b/pkgs/development/python-modules/debuglater/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ colorama ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [ dill ];
   };
 
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     numpy
     pandas
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.all;
+  ] ++ optional-dependencies.all;
 
   pythonImportsCheck = [ "debuglater" ];
 

--- a/pkgs/development/python-modules/deepdiff/default.nix
+++ b/pkgs/development/python-modules/deepdiff/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     orjson
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [
       clevercsv
       click
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytestCheckHook
     python-dateutil
     tomli-w
-  ] ++ passthru.optional-dependencies.cli;
+  ] ++ optional-dependencies.cli;
 
   disabledTests = [
     # not compatible with pydantic 2.x

--- a/pkgs/development/python-modules/defcon/default.nix
+++ b/pkgs/development/python-modules/defcon/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "defcon" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     pens = [ fontpens ];
     lxml = [ fonttools ] ++ fonttools.optional-dependencies.lxml;
   };

--- a/pkgs/development/python-modules/demoji/default.nix
+++ b/pkgs/development/python-modules/demoji/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ujson = [ ujson ];
   };
 

--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aiohttp = [ aiohttp ];
     pydantic = [ pydantic ];
     flask = [ flask ];
@@ -50,10 +50,10 @@ buildPythonPackage rec {
       pytestCheckHook
       scipy
     ]
-    ++ passthru.optional-dependencies.aiohttp
-    ++ passthru.optional-dependencies.pydantic
-    ++ passthru.optional-dependencies.yaml
-    ++ passthru.optional-dependencies.flask;
+    ++ optional-dependencies.aiohttp
+    ++ optional-dependencies.pydantic
+    ++ optional-dependencies.yaml
+    ++ optional-dependencies.flask;
 
   pythonImportsCheck = [ "dependency_injector" ];
 

--- a/pkgs/development/python-modules/detectron2/default.nix
+++ b/pkgs/development/python-modules/detectron2/default.nix
@@ -99,7 +99,7 @@ buildPythonPackage {
     pydot # no idea why this is not in their setup.py
   ];
 
-  passthru.optional-dependencies = optional-dependencies;
+  optional-dependencies = optional-dependencies;
 
   nativeCheckInputs = [
     av

--- a/pkgs/development/python-modules/diffusers/default.nix
+++ b/pkgs/development/python-modules/diffusers/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     safetensors
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     flax = [
       flax
       jax
@@ -102,7 +102,7 @@ buildPythonPackage rec {
     sentencepiece
     torchsde
     transformers
-  ] ++ passthru.optional-dependencies.torch;
+  ] ++ optional-dependencies.torch;
 
   preCheck =
     let

--- a/pkgs/development/python-modules/diofant/default.nix
+++ b/pkgs/development/python-modules/diofant/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ mpmath ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     exports = [
       cython
       numpy

--- a/pkgs/development/python-modules/discum/default.nix
+++ b/pkgs/development/python-modules/discum/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     websocket-client
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ra = [
       pycryptodome
       pypng

--- a/pkgs/development/python-modules/dissect-btrfs/default.nix
+++ b/pkgs/development/python-modules/dissect-btrfs/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     dissect-util
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     full = [
       python-lzo
       zstandard

--- a/pkgs/development/python-modules/dissect-cobaltstrike/default.nix
+++ b/pkgs/development/python-modules/dissect-cobaltstrike/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     lark
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     c2 = [
       flow-record
       httpx
@@ -68,7 +68,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-httpserver
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "dissect.cobaltstrike" ];
 

--- a/pkgs/development/python-modules/dissect-hypervisor/default.nix
+++ b/pkgs/development/python-modules/dissect-hypervisor/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     dissect-util
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     full = [
       pycryptodome
       rich

--- a/pkgs/development/python-modules/dissect-squashfs/default.nix
+++ b/pkgs/development/python-modules/dissect-squashfs/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     dissect-util
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     full = [
       lz4
       python-lzo

--- a/pkgs/development/python-modules/dissect-target/default.nix
+++ b/pkgs/development/python-modules/dissect-target/default.nix
@@ -80,7 +80,7 @@ buildPythonPackage rec {
     structlog
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     full = [
       asn1crypto
       dissect-btrfs
@@ -102,12 +102,12 @@ buildPythonPackage rec {
       yara-python
       zstandard
     ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
-    yara = [ yara-python ] ++ passthru.optional-dependencies.full;
-    smb = [ impacket ] ++ passthru.optional-dependencies.full;
-    mqtt = [ paho-mqtt ] ++ passthru.optional-dependencies.full;
+    yara = [ yara-python ] ++ optional-dependencies.full;
+    smb = [ impacket ] ++ optional-dependencies.full;
+    mqtt = [ paho-mqtt ] ++ optional-dependencies.full;
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.full;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.full;
 
   pythonImportsCheck = [ "dissect.target" ];
 

--- a/pkgs/development/python-modules/dj-rest-auth/default.nix
+++ b/pkgs/development/python-modules/dj-rest-auth/default.nix
@@ -40,13 +40,13 @@ buildPythonPackage rec {
 
   dependencies = [ djangorestframework ];
 
-  passthru.optional-dependencies.with_social = [ django-allauth ];
+  optional-dependencies.with_social = [ django-allauth ];
 
   nativeCheckInputs = [
     djangorestframework-simplejwt
     responses
     unittest-xml-reporting
-  ] ++ passthru.optional-dependencies.with_social;
+  ] ++ optional-dependencies.with_social;
 
   preCheck = ''
     # Test connects to graph.facebook.com

--- a/pkgs/development/python-modules/django-allauth/default.nix
+++ b/pkgs/development/python-modules/django-allauth/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
 
   preBuild = "${python.interpreter} -m django compilemessages";
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     saml = [ python3-saml ];
     mfa = [ qrcode ];
   };
@@ -71,7 +71,7 @@ buildPythonPackage rec {
     pillow
     pytestCheckHook
     pytest-django
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTests = [
     # Tests require network access

--- a/pkgs/development/python-modules/django-import-export/default.nix
+++ b/pkgs/development/python-modules/django-import-export/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     tablib
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [ tablib ] ++ tablib.optional-dependencies.all;
     cli = [ tablib ] ++ tablib.optional-dependencies.cli;
     ods = [ tablib ] ++ tablib.optional-dependencies.ods;
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     chardet
     psycopg2
     pytz
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/python-modules/django-markup/default.nix
+++ b/pkgs/development/python-modules/django-markup/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
 
   dependencies = [ django ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all_filter_dependencies = [
       bleach
       docutils
@@ -63,7 +63,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-django
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.all_filter_dependencies;
+  ] ++ optional-dependencies.all_filter_dependencies;
 
   preCheck = ''
     export DJANGO_SETTINGS_MODULE=django_markup.tests

--- a/pkgs/development/python-modules/django-modelcluster/default.nix
+++ b/pkgs/development/python-modules/django-modelcluster/default.nix
@@ -35,14 +35,14 @@ buildPythonPackage rec {
     pytz
   ];
 
-  passthru.optional-dependencies.taggit = [ django-taggit ];
+  optional-dependencies.taggit = [ django-taggit ];
 
   env.DJANGO_SETTINGS_MODULE = "tests.settings";
 
   nativeCheckInputs = [
     pytest-django
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.taggit;
+  ] ++ optional-dependencies.taggit;
 
   # https://github.com/wagtail/django-modelcluster/issues/173
   disabledTests = lib.optionals (lib.versionAtLeast django.version "4.2") [

--- a/pkgs/development/python-modules/django-redis/default.nix
+++ b/pkgs/development/python-modules/django-redis/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     redis
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     hiredis = [ redis ] ++ redis.optional-dependencies.hiredis;
   };
 
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     pytest-django
     pytest-mock
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pytestFlagsArray = [
     "-W"

--- a/pkgs/development/python-modules/django-storages/default.nix
+++ b/pkgs/development/python-modules/django-storages/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ django ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     azure = [ azure-storage-blob ];
     boto3 = [ boto3 ];
     dropbox = [ dropbox ];
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     moto
     pytestCheckHook
     rsa
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "storages" ];
 

--- a/pkgs/development/python-modules/django-stubs/default.nix
+++ b/pkgs/development/python-modules/django-stubs/default.nix
@@ -37,13 +37,13 @@ buildPythonPackage rec {
     typing-extensions
   ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     compatible-mypy = [ mypy ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "django-stubs" ];
 

--- a/pkgs/development/python-modules/django-tables2/default.nix
+++ b/pkgs/development/python-modules/django-tables2/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ django ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     tablib = [ tablib ] ++ tablib.optional-dependencies.xls ++ tablib.optional-dependencies.yaml;
   };
 
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     pyyaml
     pytest-django
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTestPaths = [
     # requires django-filters

--- a/pkgs/development/python-modules/django-two-factor-auth/default.nix
+++ b/pkgs/development/python-modules/django-two-factor-auth/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     qrcode
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     call = [ twilio ];
     sms = [ twilio ];
     webauthn = [

--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -94,7 +94,7 @@ buildPythonPackage rec {
     sqlparse
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     argon2 = [ argon2-cffi ];
     bcrypt = [ bcrypt ];
   };
@@ -116,7 +116,7 @@ buildPythonPackage rec {
     selenium
     tblib
     tzdata
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 

--- a/pkgs/development/python-modules/djangorestframework-simplejwt/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-simplejwt/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     pyjwt
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     python-jose = [ python-jose ];
     crypto = [ cryptography ];
   };

--- a/pkgs/development/python-modules/djangorestframework-stubs/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-stubs/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     compatible-mypy = [ mypy ] ++ django-stubs.optional-dependencies.compatible-mypy;
     coreapi = [ coreapi ];
     markdown = [ types-markdown ];
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     py
     pytest-mypy-plugins
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   # Upstream recommends mypy > 1.7 which we don't have yet, thus all testsare failing with 3.14.5 and below
   doCheck = false;

--- a/pkgs/development/python-modules/dm-sonnet/default.nix
+++ b/pkgs/development/python-modules/dm-sonnet/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     wrapt
   ] ++ etils.optional-dependencies.epath;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     tensorflow = [ tensorflow ];
   };
 

--- a/pkgs/development/python-modules/dns-lexicon/default.nix
+++ b/pkgs/development/python-modules/dns-lexicon/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     tldextract
   ] ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     route53 = [ boto3 ];
     localzone = [ localzone ];
     softlayer = [ softlayer ];
@@ -66,7 +66,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-vcr
-  ] ++ passthru.optional-dependencies.full;
+  ] ++ optional-dependencies.full;
 
   pytestFlagsArray = [ "tests/" ];
 

--- a/pkgs/development/python-modules/dnspython/default.nix
+++ b/pkgs/development/python-modules/dnspython/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ hatchling ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     DOH = [
       httpx
       h2
@@ -53,7 +53,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  checkInputs = [ cacert ] ++ passthru.optional-dependencies.DNSSEC;
+  checkInputs = [ cacert ] ++ optional-dependencies.DNSSEC;
 
   disabledTests = [
     # dns.exception.SyntaxError: protocol not found

--- a/pkgs/development/python-modules/dparse/default.nix
+++ b/pkgs/development/python-modules/dparse/default.nix
@@ -35,14 +35,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ packaging ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     # FIXME pipenv = [ pipenv ];
     conda = [ pyyaml ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "dparse" ];
 

--- a/pkgs/development/python-modules/draftjs-exporter/default.nix
+++ b/pkgs/development/python-modules/draftjs-exporter/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     sha256 = "sha256-4MmCVRx350p6N9XqTZSo8ROI/OJ0s4aKSYH9+Oxgvf4=";
   };
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     lxml = [ lxml ];
     html5lib = [
       beautifulsoup4
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     ];
   };
 
-  checkInputs = passthru.optional-dependencies.lxml ++ passthru.optional-dependencies.html5lib;
+  checkInputs = optional-dependencies.lxml ++ optional-dependencies.html5lib;
 
   checkPhase = ''
     # 2 tests in this file randomly fail because they depend on the order of

--- a/pkgs/development/python-modules/dramatiq/default.nix
+++ b/pkgs/development/python-modules/dramatiq/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ prometheus-client ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       gevent
       pika

--- a/pkgs/development/python-modules/drawsvg/default.nix
+++ b/pkgs/development/python-modules/drawsvg/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       numpy
       imageio

--- a/pkgs/development/python-modules/dsnap/default.nix
+++ b/pkgs/development/python-modules/dsnap/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     urllib3
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [ typer ];
     scannerd = [
       aws-sam-cli
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     moto
     mypy-boto3-ebs
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   # https://github.com/RhinoSecurityLabs/dsnap/issues/26
   # ImportError: cannot import name 'mock_iam' from 'moto'

--- a/pkgs/development/python-modules/dvc-render/default.nix
+++ b/pkgs/development/python-modules/dvc-render/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     table = [
       flatten-dict
       tabulate
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-mock
     pytest-test-utils
-  ] ++ passthru.optional-dependencies.table ++ passthru.optional-dependencies.markdown;
+  ] ++ optional-dependencies.table ++ optional-dependencies.markdown;
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test_vega.py" ];
 

--- a/pkgs/development/python-modules/dvc/default.nix
+++ b/pkgs/development/python-modules/dvc/default.nix
@@ -124,14 +124,14 @@ buildPythonPackage rec {
       voluptuous
       zc-lockfile
     ]
-    ++ lib.optionals enableGoogle passthru.optional-dependencies.gs
-    ++ lib.optionals enableAWS passthru.optional-dependencies.s3
-    ++ lib.optionals enableAzure passthru.optional-dependencies.azure
-    ++ lib.optionals enableSSH passthru.optional-dependencies.ssh
+    ++ lib.optionals enableGoogle optional-dependencies.gs
+    ++ lib.optionals enableAWS optional-dependencies.s3
+    ++ lib.optionals enableAzure optional-dependencies.azure
+    ++ lib.optionals enableSSH optional-dependencies.ssh
     ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ]
     ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     azure = [ dvc-azure ];
     gdrive = [ dvc-gdrive ];
     gs = [ dvc-gs ];

--- a/pkgs/development/python-modules/dvclive/default.nix
+++ b/pkgs/development/python-modules/dvclive/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pynvml
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       jsonargparse
       lightgbm

--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ jinja2 ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     reporting = [
       pandas
       pyparsing
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     pytestCheckHook
     which
     yosys
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "edalize" ];
 

--- a/pkgs/development/python-modules/elasticsearch/default.nix
+++ b/pkgs/development/python-modules/elasticsearch/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     certifi
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     requests = [ requests ];
     async = [ aiohttp ];
   };

--- a/pkgs/development/python-modules/elasticsearch8/default.nix
+++ b/pkgs/development/python-modules/elasticsearch8/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   dependencies = [ elastic-transport ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [ aiohttp ];
     requests = [ requests ];
     orjson = [ orjson ];

--- a/pkgs/development/python-modules/esig/default.nix
+++ b/pkgs/development/python-modules/esig/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ numpy ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     iisignature = [ iisignature ];
   };
 

--- a/pkgs/development/python-modules/essentials-openapi/default.nix
+++ b/pkgs/development/python-modules/essentials-openapi/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     markupsafe
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     full = [
       click
       jinja2

--- a/pkgs/development/python-modules/eth-hash/default.nix
+++ b/pkgs/development/python-modules/eth-hash/default.nix
@@ -24,11 +24,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs =
     [ pytest ]
-    ++ passthru.optional-dependencies.pycryptodome
+    ++ optional-dependencies.pycryptodome
     # eth-hash can use either safe-pysha3 or pycryptodome;
     # safe-pysha3 requires Python 3.9+ while pycryptodome does not.
     # https://github.com/ethereum/eth-hash/issues/46#issuecomment-1314029211
-    ++ lib.optional (pythonAtLeast "3.9") passthru.optional-dependencies.pysha3;
+    ++ lib.optional (pythonAtLeast "3.9") optional-dependencies.pysha3;
 
   checkPhase =
     ''
@@ -38,7 +38,7 @@ buildPythonPackage rec {
       pytest tests/backends/pysha3/
     '';
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     pycryptodome = [ pycryptodome ];
     pysha3 = [ safe-pysha3 ];
   };

--- a/pkgs/development/python-modules/eth-keys/default.nix
+++ b/pkgs/development/python-modules/eth-keys/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
       pyasn1
       pytestCheckHook
     ]
-    ++ passthru.optional-dependencies.coincurve
+    ++ optional-dependencies.coincurve
     ++ lib.optional (!isPyPy) eth-hash.optional-dependencies.pysha3
     ++ lib.optional isPyPy eth-hash.optional-dependencies.pycryptodome;
 
@@ -63,7 +63,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "eth_keys" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     coincurve = [ coincurve ];
   };
 

--- a/pkgs/development/python-modules/etils/default.nix
+++ b/pkgs/development/python-modules/etils/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ flit-core ];
 
-  passthru.optional-dependencies = rec {
+  optional-dependencies = rec {
     array-types = enp;
     eapp = [
       absl-py # FIXME package simple-parsing
@@ -91,7 +91,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
     yapf
-  ] ++ passthru.optional-dependencies.all;
+  ] ++ optional-dependencies.all;
 
   disabledTests = [
     "test_public_access" # requires network access

--- a/pkgs/development/python-modules/exchangelib/default.nix
+++ b/pkgs/development/python-modules/exchangelib/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     tzlocal
   ] ++ lib.optionals (pythonOlder "3.9") [ backports-zoneinfo ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     complete = [
       requests-gssapi
       # requests-negotiate-sspi

--- a/pkgs/development/python-modules/explorerscript/default.nix
+++ b/pkgs/development/python-modules/explorerscript/default.nix
@@ -47,9 +47,9 @@ buildPythonPackage rec {
     igraph
   ];
 
-  passthru.optional-dependencies.pygments = [ pygments ];
+  optional-dependencies.pygments = [ pygments ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.pygments;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.pygments;
 
   pythonImportsCheck = [ "explorerscript" ];
 

--- a/pkgs/development/python-modules/fakeredis/default.nix
+++ b/pkgs/development/python-modules/fakeredis/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     lua = [ lupa ];
     json = [ jsonpath-ng ];
     bf = [ pyprobables ];

--- a/pkgs/development/python-modules/fastparquet/default.nix
+++ b/pkgs/development/python-modules/fastparquet/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pandas
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     lzo = [ python-lzo ];
   };
 

--- a/pkgs/development/python-modules/fido2/default.nix
+++ b/pkgs/development/python-modules/fido2/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   dependencies = [ cryptography ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     pcsc = [ pyscard ];
   };
 

--- a/pkgs/development/python-modules/firebase-messaging/default.nix
+++ b/pkgs/development/python-modules/firebase-messaging/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     poetry-core
     sphinxHook
-  ] ++ passthru.optional-dependencies.docs;
+  ] ++ optional-dependencies.docs;
 
   propagatedBuildInputs = [
     aiohttp
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     protobuf
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     docs = [
       sphinx
       sphinx-autodoc-typehints

--- a/pkgs/development/python-modules/fixtures/default.nix
+++ b/pkgs/development/python-modules/fixtures/default.nix
@@ -26,14 +26,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pbr ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     streams = [ testtools ];
   };
 
   nativeCheckInputs = [
     mock
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.streams;
+  ] ++ optional-dependencies.streams;
 
   meta = {
     description = "Reusable state for writing clean tests and more";

--- a/pkgs/development/python-modules/flask-jwt-extended/default.nix
+++ b/pkgs/development/python-modules/flask-jwt-extended/default.nix
@@ -31,11 +31,11 @@ buildPythonPackage rec {
     werkzeug
   ];
 
-  passthru.optional-dependencies.asymmetric_crypto = [ cryptography ];
+  optional-dependencies.asymmetric_crypto = [ cryptography ];
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "flask_jwt_extended" ];
 

--- a/pkgs/development/python-modules/flask-marshmallow/default.nix
+++ b/pkgs/development/python-modules/flask-marshmallow/default.nix
@@ -32,14 +32,14 @@ buildPythonPackage rec {
     marshmallow
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     sqlalchemy = [
       flask-sqlalchemy
       marshmallow-sqlalchemy
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.sqlalchemy;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.sqlalchemy;
 
   pythonImportsCheck = [ "flask_marshmallow" ];
 

--- a/pkgs/development/python-modules/flask-mongoengine/default.nix
+++ b/pkgs/development/python-modules/flask-mongoengine/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     mongoengine
   ] ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     wtf = [
       flask-wtf
       wtforms

--- a/pkgs/development/python-modules/flask-wtf/default.nix
+++ b/pkgs/development/python-modules/flask-wtf/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     wtforms
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     email = [ email-validator ];
   };
 

--- a/pkgs/development/python-modules/flask/default.nix
+++ b/pkgs/development/python-modules/flask/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     werkzeug
   ] ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [ asgiref ];
     dotenv = [ python-dotenv ];
   };
@@ -58,7 +58,7 @@ buildPythonPackage rec {
   nativeCheckInputs =
     [ pytestCheckHook ]
     ++ lib.optionals (pythonOlder "3.11") [ greenlet ]
-    ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+    ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   passthru.tests = {
     inherit

--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [ matplotlib ];
   };
 

--- a/pkgs/development/python-modules/flow-record/default.nix
+++ b/pkgs/development/python-modules/flow-record/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   dependencies = [ msgpack ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     compression = [
       lz4
       zstandard
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest7CheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "flow.record" ];
 

--- a/pkgs/development/python-modules/foolscap/default.nix
+++ b/pkgs/development/python-modules/foolscap/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     pyopenssl
   ] ++ twisted.optional-dependencies.tls;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     i2p = [ txi2p-tahoe ];
     tor = [ txtorcon ];
   };
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     mock
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "foolscap" ];
 

--- a/pkgs/development/python-modules/fritzconnection/default.nix
+++ b/pkgs/development/python-modules/fritzconnection/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ requests ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     qr = [ segno ];
   };
 

--- a/pkgs/development/python-modules/fschat/default.nix
+++ b/pkgs/development/python-modules/fschat/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage {
     # ] ++ markdown2.optional-dependencies.all;
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     llm_judge = [
       anthropic
       openai

--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     entrypoints = [ ];
     abfs = [ adlfs ];
     adl = [ adlfs ];

--- a/pkgs/development/python-modules/fugashi/default.nix
+++ b/pkgs/development/python-modules/fugashi/default.nix
@@ -34,9 +34,9 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     ipadic
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.unidic-lite;
+  ] ++ optional-dependencies.unidic-lite;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     unidic-lite = [ unidic-lite ];
     unidic = [ unidic ];
   };

--- a/pkgs/development/python-modules/fvcore/default.nix
+++ b/pkgs/development/python-modules/fvcore/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "fvcore" ];
 
-  passthru.optional-dependencies = optional-dependencies;
+  optional-dependencies = optional-dependencies;
 
   meta = with lib; {
     description = "Collection of common code that's shared among different research projects in FAIR computer vision team";

--- a/pkgs/development/python-modules/gardena-bluetooth/default.nix
+++ b/pkgs/development/python-modules/gardena-bluetooth/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     tzlocal
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [ asyncclick ];
   };
 

--- a/pkgs/development/python-modules/githubkit/default.nix
+++ b/pkgs/development/python-modules/githubkit/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       anyio
       pyjwt
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-cov-stub
     pytest-xdist
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "githubkit" ];
 

--- a/pkgs/development/python-modules/google-api-core/default.nix
+++ b/pkgs/development/python-modules/google-api-core/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     grpc = [
       grpcio
       grpcio-status

--- a/pkgs/development/python-modules/google-auth/default.nix
+++ b/pkgs/development/python-modules/google-auth/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     rsa
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aiohttp = [
       aiohttp
       requests
@@ -75,9 +75,9 @@ buildPythonPackage rec {
       pytestCheckHook
       responses
     ]
-    ++ passthru.optional-dependencies.aiohttp
-    ++ passthru.optional-dependencies.enterprise_cert
-    ++ passthru.optional-dependencies.reauth;
+    ++ optional-dependencies.aiohttp
+    ++ optional-dependencies.enterprise_cert
+    ++ optional-dependencies.reauth;
 
   pythonImportsCheck = [
     "google.auth"

--- a/pkgs/development/python-modules/google-cloud-bigquery-storage/default.nix
+++ b/pkgs/development/python-modules/google-cloud-bigquery-storage/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     protobuf
   ] ++ google-api-core.optional-dependencies.grpc;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     fastavro = [ fastavro ];
     pandas = [ pandas ];
     pyarrow = [ pyarrow ];

--- a/pkgs/development/python-modules/google-cloud-bigquery/default.nix
+++ b/pkgs/development/python-modules/google-cloud-bigquery/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     python-dateutil
   ] ++ google-api-core.optional-dependencies.grpc;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     bqstorage = [
       google-cloud-bigquery-storage
       grpcio
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     google-cloud-storage
     pytestCheckHook
     pytest-xdist
-  ] ++ passthru.optional-dependencies.pandas ++ passthru.optional-dependencies.ipython;
+  ] ++ optional-dependencies.pandas ++ optional-dependencies.ipython;
 
   # prevent google directory from shadowing google imports
   preCheck = ''

--- a/pkgs/development/python-modules/google-cloud-bigtable/default.nix
+++ b/pkgs/development/python-modules/google-cloud-bigtable/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     protobuf
   ] ++ google-api-core.optional-dependencies.grpc;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     libcst = [ libcst ];
   };
 

--- a/pkgs/development/python-modules/google-cloud-core/default.nix
+++ b/pkgs/development/python-modules/google-cloud-core/default.nix
@@ -27,14 +27,14 @@ buildPythonPackage rec {
     google-api-core
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     grpc = [ grpcio ];
   };
 
   nativeCheckInputs = [
     mock
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.grpc;
+  ] ++ optional-dependencies.grpc;
 
   # prevent google directory from shadowing google imports
   preCheck = ''

--- a/pkgs/development/python-modules/google-cloud-pubsub/default.nix
+++ b/pkgs/development/python-modules/google-cloud-pubsub/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     protobuf
   ] ++ google-api-core.optional-dependencies.grpc;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     libcst = [ libcst ];
   };
 

--- a/pkgs/development/python-modules/google-cloud-spanner/default.nix
+++ b/pkgs/development/python-modules/google-cloud-spanner/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     sqlparse
   ] ++ google-api-core.optional-dependencies.grpc;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     libcst = [ libcst ];
   };
 

--- a/pkgs/development/python-modules/google-cloud-storage/default.nix
+++ b/pkgs/development/python-modules/google-cloud-storage/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     protobuf = [ protobuf ];
   };
 

--- a/pkgs/development/python-modules/google-resumable-media/default.nix
+++ b/pkgs/development/python-modules/google-resumable-media/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     google-crc32c
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     requests = [ requests ];
     aiohttp = [ aiohttp ];
   };
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     mock
     pytest-asyncio
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.requests;
+  ] ++ optional-dependencies.requests;
 
   preCheck = ''
     # prevent shadowing imports

--- a/pkgs/development/python-modules/gotailwind/default.nix
+++ b/pkgs/development/python-modules/gotailwind/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     zeroconf
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [ typer ];
   };
 

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -127,7 +127,7 @@ buildPythonPackage rec {
     tomlkit
   ];
 
-  passthru.optional-dependencies.oauth = [
+  optional-dependencies.oauth = [
     authlib
     itsdangerous
   ];
@@ -151,7 +151,7 @@ buildPythonPackage rec {
 
     # mock calls to `shutil.which(...)`
     (writeShellScriptBin "npm" "false")
-  ] ++ passthru.optional-dependencies.oauth ++ pydantic.optional-dependencies.email;
+  ] ++ optional-dependencies.oauth ++ pydantic.optional-dependencies.email;
 
   # Add a pytest hook skipping tests that access network, marking them as "Expected fail" (xfail).
   # We additionally xfail FileNotFoundError, since the gradio devs often fail to upload test assets to pypi.

--- a/pkgs/development/python-modules/griffe/default.nix
+++ b/pkgs/development/python-modules/griffe/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [ aiofiles ];
   };
 

--- a/pkgs/development/python-modules/hap-python/default.nix
+++ b/pkgs/development/python-modules/hap-python/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     zeroconf
   ];
 
-  passthru.optional-dependencies.QRCode = [
+  optional-dependencies.QRCode = [
     base36
     pyqrcode
   ];
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-timeout
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.QRCode;
+  ] ++ optional-dependencies.QRCode;
 
   disabledTestPaths = [
     # Disable tests requiring network access

--- a/pkgs/development/python-modules/haystack-ai/default.nix
+++ b/pkgs/development/python-modules/haystack-ai/default.nix
@@ -138,7 +138,7 @@ buildPythonPackage rec {
 
   env.HOME = "$(mktemp -d)";
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     # all = [
     #   farm-haystack
     # ];

--- a/pkgs/development/python-modules/highdicom/default.nix
+++ b/pkgs/development/python-modules/highdicom/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     pydicom
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     libjpeg = [
       pylibjpeg
       pylibjpeg-libjpeg
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.libjpeg;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.libjpeg;
   preCheck = ''
     export HOME=$TMP/test-home
     mkdir -p $HOME/.pydicom/

--- a/pkgs/development/python-modules/hikari-lightbulb/default.nix
+++ b/pkgs/development/python-modules/hikari-lightbulb/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ hikari ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     crontrigger = [ croniter ];
   };
 

--- a/pkgs/development/python-modules/hikari/default.nix
+++ b/pkgs/development/python-modules/hikari/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = true;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     server = [ pynacl ];
   };
 

--- a/pkgs/development/python-modules/hishel/default.nix
+++ b/pkgs/development/python-modules/hishel/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   dependencies = [ httpx ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     redis = [ redis ];
     s3 = [ boto3 ];
     sqlite = [ anysqlite ];
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
     trio
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "hishel" ];
 

--- a/pkgs/development/python-modules/htmldate/default.nix
+++ b/pkgs/development/python-modules/htmldate/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     urllib3
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     speed =
       [
         faust-cchardet

--- a/pkgs/development/python-modules/httpbin/default.nix
+++ b/pkgs/development/python-modules/httpbin/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     werkzeug
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     mainapp = [
       gunicorn
       gevent

--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     h11
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     asyncio = [ anyio ];
     http2 = [ h2 ];
     socks = [ socksio ];
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pytest-httpbin
     pytest-trio
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "httpcore" ];
 

--- a/pkgs/development/python-modules/httpx-socks/default.nix
+++ b/pkgs/development/python-modules/httpx-socks/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     python-socks
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     asyncio = [ async-timeout ];
     trio = [ trio ];
   };

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     sniffio
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     http2 = [ h2 ];
     socks = [ socksio ];
     brotli = if isPyPy then [ brotlicffi ] else [ brotli ];
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     pytest-trio
     trustme
     uvicorn
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   # testsuite wants to find installed packages for testing entrypoint
   preCheck = ''

--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -125,7 +125,7 @@ buildPythonPackage rec {
     pytest-snapshot
     pytest-timeout
     pytest-xdist
-  ] ++ lib.concatMap (name: passthru.optional-dependencies.${name}) testBackends;
+  ] ++ lib.concatMap (name: optional-dependencies.${name}) testBackends;
 
   pytestFlagsArray = [
     "--dist=loadgroup"
@@ -167,54 +167,52 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ibis" ] ++ map (backend: "ibis.backends.${backend}") testBackends;
 
-  passthru = {
-    optional-dependencies = {
-      bigquery = [
-        db-dtypes
-        google-cloud-bigquery
-        google-cloud-bigquery-storage
-        pydata-google-auth
-      ];
-      clickhouse = [ clickhouse-connect ];
-      dask = [
-        dask
-        regex
-        packaging
-      ];
-      datafusion = [ datafusion ];
-      druid = [ pydruid ];
-      duckdb = [ duckdb ];
-      flink = [ ];
-      geospatial = [
-        geopandas
-        shapely
-      ];
-      mssql = [ pyodbc ];
-      mysql = [ pymysql ];
-      oracle = [
-        oracledb
-        packaging
-      ];
-      pandas = [
-        regex
-        packaging
-      ];
-      polars = [
-        polars
-        packaging
-      ];
-      postgres = [ psycopg2 ];
-      pyspark = [
-        pyspark
-        packaging
-      ];
-      snowflake = [ snowflake-connector-python ];
-      sqlite = [ regex ];
-      trino = [ trino-python-client ];
-      visualization = [ graphviz ];
-      decompiler = [ black ];
-      examples = [ pins ] ++ pins.optional-dependencies.gcs;
-    };
+  optional-dependencies = {
+    bigquery = [
+      db-dtypes
+      google-cloud-bigquery
+      google-cloud-bigquery-storage
+      pydata-google-auth
+    ];
+    clickhouse = [ clickhouse-connect ];
+    dask = [
+      dask
+      regex
+      packaging
+    ];
+    datafusion = [ datafusion ];
+    druid = [ pydruid ];
+    duckdb = [ duckdb ];
+    flink = [ ];
+    geospatial = [
+      geopandas
+      shapely
+    ];
+    mssql = [ pyodbc ];
+    mysql = [ pymysql ];
+    oracle = [
+      oracledb
+      packaging
+    ];
+    pandas = [
+      regex
+      packaging
+    ];
+    polars = [
+      polars
+      packaging
+    ];
+    postgres = [ psycopg2 ];
+    pyspark = [
+      pyspark
+      packaging
+    ];
+    snowflake = [ snowflake-connector-python ];
+    sqlite = [ regex ];
+    trino = [ trino-python-client ];
+    visualization = [ graphviz ];
+    decompiler = [ black ];
+    examples = [ pins ] ++ pins.optional-dependencies.gcs;
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/igraph/default.nix
+++ b/pkgs/development/python-modules/igraph/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   dependencies = [ texttable ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cairo = [ cairocffi ];
     matplotlib = [ matplotlib ];
     plotly = [ plotly ];
@@ -58,7 +58,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [
     "testAuthorityScore"

--- a/pkgs/development/python-modules/imbalanced-learn/default.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     threadpoolctl
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     optional = [
       keras
       pandas

--- a/pkgs/development/python-modules/influxdb-client/default.nix
+++ b/pkgs/development/python-modules/influxdb-client/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     urllib3
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [
       aiocsv
       aiohttp

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -59,9 +59,9 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     intake-parquet
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     server = [
       msgpack
       python-snappy

--- a/pkgs/development/python-modules/iopath/default.nix
+++ b/pkgs/development/python-modules/iopath/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "iopath" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aws = [ boto3 ];
   };
 

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ markupsafe ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     i18n = [ babel ];
   };
 
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   # See https://github.com/pallets/jinja/issues/1158
   doCheck = !stdenv.hostPlatform.is32bit;
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.i18n;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.i18n;
 
   disabledTests = lib.optionals (pythonAtLeast "3.13") [
     # https://github.com/pallets/jinja/issues/1900

--- a/pkgs/development/python-modules/jira/default.nix
+++ b/pkgs/development/python-modules/jira/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [
       ipython
       keyring

--- a/pkgs/development/python-modules/jsonargparse/default.nix
+++ b/pkgs/development/python-modules/jsonargparse/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   dependencies = [ pyyaml ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       argcomplete
       fsspec

--- a/pkgs/development/python-modules/jsonschema/default.nix
+++ b/pkgs/development/python-modules/jsonschema/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
       pkgutil-resolve-name
     ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     format = [
       fqdn
       idna

--- a/pkgs/development/python-modules/jupyter-events/default.nix
+++ b/pkgs/development/python-modules/jupyter-events/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     traitlets
   ] ++ jsonschema.optional-dependencies.format-nongpl;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [
       click
       rich
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-console-scripts
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = ''
     export PATH="$out/bin:$PATH"

--- a/pkgs/development/python-modules/kafka-python-ng/default.nix
+++ b/pkgs/development/python-modules/kafka-python-ng/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     crc32c =  [ crc32c ];
     lz4 = [ lz4 ];
     snappy = [ python-snappy ];
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
     xxhash
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   meta = {
     changelog = "https://github.com/wbarnha/kafka-python-ng/releases/tag/v${version}";

--- a/pkgs/development/python-modules/layoutparser/default.nix
+++ b/pkgs/development/python-modules/layoutparser/default.nix
@@ -96,7 +96,7 @@ buildPythonPackage {
     "tests_deps/test_only_paddledetection.py" # requires paddlepaddle not yet packaged
   ];
 
-  passthru.optional-dependencies = optional-dependencies;
+  optional-dependencies = optional-dependencies;
 
   meta = with lib; {
     description = "Unified toolkit for Deep Learning Based Document Image Analysis";

--- a/pkgs/development/python-modules/librosa/default.nix
+++ b/pkgs/development/python-modules/librosa/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies.matplotlib = [ matplotlib ];
+  optional-dependencies.matplotlib = [ matplotlib ];
 
   # check that import works, this allows to capture errors like https://github.com/librosa/librosa/issues/1160
   pythonImportsCheck = [ "librosa" ];
@@ -90,7 +90,7 @@ buildPythonPackage rec {
     pytestCheckHook
     resampy
     samplerate
-  ] ++ passthru.optional-dependencies.matplotlib;
+  ] ++ optional-dependencies.matplotlib;
 
   preCheck = ''
     export HOME=$TMPDIR

--- a/pkgs/development/python-modules/lightgbm/default.nix
+++ b/pkgs/development/python-modules/lightgbm/default.nix
@@ -84,7 +84,7 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     arrow = [
       cffi
       pyarrow

--- a/pkgs/development/python-modules/line-profiler/default.nix
+++ b/pkgs/development/python-modules/line-profiler/default.nix
@@ -31,14 +31,14 @@ buildPythonPackage rec {
     scikit-build
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ipython = [ ipython ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
     ubelt
-  ] ++ passthru.optional-dependencies.ipython;
+  ] ++ optional-dependencies.ipython;
 
   dontUseCmakeConfigure = true;
 

--- a/pkgs/development/python-modules/litellm/default.nix
+++ b/pkgs/development/python-modules/litellm/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     tokenizers
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     proxy = [
       apscheduler
       backoff

--- a/pkgs/development/python-modules/llmx/default.nix
+++ b/pkgs/development/python-modules/llmx/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     web = [
       fastapi
       uvicorn

--- a/pkgs/development/python-modules/logbook/default.nix
+++ b/pkgs/development/python-modules/logbook/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     execnet = [ execnet ];
     sqlalchemy = [ sqlalchemy ];
     redis = [ redis ];
@@ -52,7 +52,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     zipstream-ng
   ] ++ autobahn.optional-dependencies.twisted ++ twisted.optional-dependencies.tls;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     dilation = [ noiseprotocol ];
   };
 
@@ -91,7 +91,7 @@ buildPythonPackage rec {
       mock
       pytestCheckHook
     ]
-    ++ passthru.optional-dependencies.dilation
+    ++ optional-dependencies.dilation
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ unixtools.locale ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/mako/default.nix
+++ b/pkgs/development/python-modules/mako/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ markupsafe ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     babel = [ babel ];
     lingua = [ lingua ];
   };
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     chameleon
     mock
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests =
     lib.optionals isPyPy [

--- a/pkgs/development/python-modules/mandown/default.nix
+++ b/pkgs/development/python-modules/mandown/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     typer
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     gui = [ pyside6 ];
     updateScript = nix-update-script { };
   };

--- a/pkgs/development/python-modules/manifest-ml/default.nix
+++ b/pkgs/development/python-modules/manifest-ml/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     xxhash
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     api = [
       accelerate
       # deepspeed
@@ -84,7 +84,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   preCheck = ''
     export HOME=$TMPDIR

--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-regressions
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.linkify;
+  ] ++ optional-dependencies.linkify;
 
   # disable and remove benchmark tests
   preCheck = ''
@@ -60,7 +60,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "markdown_it" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     compare = [
       commonmark
       markdown

--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -35,12 +35,10 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     code_syntax_highlighting = [ pygments ];
     wavedrom = [ wavedrom ];
-    all = lib.flatten (
-      lib.attrValues (lib.filterAttrs (n: v: n != "all") passthru.optional-dependencies)
-    );
+    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mashumaro/default.nix
+++ b/pkgs/development/python-modules/mashumaro/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ typing-extensions ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     orjson = [ orjson ];
     msgpack = [ msgpack ];
     yaml = [ pyyaml ];
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     pendulum
     pytest-mock
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "mashumaro" ];
 

--- a/pkgs/development/python-modules/mastodon-py/default.nix
+++ b/pkgs/development/python-modules/mastodon-py/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     six
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     blurhash = [ blurhash ];
     webpush = [
       http-ece
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pytest-vcr
     requests-mock
     setuptools
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTests = [
     "test_notifications_dismiss_pre_2_9_2"

--- a/pkgs/development/python-modules/matplotx/default.nix
+++ b/pkgs/development/python-modules/matplotx/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       networkx
       pypng
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   # Not sure of the details, but we can avoid it by changing the matplotlib backend during testing.
   env.MPLBACKEND = lib.optionalString stdenv.hostPlatform.isDarwin "Agg";
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.all;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.all;
 
   disabledTestPaths = [
     "tests/test_spy.py" # Requires meshzoo (non-free) and pytest-codeblocks (not packaged)

--- a/pkgs/development/python-modules/mayim/default.nix
+++ b/pkgs/development/python-modules/mayim/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     wheel
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     postgres = [ psycopg ] ++ psycopg.optional-dependencies.pool;
     mysql = [ asyncmy ];
     sqlite = [ aiosqlite ];
@@ -45,7 +45,7 @@ buildPythonPackage rec {
       pytest-asyncio
       pytest-cov-stub
     ]
-    ++ (with passthru.optional-dependencies; [
+    ++ (with optional-dependencies; [
       postgres
       mysql
       sqlite

--- a/pkgs/development/python-modules/meshtastic/default.nix
+++ b/pkgs/development/python-modules/meshtastic/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
     webencodings
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     tunnel = [ pytap2 ];
   };
 
@@ -84,7 +84,7 @@ buildPythonPackage rec {
     hypothesis
     pytestCheckHook
     riden
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = ''
     export PATH="$PATH:$out/bin";

--- a/pkgs/development/python-modules/mip/default.nix
+++ b/pkgs/development/python-modules/mip/default.nix
@@ -79,7 +79,7 @@ buildPythonPackage rec {
   # Tests that rely on Gurobi are activated only when Gurobi support is enabled
   disabledTests = lib.optional (!gurobiSupport) "gurobi";
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     inherit gurobipy numpy;
   };
 

--- a/pkgs/development/python-modules/mkdocs-material/default.nix
+++ b/pkgs/development/python-modules/mkdocs-material/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     recommended = [
       mkdocs-minify-plugin
       mkdocs-redirects

--- a/pkgs/development/python-modules/mkdocs/default.nix
+++ b/pkgs/development/python-modules/mkdocs/default.nix
@@ -66,14 +66,14 @@ buildPythonPackage rec {
     watchdog
   ] ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     i18n = [ babel ] ++ lib.optionals (pythonAtLeast "3.12") [ setuptools ];
   };
 
   nativeCheckInputs = [
     unittestCheckHook
     mock
-  ] ++ passthru.optional-dependencies.i18n;
+  ] ++ optional-dependencies.i18n;
 
   unittestFlagsArray = [
     "-v"

--- a/pkgs/development/python-modules/mne-python/default.nix
+++ b/pkgs/development/python-modules/mne-python/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     lazy-loader
   ];
 
-  passthru.optional-dependencies.hdf5 = [
+  optional-dependencies.hdf5 = [
     h5io
     pymatreader
   ];
@@ -65,7 +65,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-timeout
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/mocket/default.nix
+++ b/pkgs/development/python-modules/mocket/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     urllib3
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     pook = [ pook ];
     speedups = [ xxhash ];
   };
@@ -72,7 +72,7 @@ buildPythonPackage rec {
       sure
     ]
     ++ lib.optionals (pythonOlder "3.12") [ aiohttp ]
-    ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+    ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = lib.optionalString stdenv.hostPlatform.isLinux ''
     ${redis-server}/bin/redis-server &

--- a/pkgs/development/python-modules/moderngl-window/default.nix
+++ b/pkgs/development/python-modules/moderngl-window/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pyrr
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     trimesh = [
       trimesh
       scipy

--- a/pkgs/development/python-modules/molecule/plugins.nix
+++ b/pkgs/development/python-modules/molecule/plugins.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     docker = [ docker ];
     vagrant = [ python-vagrant ];
   };

--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     optionals = [
       matplotlib
       scikit-image
@@ -62,7 +62,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "moviepy" ];
 

--- a/pkgs/development/python-modules/mpd2/default.nix
+++ b/pkgs/development/python-modules/mpd2/default.nix
@@ -22,11 +22,11 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     twisted = [ twisted ];
   };
 
-  nativeCheckInputs = [ unittestCheckHook ] ++ passthru.optional-dependencies.twisted;
+  nativeCheckInputs = [ unittestCheckHook ] ++ optional-dependencies.twisted;
 
   meta = with lib; {
     changelog = "https://github.com/Mic92/python-mpd2/blob/v${version}/doc/changes.rst";

--- a/pkgs/development/python-modules/mpmath/default.nix
+++ b/pkgs/development/python-modules/mpmath/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     gmpy = lib.optionals (!isPyPy) [ gmpy2 ];
   };
 

--- a/pkgs/development/python-modules/mrjob/default.nix
+++ b/pkgs/development/python-modules/mrjob/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyyaml ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aws = [
       boto3
       botocore
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     pyspark
     unittestCheckHook
     warcio
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   unittestFlagsArray = [ "-v" ];
 

--- a/pkgs/development/python-modules/nats-py/default.nix
+++ b/pkgs/development/python-modules/nats-py/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   dependencies = [ ed25519 ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aiohttp = [ aiohttp ];
     nkeys = [ nkeys ];
     # fast_parse = [

--- a/pkgs/development/python-modules/ndindex/default.nix
+++ b/pkgs/development/python-modules/ndindex/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
       --replace "--flakes" ""
   '';
 
-  passthru.optional-dependencies.arrays = [ numpy ];
+  optional-dependencies.arrays = [ numpy ];
 
   pythonImportsCheck = [ "ndindex" ];
 
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     hypothesis
     pytest-cov-stub
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.arrays;
+  ] ++ optional-dependencies.arrays;
 
   meta = with lib; {
     description = "";

--- a/pkgs/development/python-modules/neo4j/default.nix
+++ b/pkgs/development/python-modules/neo4j/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     tomlkit
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     numpy = [ numpy ];
     pandas = [
       numpy

--- a/pkgs/development/python-modules/netutils/default.nix
+++ b/pkgs/development/python-modules/netutils/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   dependencies = [ jsonschema ];
 
-  passthru.optional-dependencies.optionals = [
+  optional-dependencies.optionals = [
     jsonschema
     napalm
   ];

--- a/pkgs/development/python-modules/networkx/default.nix
+++ b/pkgs/development/python-modules/networkx/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     default = [
       numpy
       scipy

--- a/pkgs/development/python-modules/nibabel/default.nix
+++ b/pkgs/development/python-modules/nibabel/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     packaging
   ] ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ];
 
-  passthru.optional-dependencies = rec {
+  optional-dependencies = rec {
     all = dicom ++ dicomfs ++ minc2 ++ spm ++ zstd;
     dicom = [ pydicom ];
     dicomfs = [ pillow ] ++ dicom;
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pytest-httpserver
     pytest-xdist
     pytest7CheckHook
-  ] ++ passthru.optional-dependencies.all;
+  ] ++ optional-dependencies.all;
 
   preCheck = ''
     export PATH=$out/bin:$PATH

--- a/pkgs/development/python-modules/nibe/default.nix
+++ b/pkgs/development/python-modules/nibe/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     tenacity
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     convert = [
       pandas
       python-slugify

--- a/pkgs/development/python-modules/norfair/default.nix
+++ b/pkgs/development/python-modules/norfair/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     scipy
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     metrics = [ motmetrics ];
     video = [ opencv4 ];
   };

--- a/pkgs/development/python-modules/nose2/default.nix
+++ b/pkgs/development/python-modules/nose2/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     coverage = [ coverage ];
   };
 
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     unittestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   meta = with lib; {
     changelog = "https://github.com/nose-devs/nose2/blob/${version}/docs/changelog.rst";

--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ numpy ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     msgpack = [ msgpack ];
     # zfpy = [ zfpy ];
   };

--- a/pkgs/development/python-modules/oauthenticator/default.nix
+++ b/pkgs/development/python-modules/oauthenticator/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     traitlets
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     googlegroups = [
       google-api-python-client
       google-auth-oauthlib
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
     requests-mock
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTests = [
     # Tests are outdated, https://github.com/jupyterhub/oauthenticator/issues/432

--- a/pkgs/development/python-modules/oauthlib/default.nix
+++ b/pkgs/development/python-modules/oauthlib/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     rsa = [ cryptography ];
     signedtoken = [
       cryptography
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     mock
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [
     # https://github.com/oauthlib/oauthlib/issues/877

--- a/pkgs/development/python-modules/objgraph/default.nix
+++ b/pkgs/development/python-modules/objgraph/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ipython = [ graphviz ];
   };
 

--- a/pkgs/development/python-modules/ome-zarr/default.nix
+++ b/pkgs/development/python-modules/ome-zarr/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     requests
     scikit-image
     toolz
-  ] ++ fsspec.passthru.optional-dependencies.s3;
+  ] ++ fsspec.optional-dependencies.s3;
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     typing-extensions
   ] ++ lib.optionals (pythonOlder "3.8") [ cached-property ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     datalib = [
       numpy
       pandas

--- a/pkgs/development/python-modules/openant/default.nix
+++ b/pkgs/development/python-modules/openant/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyusb ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     serial = [ pyserial ];
     influx = [ influxdb-client ];
   };

--- a/pkgs/development/python-modules/opencontainers/default.nix
+++ b/pkgs/development/python-modules/opencontainers/default.nix
@@ -20,11 +20,11 @@ buildPythonPackage rec {
     sed -i "/pytest-runner/d" setup.py
   '';
 
-  passthru.optional-dependencies.reggie = [ requests ];
+  optional-dependencies.reggie = [ requests ];
 
   pythonImportsCheck = [ "opencontainers" ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.reggie;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.reggie;
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/opensearch-py/default.nix
+++ b/pkgs/development/python-modules/opensearch-py/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     events
   ];
 
-  passthru.optional-dependencies.async = [ aiohttp ];
+  optional-dependencies.async = [ aiohttp ];
 
   nativeCheckInputs = [
     botocore
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pyyaml
     pytz
-  ] ++ passthru.optional-dependencies.async;
+  ] ++ optional-dependencies.async;
 
   disabledTestPaths = [
     # require network

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
@@ -33,14 +33,14 @@ buildPythonPackage rec {
     opentelemetry-util-http
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     asgi = [ opentelemetry-instrumentation-asgi ];
   };
 
   nativeCheckInputs = [
     opentelemetry-test-utils
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.asgi;
+  ] ++ optional-dependencies.asgi;
 
   pythonImportsCheck = [ "opentelemetry.instrumentation.django" ];
 

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage {
     wrapt
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     instruments = [ grpcio ];
   };
 

--- a/pkgs/development/python-modules/optuna/default.nix
+++ b/pkgs/development/python-modules/optuna/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     integration = [
       botorch
       catboost
@@ -115,7 +115,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
     scipy
-  ] ++ fakeredis.optional-dependencies.lua ++ passthru.optional-dependencies.optional;
+  ] ++ fakeredis.optional-dependencies.lua ++ optional-dependencies.optional;
 
   pytestFlagsArray = [ "-m 'not integration'" ];
 

--- a/pkgs/development/python-modules/ormar/default.nix
+++ b/pkgs/development/python-modules/ormar/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
       importlib-metadata
     ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     postgresql = [ asyncpg ];
     postgres = [ asyncpg ];
     aiopg = [ aiopg ];
@@ -89,7 +89,7 @@ buildPythonPackage rec {
     httpx
     nest-asyncio
     pytest-asyncio
-  ] ++ passthru.optional-dependencies.all;
+  ] ++ optional-dependencies.all;
 
   disabledTestPaths = [ "benchmarks/test_benchmark_*.py" ];
 

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -108,7 +108,7 @@ let
       tzdata
     ];
 
-    passthru.optional-dependencies =
+    optional-dependencies =
       let
         extras = {
           aws = [ s3fs ];
@@ -183,7 +183,7 @@ let
         pytest-xdist
         pytestCheckHook
       ]
-      ++ lib.flatten (lib.attrValues passthru.optional-dependencies)
+      ++ lib.flatten (lib.attrValues optional-dependencies)
       ++ lib.optionals (stdenv.hostPlatform.isLinux) [
         # for locale executable
         glibc

--- a/pkgs/development/python-modules/papermill/default.nix
+++ b/pkgs/development/python-modules/papermill/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     ansicolors
   ] ++ lib.optionals (pythonAtLeast "3.12") [ aiohttp ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     azure = [
       azure-datalake-store
       azure-identity
@@ -69,16 +69,12 @@ buildPythonPackage rec {
     s3 = [ boto3 ];
   };
 
-  nativeCheckInputs =
-    [
-      ipykernel
-      moto
-      pytest-mock
-      pytestCheckHook
-    ]
-    ++ passthru.optional-dependencies.azure
-    ++ passthru.optional-dependencies.s3
-    ++ passthru.optional-dependencies.gcs;
+  nativeCheckInputs = [
+    ipykernel
+    moto
+    pytest-mock
+    pytestCheckHook
+  ] ++ optional-dependencies.azure ++ optional-dependencies.s3 ++ optional-dependencies.gcs;
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -44,9 +44,9 @@ buildPythonPackage rec {
     cryptography
     pyasn1
     six
-  ] ++ passthru.optional-dependencies.ed25519; # remove on 3.0 update
+  ] ++ optional-dependencies.ed25519; # remove on 3.0 update
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     gssapi = [
       pyasn1
       gssapi
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     icecream
     mock
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTestPaths = [
     # disable tests that require pytest-relaxed, which is broken

--- a/pkgs/development/python-modules/partd/default.nix
+++ b/pkgs/development/python-modules/partd/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     toolz
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     complete = [
       blosc2
       numpy

--- a/pkgs/development/python-modules/passlib/default.nix
+++ b/pkgs/development/python-modules/passlib/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     hash = "sha256-3v1Q9ytlxUAqssVzgwppeOXyAq0NmEeTyN3ixBUuvgQ";
   };
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     argon2 = [ argon2-cffi ];
     bcrypt = [ bcrypt ];
     totp = [ cryptography ];
@@ -35,14 +35,10 @@ buildPythonPackage rec {
       "version = getattr(getattr(_bcrypt, '__about__', _bcrypt), '__version__', '<unknown>')"
   '';
 
-  nativeCheckInputs =
-    [
-      pytestCheckHook
-      pytest-xdist
-    ]
-    ++ passthru.optional-dependencies.argon2
-    ++ passthru.optional-dependencies.bcrypt
-    ++ passthru.optional-dependencies.totp;
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-xdist
+  ] ++ optional-dependencies.argon2 ++ optional-dependencies.bcrypt ++ optional-dependencies.totp;
 
   pythonImportsCheck = [ "passlib" ];
 

--- a/pkgs/development/python-modules/pettingzoo/default.nix
+++ b/pkgs/development/python-modules/pettingzoo/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       chess
       # multi-agent-ale-py

--- a/pkgs/development/python-modules/photutils/default.nix
+++ b/pkgs/development/python-modules/photutils/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       bottleneck
       gwcs

--- a/pkgs/development/python-modules/pins/default.nix
+++ b/pkgs/development/python-modules/pins/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     xxhash
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aws = [ s3fs ];
     azure = [ adlfs ];
     gcs = [ gcsfs ];
@@ -71,7 +71,7 @@ buildPythonPackage rec {
     pytest-cases
     pytest-parallel
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "pins" ];
 

--- a/pkgs/development/python-modules/pipdeptree/default.nix
+++ b/pkgs/development/python-modules/pipdeptree/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     packaging
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     graphviz = [ graphviz ];
   };
 
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
     virtualenv
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "pipdeptree" ];
 

--- a/pkgs/development/python-modules/playwrightcapture/default.nix
+++ b/pkgs/development/python-modules/playwrightcapture/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     w3lib
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     recaptcha = [
       speechrecognition
       pydub

--- a/pkgs/development/python-modules/podman/default.nix
+++ b/pkgs/development/python-modules/podman/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     urllib3
   ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     progress_bar = [ rich ];
   };
 

--- a/pkgs/development/python-modules/prance/default.nix
+++ b/pkgs/development/python-modules/prance/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     six
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [ click ];
     flex = [ flex ];
     icu = [ pyicu ];
@@ -54,7 +54,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-cov-stub
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   # Disable tests that require network
   disabledTestPaths = [ "tests/test_convert.py" ];

--- a/pkgs/development/python-modules/prometheus-async/default.nix
+++ b/pkgs/development/python-modules/prometheus-async/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     wrapt
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aiohttp = [
       aiohttp
     ];

--- a/pkgs/development/python-modules/prophet/default.nix
+++ b/pkgs/development/python-modules/prophet/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     importlib-resources
   ];
 
-  passthru.optional-dependencies.parallel = [
+  optional-dependencies.parallel = [
     dask
     distributed
   ] ++ dask.optional-dependencies.dataframe;

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -161,7 +161,7 @@ buildPythonPackage rec {
     "psycopg_pool"
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     c = [ psycopg-c ];
     pool = [ psycopg-pool ];
   };
@@ -175,8 +175,8 @@ buildPythonPackage rec {
       postgresql
     ]
     ++ lib.optional (stdenv.hostPlatform.isLinux) postgresqlTestHook
-    ++ passthru.optional-dependencies.c
-    ++ passthru.optional-dependencies.pool;
+    ++ optional-dependencies.c
+    ++ optional-dependencies.pool;
 
   env = {
     postgresqlEnableTCP = 1;

--- a/pkgs/development/python-modules/pure-python-adb/default.nix
+++ b/pkgs/development/python-modules/pure-python-adb/default.nix
@@ -19,13 +19,13 @@ buildPythonPackage rec {
     sha256 = "0kdr7w2fhgjpcf1k3l6an9im583iqkr6v8hb4q1zw30nh3bqkk0f";
   };
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [ aiofiles ];
   };
 
   doCheck = pythonOlder "3.10"; # all tests result in RuntimeError on 3.10
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.async;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.async;
 
   pythonImportsCheck = [ "ppadb.client" ] ++ lib.optionals doCheck [ "ppadb.client_async" ];
 

--- a/pkgs/development/python-modules/pyTelegramBotAPI/default.nix
+++ b/pkgs/development/python-modules/pyTelegramBotAPI/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   build-system = [ hatchling ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     json = [ ujson ];
     PIL = [ pillow ];
     redis = [ redis ];
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
     requests
-  ] ++ passthru.optional-dependencies.watchdog ++ passthru.optional-dependencies.aiohttp;
+  ] ++ optional-dependencies.watchdog ++ optional-dependencies.aiohttp;
 
   pythonImportsCheck = [ "telebot" ];
 

--- a/pkgs/development/python-modules/pycyphal/default.nix
+++ b/pkgs/development/python-modules/pycyphal/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     nunavut
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     transport-can-pythoncan = [ python-can ] ++ python-can.optional-dependencies.serial;
     transport-serial = [
       cobs
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-asyncio
-  ] ++ builtins.foldl' (x: y: x ++ y) [ ] (builtins.attrValues passthru.optional-dependencies);
+  ] ++ builtins.foldl' (x: y: x ++ y) [ ] (builtins.attrValues optional-dependencies);
 
   preCheck = ''
     export HOME=$TMPDIR

--- a/pkgs/development/python-modules/pydantic/1.nix
+++ b/pkgs/development/python-modules/pydantic/1.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ typing-extensions ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     dotenv = [ python-dotenv ];
     email = [ email-validator ];
   };
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-mock
     pytest7CheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pytestFlagsArray = [
     # https://github.com/pydantic/pydantic/issues/4817

--- a/pkgs/development/python-modules/pydeck/default.nix
+++ b/pkgs/development/python-modules/pydeck/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     carto = [
       # pydeck-carto
     ];
@@ -61,7 +61,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pandas
-  ] ++ passthru.optional-dependencies.jupyter;
+  ] ++ optional-dependencies.jupyter;
 
   # tries to start a jupyter server
   disabledTests = [ "test_nbconvert" ];

--- a/pkgs/development/python-modules/pydocstyle/default.nix
+++ b/pkgs/development/python-modules/pydocstyle/default.nix
@@ -42,9 +42,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ snowballstemmer ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
-  passthru.optional-dependencies.toml = [ tomli ];
+  optional-dependencies.toml = [ tomli ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.toml;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.toml;
 
   disabledTestPaths = [
     "src/tests/test_integration.py" # runs pip install

--- a/pkgs/development/python-modules/pydrive2/default.nix
+++ b/pkgs/development/python-modules/pydrive2/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     fsspec = [
       appdirs
       fsspec

--- a/pkgs/development/python-modules/pydruid/default.nix
+++ b/pkgs/development/python-modules/pydruid/default.nix
@@ -41,17 +41,15 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pycurl
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "pydruid" ];
 
-  passthru = {
-    optional-dependencies = {
-      pandas = [ pandas ];
-      async = [ tornado ];
-      sqlalchemy = [ sqlalchemy ];
-      # druid has a `cli` extra, but it doesn't work with nixpkgs pygments
-    };
+  optional-dependencies = {
+    pandas = [ pandas ];
+    async = [ tornado ];
+    sqlalchemy = [ sqlalchemy ];
+    # druid has a `cli` extra, but it doesn't work with nixpkgs pygments
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pyftpdlib/default.nix
+++ b/pkgs/development/python-modules/pyftpdlib/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   dependencies = [ pysendfile ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ssl = [ pyopenssl ];
   };
 

--- a/pkgs/development/python-modules/pygal/default.nix
+++ b/pkgs/development/python-modules/pygal/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ importlib-metadata ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     lxml = [ lxml ];
     png = [ cairosvg ];
   };
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pyquery
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.png;
+  ] ++ optional-dependencies.png;
 
   preCheck = ''
     # necessary on darwin to pass the testsuite

--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     typeguard
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ws = [ websockets ];
   };
 

--- a/pkgs/development/python-modules/pykoplenti/default.nix
+++ b/pkgs/development/python-modules/pykoplenti/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pydantic
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     CLI = [
       click
       prompt-toolkit

--- a/pkgs/development/python-modules/pylint-django/default.nix
+++ b/pkgs/development/python-modules/pylint-django/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pylint-plugin-utils ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     with_django = [ django ];
   };
 

--- a/pkgs/development/python-modules/pylutron-caseta/default.nix
+++ b/pkgs/development/python-modules/pylutron-caseta/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ cryptography ] ++ lib.optionals (pythonOlder "3.11") [ async-timeout ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [
       click
       xdg

--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     uncertainties
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ase = [ ase ];
     joblib = [ joblib ];
     seekpath = [ seekpath ];
@@ -78,7 +78,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-xdist
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = ''
     # ensure tests can find these

--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     repl = [
       aiohttp
       typer
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     redis
     sqlalchemy
     twisted
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = ''
     pushd test

--- a/pkgs/development/python-modules/pymysensors/default.nix
+++ b/pkgs/development/python-modules/pymysensors/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     voluptuous
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     mqtt-client = [ paho-mqtt ];
   };
 

--- a/pkgs/development/python-modules/pypsrp/default.nix
+++ b/pkgs/development/python-modules/pypsrp/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     xmldiff
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     credssp = [ requests-credssp ];
     kerberos = pyspnego.optional-dependencies.kerberos;
     named_pipe = [ psutil ];

--- a/pkgs/development/python-modules/pyreqwest-impersonate/default.nix
+++ b/pkgs/development/python-modules/pyreqwest-impersonate/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   env.BORING_BSSL_PATH = boringssl-wrapper;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     dev = [ pytest ];
   };
 

--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage rec {
     xmlschema
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     s2repoze = [
       paste
       repoze-who

--- a/pkgs/development/python-modules/pyscaffold/default.nix
+++ b/pkgs/development/python-modules/pyscaffold/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     tomlkit
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       pre-commit
       pyscaffoldext-cookiecutter

--- a/pkgs/development/python-modules/pyscaffoldext-cookiecutter/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-cookiecutter/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pyscaffold
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     testing = [
       configupdater
       pre-commit

--- a/pkgs/development/python-modules/pyscaffoldext-custom-extension/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-custom-extension/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     pyscaffold
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     testing = [
       configupdater
       pre-commit

--- a/pkgs/development/python-modules/pyscaffoldext-django/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-django/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pyscaffold
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     testing = [
       configupdater
       pre-commit

--- a/pkgs/development/python-modules/pyscaffoldext-dsproject/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-dsproject/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pyscaffoldext-markdown
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     testing = [
       configupdater
       pre-commit

--- a/pkgs/development/python-modules/pyscaffoldext-markdown/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-markdown/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     wheel
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     testing = [
       configupdater
       pre-commit

--- a/pkgs/development/python-modules/pyscaffoldext-travis/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-travis/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pyscaffold
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     testing = [
       configupdater
       pre-commit

--- a/pkgs/development/python-modules/pyspark/default.nix
+++ b/pkgs/development/python-modules/pyspark/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ py4j ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ml = [ numpy ];
     mllib = [ numpy ];
     sql = [

--- a/pkgs/development/python-modules/pyspnego/default.nix
+++ b/pkgs/development/python-modules/pyspnego/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ cryptography ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     kerberos = [
       gssapi
       krb5

--- a/pkgs/development/python-modules/pytablewriter/default.nix
+++ b/pkgs/development/python-modules/pytablewriter/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     typepy
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       dominate
       elasticsearch
@@ -84,7 +84,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "pathvalidate" ];
 

--- a/pkgs/development/python-modules/pytest-benchmark/default.nix
+++ b/pkgs/development/python-modules/pytest-benchmark/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ py-cpuinfo ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aspect = [ aspectlib ];
     histogram = [ pygal ];
     elasticsearch = [ elasticsearch ];
@@ -70,7 +70,7 @@ buildPythonPackage rec {
     mercurial
     pytestCheckHook
     pytest-xdist
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pytestFlagsArray = [
     "-W"

--- a/pkgs/development/python-modules/pytest-jupyter/default.nix
+++ b/pkgs/development/python-modules/pytest-jupyter/default.nix
@@ -40,7 +40,7 @@ let
 
     propagatedBuildInputs = [ jupyter-core ];
 
-    passthru.optional-dependencies = {
+    optional-dependencies = {
       client = [
         jupyter-client
         nbformat
@@ -59,7 +59,7 @@ let
     nativeCheckInputs = [
       pytest-timeout
       pytestCheckHook
-    ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+    ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
     passthru.tests = {
       check = self.overridePythonAttrs (_: {

--- a/pkgs/development/python-modules/pytest-regressions/default.nix
+++ b/pkgs/development/python-modules/pytest-regressions/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     "pytest_regressions.plugin"
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     dataframe = [
       pandas
       numpy

--- a/pkgs/development/python-modules/pytest/7.nix
+++ b/pkgs/development/python-modules/pytest/7.nix
@@ -60,7 +60,7 @@ let
         tomli
       ];
 
-    passthru.optional-dependencies = {
+    optional-dependencies = {
       testing = [
         argcomplete
         attrs

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
       tomli
     ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     testing = [
       argcomplete
       attrs

--- a/pkgs/development/python-modules/python-barcode/default.nix
+++ b/pkgs/development/python-modules/python-barcode/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ setuptools-scm ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     images = [ pillow ];
   };
 
@@ -33,7 +33,7 @@ buildPythonPackage rec {
       --replace "--no-cov-on-fail" ""
   '';
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.images;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.images;
 
   pythonImportsCheck = [ "barcode" ];
 

--- a/pkgs/development/python-modules/python-benedict/default.nix
+++ b/pkgs/development/python-modules/python-benedict/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       beautifulsoup4
       boto3
@@ -95,7 +95,7 @@ buildPythonPackage rec {
     orjson
     pytestCheckHook
     python-decouple
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTests = [
     # Tests require network access

--- a/pkgs/development/python-modules/python-box/default.nix
+++ b/pkgs/development/python-modules/python-box/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       msgpack
       ruamel-yaml
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     msgpack = [ msgpack ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.all;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.all;
 
   pythonImportsCheck = [ "box" ];
 

--- a/pkgs/development/python-modules/python-can/default.nix
+++ b/pkgs/development/python-modules/python-can/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     wrapt
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     serial = [ pyserial ];
     seeedstudio = [ pyserial ];
     pcan = [ uptime ];
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     parameterized
     pytest-timeout
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.serial;
+  ] ++ optional-dependencies.serial;
 
   disabledTestPaths = [
     # We don't support all interfaces

--- a/pkgs/development/python-modules/python-engineio/default.nix
+++ b/pkgs/development/python-modules/python-engineio/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   dependencies = [ simple-websocket ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     client = [
       requests
       websocket-client

--- a/pkgs/development/python-modules/python-jose/default.nix
+++ b/pkgs/development/python-modules/python-jose/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     rsa
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cryptography = [ cryptography ];
     pycrypto = [ pycrypto ];
     pycryptodome = [ pycryptodome ];
@@ -69,7 +69,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [
     # https://github.com/mpdavis/python-jose/issues/348

--- a/pkgs/development/python-modules/python-kasa/default.nix
+++ b/pkgs/development/python-modules/python-kasa/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     voluptuous
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     shell = [
       ptpython
       rich

--- a/pkgs/development/python-modules/python-libnmap/default.nix
+++ b/pkgs/development/python-modules/python-libnmap/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     hash = "sha256-cI8wdOvTmRy2cxLBkJn7vXRBRvewDMNl/tkIiRGhZJ8=";
   };
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     defusedxml = [ defusedxml ];
   };
 

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -72,25 +72,26 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "openstackclient" ];
 
+  optional-dependencies = {
+    # See https://github.com/openstack/python-openstackclient/blob/master/doc/source/contributor/plugins.rst
+    cli-plugins = [
+      osc-placement
+      python-aodhclient
+      python-barbicanclient
+      python-designateclient
+      python-heatclient
+      python-ironicclient
+      python-magnumclient
+      python-manilaclient
+      python-mistralclient
+      python-neutronclient
+      python-watcherclient
+      python-zaqarclient
+      python-zunclient
+    ];
+  };
+
   passthru = {
-    optional-dependencies = {
-      # See https://github.com/openstack/python-openstackclient/blob/master/doc/source/contributor/plugins.rst
-      cli-plugins = [
-        osc-placement
-        python-aodhclient
-        python-barbicanclient
-        python-designateclient
-        python-heatclient
-        python-ironicclient
-        python-magnumclient
-        python-manilaclient
-        python-mistralclient
-        python-neutronclient
-        python-watcherclient
-        python-zaqarclient
-        python-zunclient
-      ];
-    };
     tests.version = testers.testVersion {
       package = python-openstackclient;
       command = "openstack --version";

--- a/pkgs/development/python-modules/python-slugify/default.nix
+++ b/pkgs/development/python-modules/python-slugify/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ text-unidecode ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     unidecode = [ unidecode ];
   };
 

--- a/pkgs/development/python-modules/python-socketio/default.nix
+++ b/pkgs/development/python-modules/python-socketio/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     python-engineio
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     client = [
       requests
       websocket-client
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pytestCheckHook
     uvicorn
     simple-websocket
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "socketio" ];
 

--- a/pkgs/development/python-modules/python-stdnum/default.nix
+++ b/pkgs/development/python-modules/python-stdnum/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     SOAP = [ zeep ];
   };
 

--- a/pkgs/development/python-modules/python-u2flib-server/default.nix
+++ b/pkgs/development/python-modules/python-u2flib-server/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     six
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     u2f_server = [ webob ];
   };
 
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     "u2flib_server.u2f"
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.u2f_server;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.u2f_server;
 
   meta = with lib; {
     description = "Python based U2F server library";

--- a/pkgs/development/python-modules/pythonfinder/default.nix
+++ b/pkgs/development/python-modules/pythonfinder/default.nix
@@ -34,14 +34,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ packaging ] ++ lib.optionals (pythonOlder "3.8") [ cached-property ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [ click ];
   };
 
   nativeCheckInputs = [
     pytest-timeout
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "pythonfinder" ];
 

--- a/pkgs/development/python-modules/pytoolconfig/default.nix
+++ b/pkgs/development/python-modules/pytoolconfig/default.nix
@@ -46,11 +46,11 @@ buildPythonPackage rec {
     sphinx-autodoc-typehints
     sphinx-rtd-theme
     sphinxHook
-  ] ++ passthru.optional-dependencies.doc;
+  ] ++ optional-dependencies.doc;
 
   propagatedBuildInputs = [ packaging ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     validation = [ pydantic ];
     global = [ platformdirs ];
     doc = [
@@ -63,7 +63,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   meta = with lib; {
     description = "Python tool configuration";

--- a/pkgs/development/python-modules/pytradfri/default.nix
+++ b/pkgs/development/python-modules/pytradfri/default.nix
@@ -25,14 +25,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pydantic ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [
       aiocoap
       dtlssocket
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.async;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.async;
 
   pythonImportsCheck = [ "pytradfri" ];
 

--- a/pkgs/development/python-modules/pyutil/default.nix
+++ b/pkgs/development/python-modules/pyutil/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     versioneer
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     jsonutil = [ simplejson ];
     # Module not available
     # randcookie = [
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     mock
     twisted
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "pyutil" ];
 

--- a/pkgs/development/python-modules/pyvisa-py/default.nix
+++ b/pkgs/development/python-modules/pyvisa-py/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     gpib-ctypes = [ gpib-ctypes ];
     serial = [ pyserial ];
     usb = [ pyusb ];

--- a/pkgs/development/python-modules/pyvmomi/default.nix
+++ b/pkgs/development/python-modules/pyvmomi/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     six
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     sso = [
       lxml
       pyopenssl

--- a/pkgs/development/python-modules/pywavefront/default.nix
+++ b/pkgs/development/python-modules/pywavefront/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  passthru.optional-dependencies.visualization = [ pyglet ];
+  optional-dependencies.visualization = [ pyglet ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/qdrant-client/default.nix
+++ b/pkgs/development/python-modules/qdrant-client/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   # Tests require network access
   doCheck = false;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     fastembed = [ fastembed ];
   };
 

--- a/pkgs/development/python-modules/qpsolvers/default.nix
+++ b/pkgs/development/python-modules/qpsolvers/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     scipy
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     # FIXME commented out solvers have not been packaged yet
     clarabel = [ clarabel ];
     cvxopt = [ cvxopt ];
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     quadprog = [ quadprog ];
     scs = [ scs ];
     open_source_solvers =
-      with passthru.optional-dependencies;
+      with optional-dependencies;
       lib.flatten [
         clarabel
         cvxopt
@@ -68,7 +68,7 @@ buildPythonPackage rec {
       ];
   };
 
-  nativeCheckInputs = [ unittestCheckHook ] ++ passthru.optional-dependencies.open_source_solvers;
+  nativeCheckInputs = [ unittestCheckHook ] ++ optional-dependencies.open_source_solvers;
 
   meta = with lib; {
     changelog = "https://github.com/qpsolvers/qpsolvers/blob/${src.rev}/CHANGELOG.md";

--- a/pkgs/development/python-modules/qrcode/default.nix
+++ b/pkgs/development/python-modules/qrcode/default.nix
@@ -32,12 +32,12 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies.pil = [ pillow ];
+  optional-dependencies.pil = [ pillow ];
 
   nativeCheckInputs = [
     mock
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.pil;
+  ] ++ optional-dependencies.pil;
 
   passthru.tests = {
     version = testers.testVersion {

--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-rerunfailures
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   # QuTiP tries to access the home directory to create an rc file for us.
   # We need to go to another directory to run the tests from there.
@@ -68,7 +68,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "qutip" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     graphics = [ matplotlib ];
     ipython = [ ipython ];
     semidefinite = [

--- a/pkgs/development/python-modules/radon/default.nix
+++ b/pkgs/development/python-modules/radon/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     colorama
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     toml = [ tomli ];
   };
 

--- a/pkgs/development/python-modules/rapidfuzz/default.nix
+++ b/pkgs/development/python-modules/rapidfuzz/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
       export CMAKE_ARGS="-DCMAKE_CXX_COMPILER_AR=$AR -DCMAKE_CXX_COMPILER_RANLIB=$RANLIB"
     '';
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     full = [ numpy ];
   };
 

--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     snuggs
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ipython = [ ipython ];
     plot = [ matplotlib ];
     s3 = [ boto3 ];

--- a/pkgs/development/python-modules/raven/default.nix
+++ b/pkgs/development/python-modules/raven/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "raven" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     flask = [
       blinker
       flask

--- a/pkgs/development/python-modules/rdflib/default.nix
+++ b/pkgs/development/python-modules/rdflib/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     pyparsing
   ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     html = [ html5lib ];
     networkx = [ networkx ];
   };
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     # Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
     pytest7CheckHook
     setuptools
-  ] ++ passthru.optional-dependencies.networkx ++ passthru.optional-dependencies.html;
+  ] ++ optional-dependencies.networkx ++ optional-dependencies.html;
 
   pytestFlagsArray = [
     # requires network access

--- a/pkgs/development/python-modules/reconplogger/default.nix
+++ b/pkgs/development/python-modules/reconplogger/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       flask
       requests

--- a/pkgs/development/python-modules/redis/default.nix
+++ b/pkgs/development/python-modules/redis/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     typing-extensions
   ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     hiredis = [ hiredis ];
     ocsp = [
       cryptography

--- a/pkgs/development/python-modules/relatorio/default.nix
+++ b/pkgs/development/python-modules/relatorio/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     lxml
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     chart = [
       # pycha
       pyyaml
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     fodt = [ python-magic ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.fodt;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.fodt;
 
   pythonImportsCheck = [ "relatorio" ];
 

--- a/pkgs/development/python-modules/reportlab-qrcode/default.nix
+++ b/pkgs/development/python-modules/reportlab-qrcode/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     reportlab
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     testing = [
       pillow
       pytest

--- a/pkgs/development/python-modules/reptor/default.nix
+++ b/pkgs/development/python-modules/reptor/default.nix
@@ -69,14 +69,14 @@ buildPythonPackage rec {
     xmltodict
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ghostwriter = [ gql ] ++ gql.optional-dependencies.aiohttp;
     translate = [ deepl ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/requests-cache/default.nix
+++ b/pkgs/development/python-modules/requests-cache/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     url-normalize
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     dynamodb = [
       boto3
       botocore
@@ -79,7 +79,7 @@ buildPythonPackage rec {
     tenacity
     time-machine
     timeout-decorator
-  ] ++ passthru.optional-dependencies.json ++ passthru.optional-dependencies.security;
+  ] ++ optional-dependencies.json ++ optional-dependencies.security;
 
   preCheck = ''
     export HOME=$(mktemp -d);

--- a/pkgs/development/python-modules/requests-credssp/default.nix
+++ b/pkgs/development/python-modules/requests-credssp/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     kerberos = pyspnego.optional-dependencies.kerberos;
   };
 

--- a/pkgs/development/python-modules/rich/default.nix
+++ b/pkgs/development/python-modules/rich/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pygments
   ] ++ lib.optionals (pythonOlder "3.9") [ typing-extensions ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     jupyter = [ ipywidgets ];
   };
 

--- a/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     pytz
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     fast = [ ujson ];
   };
 

--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "s3transfer" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     crt = [ botocore.optional-dependencies.crt ];
   };
 

--- a/pkgs/development/python-modules/sagemaker/default.nix
+++ b/pkgs/development/python-modules/sagemaker/default.nix
@@ -97,7 +97,7 @@ buildPythonPackage rec {
     "sagemaker.lineage.visualizer"
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     local = [
       urllib3
       docker

--- a/pkgs/development/python-modules/samsungctl/default.nix
+++ b/pkgs/development/python-modules/samsungctl/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "0ipz3fd65rqkxlb02sql0awc3vnslrwb2pfrsnpfnf8bfgxpbh9g";
   };
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     websocket = [ websocket-client ];
     # interactive_ui requires curses package
   };

--- a/pkgs/development/python-modules/samsungtvws/default.nix
+++ b/pkgs/development/python-modules/samsungtvws/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     websocket-client
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [
       aiohttp
       websockets
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     aioresponses
     pytest-asyncio
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.async ++ passthru.optional-dependencies.encrypted;
+  ] ++ optional-dependencies.async ++ optional-dependencies.encrypted;
 
   pythonImportsCheck = [ "samsungtvws" ];
 

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     websockets
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ext = [
       # TODO: sanic-ext
     ];
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     pytestCheckHook
     sanic-testing
     uvicorn
-  ] ++ passthru.optional-dependencies.http3;
+  ] ++ optional-dependencies.http3;
 
   inherit doCheck;
 

--- a/pkgs/development/python-modules/schema-salad/default.nix
+++ b/pkgs/development/python-modules/schema-salad/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     hash = "sha256-fke75FCCn23LAMJ5bDWJpuBR6E9XIpjmzzXSbjqpxn8=";
   } ) ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.pycodegen;
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.pycodegen;
 
   preCheck = ''
     rm tox.ini
@@ -80,7 +80,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "schema_salad" ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     pycodegen = [ black ];
   };
 

--- a/pkgs/development/python-modules/scikit-image/default.nix
+++ b/pkgs/development/python-modules/scikit-image/default.nix
@@ -77,7 +77,7 @@ let
       tifffile
     ];
 
-    passthru.optional-dependencies = {
+    optional-dependencies = {
       data = [ pooch ];
       optional = [
         astropy

--- a/pkgs/development/python-modules/scim2-filter-parser/default.nix
+++ b/pkgs/development/python-modules/scim2-filter-parser/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ sly ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     django-query = [ django ];
   };
 
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     mock
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.django-query;
+  ] ++ optional-dependencies.django-query;
 
   meta = with lib; {
     description = "Customizable parser/transpiler for SCIM2.0 filters";

--- a/pkgs/development/python-modules/seaborn/default.nix
+++ b/pkgs/development/python-modules/seaborn/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     pandas
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     stats = [
       scipy
       statsmodels

--- a/pkgs/development/python-modules/seabreeze/default.nix
+++ b/pkgs/development/python-modules/seabreeze/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     libusb-compat-0_1
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     pyseabreeze = [ pyusb ];
   };
 
@@ -77,7 +77,7 @@ buildPythonPackage rec {
     pytestCheckHook
     mock
     zipp
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [ "TestHardware" ];
 

--- a/pkgs/development/python-modules/seasonal/default.nix
+++ b/pkgs/development/python-modules/seasonal/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     scipy
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     csv = [ pandas ];
     plot = [ matplotlib ];
   };
@@ -51,7 +51,7 @@ buildPythonPackage rec {
   ];
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   meta = with lib; {
     description = "Robustly estimate trend and periodicity in a timeseries";

--- a/pkgs/development/python-modules/securesystemslib/default.nix
+++ b/pkgs/development/python-modules/securesystemslib/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ hatchling ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     PySPX = [ pyspx ];
     awskms = [
       boto3
@@ -70,7 +70,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     ed25519
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "securesystemslib" ];
 

--- a/pkgs/development/python-modules/sentry-sdk/1.nix
+++ b/pkgs/development/python-modules/sentry-sdk/1.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     urllib3
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aiohttp = [ aiohttp ];
     beam = [ apache-beam ];
     bottle = [ bottle ];

--- a/pkgs/development/python-modules/sfrbox-api/default.nix
+++ b/pkgs/development/python-modules/sfrbox-api/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     httpx
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [ click ];
   };
 
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
     respx
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "sfrbox_api" ];
 

--- a/pkgs/development/python-modules/shap/default.nix
+++ b/pkgs/development/python-modules/shap/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     plots = [
       matplotlib
       ipython

--- a/pkgs/development/python-modules/simpful/default.nix
+++ b/pkgs/development/python-modules/simpful/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     plotting = [
       matplotlib
       seaborn
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "simpful" ];
 

--- a/pkgs/development/python-modules/skytemple-files/default.nix
+++ b/pkgs/development/python-modules/skytemple-files/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     range-typed-integers
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     spritecollab = [
       aiohttp
       gql
@@ -85,7 +85,7 @@ buildPythonPackage rec {
     pytestCheckHook
     parameterized
     xmldiff
-  ] ++ passthru.optional-dependencies.spritecollab;
+  ] ++ optional-dependencies.spritecollab;
   pytestFlagsArray = [ "test/" ];
   disabledTestPaths = [
     "test/skytemple_files_test/common/spritecollab/sc_online_test.py"

--- a/pkgs/development/python-modules/slack-bolt/default.nix
+++ b/pkgs/development/python-modules/slack-bolt/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
 
   dependencies = [ slack-sdk ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [
       aiohttp
       websockets
@@ -94,7 +94,7 @@ buildPythonPackage rec {
     docker
     pytest-asyncio
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = ''
     export HOME="$(mktemp -d)"

--- a/pkgs/development/python-modules/social-auth-core/default.nix
+++ b/pkgs/development/python-modules/social-auth-core/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     requests-oauthlib
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     openidconnect = [ python-jose ];
     saml = [
       lxml
@@ -56,7 +56,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     httpretty
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   # Disable checking the code coverage
   prePatch = ''

--- a/pkgs/development/python-modules/spatialmath-python/default.nix
+++ b/pkgs/development/python-modules/spatialmath-python/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     dev = [
       coverage
       flake8

--- a/pkgs/development/python-modules/sphinxext-opengraph/default.nix
+++ b/pkgs/development/python-modules/sphinxext-opengraph/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     social_cards_generation = [ matplotlib ];
   };
 
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     beautifulsoup4
-  ] ++ passthru.optional-dependencies.social_cards_generation;
+  ] ++ optional-dependencies.social_cards_generation;
 
   pythonImportsCheck = [ "sphinxext.opengraph" ];
 

--- a/pkgs/development/python-modules/splinter/default.nix
+++ b/pkgs/development/python-modules/splinter/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ urllib3 ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     "zope.testbrowser" = [
       zope-testbrowser
       lxml
@@ -54,7 +54,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [
     # driver is present and fails with a different error during loading

--- a/pkgs/development/python-modules/sqlalchemy-utils/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utils/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ sqlalchemy ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     babel = [ babel ];
     arrow = [ arrow ];
     pendulum = [ pendulum ];
@@ -78,7 +78,7 @@ buildPythonPackage rec {
       pymysql
       pyodbc
     ]
-    ++ lib.flatten (builtins.attrValues passthru.optional-dependencies)
+    ++ lib.flatten (builtins.attrValues optional-dependencies)
     ++ lib.optionals (pythonOlder "3.12") [
       # requires distutils, which were removed in 3.12
       psycopg2cffi

--- a/pkgs/development/python-modules/sqlalchemy/1_4.nix
+++ b/pkgs/development/python-modules/sqlalchemy/1_4.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ greenlet ];
 
-  passthru.optional-dependencies = lib.fix (self: {
+  optional-dependencies = lib.fix (self: {
     asyncio = [ greenlet ];
     mypy = [ mypy ];
     mssql = [ pyodbc ];

--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = lib.fix (self: {
+  optional-dependencies = lib.fix (self: {
     asyncio = [ greenlet ];
     mypy = [ mypy ];
     mssql = [ pyodbc ];

--- a/pkgs/development/python-modules/static3/default.nix
+++ b/pkgs/development/python-modules/static3/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
       --replace ", 'pytest-cov'" ""
   '';
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     KidMagic = [
       # TODO: kid
     ];
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     webtest
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   meta = with lib; {
     changelog = "https://github.com/rmohr/static3/releases/tag/v${version}";

--- a/pkgs/development/python-modules/stm32loader/default.nix
+++ b/pkgs/development/python-modules/stm32loader/default.nix
@@ -44,13 +44,13 @@ buildPythonPackage rec {
     pyserial
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     hex = [ intelhex ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pytestFlagsArray = [ "tests/unit" ];
 

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aiohttp = [
       aiohttp
       pytest-aiohttp
@@ -146,7 +146,7 @@ buildPythonPackage rec {
     pytest-snapshot
     pytestCheckHook
     sanic-testing
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "strawberry" ];
 

--- a/pkgs/development/python-modules/sunpy/default.nix
+++ b/pkgs/development/python-modules/sunpy/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     parfive
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     asdf = [
       asdf
       # asdf-astropy
@@ -91,11 +91,11 @@ buildPythonPackage rec {
       pytest-mock
       pytestCheckHook
     ]
-    ++ passthru.optional-dependencies.asdf
-    ++ passthru.optional-dependencies.database
-    ++ passthru.optional-dependencies.image
-    ++ passthru.optional-dependencies.net
-    ++ passthru.optional-dependencies.timeseries;
+    ++ optional-dependencies.asdf
+    ++ optional-dependencies.database
+    ++ optional-dependencies.image
+    ++ optional-dependencies.net
+    ++ optional-dependencies.timeseries;
 
   postPatch = ''
     substituteInPlace setup.cfg \

--- a/pkgs/development/python-modules/superqt/default.nix
+++ b/pkgs/development/python-modules/superqt/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     quantity = [ pint ];
     pyside2 = [ pyside2 ];
     pyside6 = [ pyside6 ];

--- a/pkgs/development/python-modules/tablib/default.nix
+++ b/pkgs/development/python-modules/tablib/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       markuppy
       odfpy

--- a/pkgs/development/python-modules/tabulate/default.nix
+++ b/pkgs/development/python-modules/tabulate/default.nix
@@ -26,13 +26,13 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     widechars = [ wcwidth ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   meta = {
     description = "Pretty-print tabular data";

--- a/pkgs/development/python-modules/telegraph/default.nix
+++ b/pkgs/development/python-modules/telegraph/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ requests ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     aio = [ httpx ];
   };
 

--- a/pkgs/development/python-modules/textual-universal-directorytree/default.nix
+++ b/pkgs/development/python-modules/textual-universal-directorytree/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     universal-pathlib
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     remote = [
       adlfs
       aiohttp

--- a/pkgs/development/python-modules/tree-sitter-html/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-html/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     core = [
       tree-sitter
     ];

--- a/pkgs/development/python-modules/tree-sitter-javascript/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-javascript/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     core = [
       tree-sitter
     ];

--- a/pkgs/development/python-modules/tree-sitter-json/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-json/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     core = [
       tree-sitter
     ];

--- a/pkgs/development/python-modules/tree-sitter-python/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-python/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     core = [
       tree-sitter
     ];

--- a/pkgs/development/python-modules/tree-sitter-rust/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-rust/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     core = [
       tree-sitter
     ];

--- a/pkgs/development/python-modules/trino-python-client/default.nix
+++ b/pkgs/development/python-modules/trino-python-client/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     tzlocal
   ];
 
-  passthru.optional-dependencies = lib.fix (self: {
+  optional-dependencies = lib.fix (self: {
     kerberos = [ requests-kerberos ];
     sqlalchemy = [ sqlalchemy ];
     external-authentication-token-cache = [ keyring ];
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     httpretty
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.all;
+  ] ++ optional-dependencies.all;
 
   pythonImportsCheck = [ "trino" ];
 

--- a/pkgs/development/python-modules/troposphere/default.nix
+++ b/pkgs/development/python-modules/troposphere/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     unittestCheckHook
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     policy = [ awacs ];
   };
 

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -171,13 +171,13 @@ buildPythonPackage rec {
       hypothesis
       pyhamcrest
     ]
-    ++ passthru.optional-dependencies.conch
-    ++ passthru.optional-dependencies.http2
-    ++ passthru.optional-dependencies.serial
+    ++ optional-dependencies.conch
+    ++ optional-dependencies.http2
+    ++ optional-dependencies.serial
     # not supported on aarch64-darwin: https://github.com/pyca/pyopenssl/issues/873
     ++ lib.optionals (
       !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
-    ) passthru.optional-dependencies.tls;
+    ) optional-dependencies.tls;
 
   checkPhase = ''
     export SOURCE_DATE_EPOCH=315532800
@@ -186,26 +186,26 @@ buildPythonPackage rec {
     ${python.interpreter} -m twisted.trial -j1 twisted
   '';
 
-  passthru = {
-    optional-dependencies = {
-      conch = [
-        appdirs
-        bcrypt
-        cryptography
-        pyasn1
-      ];
-      http2 = [
-        h2
-        priority
-      ];
-      serial = [ pyserial ];
-      tls = [
-        idna
-        pyopenssl
-        service-identity
-      ];
-    };
+  optional-dependencies = {
+    conch = [
+      appdirs
+      bcrypt
+      cryptography
+      pyasn1
+    ];
+    http2 = [
+      h2
+      priority
+    ];
+    serial = [ pyserial ];
+    tls = [
+      idna
+      pyopenssl
+      service-identity
+    ];
+  };
 
+  passthru = {
     tests = {
       inherit
         cassandra-driver

--- a/pkgs/development/python-modules/txtai/default.nix
+++ b/pkgs/development/python-modules/txtai/default.nix
@@ -174,7 +174,7 @@ buildPythonPackage {
     regex
   ];
 
-  passthru.optional-dependencies = optional-dependencies;
+  optional-dependencies = optional-dependencies;
 
   pythonImportsCheck = [ "txtai" ];
 

--- a/pkgs/development/python-modules/typed-settings/default.nix
+++ b/pkgs/development/python-modules/typed-settings/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   dependencies = lib.optionals (pythonOlder "3.11") [ tomli ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     all = [
       attrs
       cattrs
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     hypothesis
     pytestCheckHook
     typing-extensions
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pytestFlagsArray = [ "tests" ];
 

--- a/pkgs/development/python-modules/typepy/default.nix
+++ b/pkgs/development/python-modules/typepy/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ mbstrdecoder ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     datetime = [
       python-dateutil
       pytz
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     tcolorpy
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "typepy" ];
 

--- a/pkgs/development/python-modules/types-aiobotocore/default.nix
+++ b/pkgs/development/python-modules/types-aiobotocore/default.nix
@@ -380,7 +380,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     accessanalyzer = [ types-aiobotocore-accessanalyzer ];
     account = [ types-aiobotocore-account ];
     acm = [ types-aiobotocore-acm ];

--- a/pkgs/development/python-modules/ubelt/default.nix
+++ b/pkgs/development/python-modules/ubelt/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     wheel
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     optional = [
       numpy
       python-dateutil

--- a/pkgs/development/python-modules/ufmt/default.nix
+++ b/pkgs/development/python-modules/ufmt/default.nix
@@ -44,14 +44,14 @@ buildPythonPackage rec {
     usort
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     lsp = [ pygls ];
     ruff = [ ruff-api ];
   };
 
   nativeCheckInputs = [
     unittestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "ufmt" ];
 

--- a/pkgs/development/python-modules/ufolib2/default.nix
+++ b/pkgs/development/python-modules/ufolib2/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     fonttools
   ] ++ fonttools.optional-dependencies.ufo;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     lxml = [ lxml ];
     converters = [ cattrs ];
     json = [
@@ -47,7 +47,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "ufoLib2" ];
 

--- a/pkgs/development/python-modules/umap-learn/default.nix
+++ b/pkgs/development/python-modules/umap-learn/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  passthru.optional-dependencies = rec {
+  optional-dependencies = rec {
     plot = [
       bokeh
       colorcet

--- a/pkgs/development/python-modules/unrpa/default.nix
+++ b/pkgs/development/python-modules/unrpa/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "0yl4qdwp3in170ks98qnldqz3r2iyzil5g1775ccg98qkh95s724";
   };
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ZiX = [ uncompyle6 ];
   };
 

--- a/pkgs/development/python-modules/unstructured/default.nix
+++ b/pkgs/development/python-modules/unstructured/default.nix
@@ -143,7 +143,7 @@ buildPythonPackage {
     grpcio
   ];
 
-  passthru.optional-dependencies = optional-dependencies;
+  optional-dependencies = optional-dependencies;
 
   meta = with lib; {
     description = "Open source libraries and APIs to build custom preprocessing pipelines for labeling, training, or production machine learning pipelines";

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -34,7 +34,7 @@ let
 
     nativeBuildInputs = [ hatchling ];
 
-    passthru.optional-dependencies = {
+    optional-dependencies = {
       brotli = if isPyPy then [ brotlicffi ] else [ brotli ];
       socks = [ pysocks ];
     };
@@ -47,7 +47,7 @@ let
         trustme
       ]
       ++ lib.optionals (pythonOlder "3.9") [ backports-zoneinfo ]
-      ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+      ++ lib.flatten (builtins.attrValues optional-dependencies);
 
     # Tests in urllib3 are mostly timeout-based instead of event-based and
     # are therefore inherently flaky. On your own machine, the tests will

--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     wcwidth
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     glib = [ pygobject3 ];
     tornado = [ tornado ];
     trio = [
@@ -62,7 +62,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     glibcLocales
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   env.LC_ALL = "en_US.UTF8";
 

--- a/pkgs/development/python-modules/uvicorn/default.nix
+++ b/pkgs/development/python-modules/uvicorn/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     h11
   ] ++ lib.optionals (pythonOlder "3.11") [ typing-extensions ];
 
-  passthru.optional-dependencies.standard = [
+  optional-dependencies.standard = [
     httptools
     python-dotenv
     pyyaml

--- a/pkgs/development/python-modules/vega/default.nix
+++ b/pkgs/development/python-modules/vega/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pandas
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     widget = [ ipywidgets ];
     jupyterlab = [ jupyterlab ];
   };

--- a/pkgs/development/python-modules/versioneer/default.nix
+++ b/pkgs/development/python-modules/versioneer/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     toml = lib.optionals (pythonOlder "3.11") [ tomli ];
   };
 

--- a/pkgs/development/python-modules/visions/default.nix
+++ b/pkgs/development/python-modules/visions/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     pandas
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     type-geometry = [ shapely ];
     type-image-path = [ imagehash pillow ];
     plotting = [ matplotlib pydot pygraphviz ];
@@ -50,7 +50,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTestPaths = [
     # requires running Apache Spark:

--- a/pkgs/development/python-modules/vivisect/default.nix
+++ b/pkgs/development/python-modules/vivisect/default.nix
@@ -42,9 +42,9 @@ buildPythonPackage rec {
     cxxfilt
     msgpack
     pycparser
-  ] ++ lib.optionals (withGui) passthru.optional-dependencies.gui;
+  ] ++ lib.optionals (withGui) optional-dependencies.gui;
 
-  passthru.optional-dependencies.gui = [
+  optional-dependencies.gui = [
     pyqt5
     pyqtwebengine
   ];

--- a/pkgs/development/python-modules/volvooncall/default.nix
+++ b/pkgs/development/python-modules/volvooncall/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ aiohttp ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     console = [
       certifi
       docopt
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     mock
     pytest-asyncio
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.mqtt;
+  ] ++ optional-dependencies.mqtt;
 
   pythonImportsCheck = [ "volvooncall" ];
 

--- a/pkgs/development/python-modules/w1thermsensor/default.nix
+++ b/pkgs/development/python-modules/w1thermsensor/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ click ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async = [ aiofiles ];
   };
 
@@ -46,7 +46,7 @@ buildPythonPackage rec {
       pytestCheckHook
     ]
     ++ lib.optionals (pythonOlder "3.11") [ tomli ]
-    ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+    ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "w1thermsensor" ];
 

--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -32,14 +32,14 @@ buildPythonPackage rec {
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
 
-  passthru.optional-dependencies.watchmedo = [ pyyaml ];
+  optional-dependencies.watchmedo = [ pyyaml ];
 
   nativeCheckInputs = [
     eventlet
     flaky
     pytest-timeout
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.watchmedo;
+  ] ++ optional-dependencies.watchmedo;
 
   postPatch = ''
     substituteInPlace setup.cfg \

--- a/pkgs/development/python-modules/watermark/default.nix
+++ b/pkgs/development/python-modules/watermark/default.nix
@@ -31,13 +31,13 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     gpu = [ py3nvml ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "watermark" ];
 

--- a/pkgs/development/python-modules/web3/default.nix
+++ b/pkgs/development/python-modules/web3/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   };
 
   # Note: to reflect the extra_requires in main/setup.py.
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     ipfs = [ ipfshttpclient ];
   };
 

--- a/pkgs/development/python-modules/webdav4/default.nix
+++ b/pkgs/development/python-modules/webdav4/default.nix
@@ -47,9 +47,9 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-cov-stub
     wsgidav
-  ] ++ passthru.optional-dependencies.fsspec;
+  ] ++ optional-dependencies.fsspec;
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     fsspec = [ fsspec ];
     http2 = [ httpx.optional-dependencies.http2 ];
     all = [

--- a/pkgs/development/python-modules/weconnect/default.nix
+++ b/pkgs/development/python-modules/weconnect/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     Images = [
       ascii-magic
       pillow

--- a/pkgs/development/python-modules/werkzeug/default.nix
+++ b/pkgs/development/python-modules/werkzeug/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ markupsafe ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     watchdog = lib.optionals (!stdenv.hostPlatform.isDarwin) [
       # watchdog requires macos-sdk 10.13
       watchdog
@@ -59,7 +59,7 @@ buildPythonPackage rec {
       pytestCheckHook
     ]
     ++ lib.optionals (pythonOlder "3.11") [ greenlet ]
-    ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+    ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "werkzeug" ];
 

--- a/pkgs/development/python-modules/willow/default.nix
+++ b/pkgs/development/python-modules/willow/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     defusedxml
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     heif = [ pillow-heif ];
   };
 
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pillow
     wand
-  ] ++ passthru.optional-dependencies.heif;
+  ] ++ optional-dependencies.heif;
 
   meta = with lib; {
     description = "Python image library that sits on top of Pillow, Wand and OpenCV";

--- a/pkgs/development/python-modules/wktutils/default.nix
+++ b/pkgs/development/python-modules/wktutils/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     shapely
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     extras = [
       requests
       scikit-learn

--- a/pkgs/development/python-modules/wled/default.nix
+++ b/pkgs/development/python-modules/wled/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     yarl
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [
       typer
       zeroconf

--- a/pkgs/development/python-modules/wtforms/default.nix
+++ b/pkgs/development/python-modules/wtforms/default.nix
@@ -41,13 +41,13 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ markupsafe ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     email = [ email-validator ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
-  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "wtforms" ];
 

--- a/pkgs/development/python-modules/wyoming/default.nix
+++ b/pkgs/development/python-modules/wyoming/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     zeroconf = [ zeroconf ];
   };
 

--- a/pkgs/development/python-modules/xsdata/default.nix
+++ b/pkgs/development/python-modules/xsdata/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
 
   dependencies = [ typing-extensions ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     cli = [
       click
       click-default-group
@@ -59,11 +59,9 @@ buildPythonPackage rec {
     soap = [ requests ];
   };
 
-  nativeCheckInputs =
-    [ pytestCheckHook ]
-    ++ passthru.optional-dependencies.cli
-    ++ passthru.optional-dependencies.lxml
-    ++ passthru.optional-dependencies.soap;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ] ++ optional-dependencies.cli ++ optional-dependencies.lxml ++ optional-dependencies.soap;
 
   disabledTestPaths = [ "tests/integration/benchmarks" ];
 

--- a/pkgs/development/python-modules/yfinance/default.nix
+++ b/pkgs/development/python-modules/yfinance/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     nospam = [
       requests-cache
       requests-ratelimiter

--- a/pkgs/development/python-modules/zeep/default.nix
+++ b/pkgs/development/python-modules/zeep/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     requests-toolbelt
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     async_require = [ httpx ];
     xmlsec_require = [ xmlsec ];
   };
@@ -68,7 +68,7 @@ buildPythonPackage rec {
     pytest-httpx
     pytestCheckHook
     requests-mock
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTests = [
     # Failed: External connections not allowed during tests.

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -96,7 +96,7 @@ python3.pkgs.buildPythonApplication rec {
   ]
   ++ twisted.optional-dependencies.tls;
 
-  passthru.optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3.pkgs; {
     postgres = if isPyPy then [
       psycopg2cffi
     ] else [
@@ -138,7 +138,7 @@ python3.pkgs.buildPythonApplication rec {
     mock
     parameterized
   ])
-  ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+  ++ lib.flatten (lib.attrValues optional-dependencies);
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 

--- a/pkgs/servers/mautrix-googlechat/default.nix
+++ b/pkgs/servers/mautrix-googlechat/default.nix
@@ -32,7 +32,7 @@
     install -D mautrix_googlechat/example-config.yaml $out/$baseConfigPath
   '';
 
-  passthru.optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3.pkgs; {
     e2be = [
       python-olm
       pycryptodome
@@ -56,9 +56,9 @@
     python-magic
     protobuf
     (mautrix.override { withOlm = enableE2be; })
-  ] ++ lib.optionals enableE2be passthru.optional-dependencies.e2be
-  ++ lib.optionals enableMetrics passthru.optional-dependencies.metrics
-  ++ lib.optionals enableSqlite passthru.optional-dependencies.sqlite;
+  ] ++ lib.optionals enableE2be optional-dependencies.e2be
+  ++ lib.optionals enableMetrics optional-dependencies.metrics
+  ++ lib.optionals enableSqlite optional-dependencies.sqlite;
 
   doCheck = false;
 

--- a/pkgs/tools/audio/shaq/default.nix
+++ b/pkgs/tools/audio/shaq/default.nix
@@ -27,7 +27,7 @@ python3.pkgs.buildPythonApplication rec {
     shazamio
   ];
 
-  passthru.optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3.pkgs; {
     dev = [
       build
       shaq

--- a/pkgs/tools/backup/borgmatic/default.nix
+++ b/pkgs/tools/backup/borgmatic/default.nix
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-WYs7wiwZ1TvTdeUpWv7FbREXWfdGcYRarP4FXFOfp0Y=";
   };
 
-  nativeCheckInputs = with python3Packages; [ flexmock pytestCheckHook pytest-cov ] ++ passthru.optional-dependencies.apprise;
+  nativeCheckInputs = with python3Packages; [ flexmock pytestCheckHook pytest-cov ] ++ optional-dependencies.apprise;
 
   # - test_borgmatic_version_matches_news_version
   # The file NEWS not available on the pypi source, and this test is useless
@@ -41,7 +41,7 @@ python3Packages.buildPythonApplication rec {
     setuptools
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     apprise = [ python3Packages.apprise ];
   };
 

--- a/pkgs/tools/security/amoco/default.nix
+++ b/pkgs/tools/security/amoco/default.nix
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication rec {
     traitlets
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     app = with python3.pkgs; [
       # ccrawl
       ipython

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22599,7 +22599,7 @@ with pkgs;
 
   openstackclient = with python311Packages; toPythonApplication python-openstackclient;
   openstackclient-full = openstackclient.overridePythonAttrs (oldAttrs: {
-    dependencies = oldAttrs.dependencies ++ oldAttrs.passthru.optional-dependencies.cli-plugins;
+    dependencies = oldAttrs.dependencies ++ oldAttrs.optional-dependencies.cli-plugins;
   });
   barbicanclient = with python311Packages; toPythonApplication python-barbicanclient;
   glanceclient = with python311Packages; toPythonApplication python-glanceclient;


### PR DESCRIPTION
## Description of changes
I just ran `sed -i s/passthru\\.optional-dependencies/optional-dependencies/g **/*.nix` and manually fixed eval errors.
This leaves a lot of things like
```nix
passthru = {
  optional-dependencies = {
    ...
  };
};
```
untouched.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
