### PR TITLE
gnuradioPackages.bladeRF: init at 0-unstable-2023-11-20

### DIFF
--- a/pkgs/development/gnuradio-modules/bladeRF/default.nix
+++ b/pkgs/development/gnuradio-modules/bladeRF/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  mkDerivation,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  boost,
+  doxygen,
+  gmp,
+  gnuradio,
+  libbladeRF,
+  mpir,
+  osmosdr,
+  python,
+  spdlog,
+}:
+
+mkDerivation {
+  pname = "gr-bladeRF";
+  version = "0-unstable-2023-11-20";
+
+  src = fetchFromGitHub {
+    owner = "Nuand";
+    repo = "gr-bladeRF";
+    rev = "27de2898dbee75d55c61f541315e3853e602e526";
+    hash = "sha256-josovHEp2VxgZqItkTAISdY1LARMIvQKD604fh4iZWc=";
+  };
+
+  buildInputs =
+    [
+      boost
+      doxygen
+      gmp
+      gnuradio
+      libbladeRF
+      mpir
+      osmosdr
+      spdlog
+    ]
+    ++ lib.optionals (gnuradio.hasFeature "python-support") [
+      python.pkgs.numpy
+      python.pkgs.pybind11
+    ];
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_PYTHON" (gnuradio.hasFeature "python-support"))
+  ];
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+    ]
+    ++ lib.optionals (gnuradio.hasFeature "python-support") [
+      python.pkgs.mako
+      python.pkgs.pygccxml
+    ];
+
+  meta = {
+    description = "GNU Radio source and sink blocks for bladeRF devices";
+    homepage = "https://github.com/Nuand/gr-bladeRF";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ wucke13 ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/gnuradio-packages.nix
+++ b/pkgs/top-level/gnuradio-packages.nix
@@ -35,6 +35,8 @@ in {
 
   ### Packages
 
+  bladeRF = callPackage ../development/gnuradio-modules/bladeRF/default.nix { };
+
   osmosdr = callPackage ../development/gnuradio-modules/osmosdr/default.nix { };
 
   fosphor = callPackage ../development/gnuradio-modules/fosphor/default.nix { };


### PR DESCRIPTION
## Description of changes

This is the gnuradio blocksets for the bladeRF family of software defined radios.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
