### PR TITLE
postgresql: 16.4 -> 17.0

### DIFF
--- a/pkgs/by-name/ko/kore/package.nix
+++ b/pkgs/by-name/ko/kore/package.nix
@@ -1,8 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, openssl, curl, postgresql, yajl }:
+{ lib, stdenv, fetchFromGitHub, openssl, curl, postgresql_16, yajl }:
 
 
 stdenv.mkDerivation rec {
   pname = "kore";
+  # TODO: Check on next update whether postgresql 17 is supported.
   version = "4.2.3";
 
   src = fetchFromGitHub {
@@ -12,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-p0M2P02xwww5EnT28VnEtj5b+/jkPW3YkJMuK79vp4k=";
   };
 
-  buildInputs = [ openssl curl postgresql yajl ];
+  buildInputs = [ openssl curl postgresql_16 yajl ];
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"

--- a/pkgs/by-name/pg/pg-dump-anon/package.nix
+++ b/pkgs/by-name/pg/pg-dump-anon/package.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitLab, buildGoModule, nixosTests, postgresql_17, makeWrapper }:
+{ lib, fetchFromGitLab, buildGoModule, nixosTests, postgresql, makeWrapper }:
 
 buildGoModule rec {
   pname = "pg-dump-anon";
@@ -19,7 +19,7 @@ buildGoModule rec {
   nativeBuildInputs = [ makeWrapper ];
   postInstall = ''
     wrapProgram $out/bin/pg_dump_anon \
-      --prefix PATH : ${lib.makeBinPath [ postgresql_17 ]}
+      --prefix PATH : ${lib.makeBinPath [ postgresql ]}
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/asyncpg/default.nix
+++ b/pkgs/development/python-modules/asyncpg/default.nix
@@ -8,18 +8,19 @@
   pythonOlder,
   pytest-xdist,
   pytestCheckHook,
+  distro,
 }:
 
 buildPythonPackage rec {
   pname = "asyncpg";
-  version = "0.29.0";
+  version = "0.30.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-0cSeH0T/+v2aVeGpsQFZCFnYgdY56ikiUW9dnFEtNU4=";
+    hash = "sha256-xVHpkoq2cHYC9EgRgX+CujxEbgGL/h06vsyLpfPqyFE=";
   };
 
   # sandboxing issues on aarch64-darwin, see https://github.com/NixOS/nixpkgs/issues/198495
@@ -34,6 +35,7 @@ buildPythonPackage rec {
     postgresql
     pytest-xdist
     pytestCheckHook
+    distro
   ];
 
   preCheck = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12165,8 +12165,8 @@ with pkgs;
     postgresql_16_jit
     postgresql_17_jit
   ;
-  postgresql = postgresql_16;
-  postgresql_jit = postgresql_16_jit;
+  postgresql = postgresql_17;
+  postgresql_jit = postgresql_17_jit;
   postgresqlPackages = recurseIntoAttrs postgresql.pkgs;
   postgresqlJitPackages = recurseIntoAttrs postgresql_jit.pkgs;
   postgresql12Packages = recurseIntoAttrs postgresql_12.pkgs;


### PR DESCRIPTION
## Description of changes

[PostgreSQL 17 has been released](https://www.postgresql.org/docs/release/17.0/).

This PR adds the new major version and then updates the `postgresql` package to it. The module's default version is unchanged as discussed in https://github.com/NixOS/nixpkgs/pull/329611#discussion_r1697467876.

What I did so far:
- Built postgresql 17 with and without JIT on x86_64-linux, aarch64-darwin and with pkgsMusl.
- Built related nixos tests on linux.
- Updated some extensions breaking with the new version, where an update was available. There are more which currently still break, but no new version / fix is available, yet.
- Started a nixpkgs-review run and found one related build failure, so far: Kept `python3Packages.asyncpg` at v16. (still running)

I did all this by cherry-picking the commits here on master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
