### PR TITLE
signal-desktop: add apple emojis

### DIFF
--- a/pkgs/by-name/si/signal-desktop-apple-emoji/package.nix
+++ b/pkgs/by-name/si/signal-desktop-apple-emoji/package.nix
@@ -1,0 +1,1 @@
+{ signal-desktop-bin }: signal-desktop-bin.override { withUnfree = true; }

--- a/pkgs/by-name/si/signal-desktop-bin/generic.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/generic.nix
@@ -61,6 +61,7 @@
   version,
   hash,
   url,
+  withUnfree ? false,
 }:
 
 let
@@ -131,6 +132,7 @@ stdenv.mkDerivation rec {
     # main derivation.
     postFetch = ''
       ${extractPkg}
+    '' + lib.optionalString (!withUnfree) ''
       asar extract "$out/${libdir}/resources/app.asar" $out/asar-contents
       rm -r \
         "$out/${libdir}/resources/app.asar"{,.unpacked} \
@@ -224,6 +226,7 @@ stdenv.mkDerivation rec {
     cwebp -progress -mt -preset icon -alpha_filter best -alpha_q 20 -pass 10 -q 75 ${noto-emoji-sheet-32} -o asar-contents/images/emoji-sheet-32.webp
     cwebp -progress -mt -preset icon -alpha_filter best -alpha_q 20 -pass 10 -q 75 ${noto-emoji-sheet-64} -o asar-contents/images/emoji-sheet-64.webp
 
+  '' + lib.optionalString (!withUnfree) ''
     # Copy the Noto Color Emoji PNGs into the ASAR contents. See `src`
     # for the motivation, and the script for the technical details.
     emojiPrefix=$(
@@ -247,6 +250,7 @@ stdenv.mkDerivation rec {
       --unpack '*.node' \
       asar-contents \
       "$out/lib/signal-desktop/resources/app.asar"
+  '' + ''
 
     runHook postInstall
   '';
@@ -291,7 +295,7 @@ stdenv.mkDerivation rec {
 
       lib.licenses.asl20 # noto-emoji
       lib.licenses.mit # emoji-data
-    ];
+    ] ++ lib.optional withUnfree lib.licenses.unfree;
     maintainers = with lib.maintainers; [
       mic92
       equirosa

--- a/pkgs/by-name/si/signal-desktop-bin/package.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/package.nix
@@ -1,7 +1,16 @@
-{ stdenv, callPackage }:
+{
+  stdenv,
+  callPackage,
+  withUnfree ? false,
+}:
 if stdenv.hostPlatform.system == "aarch64-linux" then
-  callPackage ./signal-desktop-aarch64.nix { }
+  if !withUnfree then
+    callPackage ./signal-desktop-aarch64.nix { }
+  else
+    callPackage ./signal-desktop-aarch64-apple-emoji.nix { }
 else if stdenv.hostPlatform.isDarwin then
   callPackage ./signal-desktop-darwin.nix { }
-else
+else if !withUnfree then
   callPackage ./signal-desktop.nix { }
+else
+  callPackage ./signal-desktop-apple-emoji.nix { }

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64-apple-emoji.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64-apple-emoji.nix
@@ -1,0 +1,16 @@
+{ callPackage }:
+callPackage ./generic.nix { } {
+  pname = "signal-desktop";
+  version = "7.47.0-1";
+
+  libdir = "usr/lib64/signal-desktop";
+  bindir = "usr/bin";
+  extractPkg = ''
+    mkdir -p $out
+    bsdtar -xf $downloadedFile -C "$out"
+  '';
+
+  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/08795262-signal-desktop/signal-desktop-7.47.0-1.fc42.aarch64.rpm";
+  hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  withUnfree = true;
+}

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop-apple-emoji.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop-apple-emoji.nix
@@ -1,0 +1,13 @@
+{ callPackage }:
+callPackage ./generic.nix { } rec {
+  pname = "signal-desktop";
+  version = "7.47.0";
+
+  libdir = "opt/Signal";
+  bindir = libdir;
+  extractPkg = "dpkg-deb -x $downloadedFile $out";
+
+  url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
+  hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  withUnfree = true;
+}

--- a/pkgs/by-name/si/signal-desktop-bin/update.sh
+++ b/pkgs/by-name/si/signal-desktop-bin/update.sh
@@ -21,11 +21,20 @@ update-source-version signal-desktop-bin "$latestVersion" \
   --system=x86_64-linux \
   --file="$SCRIPT_DIR/signal-desktop.nix"
 
+update-source-version signal-desktop-apple-emoji "$latestVersion" \
+  --system=x86_64-linux \
+  --file="$SCRIPT_DIR/signal-desktop-apple-emoji.nix"
+
 echo "Updating signal-desktop for aarch64-linux"
 update-source-version signal-desktop-bin "$latestVersionAarch64" "" \
   "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/$(printf "%08d" $latestBuildAarch64)-signal-desktop/signal-desktop-$latestVersionAarch64.fc42.aarch64.rpm" \
   --system=aarch64-linux \
   --file="$SCRIPT_DIR/signal-desktop-aarch64.nix"
+
+update-source-version signal-desktop "$latestVersionAarch64" "" \
+  "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/$(printf "%08d" $latestBuildAarch64)-signal-desktop/signal-desktop-$latestVersionAarch64.fc42.aarch64.rpm" \
+  --system=aarch64-linux \
+  --file="$SCRIPT_DIR/signal-desktop-aarch64-apple-emoji.nix"
 
 echo "Updating signal-desktop for darwin"
 update-source-version signal-desktop-bin "$latestVersion" \


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Implement the flag proposed in https://github.com/NixOS/nixpkgs/pull/337161#issuecomment-2380874677, reverting the recent apple emoji changes.

I tried to avoid the combinatorial explosion of packages, but I couldn't get an overridable `apple-emoji` flag on `signal-desktop` to play well with `nix-update`, so I just followed the same recipe as the x86, aarch, beta variants. 

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>signal-desktop-apple-emoji</li>
    <li>signal-desktop-beta-apple-emoji</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
