### PR TITLE
google-cloud-sdk: 492.0.0 -> 494.0.0

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/components.json
+++ b/pkgs/tools/admin/google-cloud-sdk/components.json
@@ -5,7 +5,7 @@
         "checksum": "5a65179c291bc480696ca323d2f8c4874985458303eff8f233e16cdca4e88e6f",
         "contents_checksum": "038c999c7a7d70d5133eab7dc5868c4c3d0358431dad250f9833306af63016c8",
         "size": 800,
-        "source": "components/google-cloud-sdk-alpha-20240906153039.tar.gz",
+        "source": "components/google-cloud-sdk-alpha-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -23,8 +23,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240906153039,
-        "version_string": "2024.09.06"
+        "build_number": 20240920144119,
+        "version_string": "2024.09.20"
       }
     },
     {
@@ -266,15 +266,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "0.2.52"
+        "version_string": "0.2.53"
       }
     },
     {
       "data": {
-        "checksum": "b1dff49fd8a5270c26f1e86f53d802dd0f2a9523b22dd7a51d23739cc1702820",
-        "contents_checksum": "f8a87d4f50dd802ec2d3894b09db6ea3278bc609f3f6a280ca27d65a311b6ce3",
-        "size": 70632402,
-        "source": "components/google-cloud-sdk-anthoscli-darwin-arm-20240712142834.tar.gz",
+        "checksum": "02ba5e29a9e189fca93b60abd88a313aafb7fc7cbaa569edf39f45060df104d5",
+        "contents_checksum": "08db596fe3b62c4b42bc84c1fe5f5ef6b7a0cf6dabc8d81630a127ecad620bfd",
+        "size": 70611092,
+        "source": "components/google-cloud-sdk-anthoscli-darwin-arm-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -299,16 +299,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240712142834,
-        "version_string": "0.2.52"
+        "build_number": 20240920144119,
+        "version_string": "0.2.53"
       }
     },
     {
       "data": {
-        "checksum": "ebf7083c6bbb2d84bc09c6b715d21bb06420b216ff52e91062266e9dcede1f0c",
-        "contents_checksum": "1335273de68c0184e0a2215e8dff6f2a601dc745baee6b00df8b296ead9bbb45",
-        "size": 74268845,
-        "source": "components/google-cloud-sdk-anthoscli-darwin-x86-20240712142834.tar.gz",
+        "checksum": "7d08629fc687492f832a0266c5e11b28ee51e2f6a69a58b7a94880fea48d7a54",
+        "contents_checksum": "be3d18f74bbc516c3f74add8fb3d319fe04568c07252b44717e5d78599a2e9ff",
+        "size": 74259971,
+        "source": "components/google-cloud-sdk-anthoscli-darwin-x86-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -333,16 +333,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240712142834,
-        "version_string": "0.2.52"
+        "build_number": 20240920144119,
+        "version_string": "0.2.53"
       }
     },
     {
       "data": {
-        "checksum": "95cd26d9e914a9005476c95f79da7eda04bf9c7756a2e68f1e78a66c16546e3b",
-        "contents_checksum": "1335273de68c0184e0a2215e8dff6f2a601dc745baee6b00df8b296ead9bbb45",
-        "size": 74268848,
-        "source": "components/google-cloud-sdk-anthoscli-darwin-x86_64-20240712142834.tar.gz",
+        "checksum": "bc4cb34c070cc2e9cea01a859aca3b2468ff78c697f6a6cd425c1b3ab4fe793e",
+        "contents_checksum": "be3d18f74bbc516c3f74add8fb3d319fe04568c07252b44717e5d78599a2e9ff",
+        "size": 74259974,
+        "source": "components/google-cloud-sdk-anthoscli-darwin-x86_64-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -367,16 +367,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240712142834,
-        "version_string": "0.2.52"
+        "build_number": 20240920144119,
+        "version_string": "0.2.53"
       }
     },
     {
       "data": {
-        "checksum": "298acae5cd9f3f5f95ef15b43b92b604cb17efdf0f712f39aad805f28a17c36f",
-        "contents_checksum": "22fb27fa7110f719b143ef1e19fac7638567a6d7d48a909be7dd1a08badaa12f",
-        "size": 67808715,
-        "source": "components/google-cloud-sdk-anthoscli-linux-arm-20240712142834.tar.gz",
+        "checksum": "ca197aefd6e3b8f943ffce8a36b8bcf4e9f1d77569f2f5893f09242ddbefa2cc",
+        "contents_checksum": "7bb06f592f4b2adc5de37c4c7fa665a8056d22e141a1e9337ec0e6a14afd1a26",
+        "size": 67805442,
+        "source": "components/google-cloud-sdk-anthoscli-linux-arm-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -401,16 +401,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240712142834,
-        "version_string": "0.2.52"
+        "build_number": 20240920144119,
+        "version_string": "0.2.53"
       }
     },
     {
       "data": {
-        "checksum": "1bb549e7745fbb6c422a66a69de83a4100548ef289415fbb80bf3424a27f0a5c",
-        "contents_checksum": "a5cf333202e0e3dacd64388c7604752c539f484159e83fff46026990b4b466b5",
-        "size": 65492449,
-        "source": "components/google-cloud-sdk-anthoscli-linux-x86-20240712142834.tar.gz",
+        "checksum": "219bbf4fc039fc02db00cdc71d3ff84bcd8558d7ec131911a166938b6db8b90c",
+        "contents_checksum": "de4c26da762b91f1e970e6afb26bd97f77c616f69ac92992279df1b2c3e5ae93",
+        "size": 65477613,
+        "source": "components/google-cloud-sdk-anthoscli-linux-x86-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -435,16 +435,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240712142834,
-        "version_string": "0.2.52"
+        "build_number": 20240920144119,
+        "version_string": "0.2.53"
       }
     },
     {
       "data": {
-        "checksum": "69a107eef662d4ef0930a51bca72b585e4314f7f962cb54987cc072d87ff6891",
-        "contents_checksum": "878c7420eb7909d6c7073182f6ec1b96ea2adc6995d4a90e2e47634dd4c629d9",
-        "size": 72509283,
-        "source": "components/google-cloud-sdk-anthoscli-linux-x86_64-20240712142834.tar.gz",
+        "checksum": "000bc1ace0a08fc738db3af6b8fc6b21b18ce7a08a70c6965885f8836f90b970",
+        "contents_checksum": "440b7e164aad403e6685b3e9dd2a1ea5419b012bc207a7f5383c7653d218656a",
+        "size": 72514534,
+        "source": "components/google-cloud-sdk-anthoscli-linux-x86_64-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -469,16 +469,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240712142834,
-        "version_string": "0.2.52"
+        "build_number": 20240920144119,
+        "version_string": "0.2.53"
       }
     },
     {
       "data": {
-        "checksum": "7e7147b4ec408e9cd8142bd0d6eac6b89b2bc545aa8421f67eaed7e8b8a1e9f2",
-        "contents_checksum": "c8a284c543bc838e22ac0b9762c6e1a559db867025305f38974f818ef0c44c2f",
-        "size": 67415658,
-        "source": "components/google-cloud-sdk-anthoscli-windows-x86-20240712142834.tar.gz",
+        "checksum": "1b474596746104c3ce64677c4009bd6d67f50ee02c5622653fe399360bfd7016",
+        "contents_checksum": "c01fd4068732ef6856262c08039b2e95c2ff0280e5b9110f0ea1b6a868071298",
+        "size": 67406191,
+        "source": "components/google-cloud-sdk-anthoscli-windows-x86-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -503,16 +503,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240712142834,
-        "version_string": "0.2.52"
+        "build_number": 20240920144119,
+        "version_string": "0.2.53"
       }
     },
     {
       "data": {
-        "checksum": "f42e9bb1e16ea90787d639b08cd05a7e750b19cf9849d99aefe09d0808d2445c",
-        "contents_checksum": "031e4309260adf22c8cff1ad368c280186117c0906539b8180b642f9ffc0fa18",
-        "size": 73148423,
-        "source": "components/google-cloud-sdk-anthoscli-windows-x86_64-20240712142834.tar.gz",
+        "checksum": "77c7fbc4f81d1ddc09222243de8b017c69a05d2c6a1079d294d6b00709072329",
+        "contents_checksum": "86c3cea0534e1a2e7747ee09cc7ef9641b1897add71ae9537ce447e05e166f05",
+        "size": 73144414,
+        "source": "components/google-cloud-sdk-anthoscli-windows-x86_64-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -537,8 +537,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240712142834,
-        "version_string": "0.2.52"
+        "build_number": 20240920144119,
+        "version_string": "0.2.53"
       }
     },
     {
@@ -1050,10 +1050,10 @@
     },
     {
       "data": {
-        "checksum": "55d136d6b2f08b31a70183e5b80cd5b408d200aee316e87402b50eae2251c15d",
-        "contents_checksum": "ee286f0c07a3b33f0193a5ba439375f221c5d42190df5f5e17333d6b60ae3f1b",
-        "size": 134048645,
-        "source": "components/google-cloud-sdk-app-engine-java-20240712142834.tar.gz",
+        "checksum": "956e282b412d0f80a2f11484196f6279f6e1450f423c510c2ea0f814b625cec4",
+        "contents_checksum": "99df1fb3e1e7dffd61f23d19906c176df4fc64204cefa186168a82707ba3f774",
+        "size": 134269609,
+        "source": "components/google-cloud-sdk-app-engine-java-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1072,8 +1072,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240712142834,
-        "version_string": "2.0.29"
+        "build_number": 20240920144119,
+        "version_string": "2.0.30"
       }
     },
     {
@@ -1377,7 +1377,7 @@
         "checksum": "707d412854a14450b4fddee199d258e75946fe51b44eb2980c8cd7e274c15760",
         "contents_checksum": "0b4e9d8e6394dc841aece07ca4da91920a460cbd7ec22495be4a2b4f46635b4d",
         "size": 797,
-        "source": "components/google-cloud-sdk-beta-20240906153039.tar.gz",
+        "source": "components/google-cloud-sdk-beta-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1395,8 +1395,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240906153039,
-        "version_string": "2024.09.06"
+        "build_number": 20240920144119,
+        "version_string": "2024.09.20"
       }
     },
     {
@@ -1440,10 +1440,10 @@
     },
     {
       "data": {
-        "checksum": "61389b1bb5534dc7386d30df5ab3a1050cbe3a8c9deda0edb40a1d5985439049",
-        "contents_checksum": "3a7f40f835b1b713a96f5b6c404eae20c7c90d794aae8a92713fd5b59a3c778e",
-        "size": 7344145,
-        "source": "components/google-cloud-sdk-bigtable-darwin-arm-20240329151455.tar.gz",
+        "checksum": "398f3ca68cd59d46e5166dfd8f9f4224d73a1d4588024d06a2fc5e509eede161",
+        "contents_checksum": "749271d55d4110d9ce71cf9bb04bcc247b60086f9d2e3abf9ff9cb2b12788e82",
+        "size": 7696648,
+        "source": "components/google-cloud-sdk-bigtable-darwin-arm-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1469,7 +1469,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240329151455,
+        "build_number": 20240920144119,
         "version_string": ""
       }
     },
@@ -1510,10 +1510,10 @@
     },
     {
       "data": {
-        "checksum": "1d719de1aa61fb4837d221502e4113b2f786671e1139852275d69dc77d02e494",
-        "contents_checksum": "747c8a308249abd684ad2bc8bb9c3b34ed5092da0825b2887188c7f65385c81a",
-        "size": 7656241,
-        "source": "components/google-cloud-sdk-bigtable-darwin-x86_64-20240329151455.tar.gz",
+        "checksum": "e2dc76d943395989b50785ecee54aa261ddba5ba8d17a24c504385978271f333",
+        "contents_checksum": "d2e568fbf5c4af408f146fab0ffe80cc40dd634d358a47e4bf2c720942abf4c9",
+        "size": 8019559,
+        "source": "components/google-cloud-sdk-bigtable-darwin-x86_64-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1539,16 +1539,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240329151455,
+        "build_number": 20240920144119,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "573c369501c73a684744007a9fc23ca29d8a81fa6c1dd18bed18c659ed406711",
-        "contents_checksum": "5abcfae3e7a061c532d3b4acbb6659d98cc4a7077e21ae4859e4d83d9c07e84f",
-        "size": 7210539,
-        "source": "components/google-cloud-sdk-bigtable-linux-arm-20240329151455.tar.gz",
+        "checksum": "54830749a50061c2d123d35bb0f075a6208ac71e03bd0d6dd05b10e16526d250",
+        "contents_checksum": "bb3932e57f44ff1a98b8a7176a5b368b2f55cd4a7c679eb32353b85685cdaac0",
+        "size": 7583487,
+        "source": "components/google-cloud-sdk-bigtable-linux-arm-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1574,16 +1574,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240329151455,
+        "build_number": 20240920144119,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "987ee97fb43e647db218c80cb9c3381477072aa494292db4d108e23f298e8926",
-        "contents_checksum": "da67b3b932497c895d74221dd3f670374abeda9b18ea32e225b733e69dc87cdc",
-        "size": 7374147,
-        "source": "components/google-cloud-sdk-bigtable-linux-x86-20240329151455.tar.gz",
+        "checksum": "ea0c309db700a32cc18c89a5fd6887e5f777277af47451f9d4df6bff7fcf0383",
+        "contents_checksum": "2af9f0ab5704080cc63d2779451b3b24fcd20d8cfa8a8b3d9dd6d1ac06521c97",
+        "size": 7763548,
+        "source": "components/google-cloud-sdk-bigtable-linux-x86-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1609,16 +1609,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240329151455,
+        "build_number": 20240920144119,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "a21817f2aae3ea9580a34f3f169a81baf289cbbd0a3b93455252c326654fe8b2",
-        "contents_checksum": "3ac22e1972afab99190324f7b9363fe9454ae845beba9eb3750d6240f40f5ee4",
-        "size": 7668508,
-        "source": "components/google-cloud-sdk-bigtable-linux-x86_64-20240329151455.tar.gz",
+        "checksum": "d3dfa87cd2f12cbf7358065764158ca981d6afe650de78a3077fc7e348c8f2c8",
+        "contents_checksum": "938cbad478a98442d3de281f957655e8fb45a0d39e2c3ace74b88551b03e52ae",
+        "size": 8045299,
+        "source": "components/google-cloud-sdk-bigtable-linux-x86_64-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1644,16 +1644,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240329151455,
+        "build_number": 20240920144119,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "44b0bfe67b3e19db8acf4bb144f465509afe1fc25ad9c8dfee18a70c1202d3a3",
-        "contents_checksum": "2fdcda84a5bdb706895ffc4333597c2dbf48cf4fd52048174ece638e2d63348a",
-        "size": 7568622,
-        "source": "components/google-cloud-sdk-bigtable-windows-x86-20240329151455.tar.gz",
+        "checksum": "1cb1211ce675026d3e604928e409766044e287eb7e6a068e57aa24c4ee8fce50",
+        "contents_checksum": "14c9f33ec53c466dac584027302b9825f09f915876d91d613f769f22816e0022",
+        "size": 7960310,
+        "source": "components/google-cloud-sdk-bigtable-windows-x86-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1679,16 +1679,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240329151455,
+        "build_number": 20240920144119,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "36f5c9f98188e968cd53fe4545b3f8cb01dc2dfe2bda5c1f607ac384f358f329",
-        "contents_checksum": "cae59bae355fc9b8ff8fc37296d3885a9944d85b0ba84a4c2e9985380db488e6",
-        "size": 7841324,
-        "source": "components/google-cloud-sdk-bigtable-windows-x86_64-20240329151455.tar.gz",
+        "checksum": "09ef13cc7900d20431ab4f825c41c7ef6eb6685f7d6acef773c50b501d60cade",
+        "contents_checksum": "a0c28f60f50833a79c8c0b034e14921f9fa73780151df7a82eb586cece71a6ad",
+        "size": 8213154,
+        "source": "components/google-cloud-sdk-bigtable-windows-x86_64-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1714,7 +1714,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240329151455,
+        "build_number": 20240920144119,
         "version_string": ""
       }
     },
@@ -1874,10 +1874,10 @@
     },
     {
       "data": {
-        "checksum": "abfd98bebfbc56c467215ded622ab9ad41e5c5f66b9a00c9c857d08d0880ce40",
-        "contents_checksum": "01f79ef8ab21aca5ee4c57fe2fe8fc7588c87d99842dc1259114fe000659fc91",
-        "size": 77768547,
-        "source": "components/google-cloud-sdk-bundled-python3-unix-linux-x86_64-20240806142304.tar.gz",
+        "checksum": "48d35279879c7bc29aafa03983ebcea20971974b8e30656dd95eef527384b5ab",
+        "contents_checksum": "aa88f2a24033468ef86f8f1267b8f1240b2660570367787a8dd02270071004af",
+        "size": 78001783,
+        "source": "components/google-cloud-sdk-bundled-python3-unix-linux-x86_64-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1903,7 +1903,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240806142304,
+        "build_number": 20240920144119,
         "version_string": "3.11.9"
       }
     },
@@ -2449,10 +2449,10 @@
     },
     {
       "data": {
-        "checksum": "708013ee1eb1fc34fc1b33e8b562e7c276e95749685050f347af0002d96be9ef",
-        "contents_checksum": "c26bdf735c3b31bec987291b9716851c02326e1ce5d425f2bdf78bc675dc1955",
-        "size": 48564778,
-        "source": "components/google-cloud-sdk-cloud-firestore-emulator-20240816183020.tar.gz",
+        "checksum": "8b4dbc1cb4a0d1217f8283a3057d4ba704fcbe11ba7f2b12dc1c13edb87e2e22",
+        "contents_checksum": "428a9740ee97cc9b8baad30a8ad5271fe2ee46a78f42c60f91e238dd7315c289",
+        "size": 49222535,
+        "source": "components/google-cloud-sdk-cloud-firestore-emulator-20240913204132.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2470,8 +2470,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240816183020,
-        "version_string": "1.19.8"
+        "build_number": 20240913204132,
+        "version_string": "1.19.9"
       }
     },
     {
@@ -3497,10 +3497,10 @@
     },
     {
       "data": {
-        "checksum": "c6f0d392c3c760bb03ce0d47f88011ec19f77e319319f6b9e468d92aa9be0b50",
-        "contents_checksum": "fd08abc11ea832085782f21f3e16a6aae190c0f899bd05dff8b127feb96005a9",
-        "size": 20816315,
-        "source": "components/google-cloud-sdk-core-20240906153039.tar.gz",
+        "checksum": "07eb73d0e08d63d8c2715df13dcae10561dc8062727f74c65fc698be73ed9442",
+        "contents_checksum": "64887e7f351f00ed95cd5a9d2be9aa72e8ceff4a8f617d626e9bc2e8c0238223",
+        "size": 21004306,
+        "source": "components/google-cloud-sdk-core-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3522,8 +3522,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240906153039,
-        "version_string": "2024.09.06"
+        "build_number": 20240920144119,
+        "version_string": "2024.09.20"
       }
     },
     {
@@ -3902,15 +3902,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "0.3.2"
+        "version_string": "0.3.3"
       }
     },
     {
       "data": {
-        "checksum": "a3e8f5c45ac19bd3430201339c07f2f6dc21296702375c2381ecf5c8d3e88279",
-        "contents_checksum": "22e8de82f1f0cb7a6db65e095c15017866869cac0f1d5556c146c92b1c49acb9",
-        "size": 8680702,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-arm-20231208151900.tar.gz",
+        "checksum": "d08bffeb4cc07f510132c943dd3c4da5d05ad4348b1b79cc2f13ce77c1a43294",
+        "contents_checksum": "8369d34ed10b49fa49096488b8e9fde343efdeac8ec9662843ceac9a2c72a049",
+        "size": 7538571,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-arm-20240913204132.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3935,16 +3935,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231208151900,
-        "version_string": "0.3.2"
+        "build_number": 20240913204132,
+        "version_string": "0.3.3"
       }
     },
     {
       "data": {
-        "checksum": "301757a2839dce01a6435ed4b0dfd05616f9a3c8aeba4624362b48f115e5b97a",
-        "contents_checksum": "6d407b55892613efd363344f855292ddda8fdbe81f549f318264480dc167b25a",
-        "size": 9536921,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-x86_64-20231208151900.tar.gz",
+        "checksum": "1f2be11ed0d87cfb5377dec7c78a8b48fd211ab1827b43f523c7ac33d6de0b61",
+        "contents_checksum": "27fde9fc542d86f9eb256bc92e8a511c6896e8a419cd9ec089ea2ddc900bd2bd",
+        "size": 8300582,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-x86_64-20240913204132.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3969,16 +3969,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231208151900,
-        "version_string": "0.3.2"
+        "build_number": 20240913204132,
+        "version_string": "0.3.3"
       }
     },
     {
       "data": {
-        "checksum": "620e7f1598535dba84e52085cf12275e6e2264b281d7d43d71d4079ad0daab7e",
-        "contents_checksum": "1ccff0b7259285d34269926c6038535561cc6d24c0a5c40e3f1b49c7748c9808",
-        "size": 9012612,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-linux-x86_64-20231208151900.tar.gz",
+        "checksum": "755dd461d4e781fdde01f9045583b6693828b40711dd4f063943e4a9db2c0ece",
+        "contents_checksum": "e8c8acf997eab9a5298037798725fe486a70bd49a395d61e229e2f41c1f80036",
+        "size": 9024735,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-linux-x86_64-20240913204132.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4003,16 +4003,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231208151900,
-        "version_string": "0.3.2"
+        "build_number": 20240913204132,
+        "version_string": "0.3.3"
       }
     },
     {
       "data": {
-        "checksum": "d49562e0fac17a4ac3c4e30d7c7056320a69ebc157a6c3f3e744f5731bb16f92",
-        "contents_checksum": "bfa2c0f4ea80fb6e3299b6fb7554565213c39ed7b01140020f8ae00c260d09e1",
-        "size": 6801316,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-windows-x86_64-20231208151900.tar.gz",
+        "checksum": "ff4456a198f652f5b4340a94091d64930b5ed3df5adbd90a0633024d2860c07a",
+        "contents_checksum": "16f3c53cf04b266326ce4d64d084ab395d57e3718bb42d1b21d897e0e729bdf7",
+        "size": 6782214,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-windows-x86_64-20240913204132.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4037,8 +4037,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231208151900,
-        "version_string": "0.3.2"
+        "build_number": 20240913204132,
+        "version_string": "0.3.3"
       }
     },
     {
@@ -4338,10 +4338,10 @@
     },
     {
       "data": {
-        "checksum": "97b7d739d37f7189c1630cccd1567aa9ce2f429a469b96178fbda7bce0972704",
-        "contents_checksum": "cbf91e06fc39d3cd7df3cf5ed31a77c84a3eb2ba6eb5ae9dcc34aacc8f5d0cd0",
-        "size": 17424388,
-        "source": "components/google-cloud-sdk-gcloud-deps-20240806142304.tar.gz",
+        "checksum": "16131516bb7f7e9c94903abeb19dfb116973b72bb5ae24a1512d232ed7ea58b6",
+        "contents_checksum": "f6b086b59576ff9652483408d3d1bec083f6e3ee98a5e126b48197dda4427380",
+        "size": 17425755,
+        "source": "components/google-cloud-sdk-gcloud-deps-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4365,8 +4365,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240806142304,
-        "version_string": "2024.08.06"
+        "build_number": 20240920144119,
+        "version_string": "2024.09.20"
       }
     },
     {
@@ -4609,10 +4609,10 @@
     },
     {
       "data": {
-        "checksum": "f2d1e365ef5004a9e099f63b863ef4bf99e48b5d1b3c5ae8f10dfe3525642c8d",
-        "contents_checksum": "6d327392f385c820f2f937c0a1b1da6649fd9c7cadd9c43540b4e4668cc41fd5",
-        "size": 7235706,
-        "source": "components/google-cloud-sdk-gcloud-man-pages-nix-20240906153039.tar.gz",
+        "checksum": "55688439aa278229175c18395d14689411c34b088360a2543071ba483cb4cb6c",
+        "contents_checksum": "f18edf3862382326c32e28f898871617775de59c3aa0e73383d5bad4e18cae5f",
+        "size": 7283267,
+        "source": "components/google-cloud-sdk-gcloud-man-pages-nix-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4638,7 +4638,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240906153039,
+        "build_number": 20240920144119,
         "version_string": ""
       }
     },
@@ -6439,10 +6439,10 @@
     },
     {
       "data": {
-        "checksum": "93cf97d2cc5a48abbcb1716204408a7484ed8f6bd91505931893529a5b6a36f3",
-        "contents_checksum": "43417665b73406183120cc305950ab0dcf288ac116d1421b0e804fda66ca114b",
-        "size": 401984136,
-        "source": "components/google-cloud-sdk-managed-flink-client-20240906153039.tar.gz",
+        "checksum": "a90c53d83dfe10216d0aaa6ba234d028eee0fa6959ef8e0fb4c432b358b52ef3",
+        "contents_checksum": "c37e9989bc839d2ca0714d1c78a19832f22b57c999f4c9afcc08a52cb472e833",
+        "size": 401984160,
+        "source": "components/google-cloud-sdk-managed-flink-client-20240913204132.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6460,8 +6460,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240906153039,
-        "version_string": "0.5.0"
+        "build_number": 20240913204132,
+        "version_string": "0.5.1"
       }
     },
     {
@@ -7608,10 +7608,10 @@
     },
     {
       "data": {
-        "checksum": "93cc6bf1d627b67ea9afc82965a3680b978a8589ac9403112b190ff367de185d",
-        "contents_checksum": "b7a09d5ef025bd69f43cd7986f578e8481f46a50f25b80fd4b7e6ce7b7c039e5",
-        "size": 58125954,
-        "source": "components/google-cloud-sdk-tests-20240906153039.tar.gz",
+        "checksum": "a4bb42ec496f935b19acf4e5e4b48260dcf428c6909cd4a2c948cfd763c0e0e6",
+        "contents_checksum": "8814c920e3ceee53b2dd6dc5e3d727e519273bf2a58663c11e51fb48e53fc23d",
+        "size": 58197479,
+        "source": "components/google-cloud-sdk-tests-20240920144119.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -7629,8 +7629,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240906153039,
-        "version_string": "2024.09.06"
+        "build_number": 20240920144119,
+        "version_string": "2024.09.20"
       }
     }
   ],
@@ -7649,11 +7649,11 @@
   ],
   "post_processing_command": "components post-process",
   "release_notes_url": "RELEASE_NOTES",
-  "revision": 20240906153039,
+  "revision": 20240920144119,
   "schema_version": {
     "no_update": false,
     "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz",
     "version": 3
   },
-  "version": "492.0.0"
+  "version": "494.0.0"
 }

--- a/pkgs/tools/admin/google-cloud-sdk/data.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/data.nix
@@ -1,32 +1,32 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "492.0.0";
+  version = "494.0.0";
   googleCloudSdkPkgs = {
     x86_64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-492.0.0-linux-x86_64.tar.gz";
-        sha256 = "00vdmq7j67b6wdkz17wbh06lfzdq9yw4532p5jygbbg469smi8av";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-494.0.0-linux-x86_64.tar.gz";
+        sha256 = "0liyi2r1zgzjkfyjdfs5q7gjv31q2invxxh6j8bw8q2khy0varyp";
       };
     x86_64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-492.0.0-darwin-x86_64.tar.gz";
-        sha256 = "0hg24ffqcwy3xg7wjjgg6y00djwcb46866msach9s2q419cvz2z0";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-494.0.0-darwin-x86_64.tar.gz";
+        sha256 = "0dpy85b3c2rd3ndwaczxdm4kdjdx1hz7xwva590j2jbabrx0shqz";
       };
     aarch64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-492.0.0-linux-arm.tar.gz";
-        sha256 = "11ygy5qjx81nxlkgkyxwcd1z0ippkrshdxg7bfjgpw9c17zx3mp0";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-494.0.0-linux-arm.tar.gz";
+        sha256 = "0nzb1wzcqds72s5fam9wzzq8y2bs247ihkv8lib4i2652ampxfp8";
       };
     aarch64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-492.0.0-darwin-arm.tar.gz";
-        sha256 = "0y1f7bg0ji0vvaik7dlyhkqlgix89xj96dhsps51hal6m92dibpb";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-494.0.0-darwin-arm.tar.gz";
+        sha256 = "026qgsah4nhr17kh1gb2ldwi8far38ai8lq0c274vkq4h7pfxjir";
       };
     i686-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-492.0.0-linux-x86.tar.gz";
-        sha256 = "1f7fbfzyq8ycsn1whvrrncq7gycv4aswhgca8f8d1bpjcmcshs2n";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-494.0.0-linux-x86.tar.gz";
+        sha256 = "1nyx7ikarb8c08p4nshdyv0qj0rs0d1hhhpxrc96cmwp76jvhg0n";
       };
   };
 }


### PR DESCRIPTION
## Description of changes

Update google-cloud-sdk from 492.0.0 to [494.0.0](https://cloud.google.com/sdk/docs/release-notes#49400_2024-09-24).

Built with:
```
nix build --print-build-logs --impure --expr 'let pkgs = import ./. {}; in pkgs.google-cloud-sdk.withExtraComponents (with pkgs.google-cloud-sdk.components; [anthos-auth anthoscli app-engine-go app-engine-grpc app-engine-java app-engine-python app-engine-python-extras 
appctl bigtable cbt cloud-build-local cloud-datastore-emulator cloud-firestore-emulator cloud-run-proxy cloud-spanner-emulator config-connector docker-credential-gcr enterprise-certificate-proxy gcloud-crc32c gcloud-man-pages gke-gcloud-auth-plugin harbourbridge istioctl
 kpt kubectl kubectl-oidc kustomize local-extract log-streaming minikube nomos package-go-module pkg pubsub-emulator skaffold spanner-migration-tool terraform-tools managed-flink-client cloud-sql-proxy])'
```

and tested with:
```
./result/bin/gcloud components list
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
