### PR TITLE
pkgsStatic.postgresql: fix build

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -53,7 +53,11 @@ let
       , libkrb5
 
       # icu
-      , icuSupport ? true
+      # Building with icu in pkgsStatic gives tons of "undefined reference" errors like this:
+      #   /nix/store/452lkaak37d3mzzn3p9ak7aa3wzhdqaj-icu4c-74.2-x86_64-unknown-linux-musl/lib/libicuuc.a(chariter.ao):
+      #    (.data.rel.ro._ZTIN6icu_7417CharacterIteratorE[_ZTIN6icu_7417CharacterIteratorE]+0x0):
+      #    undefined reference to `vtable for __cxxabiv1::__si_class_type_info'
+      , icuSupport ? !stdenv.hostPlatform.isStatic
       , icu
 
       # JIT
@@ -71,7 +75,11 @@ let
       , gettext
 
       # PAM
-      , pamSupport ? stdenv.hostPlatform.isLinux
+      # Building with linux-pam in pkgsStatic gives a few "undefined reference" errors like this:
+      #   /nix/store/3s55icpsbc36sgn7sa8q3qq4z6al6rlr-linux-pam-static-x86_64-unknown-linux-musl-1.6.1/lib/libpam.a(pam_audit.o):
+      #     in function `pam_modutil_audit_write':(.text+0x571):
+      #     undefined reference to `audit_close'
+      , pamSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic
       , linux-pam
 
       # PL/Perl
@@ -267,7 +275,7 @@ let
         # because there is a realistic use-case for extensions to locate the /lib directory to
         # load other shared modules.
         remove-references-to -t "$dev" -t "$doc" -t "$man" "$out/bin/postgres"
-
+      '' + lib.optionalString (!stdenv'.hostPlatform.isStatic) ''
         if [ -z "''${dontDisableStatic:-}" ]; then
           # Remove static libraries in case dynamic are available.
           for i in $lib/lib/*.a; do
@@ -278,6 +286,7 @@ let
             fi
           done
         fi
+      '' + ''
         # The remaining static libraries are libpgcommon.a, libpgport.a and related.
         # Those are only used when building e.g. extensions, so go to $dev.
         moveToOutput "lib/*.a" "$dev"
@@ -306,7 +315,7 @@ let
     # Also see <nixpkgs>/doc/stdenv/platform-notes.chapter.md
     doCheck = false;
     # Tests just get stuck on macOS 14.x for v13 and v14
-    doInstallCheck = !(stdenv'.hostPlatform.isDarwin && olderThan "15");
+    doInstallCheck = !(stdenv'.hostPlatform.isDarwin && olderThan "15") && !(stdenv'.hostPlatform.isStatic);
     installCheckTarget = "check-world";
 
     passthru = let

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -149,6 +149,8 @@ let
       ];
     };
 
+    strictDeps = true;
+
     buildInputs = [
       zlib
       readline
@@ -171,6 +173,7 @@ let
       ++ lib.optionals nlsSupport [ gettext ];
 
     nativeBuildInputs = [
+      libxml2
       makeWrapper
       pkg-config
       removeReferencesTo

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -218,9 +218,8 @@ let
       ++ lib.optionals pythonSupport [ "--with-python" ]
       ++ lib.optionals jitSupport [ "--with-llvm" ]
       ++ lib.optionals pamSupport [ "--with-pam" ]
-      # This could be removed once the upstream issue is resolved:
-      # https://postgr.es/m/flat/427c7c25-e8e1-4fc5-a1fb-01ceff185e5b%40technowledgy.de
-      ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16") [ "LDFLAGS_EX_BE=-Wl,-export_dynamic" ]
+      # This can be removed once v17 is removed. v18+ ships with it.
+      ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16" && olderThan "18") [ "LDFLAGS_EX_BE=-Wl,-export_dynamic" ]
       ++ lib.optionals (atLeast "17" && !perlSupport) [ "--without-perl" ]
       ++ lib.optionals ldapSupport [ "--with-ldap" ]
       ++ lib.optionals tclSupport [ "--with-tcl" ]


### PR DESCRIPTION
The underlying problem was fixed as a side-effect of 77977286d80c9bfb77cbf80989d41c59d66dccf8, for reasons unknown to me. In the current state, it's enough to disable a few breaking dependencies to make the build pass.

Note, that this builds the full package, including backend. However, the backend is not working, yet: Loading shared modules, which PostgreSQL heavily depends is still broken. Further, all binaries in the default output, even client binaries such as psql, are currently dynamically linked against libpq.so. While the current autoconf based build system doesn't support changing this, this might be possible in the future with meson.

However, not all is bad: Fixing the build allows using the static libpq.a library, which is probably the one thing that most users want from `pkgsStatic.postgresql` anyway.

Resolves #191920

Note: I also experimented with a meson-based static build, only to then notice that autoconf works with the basics as well. Making the switch to meson eventually should make things better, though: I was able to build a working backend, too, at least enough to run basic test suites for postgresql drivers with this. We can't fully switch to meson as a build system for 16 or 17, yet, because JIT will not work correctly. The meson build system doesn't [build the required bitcode](https://www.postgresql.org/message-id/flat/206b001d-1884-4081-bd02-bed5c92f02ba%40eisentraut.org) files, yet. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
