### PR TITLE
Chatterino7: init at 7.5.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -1,49 +1,140 @@
-{ stdenv, lib, cmake, pkg-config, fetchFromGitHub, qt6, boost, openssl, libsecret }:
+{
+  stdenv,
+  lib,
+  cmake,
+  pkg-config,
+  fetchFromGitHub,
+  qt6,
+  boost,
+  openssl,
+  libsecret,
+  darwin,
+}:
+let
+  stdenv' = if stdenv.hostPlatform.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
+  mkPackage =
+    {
+      pname,
+      version,
+      src,
+      extraMeta,
+    }:
 
-stdenv.mkDerivation rec {
-  pname = "chatterino2";
-  version = "2.5.1";
-  src = fetchFromGitHub {
-    owner = "Chatterino";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-c3Vhzes54xLjKV0Of7D1eFpQvIWJwcUBXvLT2p6VwBE=";
-    fetchSubmodules = true;
+    stdenv'.mkDerivation {
+      inherit pname version src;
+      nativeBuildInputs = [
+        cmake
+        pkg-config
+        qt6.wrapQtAppsHook
+      ];
+      buildInputs = [
+        qt6.qtbase
+        qt6.qtsvg
+        qt6.qtimageformats
+        qt6.qttools
+        qt6.qt5compat
+        boost
+        openssl
+        libsecret
+      ] ++ lib.optionals stdenv.hostPlatform.isLinux [ qt6.qtwayland ];
+
+      env.GIT_HASH = "nix-${version}";
+      cmakeFlags = [ (lib.cmakeBool "BUILD_WITH_QT6" true) ];
+      postInstall =
+        lib.optionalString stdenv.hostPlatform.isDarwin ''
+          mkdir -p "$out/Applications"
+          mv bin/chatterino.app "$out/Applications/"
+        ''
+        + ''
+          mkdir -p $out/share/icons/hicolor/256x256/apps
+          cp $src/resources/icon.png $out/share/icons/hicolor/256x256/apps/chatterino.png
+        '';
+      passthru.updateScript = ./update.sh;
+      meta = {
+        description = "Chat client for Twitch chat";
+        mainProgram = "chatterino";
+        longDescription = ''
+          Chatterino is a chat client for Twitch chat.
+          It aims to be an improved/extended version of the Twitch web chat.
+          Chatterino 2 is the second installment of the Twitch chat client series "Chatterino".
+        '';
+        license = lib.licenses.mit;
+        platforms = lib.platforms.unix;
+        maintainers = with lib.maintainers; [
+          rexim
+          supa
+          hausken
+        ];
+      } // extraMeta;
+    };
+in
+{
+  chatterino2 = mkPackage rec {
+    pname = "chatterino2";
+    version = "2.5.1";
+    src = fetchFromGitHub {
+      owner = "Chatterino";
+      repo = "chatterino2";
+      rev = "v${version}";
+      hash = "sha256-c3Vhzes54xLjKV0Of7D1eFpQvIWJwcUBXvLT2p6VwBE=";
+      fetchSubmodules = true;
+    };
+    extraMeta = {
+      homepage = "https://github.com/Chatterino/chatterino2";
+      changelog = "https://github.com/Chatterino/chatterino2/blob/${src.rev}/CHANGELOG.md";
+    };
   };
-  nativeBuildInputs = [ cmake pkg-config qt6.wrapQtAppsHook ];
-  buildInputs = [
-    qt6.qtbase
-    qt6.qtsvg
-    qt6.qtimageformats
-    qt6.qttools
-    qt6.qt5compat
-    boost
-    openssl
-    libsecret
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
-    qt6.qtwayland
-  ];
-  cmakeFlags = [ "-DBUILD_WITH_QT6=ON" ];
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir -p "$out/Applications"
-    mv bin/chatterino.app "$out/Applications/"
-  '' + ''
-    mkdir -p $out/share/icons/hicolor/256x256/apps
-    cp $src/resources/icon.png $out/share/icons/hicolor/256x256/apps/chatterino.png
-  '';
-  meta = with lib; {
-    description = "Chat client for Twitch chat";
-    mainProgram = "chatterino";
-    longDescription = ''
-      Chatterino is a chat client for Twitch chat. It aims to be an
-      improved/extended version of the Twitch web chat. Chatterino 2 is
-      the second installment of the Twitch chat client series
-      "Chatterino".
-    '';
-    homepage = "https://github.com/Chatterino/chatterino2";
-    changelog = "https://github.com/Chatterino/chatterino2/blob/master/CHANGELOG.md";
-    license = licenses.mit;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ rexim supa ];
+  chatterino2-unstable = mkPackage rec {
+    pname = "chatterino2";
+    version = "0-unstable-2024-09-29";
+    src = fetchFromGitHub {
+      owner = "Chatterino";
+      repo = "chatterino2";
+      rev = "0db477665c5a4b40149aed231c09ce00a075baf7";
+      hash = "sha256-1LTfRfxodvyqLSBZsGuFrZaQ5+vYA6LNxuVkLXaTZKI=";
+      fetchSubmodules = true;
+    };
+    extraMeta = {
+      homepage = "https://github.com/Chatterino/chatterino2";
+      changelog = "https://github.com/Chatterino/chatterino2/blob/${src.rev}/CHANGELOG.md";
+    };
+  };
+  chatterino7 = mkPackage rec {
+    pname = "chatterino7";
+    version = "7.5.1";
+    src = fetchFromGitHub {
+      owner = "SevenTV";
+      repo = "chatterino7";
+      rev = "v${version}";
+      hash = "sha256-T0H+p9hyNd73gETwLilXN0uzcF75TJgx/LzHqnC099M=";
+      fetchSubmodules = true;
+    };
+    extraMeta = {
+      homepage = "https://github.com/SevenTV/chatterino7";
+      changelog = "https://github.com/SevenTV/chatterino7/blob/${src.rev}/CHANGELOG.md";
+      longDescription = ''
+        Chatterino7 is a fork of Chatterino 2.
+        This fork mainly contains features that aren't accepted into Chatterino 2, most notably 7TV subscriber features.
+      '';
+    };
+  };
+  chatterino7-unstable = mkPackage rec {
+    pname = "chatterino7";
+    version = "0-unstable-2024-09-28";
+    src = fetchFromGitHub {
+      owner = "SevenTV";
+      repo = "chatterino7";
+      rev = "978fb9820361c2e9ce1b5f1425e0243af1d5517d";
+      hash = "sha256-pkY8+UvttYLOJ/9OtJ4q5SY27rutCjR/iJ25+rVGxvk=";
+      fetchSubmodules = true;
+    };
+    extraMeta = {
+      homepage = "https://github.com/SevenTV/chatterino7";
+      changelog = "https://github.com/SevenTV/chatterino7/blob/${src.rev}/CHANGELOG.md";
+      longDescription = ''
+        Chatterino7 is a fork of Chatterino 2.
+        This fork mainly contains features that aren't accepted into Chatterino 2, most notably 7TV subscriber features.
+      '';
+    };
   };
 }

--- a/pkgs/applications/networking/instant-messengers/chatterino2/update.sh
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl common-updater-scripts jq
+
+set -euo pipefail
+
+ATTR=$1
+
+OLD_VERSION=$(nix eval --raw -f default.nix "$ATTR.version")
+OWNER=$(nix eval --raw -f default.nix "$ATTR.src.owner")
+REPO=$(nix eval --raw -f default.nix "$ATTR.src.repo")
+
+if [[ $OLD_VERSION =~ "0-unstable-" ]]; then
+    releaseDate=$(curl "https://api.github.com/repos/$OWNER/$REPO/commits/nightly-build" | jq -r '.commit.author.date' | cut -d 'T' -f 1)
+    revision=$(curl "https://api.github.com/repos/$OWNER/$REPO/commits/nightly-build" | jq -r '.sha')
+    version="0-unstable-$releaseDate"
+    update-source-version "$ATTR" "$version" --rev="$revision"
+else
+    version=$(curl --silent "https://api.github.com/repos/$OWNER/$REPO/releases" | jq -r '[.[] | select(.tag_name != "nightly-build")] | .[0].tag_name' | sed 's/v//')
+    update-source-version "$ATTR" "$version"
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33845,9 +33845,7 @@ with pkgs;
     xwaylandSupport = false;
   };
 
-  chatterino2 = callPackage ../applications/networking/instant-messengers/chatterino2 {
-    stdenv = if stdenv.hostPlatform.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
-  };
+  inherit (callPackages ../applications/networking/instant-messengers/chatterino2 { } ) chatterino2 chatterino2-unstable chatterino7 chatterino7-unstable;
 
   weston = callPackage ../applications/window-managers/weston { };
 


### PR DESCRIPTION
## Description of changes

- Added chatterino7, using same build as chatterino2 since it is a very similar fork
- Added unstable build versions for chatterino2 and chatterino7
- Added update script to support the unstable builds
- Applied formatting
- Added Hausken as maintainer
- Added GIT_HASH environment variable during build so users can identify the version from Settings > About
- Moved the **stdenv** logic from `pkgs/top-level/all-packages.nix` into the default.nix.

Hope it is fine the same maintainers is assigned for chatterino7 as for chatterino2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
