### PR TITLE
libpeas2: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/libpeas/2.x.nix
+++ b/pkgs/development/libraries/libpeas/2.x.nix
@@ -1,6 +1,8 @@
 { stdenv
 , lib
+, buildPackages
 , fetchurl
+, pkgsCross
 , substituteAll
 , pkg-config
 , gi-docgen
@@ -15,6 +17,9 @@
 , gnome
 }:
 
+let
+  luaEnv = lua5_1.withPackages (ps: with ps; [ lgi ]);
+in
 stdenv.mkDerivation rec {
   pname = "libpeas";
   version = "2.0.3";
@@ -51,8 +56,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gjs
     glib
-    lua5_1
-    lua5_1.pkgs.lgi
+    luaEnv
     python3
     python3.pkgs.pygobject3
     spidermonkey_115
@@ -67,11 +71,22 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=true"
   ];
 
+  # required for locating lua dependencies at build time (when cross compiling):
+  env.LUA_CPATH = "${luaEnv}/lib/lua/${luaEnv.luaversion}/?.so";
+  env.LUA_PATH = "${luaEnv}/share/lua/${luaEnv.luaversion}/?.lua";
+
+  strictDeps = true;
+
   postPatch = ''
-    # Checks lua51 and lua5.1 executable but we have non of them.
-    substituteInPlace meson.build --replace \
-      "find_program('lua51', required: false)" \
-      "find_program('lua', required: false)"
+    # Checks lua51 and lua5.1 executable but we have none of them.
+    # Then it tries to invoke lua to check for LGI, which requires emulation for cross.
+    substituteInPlace meson.build \
+      --replace-fail \
+        "find_program('lua51', required: false)" \
+        "find_program('${lib.getExe' lua5_1 "lua"}', required: false)" \
+      --replace-fail \
+        "run_command(lua_prg, [" \
+        "run_command('${stdenv.hostPlatform.emulator buildPackages}', [lua_prg, "
   '';
 
   postFixup = ''
@@ -85,6 +100,8 @@ stdenv.mkDerivation rec {
       packageName = "libpeas";
       versionPolicy = "odd-unstable";
     };
+
+    tests.cross = pkgsCross.aarch64-multiplatform.libpeas2;
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

- `nix-build -A libpeas2 -A pkgsCross.aarch64-multiplatform.libpeas2`

tested by placing a call in `gnome-calls`, which links against libpeas2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
