### PR TITLE
envio: 0.5.1 -> 0.6.1

### DIFF
--- a/pkgs/by-name/en/envio/package.nix
+++ b/pkgs/by-name/en/envio/package.nix
@@ -1,11 +1,14 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, darwin
-, gpgme
-, libgpg-error
-, pkg-config
-, rustPlatform
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  installShellFiles,
+  darwin,
+  gpgme,
+  libgpg-error,
+  pkg-config,
+  rustPlatform,
 }:
 
 let
@@ -24,14 +27,23 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-L7GgPocj32zAfR27dgKK7/OM106cATdCqufSvG3MFYQ=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
 
-  buildInputs = [ libgpg-error gpgme ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
+  buildInputs = [
+    libgpg-error
+    gpgme
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
+
+  postInstall = ''
+    installManPage man/*.1
+  '';
 
   meta = with lib; {
-    homepage    = "https://envio-cli.github.io/home";
-    changelog   = "https://github.com/envio-cli/envio/blob/${version}/CHANGELOG.md";
+    homepage = "https://envio-cli.github.io/home";
+    changelog = "https://github.com/envio-cli/envio/blob/${version}/CHANGELOG.md";
     description = "Modern and secure CLI tool for managing environment variables";
     mainProgram = "envio";
     longDescription = ''
@@ -40,8 +52,11 @@ rustPlatform.buildRustPackage rec {
       switch between different configurations and apply them to their current
       environment.
     '';
-    license     = with licenses; [ mit asl20 ];
-    platforms   = platforms.unix;
+    license = with licenses; [
+      mit
+      asl20
+    ];
+    platforms = platforms.unix;
     maintainers = with maintainers; [ afh ];
   };
 }

--- a/pkgs/by-name/en/envio/package.nix
+++ b/pkgs/by-name/en/envio/package.nix
@@ -13,28 +13,21 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "envio";
-  version = "0.5.1";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "envio-cli";
     repo = "envio";
     rev = "v${version}";
-    hash = "sha256-KhjHd+1IeKdASeYP2rPtyTmtkPcBbaruylmOwTPtFgo=";
+    hash = "sha256-je0DBoBIayFK//Aija5bnO/2z+hxNWgVkwOgxMyq5s4=";
   };
 
-  cargoHash = "sha256-qmJUARwsGln07RAX1Ab0cNDgJq7NkezuT0tZsyd48Mw=";
+  cargoHash = "sha256-L7GgPocj32zAfR27dgKK7/OM106cATdCqufSvG3MFYQ=";
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ libgpg-error gpgme ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
-
-  # Remove postPatch when updating to the next envio release
-  # For details see https://github.com/envio-cli/envio/pull/31
-  postPatch = ''
-    substituteInPlace build.rs\
-      --replace 'fn get_version() -> String {' 'fn get_version() -> String { return "${version}".to_string();'
-  '';
 
   meta = with lib; {
     homepage    = "https://envio-cli.github.io/home";


### PR DESCRIPTION
## Description of changes

* Update envio to 0.6.1 [envio-cli/envio@0.6.1/CHANGELOG.md](https://github.com/envio-cli/envio/blob/0.6.1/CHANGELOG.md?rgh-link-date=2024-09-27T13%3A04%3A52Z)
* Add installation of manpage
* Format using nixfmt-rfc-style

As I'm uncertain how to add commits to #344873 this PR replaces it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Supercedes #344873

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
