### PR TITLE
xen: use SeaBIOS' `passthru.firmware` attribute

### DIFF
--- a/pkgs/build-support/xen/default.nix
+++ b/pkgs/build-support/xen/default.nix
@@ -30,7 +30,8 @@
   zstd,
 
   # Optional Components
-  seabios,
+  seabios-qemu,
+  systemSeaBIOS ? seabios-qemu,
   OVMF,
   ipxe,
   checkpolicy,
@@ -261,7 +262,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-systemd"
     "--disable-qemu-traditional"
     "--with-system-qemu"
-    (if withSeaBIOS then "--with-system-seabios=${seabios}/share/seabios" else "--disable-seabios")
+    (if withSeaBIOS then "--with-system-seabios=${systemSeaBIOS.firmware}" else "--disable-seabios")
     (if withOVMF then "--with-system-ovmf=${OVMF.firmware}" else "--disable-ovmf")
     (if withIPXE then "--with-system-ipxe=${ipxe}" else "--disable-ipxe")
     (enableFeature withFlask "xsmpolicy")


### PR DESCRIPTION
## Description of changes

- Makes the generic Xen builder use `firmware` instead of hard-coding a directory path.
  - This is useful for when `seabios` is overridden by `qubes-seabios` in `qubes-vmm-xen` (#341429).

Requires #342692
Closes #345172

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 345324"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
