### PR TITLE
nixos/redis: add option services.redis.servers.*.group

### DIFF
--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -72,7 +72,28 @@ in {
               defaultText = literalExpression ''
                 if name == "" then "redis" else "redis-''${name}"
               '';
-              description = "The username and groupname for redis-server.";
+              description = ''
+                User account under which this instance of redis-server runs.
+
+                ::: {.note}
+                If left as the default value this user will automatically be
+                created on system activation, otherwise you are responsible for
+                ensuring the user exists before the redis service starts.
+              '';
+            };
+
+            group = mkOption {
+              type = types.str;
+              default = config.user;
+              defaultText = literalExpression "config.user";
+              description = ''
+                Group account under which this instance of redis-server runs.
+
+                ::: {.note}
+                If left as the default value this group will automatically be
+                created on system activation, otherwise you are responsible for
+                ensuring the group exists before the redis service starts.
+              '';
             };
 
             port = mkOption {
@@ -337,7 +358,7 @@ in {
           redisConfStore = redisConfig conf.settings;
         in ''
           touch "${redisConfVar}" "${redisConfRun}"
-          chown '${conf.user}' "${redisConfVar}" "${redisConfRun}"
+          chown '${conf.user}':'${conf.group}' "${redisConfVar}" "${redisConfRun}"
           chmod 0600 "${redisConfVar}" "${redisConfRun}"
           if [ ! -s ${redisConfVar} ]; then
             echo 'include "${redisConfRun}"' > "${redisConfVar}"
@@ -353,7 +374,7 @@ in {
         Type = "notify";
         # User and group
         User = conf.user;
-        Group = conf.user;
+        Group = conf.group;
         # Runtime directory and mode
         RuntimeDirectory = redisName name;
         RuntimeDirectoryMode = "0750";


### PR DESCRIPTION
## Description of changes

Previously if you set the "user" option and did not create a group account with the same name the module would create a service that would fail to start.

with this change:
- the module is more explicit about this behaviour
- you can configure the group directly, so that you're not forced to use a particular user/group structure
- you can read the group name used by the redis service. this is useful for giving other services permission to use the redis socket.

This PR is motivated by this bug: https://github.com/NixOS/nixpkgs/issues/344738
And by this conversation about a fix: https://github.com/NixOS/nixpkgs/pull/345126#discussion_r1779661130

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
