### PR TITLE
spiel: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12916,6 +12916,13 @@
     github = "marijanp";
     githubId = 13599169;
   };
+  mariunaise = {
+    email = "marius@nixfunktioniert.de";
+    name = "Marius";
+    github = "mariunaise";
+    githubId = 120025370;
+    keys = [ { fingerprint = "D2B5 E3FB 7214 46C0 6D51  B565 56D4 131B A310 4777"; } ];
+  };
   marius851000 = {
     email = "mariusdavid@laposte.net";
     name = "Marius David";

--- a/pkgs/by-name/sp/spiel/package.nix
+++ b/pkgs/by-name/sp/spiel/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+let
+  # Override textual version to 0.11.1 because slide transitions are broken otherwise
+  textualOverride = python3Packages.buildPythonPackage rec {
+    pname = "textual";
+    version = "0.11.1";
+
+    src = fetchPypi {
+      pname = "textual";
+      inherit version;
+      sha256 = "sha256-mwJ4U7aGrJVho9xvK2N6JQifLuZ6nje7850Np1Z2lLA=";
+    };
+  };
+in
+python3Packages.buildPythonApplication rec {
+  pname = "spiel";
+  version = "0.5.1";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-5Xrc2X14RP0ik4IwB9RA1Uhp2OTjHn2/LT+LN3ZCNoc=";
+  };
+
+  dependencies = with python3Packages; [
+    poetry-core
+    more-itertools
+    rich
+    typer
+    watchfiles
+    pillow
+    textualOverride
+  ];
+
+  meta = with lib; {
+    description = "Framework for building and presenting richly-styled presentations in a terminal using Python.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mariunaise ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Packages https://github.com/JoshKarpel/spiel which is a framework for building and presenting presentations using the terminal.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---
Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
