### PR TITLE
rtorrent: 0.9.8-unstable -> 0.10.0

### DIFF
--- a/pkgs/by-name/li/libtorrent/package.nix
+++ b/pkgs/by-name/li/libtorrent/package.nix
@@ -13,15 +13,15 @@
 , unstableGitUpdater
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "rakshasa-libtorrent";
-  version = "0.13.8-unstable-2024-09-01";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "libtorrent";
-    rev = "ca6eed1c7e7985016689004eaeed2fb2a119e5f8";
-    hash = "sha256-Hu0/T5NG7h+COLoOsfi2Uy0BVUPiEhkMhUhFo/JqZq0=";
+    rev = "v${version}";
+    hash = "sha256-MDLAp7KFmVvHL+haWVYwWG8gnLkTh6g19ydRkbu9cIs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libtorrent/package.nix
+++ b/pkgs/by-name/li/libtorrent/package.nix
@@ -10,7 +10,7 @@
 , openssl
 , pkg-config
 , zlib
-, unstableGitUpdater
+, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
+  passthru.updateScript = gitUpdater { tagPrefix = "v"; };
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/rt/rtorrent/package.nix
+++ b/pkgs/by-name/rt/rtorrent/package.nix
@@ -18,15 +18,15 @@
 , unstableGitUpdater
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "rakshasa-rtorrent";
-  version = "0.9.8-unstable-2024-09-07";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "rtorrent";
-    rev = "9a93281ded3f6c6bb40593f9bbd3597683cff263";
-    hash = "sha256-dbZ0Q6v6vu8rlr7p1rPc3Cx/9R53OelkoTNsdAVQAxE=";
+    rev = "v${version}";
+    hash = "sha256-G/30Enycpqg/pWC95CzT9LY99kN4tI+S8aSQhnQO+M8=";
   };
 
   outputs = [ "out" "man" ];

--- a/pkgs/by-name/rt/rtorrent/package.nix
+++ b/pkgs/by-name/rt/rtorrent/package.nix
@@ -15,7 +15,7 @@
 , xmlrpc_c
 , zlib
 , nixosTests
-, unstableGitUpdater
+, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   ];
 
   passthru = {
-    updateScript = unstableGitUpdater { tagPrefix = "v"; };
+    updateScript = gitUpdater { tagPrefix = "v"; };
     tests = {
       inherit (nixosTests) rtorrent;
     };


### PR DESCRIPTION
## Description of changes

Active development has been restarted, thanks @[rakshasa](https://github.com/rakshasa)
https://github.com/rakshasa/rtorrent/releases/tag/v0.10.0

supersedes #345337

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)), ran `nix-build -A nixosTests.rtorrent --check`
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
