### PR TITLE
python312Packages.ancp-bids: unbreak and minor refactor

### DIFF
--- a/pkgs/development/python-modules/ancp-bids/default.nix
+++ b/pkgs/development/python-modules/ancp-bids/default.nix
@@ -6,7 +6,6 @@
   pythonOlder,
   pytestCheckHook,
   setuptools,
-  wheel,
   numpy,
   pandas,
 }:
@@ -14,7 +13,8 @@
 buildPythonPackage rec {
   pname = "ancp-bids";
   version = "0.2.4";
-  format = "pyproject";
+  pyproject = true;
+
   disabled = pythonOlder "3.7";
 
   # `tests/data` dir missing from PyPI dist
@@ -25,19 +25,7 @@ buildPythonPackage rec {
     hash = "sha256-c6X1gCYAezgZQP6xfQPfKW8V35F1cnTdbryEp3sZ4jw=";
   };
 
-  patches = [
-    # https://github.com/ANCPLabOldenburg/ancp-bids/pull/78
-    (fetchpatch {
-      name = "unpin-wheel-build-dependency.patch";
-      url = "https://github.com/ANCPLabOldenburg/ancp-bids/commit/6e7a0733002845aacb0152c5aacfb42054a9b65e.patch";
-      hash = "sha256-WbQRwb8Wew46OJu+zo7n4qBtgtH/Lr6x3YHAyN9ko9M=";
-    })
-  ];
-
-  nativeBuildInputs = [
-    setuptools
-    wheel
-  ];
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     numpy
@@ -54,6 +42,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://ancpbids.readthedocs.io";
     description = "Read/write/validate/query BIDS datasets";
+    changelog = "https://github.com/ANCPLabOldenburg/ancp-bids/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ bcdarwin ];
   };


### PR DESCRIPTION
## Description of changes

Unbreak by removing obsolete patch (broken by mass Python updates); add changelog; slightly refactor `buildPythonPackage` arguments.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
