### PR TITLE
buildFlutterApplication: prevent conflicting app directories

### DIFF
--- a/pkgs/applications/misc/yubioath-flutter/default.nix
+++ b/pkgs/applications/misc/yubioath-flutter/default.nix
@@ -46,21 +46,21 @@ flutter322.buildFlutterApplication rec {
 
   postInstall = ''
     # Swap the authenticator-helper symlink with the correct symlink.
-    ln -fs "${passthru.helper}/bin/authenticator-helper" "$out/app/helper/authenticator-helper"
+    ln -fs "${passthru.helper}/bin/authenticator-helper" "$out/app/$pname/helper/authenticator-helper"
 
     # Move the icon.
     mkdir $out/share/icons
-    mv $out/app/linux_support/com.yubico.yubioath.png $out/share/icons
+    mv $out/app/$pname/linux_support/com.yubico.yubioath.png $out/share/icons
 
     # Cleanup.
     rm -rf \
-      "$out/app/README.adoc" \
-      "$out/app/desktop_integration.sh" \
-      "$out/app/linux_support" \
+      "$out/app/$pname/README.adoc" \
+      "$out/app/$pname/desktop_integration.sh" \
+      "$out/app/$pname/linux_support" \
       $out/bin/* # We will repopulate this directory later.
 
     # Symlink binary.
-    ln -sf "$out/app/authenticator" "$out/bin/yubioath-flutter"
+    ln -sf "$out/app/$pname/authenticator" "$out/bin/yubioath-flutter"
 
     # Set the correct path to the binary in desktop file.
     substituteInPlace "$out/share/applications/com.yubico.authenticator.desktop" \

--- a/pkgs/by-name/fi/finamp/package.nix
+++ b/pkgs/by-name/fi/finamp/package.nix
@@ -33,7 +33,7 @@ flutter322.buildFlutterApplication {
   };
 
   postFixup = ''
-    patchelf $out/app/finamp --add-needed libisar.so --add-needed libmpv.so --add-rpath ${lib.makeLibraryPath [ mpv-unwrapped ]}
+    patchelf $out/app/$pname/finamp --add-needed libisar.so --add-needed libmpv.so --add-rpath ${lib.makeLibraryPath [ mpv-unwrapped ]}
   '';
 
   postInstall = ''

--- a/pkgs/by-name/in/intiface-central/package.nix
+++ b/pkgs/by-name/in/intiface-central/package.nix
@@ -50,11 +50,13 @@ flutterPackages.v3_19.buildFlutterApplication rec {
 
   # without this, only the splash screen will be shown and the logs will contain the
   # line `Failed to load dynamic library 'lib/libintiface_engine_flutter_bridge.so'`
-  extraWrapProgramArgs = "--chdir $out/app";
+  # Environmental variables don't quite eval outside of hooks so use pname and
+  # version directly.
+  extraWrapProgramArgs = "--chdir $out/app/${pname}";
 
   postInstall = ''
     mkdir -p $out/share/pixmaps
-    cp $out/app/data/flutter_assets/assets/icons/intiface_central_icon.png $out/share/pixmaps/intiface-central.png
+    cp $out/app/$pname/data/flutter_assets/assets/icons/intiface_central_icon.png $out/share/pixmaps/intiface-central.png
   '';
 
   desktopItems = [

--- a/pkgs/desktops/expidus/calculator/default.nix
+++ b/pkgs/desktops/expidus/calculator/default.nix
@@ -23,16 +23,16 @@ flutter.buildFlutterApplication rec {
 
   postInstall = ''
     rm $out/bin/calculator
-    ln -s $out/app/calculator $out/bin/expidus-calculator
+    ln -s $out/app/$pname/calculator $out/bin/expidus-calculator
 
     mkdir -p $out/share/applications
-    mv $out/app/data/com.expidusos.calculator.desktop $out/share/applications
+    mv $out/app/$pname/data/com.expidusos.calculator.desktop $out/share/applications
 
     mkdir -p $out/share/icons
-    mv $out/app/data/com.expidusos.calculator.png $out/share/icons
+    mv $out/app/$pname/data/com.expidusos.calculator.png $out/share/icons
 
     mkdir -p $out/share/metainfo
-    mv $out/app/data/com.expidusos.calculator.metainfo.xml $out/share/metainfo
+    mv $out/app/$pname/data/com.expidusos.calculator.metainfo.xml $out/share/metainfo
 
     substituteInPlace "$out/share/applications/com.expidusos.calculator.desktop" \
       --replace "Exec=calculator" "Exec=$out/bin/expidus-calculator" \

--- a/pkgs/desktops/expidus/file-manager/default.nix
+++ b/pkgs/desktops/expidus/file-manager/default.nix
@@ -23,16 +23,16 @@ flutter.buildFlutterApplication rec {
 
   postInstall = ''
     rm $out/bin/file_manager
-    ln -s $out/app/file_manager $out/bin/expidus-file-manager
+    ln -s $out/app/$pname/file_manager $out/bin/expidus-file-manager
 
     mkdir -p $out/share/applications
-    mv $out/app/data/com.expidusos.file_manager.desktop $out/share/applications
+    mv $out/app/$pname/data/com.expidusos.file_manager.desktop $out/share/applications
 
     mkdir -p $out/share/icons
-    mv $out/app/data/com.expidusos.file_manager.png $out/share/icons
+    mv $out/app/$pname/data/com.expidusos.file_manager.png $out/share/icons
 
     mkdir -p $out/share/metainfo
-    mv $out/app/data/com.expidusos.file_manager.metainfo.xml $out/share/metainfo
+    mv $out/app/$pname/data/com.expidusos.file_manager.metainfo.xml $out/share/metainfo
 
     substituteInPlace "$out/share/applications/com.expidusos.file_manager.desktop" \
       --replace "Exec=file_manager" "Exec=$out/bin/expidus-file-manager" \

--- a/pkgs/development/compilers/flutter/build-support/build-flutter-application.nix
+++ b/pkgs/development/compilers/flutter/build-support/build-flutter-application.nix
@@ -146,21 +146,22 @@ let
         built=build/linux/*/$flutterMode/bundle
 
         mkdir -p $out/bin
-        mv $built $out/app
+        mkdir -p $out/app
+        mv $built $out/app/$pname
 
-        for f in $(find $out/app -iname "*.desktop" -type f); do
+        for f in $(find $out/app/$pname -iname "*.desktop" -type f); do
           install -D $f $out/share/applications/$(basename $f)
         done
 
-        for f in $(find $out/app -maxdepth 1 -type f); do
+        for f in $(find $out/app/$pname -maxdepth 1 -type f); do
           ln -s $f $out/bin/$(basename $f)
         done
 
         # make *.so executable
-        find $out/app -iname "*.so" -type f -exec chmod +x {} +
+        find $out/app/$pname -iname "*.so" -type f -exec chmod +x {} +
 
         # remove stuff like /build/source/packages/ubuntu_desktop_installer/linux/flutter/ephemeral
-        for f in $(find $out/app -executable -type f); do
+        for f in $(find $out/app/$pname -executable -type f); do
           if patchelf --print-rpath "$f" | grep /build; then # this ignores static libs (e,g. libapp.so) also
             echo "strip RPath of $f"
             newrp=$(patchelf --print-rpath $f | sed -r "s|/build.*ephemeral:||g" | sed -r "s|/build.*profile:||g")


### PR DESCRIPTION
## Description of changes

Place app directories in `$out/app/$name` to prevent `environment.systemPackages` to complain about colliding app directories. This should result in paths like `$out/app/example-1.2.3`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
