### PR TITLE
vscode-extensions.chenglou92.rescript-vscode: 1.54.0 → 1.58.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/default.nix
@@ -5,7 +5,7 @@
   callPackage,
 }:
 let
-  version = "1.54.0";
+  version = "1.58.0";
   rescript-editor-analysis = callPackage ./rescript-editor-analysis.nix { inherit version; };
   arch =
     if stdenv.hostPlatform.isLinux then
@@ -21,7 +21,7 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
     name = "rescript-vscode";
     publisher = "chenglou92";
     inherit version;
-    hash = "sha256-c7TJED5YpHRwn7Ooq8sG+N99b7tH6TOgeC9TTYdb4JA=";
+    hash = "sha256-EuEBbtdCaS4l8ykkxyLLMjEnUMs0IsXoc994a8Pw1Ws=";
   };
   postPatch = ''
     rm -r ${analysisDir}

--- a/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
+++ b/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     owner = "rescript-lang";
     repo = "rescript-vscode";
     rev = version;
-    hash = "sha256-+Ht8qWwxtFWHFMiV/aoZIs2S3SxkOWgdwSKN+akp/LU=";
+    hash = "sha256-v+qCVge57wvA97mtzbxAX9Fvi7ruo6ZyIC14O8uWl9Y=";
   };
 
   nativeBuildInputs = [
@@ -25,16 +25,12 @@ stdenv.mkDerivation {
     ocamlPackages.cppo
   ];
 
-  # Skip testing phases because they need to download and install node modules
-  postPatch = ''
-    cd analysis
-    substituteInPlace Makefile \
-      --replace "build: build-analysis-binary build-reanalyze build-tests" "build: build-analysis-binary" \
-      --replace "test: test-analysis-binary test-reanalyze" "test: test-analysis-binary"
+  buildPhase = ''
+    dune build -p analysis
   '';
 
   installPhase = ''
-    install -D -m0555 rescript-editor-analysis.exe $out/bin/rescript-editor-analysis.exe
+    install -D -m0555 _build/default/analysis/bin/main.exe $out/bin/rescript-editor-analysis.exe
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes

Compat with latest OCaml.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
