### PR TITLE
python312Packages.optimistix: init at 0.0.8

### DIFF
--- a/pkgs/development/python-modules/lineax/default.nix
+++ b/pkgs/development/python-modules/lineax/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  equinox,
+  jax,
+  jaxtyping,
+  typing-extensions,
+
+  # tests
+  beartype,
+  pytest,
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "lineax";
+  version = "0.0.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "patrick-kidger";
+    repo = "lineax";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-rM3H+q75F98eEIJkEszWgxD5C5vGK5RlYtVv8GD/VC0=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    equinox
+    jax
+    jaxtyping
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "lineax" ];
+
+  nativeCheckInputs = [
+    beartype
+    pytest
+  ];
+
+  # Intentionaly not using pytest directly as it leads to JAX out-of-memory'ing
+  # https://github.com/patrick-kidger/lineax/blob/1909d190c1963d5f2d991508c1b2714f2266048b/tests/README.md
+  checkPhase = ''
+    runHook preCheck
+
+    ${python.interpreter} -m tests
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Linear solvers in JAX and Equinox";
+    homepage = "https://github.com/patrick-kidger/lineax";
+    changelog = "https://github.com/patrick-kidger/lineax/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/optimistix/default.nix
+++ b/pkgs/development/python-modules/optimistix/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  equinox,
+  jax,
+  jaxtyping,
+  lineax,
+  typing-extensions,
+
+  # checks
+  beartype,
+  jaxlib,
+  optax,
+  pytestCheckHook,
+  pytest-xdist,
+}:
+
+buildPythonPackage rec {
+  pname = "optimistix";
+  version = "0.0.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "patrick-kidger";
+    repo = "optimistix";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-0ehNApiBoiAb8LFBW81ZCRPsjTVQG8zRTVSAp7oHF8w=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    equinox
+    jax
+    jaxtyping
+    lineax
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "optimistix" ];
+
+  nativeCheckInputs = [
+    beartype
+    jaxlib
+    optax
+    pytestCheckHook
+    pytest-xdist
+  ];
+
+  meta = {
+    description = "Nonlinear optimisation (root-finding, least squares, ...) in JAX+Equinox";
+    homepage = "https://github.com/patrick-kidger/optimistix";
+    changelog = "https://github.com/patrick-kidger/optimistix/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7226,6 +7226,8 @@ self: super: with self; {
 
   linear-operator = callPackage ../development/python-modules/linear-operator { };
 
+  lineax = callPackage ../development/python-modules/lineax { };
+
   linecache2 = callPackage ../development/python-modules/linecache2 { };
 
   lineedit = callPackage ../development/python-modules/lineedit { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9410,6 +9410,8 @@ self: super: with self; {
 
   optax = callPackage ../development/python-modules/optax { };
 
+  optimistix = callPackage ../development/python-modules/optimistix { };
+
   optimum = callPackage ../development/python-modules/optimum { };
 
   optree = callPackage ../development/python-modules/optree { };


### PR DESCRIPTION
## Description of changes

Add [optimistix](https://github.com/patrick-kidger/optimistix), a JAX+Equinox library for nonlinear optimisation.

- **python312Packages.lineax: init at 0.0.6**
- **python312Packages.optimistix: init at 0.0.8**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
