### PR TITLE
flake: `lib.nixpkgs.mkPkgs`

### DIFF
--- a/doc/using-nixpkgs.md
+++ b/doc/using-nixpkgs.md
@@ -2,6 +2,7 @@
 
 ```{=include=} chapters
 using/platform-support.chapter.md
+using/as-a-function.chapter.md
 using/configuration.chapter.md
 using/overlays.chapter.md
 using/overrides.chapter.md

--- a/doc/using/as-a-function.chapter.md
+++ b/doc/using/as-a-function.chapter.md
@@ -1,0 +1,151 @@
+# Nixpkgs as a Function {#sec-nixpkgs-function}
+
+Depending on how you use Nixpkgs, you may interact with it as a [Nix function].
+The Nixpkgs function returns an attribute set containing mostly packages, but also other things, such as more package sets, and functions.
+This return value is often referred to with the identifier `pkgs`, and it has a marker attribute, `_type = "pkgs";`.
+
+The Nixpkgs function can be retrieved in multiple ways.
+
+In a setup with [Nix channels], you may look up the Nixpkgs files with [`<nixpkgs>`][Nix lookup path]; for example
+
+```console
+$ nix repl -f '<nixpkgs>'
+Added 21938 variables.
+nix-repl>
+```
+
+<!-- -f: abbreviated form because it is very frequently used -->
+[`nix repl`] [`-f`][`nix repl -f`] automatically imports the Nixpkgs function and invokes it for you.
+
+Most Nix commands accept [`--arg`] and [`--argstr`] options to pass arguments to the Nixpkgs function.
+
+In an expression, you can use the `import <nixpkgs> { }` syntax to import the Nixpkgs function, and immmediately [apply] it.
+
+```nix
+let
+  pkgs = import <nixpkgs> {
+    config = { allowUnfree = true; };
+  };
+in
+```
+
+Note that these examples so far have relied on the implicit, [impure] [`builtins.currentSystem`] variable to configure the package set to be able to run on your system.
+
+If you wish not to accidentally rely on the implicit [`builtins.currentSystem`] variable, and you'd like to avoid configuration in `~/.config/nixpkgs`, you may invoke `<nixpkgs/pkgs/top-level>` instead.
+
+To make sure you can reproduce your evaluations, you may use [pinning] or locking, such as provided by [`npins`] or [Flakes].
+
+## Arguments {#sec-nixpkgs-arguments}
+
+For historical reasons, the platform and cross compilation parameters can be specified in multiple ways.
+
+If you run Nix in pure mode, or if you work with expressions for multiple host platforms, you are recommended to use `hostPlatform` for native compilation (locally or on a remote machine), and both `hostPlatform` and `buildPlatform` for cross compilation.
+
+### `hostPlatform` and `buildPlatform` {#sec-nixpkgs-arguments-platforms}
+
+- `hostPlatform` is the platform for which the package set is built. This means that the binaries in the outputs are compatible with `hostPlatform`.
+
+  You may specify this as a cpu-os string, such as `"x86_64-linux"`, or `aarch64-darwin`, or you can pass a more details platform object produced with `lib.systems`.
+
+- `buildPlatform` (default: `hostPlatform`) is the platform on which the derivations will run. The derivations produced by Nixpkgs will have a [`system` attribute] that matches `buildPlatform`, so that builds are sent to a machine that is capable of running the `builder` command, which is also configured to be compatible with `buildPlatform`.
+
+  Values are specified in the same formats as `hostPlatform`.
+
+::: {.example #ex-nixpkgs-pure-native}
+
+# Natively compiled packages
+
+This shows how to explicitly request packages that are built for a specific platform, not relying on [`builtins.currentSystem`].
+The packages will be built natively.
+
+If you request to build this on a host that is not compatible, you need a remote builder.
+
+```nix
+let
+  pkgs = imports <nixpkgs> {
+    hostPlatform = "x86_64-linux";
+  };
+in pkgs.hello
+```
+
+:::
+
+::: {.example #ex-nixpkgs-pure-cross}
+
+# Cross compiled packages
+
+This expression will produce packages that are built on `x86_64-linux` machines, but whose outputs can run on `riscv64-linux`.
+
+The expression is pure, so it will produce the same outcome even if run on e.g. an `aarch64-darwin` machine. For that to work, the macOS machine needs the packages to be available in a cache or it needs a remote builder that can build `x86_64-linux` derivations.
+
+If you were to use [`builtins.currentSystem`] for `buildPlatform`, you would be able to build the packages directly on any machine, but the resulting store paths will be different, depending on the current system.
+Especially if you are in a team that doesn't run a single CPU architecture and operating system or you use Nix on machines of more than one platform, you might notice that equivalent deployments would have different store paths, resulting in unnecessary rebuilds, more store path copying, and unnecessary updates to equivalent configurations with different `buildPlatform`s.
+For these reason, it is recommended to use pure configurations where the platform parameters are set to fixed values for each deployment target.
+
+```nix
+let
+  pkgs = imports <nixpkgs> {
+    hostPlatform = "riscv64-linux";
+    buildPlatform = "x86_64-linux";
+  };
+in pkgs.hello
+```
+
+:::
+
+### Legacy arguments `system`, `localSystem` and `crossSystem` {#sec-nixpkgs-arguments-systems-legacy}
+
+These parameters existed before [`hostPlatform` and `buildPlatform`](#sec-nixpkgs-arguments-platforms) were introduced.
+They are still supported, but are not recommended for new code.
+
+The main difference is that these parameters default to [`builtins.currentSystem`], which is not recommended for pure code.
+
+Furthermore, their design is optimized for impure command line use.
+
+Unlike `hostPlatform`, `crossSystem` is not always set, so it does not make for a nice abstraction of compilation.
+
+<!-- This example transgresses the guidelines a bit, but we have an audience here that needs answers, because who likes change. Without explanation, this comes across as a superficial, unnecessary and annoying change. Remove this example in 2026 when it is irrelevant. -->
+For example, [`nixos-generate-config`] wasn't initially able to set the platform in `hardware-configuration.nix` without making assumptions about cross versus native compilation, resulting in a need for you to manually specify `system` when Flakes were introduced.
+
+### `config` {#sec-nixpkgs-arguments-config}
+
+Example:
+
+```nix
+import <nixpkgs> { config = { allowUnfree = true; }; }
+```
+
+See [Configuration](#sec-config-options-reference) for details.
+
+### `overlays` {#sec-nixpkgs-arguments-overlays}
+
+Overlays are expressions that modify the package set.
+
+See [Overlays](#chap-overlays) for more information.
+
+### `crossOverlays` {#sec-nixpkgs-arguments-crossOverlays}
+
+<!-- Source: https://matthewbauer.us/slides/always-be-cross-compiling.pdf -->
+Cross overlays apply only to the final package set in cross compilation.
+This means that [`buildPackages`] and [`nativeBuildInputs`] are unaffected by these overlays and this increases the number of build dependencies that can be retrieved from the cache, or can be reused from a previous build.
+
+[Nix function]: https://nix.dev/manual/nix/latest/language/constructs.html#functions
+[Nix channels]: https://nix.dev/manual/nix/latest/command-ref/nix-channel.html
+[Nix lookup path]: https://nix.dev/manual/nix/latest/language/constructs/lookup-path.html
+[`builtins.currentSystem`]: https://nix.dev/manual/nix/latest/language/builtin-constants.html#builtins-currentSystem
+[`system` attribute]: https://nix.dev/manual/nix/latest/language/derivations#attr-system
+[`--arg`]: https://nix.dev/manual/nix/latest/command-ref/opt-common.html?highlight=--arg#opt-arg
+[`--argstr`]: https://nix.dev/manual/nix/latest/command-ref/opt-common.html?highlight=--argstr#opt-argstr
+[apply]: https://nix.dev/manual/nix/latest/language/operators
+[impure]: https://nix.dev/manual/nix/latest/command-ref/conf-file.html?highlight=pure-eval#conf-pure-eval
+[`npins`]: https://nix.dev/guides/recipes/dependency-management.html
+[Flakes]: https://nix.dev/concepts/flakes.html#flakes
+[pinning]: https://nix.dev/reference/pinning-nixpkgs.html
+<!-- TODO: publish NixOS man pages -->
+[`nixos-generate-config`]: https://nixos.org/manual/nixos/stable/#sec-installation
+<!-- TODO: make more specific -->
+[`buildPackages`]: #ssec-cross-dependency-implementation
+<!-- TODO: make more specific -->
+[`nativeBuildInputs`]: #ssec-stdenv-dependencies-propagated
+[`nix repl`]: https://nix.dev/manual/nix/latest/command-ref/new-cli/nix3-repl.html
+[`nix repl -f`]: https://nix.dev/manual/nix/latest/command-ref/new-cli/nix3-repl?highlight=--file#opt-file

--- a/doc/using/as-a-function.chapter.md
+++ b/doc/using/as-a-function.chapter.md
@@ -95,6 +95,8 @@ in pkgs.hello
 
 ### Legacy arguments `system`, `localSystem` and `crossSystem` {#sec-nixpkgs-arguments-systems-legacy}
 
+`crossSystem` and `system` (or `localSystem`) are ok to use on the command line, but are not recommended for pure Nix code (such as Nix flakes), or Nix code that manages the invocation of the Nixpkgs function.
+
 These parameters existed before [`hostPlatform` and `buildPlatform`](#sec-nixpkgs-arguments-platforms) were introduced.
 They are still supported, but are not recommended for new code.
 

--- a/doc/using/as-a-function.chapter.md
+++ b/doc/using/as-a-function.chapter.md
@@ -98,12 +98,15 @@ in pkgs.hello
 These parameters existed before [`hostPlatform` and `buildPlatform`](#sec-nixpkgs-arguments-platforms) were introduced.
 They are still supported, but are not recommended for new code.
 
-The main difference is that these parameters default to [`builtins.currentSystem`], which is not recommended for pure code.
+The main difference is that these parameters default to [`builtins.currentSystem`], which does not work for pure code.
 
 Furthermore, their design is optimized for impure command line use.
 
-Unlike `hostPlatform`, `crossSystem` is not always set, so it does not make for a nice abstraction of compilation.
+The term "local" is misleading, because it need not match the platform where the Nix command is run.
 
+The term "cross" is also misleading because its value may equal `localSystem`.
+
+Finally `crossSystem` may have to be unset as an input, complicating some code that calls the Nixpkgs function.
 <!-- This example transgresses the guidelines a bit, but we have an audience here that needs answers, because who likes change. Without explanation, this comes across as a superficial, unnecessary and annoying change. Remove this example in 2026 when it is irrelevant. -->
 For example, [`nixos-generate-config`] wasn't initially able to set the platform in `hardware-configuration.nix` without making assumptions about cross versus native compilation, resulting in a need for you to manually specify `system` when Flakes were introduced.
 

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,59 @@
               ];
             } // builtins.removeAttrs args [ "modules" ]
           );
+
+        /**
+          The public interface to the Nixpkgs package set
+
+          This sublibrary is part of the Nixpkgs flake, but not part of the Nixpkgs library.
+         */
+        # NOTE: Almost everything about Nixpkgs lives in the `pkgs` attribute set,
+        #       so we better make very sure that if we add something here it really
+        #       belongs here and we have a good plan for whatever kind of thing that is.
+        nixpkgs = {
+          /**
+            _Create the Nixpkgs package set_
+
+            See <https://nixos.org/manual/nixpkgs/unstable/index.html#sec-nixpkgs-function> for details descriptions of the arguments.
+
+            # Inputs
+
+            - `hostPlatform` (string or platform): The platform on which the packages will run.
+
+            - `buildPlatform` (string or platform): The platform on which the derivations are built. Default: `hostPlatform`.
+
+            - `config` (attrset): See <https://nixos.org/manual/nixpkgs/unstable/index.html#sec-nixpkgs-arguments-config>.
+
+            - `overlays` (list of functions): List of overlays layers used to modify Nixpkgs.
+
+            - `crossOverlays` (list of functions): List of overlays layers used to modify the host packages only.
+
+            # Return value
+
+            The "pkgs" attribute set, containing:
+            - packages
+            - package sets
+            - other things such as functions that rely on the package set
+            - `_type = "pkgs";`
+           */
+          # Note to developers:
+          # This intentionally omits legacy arguments like `localSystem`
+          # and `crossSystem`, so that the ecosystem moves towards a more
+          # consistent terminology and usage. Please don't add them.
+          # You won't be required to use this until perhaps we deprecate
+          # inputs.nixpkgs.outPath (used by `import`), which would require a
+          # change in Nix that may take another while.
+          mkPkgs = args@{
+            hostPlatform,
+            buildPlatform ? null, # default handled downstream
+            config ? null, # default handled downstream
+            overlays ? null, # default handled downstream
+            crossOverlays ? null, # default handled downstream
+            stdenvStages ? null, # default handled downstream
+          }:
+            import ./pkgs/top-level/default.nix args;
+        };
+
       });
 
       checks = forAllSystems (system: {

--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -1,3 +1,4 @@
+# nix-build -A tests.top-level
 { lib, pkgs, ... }:
 let
   nixpkgsFun = import ../../top-level;
@@ -44,4 +45,177 @@ lib.recurseIntoAttrs {
     assert lib.all (p: p.buildPlatform == p.hostPlatform) pkgsLocal;
     assert lib.all (p: p.buildPlatform != p.hostPlatform) pkgsCross;
     pkgs.emptyFile;
+
+  invocations-pure =
+    let
+      inherit (lib.systems) elaborate;
+      assertEqualPkgPlatforms = a: b:
+        # NOTE: equals should become obsolete, but currently isn't when comparing
+        #       between two distinct Nixpkgs invocations
+        #       `equals` should not be used in most places because it is a bit slow.
+        assert lib.systems.equals a.stdenv.hostPlatform b.stdenv.hostPlatform;
+        assert lib.systems.equals a.stdenv.buildPlatform b.stdenv.buildPlatform;
+        assert lib.systems.equals a.stdenv.targetPlatform b.stdenv.targetPlatform;
+        true;
+
+      native-s = import ../../.. { system = "i686-linux"; };
+      native-ls = import ../../.. { localSystem.system = "i686-linux"; };
+      native-le = import ../../.. { localSystem = lib.systems.elaborate "i686-linux"; };
+      native-h = import ../../.. { hostPlatform = "i686-linux"; };
+      native-he = import ../../.. { hostPlatform = lib.systems.elaborate "i686-linux"; };
+
+      cross-1-s-cs = import ../../.. { system = "i686-linux"; crossSystem = "armv7l-linux"; };
+      cross-1-s-css = import ../../.. { system = "i686-linux"; crossSystem.system = "armv7l-linux"; };
+      cross-1-s-cse = import ../../.. { system = "i686-linux"; crossSystem = elaborate "armv7l-linux"; };
+      cross-1-ls-cs = import ../../.. { localSystem.system = "i686-linux"; crossSystem = "armv7l-linux"; };
+      cross-1-ls-css = import ../../.. { localSystem.system = "i686-linux"; crossSystem.system = "armv7l-linux"; };
+      cross-1-ls-cse = import ../../.. { localSystem.system = "i686-linux"; crossSystem = elaborate "armv7l-linux"; };
+      cross-1-le-cs = import ../../.. { localSystem = elaborate "i686-linux"; crossSystem = "armv7l-linux"; };
+      cross-1-le-css = import ../../.. { localSystem = elaborate "i686-linux"; crossSystem.system = "armv7l-linux"; };
+      cross-1-le-cse = import ../../.. { localSystem = elaborate "i686-linux"; crossSystem = elaborate "armv7l-linux"; };
+      cross-1-b-h = import ../../.. { buildPlatform = "i686-linux"; hostPlatform = "armv7l-linux"; };
+      cross-1-b-hs = import ../../.. { buildPlatform = "i686-linux"; hostPlatform.system = "armv7l-linux"; };
+      cross-1-b-he = import ../../.. { buildPlatform = "i686-linux"; hostPlatform = elaborate "armv7l-linux"; };
+      cross-1-bs-h = import ../../.. { buildPlatform.system = "i686-linux"; hostPlatform = "armv7l-linux"; };
+      cross-1-bs-hs = import ../../.. { buildPlatform.system = "i686-linux"; hostPlatform.system = "armv7l-linux"; };
+      cross-1-bs-he = import ../../.. { buildPlatform.system = "i686-linux"; hostPlatform = elaborate "armv7l-linux"; };
+      cross-1-be-h = import ../../.. { buildPlatform = elaborate "i686-linux"; hostPlatform = "armv7l-linux"; };
+      cross-1-be-hs = import ../../.. { buildPlatform = elaborate "i686-linux"; hostPlatform.system = "armv7l-linux"; };
+      cross-1-be-he = import ../../.. { buildPlatform = elaborate "i686-linux"; hostPlatform = elaborate "armv7l-linux"; };
+
+    in
+
+    # NATIVE
+    # ------
+
+    assert lib.systems.equals native-s.stdenv.hostPlatform (elaborate "i686-linux");
+    assert lib.systems.equals native-s.stdenv.buildPlatform (elaborate "i686-linux");
+
+    # sample reflexivity (sanity check)
+    assert assertEqualPkgPlatforms native-s native-s;
+    # check the rest (assume transitivity to avoid n^2 checks)
+    assert assertEqualPkgPlatforms native-s native-ls;
+    assert assertEqualPkgPlatforms native-s native-le;
+    assert assertEqualPkgPlatforms native-s native-h;
+    assert assertEqualPkgPlatforms native-s native-he;
+
+    # These pairs must be identical
+    assert native-s.stdenv.hostPlatform == native-s.stdenv.buildPlatform;
+    assert native-ls.stdenv.hostPlatform == native-ls.stdenv.buildPlatform;
+    assert native-le.stdenv.hostPlatform == native-le.stdenv.buildPlatform;
+    assert native-h.stdenv.hostPlatform == native-h.stdenv.buildPlatform;
+    assert native-he.stdenv.hostPlatform == native-he.stdenv.buildPlatform;
+
+
+    # CROSS
+    # -----
+
+    assert lib.systems.equals cross-1-s-cs.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-s-cs.stdenv.buildPlatform (elaborate "i686-linux");
+
+    # sample reflexivity (sanity check)
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-s-cs;
+    # check the rest (assume transitivity to avoid n^2 checks)
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-s-css;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-s-cse;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-ls-cs;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-ls-css;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-ls-cse;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-le-cs;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-le-css;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-le-cse;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-b-h;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-b-hs;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-b-he;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-bs-h;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-bs-hs;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-bs-he;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-be-h;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-be-hs;
+    assert assertEqualPkgPlatforms cross-1-s-cs cross-1-be-he;
+
+    assert lib.systems.equals cross-1-s-cs.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-s-css.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-s-cse.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-ls-cs.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-ls-css.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-ls-cse.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-le-cs.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-le-css.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-le-cse.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-b-h.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-b-hs.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-b-he.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-bs-h.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-bs-hs.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-bs-he.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-be-h.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-be-hs.stdenv.hostPlatform (elaborate "armv7l-linux");
+    assert lib.systems.equals cross-1-be-he.stdenv.hostPlatform (elaborate "armv7l-linux");
+
+    assert lib.systems.equals cross-1-s-cs.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-s-css.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-s-cse.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-ls-cs.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-ls-css.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-ls-cse.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-le-cs.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-le-css.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-le-cse.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-b-h.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-b-hs.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-b-he.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-bs-h.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-bs-hs.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-bs-he.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-be-h.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-be-hs.stdenv.buildPlatform (elaborate "i686-linux");
+    assert lib.systems.equals cross-1-be-he.stdenv.buildPlatform (elaborate "i686-linux");
+
+    # builtins.trace ''
+    #   Tests passed, but note that the impure use cases are not included here.
+
+    #   Impurely specified native compilation,
+    #   currentSystem as build -> currentSystem as host:
+
+    #       nix-build -A hello
+
+    #   Impurely specified cross compilation for specified host,
+    #   currentSystem as build -> crossSystem as host:
+
+    #       nix-build --argstr crossSystem armv7l-linux -A hello
+
+    # ''
+
+
+
+    pkgs.emptyFile;
+
+  invocations-impure =
+    if !builtins?currentSystem
+    then
+      lib.trace
+        "Skipping invocations-impure test, because we don't have currentSystem here. Don't forget to also run the top-level tests in impure mode!"
+        pkgs.emptyFile
+    else
+      let
+        # As a mere expression, we don't get to pick currentSystem, so we have to
+        # pick a different one dynamically.
+        otherSystem = if builtins.currentSystem == "x86_64-linux" then "aarch64-linux" else "x86_64-linux";
+        otherSystemElaborated = lib.systems.elaborate otherSystem;
+        currentSystemElaborated = lib.systems.elaborate builtins.currentSystem;
+
+        impureNative = import ../../.. { };
+        impureCross = import ../../.. { crossSystem = otherSystem; };
+      in
+        # Obviously
+        assert ! lib.systems.equals currentSystemElaborated otherSystemElaborated;
+
+        assert lib.systems.equals impureNative.stdenv.hostPlatform currentSystemElaborated;
+        assert lib.systems.equals impureNative.stdenv.buildPlatform currentSystemElaborated;
+
+        assert lib.systems.equals impureCross.stdenv.hostPlatform otherSystemElaborated;
+        assert lib.systems.equals impureCross.stdenv.buildPlatform currentSystemElaborated;
+
+        pkgs.emptyFile;
 }

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -17,7 +17,8 @@
    or dot-files. */
 
 let
-  # This is not pkgs/top-level/impure.nix or default.nix, so we'll need at least something.
+  # This file has pure behavior, unlike pkgs/top-level/impure.nix or default.nix,
+  # so we can't infer everything from the expression language environment.
   noArgumentError =
     abort ''
       You must specify the hostPlatform argument to nixpkgs, to specify the platform on which the packages will run.
@@ -27,11 +28,11 @@ let
 in
 {
   # Where the packages will run
-  # TODO: document in the manual
+  # See doc/using/as-a-function.chapter.md
   hostPlatform ? noArgumentError,
 
   # Where the derivations are built. Default: hostPlatform.
-  # TODO: document in the manual
+  # See doc/using/as-a-function.chapter.md
   buildPlatform ? hostPlatform,
 
   # (legacy) The system packages will be built on. See the manual for the

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -16,15 +16,33 @@
    evaluation is taking place, and the configuration from environment variables
    or dot-files. */
 
-{ # The system packages will be built on. See the manual for the
+let
+  # This is not pkgs/top-level/impure.nix or default.nix, so we'll need at least something.
+  noArgumentError =
+    abort ''
+      You must specify the hostPlatform argument to nixpkgs, to specify the platform on which the packages will run.
+      Example:
+        nixpkgs { hostPlatform = "x86_64-linux"; }
+    '';
+in
+{
+  # Where the packages will run
+  # TODO: document in the manual
+  hostPlatform ? noArgumentError,
+
+  # Where the derivations are built. Default: hostPlatform.
+  # TODO: document in the manual
+  buildPlatform ? hostPlatform,
+
+  # (legacy) The system packages will be built on. See the manual for the
   # subtle division of labor between these two `*System`s and the three
   # `*Platform`s.
-  localSystem
+  localSystem ? noArgumentError,
 
-, # The system packages will ultimately be run on.
-  crossSystem ? localSystem
+  # (legacy) The system packages will ultimately be run on.
+  crossSystem ? localSystem,
 
-, # Allow a configuration attribute set to be passed in as an argument.
+  # Allow a configuration attribute set to be passed in as an argument.
   config ? {}
 
 , # List of overlays layers used to extend Nixpkgs.
@@ -49,16 +67,42 @@ let # Rename the function arguments
 in let
   lib = import ../../lib;
 
-  inherit (lib) throwIfNot;
+  inherit (lib) intersectAttrs throwIfNot throwIf;
+
+  legacySystemArgsUsed = intersectAttrs { system = null; localSystem = null; crossSystem = null; } args;
+
+  intentToCrossCompile =
+    # is it legacy cross?
+    (args?localSystem && !lib.systems.equals crossSystem localSystem)
+    || # is it new cross?
+    (args?buildPlatform && args?hostPlatform && !lib.systems.equals crossSystem localSystem);
 
   checked =
     throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list."
     lib.foldr (x: throwIfNot (lib.isFunction x) "All overlays passed to nixpkgs must be functions.") (r: r) overlays
     throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list."
     lib.foldr (x: throwIfNot (lib.isFunction x) "All crossOverlays passed to nixpkgs must be functions.") (r: r) crossOverlays
+    throwIf (args?buildPlatform && !args?hostPlatform) ''
+      nixpkgs: You have only specified buildPlatform, but not hostPlatform.
+        - For cross compilation: specify both
+        - For native compilation: just specify hostPlatform; buildPlatform defaults to it
+    ''
+    throwIf (args?hostPlatform && (legacySystemArgsUsed != {})) ''
+      nixpkgs: You have specified hostPlatform, but also one of the system, localSystem, or crossSystem.
+      Mixing legacy system arguments and hostPlatform is not supported.
+      ${if intentToCrossCompile then ''
+        For cross compilation, please specify the nixpkgs arguments
+          - hostPlatform: the platform on which the packages will run
+          - buildPlatform: the platform on which the derivations are built
+      '' else ""}
+      If you are not cross-compiling, please specify only hostPlatform.
+    ''
     ;
 
-  localSystem = lib.systems.elaborate args.localSystem;
+  localSystem =
+    if args?hostPlatform
+    then lib.systems.elaborate buildPlatform
+    else lib.systems.elaborate args.localSystem;
 
   # Condition preserves sharing which in turn affects equality.
   #
@@ -73,10 +117,18 @@ in let
   # Both systems are semantically equivalent as the same vendor and ABI are
   # inferred from the system double in `localSystem`.
   crossSystem =
-    let system = lib.systems.elaborate crossSystem0; in
-    if crossSystem0 == null || lib.systems.equals system localSystem
-    then localSystem
-    else system;
+    if args?hostPlatform
+      then
+        if lib.systems.equals (lib.systems.elaborate buildPlatform) (lib.systems.elaborate hostPlatform)
+        then
+          # If equal, make them identical, so `==` works on this pair of platforms.
+          localSystem
+        else (lib.systems.elaborate hostPlatform)
+      else
+        let system = lib.systems.elaborate crossSystem0; in
+        if crossSystem0 == null || lib.systems.equals system localSystem
+        then localSystem
+        else system;
 
   # Allow both:
   # { /* the config */ } and


### PR DESCRIPTION
## Description of changes

Depends on https://github.com/NixOS/nixpkgs/pull/324614 (and includes it for now)
=> Only review the final commit(s?)

Adds a nicer Nixpkgs entrypoint that
- Does not rely being able to access files in a Flake (something which Flakes seems to have done for ease of adoption; it's bad design)
- Has `nix-repl> :doc` documentation
- Does not carry unnecessary baggage and inconsistencies
- Does not require `--ignore-try` when debugging, because it doesn't try impure stuff (TODO double check)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
