### PR TITLE
nixos/logrotate: test hardened logrotate service

### DIFF
--- a/nixos/tests/logrotate.nix
+++ b/nixos/tests/logrotate.nix
@@ -1,82 +1,94 @@
 # Test logrotate service works and is enabled by default
 
 let
-  importTest = { ... }: {
-    services.logrotate.settings.import = {
-      olddir = false;
+  importTest =
+    { ... }:
+    {
+      services.logrotate.settings.import = {
+        olddir = false;
+      };
     };
-  };
 
 in
 
-import ./make-test-python.nix ({ pkgs, ... }: rec {
-  name = "logrotate";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ martinetd ];
-  };
-
-  nodes = {
-    defaultMachine = { ... }: {
-      services.logrotate.enable = true;
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  rec {
+    name = "logrotate";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ martinetd ];
     };
-    failingMachine = { ... }: {
-      services.logrotate = {
-        enable = true;
-        configFile = pkgs.writeText "logrotate.conf" ''
-          # self-written config file
-          su notarealuser notagroupeither
-        '';
-      };
-    };
-    machine = { config, ... }: {
-      imports = [ importTest ];
 
-      services.logrotate = {
-        enable = true;
-        settings = {
-          # remove default frequency header and add another
-          header = {
-            frequency = null;
-            delaycompress = true;
-          };
-          # extra global setting... affecting nothing
-          last_line = {
-            global = true;
-            priority = 2000;
-            shred = true;
-          };
-          # using mail somewhere should add --mail to logrotate invocation
-          sendmail = {
-            mail = "user@domain.tld";
-          };
-          # postrotate should be suffixed by 'endscript'
-          postrotate = {
-            postrotate = "touch /dev/null";
-          };
-          # check checkConfig works as expected: there is nothing to check here
-          # except that the file build passes
-          checkConf = {
-            su = "root utmp";
-            createolddir = "0750 root utmp";
-            create = "root utmp";
-            "create " = "0750 root utmp";
-          };
-          # multiple paths should be aggregated
-          multipath = {
-            files = [ "file1" "file2" ];
-          };
-          # overriding imported path should keep existing attributes
-          # (e.g. olddir is still set)
-          import = {
-            notifempty = true;
+    nodes = {
+      defaultMachine =
+        { ... }:
+        {
+          services.logrotate.enable = true;
+        };
+      failingMachine =
+        { ... }:
+        {
+          services.logrotate = {
+            enable = true;
+            configFile = pkgs.writeText "logrotate.conf" ''
+              # self-written config file
+              su notarealuser notagroupeither
+            '';
           };
         };
-      };
-    };
-  };
+      machine =
+        { config, ... }:
+        {
+          imports = [ importTest ];
 
-  testScript =
-    ''
+          services.logrotate = {
+            enable = true;
+            settings = {
+              # remove default frequency header and add another
+              header = {
+                frequency = null;
+                delaycompress = true;
+              };
+              # extra global setting... affecting nothing
+              last_line = {
+                global = true;
+                priority = 2000;
+                shred = true;
+              };
+              # using mail somewhere should add --mail to logrotate invocation
+              sendmail = {
+                mail = "user@domain.tld";
+              };
+              # postrotate should be suffixed by 'endscript'
+              postrotate = {
+                postrotate = "touch /dev/null";
+              };
+              # check checkConfig works as expected: there is nothing to check here
+              # except that the file build passes
+              checkConf = {
+                su = "root utmp";
+                createolddir = "0750 root utmp";
+                create = "root utmp";
+                "create " = "0750 root utmp";
+              };
+              # multiple paths should be aggregated
+              multipath = {
+                files = [
+                  "file1"
+                  "file2"
+                ];
+              };
+              # overriding imported path should keep existing attributes
+              # (e.g. olddir is still set)
+              import = {
+                notifempty = true;
+              };
+            };
+          };
+        };
+    };
+
+    testScript = ''
       with subtest("whether logrotate works"):
           # we must rotate once first to create logrotate stamp
           defaultMachine.succeed("systemctl start logrotate.service")
@@ -130,4 +142,5 @@ import ./make-test-python.nix ({ pkgs, ... }: rec {
       machine.log(machine.execute("systemd-analyze security logrotate.service | grep -v ✓")[1])
 
     '';
-})
+  }
+)


### PR DESCRIPTION
## Description of changes

Discussed in https://github.com/NixOS/nixpkgs/pull/339050

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
