### PR TITLE
mim-solvers: init at 0.0.5

### DIFF
--- a/pkgs/by-name/mi/mim-solvers/package.nix
+++ b/pkgs/by-name/mi/mim-solvers/package.nix
@@ -1,0 +1,68 @@
+{
+  cmake,
+  crocoddyl,
+  fetchFromGitHub,
+  lib,
+  llvmPackages,
+  pkg-config,
+  proxsuite,
+  python3Packages,
+  pythonSupport ? false,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mim-solvers";
+  version = "0.0.5";
+
+  src = fetchFromGitHub {
+    owner = "machines-in-motion";
+    repo = "mim_solvers";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-XV8EJqCOTYqljZe2PQvnhIaPUOJ+bBjRIoshdeqZycA=";
+  };
+
+  # eigenpy is not used without python support
+  postPatch = lib.optionalString (!pythonSupport) ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "add_project_dependency(eigenpy 2.7.10 REQUIRED)" \
+      ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ] ++ lib.optional pythonSupport python3Packages.pythonImportsCheckHook;
+  buildInputs = lib.optional stdenv.hostPlatform.isDarwin llvmPackages.openmp;
+  propagatedBuildInputs =
+    lib.optionals pythonSupport [
+      python3Packages.crocoddyl
+      python3Packages.osqp
+      python3Packages.proxsuite
+      python3Packages.scipy
+    ]
+    ++ lib.optionals (!pythonSupport) [
+      crocoddyl
+      proxsuite
+    ];
+
+  cmakeFlags =
+    [
+      (lib.cmakeBool "BUILD_PYTHON_INTERFACE" pythonSupport)
+      (lib.cmakeBool "BUILD_WITH_PROXSUITE" true)
+    ]
+    ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) (
+      lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'test_solvers'"
+    );
+
+  doCheck = true;
+  pythonImportsCheck = [ "mim_solvers" ];
+
+  meta = {
+    description = "Numerical solvers used in the Machines in Motion Laboratory";
+    homepage = "https://github.com/machines-in-motion/mim_solvers";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7870,6 +7870,11 @@ self: super: with self; {
 
   millheater = callPackage ../development/python-modules/millheater { };
 
+  mim-solvers = toPythonModule (pkgs.mim-solvers.override {
+    python3Packages = self;
+    pythonSupport = true;
+  });
+
   minari = callPackage ../development/python-modules/minari { };
 
   mindsdb-evaluator = callPackage ../development/python-modules/mindsdb-evaluator { };


### PR DESCRIPTION
## Description of changes

This add [mim-solvers](https://github.com/machines-in-motion/mim_solvers), an "Implementation of numerical solvers" used in the Machines in Motion Laboratory at  NYU.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
