### PR TITLE
librespeed-{go,rust},nixos/librespeed: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1441,6 +1441,7 @@
   ./services/web-apps/komga.nix
   ./services/web-apps/lanraragi.nix
   ./services/web-apps/lemmy.nix
+  ./services/web-apps/librespeed.nix
   ./services/web-apps/limesurvey.nix
   ./services/web-apps/mainsail.nix
   ./services/web-apps/mastodon.nix

--- a/nixos/modules/services/web-apps/librespeed.nix
+++ b/nixos/modules/services/web-apps/librespeed.nix
@@ -1,0 +1,408 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.librespeed;
+in
+{
+  options.services.librespeed =
+    let
+      inherit (lib) mkOption types;
+    in
+    {
+      enable = lib.mkEnableOption "LibreSpeed server";
+      package = lib.mkPackageOption pkgs "librespeed-rust" { };
+      domain = mkOption {
+        description = ''
+          If not `null`, this will add an entry to `services.librespeed.servers` and
+          configure librespeed to use TLS.
+        '';
+        default = null;
+        type = with types; nullOr nonEmptyStr;
+      };
+      downloadIPDB = mkOption {
+        description = ''
+          Whether to download the IP info database before starting librespeed.
+          Disable this if you want to use the Go implementation.
+        '';
+        default = !(cfg.secrets ? "ipinfo_api_key");
+        defaultText = lib.literalExpression ''!(cfg.secrets ? "ipinfo_api_key")'';
+        type = types.bool;
+      };
+      openFirewall = mkOption {
+        description = ''
+          Whether to open the firewall for the specified port.
+        '';
+        default = false;
+        type = types.bool;
+      };
+      secrets = mkOption {
+        description = ''
+          Attribute set of filesystem paths.
+          The contents of the specified paths will be read at service start time and merged with the attributes provided in `settings`.
+        '';
+        default = { };
+        type = with types; nullOr (attrsOf path);
+      };
+      settings = mkOption {
+        description = ''
+          LibreSpeed configuration written as Nix expression.
+          All values set to `null` will be excluded from the evaluated config.
+          This is useful if you want to omit certain defaults when using a different LibreSpeed implementation.
+
+          See [github.com/librespeed][librespeed] for configuration help.
+
+          [librespeed]: https://github.com/librespeed/speedtest-rust
+        '';
+        default = { };
+        type =
+          with types;
+          nullOr (
+            attrsOf (oneOf [
+              (nullOr bool)
+              int
+              str
+              package
+            ])
+          );
+      };
+      frontend = {
+        enable = lib.mkEnableOption ''
+          Enables the LibreSpeed frontend and adds a nginx virtual host if
+          not explicetly disabled and `services.librespeed.domain` is not `null`.
+        '';
+        contactEmail = mkOption {
+          description = "Email address listed in the privacy policy.";
+          default =
+            if (cfg.domain != null) then "webmaster@${cfg.domain}" else "webmaster@${config.networking.fqdn}";
+          defaultText = lib.literalExpression ''
+            if (config.services.librespeed.domain != null) then
+              "webmaster@''${config.services.librespeed.domain}"
+            else
+              "webmaster@''${config.networking.fqdn}";
+          '';
+          type = types.str;
+        };
+        pageTitle = mkOption {
+          description = "Title of the webpage.";
+          default = "LibreSpeed";
+          type = types.str;
+        };
+        useNginx = mkOption {
+          description = ''
+            Configure nginx for the LibreSpeed frontend.
+            This will only create a virtual host for the frontend and won't proxy all requests because
+            the reported upload and download speeds are inaccurate if proxied.
+          '';
+          default = cfg.domain != null;
+          defaultText = lib.literalExpression "config.services.librespeed.domain != null";
+          type = types.bool;
+        };
+        settings = mkOption {
+          description = ''
+            Override default settings of the speedtest web client.
+            See [speedtest_worker.js][link] for a list of possible values.
+
+            [link]: https://github.com/librespeed/speedtest/blob/master/speedtest_worker.js#L39
+          '';
+          default = {
+            telemetry_level = "basic";
+          };
+          type =
+            with types;
+            nullOr (
+              attrsOf (oneOf [
+                bool
+                int
+                str
+                float
+              ])
+            );
+        };
+        servers = mkOption {
+          description = "LibreSpeed servers that should apper in the server list.";
+          type = types.listOf (
+            types.submodule {
+              options =
+                let
+                  inherit (types) nonEmptyStr;
+                in
+                {
+                  name = mkOption {
+                    description = "Name shown in the server list.";
+                    type = nonEmptyStr;
+                  };
+                  server = mkOption {
+                    description = "URL to the server. You may use `//` instead of `http://` or `https://`.";
+                    type = nonEmptyStr;
+                  };
+                  dlURL = mkOption {
+                    description = ''
+                      URL path to download test on this server.
+                      Append `.php` to the default value if the server uses the php implementation.
+                    '';
+                    default = "backend/garbage";
+                    type = nonEmptyStr;
+                  };
+                  ulURL = mkOption {
+                    description = ''
+                      URL path to upload test on this server.
+                      Append `.php` to the default value if the server uses the php implementation.
+                    '';
+                    default = "backend/empty";
+                    type = nonEmptyStr;
+                  };
+                  pingURL = mkOption {
+                    description = ''
+                      URL path to latency/jitter test on this server.
+                      Append `.php` to the default value if the server uses the php implementation.
+                    '';
+                    default = "backend/empty";
+                    type = nonEmptyStr;
+                  };
+                  getIpURL = mkOption {
+                    description = ''
+                      URL path to IP lookup on this server.
+                      Append `.php` to the default value if the server uses the php implementation.
+                    '';
+                    default = "backend/getIP";
+                    type = nonEmptyStr;
+                  };
+                };
+            }
+          );
+        };
+      };
+    };
+  config = lib.mkIf cfg.enable (
+    let
+      librespeedAssets =
+        pkgs.runCommand "librespeed-assets"
+          (
+            let
+              mapValue =
+                arg:
+                if (lib.isBool arg) then
+                  lib.boolToString arg
+                else if ((lib.isInt arg) || (lib.isFloat arg)) then
+                  toString arg
+                else
+                  "\"${lib.escape [ "\"" ] (toString arg)}\"";
+
+              mapSettings = lib.pipe cfg.frontend.settings [
+                (lib.mapAttrs (name: val: "  s.setParameter(\"${lib.escape [ "\"" ] name}\",${mapValue val});"))
+                (lib.attrValues)
+                (lib.concatLines)
+              ];
+            in
+            {
+              preferLocal = true;
+
+              serversList = ''
+                function get_servers() {
+                  return ${builtins.toJSON cfg.frontend.servers}
+                }
+                function override_settings () {
+                ${mapSettings}
+                }
+              '';
+            }
+          )
+          ''
+            cp -r ${pkgs.librespeed-rust}/assets $out
+            chmod 666 $out/servers_list.js
+            cat >$out/servers_list.js <<<"$serversList"
+            substitute ${pkgs.librespeed-rust}/assets/index.html $out/index.html \
+              --replace-fail "s.setParameter(\"telemetry_level\",\"basic\"); //enable telemetry" "override_settings();" \
+              --replace-fail "LibreSpeed Example" ${lib.escapeShellArg (lib.escapeXML cfg.frontend.pageTitle)} \
+              --replace-fail "PUT@YOUR_EMAIL.HERE" ${lib.escapeShellArg (lib.escapeXML cfg.frontend.contactEmail)} \
+              --replace-fail "TO BE FILLED BY DEVELOPER" ${lib.escapeShellArg (lib.escapeXML cfg.frontend.contactEmail)}
+          '';
+    in
+    {
+      assertions = [
+        {
+          assertion = cfg.frontend.useNginx -> cfg.domain != null;
+          message = ''
+            `services.librespeed.frontend.useNginx` requires `services.librespeed.frontend.domain` to be set.
+          '';
+        }
+      ];
+
+      networking.firewall = lib.mkIf cfg.openFirewall {
+        allowedTCPPorts = [ cfg.settings.listen_port ];
+      };
+      services.nginx.virtualHosts = lib.mkIf (cfg.frontend.enable && cfg.frontend.useNginx) {
+        ${cfg.domain} = {
+          locations."/".root = librespeedAssets;
+          locations."= /servers.json".return = "200 '${builtins.toJSON cfg.frontend.servers}'";
+          locations."/backend/".return = "301 https://$host:${toString cfg.settings.listen_port}$request_uri";
+          enableACME = true;
+          forceSSL = true;
+        };
+      };
+      security.acme.certs = lib.mkIf (cfg.domain != null) {
+        ${cfg.domain} = {
+          reloadServices = [ "librespeed.service" ];
+          webroot = "/var/lib/acme/acme-challenge";
+        };
+      };
+
+      services.librespeed.frontend.servers = lib.mkIf (cfg.frontend.enable && (cfg.domain != null)) [
+        {
+          name = cfg.domain;
+          server = "//${cfg.domain}:${toString cfg.settings.listen_port}";
+        }
+      ];
+
+      services.librespeed.settings =
+        let
+          inherit (lib) mkDefault mkIf;
+        in
+        {
+          assets_path =
+            if (cfg.frontend.enable && !cfg.frontend.useNginx) then
+              librespeedAssets
+            else
+              pkgs.writeTextDir "index.html" "";
+
+          bind_address = mkDefault "::";
+          listen_port = mkDefault 8989;
+          base_url = mkDefault "backend";
+          worker_threads = mkDefault "auto";
+
+          database_type = mkDefault "none";
+          database_file = mkDefault "/var/lib/librespeed/speedtest.sqlite";
+
+          #librespeed-rust will fail to start if the following config parameters are omitted.
+          ipinfo_api_key = mkIf (!cfg.secrets ? "ipinfo_api_key") "";
+          stats_password = mkIf (!cfg.secrets ? "stats_password") "";
+          tls_cert_file =
+            if (cfg.domain != null) then
+              (mkDefault "/run/credentials/librespeed.service/cert.pem")
+            else
+              (mkDefault "");
+          tls_key_file =
+            if (cfg.domain != null) then
+              (mkDefault "/run/credentials/librespeed.service/key.pem")
+            else
+              (mkDefault "");
+
+          enable_tls = mkDefault (cfg.domain != null);
+        };
+
+      systemd.services =
+        let
+          configFile =
+            let
+              mapValue =
+                arg:
+                if (lib.isBool arg) then
+                  lib.boolToString arg
+                else if (lib.isInt arg) then
+                  toString arg
+                else
+                  "\"${lib.escape [ "\"" ] (toString arg)}\"";
+            in
+            with lib;
+            pipe cfg.settings [
+              (filterAttrs (_: val: val != null))
+              (mapAttrs (name: val: "${name}=${mapValue val}"))
+              (attrValues)
+              (concatLines)
+              (pkgs.writeText "${cfg.package.name}-config.toml")
+            ];
+        in
+        {
+          librespeed-secrets = lib.mkIf (cfg.secrets != { }) {
+            description = "LibreSpeed secret helper";
+
+            ExecStart =
+              let
+                script = pkgs.writeShellApplication {
+                  name = "librespeed-secrets";
+                  runtimeInputs = [ pkgs.coreutils ];
+                  text =
+                    ''
+                      cp ${configFile} ''${RUNTIME_DIRECTORY%%:*}/config.toml
+                    ''
+                    + lib.pipe cfg.secrets [
+                      (lib.mapAttrs (
+                        name: file: ''
+                          cat >>''${RUNTIME_DIRECTORY%%:*}/config.toml <<EOF
+                          ${name}="$(<${lib.escapeShellArg file})"
+                          EOF
+                        ''
+                      ))
+                      (lib.concatLines lib.attrValues)
+                    ];
+                };
+              in
+              lib.getExe script;
+
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              RuntimeDirectory = "librespeed";
+              UMask = "u=rw";
+            };
+          };
+          librespeed = {
+            description = "LibreSpeed server daemon";
+            wantedBy = [ "multi-user.target" ];
+            wants = [ "network-online.target" ];
+            requires = lib.optionals (cfg.secrets != { }) [ "librespeed-secrets.service" ];
+
+            serviceConfig = {
+              Type = "simple";
+              Restart = "always";
+
+              DynamicUser = true;
+
+              LoadCredential = lib.mkIf (cfg.domain != null) [
+                "cert.pem:${config.security.acme.certs.${cfg.domain}.directory}/cert.pem"
+                "key.pem:${config.security.acme.certs.${cfg.domain}.directory}/key.pem"
+              ];
+
+              ExecStartPre = lib.mkIf cfg.downloadIPDB "${lib.getExe cfg.package} --update-ipdb";
+              ExecStart = "${lib.getExe cfg.package} -c ${
+                if (cfg.secrets == { }) then configFile else "\${RUNTIME_DIRECTORY%%:*}/config.toml"
+              }";
+              WorkingDirectory = "/var/cache/librespeed";
+              RuntimeDirectory = "librespeed";
+              RuntimeDirectoryPreserve = true;
+              StateDirectory = "librespeed";
+              CacheDirectory = "librespeed";
+              SyslogIdentifier = "librespeed";
+
+              ReadOnlyPaths = [ cfg.package ];
+              RestrictSUIDSGID = true;
+              RestrictNamespaces = true;
+              PrivateTmp = true;
+              PrivateDevices = true;
+              PrivateUsers = true;
+              ProtectHostname = true;
+              ProtectClock = true;
+              ProtectKernelTunables = true;
+              ProtectKernelModules = true;
+              ProtectKernelLogs = true;
+              ProtectControlGroups = true;
+              ProtectSystem = "strict";
+              ProtectHome = true;
+              ProtectProc = "invisible";
+              SystemCallArchitectures = "native";
+              SystemCallFilter = "@system-service";
+              SystemCallErrorNumber = "EPERM";
+              LockPersonality = true;
+              NoNewPrivileges = true;
+            };
+          };
+        };
+    }
+  );
+
+  meta.maintainers = with lib.maintainers; [ snaki ];
+}

--- a/pkgs/by-name/li/librespeed-go/package.nix
+++ b/pkgs/by-name/li/librespeed-go/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+let
+  version = "1.1.5";
+  src = fetchFromGitHub {
+    owner = "librespeed";
+    repo = "speedtest-go";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ywGrodl/mj/WB25F0TKVvaV0PV4lgc+KEj0x/ix9HT8=";
+  };
+in
+buildGoModule {
+  pname = "librespeed-go";
+  inherit version src;
+
+  vendorHash = "sha256-ev5TEv8u+tx7xIvNaK8b5iq2XXF6I37Fnrr8mb+N2WM=";
+
+  ldflags = [
+    "-w"
+    "-s"
+  ];
+
+  postInstall = ''
+    cp -r web/assets $out/
+  '';
+
+  meta = {
+    description = "A very lightweight speed test implementation in Go";
+    homepage = "https://github.com/librespeed/speedtest-go";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ snaki ];
+    mainProgram = "speedtest";
+  };
+}

--- a/pkgs/by-name/li/librespeed-rust/package.nix
+++ b/pkgs/by-name/li/librespeed-rust/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "librespeed-rust";
+  version = "unstable-2024-09-28";
+
+  # https://github.com/librespeed/speedtest-rust/pull/7
+  src = fetchFromGitHub {
+    owner = "librespeed";
+    repo = "speedtest-rust";
+    rev = "a74f25d07da3eb665ce806e015c537264f7254c9";
+    hash = "sha256-+G1DFHQONXXg/5apSBlBkRvuLT4qCJaeFnQSLWt0CD0=";
+  };
+
+  cargoHash = "sha256-4TGm7vesjeJjPxFehFZG1wICs7P0gfKcot+Cu+3Ybt8=";
+
+  # error: linker `aarch64-linux-gnu-gcc` not found
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
+
+  postInstall = ''
+    cp -r assets $out/
+  '';
+
+  meta = {
+    description = "A very lightweight speed test implementation in Rust";
+    homepage = "https://github.com/librespeed/speedtest-rust";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ snaki ];
+    mainProgram = "librespeed-rs";
+  };
+}


### PR DESCRIPTION
## Description of changes
A web based speed test server.

This adds the [Go](https://github.com/librespeed/speedtest-go) and [Rust](https://github.com/librespeed/speedtest-rust) implementations of LibreSpeed with a common module.

I tested the module with both implementations. Originally I planed to use nginx as a reverse proxy, but while testing I noticed that the download speed was always half of the theoretical maximum. Also when using the rust implementation behind a reverse proxy, speed tests would never finish. I tried tinkering with nginx settings without any luck. That's why I settled to use nginx only to make the frontend available on common ports for users who want to run more web services alongside LibreSpeed.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
