### PR TITLE
nixos/open-webui: fix opensearch

### DIFF
--- a/nixos/modules/services/misc/open-webui.nix
+++ b/nixos/modules/services/misc/open-webui.nix
@@ -93,6 +93,7 @@ in
         DATA_DIR = ".";
         HF_HOME = ".";
         SENTENCE_TRANSFORMERS_HOME = ".";
+        WEBUI_URL = "http://localhost:${toString cfg.port}";
       } // cfg.environment;
 
       serviceConfig = {

--- a/nixos/tests/open-webui.nix
+++ b/nixos/tests/open-webui.nix
@@ -31,6 +31,7 @@ in
 
   testScript = ''
     import json
+    import xml.etree.ElementTree as xml
 
     machine.start()
 
@@ -45,5 +46,18 @@ in
 
     # Check that the name was overridden via the environmentFile option.
     assert webui_config["name"] == "${webuiName} (Open WebUI)"
+
+    webui_opensearch_xml = machine.succeed("curl http://127.0.0.1:${mainPort}/opensearch.xml")
+    webui_opensearch = xml.fromstring(webui_opensearch_xml)
+
+    webui_opensearch_url = webui_opensearch.find(
+        ".//{http://a9.com/-/spec/opensearch/1.1/}Url"
+    )
+    assert (
+        webui_opensearch_url is not None
+    ), f"no url tag found in {webui_opensearch_xml}"
+    assert (
+        webui_opensearch_url.get("template") == "http://localhost:8080/?q={searchTerms}"
+    ), "opensearch url doesn't match the configured port"
   '';
 }


### PR DESCRIPTION
When [adding Open WebUI as search engine in Firefox](https://docs.openwebui.com/tutorials/integrations/browser-search-engine/#for-firefox) it always links to `http://localhost:3000` instead of the configured port

It is because [the response use `WEBUI_URL` environment variable](https://github.com/open-webui/open-webui/blob/1d225dd804575af9ae5981528dfdce695f7f7040/backend/open_webui/main.py#L2370) which [is set by default to `http://localhost:3000`](https://github.com/open-webui/open-webui/blob/1d225dd804575af9ae5981528dfdce695f7f7040/backend/open_webui/env.py#L106)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Setting this variable by default to re-use the configured port

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
I run `nix-build -A nixosTests.open-webui` but i didn't tested with my config because i'm using the `nixos-24.05` and the `master` branch seems to have breaking changes (removed options)


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
