### PR TITLE
lib: let `getAttrs` ignore nonexistent keys

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -541,7 +541,8 @@ rec {
 
   /**
     Given a set of attribute names, return the set of the corresponding
-    attributes from the given set.
+    attributes from the given set. If the attributes does not exist,
+    they will be ignored.
 
 
     # Inputs
@@ -565,7 +566,7 @@ rec {
     ## `lib.attrsets.getAttrs` usage example
 
     ```nix
-    getAttrs [ "a" "b" ] { a = 1; b = 2; c = 3; }
+    getAttrs [ "a" "b" "d" ] { a = 1; b = 2; c = 3; }
     => { a = 1; b = 2; }
     ```
 
@@ -573,7 +574,7 @@ rec {
   */
   getAttrs =
     names:
-    attrs: genAttrs names (name: attrs.${name});
+    attrs: intersectAttrs (genAttrs names (_: null)) attrs;
 
   /**
     Collect each attribute named `attr` from a list of attribute

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -57,6 +57,7 @@ let
     functionArgs
     generators
     genList
+    getAttrs
     getExe
     getExe'
     getLicenseFromSpdxIdOr
@@ -2091,6 +2092,18 @@ runTests {
     expected = {
       a.b = 1;
       a.x = 1;
+    };
+  };
+
+  testGetAttrs = {
+    expr = getAttrs [ "a" "b" "nonexistent" ] {
+      a = 1;
+      b = true;
+      c = "hello";
+    };
+    expected = {
+      a = 1;
+      b = true;
     };
   };
 


### PR DESCRIPTION
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR contains an alternative implementation of `lib.attrsets.getAttrs` which ignores keys which do not exist in the attrset. It now behaves more similarly to `lib.removeAttrs`, which I've considered to be it's opposite. I am not aware of any usage where we depend on `getAttrs` throwing in absence of expected attributes (at least not solely), but I've only looked at in-tree usage.

I'm not really sure that this is the behavior we want for this function considering it's named `getAttrs`, but it would be useful to have a function that mirrors `removeAttrs` more accurately. I don't mind making this into a new function if we want to keep the old behavior for this one.

I believe this increases the time complexity. As far as I can tell, the old implementation was `O(n)` where `n` is the size of the key list, while this is `O(n) + O(x log y)` where `n` is the key list and `x` and `y` depends on which is large of the key list and the input attrs (according to [`builtins.intersectAttrs`](https://nix.dev/manual/nix/2.18/language/builtins#builtins-intersectAttrs)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
