### PR TITLE
lib: improve filterAttrs

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -644,8 +644,7 @@ rec {
   filterAttrs =
     pred:
     set:
-    listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [(nameValuePair name v)] else []) (attrNames set));
-
+    removeAttrs set (concatMap (name: if pred name set.${name} then [ ] else [ name ]) (attrNames set));
 
   /**
     Filter an attribute set recursively by removing all attributes for

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -7,7 +7,7 @@ let
   inherit (builtins) head length;
   inherit (lib.trivial) isInOldestRelease mergeAttrs warn warnIf;
   inherit (lib.strings) concatStringsSep concatMapStringsSep escapeNixIdentifier sanitizeDerivationName;
-  inherit (lib.lists) foldr foldl' concatMap elemAt all partition groupBy take foldl;
+  inherit (lib.lists) filter foldr foldl' concatMap elemAt all partition groupBy take foldl;
 in
 
 rec {
@@ -644,7 +644,7 @@ rec {
   filterAttrs =
     pred:
     set:
-    removeAttrs set (concatMap (name: if pred name set.${name} then [ ] else [ name ]) (attrNames set));
+    removeAttrs set (filter (name: ! pred name set.${name}) (attrNames set));
 
   /**
     Filter an attribute set recursively by removing all attributes for

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -47,6 +47,7 @@ let
     evalModules
     extends
     filter
+    filterAttrs
     fix
     fold
     foldAttrs
@@ -1099,6 +1100,25 @@ runTests {
       foo = "bar";
       foobar = "baz";
       foobarbaz = "baz";
+    };
+  };
+
+  testFilterAttrs = {
+    expr = filterAttrs (n: v: n != "a" && (v.hello or false) == true) {
+      a.hello = true;
+      b.hello = true;
+      c = {
+        hello = true;
+        world = false;
+      };
+      d.hello = false;
+    };
+    expected = {
+      b.hello = true;
+      c = {
+        hello = true;
+        world = false;
+      };
     };
   };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Small optimization. Instead of having `filterAttrs` collect values and merge them, it only collects the names of the unwanted attributes and passes them to `removeAttrs`. This leads to slightly less memory copied around. Also added a test

<details>
  <summary><code>NIX_SHOW_STATS=1 nix flake check</code> before</summary>

```json
{
  "cpuTime": 10.154743194580078,
  "envs": {
    "bytes": 693836664,
    "elements": 35023599,
    "number": 25852992
  },
  "gc": {
    "heapSize": 789245952,
    "totalBytes": 3407736128
  },
  "list": {
    "bytes": 60538296,
    "concats": 866078,
    "elements": 7567287
  },
  "nrAvoided": 28680092,
  "nrFunctionCalls": 23458684,
  "nrLookups": 11705269,
  "nrOpUpdateValuesCopied": 32773039,
  "nrOpUpdates": 1231329,
  "nrPrimOpCalls": 11339176,
  "nrThunks": 27686197,
  "sets": {
    "bytes": 913395872,
    "elements": 51894915,
    "number": 5192327
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 16,
    "Value": 24
  },
  "symbols": {
    "bytes": 1220932,
    "number": 99185
  },
  "values": {
    "bytes": 1055012784,
    "number": 43958866
  }
}
```

</details>

<details>
  <summary><code>NIX_SHOW_STATS=1 nix flake check</code> after</summary>

```json
{
  "cpuTime": 10.344867706298828,
  "envs": {
    "bytes": 691711896,
    "elements": 34935067,
    "number": 25764460
  },
  "gc": {
    "heapSize": 738914304,
    "totalBytes": 3402504560
  },
  "list": {
    "bytes": 60176696,
    "concats": 866078,
    "elements": 7522087
  },
  "nrAvoided": 28543943,
  "nrFunctionCalls": 23401274,
  "nrLookups": 11712564,
  "nrOpUpdateValuesCopied": 32773039,
  "nrOpUpdates": 1231329,
  "nrPrimOpCalls": 11339176,
  "nrThunks": 27657492,
  "sets": {
    "bytes": 912128368,
    "elements": 51843610,
    "number": 5164413
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 16,
    "Value": 24
  },
  "symbols": {
    "bytes": 1220945,
    "number": 99186
  },
  "values": {
    "bytes": 1054323864,
    "number": 43930161
  }
}
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
