### PR TITLE
stdoutisatty: init at 1.0

### DIFF
--- a/pkgs/by-name/st/stdoutisatty/package.nix
+++ b/pkgs/by-name/st/stdoutisatty/package.nix
@@ -24,11 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
     makeBinaryWrapper
   ];
 
-  preFixup = ''
-    # necessary for dynamic loading of `lib/libstdoutisatty.so` at runtime
-    wrapProgram $out/bin/${finalAttrs.pname} \
-      --prefix LD_LIBRARY_PATH : "$out/lib"
-  '';
+  cmakeFlags = [
+    # must specify the full path to `libstdoutisatty.so` in the nix store
+    (lib.cmakeFeature "CMAKE_C_FLAGS" "-DLIB_FILE='\"${placeholder "out"}/lib/libstdoutisatty.so\"'")
+  ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/st/stdoutisatty/package.nix
+++ b/pkgs/by-name/st/stdoutisatty/package.nix
@@ -5,6 +5,7 @@
   cmake,
   makeBinaryWrapper,
   nix-update-script,
+  runCommand,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,6 +32,23 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
+    tests = {
+      ls-color = runCommand "${finalAttrs.pname}-ls-color" { } ''
+        set -x
+        mkdir somedir
+        ln -s somedir somelink
+
+        color_auto=$(ls -1 --color=auto)
+        color_always=$(ls -1 --color=always)
+
+        ${finalAttrs.finalPackage}/bin/${finalAttrs.meta.mainProgram} \
+          ls -1 --color=auto > $out
+
+        [[ "$(cat $out)" == "$color_always" ]]
+        [[ "$(cat $out)" != "$color_auto" ]]
+        set +x
+      '';
+    };
   };
 
   meta = {

--- a/pkgs/by-name/st/stdoutisatty/package.nix
+++ b/pkgs/by-name/st/stdoutisatty/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "lilydjwg";
-    repo = finalAttrs.pname;
+    repo = "stdoutisatty";
     rev = finalAttrs.version;
     hash = "sha256-NyVn9cxx0rY1ridNDTqe0pzcVhdLVaPCKT4hoQkQzRs=";
   };
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
     tests = {
-      ls-color = runCommand "${finalAttrs.pname}-ls-color" { } ''
+      ls-color = runCommand "${finalAttrs.pname}-test-ls-color" { } ''
         set -x
         mkdir somedir
         ln -s somedir somelink
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/lilydjwg/stdoutisatty";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ bryango ];
-    mainProgram = finalAttrs.pname;
+    mainProgram = "stdoutisatty";
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/st/stdoutisatty/package.nix
+++ b/pkgs/by-name/st/stdoutisatty/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  makeBinaryWrapper,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stdoutisatty";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "lilydjwg";
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
+    hash = "sha256-NyVn9cxx0rY1ridNDTqe0pzcVhdLVaPCKT4hoQkQzRs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeBinaryWrapper
+  ];
+
+  preFixup = ''
+    # necessary for dynamic loading of `lib/libstdoutisatty.so` at runtime
+    wrapProgram $out/bin/${finalAttrs.pname} \
+      --prefix LD_LIBRARY_PATH : "$out/lib"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Make programs think their stdout is a tty / terminal";
+    longDescription = ''
+      `stdoutisatty command` makes `command` think their stdout is a terminal,
+      even if it is actually being piped into another program (e.g. `less`).
+      This is most useful for preserving user-friendly, colored outputs.
+
+      For example, `stdoutisatty ls --color=auto | less` will always show
+      colored output, despite being piped into a pager.
+    '';
+    homepage = "https://github.com/lilydjwg/stdoutisatty";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ bryango ];
+    mainProgram = finalAttrs.pname;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/st/stdoutisatty/package.nix
+++ b/pkgs/by-name/st/stdoutisatty/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
         color_auto=$(ls -1 --color=auto)
         color_always=$(ls -1 --color=always)
 
-        ${finalAttrs.finalPackage}/bin/${finalAttrs.meta.mainProgram} \
+        ${lib.getExe finalAttrs.finalPackage} \
           ls -1 --color=auto > $out
 
         [[ "$(cat $out)" == "$color_always" ]]


### PR DESCRIPTION
## Description of changes

Homepage: https://github.com/lilydjwg/stdoutisatty

It is surprisingly difficult to get consistent, colored outputs in the terminal, especially when commands are piped into a pager. In fact, there is a whole Arch wiki page on related topics:
- https://wiki.archlinux.org/title/Color_output_in_console#Reading_from_stdin

Among the solutions listed there, `stdoutisatty` is one of the simplest: it hijacks the [`isatty` function call](https://man.archlinux.org/man/isatty.3) used by most apps to determine whether `stdout` is an actual terminal, and always returns `1 (true)`. With this I can simply do:
```bash
stdoutisatty tree | less
cat flake.lock | stdoutisatty jq | less
...
```
... and enjoy my colorful outputs, without figuring out whatever `--color=always` type of flags these cli apps may or may not provide for colored outputs. Afaik, there is nothing like this in nixpkgs yet, so I would like to package and maintain it.

<!--
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
