### PR TITLE
nixos/nextcloud: re-add declarative-redis-and-secrets to matrix

### DIFF
--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -44,13 +44,13 @@ let
 
     nodes = {
       client = { ... }: {};
-      nextcloud = {
+      nextcloud = { lib, ... }: {
         networking.firewall.allowedTCPPorts = [ 80 ];
         services.nextcloud = {
           enable = true;
           hostName = "nextcloud";
           https = false;
-          database.createLocally = true;
+          database.createLocally = lib.mkDefault true;
           config = {
             adminpassFile = "${pkgs.writeText "adminpass" config.adminpass}"; # Don't try this at home!
           };
@@ -104,6 +104,7 @@ let
         });
     in map callNextcloudTest [
       ./basic.nix
+      ./with-declarative-redis-and-secrets.nix
       ./with-mysql-and-memcached.nix
       ./with-postgresql-and-redis.nix
       ./with-objectstore.nix

--- a/nixos/tests/nextcloud/with-declarative-redis-and-secrets.nix
+++ b/nixos/tests/nextcloud/with-declarative-redis-and-secrets.nix
@@ -1,8 +1,8 @@
-{ pkgs, testBase, system, ... }:
+{ name, pkgs, testBase, system, ... }:
 
 with import ../../lib/testing-python.nix { inherit system pkgs; };
 runTest ({ config, ... }: let inherit (config) adminuser; in {
-  name = "nextcloud-with-declarative-redis";
+  inherit name;
   meta = with pkgs.lib.maintainers; {
     maintainers = [ eqyiel ma27 ];
   };

--- a/nixos/tests/nextcloud/with-declarative-redis-and-secrets.nix
+++ b/nixos/tests/nextcloud/with-declarative-redis-and-secrets.nix
@@ -1,29 +1,18 @@
-args@{ nextcloudVersion ? 27, ... }:
-(import ../make-test-python.nix ({ pkgs, ...}: let
-  adminuser = "custom_admin_username";
-  # This will be used both for redis and postgresql
-  pass = "hunter2";
-  # Don't do this at home, use a file outside of the nix store instead
-  passFile = toString (pkgs.writeText "pass-file" ''
-    ${pass}
-  '');
-in {
+{ pkgs, testBase, system, ... }:
+
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+runTest ({ config, ... }: let inherit (config) adminuser; in {
   name = "nextcloud-with-declarative-redis";
   meta = with pkgs.lib.maintainers; {
     maintainers = [ eqyiel ma27 ];
   };
 
+  imports = [ testBase ];
+
   nodes = {
-    # The only thing the client needs to do is download a file.
-    client = { ... }: {};
-
     nextcloud = { config, pkgs, ... }: {
-      networking.firewall.allowedTCPPorts = [ 80 ];
-
+      environment.systemPackages = [ pkgs.jq ];
       services.nextcloud = {
-        enable = true;
-        hostName = "nextcloud";
-        package = pkgs.${"nextcloud" + (toString nextcloudVersion)};
         caching = {
           apcu = false;
           redis = true;
@@ -35,10 +24,9 @@ in {
           dbtype = "pgsql";
           dbname = "nextcloud";
           dbuser = adminuser;
-          dbpassFile = passFile;
-          adminuser = adminuser;
-          adminpassFile = passFile;
+          dbpassFile = config.services.nextcloud.config.adminpassFile;
         };
+
         secretFile = "/etc/nextcloud-secrets.json";
 
         settings = {
@@ -68,7 +56,7 @@ in {
         package = pkgs.postgresql_14;
       };
       systemd.services.postgresql.postStart = pkgs.lib.mkAfter ''
-        password=$(cat ${passFile})
+        password=$(cat ${config.services.nextcloud.config.dbpassFile})
         ${config.services.postgresql.package}/bin/psql <<EOF
           CREATE ROLE ${adminuser} WITH LOGIN PASSWORD '$password' CREATEDB;
           CREATE DATABASE nextcloud;
@@ -89,38 +77,9 @@ in {
     };
   };
 
-  testScript = let
-    withRcloneEnv = pkgs.writeScript "with-rclone-env" ''
-      #!${pkgs.runtimeShell}
-      export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
-      export RCLONE_CONFIG_NEXTCLOUD_URL="http://nextcloud/remote.php/dav/files/${adminuser}"
-      export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
-      export RCLONE_CONFIG_NEXTCLOUD_USER="${adminuser}"
-      export RCLONE_CONFIG_NEXTCLOUD_PASS="$(${pkgs.rclone}/bin/rclone obscure ${pass})"
-      "''${@}"
-    '';
-    copySharedFile = pkgs.writeScript "copy-shared-file" ''
-      #!${pkgs.runtimeShell}
-      echo 'hi' | ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file
-    '';
-
-    diffSharedFile = pkgs.writeScript "diff-shared-file" ''
-      #!${pkgs.runtimeShell}
-      diff <(echo 'hi') <(${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file)
-    '';
-  in ''
-    start_all()
-    nextcloud.wait_for_unit("multi-user.target")
-    nextcloud.succeed("curl -sSf http://nextcloud/login")
-    nextcloud.succeed(
-        "${withRcloneEnv} ${copySharedFile}"
-    )
-    client.wait_for_unit("multi-user.target")
-    client.succeed(
-        "${withRcloneEnv} ${diffSharedFile}"
-    )
-
-    # redis cache should not be empty
-    nextcloud.fail('test "[]" = "$(redis-cli --json KEYS "*")"')
+  test-helpers.extraTests = ''
+    with subtest("non-empty redis cache"):
+        # redis cache should not be empty
+        nextcloud.fail('test 0 -lt "$(redis-cli --pass secret --json KEYS "*" | jq "len")"')
   '';
-})) args
+})

--- a/nixos/tests/nextcloud/with-mysql-and-memcached.nix
+++ b/nixos/tests/nextcloud/with-mysql-and-memcached.nix
@@ -1,8 +1,8 @@
-{ pkgs, testBase, system, ... }:
+{ name, pkgs, testBase, system, ... }:
 
 with import ../../lib/testing-python.nix { inherit system pkgs; };
 runTest ({ config, ... }: {
-  name = "nextcloud-with-mysql-and-memcached";
+  inherit name;
   meta = with pkgs.lib.maintainers; {
     maintainers = [ eqyiel ];
   };


### PR DESCRIPTION


## Description of changes
Just noticed that I apparently disabled this test while restructuring the Nextcloud tests[1] effectively disabling the test.

This patch re-adds it and adjusts the code accordingly.

[1] 0b31ada92bde7f573d2a616d5111e396d501a76f
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
