### PR TITLE
nixos/komga: introduce 'settings' option

### DIFF
--- a/nixos/modules/services/web-apps/komga.nix
+++ b/nixos/modules/services/web-apps/komga.nix
@@ -9,17 +9,30 @@ let
   cfg = config.services.komga;
   inherit (lib) mkOption mkEnableOption maintainers;
   inherit (lib.types) port str bool;
+
+  settingsFormat = pkgs.formats.yaml { };
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "komga"
+        "port"
+      ]
+      [
+        "services"
+        "komga"
+        "settings"
+        "server"
+        "port"
+      ]
+    )
+  ];
+
   options = {
     services.komga = {
       enable = mkEnableOption "Komga, a free and open source comics/mangas media server";
-
-      port = mkOption {
-        type = port;
-        default = 8080;
-        description = "The port that Komga will listen on.";
-      };
 
       user = mkOption {
         type = str;
@@ -39,10 +52,25 @@ in
         description = "State and configuration directory Komga will use.";
       };
 
+      settings = lib.mkOption {
+        inherit (settingsFormat) type;
+        default = { };
+        defaultText = lib.literalExpression ''
+          {
+            server.port = 8080;
+          }
+        '';
+        description = ''
+          Komga configuration.
+
+          See [documentation](https://komga.org/docs/installation/configuration).
+        '';
+      };
+
       openFirewall = mkOption {
         type = bool;
         default = false;
-        description = "Whether to open the firewall for the port in {option}`services.komga.port`.";
+        description = "Whether to open the firewall for the port in {option}`services.komga.settings.server.port`.";
       };
     };
   };
@@ -52,6 +80,16 @@ in
       inherit (lib) mkIf getExe;
     in
     mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = (cfg.settings.komga.config-dir or cfg.stateDir) == cfg.stateDir;
+          message = "You must use the `services.komga.stateDir` option to properly configure `komga.config-dir`.";
+        }
+      ];
+
+      services.komga.settings = {
+        server.port = lib.mkDefault 8080;
+      };
 
       networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
 
@@ -66,9 +104,17 @@ in
         };
       };
 
+      systemd.tmpfiles.settings."10-komga" = {
+        ${cfg.stateDir}.d = {
+          inherit (cfg) user group;
+        };
+        "${cfg.stateDir}/application.yml"."L+" = {
+          argument = builtins.toString (settingsFormat.generate "application.yml" cfg.settings);
+        };
+      };
+
       systemd.services.komga = {
         environment = {
-          SERVER_PORT = builtins.toString cfg.port;
           KOMGA_CONFIGDIR = cfg.stateDir;
         };
 

--- a/nixos/tests/komga.nix
+++ b/nixos/tests/komga.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ lib, ... }:
     { pkgs, ... }:
     { services.komga = {
         enable = true;
-        port = 1234;
+        settings.server.port = 1234;
       };
     };
 


### PR DESCRIPTION
## Description of changes

Makes it easier to set the option, rather than adding environment variables on the systemd service definition.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
