### PR TITLE
tigerbeetle: add update script to update all hashes at the same time

### DIFF
--- a/pkgs/by-name/ti/tigerbeetle/package.nix
+++ b/pkgs/by-name/ti/tigerbeetle/package.nix
@@ -42,7 +42,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       package = tigerbeetle;
       command = "tigerbeetle version";
     };
-    updateScript = nix-update-script { };
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/ti/tigerbeetle/update.sh
+++ b/pkgs/by-name/ti/tigerbeetle/update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix mktemp unzip gnused
+
+set -euo pipefail
+
+latest_release_info=$(curl -s ${GITHUB_TOKEN:+ -H "Authorization: Bearer $GITHUB_TOKEN"} https://api.github.com/repos/tigerbeetle/tigerbeetle/releases?per_page=5 | jq -r "map(select(.properties.draft and .properties.prerelease | not)) | .[0]")
+latestVersion=$(jq -r ".tag_name" <<< $latest_release_info)
+currentVersion=$(nix-instantiate --eval -E "let pkgs = import ./. {}; in pkgs.tigerbeetle.version" | tr -d '"')
+
+if [[ "$currentVersion" == "$latestVersion" ]]
+then
+    echo "New version same as old version, nothing to do." >&2
+    exit 0
+fi
+
+# Note: our own nix-prefetch-url impersonation because the way that nix-prefetch-url treats tigerbeetle's zip files (which are just a single executable, no directories) is different from how Nixpkgs's fetchzip treats them.
+retrieved_hash=""
+function retrieve_hash {
+    download_dir=$(mktemp -d)
+    curl -s --location $1 --output "$download_dir/tigerbeetle.zip"
+    unzip -q "$download_dir/tigerbeetle.zip" -d "$download_dir"
+    rm "$download_dir/tigerbeetle.zip"
+    retrieved_hash=$(nix --extra-experimental-features nix-command hash path "$download_dir")
+    rm -rf "$download_dir"
+}
+
+nixFile=$(nix-instantiate --eval --strict -A "tigerbeetle.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
+
+sed -i "s|\(version = \"\)\(.*\)\"|\1$latestVersion\"|" $nixFile
+retrieve_hash "https://github.com/tigerbeetle/tigerbeetle/releases/download/${latestVersion}/tigerbeetle-x86_64-linux.zip"
+sed -i "s|\(\"x86_64-linux\" = \"\)\(.*\)\"|\1$retrieved_hash\"|" $nixFile
+retrieve_hash "https://github.com/tigerbeetle/tigerbeetle/releases/download/${latestVersion}/tigerbeetle-aarch64-linux.zip"
+sed -i "s|\(\"aarch64-linux\" = \"\)\(.*\)\"|\1$retrieved_hash\"|" $nixFile
+retrieve_hash "https://github.com/tigerbeetle/tigerbeetle/releases/download/${latestVersion}/tigerbeetle-universal-macos.zip"
+sed -i "s|\(\"universal-macos\" = \"\)\(.*\)\"|\1$retrieved_hash\"|" $nixFile


### PR DESCRIPTION
With the recent change to directly unpack the zip files provided by upstream instead of trying to build tigerbeetle from source within Nixpkgs, we introduced hashes for all versions of tigerbeetle that we support in Nixpkgs. However, the automated update script can only update one of the hashes automatically, so I decided to roll my own update script for tigerbeetle which updates the hashes for all versions at the same time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
