### PR TITLE
satyrographos: init at 0.0.2.13

### DIFF
--- a/pkgs/by-name/sa/satyrographos/package.nix
+++ b/pkgs/by-name/sa/satyrographos/package.nix
@@ -1,0 +1,50 @@
+{
+  ocamlPackages,
+  fetchFromGitHub,
+  lib,
+}:
+
+let
+  pname = "satyrographos";
+  version = "0.0.2.13";
+  src = fetchFromGitHub {
+    owner = "na4zagin3";
+    repo = "satyrographos";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-f9iJTr4nV7dFCMkI8+zv9qvYWRSw8H/xbbZm2LR9cB4=";
+  };
+in
+ocamlPackages.buildDunePackage {
+  inherit pname version src;
+
+  duneVersion = "3";
+
+  nativeBuildInputs = with ocamlPackages; [
+    menhir
+  ];
+
+  buildInputs = with ocamlPackages; [
+    core_unix
+    fileutils
+    opam-format
+    opam-state
+    ppx_deriving
+    ppx_deriving_yojson
+    ppx_import
+    ppx_jane
+    shexp
+    uri
+    uri-sexp
+    yaml-sexp
+    yojson
+  ];
+
+  meta = {
+    changelog = "https://github.com/na4zagin3/satyrographos/releases/tag/${src.rev}";
+    description = "Package manager for SATySFi";
+    homepage = "https://github.com/na4zagin3/satyrographos";
+    maintainers = with lib.maintainers; [ momeemt ];
+    mainProgram = "satyrographos";
+    license = lib.licenses.lgpl3Plus;
+  };
+}


### PR DESCRIPTION
satyrographos is a package manager for SATySFi.

https://github.com/na4zagin3/satyrographos

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
