### PR TITLE
opensc: 0.25.1 -> 0.26.0

### DIFF
--- a/pkgs/by-name/op/opensc/package.nix
+++ b/pkgs/by-name/op/opensc/package.nix
@@ -1,8 +1,23 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, zlib, readline, openssl
-, libiconv, pcsclite, libassuan, libXt
-, docbook_xsl, libxslt, docbook_xml_dtd_412
-, Carbon, PCSC, buildPackages
-, withApplePCSC ? stdenv.hostPlatform.isDarwin
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  zlib,
+  readline,
+  openssl,
+  libiconv,
+  pcsclite,
+  libassuan,
+  libXt,
+  docbook_xsl,
+  libxslt,
+  docbook_xml_dtd_412,
+  darwin,
+  buildPackages,
+  nix-update-script,
+  withApplePCSC ? stdenv.hostPlatform.isDarwin,
 }:
 
 stdenv.mkDerivation rec {
@@ -16,13 +31,23 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Ktvp/9Hca87qWmDlQhFzvWsr7TvNpIAvOFS+4zTZbB8=";
   };
 
-  nativeBuildInputs = [ pkg-config autoreconfHook ];
-  buildInputs = [
-    zlib readline openssl libassuan
-    libXt libxslt libiconv docbook_xml_dtd_412
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin Carbon
-  ++ (if withApplePCSC then [ PCSC ] else [ pcsclite ]);
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+  buildInputs =
+    [
+      zlib
+      readline
+      openssl
+      libassuan
+      libXt
+      libxslt
+      libiconv
+      docbook_xml_dtd_412
+    ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Carbon
+    ++ (if withApplePCSC then [ darwin.apple_sdk.frameworks.PCSC ] else [ pcsclite ]);
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
@@ -39,21 +64,23 @@ stdenv.mkDerivation rec {
     "--with-xsl-stylesheetsdir=${docbook_xsl}/xml/xsl/docbook"
     "--with-pcsc-provider=${
       if withApplePCSC then
-        "${PCSC}/Library/Frameworks/PCSC.framework/PCSC"
+        "${darwin.apple_sdk.frameworks.PCSC}/Library/Frameworks/PCSC.framework/PCSC"
       else
         "${lib.getLib pcsclite}/lib/libpcsclite${stdenv.hostPlatform.extensions.sharedLibrary}"
-      }"
-    (lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform)
-      "XSLTPROC=${buildPackages.libxslt}/bin/xsltproc")
+    }"
+    (lib.optionalString (
+      stdenv.hostPlatform != stdenv.buildPlatform
+    ) "XSLTPROC=${buildPackages.libxslt}/bin/xsltproc")
   ];
 
-  PCSC_CFLAGS = lib.optionalString withApplePCSC
-    "-I${PCSC}/Library/Frameworks/PCSC.framework/Headers";
+  PCSC_CFLAGS = lib.optionalString withApplePCSC "-I${darwin.apple_sdk.frameworks.PCSC}/Library/Frameworks/PCSC.framework/Headers";
 
   installFlags = [
     "sysconfdir=$(out)/etc"
     "completiondir=$(out)/etc"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Set of libraries and utilities to access smart cards";

--- a/pkgs/by-name/op/opensc/package.nix
+++ b/pkgs/by-name/op/opensc/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "opensc";
-  version = "0.25.1";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "OpenSC";
     repo = "OpenSC";
     rev = version;
-    sha256 = "sha256-Ktvp/9Hca87qWmDlQhFzvWsr7TvNpIAvOFS+4zTZbB8=";
+    sha256 = "sha256-EIQ9YpIGwckg/JjpK0S2ZYdFf/0YC4KaWcLXRNRMuzA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4754,10 +4754,6 @@ with pkgs;
 
   openrgb-plugin-hardwaresync = libsForQt5.callPackage ../applications/misc/openrgb-plugins/hardwaresync { };
 
-  opensc = callPackage ../tools/security/opensc {
-    inherit (darwin.apple_sdk.frameworks) Carbon PCSC;
-  };
-
   toastify = darwin.apple_sdk_11_0.callPackage ../tools/misc/toastify {};
 
   opensshPackages = dontRecurseIntoAttrs (callPackage ../tools/networking/openssh {});


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**Security fixes**:

https://github.com/advisories/GHSA-3q68-hm47-94vg: Usage of uninitialized values in libopensc and pkcs15init (https://github.com/OpenSC/OpenSC/pull/3225)
    https://github.com/advisories/GHSA-2mjg-798r-mxwh: Uninitialized values after incorrect check or usage of APDU response values in libopensc (https://github.com/OpenSC/OpenSC/pull/3225)
    https://github.com/advisories/GHSA-cf2w-h975-2fpg: Uninitialized values after incorrect or missing checking return values of functions in libopensc (https://github.com/OpenSC/OpenSC/pull/3225)
    https://github.com/advisories/GHSA-f2v6-mw6x-qmwc: Uninitialized values after incorrect or missing checking return values of functions in pkcs15init (https://github.com/OpenSC/OpenSC/pull/3225)
    https://github.com/advisories/GHSA-9vxw-3j77-cj78: Incorrect handling length of buffers or files in libopensc (https://github.com/OpenSC/OpenSC/pull/3225)
    https://github.com/advisories/GHSA-9c2g-6v5v-57qg: Incorrect handling of the length of buffers or files in pkcs15init (https://github.com/OpenSC/OpenSC/pull/3225)
    https://github.com/advisories/GHSA-mgc5-p43f-72pc: Heap buffer overflow in OpenPGP driver when generating key (https://github.com/OpenSC/OpenSC/pull/3219)

## Things done

Also: move to pkgs/by-name, format, add updateScript

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
