### PR TITLE
python312Packages.speechbrain: update hash

### DIFF
--- a/pkgs/development/python-modules/speechbrain/default.nix
+++ b/pkgs/development/python-modules/speechbrain/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "speechbrain";
     repo = "speechbrain";
     rev = "refs/tags/v${version}";
-    hash = "sha256-JoVu53HuTPkUIyJGqLE80yu7jzPje8/r5Hk6lJsz2XA=";
+    hash = "sha256-5ZMS1g74G4w83kNrXyt9IUsXe5uYS1qC+MwleQrjhTY=";
   };
 
   dependencies = [


### PR DESCRIPTION
## Things done

Upstream has _re-released_ the existing latest version.
Hence, we need to update the hash in consequence.

The diff between the previous and new source archives looks fairly minimal:

<details>

```
15a16
> import better_apidoc
16a18
> from sphinx.ext.autodoc.mock import mock
72,73c74,86
< # Autodoc mock extra dependencies:
< autodoc_mock_imports = []
---
> # Autodoc mock extra dependencies -- doesn't work out of the box, because of better_apidoc.
> #
> # So, let's reuse the autodoc mock...
> #
> # We would also like to mock more imports than this but this is shockingly prone
> # to randomly breaking, so let's keep a small-ish set of dependencies that tend
> # to be more annoying to install and to nuke our CI on update
> autodoc_mock_imports = [
>     "k2",
>     "flair",
>     "fairseq",
>     "spacy",
> ]
98d110
<     import better_apidoc
100,114c112,146
<     better_apidoc.APP = app
<     better_apidoc.main(
<         [
<             "better-apidoc",
<             "-t",
<             "_apidoc_templates",
<             "--force",
<             "--no-toc",
<             "--separate",
<             "-o",
<             "API",
<             os.path.join("../", "speechbrain"),
<             os.path.dirname(hyperpyyaml.__file__),
<         ]
<     )
---
>     with mock(autodoc_mock_imports):
>         try:
>             better_apidoc.APP = app
>             better_apidoc.main(
>                 [
>                     "better-apidoc",
>                     "-t",
>                     "_apidoc_templates",
>                     "--force",
>                     "--no-toc",
>                     "--separate",
>                     "-o",
>                     "API",
>                     os.path.join("../", "speechbrain"),
>                 ]
>             )
>             better_apidoc.main(
>                 [
>                     "better-apidoc",
>                     "-t",
>                     "_apidoc_templates",
>                     "--force",
>                     "--no-toc",
>                     "--separate",
>                     "-o",
>                     "API",
>                     os.path.dirname(hyperpyyaml.__file__),
>                 ]
>             )
>         except Exception:
>             # because otherwise sphinx very helpfully eats the backtrace
>             import traceback
> 
>             print(traceback.format_exc(), file=sys.stderr)
>             raise
diff '--color=auto' -r /nix/store/qmwsszpdx3013xg5fx417dcdrlk6bziq-source/docs/docs-requirements.txt /nix/store/4ccwqzv6awvd111rix33w8xl636ilkxd-source/docs/docs-requirements.txt
3,4d2
< fairseq @ git+https://github.com/facebookresearch/fairseq.git@v0.12.3
< flair==0.13.1
11d8
< spacy==3.7.4
diff: /nix/store/qmwsszpdx3013xg5fx417dcdrlk6bziq-source/tests/templates/fetching_ddp_dynbatch_finetuning/source_pretrained/asr.ckpt: No such file or directory
diff: /nix/store/4ccwqzv6awvd111rix33w8xl636ilkxd-source/tests/templates/fetching_ddp_dynbatch_finetuning/source_pretrained/asr.ckpt: No such file or directory
diff: /nix/store/qmwsszpdx3013xg5fx417dcdrlk6bziq-source/tests/templates/fetching_ddp_dynbatch_finetuning/source_pretrained/lm.ckpt: No such file or directory
diff: /nix/store/4ccwqzv6awvd111rix33w8xl636ilkxd-source/tests/templates/fetching_ddp_dynbatch_finetuning/source_pretrained/lm.ckpt: No such file or directory
diff: /nix/store/qmwsszpdx3013xg5fx417dcdrlk6bziq-source/tests/templates/fetching_ddp_dynbatch_finetuning/source_pretrained/normalizer.ckpt: No such file or directory
diff: /nix/store/4ccwqzv6awvd111rix33w8xl636ilkxd-source/tests/templates/fetching_ddp_dynbatch_finetuning/source_pretrained/normalizer.ckpt: No such file or directory
diff: /nix/store/qmwsszpdx3013xg5fx417dcdrlk6bziq-source/tests/templates/fetching_ddp_dynbatch_finetuning/source_pretrained/tokenizer.ckpt: No such file or directory
diff: /nix/store/4ccwqzv6awvd111rix33w8xl636ilkxd-source/tests/templates/fetching_ddp_dynbatch_finetuning/source_pretrained/tokenizer.ckpt: No such file or directory
diff: /nix/store/qmwsszpdx3013xg5fx417dcdrlk6bziq-source/tests/templates/fetching_ddp_dynbatch_finetuning/speechbrain/asr-crdnn-rnnlm-librispeech: No such file or directory
diff: /nix/store/4ccwqzv6awvd111rix33w8xl636ilkxd-source/tests/templates/fetching_ddp_dynbatch_finetuning/speechbrain/asr-crdnn-rnnlm-librispeech: No such file or directory
```

</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
