### PR TITLE
fluxcd: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -8,9 +8,10 @@
 }:
 
 let
-  version = "2.3.0";
-  hash = "sha256-ZQs1rWI31qDo/BgjrmiNnEdR2OL8bUHVz+j5VceEp2k=";
-  manifestsSha256 = "sha256-PdhR+UDquIJWtpSymtT6V7qO5fVJOkFz6RGzAx7xeb4=";
+  version = "2.4.0";
+  hash = "sha256-b4mu/iijfALBm+7OIdKgZs55fR6xWfPgL6OMOgIOi3w=";
+  vendorHash = "sha256-rVyirt6+D1qedbTvPZjLog16sMAq+zyFUmbjnJIieRg=";
+  manifestsSha256 = "sha256-85Ykc6B+DP9PVqwGbvqsQCUHpx/IzIP9TgOt3id7P5g=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";
@@ -21,7 +22,7 @@ in
 
 buildGoModule rec {
   pname = "fluxcd";
-  inherit version;
+  inherit vendorHash version;
 
   src = fetchFromGitHub {
     owner = "fluxcd";
@@ -29,8 +30,6 @@ buildGoModule rec {
     rev = "v${version}";
     inherit hash;
   };
-
-  vendorHash = "sha256-0YH3pgFrsnh5jIsZpj/sIgfiOCTtIlPltMS5mdGz1eM=";
 
   postUnpack = ''
     cp -r ${manifests} source/cmd/flux/manifests

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -9,13 +9,13 @@
 
 let
   version = "2.4.0";
-  hash = "sha256-b4mu/iijfALBm+7OIdKgZs55fR6xWfPgL6OMOgIOi3w=";
+  srcHash = "sha256-b4mu/iijfALBm+7OIdKgZs55fR6xWfPgL6OMOgIOi3w=";
   vendorHash = "sha256-rVyirt6+D1qedbTvPZjLog16sMAq+zyFUmbjnJIieRg=";
-  manifestsSha256 = "sha256-85Ykc6B+DP9PVqwGbvqsQCUHpx/IzIP9TgOt3id7P5g=";
+  manifestsHash = "sha256-85Ykc6B+DP9PVqwGbvqsQCUHpx/IzIP9TgOt3id7P5g=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";
-    hash = manifestsSha256;
+    hash = manifestsHash;
     stripRoot = false;
   };
 in
@@ -28,7 +28,7 @@ buildGoModule rec {
     owner = "fluxcd";
     repo = "flux2";
     rev = "v${version}";
-    inherit hash;
+    hash = srcHash;
   };
 
   postUnpack = ''

--- a/pkgs/by-name/fl/fluxcd/update.sh
+++ b/pkgs/by-name/fl/fluxcd/update.sh
@@ -8,30 +8,30 @@ FLUXCD_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_PATH {}; fluxcd.version or (builtins.parseDrvName fluxcd.name).version" | tr -d '"')"
 LATEST_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} --silent https://api.github.com/repos/fluxcd/flux2/releases/latest | jq -r '.tag_name')
-LATEST_VERSION=$(echo ${LATEST_TAG} | sed 's/^v//')
+LATEST_VERSION=$(echo "${LATEST_TAG}" | sed 's/^v//')
 
 if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
-    SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/archive/refs/tags/${LATEST_TAG}.tar.gz)
-    SHA256=$(nix hash convert --hash-algo sha256 --to sri $SHA256)
-    SPEC_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/releases/download/${LATEST_TAG}/manifests.tar.gz)
-    SPEC_SHA256=$(nix hash convert --hash-algo sha256 --to sri $SPEC_SHA256)
+    SHA256=$(nix-prefetch-url --quiet --unpack "https://github.com/fluxcd/flux2/archive/refs/tags/${LATEST_TAG}.tar.gz")
+    SHA256=$(nix hash convert --hash-algo sha256 --to sri "$SHA256")
+    SPEC_SHA256=$(nix-prefetch-url --quiet --unpack "https://github.com/fluxcd/flux2/releases/download/${LATEST_TAG}/manifests.tar.gz")
+    SPEC_SHA256=$(nix hash convert --hash-algo sha256 --to sri "$SPEC_SHA256")
 
     setKV () {
         sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${FLUXCD_PATH}/package.nix"
     }
 
-    setKV version ${LATEST_VERSION}
-    setKV sha256 ${SHA256}
-    setKV manifestsSha256 ${SPEC_SHA256}
+    setKV version "${LATEST_VERSION}"
+    setKV sha256 "${SHA256}"
+    setKV manifestsSha256 "${SPEC_SHA256}"
     setKV vendorHash "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" # The same as lib.fakeHash
 
     set +e
-    VENDOR_HASH=$(nix-build --no-out-link -A fluxcd $NIXPKGS_PATH 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
-    VENDOR_HASH=$(nix hash convert --hash-algo sha256 --to sri $VENDOR_HASH)
+    VENDOR_HASH=$(nix-build --no-out-link -A fluxcd "$NIXPKGS_PATH" 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
+    VENDOR_HASH=$(nix hash convert --hash-algo sha256 --to sri "$VENDOR_HASH")
     set -e
 
     if [ -n "${VENDOR_HASH:-}" ]; then
-        setKV vendorHash ${VENDOR_HASH}
+        setKV vendorHash "${VENDOR_HASH}"
     else
         echo "Update failed. VENDOR_HASH is empty."
         exit 1

--- a/pkgs/by-name/fl/fluxcd/update.sh
+++ b/pkgs/by-name/fl/fluxcd/update.sh
@@ -12,9 +12,9 @@ LATEST_VERSION=$(echo ${LATEST_TAG} | sed 's/^v//')
 
 if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
     SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/archive/refs/tags/${LATEST_TAG}.tar.gz)
-    SHA256=$(nix hash to-sri --type sha256 $SHA256)
+    SHA256=$(nix hash convert --hash-algo sha256 --to sri $SHA256)
     SPEC_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/releases/download/${LATEST_TAG}/manifests.tar.gz)
-    SPEC_SHA256=$(nix hash to-sri --type sha256 $SPEC_SHA256)
+    SPEC_SHA256=$(nix hash convert --hash-algo sha256 --to sri $SPEC_SHA256)
 
     setKV () {
         sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${FLUXCD_PATH}/package.nix"
@@ -27,7 +27,7 @@ if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
 
     set +e
     VENDOR_HASH=$(nix-build --no-out-link -A fluxcd $NIXPKGS_PATH 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
-    VENDOR_HASH=$(nix hash to-sri --type sha256 $VENDOR_HASH)
+    VENDOR_HASH=$(nix hash convert --hash-algo sha256 --to sri $VENDOR_HASH)
     set -e
 
     if [ -n "${VENDOR_HASH:-}" ]; then


### PR DESCRIPTION
- Release: https://github.com/fluxcd/flux2/releases/tag/v2.4.0

- Fixes update script

To test update script, delete information:

![image](https://github.com/user-attachments/assets/03dd31fe-bd08-48e9-9af4-692559598c8f)

And execute: `pkgs/by-name/fl/fluxcd/update.sh`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
