### PR TITLE
oink-solver: init at 1.0.0

### DIFF
--- a/pkgs/by-name/la/lace/package.nix
+++ b/pkgs/by-name/la/lace/package.nix
@@ -5,14 +5,14 @@
   cmake,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lace";
   version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "trolando";
-    repo = pname;
-    rev = "v${version}";
+    repo = "lace";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-yWlRkEvR7k322MlZVj5X062TsuSquPQd4TmFv7ufUc4=";
   };
 
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/trolando/lace";
     maintainers = [ maintainers.mgttlinger ];
     license = licenses.asl20;
-    platforms = with platforms; linux ++ darwin ++ windows;
+    platforms = platforms.all;
   };
-}
+})

--- a/pkgs/by-name/la/lace/package.nix
+++ b/pkgs/by-name/la/lace/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lace";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "trolando";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-yWlRkEvR7k322MlZVj5X062TsuSquPQd4TmFv7ufUc4=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Implementation of work-stealing in C";
+    homepage = "https://github.com/trolando/lace";
+    maintainers = [ maintainers.mgttlinger ];
+    license = licenses.asl20;
+    platforms = with platforms; linux ++ darwin ++ windows;
+  };
+}

--- a/pkgs/by-name/oi/oink-solver/package.nix
+++ b/pkgs/by-name/oi/oink-solver/package.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  lace,
+  boost,
+  build-extra-tools ? false,
+  doCheck ? false, # The tests are very memory and computationally intensive
+}:
+
+stdenv.mkDerivation {
+  pname = "oink";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "trolando";
+    repo = "oink";
+    rev = "257d0d088361204449c9bb204b457c2042e26cae";
+    sha256 = "sha256-HpDyDQbng0GfALF0dRcdIAAf6VhG/yfVmQKQPuZx0C0=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    lace
+    boost
+  ];
+
+  inherit doCheck;
+
+  postInstall = lib.optionalString build-extra-tools ''
+    install -m755 {nudge,dotty,verify,simple,rngame,stgame,counter_rr,counter_dp,counter_m,counter_core,counter_rob,counter_symsi,counter_ortl,counter_qpt,tc,tc+} $out/bin/
+  '';
+
+  cmakeFlags = [
+    (lib.strings.cmakeBool "OINK_BUILD_EXTRA_TOOLS" build-extra-tools)
+    (lib.strings.cmakeBool "OINK_BUILD_TESTS" doCheck)
+  ];
+
+  meta = with lib; {
+    description = "An implementation of modern parity game solvers";
+    homepage = "https://github.com/trolando/oink";
+    maintainers = [ maintainers.mgttlinger ];
+    license = licenses.asl20;
+    platforms = platforms.all;
+    mainProgram = "oink";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Packaged `lace` library (https://github.com/trolando/lace) as a dependency of `oink-solver` (added the suffix as different package `oink` already exists). 
- Packaged `oink-solver`(https://github.com/trolando/oink) a state of the art solver for parity games. Note that while the tests do compile they are using an excessive amount of RAM (> 16GiB) and hence are disabled by default

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
