### PR TITLE
gbenchmark: 1.8.5 -> 1.9.0, disable `-Werror`, tweaks

### DIFF
--- a/pkgs/development/libraries/gbenchmark/default.nix
+++ b/pkgs/development/libraries/gbenchmark/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gbenchmark";
-  version = "1.8.5";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "benchmark";
     rev = "v${version}";
-    hash = "sha256-c46Xna/t21WKaFa7n4ieIacsrxJ+15uGNYWCUVuUhsI=";
+    hash = "sha256-5cl1PIjhXaL58kSyWZXRWLq6BITS2BwEovPhwvk2e18=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/gbenchmark/default.nix
+++ b/pkgs/development/libraries/gbenchmark/default.nix
@@ -22,11 +22,6 @@ stdenv.mkDerivation rec {
   postPatch = ''
     cp -r ${gtest.src} googletest
     chmod -R u+w googletest
-
-    # https://github.com/google/benchmark/issues/1396
-    substituteInPlace cmake/benchmark.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
   # Tests fail on 32-bit due to not enough precision

--- a/pkgs/development/libraries/gbenchmark/default.nix
+++ b/pkgs/development/libraries/gbenchmark/default.nix
@@ -20,6 +20,19 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ninja ];
 
+  cmakeFlags = [
+    # We ran into issues with gtest 1.8.5 conditioning on
+    # `#if __has_cpp_attribute(maybe_unused)`, which was, for some
+    # reason, going through even when C++14 was being used and
+    # breaking the build on Darwin by triggering warnings about using
+    # C++17 features.
+    #
+    # This might be a problem with our Clang, as it does not reproduce
+    # with Xcode, but since `-Werror` is painful for us anyway and
+    # upstream exposes a CMake flag to turn it off, we just use that.
+    (lib.cmakeBool "BENCHMARK_ENABLE_WERROR" false)
+  ];
+
   postPatch = ''
     cp -r ${gtest.src} googletest
     chmod -R u+w googletest

--- a/pkgs/development/libraries/gbenchmark/default.nix
+++ b/pkgs/development/libraries/gbenchmark/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, ninja
 , gtest
 , prometheus-cpp
 }:
@@ -17,7 +18,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-5cl1PIjhXaL58kSyWZXRWLq6BITS2BwEovPhwvk2e18=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ninja ];
 
   postPatch = ''
     cp -r ${gtest.src} googletest


### PR DESCRIPTION
Release notes: <https://github.com/google/benchmark/releases/tag/v1.9.0>

Fixes the build on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
