### PR TITLE
python3Packages.replicate: init at 0.34.1

### DIFF
--- a/pkgs/development/python-modules/replicate/default.nix
+++ b/pkgs/development/python-modules/replicate/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  httpx,
+  packaging,
+  pydantic,
+  typing-extensions,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-recording,
+  respx,
+}:
+
+buildPythonPackage rec {
+  pname = "replicate";
+  version = "0.34.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "replicate";
+    repo = "replicate-python";
+    rev = version;
+    hash = "sha256-DhmuGh0OASd4rBvizf1qx537j4RGs4eVe0jH1BrhZa4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    httpx
+    packaging
+    pydantic
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "replicate" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-recording
+    respx
+  ];
+
+  meta = {
+    description = "Python client for Replicate";
+    homepage = "https://replicate.com/";
+    changelog = "https://github.com/replicate/replicate-python/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jokatzke ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13488,6 +13488,8 @@ self: super: with self; {
 
   repl-python-wakatime = callPackage ../development/python-modules/repl-python-wakatime { };
 
+  replicate = callPackage ../development/python-modules/replicate { };
+
   repocheck = callPackage ../development/python-modules/repocheck { };
 
   reportengine = callPackage ../development/python-modules/reportengine { };


### PR DESCRIPTION
Add the official Python-API to [replicate.com](https://replicate.com), an online service that provides access to various AI models.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux, _on aarch64-darwin_
  - [x] x86_64-darwin, _on aarch64-darwn_
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
