### PR TITLE
wxedid: init at 0.0.33

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16813,6 +16813,11 @@
     githubId = 14259816;
     name = "Abin Simon";
   };
+  meanwhile131 = {
+    name = "meanwhile131";
+    github = "meanwhile131";
+    githubId = 51206659;
+  };
   meatcar = {
     email = "nixpkgs@denys.me";
     github = "meatcar";

--- a/pkgs/by-name/wx/wxedid/package.nix
+++ b/pkgs/by-name/wx/wxedid/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  wrapGAppsHook3,
+  wxwidgets_3_3,
+}:
+stdenv.mkDerivation rec {
+  pname = "wxedid";
+  version = "0.0.33";
+
+  src = fetchzip {
+    url = "https://downloads.sourceforge.net/project/wxedid/wxedid-${version}.tar.gz";
+    hash = "sha256-ShO2e5rQCVBdgyg4iiFzFEywl2m9A+jILMGI+MT8qgo=";
+  };
+  nativeBuildInputs = [
+    wrapGAppsHook3
+  ];
+  buildInputs = [
+    wxwidgets_3_3
+  ];
+  prePatch = ''
+    patchShebangs src/rcode/rcd_autogen
+  '';
+
+  meta = with lib; {
+    description = "wxWidgets-based EDID (Extended Display Identification Data) editor";
+    homepage = "https://sourceforge.net/projects/wxedid";
+    license = licenses.gpl3Only;
+    mainProgram = "wxedid";
+    maintainers = [ maintainers.meanwhile131 ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
wxWidgets-based EDID (Extended Display Identification Data) editor
https://sourceforge.net/projects/wxedid/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
