### PR TITLE
classicube: 1.3.6 -> 1.3.7

### DIFF
--- a/pkgs/games/classicube/default.nix
+++ b/pkgs/games/classicube/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     ./font-location.patch
     # For some reason, the Makefile doesn't link
     # with libcurl and openal when ClassiCube requires them.
-    # ./fix-linking.patch
+    ./fix-linking.patch
   ];
 
   font_path = "${liberation_ttf}/share/fonts/truetype";

--- a/pkgs/games/classicube/default.nix
+++ b/pkgs/games/classicube/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ClassiCube";
-  version = "1.3.6";
+  version = "1.3.7";
 
   src = fetchFromGitHub {
     owner = "UnknownShadow200";
     repo = "ClassiCube";
     rev = version;
-    sha256 = "sha256-7VPn5YXNoAR3ftYMDQuQRqeMCrbyB56ir1sQWBiPWAI=";
+    sha256 = "sha256-ZITyfxkQB4Jpm2ZsQyM+ouPLqCVmGB7UZRXDSU/BX0k=";
   };
 
   nativeBuildInputs = [ dos2unix makeWrapper copyDesktopItems ];
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     ./font-location.patch
     # For some reason, the Makefile doesn't link
     # with libcurl and openal when ClassiCube requires them.
-    ./fix-linking.patch
+    # ./fix-linking.patch
   ];
 
   font_path = "${liberation_ttf}/share/fonts/truetype";

--- a/pkgs/games/classicube/fix-linking.patch
+++ b/pkgs/games/classicube/fix-linking.patch
@@ -1,13 +1,14 @@
 diff --git a/Makefile b/Makefile
-index 83188ce..3439cdb 100644
+index a10eb5214..70e2f720e 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -40,7 +40,7 @@ LIBS=-mwindows -lws2_32 -lwininet -lwinmm -limagehlp -lcrypt32 -ld3d9
- endif
+@@ -55,7 +55,7 @@ endif
  
  ifeq ($(PLAT),linux)
--LIBS=-lX11 -lXi -lpthread -lGL -lm -ldl
-+LIBS=-lX11 -lXi -lpthread -lGL -lm -ldl -lcurl -lopenal
+ 	CFLAGS  += -DCC_BUILD_ICON
+-	LIBS    =  -lX11 -lXi -lpthread -lGL -ldl
++	LIBS    =  -lX11 -lXi -lpthread -lGL -ldl -lcurl -lopenal
+ 	BUILD_DIR = build-linux
  endif
  
- ifeq ($(PLAT),sunos)
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/ClassiCube/ClassiCube/releases/tag/1.3.7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
