### PR TITLE
python312Packages.reflex: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/reflex-chakra/default.nix
+++ b/pkgs/development/python-modules/reflex-chakra/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "reflex-chakra";
-  version = "0.6.0";
+  version = "0.6.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "reflex-dev";
     repo = "reflex-chakra";
     rev = "refs/tags/v${version}";
-    hash = "sha256-5Lins7cbZWQTbJFBwR9qUdgTPHifPxD3BrvaawIKCJE=";
+    hash = "sha256-nmZ41V/1TbslAQIkJQLgdLfWS2qSVrAnVqbv8sajL5c=";
   };
 
   pythonRemoveDeps = [

--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -23,6 +23,7 @@
   pydantic,
   pytest-asyncio,
   pytest-mock,
+  playwright,
   pytestCheckHook,
   python-engineio,
   python-multipart,
@@ -46,7 +47,7 @@
 
 buildPythonPackage rec {
   pname = "reflex";
-  version = "0.6.0";
+  version = "0.6.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -55,7 +56,7 @@ buildPythonPackage rec {
     owner = "reflex-dev";
     repo = "reflex";
     rev = "refs/tags/v${version}";
-    hash = "sha256-6yu9EfyX/1kvvmkmKGJrZnVffRHGWY/iUrn5BIrNx38=";
+    hash = "sha256-p7o7e/OBX8P5QKsHNInKKQO1jklTr61SXuGk+ceakJU=";
   };
 
   pythonRelaxDeps = [
@@ -106,6 +107,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
     pytest-mock
+    playwright
     attrs
     numpy
     plotly
@@ -114,11 +116,16 @@ buildPythonPackage rec {
     unzip
   ];
 
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+  '';
+
   disabledTests = [
-    # Tests touche network
+    # Tests touch network
     "test_find_and_check_urls"
     "test_event_actions"
     "test_upload_file"
+    "test_node_version"
     # /proc is too funky in nix sandbox
     "test_get_cpu_info"
     # broken
@@ -130,7 +137,7 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     "benchmarks/"
-    "integration/"
+    "tests/integration/"
   ];
 
   pythonImportsCheck = [ "reflex" ];


### PR DESCRIPTION
Changelog: https://github.com/reflex-dev/reflex/releases/tag/v0.6.1
Changelog: https://github.com/reflex-dev/reflex-chakra/releases/tag/v0.6.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
