### PR TITLE
vulkan-hdr-layer-kwin6: init at 0-unstable-2024-10-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4719,6 +4719,12 @@
     github = "d4ilyrun";
     githubId = 34611103;
   };
+  d4rk = {
+    name = "Anoop Menon";
+    email = "d4rk@blackvoltage.org";
+    github = "d4rk";
+    githubId = 22163;
+  };
   d4rkstar = {
     name = "Bruno Salzano";
     email = "d4rkstar@gmail.com";

--- a/pkgs/by-name/vu/vulkan-hdr-layer-kwin6/package.nix
+++ b/pkgs/by-name/vu/vulkan-hdr-layer-kwin6/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  libX11,
+  meson,
+  ninja,
+  pkg-config,
+  vulkan-headers,
+  vulkan-loader,
+  wayland-scanner,
+  wayland,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vulkan-hdr-layer-kwin6";
+  version = "0-unstable-2024-10-19";
+
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    cmake
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+    libX11
+    wayland
+  ];
+
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "Zamundaaa";
+    repo = "VK_hdr_layer";
+    rev = "e173f2617262664901039e3c821929afce05d2c1";
+    hash = "sha256-hBxRwbn29zFeHcRpfMF6I4piSASpN2AvZY0ci5Utj4U=";
+    fetchSubmodules = true;
+  };
+
+  meta = {
+    description = "Vulkan Wayland HDR WSI Layer (Xaver Hugl's fork for KWin 6)";
+    homepage = "https://github.com/Zamundaaa/VK_hdr_layer";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ d4rk ];
+  };
+}


### PR DESCRIPTION
Enables HDR support for Vulkan clients (such as `mpv`) on kwin6.

https://github.com/Zamundaaa/VK_hdr_layer

This is likely to be a temporary solution until Wayland upstream adopts the necessary protocols, however that has been in the works for [many years](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14).

For the time being, this provides a path for users to experiment with HDR, share feedback and hopefully make progress.

Arch provides a similar package:
https://aur.archlinux.org/packages/vk-hdr-layer-kwin6-git

Example usage after installing the layer:
```
ENABLE_HDR_WSI=1 mpv \
    --hwdec=auto-safe --vo=gpu-next --target-colorspace-hint \
    --gpu-api=vulkan --gpu-context=waylandvk \
    <filename>
```
To enable Vulkan loader logs:
```
VK_LOADER_DEBUG=error,warn,info ENABLE_HDR_WSI=1 mpv \
    --hwdec=auto-safe --vo=gpu-next --target-colorspace-hint \
    --gpu-api=vulkan --gpu-context=waylandvk \
    <filename>
```

PS: The latest version of `gamescope` [doesn't](https://zamundaaa.github.io/wayland/2024/05/11/more-hdr-and-color.html) need Vulkan for HDR.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
