### PR TITLE
nixos/terminfo, contour: mark contour broken, remove from `enableAllTerminfo`

### DIFF
--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -24,25 +24,35 @@
 
   config = {
 
+    # This should not contain packages that are broken or can't build, since it
+    # will break this expression
+    #
+    # Currently broken packages:
+    # - contour
+    #
     # can be generated with:
     # lib.attrNames (lib.filterAttrs
     #  (_: drv: (builtins.tryEval (lib.isDerivation drv && drv ? terminfo)).value)
     #  pkgs)
-    environment.systemPackages = lib.mkIf config.environment.enableAllTerminfo (map (x: x.terminfo) (with pkgs.pkgsBuildBuild; [
-      alacritty
-      contour
-      foot
-      kitty
-      mtm
-      rio
-      rxvt-unicode-unwrapped
-      rxvt-unicode-unwrapped-emoji
-      st
-      termite
-      tmux
-      wezterm
-      yaft
-    ]));
+    environment.systemPackages = lib.mkIf config.environment.enableAllTerminfo (
+      map (x: x.terminfo) (
+        with pkgs.pkgsBuildBuild;
+        [
+          alacritty
+          foot
+          kitty
+          mtm
+          rio
+          rxvt-unicode-unwrapped
+          rxvt-unicode-unwrapped-emoji
+          st
+          termite
+          tmux
+          wezterm
+          yaft
+        ]
+      )
+    );
 
     environment.pathsToLink = [
       "/share/terminfo"

--- a/pkgs/applications/terminal-emulators/contour/default.nix
+++ b/pkgs/applications/terminal-emulators/contour/default.nix
@@ -99,5 +99,8 @@ stdenv.mkDerivation (final: {
     maintainers = with maintainers; [ moni ];
     platforms = platforms.unix;
     mainProgram = "contour";
+    # This was caused by boxed-cpp 1.4.2 -> 1.4.3
+    # More details in issue #345752
+    broken = true;
   };
 })


### PR DESCRIPTION
## Things done

This remove remove broken package contour from nixos/terminfo, and marks
contour broken.

Contour was broken for aarch64 in #253334, and completely broke in #344788 for
all platforms.

This removes the broken package, and adds a notice to remove broken packages in
the future. aarch64 users have waited a year for this to be fixed, so I think
we should lean to be more eager to remove in general, and then the fix can come
when it is ready, instead of letting it block this.

Additionally, the current contour version is far behind upstream, and has
been broken on aarch64 for over a year, so this probably isn't right around the corner.

Resolves: #258515
Refs: #345752 648fd81e3e4834328d5d79f6fa22981f4d75ac89
Signed-off-by: Christina Sørensen <christina@cafkafk.com>

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [-] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
