### PR TITLE
erlang-ls: 0.52.0 -> 1.1.0

### DIFF
--- a/pkgs/development/beam-modules/erlang-ls/default.nix
+++ b/pkgs/development/beam-modules/erlang-ls/default.nix
@@ -1,7 +1,7 @@
 { fetchFromGitHub, fetchgit, fetchHex, rebar3Relx, buildRebar3, rebar3-proper
 , stdenv, writeScript, lib }:
 let
-  version = "0.52.0";
+  version = "1.1.0";
   owner = "erlang-ls";
   repo = "erlang_ls";
   deps = import ./rebar-deps.nix {
@@ -16,6 +16,15 @@ let
           substituteInPlace rebar.config --replace ", warnings_as_errors" ""
           '';
       });
+      json_polyfill = super.json_polyfill.overrideAttrs (_: {
+        # When compiling with erlang >= 27, the json_polyfill rebar script will
+        # delete the json.beam file as it's not needed. However, we need to
+        # adjust this path as the nix build will put the beam file under `ebin`
+        # instead of `$REBAR_DEPS_DIR/json_polyfill/ebin`.
+        postPatch = ''
+          substituteInPlace rebar.config.script --replace "{erlc_compile, \"rm \\\"\$REBAR_DEPS_DIR/json_polyfill/ebin/json.beam\\\"\"}" "{erlc_compile, \"rm \\\"ebin/json.beam\\\"\"}"
+          '';
+      });
     });
   };
 in
@@ -24,7 +33,7 @@ rebar3Relx {
   inherit version;
   src = fetchFromGitHub {
     inherit owner repo;
-    hash = "sha256-tV7M8y0R+BN5ATxM03K0/gtHgITI9KxtvA7o0ft8RuE=";
+    hash = "sha256-MSDBU+blsAdeixaHMMXmeMJ+9Yrzn3HekE8KbIc/Guo=";
     rev = version;
   };
   releaseType = "escript";

--- a/pkgs/development/beam-modules/erlang-ls/rebar-deps.nix
+++ b/pkgs/development/beam-modules/erlang-ls/rebar-deps.nix
@@ -26,11 +26,11 @@ let
     };
     quickrand = builder {
       name = "quickrand";
-      version = "2.0.1";
+      version = "2.0.7";
       src = fetchHex {
         pkg = "quickrand";
-        version = "2.0.1";
-        sha256 = "sha256-FNtn1K72uIFYEOyfPM714yS3O1bK42h/mddSuFvdTJY=";
+        version = "2.0.7";
+        sha256 = "sha256-uKy/iaIkvCF8MHDKi+vG6yNtvn+XZ5k7J0CE6gRNNfA=";
       };
       beamDeps = [ ];
     };
@@ -46,11 +46,11 @@ let
     };
     katana_code = builder {
       name = "katana_code";
-      version = "0.2.1";
+      version = "2.1.1";
       src = fetchHex {
         pkg = "katana_code";
-        version = "0.2.1";
-        sha256 = "sha256-hEitP1bZgU+YoovmUPcZG91QZXXjRcwW1YZmCxD26ZI=";
+        version = "2.1.1";
+        sha256 = "sha256-BoDzNSW5qILm9NMCJRixXEb2SL17Db6GkAmA/hwpFAQ=";
       };
       beamDeps = [ ];
     };
@@ -115,13 +115,23 @@ let
       };
       beamDeps = [ katana_code ];
     };
+    json_polyfill = builder {
+      name = "json_polyfill";
+      version = "0.1.4";
+      src = fetchHex {
+        pkg = "json_polyfill";
+        version = "0.1.4";
+        sha256 = "sha256-SMOX7iVH+kWe3gGjDsDoVxer7TAQhnpj7qrF8gMnQwM=";
+      };
+      beamDeps = [ ];
+    };
     jsx = builder {
       name = "jsx";
-      version = "3.0.0";
+      version = "2.10.0";
       src = fetchHex {
         pkg = "jsx";
-        version = "3.0.0";
-        sha256 = "sha256-N77KBDX1yoovRfdqRiEedkGPvvgMNvA2HCSfx1BZ3G0=";
+        version = "2.10.0";
+        sha256 = "sha256-moPjcEgHKYAWlo21Bvn60PAn3jdUbrg4s64QZMOgrWI=";
       };
       beamDeps = [ ];
     };
@@ -138,11 +148,11 @@ let
     };
     erlfmt = builder {
       name = "erlfmt";
-      version = "1.3.0";
+      version = "1.5.0";
       src = fetchHex {
         pkg = "erlfmt";
-        version = "1.3.0";
-        sha256 = "sha256-KoSqHrovT8190x1cV+neK8JwXdoY2kVT8n33EUz6oFI=";
+        version = "1.5.0";
+        sha256 = "sha256-OTOkDPvnkK2U5bZQs2iB3nBFYxkmPBR5tVbpr9vYDHU=";
       };
       beamDeps = [ ];
     };
@@ -158,11 +168,11 @@ let
     };
     elvis_core = builder {
       name = "elvis_core";
-      version = "1.3.1";
+      version = "3.2.5";
       src = fetchHex {
         pkg = "elvis_core";
-        version = "1.3.1";
-        sha256 = "sha256-eoiQv4GFoyUs1OvYJv5fita5MCTt+IV26yeunl3BnWk=";
+        version = "3.2.5";
+        sha256 = "sha256-NNkhjwuAclEZA79sy/WesXZd7Pxz/MaDO6XIlZ2384M=";
       };
       beamDeps = [ katana_code zipper ];
     };


### PR DESCRIPTION
## Description of changes

https://github.com/erlang-ls/erlang_ls/compare/0.52.0...1.1.0
https://github.com/erlang-ls/erlang_ls/releases/tag/0.53.0
https://github.com/erlang-ls/erlang_ls/releases/tag/0.54.0
https://github.com/erlang-ls/erlang_ls/releases/tag/1.0.0
https://github.com/erlang-ls/erlang_ls/releases/tag/1.1.0

Had to patch the `json_polyfill` dep since [it would attempt to `rm` a file that won't exist on Erlang >= 27](https://github.com/williamthome/json_polyfill/blob/fcc444f5897105830d5ab1c79f82bf8e735e12a2/rebar.config.script#L10) during the build. (See #342843.)

Closes https://github.com/NixOS/nixpkgs/pull/345328

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
