### PR TITLE
ngs: init at 0.2.16

### DIFF
--- a/pkgs/by-name/ng/ngs/package.nix
+++ b/pkgs/by-name/ng/ngs/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchurl,
+  fetchFromGitHub,
+  pkg-config,
+  libffi,
+  pandoc,
+  pcre,
+  json_c,
+  boehmgc,
+}:
+
+let
+  version = "0.2.16";
+  peg-homepage = "http://piumarta.com/software/peg/";
+  peg-pname = "peg";
+  peg-version = "0.1.19";
+  # peg v0.1.20 (latest) causes a compilation error against syntax.legs
+  # ref: https://github.com/ngs-lang/ngs/issues/662
+  peg-0-1-19 = stdenv.mkDerivation {
+    pname = peg-pname;
+    version = peg-version;
+    src = fetchurl {
+      url = "${peg-homepage}/${peg-pname}-${peg-version}.tar.gz";
+      sha256 = "sha256-ABPdg6Zzl3hEWmS87T10ufUMB1U/hupDMzrl+rXCu7Q=";
+    };
+    preBuild = "makeFlagsArray+=( PREFIX=$out )";
+    meta = {
+      homepage = peg-homepage;
+      license = lib.licenses.mit;
+    };
+  };
+  src = fetchFromGitHub {
+    owner = "ngs-lang";
+    repo = "ngs";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-hIjhy62HB5WyT3VUZP+kZWhE9PdP1cT4lGMEQiFIZdI=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "ngs";
+  inherit version src;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libffi
+    pandoc
+    peg-0-1-19
+    pcre
+    json_c
+    boehmgc
+  ];
+
+  postPatch = ''
+    patchShebangs build-scripts
+  '';
+
+  meta = {
+    description = "Next Generation Shell (NGS)";
+    homepage = "https://ngs-lang.org/";
+    changelog = "https://github.com/ngs-lang/ngs/releases/tag/${src.rev}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.all;
+    mainProgram = "ngs";
+    maintainers = with lib.maintainers; [ momeemt ];
+  };
+}


### PR DESCRIPTION
ngs is the next generation shell.
I defined a derivation because #344215 and https://github.com/ngs-lang/ngs/issues/661 requests this package.

https://github.com/ngs-lang/ngs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
