### PR TITLE
treewide: `\xc2\xa0` -> ` `

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -8,7 +8,7 @@ let
    * to a menuentry for use in grub.
    *
    *  * defaults: {name, image, params, initrd}
-   *  * options: [ option... ]
+   *  * options: [ option... ]
    *  * option: {name, params, class}
    */
   menuBuilderGrub2 =

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -344,7 +344,7 @@ let
       serviceConfig = commonServiceConfig // {
         Group = data.group;
 
-        # Let's Encrypt Failed Validation Limit allows 5 retries per hour, per account, hostname and hour.
+        # Let's Encrypt Failed Validation Limit allows 5 retries per hour, per account, hostname and hour.
         # This avoids eating them all up if something is misconfigured upon the first try.
         RestartSec = 15 * 60;
 

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1020,7 +1020,7 @@ in {
           '';
           serviceConfig.Type = "oneshot";
           serviceConfig.User = "nextcloud";
-          # On Nextcloud ≥ 26, it is not necessary to patch the database files to prevent
+          # On Nextcloud ≥ 26, it is not necessary to patch the database files to prevent
           # an automatic creation of the database user.
           environment.NC_setup_create_db_user = lib.mkIf (nextcloudGreaterOrEqualThan "26") "false";
         };

--- a/nixos/modules/services/web-apps/pixelfed.nix
+++ b/nixos/modules/services/web-apps/pixelfed.nix
@@ -406,7 +406,7 @@ in {
         # is unnecessary as it's part of the installPhase of pixelfed.
 
         # Install Horizon
-        # FIXME: require write access to public/ — should be done as part of install — pixelfed-manage horizon:publish
+        # FIXME: require write access to public/ — should be done as part of install — pixelfed-manage horizon:publish
 
         # Perform the first migration.
         [[ ! -f ${cfg.dataDir}/.initial-migration ]] && pixelfed-manage migrate --force && touch ${cfg.dataDir}/.initial-migration

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -154,7 +154,7 @@ in {
 
   with subtest("run_distributed_command"):
       # Run `hostname` on 3 nodes of the partition (so on all the 3 nodes).
-      # The output must contain the 3 different names
+      # The output must contain the 3 different names
       submit.succeed("srun -N 3 hostname | sort | uniq | wc -l | xargs test 3 -eq")
 
       with subtest("check_slurm_dbd"):

--- a/pkgs/by-name/os/ossia-score/package.nix
+++ b/pkgs/by-name/os/ossia-score/package.nix
@@ -111,7 +111,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     "-DSuil_INCLUDE_DIR=${suil}/include/suil-0"
   ];
 
-  # Needed for libraries that get dlopen'd
+  # Needed for libraries that get dlopen'd
   env.NIX_LDFLAGS = toString [
     "-lasound"
     "-llilv-0"

--- a/pkgs/data/fonts/league-spartan/default.nix
+++ b/pkgs/data/fonts/league-spartan/default.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       Taking a strong influence from ATF's classic Spartan family, we're
       starting our own family out with a single strong weight. We've put a few
       unique touches into a beautiful, historical typeface, and made sure to
-      include an extensive characterset – currently totaling over 300 glyphs.
+      include an extensive characterset – currently totaling over 300 glyphs.
 
       Over time, the open-source license will allow us expand League Spartan
       into a full family, with multiple weights and styles, and we're starting

--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
     # Disable any integration tests, which need to contact the internet.
     # Also disable the `storage_benchmark_*` tests.
     # With Protobuf < 23.x they require -DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_WORKAROUND=ON.
-    # With Protobuf >= 23.x they require They require setting -DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_WORKAROUND=OFF
+    # With Protobuf >= 23.x they require They require setting -DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_WORKAROUND=OFF
     ctest --label-exclude integration-test --exclude-regex storage_benchmarks_
 
     runHook postInstallCheck

--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -113,7 +113,7 @@ buildPythonPackage rec {
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
       # works locally on APFS, fails on hydra with AssertionError comparing timestamps
       # darwin hydra builder uses HFS+ and has only one second timestamp resolution
-      # this two tests however, assume nanosecond resolution
+      # this two tests however, assume nanosecond resolution
       "test_modified"
       "test_touch"
       # tries to access /home, ignores $HOME

--- a/pkgs/development/python-modules/layoutparser/default.nix
+++ b/pkgs/development/python-modules/layoutparser/default.nix
@@ -40,7 +40,7 @@ let
       torchvision
       effdet
     ];
-    # paddledetection = [ paddlepaddle ]
+    # paddledetection = [ paddlepaddle ]
   };
 in
 buildPythonPackage {

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -562,7 +562,7 @@ let
 
       USB_EHCI_ROOT_HUB_TT = yes; # Root Hub Transaction Translators
       USB_EHCI_TT_NEWSCHED = yes; # Improved transaction translator scheduling
-      USB_HIDDEV = yes; # USB Raw HID Devices (like monitor controls and Uninterruptable Power Supplies)
+      USB_HIDDEV = yes; # USB Raw HID Devices (like monitor controls and Uninterruptable Power Supplies)
 
       # default to dual role mode
       USB_DWC2_DUAL_ROLE = yes;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1561,7 +1561,7 @@ mapAliases {
   invalidateFetcherByDrvHash = testers.invalidateFetcherByDrvHash; # Added 2022-05-05
   timescale-prometheus = promscale; # Added 2020-09-29
   tinygltf = throw "TinyglTF has been embedded in draco due to lack of other users and compatibility breaks."; # Added 2023-06-25
-  tightvnc = throw "'tightvnc' has been removed as the version 1.3 is not maintained upstream anymore and is insecure"; # Added 2024-08-22
+  tightvnc = throw "'tightvnc' has been removed as the version 1.3 is not maintained upstream anymore and is insecure"; # Added 2024-08-22
   tixati = throw "'tixati' has been removed from nixpkgs as it is unfree and unmaintained"; # Added 2023-03-17
   tkcvs = tkrev; # Added 2022-03-07
   toil = throw "toil was removed as it was broken and requires obsolete versions of libraries"; # Added 2024-09-22

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18770,7 +18770,7 @@ with self; {
     buildInputs = [ TestNoWarnings ];
     perlPreHook = "export LD=$CC";
     meta = {
-      description = "Internationalizing Domain Names in Applications (UTS #46)";
+      description = "Internationalizing Domain Names in Applications (UTS #46)";
       homepage = "https://metacpan.org/release/Net-IDN-Encode";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };


### PR DESCRIPTION
I have no idea what this escape sequence even is (edit: [found it, its the utf-8 encoding of nbsb](https://www.compart.com/en/unicode/U+00A0)), but it breaks the nix parser with cryptic errors if not used in a comment or string literal. A friend let me know MacOS is prone to input weird spaces, not sure if that is the source.

Candidates were located and created with:

    chr="$(echo -e '\xc2\xa0')"; rg -F "$chr" -l | xe sd -F "$chr" " "

There are some examples left, most being example output from `tree` in various markdown documents, some patches which we can't really touch, and `pkgs/tools/nix/nixos-render-docs/src/tests/test_commonmark.py` which I'm not sure if should be addressed


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
