### PR TITLE
nixos/filesystems: fix special file-systems for systemd-nspawn

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -255,6 +255,14 @@
 - `services.nextcloud.configureRedis` now defaults to `true` in accordance with upstream recommendations to have caching for file locking. See the [upstream doc](https://docs.nextcloud.com/server/31/admin_manual/configuration_files/files_locking_transactional.html) for further details.
 
 - mate-wayland-session 1.28.4 is now using the default wayfire decorator instead of firedecor, thus `services.xserver.desktopManager.mate.enableWaylandSession` is no longer shipping firedecor. If you are experiencing broken window decorations after upgrade, backup and remove `~/.config/mate/wayfire.ini` and re-login.
+-
+- A new option [](#opt-boot.isNspawnContainer) has been added. This option will be used to guard nspawn-specific configuration in NixOS since [](#opt-boot.isContainer) is also used for different container-runtimes such as LXC.
+  - The new option is automatically set to `true` by the declarative container module and `nixos-container` when not using flakes.
+    - Existing setups can be migrated by running either
+      - `nixos-container update <container-name> --config-file /path/to/the/config-file-in-use.nix`
+      - `nixos-container update <container-name> --config '/* config code */'`
+  - In all other cases, you'll need to set this option to `true` yourself.
+  - `boot.isNspawnContainer` being `true` implies [](#opt-boot.isContainer) being `true`.
 
 - Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -261,6 +261,7 @@
     - Existing setups can be migrated by running either
       - `nixos-container update <container-name> --config-file /path/to/the/config-file-in-use.nix`
       - `nixos-container update <container-name> --config '/* config code */'`
+      - Setting the option by hand in your configuration when using flakes.
   - In all other cases, you'll need to set this option to `true` yourself.
   - `boot.isNspawnContainer` being `true` implies [](#opt-boot.isContainer) being `true`.
 

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -306,7 +306,7 @@ if ($virt eq "microsoft") {
 
 # Pull in NixOS configuration for containers.
 if ($virt eq "systemd-nspawn") {
-    push @attrs, "boot.isContainer = true;";
+    push @attrs, "boot.isNspawnContainer = true;";
 }
 
 

--- a/nixos/modules/profiles/nix-builder-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vm.nix
@@ -40,6 +40,10 @@ in
         default = false;
         internal = true;
       };
+      options.boot.isNspawnContainer = lib.mkOption {
+        default = false;
+        internal = true;
+      };
     }
   ];
 

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -567,7 +567,8 @@ in
           "nodev"
         ];
       };
-
+    }
+    // optionalAttrs (!config.boot.isNspawnContainer) {
       "/proc" = {
         fsType = "proc";
         options = [

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -545,6 +545,29 @@ in
 
     # Sync mount options with systemd's src/core/mount-setup.c: mount_table.
     boot.specialFileSystems = {
+      # To hold secrets that shouldn't be written to disk
+      "/run/keys" = {
+        fsType = "ramfs";
+        options = [
+          "nosuid"
+          "nodev"
+          "mode=750"
+        ];
+      };
+    }
+    // optionalAttrs (!config.boot.isContainer) {
+      # systemd-nspawn populates /sys by itself, and remounting it causes all
+      # kinds of weird issues (most noticeably, waiting for host disk device
+      # nodes).
+      "/sys" = {
+        fsType = "sysfs";
+        options = [
+          "nosuid"
+          "noexec"
+          "nodev"
+        ];
+      };
+
       "/proc" = {
         fsType = "proc";
         options = [
@@ -590,29 +613,6 @@ in
           "mode=620"
           "ptmxmode=0666"
           "gid=${toString config.ids.gids.tty}"
-        ];
-      };
-
-      # To hold secrets that shouldn't be written to disk
-      "/run/keys" = {
-        fsType = "ramfs";
-        options = [
-          "nosuid"
-          "nodev"
-          "mode=750"
-        ];
-      };
-    }
-    // optionalAttrs (!config.boot.isContainer) {
-      # systemd-nspawn populates /sys by itself, and remounting it causes all
-      # kinds of weird issues (most noticeably, waiting for host disk device
-      # nodes).
-      "/sys" = {
-        fsType = "sysfs";
-        options = [
-          "nosuid"
-          "noexec"
-          "nodev"
         ];
       };
     };

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -509,10 +509,22 @@ in
 
     boot.isContainer = mkOption {
       type = types.bool;
-      default = false;
+      default = config.boot.isNspawnContainer;
+      defaultText = "config.boot.isNspawnContainer";
       description = ''
         Whether this NixOS machine is a lightweight container running
         in another NixOS system.
+      '';
+    };
+
+    boot.isNspawnContainer = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether the machine is running in an nspawn container. This
+        option is added because [](#opt-boot.isContainer) is heavily used
+        for non-nspawn environments as well, hence nspawn-specific settings
+        are guarded by this option.
       '';
     };
 
@@ -558,7 +570,7 @@ in
                                     { inherit (host.pkgs.stdenv) hostPlatform; }
                                   else
                                     { localSystem = host.pkgs.stdenv.hostPlatform; };
-                                boot.isContainer = true;
+                                boot.isNspawnContainer = true;
                                 networking.hostName = mkDefault name;
                                 networking.useDHCP = false;
                                 assertions = [

--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -5,7 +5,7 @@ let
     { config, ... }:
     {
       # We re-use the NixOS container option ...
-      boot.isContainer = true;
+      boot.isNspawnContainer = true;
       # ... and revert unwanted defaults
       networking.useHostResolvConf = false;
 

--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -98,11 +98,6 @@ in
         serviceConfig.Environment = [
           # Disable tmpfs for /tmp
           "SYSTEMD_NSPAWN_TMPFS_TMP=0"
-
-          # force unified cgroup delegation, which would be the default
-          # if systemd could check the capabilities of the installed systemd.
-          # see also: https://github.com/NixOS/nixpkgs/pull/198526
-          "SYSTEMD_NSPAWN_UNIFIED_HIERARCHY=1"
         ];
         overrideStrategy = "asDropin";
       };
@@ -152,7 +147,7 @@ in
 
     # Test if systemd-nspawn provides a working environment for nix to build derivations
     # https://nixos.org/guides/nix-pills/07-working-derivation
-    machine.succeed('systemd-run --pty --wait -M ${containerName} /run/current-system/sw/bin/nix-instantiate --expr \'derivation { name = "myname"; builder = "/bin/sh"; args = [ "-c" "echo foo > $out" ]; system = "${pkgs.system}"; }\' --add-root /tmp/drv')
+    machine.succeed('systemd-run --pty --wait -M ${containerName} /run/current-system/sw/bin/nix-instantiate --expr \'derivation { name = "myname"; builder = "/bin/sh"; args = [ "-c" "echo foo > $out" ]; system = "${pkgs.stdenv.hostPlatform.system}"; }\' --add-root /tmp/drv')
     machine.succeed('systemd-run --pty --wait -M ${containerName} /run/current-system/sw/bin/nix-store --option substitute false --realize /tmp/drv')
 
     # Test nss_mymachines without nscd

--- a/pkgs/by-name/ni/nixos-container/nixos-container.pl
+++ b/pkgs/by-name/ni/nixos-container/nixos-container.pl
@@ -171,7 +171,7 @@ sub writeNixOSConfig {
     my $nixosConfig = <<EOF;
 { config, lib, pkgs, ... }:
 
-{ boot.isContainer = true;
+{ boot.isNspawnContainer = true;
   networking.hostName = lib.mkDefault "$containerName";
   networking.useDHCP = false;
   $localExtraConfig

--- a/pkgs/by-name/ni/nixos-container/nixos-container.pl
+++ b/pkgs/by-name/ni/nixos-container/nixos-container.pl
@@ -8,6 +8,11 @@ use Fcntl ':flock';
 use Getopt::Long qw(:config gnu_getopt no_bundling);
 use Cwd 'abs_path';
 use Time::HiRes;
+use IPC::Run 'run';
+
+# Version::Compare et al. don't work because they do the wrong thing on e.g.
+# 25.11pre-git.
+my $nixpkgsLib = "@lib@";
 
 my $nsenter = "@util-linux@/bin/nsenter";
 my $su = "@su@";
@@ -368,6 +373,35 @@ sub runInContainer {
     die "cannot run ‘nsenter’: $!\n";
 }
 
+sub evalAttribute {
+    my ($attribute, $nixosF, $nixosConfigF, $extraArgs) = @_;
+    run [
+        "nix-instantiate", $nixosF, "-I", "nixos-config=$nixosConfigF", "-A", $attribute, "--eval"
+    ], ">", \my $result;
+    chomp $result;
+    $result =~ s/^"([^"]+)"$/$1/g;
+    return $result;
+}
+
+sub evalAttributeFlake {
+    my ($attribute) = @_;
+    run [
+        "nix", "eval", "$flake#nixosConfigurations.\"$flakeAttr\".$attribute"
+    ], ">", \my $result;
+    chomp $result;
+    $result =~ s/^"([^"]+)"$/$1/g;
+    return $result;
+}
+
+sub isAtLeast2511 {
+    my ($version) = @_;
+    run [
+        "nix-instantiate", "--eval", "-E", "with import $nixpkgsLib; versionAtLeast \"$version\" \"25.11pre-git\""
+    ], ">", \my $result;
+    chomp $result;
+    return $result eq "true";
+}
+
 # Remove a directory while recursively unmounting all mounted filesystems within
 # that directory and unmounting/removing that directory afterwards as well.
 #
@@ -426,6 +460,10 @@ elsif ($action eq "update") {
     }
 
     if (defined $flake) {
+        my $nixpkgsVersion = evalAttributeFlake "lib.version";
+        if (isAtLeast2511($nixpkgsVersion) && evalAttributeFlake("config.boot.isNspawnContainer") ne "true") {
+            die "$0: on 25.11 and newer, containers require boot.isNspawnContainer=true. Please set this in $flake";
+        }
         buildFlake();
         system("nix-env", "-p", "$profileDir/system", "--set", $systemPath) == 0
             or die "$0: failed to set container configuration\n";
@@ -441,6 +479,14 @@ elsif ($action eq "update") {
         }
 
         my $nixenvF = $nixosPath // "<nixpkgs/nixos>";
+
+        my $nixpkgsVersion = evalAttribute "pkgs.lib.version", $nixenvF, $nixosConfigFile;
+        if (isAtLeast2511($nixpkgsVersion)
+            && evalAttribute("config.boot.isNspawnContainer", $nixenvF, $nixosConfigFile) ne "true"
+        ) {
+            die "$0: on 25.11 and newer, containers require boot.isNspawnContainer=true. Refresh your configuration (or check the 25.11 release notes on how to correctly do that)";
+        }
+
         system("nix-env", "-p", "$profileDir/system",
                "-I", "nixos-config=$nixosConfigFile", "-f", $nixenvF,
                "--set", "-A", "system", @nixFlags) == 0

--- a/pkgs/by-name/ni/nixos-container/package.nix
+++ b/pkgs/by-name/ni/nixos-container/package.nix
@@ -7,6 +7,7 @@
   configurationDirectory ? "/etc/nixos-containers",
   stateDirectory ? "/var/lib/nixos-containers",
   nixosTests,
+  path,
 }:
 replaceVarsWith {
   name = "nixos-container";
@@ -15,8 +16,12 @@ replaceVarsWith {
   src = ./nixos-container.pl;
 
   replacements = {
-    perl = perl.withPackages (p: [ p.FileSlurp ]);
+    perl = perl.withPackages (p: [
+      p.FileSlurp
+      p.IPCRun
+    ]);
     su = "${shadow.su}/bin/su";
+    lib = "${path + "/lib"}";
 
     inherit configurationDirectory stateDirectory util-linux;
   };


### PR DESCRIPTION
This is a subset of aba55d1b960b4b1817bc2a32deeba447ae51f0a3 (#67336)[1] that I (Ma27) am using for quite a while in my systemd-nspawn setup (without `nixos-container`) to have unprivileged containers.

Recently, @lheckemann  reminded me that this isn't part of upstream NixOS and their setup fails like this when activating config in an nspawn instance (no shared store):

    stderr) activating the configuration...
    stdout) setting up /etc...
    stderr) mount: /dev: permission denied.
    stderr)        dmesg(1) may have more information after failed mount system call.
    stderr) mount: /dev/pts: permission denied.
    stderr)        dmesg(1) may have more information after failed mount system call.
    stderr) mount: /dev/shm: permission denied.
    stderr)        dmesg(1) may have more information after failed mount system call.
    stderr) mount: /run: permission denied.
    stderr)        dmesg(1) may have more information after failed mount system call.
    stdout) Activation script snippet 'specialfs' failed (32)

So I decided to submit this portion again.

[1] Hence I retained the original authorship.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
