### PR TITLE
[WIP]: screen-pipe: 0.1.48 -> 0.1.93; switch remote.

### DIFF
--- a/pkgs/by-name/sc/screen-pipe/package.nix
+++ b/pkgs/by-name/sc/screen-pipe/package.nix
@@ -15,13 +15,13 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "screen-pipe";
-  version = "0.1.48";
+  version = "0.1.93";
 
   src = fetchFromGitHub {
-    owner = "louis030195";
+    owner = "mediar-ai";
     repo = "screen-pipe";
     rev = "v${version}";
-    hash = "sha256-rWKRCqWFuPO84C52mMrrS4euD6XdJU8kqZsAz28+vWE=";
+    hash = "sha256-70cb41a6229a45fb150884baf9768febe41a629f3e40fb75a931150fd7341b1a=";
   };
 
   cargoLock = {
@@ -80,7 +80,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Personalized AI powered by what you've seen, said, or heard";
-    homepage = "https://github.com/louis030195/screen-pipe";
+    homepage = "https://github.com/mediar-ai/screen-pipe";
     license = licenses.mit;
     maintainers = with maintainers; [ dit7ya ];
     mainProgram = "screen-pipe";

--- a/pkgs/by-name/sc/screen-pipe/package.nix
+++ b/pkgs/by-name/sc/screen-pipe/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     owner = "mediar-ai";
     repo = "screen-pipe";
     rev = "v${version}";
-    hash = "sha256-70cb41a6229a45fb150884baf9768febe41a629f3e40fb75a931150fd7341b1a=";
+    hash = "sha256-EiMbJRxsgln5ElY9/6EO2k29MK0QUyk2ThPDS7PQ64JN++E84hpOPSdugbFPVkYs";
   };
 
   cargoLock = {

--- a/pkgs/by-name/sc/screen-pipe/package.nix
+++ b/pkgs/by-name/sc/screen-pipe/package.nix
@@ -78,11 +78,11 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = false; # Tests fail to build
 
-  meta = with lib; {
+  meta = {
     description = "Personalized AI powered by what you've seen, said, or heard";
     homepage = "https://github.com/mediar-ai/screen-pipe";
-    license = licenses.mit;
-    maintainers = with maintainers; [ dit7ya ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dit7ya ];
     mainProgram = "screen-pipe";
   };
 }


### PR DESCRIPTION
## Changes
1. Bump tag to `v0.1.93`
2. Change repo slug to https://github.com/mediar-ai/screenpipe (owner transferred it to an org)

## Things done

(Don't know how to locally test a build, happy to do so if someone could point me in the right direction)

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
