### PR TITLE
nixos/nginx: report actual vhosts name in assertions/warnings

### DIFF
--- a/nixos/modules/services/misc/radicle.nix
+++ b/nixos/modules/services/misc/radicle.nix
@@ -209,15 +209,14 @@ in
         };
         nginx = lib.mkOption {
           # Type of a single virtual host, or null.
-          type = lib.types.nullOr (lib.types.submodule (
-            lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
-              options.serverName = {
-                default = "radicle-${config.networking.hostName}.${config.networking.domain}";
-                defaultText = "radicle-\${config.networking.hostName}.\${config.networking.domain}";
-              };
-            }
-          ));
+          type = lib.types.nullOr (lib.types.submodule
+            (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; }));
           default = null;
+          defaultText = ''
+            {
+              serverName = "radicle-''${config.networking.hostName}.''${config.networking.domain}";
+            }
+          '';
           example = lib.literalExpression ''
             {
               serverAliases = [
@@ -333,6 +332,7 @@ in
           {
             forceSSL = lib.mkDefault true;
             enableACME = lib.mkDefault true;
+            serverName = lib.mkDefault "radicle-${config.networking.hostName}.${config.networking.domain}";
             locations."/" = {
               proxyPass = "http://${cfg.httpd.listenAddress}:${toString cfg.httpd.listenPort}";
               recommendedProxySettings = true;

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -197,11 +197,7 @@ in
     };
 
     nginx = mkOption {
-      type = types.submodule (
-        recursiveUpdate
-          (import ../web-servers/nginx/vhost-options.nix { inherit config lib; })
-          { }
-      );
+      type = types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = { };
       example = literalExpression ''
         {

--- a/nixos/modules/services/networking/fedimintd.nix
+++ b/nixos/modules/services/networking/fedimintd.nix
@@ -166,10 +166,11 @@ let
             description = "Path to host the API on and forward to the daemon's api port";
           };
           config = mkOption {
-            type = types.submodule
-              (lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
+            type = types.submodule (
+              lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
                 inherit config lib;
-              });
+              }
+            );
             default = { };
             description = "Overrides to the nginx vhost section for api";
           };

--- a/nixos/modules/services/networking/fedimintd.nix
+++ b/nixos/modules/services/networking/fedimintd.nix
@@ -166,11 +166,10 @@ let
             description = "Path to host the API on and forward to the daemon's api port";
           };
           config = mkOption {
-            type = types.submodule (
-              recursiveUpdate (import ../web-servers/nginx/vhost-options.nix {
+            type = types.submodule
+              (lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
                 inherit config lib;
-              }) { }
-            );
+              });
             default = { };
             description = "Overrides to the nginx vhost section for api";
           };

--- a/nixos/modules/services/web-apps/agorakit.nix
+++ b/nixos/modules/services/web-apps/agorakit.nix
@@ -205,9 +205,9 @@ in
 
     nginx = mkOption {
       type = types.submodule (
-        recursiveUpdate (import ../web-servers/nginx/vhost-options.nix {
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
           inherit config lib;
-        }) { }
+        }
       );
       default = { };
       example = ''

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -942,7 +942,7 @@ in {
 
       nginx = mkOption {
         type = with types; nullOr (submodule
-          (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }));
+          (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; }));
         default = null;
         description = ''
           Extra configuration for the nginx virtual host of Akkoma.

--- a/nixos/modules/services/web-apps/anuko-time-tracker.nix
+++ b/nixos/modules/services/web-apps/anuko-time-tracker.nix
@@ -121,10 +121,7 @@ in
     };
 
     nginx = lib.mkOption {
-      type = lib.types.submodule (
-        lib.recursiveUpdate
-          (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {}
-      );
+      type = lib.types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = {};
       example = lib.literalExpression ''
         {

--- a/nixos/modules/services/web-apps/bookstack.nix
+++ b/nixos/modules/services/web-apps/bookstack.nix
@@ -195,10 +195,7 @@ in {
     };
 
     nginx = mkOption {
-      type = types.submodule (
-        recursiveUpdate
-          (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {}
-      );
+      type = types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = {};
       example = literalExpression ''
         {

--- a/nixos/modules/services/web-apps/davis.nix
+++ b/nixos/modules/services/web-apps/davis.nix
@@ -220,7 +220,9 @@ in
     };
 
     nginx = lib.mkOption {
-      type = lib.types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+      type = lib.types.submodule (
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; }
+      );
       default = null;
       example = ''
         {

--- a/nixos/modules/services/web-apps/davis.nix
+++ b/nixos/modules/services/web-apps/davis.nix
@@ -220,9 +220,7 @@ in
     };
 
     nginx = lib.mkOption {
-      type = lib.types.submodule (
-        lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
-      );
+      type = lib.types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = null;
       example = ''
         {

--- a/nixos/modules/services/web-apps/fluidd.nix
+++ b/nixos/modules/services/web-apps/fluidd.nix
@@ -18,7 +18,7 @@ in
 
     nginx = mkOption {
       type = types.submodule
-        (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+        (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = { };
       example = literalExpression ''
         {

--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -153,7 +153,9 @@ in
     };
 
     nginx = mkOption {
-      type = types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+      type = types.submodule (
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; }
+      );
       default = { };
       defaultText = ''
         {

--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -153,15 +153,14 @@ in
     };
 
     nginx = mkOption {
-      type = types.submodule (
-        lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
-          # enable encryption by default,
-          # as sensitive login credentials should not be transmitted in clear text.
-          options.forceSSL.default = true;
-          options.enableACME.default = true;
-        }
-      );
+      type = types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = { };
+      defaultText = ''
+        {
+          enableACME = true;
+          forceSSL = true;
+        }
+      '';
       example = {
         enableACME = false;
         forceSSL = false;
@@ -267,6 +266,8 @@ in
       virtualHosts."${cfg.settings.hostname}" = mkMerge [
         cfg.nginx
         {
+          enableACME = lib.mkDefault true;
+          forceSSL = lib.mkDefault true;
           locations = {
             "/" = {
               index = "index.html";

--- a/nixos/modules/services/web-apps/jirafeau.nix
+++ b/nixos/modules/services/web-apps/jirafeau.nix
@@ -80,7 +80,7 @@ in
 
     nginxConfig = mkOption {
       type = types.submodule
-        (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+        (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = {};
       example = literalExpression ''
         {

--- a/nixos/modules/services/web-apps/mainsail.nix
+++ b/nixos/modules/services/web-apps/mainsail.nix
@@ -18,7 +18,7 @@ in
 
     nginx = mkOption {
       type = types.submodule
-        (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+        (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = { };
       example = literalExpression ''
         {

--- a/nixos/modules/services/web-apps/misskey.nix
+++ b/nixos/modules/services/web-apps/misskey.nix
@@ -231,7 +231,7 @@ in
         webserver = lib.mkOption {
           type = lib.types.attrTag {
             nginx = lib.mkOption {
-              type = lib.types.submodule (import ../web-servers/nginx/vhost-options.nix);
+              type = lib.types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
               default = { };
               description = ''
                 Extra configuration for the nginx virtual host of Misskey.

--- a/nixos/modules/services/web-apps/misskey.nix
+++ b/nixos/modules/services/web-apps/misskey.nix
@@ -231,7 +231,9 @@ in
         webserver = lib.mkOption {
           type = lib.types.attrTag {
             nginx = lib.mkOption {
-              type = lib.types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+              type = lib.types.submodule (
+                lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; }
+              );
               default = { };
               description = ''
                 Extra configuration for the nginx virtual host of Misskey.

--- a/nixos/modules/services/web-apps/monica.nix
+++ b/nixos/modules/services/web-apps/monica.nix
@@ -197,10 +197,7 @@ in {
     };
 
     nginx = mkOption {
-      type = types.submodule (
-        recursiveUpdate
-        (import ../web-servers/nginx/vhost-options.nix {inherit config lib;}) {}
-      );
+      type = types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix {inherit config lib;});
       default = {};
       example = ''
         {

--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -402,7 +402,7 @@ in
 
       nginx = mkOption {
         type = with types; nullOr (submodule
-          (import ../web-servers/nginx/vhost-options.nix {
+          (lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
             inherit config lib;
           }));
         default = null;

--- a/nixos/modules/services/web-apps/pixelfed.nix
+++ b/nixos/modules/services/web-apps/pixelfed.nix
@@ -95,7 +95,7 @@ in {
 
       nginx = mkOption {
         type = types.nullOr (types.submodule
-          (import ../web-servers/nginx/vhost-options.nix {
+          (lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
             inherit config lib;
           }));
         default = null;

--- a/nixos/modules/services/web-apps/slskd.nix
+++ b/nixos/modules/services/web-apps/slskd.nix
@@ -31,7 +31,7 @@ in {
     };
 
     nginx = mkOption {
-      type = types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+      type = types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = {};
       example = lib.literalExpression ''
         {

--- a/nixos/modules/services/web-apps/snipe-it.nix
+++ b/nixos/modules/services/web-apps/snipe-it.nix
@@ -217,10 +217,7 @@ in {
     };
 
     nginx = mkOption {
-      type = types.submodule (
-        recursiveUpdate
-          (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {}
-      );
+      type = types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = {};
       example = literalExpression ''
         {

--- a/nixos/modules/services/web-apps/zabbix.nix
+++ b/nixos/modules/services/web-apps/zabbix.nix
@@ -208,7 +208,9 @@ in
       };
 
       nginx.virtualHost = mkOption {
-        type = types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+        type = types.submodule (
+          lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; }
+        );
         example = literalExpression ''
           {
             forceSSL = true;

--- a/nixos/modules/services/web-apps/zabbix.nix
+++ b/nixos/modules/services/web-apps/zabbix.nix
@@ -208,7 +208,7 @@ in
       };
 
       nginx.virtualHost = mkOption {
-        type = types.submodule (import ../web-servers/nginx/vhost-options.nix);
+        type = types.submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { inherit config lib; });
         example = literalExpression ''
           {
             forceSSL = true;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1121,45 +1121,9 @@ in
   ];
 
   config = mkIf cfg.enable {
-    warnings =
-    let
-      deprecatedSSL = name: config: optional config.enableSSL
-      ''
-        config.services.nginx.virtualHosts.<name>.enableSSL is deprecated,
-        use config.services.nginx.virtualHosts.<name>.onlySSL instead.
-      '';
+    warnings = concatMap (host: host.warnings) (lib.attrValues virtualHosts);
 
-    in flatten (mapAttrsToList deprecatedSSL virtualHosts);
-
-    assertions =
-    let
-      hostOrAliasIsNull = l: l.root == null || l.alias == null;
-    in [
-      {
-        assertion = all (host: all hostOrAliasIsNull (attrValues host.locations)) (attrValues virtualHosts);
-        message = "Only one of nginx root or alias can be specified on a location.";
-      }
-
-      {
-        assertion = all (host: with host;
-          count id [ addSSL (onlySSL || enableSSL) forceSSL rejectSSL ] <= 1
-        ) (attrValues virtualHosts);
-        message = ''
-          Options services.nginx.service.virtualHosts.<name>.addSSL,
-          services.nginx.virtualHosts.<name>.onlySSL,
-          services.nginx.virtualHosts.<name>.forceSSL and
-          services.nginx.virtualHosts.<name>.rejectSSL are mutually exclusive.
-        '';
-      }
-
-      {
-        assertion = all (host: !(host.enableACME && host.useACMEHost != null)) (attrValues virtualHosts);
-        message = ''
-          Options services.nginx.service.virtualHosts.<name>.enableACME and
-          services.nginx.virtualHosts.<name>.useACMEHost are mutually exclusive.
-        '';
-      }
-
+    assertions = [
       {
         assertion = cfg.package.pname != "nginxQuic" && cfg.package.pname != "angieQuic" -> !(cfg.enableQuicBPF);
         message = ''
@@ -1168,49 +1132,14 @@ in
           `services.nginx.package = pkgs.angieQuic;`.
         '';
       }
-
-      {
-        assertion = cfg.package.pname != "nginxQuic" && cfg.package.pname != "angieQuic" -> all (host: !host.quic) (attrValues virtualHosts);
-        message = ''
-          services.nginx.service.virtualHosts.<name>.quic requires using nginxQuic or angie packages,
-          which can be achieved by setting `services.nginx.package = pkgs.nginxQuic;` or
-          `services.nginx.package = pkgs.angieQuic;`.
-        '';
-      }
-
-      {
-        # The idea is to understand whether there is a virtual host with a listen configuration
-        # that requires ACME configuration but has no HTTP listener which will make deterministically fail
-        # this operation.
-        # Options' priorities are the following at the moment:
-        # listen (vhost) > defaultListen (server) > listenAddresses (vhost) > defaultListenAddresses (server)
-        assertion =
-        let
-          hasAtLeastHttpListener = listenOptions: any (listenLine: if listenLine ? proxyProtocol then !listenLine.proxyProtocol else true) listenOptions;
-          hasAtLeastDefaultHttpListener = if cfg.defaultListen != [] then hasAtLeastHttpListener cfg.defaultListen else (cfg.defaultListenAddresses != []);
-        in
-          all (host:
-            let
-              hasAtLeastVhostHttpListener = if host.listen != [] then hasAtLeastHttpListener host.listen else (host.listenAddresses != []);
-              vhostAuthority = host.listen != [] || (cfg.defaultListen == [] && host.listenAddresses != []);
-            in
-              # Either vhost has precedence and we need a vhost specific http listener
-              # Either vhost set nothing and inherit from server settings
-              host.enableACME -> ((vhostAuthority && hasAtLeastVhostHttpListener) || (!vhostAuthority && hasAtLeastDefaultHttpListener))
-          ) (attrValues virtualHosts);
-        message = ''
-          services.nginx.virtualHosts.<name>.enableACME requires a HTTP listener
-          to answer to ACME requests.
-        '';
-      }
-
       {
         assertion = cfg.resolver.ipv4 || cfg.resolver.ipv6;
         message = ''
           At least one of services.nginx.resolver.ipv4 and services.nginx.resolver.ipv6 must be true.
         '';
       }
-    ] ++ map (name: mkCertOwnershipAssertion {
+    ] ++ lib.flatten (map (host: host.assertions) (lib.attrValues virtualHosts))
+    ++ map (name: mkCertOwnershipAssertion {
       cert = config.security.acme.certs.${name};
       groups = config.users.groups;
       services = [ config.systemd.services.nginx ] ++ lib.optional (cfg.enableReload || vhostCertNames != []) config.systemd.services.nginx-config-reload;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1138,7 +1138,7 @@ in
           At least one of services.nginx.resolver.ipv4 and services.nginx.resolver.ipv6 must be true.
         '';
       }
-    ] ++ lib.flatten (map (host: host.assertions) (lib.attrValues virtualHosts))
+    ] ++ concatMap (host: host.assertions) (lib.attrValues virtualHosts)
     ++ map (name: mkCertOwnershipAssertion {
       cert = config.security.acme.certs.${name};
       groups = config.users.groups;

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -394,10 +394,14 @@ with lib;
       '';
 
     assertions = [
-      {
-        assertion = all (l: l.root == null || l.alias == null) (attrValues config.locations);
-        message = "Only one of nginx root or alias can be specified on a location.";
-      }
+      (let
+        matchedLocations = filterAttrs (n: v: v.root != null && v.alias != null) config.locations;
+      in {
+        assertion = matchedLocations == { };
+        message = ''
+          Only one of root or alias can be specified on services.nginx.virtualHosts."${name}".locations: ${lib.concatStringsSep ", " (attrValues matchedLocations)}.
+        '';
+      })
       {
         assertion = count id [ config.addSSL (config.onlySSL || config.enableSSL) config.forceSSL config.rejectSSL ] <= 1;
         message = ''

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -4,10 +4,28 @@
 # the user/group to run under.)
 
 { config, lib, ... }:
+let
+  global-config = config;
+in
+{ config, name, ... }:
 
 with lib;
 {
   options = {
+    assertions = mkOption {
+      type = types.listOf (types.attrsOf types.unspecified);
+      default = [ ];
+      description = "This is just a helper option to carry assertions out of virtualHosts.";
+      internal = true;
+    };
+
+    warnings = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "This is just a helper option to carry warnings out of virtualHosts.";
+      internal = true;
+    };
+
     serverName = mkOption {
       type = types.nullOr types.str;
       default = null;
@@ -351,7 +369,8 @@ with lib;
 
     locations = mkOption {
       type = types.attrsOf (types.submodule (import ./location-options.nix {
-        inherit lib config;
+        config = global-config;
+        inherit lib;
       }));
       default = {};
       example = literalExpression ''
@@ -363,5 +382,68 @@ with lib;
       '';
       description = "Declarative location config";
     };
+  };
+
+  config = let
+   inherit (global-config.services.nginx) package;
+  in {
+    warnings = optional config.enableSSL
+      ''
+        config.services.nginx.virtualHosts."${name}".enableSSL is deprecated,
+        use config.services.nginx.virtualHosts."${name}".onlySSL instead.
+      '';
+
+    assertions = [
+      {
+        assertion = all (l: l.root == null || l.alias == null) (attrValues config.locations);
+        message = "Only one of nginx root or alias can be specified on a location.";
+      }
+      {
+        assertion = count id [ config.addSSL (config.onlySSL || config.enableSSL) config.forceSSL config.rejectSSL ] <= 1;
+        message = ''
+          Options services.nginx.service.virtualHosts."${name}".addSSL,
+          services.nginx.virtualHosts."${name}".onlySSL,
+          services.nginx.virtualHosts."${name}".forceSSL and
+          services.nginx.virtualHosts."${name}".rejectSSL are mutually exclusive.
+        '';
+      }
+      {
+        assertion = !(config.enableACME && config.useACMEHost != null);
+        message = ''
+          Options services.nginx.service.virtualHosts."${name}".enableACME and
+          services.nginx.virtualHosts."${name}".useACMEHost are mutually exclusive.
+        '';
+      }
+      {
+        assertion = package.pname != "nginxQuic" && package.pname != "angieQuic" -> !config.quic;
+        message = ''
+          services.nginx.service.virtualHosts."${name}".quic requires using nginxQuic or angie packages,
+          which can be achieved by setting `services.nginx.package = pkgs.nginxQuic;` or
+          `services.nginx.package = pkgs.angieQuic;`.
+        '';
+      }
+      {
+        # The idea is to understand whether there is a virtual host with a listen configuration
+        # that requires ACME configuration but has no HTTP listener which will make deterministically fail
+        # this operation.
+        # Options' priorities are the following at the moment:
+        # listen (vhost) > defaultListen (server) > listenAddresses (vhost) > defaultListenAddresses (server)
+        assertion =
+        let
+          cfg = global-config.services.nginx;
+          hasAtLeastHttpListener = listenOptions: any (listenLine: if listenLine ? proxyProtocol then !listenLine.proxyProtocol else true) listenOptions;
+          hasAtLeastDefaultHttpListener = if cfg.defaultListen != [] then hasAtLeastHttpListener cfg.defaultListen else (cfg.defaultListenAddresses != []);
+          hasAtLeastVhostHttpListener = if config.listen != [] then hasAtLeastHttpListener config.listen else (config.listenAddresses != []);
+          vhostAuthority = config.listen != [] || (cfg.defaultListen == [] && config.listenAddresses != []);
+        in
+          # Either vhost has precedence and we need a vhost specific http listener
+          # Either vhost set nothing and inherit from server settings
+          config.enableACME -> ((vhostAuthority && hasAtLeastVhostHttpListener) || (!vhostAuthority && hasAtLeastDefaultHttpListener));
+        message = ''
+          services.nginx.virtualHosts."${name}".enableACME requires a HTTP listener
+          to answer to ACME requests.
+        '';
+      }
+    ];
   };
 }


### PR DESCRIPTION
Before assertions where not really helpful as they didn't show what vhost had the problem which is very essential to fix it.

```
- Options services.nginx.service.virtualHosts.<name>.enableACME and
services.nginx.virtualHosts.<name>.useACMEHost are mutually exclusive.
```

and now they do 🎉 

```
- Options services.nginx.service.virtualHosts."example.org".enableACME and
services.nginx.virtualHosts."example.org".useACMEHost are mutually exclusive.
```

Actual assertion with mocked host name while I had the old assertions still in place:

```
       error:
       Failed assertions:
       - Options services.nginx.service.virtualHosts.<name>.enableACME and
       services.nginx.virtualHosts.<name>.useACMEHost are mutually exclusive.

       - Options services.nginx.service.virtualHosts."example.org".enableACME and
       services.nginx.virtualHosts."example.org".useACMEHost are mutually exclusiv
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
