### PR TITLE
katawa-shoujo: Fetch from archive.org

### DIFF
--- a/pkgs/games/katawa-shoujo/default.nix
+++ b/pkgs/games/katawa-shoujo/default.nix
@@ -31,11 +31,13 @@ let
   stdenv = stdenvNoCC;
   srcDetails = rec {
     x86_64-linux = {
+      archiveDate = "20240825224413";
       urlSuffix = "%5blinux-x86%5d%5b18161880%5d.tar.bz2";
       hash = "sha256-7FoFz88dWYHs2/pxkEwnmiFeeb3+slayrWknEJoAB9o=";
     };
     i686-linux = x86_64-linux;
     x86_64-darwin = {
+      archiveDate = "20240825224411";
       urlSuffix = "%5bmac%5d%5b1DFC84A6%5d.dmg";
       hash = "sha256-Sc5BAlpJsffjcNrZ8+VU3n7G10DoqDKQn/leHDW32Y8=";
     };
@@ -46,7 +48,7 @@ stdenv.mkDerivation rec {
   version = "1.3.1";
 
   src = fetchurl {
-    url = "https://cdn.fhs.sh/ks/bin/gold_${version}/%5b4ls%5d_katawa_shoujo_${version}-${srcDetails.urlSuffix}";
+    url = "https://web.archive.org/web/${srcDetails.archiveDate}/https://cdn.fhs.sh/ks/bin/gold_${version}/%5b4ls%5d_katawa_shoujo_${version}-${srcDetails.urlSuffix}";
     inherit (srcDetails) hash;
   };
 


### PR DESCRIPTION
Download speed has been unbearable since the migration to fhs.sh and their CDN. Go via archive.org instead.

![image](https://github.com/user-attachments/assets/c9888886-dc57-4a74-b195-bb3c30323e67)

Upstream CDN is 30 kB/s for me, 300 kB/s for someone else I asked. archive.org lets me pull at more than 300 kB/s, sometimes up to 1 or 2 MB/s. Not lightning-fast either, but better.

![image](https://github.com/user-attachments/assets/614343f9-be4a-4b1a-ba95-f7fe6e516afa)

---

Upstream also provides torrents, but `fetchtorrent` seems to misbehave - download completes (most times, sometimes it just fails to resolve), but directory structure is wrong for this:

https://github.com/NixOS/nixpkgs/blob/e95a3a311ba521d46b2ff29313c4004ff2dbca52/pkgs/build-support/fetchtorrent/default.nix#L22-L27

Structure is just `$downloadedDirectory/(downloaded bz2)`, so this throws away the whole download. And I couldn't get the hash to match what we already have.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (actually managed to build this again)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
