### PR TITLE
nixos/test-driver: rewrite assert statements with debug info

### DIFF
--- a/nixos/lib/test-driver/test_driver/__init__.py
+++ b/nixos/lib/test-driver/test_driver/__init__.py
@@ -103,6 +103,11 @@ def main() -> None:
         type=Path,
     )
     arg_parser.add_argument(
+        "--no-rewrite-asserts",
+        help="Do not rewrite assert statements with debugging information",
+        action="store_true",
+    )
+    arg_parser.add_argument(
         "testscript",
         action=EnvDefault,
         envvar="testScript",
@@ -132,6 +137,7 @@ def main() -> None:
         logger,
         args.keep_vm_state,
         args.global_timeout,
+        not args.no_rewrite_asserts,
     ) as driver:
         if args.interactive:
             history_dir = os.getcwd()

--- a/nixos/lib/test-driver/test_driver/rewrite.py
+++ b/nixos/lib/test-driver/test_driver/rewrite.py
@@ -1,0 +1,168 @@
+import ast
+import types
+import typing
+
+# inspired by https://github.com/pytest-dev/pytest/blob/main/src/_pytest/assertion/rewrite.py
+
+
+def rewrite_and_compile_python_test_code(source: str) -> types.CodeType:
+    tree = ast.parse(source, filename="<stdin>")
+    rewrite_test_code_ast(tree)
+    ast.fix_missing_locations(tree)
+    return compile(tree, "<stdin>", "exec", dont_inherit=True)
+
+
+def rewrite_test_code_ast(node: ast.AST) -> None:  # mutates node
+    """
+    Applies rewrite_assert_stmt to all ast.Assert statements in node
+    """
+    assert isinstance(node, ast.AST)
+
+    if isinstance(node, ast.Module):
+        if not node.body:
+            return
+
+    # recurse
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        rewrite_test_code_ast(node)
+
+    # traverse
+    else:
+        for name, field in ast.iter_fields(node):
+            # expressions can't contain (assert) statements
+            if isinstance(field, ast.expr):
+                continue
+
+            # find asserts, rewrite or recurse
+            if isinstance(field, list):
+                new_field: list[ast.AST] = []
+                for i, child in enumerate(field):
+                    if isinstance(child, ast.Assert):
+                        new_field += rewrite_assert_stmt(child)
+                    else:
+                        new_field.append(child)
+                        rewrite_test_code_ast(child)
+                setattr(node, name, new_field)
+
+
+CMPOP_TO_STR: dict[type[ast.cmpop], str] = {
+    ast.Eq: "==",
+    ast.NotEq: "!=",
+    ast.Is: "is",
+    ast.IsNot: "is not",
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+}
+
+_VARIABLE_NAME_COUNTER: int = 0
+
+
+def _mk_var_name() -> str:
+    global _VARIABLE_NAME_COUNTER
+    _VARIABLE_NAME_COUNTER += 1
+    # Use a character invalid in python identifiers to avoid name clashes
+    return f"@nixos_test_assert_{_VARIABLE_NAME_COUNTER}"
+
+
+def rewrite_assert_stmt(assert_node: ast.Assert) -> typing.Iterable[ast.stmt]:
+    """
+    Converts an assert statement into a sequence of statements
+
+        assert x == y != z
+
+    becomes
+
+        @nixos_test_assert_1 = x
+        @nixos_test_assert_2 = y
+        assert @nixos_test_assert_1 == @nixos_test_assert_2, \
+            f"(x == y)\n  {@nixos_test_assert_1!r} == {@nixos_test_assert_2!r}"
+        @nixos_test_assert_3 = z
+        assert @nixos_test_assert_2 != @nixos_test_assert_3, \
+            f"(y != z)\n  {@nixos_test_assert_2!r} != {@nixos_test_assert_3!r}"
+
+    Supported operands: ==, !=, is, is not, >, <, >=, >=
+    """
+    assert isinstance(assert_node, ast.Assert)
+
+    # in this case we already have a warning raised by python:
+    #     SyntaxWarning: assertion is always true, perhaps remove parentheses?
+    if isinstance(assert_node.test, ast.Tuple) and len(assert_node.test.elts) >= 1:
+        yield assert_node
+        return
+
+    # the assert already has a message
+    if assert_node.msg is not None:
+        yield assert_node
+        return
+
+    # if the assert is not one of the supported binary comparision ops, ignore
+    if not isinstance(assert_node.test, ast.Compare) or not all(
+        isinstance(op, (*CMPOP_TO_STR.keys(),)) for op in assert_node.test.ops
+    ):
+        yield assert_node
+        return
+
+    test_lhs_node: ast.expr = assert_node.test.left
+    test_rhs_nodes: list[ast.expr] = assert_node.test.comparators
+
+    # precompute lhs
+    test_lhs_name: str = _mk_var_name()
+    yield ast.Assign(
+        targets=[ast.Name(id=test_lhs_name, ctx=ast.Store())],
+        value=test_lhs_node,
+        lineno=assert_node.lineno,
+        end_lineno=assert_node.end_lineno,
+    )
+
+    # for each comparision, emit an assert with a more specific message
+    for i, (cmpop, test_rhs_node) in enumerate(
+        zip(assert_node.test.ops, test_rhs_nodes)
+    ):
+        test_rhs_name: str = _mk_var_name()
+
+        # precompute rhs
+        yield ast.Assign(
+            targets=[ast.Name(id=test_rhs_name, ctx=ast.Store())],
+            value=test_rhs_node,
+            lineno=assert_node.lineno,
+            end_lineno=assert_node.end_lineno,
+        )
+
+        if len(test_rhs_nodes) > 1:
+            subexpr = ast.Compare(
+                left=test_lhs_node, ops=[cmpop], comparators=[test_rhs_node]
+            )
+            msg_prefix = f"( {ast.unparse(subexpr)} )\n  "
+        else:
+            msg_prefix = ""
+
+        # assert lhs op rhs, f"{lhs"r} op {rhs!r}"
+        yield ast.Assert(
+            test=ast.Compare(
+                left=ast.Name(id=test_lhs_name, ctx=ast.Load()),
+                ops=[cmpop],
+                comparators=[ast.Name(id=test_rhs_name, ctx=ast.Load())],
+            ),
+            msg=ast.JoinedStr(
+                values=[
+                    ast.Constant(value=msg_prefix),
+                    ast.FormattedValue(
+                        value=ast.Name(id=test_lhs_name, ctx=ast.Load()),
+                        conversion=114,  # `!r` repr formatting
+                    ),
+                    ast.Constant(value=f" {CMPOP_TO_STR[cmpop.__class__]} "),
+                    ast.FormattedValue(
+                        value=ast.Name(id=test_rhs_name, ctx=ast.Load()),
+                        conversion=114,  # `!r` repr formatting
+                    ),
+                ],
+            ),
+            lineno=assert_node.lineno,
+            end_lineno=assert_node.end_lineno,
+        )
+
+        # set current rhs to next lhs
+        test_lhs_name = test_rhs_name
+        test_lhs_node = test_rhs_node

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -96,6 +96,7 @@ let
           --set testScript "$out/test-script" \
           --set globalTimeout "${toString config.globalTimeout}" \
           --set vlans '${toString vlans}' \
+          ${lib.optionalString (!config.rewriteAsserts) "--add-flags --no-rewrite-asserts"} \
           ${lib.escapeShellArgs (lib.concatMap (arg: ["--add-flags" arg]) config.extraDriverArgs)}
       '';
 
@@ -183,6 +184,14 @@ in
         Disable type checking. This must not be enabled for new NixOS tests.
 
         This may speed up your iteration cycle, unless you're working on the [{option}`testScript`](#test-opt-testScript).
+      '';
+    };
+
+    rewriteAsserts = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to rewrite assert statements akin to what pytest does, for debugging purposes.
       '';
     };
   };


### PR DESCRIPTION
I nerd-sniped myself while authoring https://github.com/NixOS/nixpkgs/pull/345891

This will rewrite `assert` statements to provide the actual values like in pytest.

tested by adding this change to this branch

```patch
diff --git a/nixos/tests/mihomo.nix b/nixos/tests/mihomo.nix
index 472d10050f7f..ea5562bcbd29 100644
--- a/nixos/tests/mihomo.nix
+++ b/nixos/tests/mihomo.nix
@@ -39,6 +39,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     machine.fail("curl --fail --max-time 10 --proxy socks5://user:supervillain@localhost:7890 http://localhost")
 
     # Web UI
-    machine.succeed("curl --fail http://localhost:9090") == '{"hello":"clash"}'
+    assert machine.succeed("curl --fail http://localhost:9090") == '{"hello":"clash"}'
   '';
 })
```

`nom-build . -A nixosTests.mihomo` output:

```
vm-test-run-mihomo> machine: must succeed: curl --fail http://localhost:9090
vm-test-run-mihomo> machine #   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
vm-test-run-mihomo> machine #                                  Dload  Upload   Total   Spent    Left  Speed
vm-test-run-mihomo> machine #   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0100    19  100    19    0     0    908      0 --:--:-- --:--:-- --:--:--   950
vm-test-run-mihomo> (finished: must succeed: curl --fail http://localhost:9090, in 0.06 seconds)
vm-test-run-mihomo> cleanup
vm-test-run-mihomo> kill machine (pid 10)
vm-test-run-mihomo> qemu-kvm: terminating on signal 15 from pid 7 (/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/bin/python3.12)
vm-test-run-mihomo> (finished: cleanup, in 0.01 seconds)
vm-test-run-mihomo> Traceback (most recent call last):
vm-test-run-mihomo>   File "/nix/store/dd4yvl932s1mw04fcfmbs2s4gy60vvfp-nixos-test-driver-1.1/bin/.nixos-test-driver-wrapped", line 9, in <module>
vm-test-run-mihomo>     sys.exit(main())
vm-test-run-mihomo>              ^^^^^^
vm-test-run-mihomo>   File "/nix/store/dd4yvl932s1mw04fcfmbs2s4gy60vvfp-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/__init__.py", line 152, in main
vm-test-run-mihomo>     driver.run_tests()
vm-test-run-mihomo>   File "/nix/store/dd4yvl932s1mw04fcfmbs2s4gy60vvfp-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/driver.py", line 177, in run_tests
vm-test-run-mihomo>     self.test_script()
vm-test-run-mihomo>   File "/nix/store/dd4yvl932s1mw04fcfmbs2s4gy60vvfp-nixos-test-driver-1.1/lib/python3.12/site-packages/test_driver/driver.py", line 169, in test_script
vm-test-run-mihomo>     exec(tests, symbols, None)
vm-test-run-mihomo>   File "<stdin>", line 15, in <module>
vm-test-run-mihomo> AssertionError: '{"hello":"mihomo"}\n' == '{"hello":"clash"}' 
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
