### PR TITLE
Add NixOS containers (or other `loc`) to crucial warning context

### DIFF
--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -36,7 +36,7 @@ let
   pythonizedNames = map pythonizeName nodeHostNames;
   machineNames = map (name: "${name}: Machine;") pythonizedNames;
 
-  withChecks = lib.warnIf config.skipLint "Linting is disabled";
+  withChecks = lib.warnIf config.skipLint "Linting is disabled in NixOS test named ${config.name}";
 
   driver =
     hostPkgs.runCommand "nixos-test-driver-${config.name}"

--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -395,7 +395,7 @@ in
               let
                 from = "fonts.fontconfig.hinting.style";
                 val' = lib.removePrefix "hint" val;
-                warning = "The option `${from}` contains a deprecated value `${val}`. Use `${val'}` instead.";
+                warning = "${config.system.diagnostics.prefix}The option `${from}` contains a deprecated value `${val}`. Use `${val'}` instead.";
               in
               lib.warnIf (lib.hasPrefix "hint" val) warning val';
           };

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -252,8 +252,8 @@ in
       # These may be used in auxiliary scripts (ie not part of toplevel), so they are defined unconditionally.
       system.build = {
         inherit nixos-generate-config nixos-install nixos-rebuild;
-        nixos-option = lib.warn "Accessing nixos-option through `config.system.build` is deprecated, use `pkgs.nixos-option` instead." pkgs.nixos-option;
-        nixos-enter = lib.warn "Accessing nixos-enter through `config.system.build` is deprecated, use `pkgs.nixos-enter` instead." pkgs.nixos-enter;
+        nixos-option = lib.warn "${config.system.diagnostics.prefix}Accessing nixos-option through `config.system.build` is deprecated, use `pkgs.nixos-option` instead." pkgs.nixos-option;
+        nixos-enter = lib.warn "${config.system.diagnostics.prefix}Accessing nixos-enter through `config.system.build` is deprecated, use `pkgs.nixos-enter` instead." pkgs.nixos-enter;
       };
     }
   ];

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -75,7 +75,7 @@ let
           (name: value:
             let
               wholeName = "${namePrefix}.${name}";
-              guard = warn "Attempt to evaluate package ${wholeName} in option documentation; this is not supported and will eventually be an error. Use `mkPackageOption{,MD}` or `literalExpression` instead.";
+              guard = warn "${config.system.diagnostics.prefix}Attempt to evaluate package ${wholeName} in option documentation; this is not supported and will eventually be an error. Use `mkPackageOption{,MD}` or `literalExpression` instead.";
             in if isAttrs value then
               scrubDerivations wholeName value
               // optionalAttrs (isDerivation value) {

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -156,7 +156,7 @@ in
       # Doing this also means fixing the comment in nixos/modules/testing/test-instrumentation.nix
       apply = v:
         lib.warnIf (options.system.stateVersion.highestPrio == (lib.mkOptionDefault { }).priority)
-          "system.stateVersion is not set, defaulting to ${v}. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion."
+          "${config.system.diagnostics.prefix}system.stateVersion is not set, defaulting to ${v}. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion."
           v;
       default = cfg.release;
       defaultText = literalExpression "config.${opt.release}";

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1595,7 +1595,7 @@ in
         # TODO(@uninsane): replace this warning + lib.filter with just an assertion
         (map (modulePath: lib.warnIfNot
           (lib.hasPrefix "/" modulePath)
-          ''non-absolute PAM modulePath "${modulePath}" is unsupported by apparmor and will be treated as an error by future versions of nixpkgs; see <https://github.com/NixOS/nixpkgs/pull/314791>''
+          ''${config.system.diagnostics.prefix}non-absolute PAM modulePath "${modulePath}" is unsupported by apparmor and will be treated as an error by future versions of nixpkgs; see <https://github.com/NixOS/nixpkgs/pull/314791>''
           modulePath
         ))
         (lib.filter (lib.hasPrefix "/"))

--- a/nixos/modules/services/networking/nebula.nix
+++ b/nixos/modules/services/networking/nebula.nix
@@ -205,7 +205,7 @@ in
           warnIf
             ((settings.lighthouse.am_lighthouse || settings.relay.am_relay) && settings.listen.port == 0)
             ''
-              Nebula network '${netName}' is configured as a lighthouse or relay, and its port is ${builtins.toString settings.listen.port}.
+              ${config.system.diagnostics.prefix}Nebula network '${netName}' is configured as a lighthouse or relay, and its port is ${builtins.toString settings.listen.port}.
               You will likely experience connectivity issues: https://nebula.defined.net/docs/config/listen/#listenport
             ''
             settings

--- a/nixos/modules/services/security/oauth2-proxy-nginx.nix
+++ b/nixos/modules/services/security/oauth2-proxy-nginx.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, options, ... }:
 let
   cfg = config.services.oauth2-proxy.nginx;
 in
@@ -46,7 +46,7 @@ in
         };
         oldType = lib.types.listOf lib.types.str;
         convertFunc = x:
-          lib.warn "services.oauth2-proxy.nginx.virtualHosts should be an attrset, found ${lib.generators.toPretty {} x}"
+          lib.warn "${options.services.oauth2-proxy.nginx.virtualHosts} should be an attrset, found ${lib.generators.toPretty {} x}"
           lib.genAttrs x (_: {});
         newType = lib.types.attrsOf vhostSubmodule;
       in lib.types.coercedTo oldType convertFunc newType;

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -104,7 +104,7 @@ let
     fi
   '';
 
-  siteOpts = { lib, name, config, ... }:
+  siteOpts = { lib, name, config, options, ... }:
     {
       options = {
         package = mkPackageOption pkgs "wordpress" { };
@@ -130,7 +130,7 @@ let
         plugins = mkOption {
           type = with types; coercedTo
             (listOf path)
-            (l: warn "setting this option with a list is deprecated"
+            (l: warn "setting ${options.plugins} with a list is deprecated"
               listToAttrs (map (p: nameValuePair (p.name or (throw "${p} does not have a name")) p) l))
             (attrsOf path);
           default = {};
@@ -151,7 +151,7 @@ let
         themes = mkOption {
           type = with types; coercedTo
             (listOf path)
-            (l: warn "setting this option with a list is deprecated"
+            (l: warn "setting ${options.themes} with a list is deprecated"
               listToAttrs (map (p: nameValuePair (p.name or (throw "${p} does not have a name")) p) l))
             (attrsOf path);
           default = { inherit (pkgs.wordpressPackages.themes) twentytwentyfour; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Motivation

Knowning that a warning comes from a specific container can make all the difference.

Original report: https://social.treehouse.systems/@krutonium/113238265178442734

## Things done

Add a new option that contains diagnostic context for warnings, errors.

Add it to all `warnings` warnings, and most `lib.warn` warnings.

This does not add it to `throw`s and `aborts` or built-in generated modules like `mkRenamedOptionModule`.

Manually tested with:

```nix
nix-repl> (nixos ({ config, ... }: { fileSystems."/".device = "x"; boot.loader.grub.enable = false; warnings = ["hi" (builtins.seq config.containers.foo.config.services.oauth2-proxy.nginx.virtualHosts "hi again")]; containers.foo.config = { warnings = ["hi from container"]; services.oauth2-proxy.nginx.virtualHosts = ["hi"]; }; })).toplevel
```
```
evaluation warning: system.stateVersion is not set, defaulting to 24.11. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
evaluation warning: containers.foo.services.oauth2-proxy.nginx.virtualHosts should be an attrset, found [
                      "hi"
                    ]
evaluation warning: containers.foo.services.oauth2-proxy.nginx.virtualHosts should be an attrset, found [
                      "hi"
                    ]
evaluation warning: hi
evaluation warning: hi again
evaluation warning: in containers.foo: system.stateVersion is not set, defaulting to 24.11. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
evaluation warning: in containers.foo: hi from container
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
