### PR TITLE
xdg-desktop-portal-gtk: Enable all default portals unconditionally

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -192,10 +192,7 @@ in
       xdg.portal.enable = true;
       xdg.portal.extraPortals = [
         pkgs.xdg-desktop-portal-xapp
-        (pkgs.xdg-desktop-portal-gtk.override {
-          # Do not build portals that we already have.
-          buildPortalsInGnome = false;
-        })
+        pkgs.xdg-desktop-portal-gtk
       ];
 
       services.orca.enable = mkDefault (notExcluded pkgs.orca);

--- a/nixos/modules/services/x11/desktop-managers/deepin.nix
+++ b/nixos/modules/services/x11/desktop-managers/deepin.nix
@@ -74,9 +74,7 @@ in
       xdg.icons.enable = true;
       xdg.portal.enable = mkDefault true;
       xdg.portal.extraPortals = mkDefault [
-        (pkgs.xdg-desktop-portal-gtk.override {
-          buildPortalsInGnome = false;
-        })
+        pkgs.xdg-desktop-portal-gtk
       ];
 
       # https://github.com/NixOS/nixpkgs/pull/247766#issuecomment-1722839259

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -281,10 +281,7 @@ in
       xdg.portal.enable = true;
       xdg.portal.extraPortals = [
         pkgs.xdg-desktop-portal-gnome
-        (pkgs.xdg-desktop-portal-gtk.override {
-          # Do not build portals that we already have.
-          buildPortalsInGnome = false;
-        })
+        pkgs.xdg-desktop-portal-gtk
       ];
       xdg.portal.configPackages = mkDefault [ pkgs.gnome-session ];
 

--- a/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
@@ -11,7 +11,6 @@
 , glib
 , wrapGAppsHook3
 , gsettings-desktop-schemas
-, buildPortalsInGnome ? true
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -36,17 +35,9 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     gtk3
     xdg-desktop-portal
-  ] ++ lib.optionals buildPortalsInGnome [
     gsettings-desktop-schemas # settings exposed by settings portal
     gnome-desktop
     gnome-settings-daemon # schemas needed for settings api (mostly useless now that fonts were moved to g-d-s, just mouse and xsettings)
-  ];
-
-  mesonFlags = lib.optionals (!buildPortalsInGnome) [
-    "-Dwallpaper=disabled"
-    "-Dsettings=disabled"
-    "-Dappchooser=disabled"
-    "-Dlockdown=disabled"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Things done

xdg-desktop-portal-gtk: Enable all default portals unconditionally

In 80ea989ac96cc420089326b2e0d725b1e634499f we updated to x-d-p-gtk 1.10.0, in which some portals were extracted to x-d-p-gnome and were disabled by default in x-d-p-gtk. This was continued with x-d-p-gtk 1.15 bump in 6d646062c8636178e03a4eeea8b75ab7110bcf0f, which default-enabled all portals because of port to Meson’s auto features.

But I do not think the conflict between portal implementations from x-d-p-gtk and x-d-p-gnome has ever been an issue at runtime – since `gnome` comes before `gtk` alphabetically, the `gnome` portal should have been always preferred when both were available.
And since x-d-p 1.17.0, the portal implementation conflicts are a complete non-issue, as desktop environments can configure which implementation to use for each portal.

Since the benefits of disabling the extra portals are minimal and can lead to conflicts when multiple DEs are enable, we have stopped DEs from doing that in parent commits. This makes the argument unused so let’s remove it.

Fixes: https://github.com/NixOS/nixpkgs/issues/345733

cc @wineee @bobby285271 @Frontear

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
