### PR TITLE
nixos/installer/cd-dvd: loadfont check before gfxterm init, to prevent crash in nonuefi graphic card platform

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -203,7 +203,7 @@ let
       # Load theme fonts
       $(find ${config.isoImage.grubTheme} -iname '*.pf2' -printf "loadfont (\$root)/EFI/BOOT/grub-theme/%P\n")
     '' else ''
-    if background_image (\$root)/EFI/BOOT/efi-background.png; then
+      if background_image (\$root)/EFI/BOOT/efi-background.png; then
         # Black background means transparent background when there
         # is a background image set... This seems undocumented :(
         set color_normal=black/black

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -201,7 +201,11 @@ let
       # Sets theme.
       set theme=(\$root)/EFI/BOOT/grub-theme/theme.txt
       # Load theme fonts
-      $(find ${config.isoImage.grubTheme} -iname '*.pf2' -printf "loadfont (\$root)/EFI/BOOT/grub-theme/%P\n")
+      set loadfontdone=false
+      $(find ${config.isoImage.grubTheme} -iname '*.pf2' -printf "if loadfont (\$root)/EFI/BOOT/grub-theme/%P; then set loadfontdone=true; fi\n")
+      if [ "\$loadfontdone" == "false" ]; then
+        loadfont (\$root)/EFI/BOOT/unicode.pf2
+      fi
     '' else ''
       if background_image (\$root)/EFI/BOOT/efi-background.png; then
         # Black background means transparent background when there
@@ -214,13 +218,6 @@ let
         set menu_color_highlight=white/blue
       fi
     ''}
-
-    set loadfontdone=false
-    $(find ${config.isoImage.grubTheme} -iname '*.pf2' -printf "if loadfont (\$root)/EFI/BOOT/grub-theme/%P; then set loadfontdone=true; fi\n")
-
-    if [ "\$loadfontdone" == "false" ]; then
-      loadfont (\$root)/EFI/BOOT/unicode.pf2
-    fi
 
     if [ "\$textmode" == "false" ]; then
       insmod gfxterm

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -175,7 +175,6 @@ let
     # Search using a "marker file"
     search --set=root --file /EFI/nixos-installer-image
 
-    insmod gfxterm
     insmod png
     set gfxpayload=keep
     set gfxmode=${lib.concatStringsSep "," [
@@ -196,16 +195,6 @@ let
       "auto"
     ]}
 
-    if [ "\$textmode" == "false" ]; then
-      terminal_output gfxterm
-      terminal_input  console
-    else
-      terminal_output console
-      terminal_input  console
-      # Sets colors for console term.
-      set menu_color_normal=cyan/blue
-      set menu_color_highlight=white/blue
-    fi
 
     ${ # When there is a theme configured, use it, otherwise use the background image.
     if config.isoImage.grubTheme != null then ''
@@ -214,7 +203,7 @@ let
       # Load theme fonts
       $(find ${config.isoImage.grubTheme} -iname '*.pf2' -printf "loadfont (\$root)/EFI/BOOT/grub-theme/%P\n")
     '' else ''
-      if background_image (\$root)/EFI/BOOT/efi-background.png; then
+    if background_image (\$root)/EFI/BOOT/efi-background.png; then
         # Black background means transparent background when there
         # is a background image set... This seems undocumented :(
         set color_normal=black/black
@@ -225,6 +214,26 @@ let
         set menu_color_highlight=white/blue
       fi
     ''}
+
+    set loadfontdone=false
+    $(find ${config.isoImage.grubTheme} -iname '*.pf2' -printf "if loadfont (\$root)/EFI/BOOT/grub-theme/%P; then set loadfontdone=true; fi\n")
+
+    if [ "\$loadfontdone" == "false" ]; then
+      loadfont (\$root)/EFI/BOOT/unicode.pf2
+    fi
+
+    if [ "\$textmode" == "false" ]; then
+      insmod gfxterm
+      terminal_output gfxterm
+      terminal_input  console
+    else
+      terminal_output console
+      terminal_input  console
+      # Sets colors for console term.
+      set menu_color_normal=cyan/blue
+      set menu_color_highlight=white/blue
+    fi
+
   '';
 
   # The EFI boot image.


### PR DESCRIPTION
Fix crash iso installation in some old hardwares.
I reproduced is issue and tested in x99 + gt405(old pc gpu), also regression tested newer platform(i5 12500h)

Add a font dectection code , to prevent "gfxterm" cash. also added a fontloaded flag , to check if font load sucess.  If font load failed (default dejavu.pf2), it will fallback loading a default font that  consume lower resource.
Also move gfxterm init order later, because of font loading problem, make sure that it's bootstrap will not be affected


press "g" will  force to use dejavu.pf2 font and gfxterm render . here is the screen shot of error 

 
![屏幕截图 2024-10-03 013430](https://github.com/user-attachments/assets/8c4a41c6-a8f7-4039-a8b8-9562933ba43c)



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
