### PR TITLE
nixos: improve systemd slice names

### DIFF
--- a/nixos/modules/security/isolate.nix
+++ b/nixos/modules/security/isolate.nix
@@ -125,7 +125,7 @@ in
     };
 
     systemd.slices.isolate = {
-      description = "Isolate sandbox slice";
+      description = "Isolate Sandbox Slice";
     };
 
     meta.maintainers = with maintainers; [ virchau13 ];

--- a/nixos/modules/services/backup/bacula.nix
+++ b/nixos/modules/services/backup/bacula.nix
@@ -657,7 +657,7 @@ in {
 
   config = mkIf (fd_cfg.enable || sd_cfg.enable || dir_cfg.enable) {
     systemd.slices.system-bacula = {
-      description = "Bacula Slice";
+      description = "Bacula Backup System Slice";
       documentation = [ "man:bacula(8)" "https://www.bacula.org/" ];
     };
 

--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -311,7 +311,7 @@ in
     ];
 
     systemd.slices.system-hydra = {
-      description = "Hydra Slice";
+      description = "Hydra CI Server Slice";
       documentation = [ "file://${cfg.package}/share/doc/hydra/index.html" "https://nixos.org/hydra/manual/" ];
     };
 

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -234,7 +234,7 @@ in
     services.redis.servers.paperless.enable = mkIf enableRedis true;
 
     systemd.slices.system-paperless = {
-      description = "Paperless slice";
+      description = "Paperless Document Management System Slice";
       documentation = [ "https://docs.paperless-ngx.com" ];
     };
 

--- a/nixos/modules/services/monitoring/rustdesk-server.nix
+++ b/nixos/modules/services/monitoring/rustdesk-server.nix
@@ -86,7 +86,7 @@ in {
 
     systemd.slices.system-rustdesk = {
       enable = true;
-      description = "Slice designed to contain RustDesk Signal & RustDesk Relay";
+      description = "RustDesk Remote Desktop Slice";
     };
 
     systemd.targets.rustdesk = {

--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -179,7 +179,7 @@ in
 
         systemd = {
           slices.system-samba = {
-            description = "Samba slice";
+            description = "Samba (SMB Networking Protocol) Slice";
           };
           targets.samba = {
             description = "Samba Server";

--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -165,7 +165,7 @@ in
     environment.etc."clamav/clamd.conf".source = clamdConfigFile;
 
     systemd.slices.system-clamav = {
-      description = "ClamAV slice";
+      description = "ClamAV Antivirus Slice";
     };
 
     systemd.services.clamav-daemon = mkIf cfg.daemon.enable {

--- a/nixos/modules/services/web-servers/phpfpm/default.nix
+++ b/nixos/modules/services/web-servers/phpfpm/default.nix
@@ -240,7 +240,7 @@ in {
     };
 
     systemd.slices.system-phpfpm = {
-      description = "PHP FastCGI Process manager pools slice";
+      description = "PHP FastCGI Process Manager Slice";
     };
 
     systemd.targets.phpfpm = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Following
https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Description=,
update slice names to be short, descriptive and capitalized.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
