### PR TITLE
neomutt: 20240425 -> 20241002

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -35,15 +35,17 @@
   withContrib ? true,
 }:
 
+assert lib.warnIf (enableMixmaster) "Support for mixmaster has been removed from neomutt since the 20241002 release" true;
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "neomutt";
-  version = "20240425";
+  version = "20241002";
 
   src = fetchFromGitHub {
     owner = "neomutt";
     repo = "neomutt";
     rev = finalAttrs.version;
-    hash = "sha256-QBqPFteoAm3AdQN0XTWpho8DEW2BFCCzBcHUZIiSxyQ=";
+    hash = "sha256-c8G0CGg4jrwq+HVR4O0AtaJNzr7pDYsie1410tisLEY=";
   };
 
   buildInputs = [
@@ -112,8 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
       "--zlib"
     ]
     ++ lib.optional enableZstd "--zstd"
-    ++ lib.optional enableLua "--lua"
-    ++ lib.optional enableMixmaster "--mixmaster";
+    ++ lib.optional enableLua "--lua";
 
   postInstall =
     ''

--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -35,7 +35,9 @@
   withContrib ? true,
 }:
 
-assert lib.warnIf (enableMixmaster) "Support for mixmaster has been removed from neomutt since the 20241002 release" true;
+assert lib.warnIf (
+  enableMixmaster
+) "Support for mixmaster has been removed from neomutt since the 20241002 release" true;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "neomutt";
@@ -97,24 +99,21 @@ stdenv.mkDerivation (finalAttrs: {
       --replace /etc/mime.types ${mailcap}/etc/mime.types
   '';
 
-  configureFlags =
-    [
-      "--enable-autocrypt"
-      "--gpgme"
-      "--gss"
-      "--lmdb"
-      "--notmuch"
-      "--ssl"
-      "--sasl"
-      "--with-homespool=mailbox"
-      "--with-mailpath="
-      # To make it not reference .dev outputs. See:
-      # https://github.com/neomutt/neomutt/pull/2367
-      "--disable-include-path-in-cflags"
-      "--zlib"
-    ]
-    ++ lib.optional enableZstd "--zstd"
-    ++ lib.optional enableLua "--lua";
+  configureFlags = [
+    "--enable-autocrypt"
+    "--gpgme"
+    "--gss"
+    "--lmdb"
+    "--notmuch"
+    "--ssl"
+    "--sasl"
+    "--with-homespool=mailbox"
+    "--with-mailpath="
+    # To make it not reference .dev outputs. See:
+    # https://github.com/neomutt/neomutt/pull/2367
+    "--disable-include-path-in-cflags"
+    "--zlib"
+  ] ++ lib.optional enableZstd "--zstd" ++ lib.optional enableLua "--lua";
 
   postInstall =
     ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release Notes: https://github.com/neomutt/neomutt/releases/tag/20241002
Diff: https://github.com/neomutt/neomutt/compare/20240425...20241002

**N.B.:** If neomutt is being build with `enableMixmaster = true;` the neomutt nixpkgs will abort the build with a warning stating that support for mixmaster has been removed from upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
