### PR TITLE
libguestfs-with-appliance: use symlinkJoin & patch GUESTFS_DEFAULT_PATH

### DIFF
--- a/pkgs/development/libraries/libguestfs/appliance.nix
+++ b/pkgs/development/libraries/libguestfs/appliance.nix
@@ -1,6 +1,7 @@
-{ lib
-, stdenvNoCC
-, fetchurl
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -15,8 +16,8 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out
-    cp README.fixed initrd kernel root $out
+    mkdir -p $out/lib/guestfs/
+    cp README.fixed initrd kernel root $out/lib/guestfs/
 
     runHook postInstall
   '';
@@ -24,8 +25,14 @@ stdenvNoCC.mkDerivation rec {
   meta = with lib; {
     description = "VM appliance disk image used in libguestfs package";
     homepage = "https://libguestfs.org";
-    license = with licenses; [ gpl2Plus lgpl2Plus ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    license = with licenses; [
+      gpl2Plus
+      lgpl2Plus
+    ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
     hydraPlatforms = [ ]; # Hydra fails with "Output limit exceeded"
   };
 }

--- a/pkgs/development/libraries/libguestfs/libguestfs_guestfs_path_section.patch
+++ b/pkgs/development/libraries/libguestfs/libguestfs_guestfs_path_section.patch
@@ -1,0 +1,28 @@
+--- a/lib/handle.c
++++ b/lib/handle.c
+@@ -52,6 +52,8 @@ static pthread_mutex_t init_lock = PTHREAD_MUTEX_INITIALIZER;
+ 
+ static void init_libguestfs (void) __attribute__((constructor));
+ 
++const char guestfs_default_path[] __attribute__((section("guestfs_path_str"))) = GUESTFS_DEFAULT_PATH;
++
+ /**
+  * No initialization is required by libguestfs, but libvirt and
+  * libxml2 require initialization if they might be called from
+@@ -115,7 +117,7 @@ guestfs_create_flags (unsigned flags, ...)
+   /* Default is uniprocessor appliance. */
+   g->smp = 1;
+ 
+-  g->path = strdup (GUESTFS_DEFAULT_PATH);
++  g->path = strdup (guestfs_default_path);
+   if (!g->path) goto error;
+ 
+ #ifdef QEMU
+@@ -522,7 +524,7 @@ guestfs_impl_set_path (guestfs_h *g, const char *path)
+ 
+   g->path =
+     path == NULL ?
+-    safe_strdup (g, GUESTFS_DEFAULT_PATH) : safe_strdup (g, path);
++    safe_strdup (g, guestfs_default_path) : safe_strdup (g, path);
+   return 0;
+ }

--- a/pkgs/development/libraries/libguestfs/with-appliance.nix
+++ b/pkgs/development/libraries/libguestfs/with-appliance.nix
@@ -1,0 +1,72 @@
+{
+  pkgs,
+  libguestfs-appliance,
+  libguestfs,
+  qemu,
+  symlinkJoin,
+  makeWrapper,
+  binutils-unwrapped,
+  libguestfs-with-appliance,
+}:
+
+symlinkJoin rec {
+  pname = "libguestfs-with-appliance";
+  inherit (libguestfs) version;
+  name = "${pname}-${version}";
+
+  paths = [
+    libguestfs
+    libguestfs-appliance
+  ];
+  buildInputs = [
+    makeWrapper
+    binutils-unwrapped
+  ];
+  postBuild = ''
+    for bin in $out/bin/*; do
+      wrapProgram "$bin" --suffix LD_LIBRARY_PATH : ${placeholder "out"}/lib/
+    done
+
+    sofile=$(realpath $out/lib/libguestfs.so)
+    cp --no-preserve=mode "$sofile" .
+    copy_sofile=./$(basename "$sofile")
+
+    printf '${placeholder "out"}/lib/guestfs/\x00' > new_guestfs_default_path.bin
+    objcopy --update-section guestfs_path_str=new_guestfs_default_path.bin $copy_sofile
+
+    install -m 555  $copy_sofile $out/lib/
+  '';
+  passthru.tests = libguestfs.passthru.tests // {
+    libguestfs-test-tool = pkgs.runCommand "run-libguestfs-test-tool" { } ''
+      set -e
+      ${libguestfs-with-appliance}/bin/libguestfs-test-tool
+      touch $out
+    '';
+    diskFormat = pkgs.runCommand "format-disk" { } ''
+      set -e
+      export HOME=$(mktemp -d) # avoid access to /homeless-shelter/.guestfish
+      ${qemu}/bin/qemu-img create -f qcow2 disk1.img 10G
+
+      ${libguestfs-with-appliance}/bin/guestfish <<'EOF'
+      add-drive disk1.img
+      run
+      list-filesystems
+      part-disk /dev/sda mbr
+      mkfs ext2 /dev/sda1
+      list-filesystems
+      EOF
+      touch $out
+    '';
+  };
+
+  meta = {
+    hydraPlatforms = [ ];
+    inherit (libguestfs.meta)
+      description
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21200,11 +21200,7 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook264;
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;
   };
-  libguestfs-with-appliance = libguestfs.override {
-    appliance = libguestfs-appliance;
-    autoreconfHook = buildPackages.autoreconfHook264;
-  };
-
+  libguestfs-with-appliance = pkgs.callPackage ../development/libraries/libguestfs/with-appliance.nix { };
 
   libhangul = callPackage ../development/libraries/libhangul { };
 


### PR DESCRIPTION
Closes #86633 but does not wrap instead it patches GUESTFS_DEFAULT_PATH in `libguestfs-with-appliance` otherwise all importers of `libguestfs.so` would need wrappers (e.g guestfs-tools, virt-v2v ...). 
The result is that libguestfs is no longer built twice, which was noticeable as `libguestfs-with-appliance` was always built locally.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
