### PR TITLE
xdis: 6.1.0 -> 6.1.1

### DIFF
--- a/pkgs/development/python-modules/xdis/default.nix
+++ b/pkgs/development/python-modules/xdis/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   click,
   fetchFromGitHub,
+  fetchpatch,
   pytestCheckHook,
   pythonOlder,
   six,
@@ -10,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "xdis";
-  version = "6.1.0";
+  version = "6.1.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -19,8 +20,16 @@ buildPythonPackage rec {
     owner = "rocky";
     repo = "python-xdis";
     rev = "refs/tags/${version}";
-    hash = "sha256-KgKTO99T2/be1sBs5rY3Oy7/Yl9WGgdG3hqqkZ7D7ZY=";
+    hash = "sha256-Fn1cyUPMrn1SEXl4sdQwJiNHaY+BbxBDz3nKZY965/0=";
   };
+  patches = [
+    (fetchpatch {
+      # 2.13.5 support, already committed to main, expected in 6.1.2
+      url = "https://github.com/rocky/python-xdis/commit/fcba74a7f64c5e2879ca0779ff10f38f9229e7da.patch";
+      hash = "sha256-D7eJ97g4G6pmYL/guq0Ndf8yKTVBD2gAuUCAKwvlYbE=";
+    })
+    ./test_nested_scopes.patch
+  ];
 
   propagatedBuildInputs = [
     click

--- a/pkgs/development/python-modules/xdis/test_nested_scopes.patch
+++ b/pkgs/development/python-modules/xdis/test_nested_scopes.patch
@@ -1,0 +1,97 @@
+commit 7f3dd6fb7ff92ad23b2e1bcc978eb6c63a28dcdb
+Author: Arnout Engelen <arnout@bzzt.net>
+Date:   Wed Oct 2 21:01:35 2024 +0200
+
+    Make test/decompyle/test_nested_scopes.py compile
+
+diff --git a/test/decompyle/test_nested_scopes.py b/test/decompyle/test_nested_scopes.py
+index 32646e1..5dc207e 100644
+--- a/test/decompyle/test_nested_scopes.py
++++ b/test/decompyle/test_nested_scopes.py
+@@ -22,7 +22,7 @@ def x0():
+ 
+ def x1():
+      def y1():
+-         print 'y-blurb =', blurb
++         print('y-blurb =', blurb)
+      y1()
+ 
+ def x2():
+@@ -33,41 +33,41 @@ def x2():
+ 
+ def x3a():
+     def y3a(x):
+-        print 'y-blurb =', blurb, flurb
++        print('y-blurb =', blurb, flurb)
+     print
+     blurb = 3
+     flurb = 7
+     y3a(1)
+-    print 'x3a-blurb =', blurb
++    print('x3a-blurb =', blurb)
+ 
+ def x3():
+     def y3(x):
+         def z():
+             blurb = 25
+-            print 'z-blurb =', blurb,
++            print('z-blurb =', blurb)
+         z()
+-        print 'y-blurb =', blurb,
++        print('y-blurb =', blurb)
+     print
+     blurb = 3
+     y3(1)
+-    print 'x3-blurb =', blurb
++    print('x3-blurb =', blurb)
+ 
+ def x3b():
+     def y3b(x):
+         def z():
+-            print 'z-blurb =', blurb,
++            print('z-blurb =', blurb)
+         blurb = 25
+         z()
+-        print 'y-blurb =', blurb,
++        print('y-blurb =', blurb)
+     print
+     blurb = 3
+     y3b(1)
+-    print 'x3-blurb =', blurb
++    print('x3-blurb =', blurb)
+ 
+ def x4():
+     def y4(x):
+         def z():
+-            print 'z-blurb =', blurb
++            print('z-blurb =', blurb)
+         z()
+     global blurb
+     blurb = 3
+@@ -75,15 +75,15 @@ def x4():
+ 
+ def x():
+     def y(x):
+-        print 'y-blurb =', blurb
++        print('y-blurb =', blurb)
+     blurb = 2
+     y(1)
+ 
+ 
+-def func_with_tuple_args6((a,b), (c,d)=(2,3), *args, **kwargs):
+-    def y(x):
+-        print 'y-a =', a
+-    print c
++#def func_with_tuple_args6((a,b), (c,d)=(2,3), *args, **kwargs):
++#    def y(x):
++#        print('y-a =', a)
++#    print c
+ 
+ def find(self, name):
+     # This is taken from 'What's new in Python 2.1' by amk
+@@ -92,4 +92,4 @@ def find(self, name):
+ x0(); x1(); x2();
+ x3(); x3a(); x3b();
+ x4(); x()
+-print 'blurb =', blurb
++print('blurb =', blurb)


### PR DESCRIPTION
## Things done

Including an additional patch to support Python 3.12.5, which is the current default Python version in nixpkgs

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
