### PR TITLE
nixos/tests/acme: Fix fullchain validation

### DIFF
--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -471,14 +471,18 @@ in {
 
       # Ensure cert comes before chain in fullchain.pem
       def check_fullchain(node, cert_name):
-          subject_data = node.succeed(
-              f"openssl crl2pkcs7 -nocrl -certfile /var/lib/acme/{cert_name}/fullchain.pem"
-              " | openssl pkcs7 -print_certs -noout"
+          cert_file = f"/var/lib/acme/{cert_name}/fullchain.pem"
+          num_certs = node.succeed(f"grep -o 'END CERTIFICATE' {cert_file}")
+          assert len(num_certs.strip().split("\n")) > 1, "Insufficient certs in fullchain.pem"
+
+          first_cert_data = node.succeed(
+              f"grep -m1 -B50 'END CERTIFICATE' {cert_file}"
+              " | openssl x509 -noout -text"
           )
-          for line in subject_data.lower().split("\n"):
-              if "subject" in line:
-                  print(f"First subject in fullchain.pem: {line}")
-                  assert cert_name.lower() in line
+          for line in first_cert_data.lower().split("\n"):
+              if "dns:" in line:
+                  print(f"First DNSName in fullchain.pem: {line}")
+                  assert cert_name.lower() in line, f"{cert_name} not found in {line}"
                   return
 
           assert False


### PR DESCRIPTION
Blocks #331721

In the next release of Pebble, the certificate
subject is no longer populated with a useful domain name. This change will refactor the fullchain validation assertions to avoid checking the subject line.

This was tested with both pebble 2.4.0 and 2.6.0

CC @NixOS/acme 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
