### PR TITLE
Fixing JOE, the fully functional text editor, on macOS

### DIFF
--- a/pkgs/by-name/jo/joe/macos-fix.patch
+++ b/pkgs/by-name/jo/joe/macos-fix.patch
@@ -1,0 +1,13 @@
+diff -Naru i/joe/tty.c w/joe/tty.c
+--- ./joe/tty.c	2018-01-10 17:28:34
++++ ../joe-i-4.6/joe/tty.c	2024-10-02 14:08:22
+@@ -6,6 +6,9 @@
+  *	This file is part of JOE (Joe's Own Editor)
+  */
+ #include "types.h"
++#if defined(__APPLE__) && defined(__MACH__)
++#include <util.h>
++#endif
+ 
+ /* Needed for TIOCGWINSZ detection below */
+ #ifdef GWINSZ_IN_SYS_IOCTL

--- a/pkgs/by-name/jo/joe/package.nix
+++ b/pkgs/by-name/jo/joe/package.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1pmr598xxxm9j9dl93kq4dv36zyw0q2dh6d7x07hf134y9hhlnj9";
   };
 
+  patches = [ ./macos-fix.patch ];
+
   meta = with lib; {
     description = "Full featured terminal-based screen editor";
     longDescription = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

JOE didn't compile on macOS.

## Things done

Wrote a patch to add a missing `#include`.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
