### PR TITLE
stellarium: add passthru.updateScript

### DIFF
--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -22,6 +22,7 @@
 , nlopt
 , testers
 , xvfb-run
+, gitUpdater
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -95,16 +96,19 @@ stdenv.mkDerivation (finalAttrs: {
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    command = ''
-      # Create a temporary home directory because stellarium aborts with an
-      # error if it can't write some configuration files.
-      tmpdir=$(mktemp -d)
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = ''
+        # Create a temporary home directory because stellarium aborts with an
+        # error if it can't write some configuration files.
+        tmpdir=$(mktemp -d)
 
-      # stellarium can't be run in headless mode, therefore we need xvfb-run.
-      HOME="$tmpdir" ${xvfb-run}/bin/xvfb-run stellarium --version
-    '';
+        # stellarium can't be run in headless mode, therefore we need xvfb-run.
+        HOME="$tmpdir" ${xvfb-run}/bin/xvfb-run stellarium --version
+      '';
+    };
+    updateScript = gitUpdater { rev-prefix = "v"; };
   };
 
   meta =  {

--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
         tmpdir=$(mktemp -d)
 
         # stellarium can't be run in headless mode, therefore we need xvfb-run.
-        HOME="$tmpdir" ${xvfb-run}/bin/xvfb-run stellarium --version
+        HOME="$tmpdir" ${lib.getExe xvfb-run} stellarium --version
       '';
     };
     updateScript = gitUpdater { rev-prefix = "v"; };


### PR DESCRIPTION
## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
