### PR TITLE
physfs: don't set CMAKE_SKIP_RPATH

### DIFF
--- a/pkgs/development/libraries/physfs/default.nix
+++ b/pkgs/development/libraries/physfs/default.nix
@@ -13,6 +13,10 @@ let
       inherit sha256;
     };
 
+    patches = [
+      ./dont-set-cmake-skip-rpath-${version}.patch
+    ];
+
     nativeBuildInputs = [ cmake doxygen ];
 
     buildInputs = [ zlib ]

--- a/pkgs/development/libraries/physfs/dont-set-cmake-skip-rpath-2.1.1.patch
+++ b/pkgs/development/libraries/physfs/dont-set-cmake-skip-rpath-2.1.1.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b4ef61e..7b2f26c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,11 +29,6 @@ if(APPLE)
+     set(PHYSFS_M_SRCS src/physfs_platform_apple.m)
+ endif()
+ 
+-if(CMAKE_COMPILER_IS_GNUCC)
+-    # Don't use -rpath.
+-    set(CMAKE_SKIP_RPATH ON CACHE BOOL "Skip RPATH" FORCE)
+-endif()
+-
+ if(CMAKE_C_COMPILER_ID STREQUAL "SunPro")
+     add_definitions(-erroff=E_EMPTY_TRANSLATION_UNIT)
+     add_definitions(-xldscope=hidden)

--- a/pkgs/development/libraries/physfs/dont-set-cmake-skip-rpath-3.2.0.patch
+++ b/pkgs/development/libraries/physfs/dont-set-cmake-skip-rpath-3.2.0.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b3291cc..11e7ad1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,8 +32,6 @@ endif()
+ 
+ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+     add_compile_options(-Wall)
+-    # Don't use -rpath.
+-    set(CMAKE_SKIP_RPATH ON CACHE BOOL "Skip RPATH" FORCE)
+ endif()
+ 
+ if(CMAKE_C_COMPILER_ID STREQUAL "SunPro")


### PR DESCRIPTION
This is a small change that removes the overriding of `CMAKE_SKIP_RPATH` in the CMake build script. This same change was made soon after the 3.2.0 release upstream in this commit: https://github.com/icculus/physfs/commit/2ff4a37a0c375f6ef43e8092d06f5334e9d83174.

The build system setting that option causes the install name of the library on macOS to become `libphysfs.1.dylib` instead of `@rpath/libphysfs.1.dylib` (and in the final path in the store, `/nix/store/[...]/libphysfs.1.dylib`), so things that link physfs such as the VVVVVV game will fail to load the library at runtime as the dynamic linker won't know where to find it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
