### PR TITLE
virt-v2v: init at 2.6.0

### DIFF
--- a/pkgs/by-name/vi/virt-v2v/package.nix
+++ b/pkgs/by-name/vi/virt-v2v/package.nix
@@ -1,0 +1,106 @@
+{
+  stdenv,
+  lib,
+  testers,
+  fetchurl,
+  pkg-config,
+  makeWrapper,
+  autoreconfHook,
+  bash-completion,
+  OVMF,
+  qemu,
+  ocamlPackages,
+  perl,
+  cpio,
+  getopt,
+  libosinfo,
+  pcre2,
+  libxml2,
+  jansson,
+  glib,
+  libguestfs-with-appliance,
+  cdrkit,
+  nbdkit,
+  withWindowsGuestSupport ? true,
+  pkgsCross, # for rsrvany
+  virtio-win,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "virt-v2v";
+  version = "2.6.0";
+
+  src = fetchurl {
+    url = "https://download.libguestfs.org/virt-v2v/${lib.versions.majorMinor finalAttrs.version}-stable/virt-v2v-${finalAttrs.version}.tar.gz";
+    sha256 = "sha256-W7t/n1QO9UebyH85abtnSY5i7kH/6h8JIAlFQoD1vkU=";
+  };
+
+  postPatch = ''
+    substituteInPlace common/mlv2v/uefi.ml \
+        --replace-fail '/usr/share/OVMF/OVMF_CODE.fd' "${OVMF.firmware}" \
+        --replace-fail '/usr/share/OVMF/OVMF_VARS.fd' "${OVMF.variables}"
+
+    patchShebangs .
+  '';
+
+  nativeBuildInputs =
+    [
+      pkg-config
+      autoreconfHook
+      makeWrapper
+      bash-completion
+      perl
+      libguestfs-with-appliance
+      qemu
+      cpio
+      cdrkit
+      getopt
+    ]
+    ++ (with ocamlPackages; [
+      ocaml
+      findlib
+    ]);
+
+  buildInputs =
+    [
+      libosinfo
+      pcre2
+      libxml2
+      jansson
+      glib
+    ]
+    ++ (with ocamlPackages; [
+      ocaml_libvirt
+      nbd
+    ]);
+
+  postInstall =
+    ''
+      for bin in $out/bin/*; do
+      wrapProgram "$bin" \
+        --prefix PATH : "$out/bin:${
+          lib.makeBinPath [
+            nbdkit
+            qemu
+          ]
+        }"
+      done
+    ''
+    + lib.optionalString withWindowsGuestSupport ''
+      ln -s "${virtio-win}" $out/share/virtio-win
+      ln -s "${pkgsCross.mingwW64.rhsrvany}/bin/" $out/share/virt-tools
+    '';
+
+  PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR = "${placeholder "out"}/share/bash-completion/completions";
+
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+
+  meta = {
+    homepage = "https://github.com/libguestfs/virt-v2v";
+    description = "Convert guests from foreign hypervisors to run on KVM";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ lukts30 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "virt-v2v";
+  };
+})


### PR DESCRIPTION
- https://libguestfs.org/virt-v2v.1.html

- ~Currently does not build as multiple dependencies are needed to be merged first~
  - https://github.com/NixOS/nixpkgs/pull/345977
  - https://github.com/NixOS/nixpkgs/pull/345918
  - https://github.com/NixOS/nixpkgs/pull/345908

~I am also currently running another version of libguestfs which I will check again if it is needed.~ 

~The outdated `libguestfs-appliance` remains a problem https://github.com/NixOS/nixpkgs/issues/280881~


This PR supercedes https://github.com/NixOS/nixpkgs/pull/235432

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
