### PR TITLE
taterclient-ddnet: init at 8.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13515,6 +13515,12 @@
     githubId = 1215331;
     name = "Matt Melling";
   };
+  melon = {
+    email = "melontime05@gmail.com";
+    github = "BlaiZephyr";
+    githubId = 101197249;
+    name = "Tim";
+  };
   melsigl = {
     email = "melanie.bianca.sigl@gmail.com";
     github = "melsigl";

--- a/pkgs/by-name/ta/taterclient-ddnet/package.nix
+++ b/pkgs/by-name/ta/taterclient-ddnet/package.nix
@@ -1,0 +1,136 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cargo,
+  cmake,
+  ninja,
+  pkg-config,
+  rustPlatform,
+  rustc,
+  curl,
+  freetype,
+  libGLU,
+  libnotify,
+  libogg,
+  libX11,
+  opusfile,
+  pcre,
+  python3,
+  SDL2,
+  sqlite,
+  wavpack,
+  ffmpeg,
+  x264,
+  vulkan-headers,
+  vulkan-loader,
+  glslang,
+  spirv-tools,
+  gtest,
+  darwin,
+}:
+let
+  clientExecutable = "TaterClient-DDNet";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "taterclient-ddnet";
+  version = "8.6.0";
+
+  src = fetchFromGitHub {
+    owner = "sjrc6";
+    repo = "taterclient-ddnet";
+    rev = finalAttrs.version;
+    hash = "sha256-IfTQRMC2wcEH+KhlADHVIhfavlTN4mfTtlN5+/KojA0=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) pname src version;
+    hash = "sha256-L6NsLC5hg4/MlTfnOITBNoPIoKxlDx5BwXWnV7W4uT0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    rustc
+    cargo
+    rustPlatform.cargoSetupHook
+  ];
+
+  nativeCheckInputs = [ gtest ];
+
+  buildInputs =
+    [
+      curl
+      libnotify
+      pcre
+      python3
+      sqlite
+      freetype
+      libGLU
+      libogg
+      opusfile
+      SDL2
+      wavpack
+      ffmpeg
+      x264
+      vulkan-loader
+      vulkan-headers
+      glslang
+      spirv-tools
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ libX11 ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        Carbon
+        Cocoa
+        OpenGL
+        Security
+      ]
+    );
+
+  postPatch = ''
+    substituteInPlace src/engine/shared/storage.cpp \
+      --replace-fail /usr/ $out/
+  '';
+
+  cmakeFlags = [
+    "-DAUTOUPDATE=OFF"
+    "-DCLIENT=ON"
+    "-DSERVER=OFF"
+    "-DTOOLS=OFF"
+    "-DCLIENT_EXECUTABLE=${clientExecutable}"
+  ];
+
+  # Tests loop forever on Darwin for some reason
+  doCheck = !stdenv.hostPlatform.isDarwin;
+  checkTarget = "run_tests";
+
+  preFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Upstream links against <prefix>/lib while it installs this library in <prefix>/lib/ddnet
+    install_name_tool -change "$out/lib/libsteam_api.dylib" "$out/lib/ddnet/libsteam_api.dylib" "$out/bin/${clientExecutable}"
+  '';
+
+  postInstall = ''
+    # Desktop application conflicts with the ddnet package
+    mv "$out/share/applications/ddnet.desktop" "$out/share/applications/taterclient-ddnet.desktop"
+
+    substituteInPlace $out/share/applications/taterclient-ddnet.desktop \
+      --replace-fail "Exec=DDNet" "Exec=${clientExecutable}" \
+      --replace-fail "Name=DDNet" "Name=TaterClient (DDNet)" \
+      --replace-fail "Comment=Launch DDNet" "Comment=Launch ${clientExecutable}"
+  '';
+
+  meta = {
+    description = "Modification of DDNet teeworlds client";
+    homepage = "https://github.com/sjrc6/taterclient-ddnet";
+    changelog = "https://github.com/sjrc6/taterclient-ddnet/releases";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      melon
+      theobori
+    ];
+    mainProgram = clientExecutable;
+  };
+})

--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -122,6 +122,11 @@ stdenv.mkDerivation rec {
     rm -rf $out/share/metainfo
   '';
 
+  preFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Upstream links against <prefix>/lib while it installs this library in <prefix>/lib/ddnet
+    install_name_tool -change "$out/lib/libsteam_api.dylib" "$out/lib/ddnet/libsteam_api.dylib" "$out/bin/DDNet"
+  '';
+
   meta = with lib; {
     description = "Teeworlds modification with a unique cooperative gameplay";
     longDescription = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the package taterclient-ddnet.
This is a DDNet-based client that is very popular and used in the community.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
