### PR TITLE
tor-browser: 13.5.5 -> 13.5.6, mullvad-browser: 13.5.3 -> 13.5.6

### DIFF
--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -90,7 +90,7 @@ let
       ++ lib.optionals mediaSupport [ ffmpeg ]
   );
 
-  version = "13.5.3";
+  version = "13.5.6";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -102,7 +102,7 @@ let
         "https://tor.eff.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-rJKOkVfWs5q3eF+ffeBLIQaAMtoR7KzoNQlv64iNWJ8=";
+      hash = "sha256-AayGWFfsdAK9Ku4J4nDolJxnQn0HhGeZeEf//9OspWA=";
     };
   };
 

--- a/pkgs/by-name/mu/mullvad-browser/update.nix
+++ b/pkgs/by-name/mu/mullvad-browser/update.nix
@@ -56,7 +56,7 @@ in writeShellScript "update-${pname}" ''
 
   for platform in ${lib.escapeShellArgs meta.platforms}; do
     arch="''${platforms[$platform]}"
-    sha256=$(grep "${name}-$arch-$version.tar.xz" "$HOME/shasums" | cut -d" " -f1)
+    sha256=$(grep "${name}-$arch-$version.tar.xz" "$HOME/shasums" | head -1 | cut -d" " -f1)
     hash=$(nix hash to-sri --type sha256 "$sha256")
 
     update-source-version "${pname}" "$version" "$hash" --ignore-same-version --source-key="sources.$platform"

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -101,7 +101,7 @@ lib.warnIf (useHardenedMalloc != null)
       ++ lib.optionals mediaSupport [ ffmpeg ]
   );
 
-  version = "13.5.5";
+  version = "13.5.6";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -111,7 +111,7 @@ lib.warnIf (useHardenedMalloc != null)
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-5Gwr7gKI5HVyAymi04BjiKTAIrYSSLVmIBu882XZ7gw=";
+      hash = "sha256-dEairGoBMsXF4gtnnqa2KsA8PpW9VwF8woUrInVWuKM=";
     };
 
     i686-linux = fetchurl {
@@ -121,7 +121,7 @@ lib.warnIf (useHardenedMalloc != null)
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
       ];
-      hash = "sha256-kpRtPM7jTYm6wmYiFT89B4Ue7kbsWweUxqXzeNtLCdo=";
+      hash = "sha256-9WRN+iU7vvt9KvVudsS7qe0hoJwDP/J+yOTHW7nmrxs=";
     };
   };
 

--- a/pkgs/by-name/to/tor-browser/update.nix
+++ b/pkgs/by-name/to/tor-browser/update.nix
@@ -56,7 +56,7 @@ in writeShellScript "update-${pname}" ''
 
   for platform in ${lib.escapeShellArgs meta.platforms}; do
     arch="''${platforms[$platform]}"
-    sha256=$(grep "${name}-$arch-$version.tar.xz" "$HOME/shasums" | cut -d" " -f1)
+    sha256=$(grep "${name}-$arch-$version.tar.xz" "$HOME/shasums" | head -1 | cut -d" " -f1)
     hash=$(nix hash to-sri --type sha256 "$sha256")
 
     update-source-version "${pname}" "$version" "$hash" --ignore-same-version --source-key="sources.$platform"


### PR DESCRIPTION
Updates Tor Browser & Mullvad Browser to latest versions.
Also fixes an issue with the update scripts where it would compare the wrong hash (`tar.xz.asc` instead of `tar.xz`).

https://blog.torproject.org/new-release-tor-browser-1356/
https://github.com/mullvad/mullvad-browser/releases/tag/13.5.6

> This version includes important [security updates](https://www.mozilla.org/en-US/security/advisories/) to Firefox.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
