### PR TITLE
[WIP] libguestfs-guestfsd: init at 1.50.1

### DIFF
--- a/pkgs/development/libraries/libguestfs/guestfsd_skip_setenv_systemd.patch
+++ b/pkgs/development/libraries/libguestfs/guestfsd_skip_setenv_systemd.patch
@@ -1,0 +1,19 @@
+--- a/daemon/guestfsd.c
++++ b/daemon/guestfsd.c
+@@ -98,6 +98,7 @@ main (int argc, char *argv[])
+   int c;
+   const char *channel = NULL;
+   int listen_mode = 0;
++  const bool running_in_systemd = getenv ("INVOCATION_ID") != NULL;
+ 
+   ignore_value (chdir ("/"));
+ 
+@@ -181,7 +182,7 @@ main (int argc, char *argv[])
+    * environment is essentially empty.
+    * https://bugzilla.redhat.com/show_bug.cgi?id=502074#c5
+    */
+-  if (!test_mode)
++  if (!test_mode && !running_in_systemd)
+     setenv ("PATH", "/sbin:/usr/sbin:/bin:/usr/bin", 1);
+   setenv ("SHELL", "/bin/sh", 1);
+   setenv ("LC_ALL", "C", 1);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21166,6 +21166,7 @@ with pkgs;
   libgudev = callPackage ../development/libraries/libgudev { };
 
   libguestfs-appliance = callPackage ../development/libraries/libguestfs/appliance.nix { };
+  libguestfs-guestfsd = libguestfs.override { guestfsdOnly = true; };
   libguestfs = callPackage ../development/libraries/libguestfs {
     autoreconfHook = buildPackages.autoreconfHook264;
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;


### PR DESCRIPTION
https://libguestfs.org/guestfsd.8.html

Needed to build a NixOS-based appliance which removes the dependency on the [infrequently updated Fedora-based upstream appliance](http://libguestfs.org/download/binaries/appliance/). 

By eventually providing an NixOS appliance with `guestfsd` running this could fix  https://github.com/NixOS/nixpkgs/issues/280881

[My attempt](https://gist.github.com/lukts30/aa74abfa1afcfd966d8f28015a53e304) building on top of this PR so far involve a full systemd running NixOS appliance guest (libguestfs-make-fixed-appliance, supermin, custom initramfs and pid0 are all not used) instead `pkgs.nixos + make-disk-image.nix` are used.

**This should be merged after**: https://github.com/NixOS/nixpkgs/pull/345999

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
