### PR TITLE
vpp: init at 24.06

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18287,6 +18287,18 @@
     githubId = 1217934;
     name = "José Romildo Malaquias";
   };
+  romner-set = {
+    email = "admin@cynosure.red";
+    github = "romner-set";
+    githubId = 41077433;
+    name = "romner-set";
+    keys = [
+      {
+        # uploaded to https://keys.openpgp.org
+        fingerprint = "4B75 244B 0279 9598 FF3B  C21F 95FC 58F1 8CFD FAB0";
+      }
+    ];
+  };
   ronanmacf = {
     email = "macfhlar@tcd.ie";
     github = "RonanMacF";

--- a/pkgs/by-name/vp/vpp/package.nix
+++ b/pkgs/by-name/vp/vpp/package.nix
@@ -1,0 +1,126 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  pkg-config,
+  check,
+  openssl,
+  python3,
+  subunit,
+  mbedtls_2,
+  libpcap,
+  libnl,
+  libmnl,
+  libelf,
+  dpdk,
+  jansson,
+  zlib,
+  rdma-core,
+  libbpf,
+  xdp-tools,
+  enableDpdk ? true,
+  enableRdma ? true,
+  # FIXME: broken: af_xdp plugins - no working libbpf found - af_xdp plugin disabled
+  enableAfXdp ? false,
+}:
+
+let
+  dpdk' = dpdk.overrideAttrs (old: {
+    mesonFlags = old.mesonFlags ++ [ "-Denable_driver_sdk=true" ];
+  });
+
+  rdma-core' = rdma-core.overrideAttrs (old: {
+    cmakeFlags = old.cmakeFlags ++ [
+      "-DENABLE_STATIC=1"
+      "-DBUILD_SHARED_LIBS:BOOL=false"
+    ];
+  });
+
+  xdp-tools' = xdp-tools.overrideAttrs (old: {
+    postInstall = "";
+    dontDisableStatic = true;
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "vpp";
+  version = "24.06";
+
+  src = fetchFromGitHub {
+    owner = "FDio";
+    repo = "vpp";
+    rev = "v${version}";
+    hash = "sha256-AbdtH3ha/Bzj9tAkp4OhjRcUZilUEt+At0LukWN2LJU=";
+  };
+
+  postPatch = ''
+    patchShebangs scripts/
+    substituteInPlace CMakeLists.txt \
+      --replace "plugins tools/vppapigen tools/g2 tools/perftool cmake pkg" \
+      "plugins tools/vppapigen tools/g2 tools/perftool cmake"
+  '';
+
+  preConfigure = ''
+    echo "${version}-nixos" > scripts/.version
+    scripts/version
+  '';
+
+  postConfigure = ''
+    patchShebangs ../tools/
+    patchShebangs ../vpp-api/
+  '';
+
+  sourceRoot = "source/src";
+
+  enableParallelBuilding = true;
+  env.NIX_CFLAGS_COMPILE = "-Wno-error -Wno-array-bounds -Wno-maybe-uninitialized";
+
+  cmakeFlags = [
+    "-DVPP_PLATFORM=default"
+    "-DVPP_LIBRARY_DIR=lib"
+  ] ++ lib.optional enableDpdk "-DVPP_USE_SYSTEM_DPDK=ON";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ] ++ lib.optional enableDpdk dpdk' ++ lib.optional enableRdma rdma-core'.dev;
+
+  buildInputs =
+    [
+      check
+      openssl
+      (python3.withPackages (ps: [ ps.ply ]))
+
+      subunit # vapi tests
+      mbedtls_2 # tlsmbed plugin
+      libpcap # bpf_trace_filter plugin
+
+      # linux-cp plugin
+      libnl
+      libmnl
+    ]
+    ++ lib.optionals enableDpdk [
+      # dpdk plugin
+      libelf
+      jansson
+      zlib
+    ]
+    ++ lib.optionals enableAfXdp [
+      # af_xdp plugin
+      libelf
+      libbpf
+      xdp-tools'
+    ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast, scalable layer 2-4 multi-platform network stack running in user space";
+    homepage = "https://s3-docs.fd.io/vpp/${version}/";
+    license = [ lib.licenses.asl20 ];
+    maintainers = with lib.maintainers; [ romner-set ];
+    mainProgram = "vpp";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Description of changes

VPP is a high-performance userland network stack for routing/switching on general purpose computers.

Supersedes #290529 & #256601, module & tests will be added later in a separate PR (#347797). Basic multithread routing functionality w/ DPDK was tested on an Intel X520-DA2 NIC.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
