### PR TITLE
namida: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9839,6 +9839,13 @@
     github = "jdupak";
     githubId = 22683640;
   };
+  jebriggsy = {
+    name = "Jacob Briggs";
+    email = "jebriggsy@protonmail.com";
+    github = "jebriggsy";
+    githubId = 319954;
+    keys = [ { fingerprint = "2F83 B9C6 3175 AFC1 9DD6  5A53 4AB1 0A34 202A 2D04"; } ];
+  };
   jecaro = {
     email = "jeancharles.quillet@gmail.com";
     github = "jecaro";

--- a/pkgs/by-name/na/namida/client_get_mem_size_of.patch
+++ b/pkgs/by-name/na/namida/client_get_mem_size_of.patch
@@ -1,0 +1,12 @@
+diff --git a/src/client/get.rs b/src/client/get.rs
+index 5e38e02..27355fa 100644
+--- a/src/client/get.rs
++++ b/src/client/get.rs
+@@ -3,6 +3,7 @@ use std::{
+     path::{Path, PathBuf},
+     sync::Arc,
+     time::Instant,
++    mem::size_of,
+ };
+ 
+ use anyhow::bail;

--- a/pkgs/by-name/na/namida/make_deterministic.patch
+++ b/pkgs/by-name/na/namida/make_deterministic.patch
@@ -1,0 +1,45 @@
+diff --git a/build.rs b/build.rs
+index 799ec48..ed12e68 100644
+--- a/build.rs
++++ b/build.rs
+@@ -1,17 +1,27 @@
+-use std::process::Command;
++use std::{
++    process::Command,
++    env,
++};
+
+ fn main() {
+-    // https://stackoverflow.com/a/44407625
+-    let output = Command::new("git")
+-        .args(["rev-parse", "HEAD"])
+-        .output()
+-        .unwrap();
+-    let git_hash = String::from_utf8(output.stdout).unwrap();
+-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
++    // Check if we are in a Nix environment
++    // Nix does not work well with with variable compile-time outputs
++    match env::var("NIX_BUILD_TOP"){
++        Ok(..) => println!("Nix builder detected, disabling non-deterministic compile time operations"),
++        Err(..) => {
++            // https://stackoverflow.com/a/44407625
++            let output = Command::new("git")
++                .args(["rev-parse", "HEAD"])
++                .output()
++                .unwrap();
++            let git_hash = String::from_utf8(output.stdout).unwrap();
++            println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+
+-    // Get compilation date / time
+-    let dt_local = chrono::Local::now();
+-    let naive_utc = dt_local.naive_utc();
+-    let formatted = naive_utc.format("%Y-%m-%d %H:%M:%S");
+-    println!("cargo:rustc-env=NAMIDA_COMPILE_DT={} UTC", formatted);
++            // Get compilation date / time
++            let dt_local = chrono::Local::now();
++            let naive_utc = dt_local.naive_utc();
++            let formatted = naive_utc.format("%Y-%m-%d %H:%M:%S");
++            println!("cargo:rustc-env=NAMIDA_COMPILE_DT={} UTC", formatted);
++        },
++    };
+ }

--- a/pkgs/by-name/na/namida/package.nix
+++ b/pkgs/by-name/na/namida/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "namida";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "meew0";
+    repo = "namida";
+    rev = "782ab6baf679f830c4242bf071d8e85743fe77f7";
+    hash = "sha256-pflucKCzfM3Fc2+M8GNq3fsTCln+9bHBGb7/mv/GKVs=";
+  };
+  cargoHash = "sha256-FT5pxu40A8CSPL0pd1EVK+Ti80F3pdNvh5ojKNlz9Rc=";
+
+  patches = [
+    # Needed for rustc/cargo < 1.80
+    # std::mem::size_of
+    ./client_get_mem_size_of.patch
+
+    # Removes checking git for revision and generating build-time timestamp
+    # Provided by environment variables in this nixpkg instead
+    ./make_deterministic.patch
+  ];
+
+  # Set the git revision and build datetime declaritively
+  env = {
+    GIT_HASH = src.rev;
+    NAMIDA_COMPILE_DT = "1970-01-01 00:00:00";
+  };
+
+  meta = {
+    description = "Client/server for fast file transfer over high-latency connections via UDP";
+    longDescription = ''
+      namida is a tool for fast file downloads over high-latency and/or unreliable networks.
+      It uses UDP for bulk data transmission, together with a minimal TCP control stream to mediate retransmission of lost data.
+
+      namida is based upon Tsunami, a 2000s-era protocol and software suite for UDP-based file transmission. While Tsunami is still usable today,
+      it has essentially not been updated since 2009, and has several problems that make it annoying to use nowadays. So, namida was created by
+      first converting Tsunami's source code to Rust using C2Rust, manually converting the generated unsafe code to safe, more idiomatic Rust,
+      and then making various improvements.
+
+      In the process some parts of Tsunami were also removed. In particular, after 2006 Tsunami was primarily maintained by Finnish VLBI scientists
+      (primarily Jan Wagner at Metsähovi Radio Observatory), who added support for VLBI-specific real-time networking hardware. The project does not
+      have access to any of this hardware, so porting is unfeasible. Presumably, the VLBI people are either still happily using Tsunami or have their
+      own updated tools anyway.
+    '';
+    homepage = "https://github.com/meew0/namida";
+    license = lib.licenses.free;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ jebriggsy ];
+    platforms = lib.platforms.linux;
+    mainProgram = "namida";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

# namida

namida is a tool for fast file downloads over high-latency and/or unreliable networks. It uses UDP for bulk data transmission, together with a minimal TCP control stream to mediate retransmission of lost data.

namida is based upon [Tsunami](https://tsunami-udp.sourceforge.net), a 2000s-era protocol and software suite for UDP-based file transmission. While Tsunami is still usable today, it has essentially not been updated since 2009, and has several problems that make it annoying to use nowadays. So, namida was created by first converting Tsunami's source code to Rust using [C2Rust](https://github.com/immunant/c2rust), manually converting the generated unsafe code to safe, more idiomatic Rust, and then making various improvements.

In the process some parts of Tsunami were removed. In particular, after 2006 Tsunami was primarily maintained by Finnish [VLBI](https://en.wikipedia.org/wiki/Very-long-baseline_interferometry) scientists (primarily Jan Wagner at Metsähovi Radio Observatory), who added support for VLBI-specific real-time networking hardware. The project does not have access to this hardware so the features were deprecated

## Features

- Dynamic UDP transfer rate adjustment to avoid overloading the client (it may still use all the available bandwidth, leaving none for other applications. It is highly recommended to use the `--rate` command to limit the transfer rate to a suitable value)
- Optional lossy transfer mode: if some amount of data loss can be tolerated, namida can be configured to allow packets to be dropped, with an optional limit. By default, transfers are always lossless.

New features compared to Tsunami:

- Simple CLI that allows everything to be done in one command invocation (in return, Tsunami's FTP-like interactive console has been removed)
- Client-side NAT traversal: UDP packets can be received even if the client is behind NAT, without any additional manual configuration required.
- Encrypted communication by default: [snow](https://github.com/mcginty/snow) is used to encrypt both TCP and UDP communication.
- Resumption of interrupted transfers: if parts of a file to be downloaded are already present locally, those parts will be skipped by default

## Usage

Run a namida server providing all files in the local directory:

```
$ namida serve
```

Run a namida server providing only some specific files:

```
$ namida serve file1.txt file2.txt
```

List the files a server has available:

```
$ namida dir --server example.com
```

Get a specific file from a server:

```
$ namida get --server example.com file1.txt
```

Get all files from a server:

```
$ namida get --server example.com --all
```

Many more options are available for the individual subcommands. Run `namida help [command]` to get more information.

## Licensing information

namida is available under the same license as Tsunami (both the original Tsunami from Indiana University, and Jan Wagner's updated version), which is a permissive BSD-style license with the additional restriction that derivative programs may not be called “Tsunami” without permission from Indiana University. See `LICENSE.txt` on the [project repository](https://github.com/meew0/namida/blob/namida/LICENSE.txt) for the full license text.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
