### PR TITLE
forge-mtg: 1.6.57 -> 1.6.65

### DIFF
--- a/pkgs/games/forge-mtg/default.nix
+++ b/pkgs/games/forge-mtg/default.nix
@@ -1,20 +1,21 @@
-{ coreutils
-, fetchFromGitHub
-, gnused
-, lib
-, maven
-, makeWrapper
-, openjdk
+{
+  coreutils,
+  fetchFromGitHub,
+  gnused,
+  lib,
+  maven,
+  makeWrapper,
+  openjdk,
 }:
 
 let
-  version = "1.6.57";
+  version = "1.6.65";
 
   src = fetchFromGitHub {
     owner = "Card-Forge";
     repo = "forge";
     rev = "forge-${version}";
-    hash = "sha256-pxnnqLfyblbIgIRZZrx8Y8K43zUv9mu7PzZ7zltpEUQ=";
+    hash = "sha256-MCJl3nBHbX/O24bzD4aQ12eMWxYY2qJC5vomvtsIBek=";
   };
 
   # launch4j downloads and runs a native binary during the package phase.
@@ -25,7 +26,7 @@ maven.buildMavenPackage {
   pname = "forge-mtg";
   inherit version src patches;
 
-  mvnHash = "sha256-QK9g0tG75lIhEtf4jW03N32YbD9Fe5iI0JTuqmCTtnE=";
+  mvnHash = "sha256-ouF0Ja3oGrlUCcT0PzI5i9FQ+oLdEhE/LvhJ0QGErvI=";
 
   doCheck = false; # Needs a running Xorg
 
@@ -50,7 +51,13 @@ maven.buildMavenPackage {
     for commandToInstall in forge forge-adventure forge-adventure-editor; do
       chmod 555 $out/share/forge/$commandToInstall.sh
       makeWrapper $out/share/forge/$commandToInstall.sh $out/bin/$commandToInstall \
-        --prefix PATH : ${lib.makeBinPath [ coreutils openjdk gnused ]} \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            openjdk
+            gnused
+          ]
+        } \
         --set JAVA_HOME ${openjdk}/lib/openjdk \
         --set SENTRY_DSN ""
     done


### PR DESCRIPTION
Diff: https://github.com/Card-Forge/forge/compare/refs/tags/1.6.57...1.6.64

Changelog: https://github.com/Card-Forge/forge/releases/tag/forge-1.6.64

`buildOffline` is needed for the package to build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
