### PR TITLE
teamviewer: add services.teamviewer.package Option + misc improvemens

### DIFF
--- a/nixos/modules/services/monitoring/teamviewer.nix
+++ b/nixos/modules/services/monitoring/teamviewer.nix
@@ -5,13 +5,16 @@ let
 in
 {
   options = {
-    services.teamviewer.enable = lib.mkEnableOption "TeamViewer daemon";
+    services.teamviewer = {
+      enable = lib.mkEnableOption "TeamViewer daemon & system package";
+      package = lib.mkPackageOption pkgs "teamviewer" { };
+    };
   };
 
   config = lib.mkIf (cfg.enable) {
-    environment.systemPackages = [ pkgs.teamviewer ];
+    environment.systemPackages = [ cfg.package ];
 
-    services.dbus.packages = [ pkgs.teamviewer ];
+    services.dbus.packages = [ cfg.package ];
 
     systemd.services.teamviewerd = {
       description = "TeamViewer remote control daemon";
@@ -30,7 +33,7 @@ in
       startLimitBurst = 10;
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${pkgs.teamviewer}/bin/teamviewerd -f";
+        ExecStart = "${cfg.package}/bin/teamviewerd -f";
         PIDFile = "/run/teamviewerd.pid";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         Restart = "on-abort";

--- a/nixos/modules/services/monitoring/teamviewer.nix
+++ b/nixos/modules/services/monitoring/teamviewer.nix
@@ -1,16 +1,14 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.services.teamviewer;
 in
 {
   options = {
-    services.teamviewer.enable = mkEnableOption "TeamViewer daemon";
+    services.teamviewer.enable = lib.mkEnableOption "TeamViewer daemon";
   };
 
-  config = mkIf (cfg.enable) {
+  config = lib.mkIf (cfg.enable) {
     environment.systemPackages = [ pkgs.teamviewer ];
 
     services.dbus.packages = [ pkgs.teamviewer ];

--- a/nixos/modules/services/monitoring/teamviewer.nix
+++ b/nixos/modules/services/monitoring/teamviewer.nix
@@ -3,25 +3,14 @@
 with lib;
 
 let
-
   cfg = config.services.teamviewer;
-
 in
-
 {
-
-  ###### interface
-
   options = {
-
     services.teamviewer.enable = mkEnableOption "TeamViewer daemon";
-
   };
 
-  ###### implementation
-
   config = mkIf (cfg.enable) {
-
     environment.systemPackages = [ pkgs.teamviewer ];
 
     services.dbus.packages = [ pkgs.teamviewer ];
@@ -31,7 +20,11 @@ in
 
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
-      after = [ "network-online.target" "network.target" "dbus.service" ];
+      after = [
+        "network-online.target"
+        "network.target"
+        "dbus.service"
+      ];
       requires = [ "dbus.service" ];
       preStart = "mkdir -pv /var/lib/teamviewer /var/log/teamviewer";
 
@@ -46,5 +39,4 @@ in
       };
     };
   };
-
 }


### PR DESCRIPTION
This adds a `services.teamviewer.package` option along with some misc improvements for the `teamviewer` service NixOS module file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
