### PR TITLE
zepp-simulator: init at 2.0.2

### DIFF
--- a/pkgs/by-name/ze/zepp-simulator/0001-force_qemu_x11.patch
+++ b/pkgs/by-name/ze/zepp-simulator/0001-force_qemu_x11.patch
@@ -1,0 +1,13 @@
+diff --git a/opt/simulator/resources/firmware/start_qemu.sh b/opt/simulator/resources/firmware/start_qemu.sh
+index cfdad8b..64fba99 100644
+--- a/opt/simulator/resources/firmware/start_qemu.sh
++++ b/opt/simulator/resources/firmware/start_qemu.sh
+@@ -75,6 +75,8 @@ fi
+ host_os=$(uname -s)
+ echo "Host OS type : \"$(uname -v)\"."
+ if [ "$host_os" = "Linux" ]; then
++    export GDK_BACKEND=x11
++
+     qemu_bin="qemu_linux/qemu-system-arm"
+     check_file_exists "$qemu_bin"
+

--- a/pkgs/by-name/ze/zepp-simulator/package.nix
+++ b/pkgs/by-name/ze/zepp-simulator/package.nix
@@ -1,0 +1,176 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  makeWrapper,
+  copyDesktopItems,
+  autoPatchelfHook,
+
+  # Upstream is officialy built with Electron 18
+  # (but it works with latest Electron with minor changes, see HACK below)
+  electron,
+  asar,
+  dpkg,
+
+  # qemu deps
+  # (it's not possible to de-vendor the qemu binary since it relies on proprietary cpu extensions)
+  glib,
+  libgcc,
+  libcxx,
+  zlib,
+  libepoxy,
+  libpng,
+  libaio,
+  xorg,
+  libvterm,
+  vte,
+  gsasl,
+  gtk3,
+  cairo,
+  gdk-pixbuf,
+  numactl,
+  cyrus_sasl,
+  SDL2,
+  # aarch64-only?
+  dtc,
+  capstone_4,
+  libjpeg8,
+  mesa,
+  curlWithGnuTls,
+}:
+
+let
+  # CDN links for 2.0.2:
+  # MacOS: https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/ecb6ca54f4dc97a2f91e53358bbb532d.dmg
+  # Windows: https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/9db7ae1c60c26836a447a71a6fb25b3b.exe
+  # Linux ARM64: https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/02ec69e6a2f3b744d964fd7ba4f40fc3.deb
+  # Linux AMD64: https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/3e688d423cd0cd31a8a589b8325a309e.deb
+  srcs = {
+    x86_64-linux = {
+      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/3e688d423cd0cd31a8a589b8325a309e.deb";
+      sha256 = "sha256-ZHqaEL8FoSnRtuqGWpTyJka7D0dHtRADZthq8DG2k24=";
+    };
+    aarch64-linux = {
+      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/02ec69e6a2f3b744d964fd7ba4f40fc3.deb";
+      sha256 = "sha256-J5Y4wLiFOM9D2MIMiRyUtHIZ19rt65ktVCOMZQQwBCI=";
+    };
+  };
+
+in
+
+stdenv.mkDerivation {
+  pname = "zepp-simulator";
+  version = "2.0.2";
+
+  src = fetchurl srcs.${stdenv.hostPlatform.system};
+
+  patches = [
+    # Fix for qemu input grab not working with NIXOS_OZONE_WL=1
+    ./0001-force_qemu_x11.patch
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+    dpkg
+    asar
+  ];
+
+  buildInputs =
+    [
+      # QEMU deps (runtime):
+      glib
+      libgcc
+      libcxx
+      zlib
+      libepoxy
+      libpng
+      libaio
+      xorg.libX11
+      libvterm
+      vte
+      gsasl
+      numactl
+      cyrus_sasl
+      gtk3
+      cairo
+      gdk-pixbuf
+      SDL2
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+      libjpeg8
+      dtc
+      capstone_4
+      mesa
+      curlWithGnuTls
+    ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Create output file strucure
+    mkdir -p $out/{bin,opt,share}
+    cp -r opt/simulator $out/opt
+    cp -r usr/share/* $out/share
+
+    # Patch desktop file executable path
+    substituteInPlace $out/share/applications/simulator.desktop \
+      --replace-fail '/opt/simulator/simulator' 'simulator'
+
+    # Remove unnecessary files
+    rm -rf \
+      $out/usr/share/applications/simulator.desktop \
+      $out/opt/simulator/*.so \
+      $out/opt/simulator/libvulkan.so.1 \
+      $out/opt/simulator/swiftshader \
+      $out/opt/simulator/simulator \
+      $out/opt/simulator/resources/firmware/setup_for_linux.sh
+
+    # Use system electron
+    makeWrapper ${lib.getExe electron} $out/bin/simulator \
+      --add-flags "--no-sandbox" \
+      --add-flags $out/opt/simulator/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --set-default NODE_ENV production \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default ELECTRON_IS_DEV 0 \
+      --set-default ELECTRON_DISABLE_SECURITY_WARNINGS 1 \
+      --inherit-argv0;
+
+    # HACK: disable sandbox introduced in Electron 20
+    asar extract $out/opt/simulator/resources/app.asar app_unpacked
+    rm $out/opt/simulator/resources/app.asar
+    sed -i \
+      's|contextIsolation: false,|contextIsolation: false, sandbox: false,|g' \
+      app_unpacked/build/electron/process/side-service.js
+    asar pack app_unpacked $out/opt/simulator/resources/app.asar
+    rm -rf app_unpacked
+
+    runHook postInstall
+  '';
+
+  # HACK: Replace libsasl2.so.ls with libsasl2.so.3
+  postFixup = ''
+    patchelf \
+      --replace-needed libsasl2.so.2 libsasl2.so.3 \
+      $out/opt/simulator/resources/firmware/qemu_linux/qemu-system-arm
+    chmod +x $out/opt/simulator/resources/firmware/qemu_linux/qemu-system-arm
+  '';
+
+  meta = {
+    description = "Zepp OS Simulator";
+    homepage = "https://developer.zepp.com/os/home";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    # TODO Darwin
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    maintainers = with lib.maintainers; [ griffi-gh ];
+    mainProgram = "simulator";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
# Zepp OS Simulator
https://docs.zepp.com/docs/guides/tools/simulator/download/

Zepp OS Simulator is an emulator and development tool for Amazfit and other watches based on Zepp OS/huamios.

The application is based on Electron 18.x, which i couldnt get to run...\
Seems to run just fine on the latest Electron with a minor patch to one of the files though...

This is my first attempt at packaging stuff for nix so any feedback appreciated.  

Closes #344056

![image](https://github.com/user-attachments/assets/75bd6778-a88f-4b1b-8e7b-05ae24993ee0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
