### PR TITLE
python312Packages.jinja2: disable test_elif_deep on s390x

### DIFF
--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -45,13 +45,15 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.i18n;
 
-  disabledTests = lib.optionals (pythonAtLeast "3.13") [
-    # https://github.com/pallets/jinja/issues/1900
-    "test_custom_async_iteratable_filter"
-    "test_first"
-    "test_loop_errors"
-    "test_package_zip_list"
-  ];
+  disabledTests =
+    lib.optionals (pythonAtLeast "3.13") [
+      # https://github.com/pallets/jinja/issues/1900
+      "test_custom_async_iteratable_filter"
+      "test_first"
+      "test_loop_errors"
+      "test_package_zip_list"
+    ]
+    ++ lib.optional stdenv.hostPlatform.isS390x [ "test_elif_deep" ];
 
   passthru.doc = stdenv.mkDerivation {
     # Forge look and feel of multi-output derivation as best as we can.


### PR DESCRIPTION


## Things done

- Built on platform(s)
- [x] s390x
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`

this test will fail when natively compiling jinja2 for the s390x mainframe architecture as of `FAILED tests/test_core_tags.py::TestIfCondition::test_elif_deep - RecursionError: maximum recursion depth exceeded during compilation`

abstarct:
```
=================================== FAILURES ===================================
________________________ TestIfCondition.test_elif_deep ________________________

self = <test_core_tags.TestIfCondition object at 0x3fffb011be0>
env = <jinja2.environment.Environment object at 0x3fffa9d1eb0>

    def test_elif_deep(self, env):
        elifs = "\n".join(f"{{% elif a == {i} %}}{i}" for i in range(1, 1000))
>       tmpl = env.from_string(f"{{% if a == 0 %}}0{elifs}{{% else %}}x{{% endif %}}")

tests/test_core_tags.py:315:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/2c3a1zrgs565l1fn95y6rc7bdgj7iki5-python3.12-jinja2-3.1.4/lib/python3.12/site-packages/jinja2/environment.py:1108: in from_string
    return cls.from_code(self, self.compile(source), gs, None)
/nix/store/2c3a1zrgs565l1fn95y6rc7bdgj7iki5-python3.12-jinja2-3.1.4/lib/python3.12/site-packages/jinja2/environment.py:766: in compile
    return self._compile(source, filename)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <jinja2.environment.Environment object at 0x3fffa9d1eb0>
source = "from jinja2.runtime import LoopContext, Macro, Markup, Namespace, TemplateNotFound, TemplateReference, TemplateRuntim...&987=2973&988=2976&989=2979&990=2982&991=2985&992=2988&993=2991&994=2994&995=2997&996=3000&997=3003&998=3006&999=3009'"
filename = '<template>'

    def _compile(self, source: str, filename: str) -> CodeType:
        """Internal hook that can be overridden to hook a different compile
        method in.

        .. versionadded:: 2.5
        """
>       return compile(source, filename, "exec")
E       RecursionError: maximum recursion depth exceeded during compilation

/nix/store/2c3a1zrgs565l1fn95y6rc7bdgj7iki5-python3.12-jinja2-3.1.4/lib/python3.12/site-packages/jinja2/environment.py:706: RecursionError
=========================== short test summary info ============================
FAILED tests/test_core_tags.py::TestIfCondition::test_elif_deep - RecursionError: maximum recursion depth exceeded during compilation
======================== 1 failed, 850 passed in 12.13s ========================
```

disabling the test for stdenv.hostPlatform s390x resolves the issue. 

*The `nginx.conf` derivation depends on `gixy` a static nginx configuration analyzer which in turn depends on jinja2, thus this is needed to get nginx to work properly on s390x* 