### PR TITLE
python3Packages.furl: disable failing test for all python version

### DIFF
--- a/pkgs/development/python-modules/furl/default.nix
+++ b/pkgs/development/python-modules/furl/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = lib.optionals (pythonAtLeast "3.12") [
+  disabledTests = [
     # AssertionError: assert '//////path' == '////path'
     "test_odd_urls"
   ];


### PR DESCRIPTION
Disable `test_odd_urls` test for all Python version.

It fails with Python 3.10 as well:

```
$ nix-build -A python310Packages.furl

.... 

>       assert f.url == '////path'
E       AssertionError: assert '//////path' == '////path'
E
E         - ////path
E         + //////path
E         ? ++

tests/test_furl.py:1642: AssertionError
=========================== short test summary info ============================
FAILED tests/test_furl.py::TestFurl::test_odd_urls - AssertionError: assert '//////path' == '////path'
========================= 1 failed, 77 passed in 3.70s =========================
error: build of '/nix/store/myyx8jdvx8rvpx2ljzbbj4h30zidlsjk-python3.10-furl-2.1.3.drv' on 'ssh-ng://im-builder' failed: builder for '/nix/store/myyx8jdvx8rvpx2ljzbbj4h30zidlsjk-python3.10-furl-2.1.3.drv' failed with exit code 1;
       last 10 log lines:
       > E       AssertionError: assert '//////path' == '////path'
       > E
       > E         - ////path
       > E         + //////path
       > E         ? ++
       >
       > tests/test_furl.py:1642: AssertionError
       > =========================== short test summary info ============================
       > FAILED tests/test_furl.py::TestFurl::test_odd_urls - AssertionError: assert '//////path' == '////path'
       > ========================= 1 failed, 77 passed in 3.70s =========================
       For full logs, run 'nix log /nix/store/myyx8jdvx8rvpx2ljzbbj4h30zidlsjk-python3.10-furl-2.1.3.drv'.
error: builder for '/nix/store/myyx8jdvx8rvpx2ljzbbj4h30zidlsjk-python3.10-furl-2.1.3.drv' failed with exit code 1
```

According git bisect, python 3.10 build started to fail since 

```
commit 36a44e333b9cc879ae2ba5a93bdfeeed32e1713c
Author: Martin Weinelt <hexa@darmstadt.ccc.de>
Date:   Sat Sep 7 17:40:41 2024 +0200

    python310: 3.10.14 -> 3.10.15

    https://docs.python.org/release/3.10.15/whatsnew/changelog.html
    (cherry picked from commit 53a9c0f5a8c58c1e5508a8e9af9bad85451bb107)

 pkgs/development/interpreters/python/default.nix | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
