### PR TITLE
nixos/userborn: explictly check that stage1 systemd is enabled

### DIFF
--- a/nixos/modules/services/system/userborn.nix
+++ b/nixos/modules/services/system/userborn.nix
@@ -75,6 +75,10 @@ in
 
     assertions = [
       {
+        assertion = config.boot.initrd.systemd.enable;
+        message = "`services.userborn.enable = true` requires `config.boot.initrd.systemd.enable = true`";
+      }
+      {
         assertion = !(config.systemd.sysusers.enable && cfg.enable);
         message = "You cannot use systemd-sysusers and Userborn at the same time";
       }

--- a/nixos/tests/userborn-immutable-users.nix
+++ b/nixos/tests/userborn-immutable-users.nix
@@ -6,6 +6,7 @@ let
   common = {
     services.userborn.enable = true;
     users.mutableUsers = false;
+    boot.initrd.systemd.enable = true;
   };
 in
 

--- a/nixos/tests/userborn-mutable-users.nix
+++ b/nixos/tests/userborn-mutable-users.nix
@@ -5,6 +5,7 @@ let
 
   common = {
     services.userborn.enable = true;
+    boot.initrd.systemd.enable = true;
     users.mutableUsers = true;
   };
 in

--- a/nixos/tests/userborn.nix
+++ b/nixos/tests/userborn.nix
@@ -22,6 +22,7 @@ in
 
   nodes.machine = {
     services.userborn.enable = true;
+    boot.initrd.systemd.enable = true;
 
     # Read this password file at runtime from outside the Nix store.
     environment.etc."rootpw.secret".text = rootHashedPasswordFile;


### PR DESCRIPTION
other parts of the ecosystem run after the user activation script to set up permissions. They now instead need to run after the systemd-sysusers.service, which they commonly only do if stage1 systemd is enabled.
Since all the tests currently enable stage1 systemd, this now explicitly enforce that users have this set.

One project affected by this is impermanence.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
