### PR TITLE
nsncd: s390x disable test_hostent_serialization test

### DIFF
--- a/pkgs/os-specific/linux/nsncd/default.nix
+++ b/pkgs/os-specific/linux/nsncd/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage {
     # on IPv4. That's not the case in the Nix sandbox somehow. Works
     # when running cargo test impurely on a (NixOS|Debian) machine.
     "--skip=ffi::test_gethostbyname2_r"
-  ];
+  ] ++ (lib.optional stdenv.hostPlatform.isS390x "-skip=handlers::test::test_hostent_serialization");
 
   meta = with lib; {
     description = "Name service non-caching daemon";


### PR DESCRIPTION

- Built on platform(s)
  - [ x ] s390x-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ x ] `sandbox = true`

this should disable the `test_hostent_serialization` test on s390x builds as that test seems unable to run on this platform