### PR TITLE
libuv: s390x disable signal_multiple_loops test

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -78,6 +78,8 @@ stdenv.mkDerivation (finalAttrs: {
       # I observe this test failing with some regularity on ARMv7:
       # https://github.com/libuv/libuv/issues/1871
       "shutdown_close_pipe"
+    ] ++ lib.optionals stdenv.hostPlatform.isS390x [
+      "signal_multiple_loops"
     ];
     tdRegexp = lib.concatStringsSep "\\|" toDisable;
     in lib.optionalString (finalAttrs.finalPackage.doCheck) ''


### PR DESCRIPTION
- Built on platform(s)
  - [x] s390x-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = true`

this should disable the `signal_multiple_loops test` test on s390x builds as that test seems to fail (in a non-reprod fashion) on this platform