### PR TITLE
apfsprogs: unstable-2023-11-30 -> 0-unstable-2024-09-27

### DIFF
--- a/nixos/tests/apfs.nix
+++ b/nixos/tests/apfs.nix
@@ -18,6 +18,10 @@
     with subtest("mkapfs works with the maximum label length"):
       machine.succeed("mkapfs -L '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7' /dev/vdb")
 
+    with subtest("apfs-label works"):
+      machine.succeed("mkapfs -L 'myLabel' /dev/vdb")
+      machine.succeed("apfs-label /dev/vdb | grep -q myLabel")
+
     with subtest("Enable case sensitivity and normalization sensitivity"):
       machine.succeed(
           "mkapfs -s -z /dev/vdb",

--- a/pkgs/by-name/ap/apfsprogs/package.nix
+++ b/pkgs/by-name/ap/apfsprogs/package.nix
@@ -6,20 +6,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "apfsprogs";
-  version = "unstable-2023-11-30";
+  version = "0-unstable-2024-09-27";
 
   src = fetchFromGitHub {
     owner = "linux-apfs";
     repo = "apfsprogs";
-    rev = "990163894d871f51ba102a75aed384a275c5991b";
-    hash = "sha256-yCShZ+ALzSe/svErt9/i1JyyEvbIeABGPbpS4lVil0A=";
+    rev = "f31d7c2d69d212ce381399d2bb1e91410f592484";
+    hash = "sha256-+c+wU52XKNOTxSpSrkrNWoGEYw6Zo4CGEOyKMvkXEa0=";
   };
 
   postPatch = let
     shortRev = builtins.substring 0 9 finalAttrs.src.rev;
   in ''
     substituteInPlace \
-      apfs-snap/Makefile apfsck/Makefile mkapfs/Makefile \
+      apfs-snap/Makefile apfsck/Makefile mkapfs/Makefile apfs-label/Makefile \
       --replace-fail \
         '$(shell git describe --always HEAD | tail -c 9)' \
         '${shortRev}'
@@ -30,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     make -C apfs-snap $makeFlags
     make -C apfsck $makeFlags
     make -C mkapfs $makeFlags
+    make -C apfs-label $makeFlags
     runHook postBuild
   '';
 
@@ -38,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     make -C apfs-snap install DESTDIR="$out" $installFlags
     make -C apfsck install DESTDIR="$out" $installFlags
     make -C mkapfs install DESTDIR="$out" $installFlags
+    make -C apfs-label install DESTDIR="$out" $installFlags
     runHook postInstall
   '';
 


### PR DESCRIPTION
Diff: https://github.com/linux-apfs/apfsprogs/compare/990163894d871f51ba102a75aed384a275c5991b...f31d7c2d69d212ce381399d2bb1e91410f592484

This adds `apfs-label`, a new utility, so add a small test for it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
