### PR TITLE
rewind-ai: 1.5284-15284.1-dcd0176-20240504 -> 1.5310-15310.1-5f6bcc5-20240930

### DIFF
--- a/pkgs/by-name/re/rewind-ai/package.nix
+++ b/pkgs/by-name/re/rewind-ai/package.nix
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   # 15284.1 (build number)
   # dcd0176 (commit hash)
   # 20240504 (pub date)
-  version = "1.5284-15284.1-dcd0176-20240504";
+  version = "1.5310-15310.1-5f6bcc5-20240930";
 
   src = fetchzip {
     url =
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         commitHash = lib.elemAt (lib.splitString "-" finalAttrs.version) 2;
       in
       "https://updates.rewind.ai/builds/main/b${buildNumber}-main-${commitHash}.zip";
-    hash = "sha256-Y7iAYHH/msZoXFzAZHJb6YoDz5fwMPHJx1kg7TqP5Gw=";
+    hash = "sha256-uNqblEOezCj1JanDl6MZZO3GLX5jgWh19VeMcmwZvZg=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc