### PR TITLE
styluslabs-write: init at 2024-10-12

### DIFF
--- a/pkgs/by-name/st/styluslabs-write-bin/package.nix
+++ b/pkgs/by-name/st/styluslabs-write-bin/package.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, stdenv, lib, qtbase, qtsvg, libglvnd, libX11, libXi, fetchurl, makeDesktopItem }:
+{ stdenv, lib, libsForQt5, libglvnd, libX11, libXi, fetchurl, makeDesktopItem }:
 let
   desktopItem = makeDesktopItem {
     name = "Write";
@@ -10,8 +10,8 @@ let
     categories = [ "Office" "Graphics" ];
   };
 in
-mkDerivation rec {
-  pname = "write_stylus";
+stdenv.mkDerivation rec {
+  pname = "styluslabs-write-bin";
   version = "300";
 
   src = fetchurl {
@@ -37,8 +37,8 @@ mkDerivation rec {
   '';
   preFixup = let
     libPath = lib.makeLibraryPath [
-      qtbase            # libQt5PrintSupport.so.5
-      qtsvg             # libQt5Svg.so.5
+      libsForQt5.qtbase # libQt5PrintSupport.so.5
+      libsForQt5.qtsvg  # libQt5Svg.so.5
       stdenv.cc.cc.lib  # libstdc++.so.6
       libglvnd          # libGL.so.1
       libX11            # libX11.so.6
@@ -57,6 +57,6 @@ mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     platforms = platforms.linux;
     license = lib.licenses.unfree;
-    maintainers = with maintainers; [ oyren ];
+    maintainers = with maintainers; [ oyren lukts30 atemu ];
   };
 }

--- a/pkgs/by-name/st/styluslabs-write/package.nix
+++ b/pkgs/by-name/st/styluslabs-write/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  pkg-config,
+  SDL2,
+  xorg,
+  libGL,
+  roboto,
+  imagemagick,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "styluslabs-write";
+  version = "2024-10-12";
+
+  src = fetchFromGitHub {
+    owner = "styluslabs";
+    repo = "Write";
+    rev = "b13572e2dd6a87af35cd3edde92c9144a6dd8a2b";
+    hash = "sha256-cL6jU54LTkYu0mLNOgSDgChkDdg7eQaM00hTMas6cTg=";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+    # Delete .git folder for better reproducibility
+    # TODO: fix GITCOUNT is always 1 but is not used in Linux Build anyway
+    postFetch = ''
+      cd $out
+      git rev-parse --short HEAD > $out/GITREV
+      git rev-list --count HEAD > $out/GITCOUNT
+      rm -rf $out/.git
+    '';
+  };
+
+  hardeningDisable = [ "format" ];
+  makeFlags = [
+    "DEBUG=0"
+    "USE_SYSTEM_SDL=1"
+  ];
+  preBuild = ''
+    makeFlagsArray+=(
+      "GITREV=$(cat ./GITREV)"
+      "GITCOUNT=$(cat ./GITCOUNT)"
+    )
+    pushd syncscribble
+  '';
+
+  postBuild = ''
+    popd
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    imagemagick # magick
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    xorg.libX11
+    xorg.libXi
+    xorg.libXcursor
+    libGL
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,opt}
+    install -m555 -D syncscribble/Release/Write $out/opt/
+    install -m444 -D scribbleres/Intro.svg $out/opt/
+    install -m444 -D scribbleres/fonts/DroidSansFallback.ttf $out/opt/
+    ln -s ${roboto}/share/fonts/truetype/Roboto-Regular.ttf $out/opt/Roboto-Regular.ttf
+
+    ln -s ../opt/Write $out/bin/Write
+
+    for i in 16 24 48 64 96 128 256 512; do
+      mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
+      magick scribbleres/write_512.png -resize ''${i}x''${i} $out/share/icons/hicolor/''${i}x''${i}/apps/${finalAttrs.pname}.png
+    done
+
+    install -Dm444 scribbleres/linux/Write.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/Write.desktop \
+        --replace-fail 'Exec=/opt/Write/Write' 'Exec=Write' \
+        --replace-fail 'Icon=Write144x144' 'Icon=${finalAttrs.pname}'
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "https://styluslabs.com/";
+    description = "Cross-platform (Windows, Mac, Linux, iOS, Android) application for handwritten notes";
+    license = with lib.licenses; [
+      # miniz, pugixml, stb, ugui, ulib, usvg
+      mit
+      # nanovgXC
+      zlib
+      # styluslabs-write itself
+      agpl3Only
+    ];
+    maintainers = with lib.maintainers; [
+      lukts30
+      atemu
+    ];
+    platforms = with lib.platforms; linux ++ darwin ++ windows;
+    broken = !stdenv.isLinux;
+    mainProgram = "Write";
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1699,6 +1699,7 @@ mapAliases {
   wrapLisp_old = throw "Lisp packages have been redesigned. See 'lisp-modules' in the nixpkgs manual."; # Added 2024-05-07
   wmii_hg = wmii;
   wrapGAppsHook = wrapGAppsHook3; # Added 2024-03-26
+  write_stylus = styluslabs-write-bin; # Added 2024-10-09
   wxGTK30 = throw "wxGTK30 has been removed from nixpkgs as it has reached end of life"; # Added 2023-03-22
   wxGTK30-gtk2 = wxGTK30; # Added 2022-12-03
   wxGTK30-gtk3 = wxGTK30; # Added 2022-12-03

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33635,8 +33635,6 @@ with pkgs;
 
   wings = callPackage ../applications/graphics/wings { };
 
-  write_stylus = libsForQt5.callPackage ../applications/graphics/write_stylus { };
-
   wlc = callPackage  ../tools/misc/wlc { };
 
   wlclock = callPackage ../applications/misc/wlclock { };


### PR DESCRIPTION
>Cross-platform (Windows, Mac, Linux, iOS, Android) application for handwritten notes. 
- https://www.styluslabs.com/
- https://github.com/styluslabs/Write

Was (binary release still are?) under a nonfree license but source code that is now available is licensed under the AGPL.  
This PR adds the AGPL version and does not replace the existing [write_stylus](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/graphics/write_stylus/default.nix) which still uses binaries from 2020 (see https://github.com/NixOS/nixpkgs/issues/281368).

cc @oyren

This build deviates from the upstream SRC in that SDL2 is dynamically linked instead statically linking to the vendored version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
