### PR TITLE
treewide: remove empty build inputs

### DIFF
--- a/pkgs/applications/misc/nanoblogger/default.nix
+++ b/pkgs/applications/misc/nanoblogger/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "09mv52a5f0h3das8x96irqyznm69arfskx472b7w3b9q4a2ipxbq";
   };
 
-  buildInputs = [ ];
-
   installPhase = ''
     mkdir -p $out/bin
     cp -r * $out

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -31,7 +31,6 @@ in stdenv.mkDerivation {
     env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
     nativeBuildInputs = [ patchelf makeWrapper virtualBoxNixGuestAdditionsBuilder ] ++ kernel.moduleBuildDependencies;
-    buildInputs = [ ];
 
     buildPhase = ''
       runHook preBuild

--- a/pkgs/by-name/od/odoo15/package.nix
+++ b/pkgs/by-name/od/odoo15/package.nix
@@ -17,8 +17,6 @@ let
           hash = "sha256-WnRbsy/PJcotZqY9mJPLadrYqkXykOVifLIbDyNf4s4=";
         };
 
-        nativeBuildInputs = [ ];
-
         nativeCheckInputs = with self; [ pytestCheckHook pillow ];
       });
       flask = super.flask.overridePythonAttrs (old: rec {

--- a/pkgs/development/libraries/arguments/default.nix
+++ b/pkgs/development/libraries/arguments/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ ];
 
   #cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib" "-DBICPL_DIR=${bicpl}/lib" ];
 

--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
     ninja
   ];
 
-  buildInputs = [ ];
-
   mesonFlags = [
     # install validators to $dev
     "--bindir=${placeholder "dev"}/bin"

--- a/pkgs/development/libraries/dotconf/default.nix
+++ b/pkgs/development/libraries/dotconf/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ];
 
   meta = with lib; {
     description = "Configuration parser library";

--- a/pkgs/development/libraries/libbdplus/default.nix
+++ b/pkgs/development/libraries/libbdplus/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libgcrypt libgpg-error gettext ];
 
-  nativeBuildInputs = [ ];
-
   meta = with lib; {
     homepage = "http://www.videolan.org/developers/libbdplus.html";
     description = "Library to access BD+ protected Blu-Ray disks";

--- a/pkgs/development/libraries/libtar/default.nix
+++ b/pkgs/development/libraries/libtar/default.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
     ];
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ];
 
   meta = with lib; {
     description = "C library for manipulating POSIX tar files";

--- a/pkgs/development/libraries/qt-5/modules/qtgamepad.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtgamepad.nix
@@ -4,7 +4,6 @@ qtModule {
   pname = "qtgamepad";
   propagatedBuildInputs = [ qtbase qtdeclarative ]
     ++ lib.optional stdenv.hostPlatform.isDarwin GameController;
-  buildInputs = [ ];
   nativeBuildInputs = [ pkg-config ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -42,7 +42,6 @@ tcl.mkTclDerivation {
     ++ lib.optional enableAqua "--enable-aqua";
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ];
 
   propagatedBuildInputs = [
     libXft

--- a/pkgs/development/python-modules/apeye-core/default.nix
+++ b/pkgs/development/python-modules/apeye-core/default.nix
@@ -29,8 +29,6 @@ buildPythonPackage rec {
     idna
   ];
 
-  nativeCheckInputs = [ ];
-
   meta = {
     description = "Core (offline) functionality for the apeye library.";
     homepage = "https://github.com/domdfcoding/apyey-core";

--- a/pkgs/development/python-modules/consolekit/default.nix
+++ b/pkgs/development/python-modules/consolekit/default.nix
@@ -31,8 +31,6 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  nativeCheckInputs = [ ];
-
   meta = {
     description = "Additional utilities for click.";
     homepage = "https://pypi.org/project/consolekit";

--- a/pkgs/development/python-modules/deprecation-alias/default.nix
+++ b/pkgs/development/python-modules/deprecation-alias/default.nix
@@ -23,8 +23,6 @@ buildPythonPackage rec {
     packaging
   ];
 
-  nativeCheckInputs = [ ];
-
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"setuptools!=61.*,<=67.1.0,>=40.6.0"' '"setuptools"'

--- a/pkgs/development/python-modules/dist-meta/default.nix
+++ b/pkgs/development/python-modules/dist-meta/default.nix
@@ -25,8 +25,6 @@ buildPythonPackage rec {
     packaging
   ];
 
-  nativeCheckInputs = [ ];
-
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"setuptools!=61.*,<=67.1.0,>=40.6.0"' '"setuptools"'

--- a/pkgs/development/python-modules/dom-toml/default.nix
+++ b/pkgs/development/python-modules/dom-toml/default.nix
@@ -27,8 +27,6 @@ buildPythonPackage rec {
     tomli
   ];
 
-  nativeCheckInputs = [ ];
-
   meta = {
     description = "Dom's tools for Tom's Obvious, Minimal Language.";
     homepage = "https://github.com/domdfcoding/dom_toml";

--- a/pkgs/development/python-modules/domdf-python-tools/default.nix
+++ b/pkgs/development/python-modules/domdf-python-tools/default.nix
@@ -24,8 +24,6 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  nativeCheckInputs = [ ];
-
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"setuptools!=61.*,<=67.1.0,>=40.6.0"' '"setuptools"'

--- a/pkgs/development/python-modules/handy-archives/default.nix
+++ b/pkgs/development/python-modules/handy-archives/default.nix
@@ -21,8 +21,6 @@ buildPythonPackage rec {
     [
     ];
 
-  nativeCheckInputs = [ ];
-
   meta = {
     description = "Some handy archive helpers for Python.";
     homepage = "https://github.com/domdfcoding/handy-archives";

--- a/pkgs/development/python-modules/pyproject-parser/default.nix
+++ b/pkgs/development/python-modules/pyproject-parser/default.nix
@@ -34,8 +34,6 @@ buildPythonPackage rec {
     shippinglabel
     typing-extensions
   ];
-
-  nativeCheckInputs = [ ];
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"setuptools!=61.*,<=67.1.0,>=40.6.0"' '"setuptools"'

--- a/pkgs/development/python-modules/shippinglabel/default.nix
+++ b/pkgs/development/python-modules/shippinglabel/default.nix
@@ -29,8 +29,6 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  nativeCheckInputs = [ ];
-
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"setuptools!=61.*,<=67.1.0,>=40.6.0"' '"setuptools"'

--- a/pkgs/development/python-modules/whey-pth/default.nix
+++ b/pkgs/development/python-modules/whey-pth/default.nix
@@ -23,8 +23,6 @@ buildPythonPackage rec {
     whey
   ];
 
-  nativeCheckInputs = [ ];
-
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"setuptools!=61.*,<=67.1.0,>=40.6.0"' '"setuptools"'

--- a/pkgs/development/python-modules/whey/default.nix
+++ b/pkgs/development/python-modules/whey/default.nix
@@ -41,8 +41,6 @@ buildPythonPackage rec {
     shippinglabel
   ];
 
-  nativeCheckInputs = [ ];
-
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"setuptools!=61.*,<=67.1.0,>=40.6.0"' '"setuptools"'

--- a/pkgs/development/tools/misc/tet/default.nix
+++ b/pkgs/development/tools/misc/tet/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation ({
     sha256 = "1j57hv56df38w249l595b8rsgmsyvjkbysai03a9724gax5jl9av" ;
   };
 
-  buildInputs = [ ];
-
   patchPhase = "chmod +x configure";
 
   configurePhase = "./configure -t lite";

--- a/pkgs/tools/filesystems/snapraid/default.nix
+++ b/pkgs/tools/filesystems/snapraid/default.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  buildInputs = [ ];
-
   # SMART is only supported on Linux and requires the smartmontools package
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     wrapProgram $out/bin/snapraid \

--- a/pkgs/tools/misc/enjarify/default.nix
+++ b/pkgs/tools/misc/enjarify/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
     chmod +x $out/bin/enjarify
   '';
 
-  buildInputs = [ ];
-
   meta = with lib; {
     description = "Tool for translating Dalvik bytecode to equivalent Java bytecode";
     homepage = "https://github.com/google/enjarify/";

--- a/pkgs/tools/networking/samplicator/default.nix
+++ b/pkgs/tools/networking/samplicator/default.nix
@@ -5,7 +5,6 @@ stdenv.mkDerivation rec {
   version = "1.3.8rc1";
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ];
 
   src = fetchFromGitHub {
     owner = "sleinen";

--- a/pkgs/tools/system/dcfldd/default.nix
+++ b/pkgs/tools/system/dcfldd/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "1y6mwsvm75f5jzxsjjk0yhf8xnpmz6y8qvcxfandavx59lc3l57m";
   };
 
-  buildInputs = [ ];
-
   meta = with lib; {
     description = "Enhanced version of GNU dd";
 


### PR DESCRIPTION
repeat of https://github.com/NixOS/nixpkgs/pull/69479, part of https://github.com/NixOS/nixpkgs/issues/346453

Done with

```sh
#!/usr/bin/env nix-shell
#!nix-shell --pure -i bash -p ripgrep sd xe
regex='\s*(nativeBuild|build|check|nativeCheck)Inputs *= *\[ *\];'
rg "^$regex$" -l | xe sd "\n\n$regex\n" "\n"
rg "^$regex$" -l | xe sd "\n$regex\n" "\n"
rg "^$regex$" -l | xe sd "\n$regex\n" "\n"
```

and cherry-picked, should be 0 rebuilds

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
