### PR TITLE
k3s: Update 1_28, 1_29, 1_30, 1_31

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_28/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_28/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.13%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "1v3vyrb86xijyvljs0s0skhxpjbarjqg2sx9m40332dfq9din7xq"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.14%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "0rydihys7r9sscl7bv2ixbs3b25jjxr9rsgzz5nwgz6ncsr6nn7v"
   },
   "airgap-images-arm": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.13%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "0yifpx6vix5bjzkz81i5rsn89hkpp0rhk77ndl1lgy66pq4csbmm"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.14%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "036inn29k2c0wdbkxxh4fl6gs2g2wckv7856n7dhy791j33v8v0f"
   },
   "airgap-images-arm64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.13%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "1p8zf47pghhjqhrcvmzdbcfxxy78pjpqwvmhm3wdidsa8xyy375a"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.14%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "107s3imimc3gg8hmahihqc8930yzqcgxly7rhjia1z76vskswhpx"
   },
   "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.13%2Bk3s1/k3s-images.txt",
-    "sha256": "1f1d33jn4g5b6zmzdzzm4ffwfrmjwh60v9gnph0ysxjwsq1k0pxp"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.14%2Bk3s1/k3s-images.txt",
+    "sha256": "1l71xhcj2z9fz3mn89iyyxznrgk59qgng549iq3zc8w3l0hl0qry"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
@@ -1,15 +1,15 @@
 {
-  k3sVersion = "1.28.13+k3s1";
-  k3sCommit = "47737e1c4c941325574e8aa14e4a3af2e596f696";
-  k3sRepoSha256 = "1x66n36lxcvi5d9bdz0f1w2p24493rh3vbk1pskqd1f3v3fbv7kn";
-  k3sVendorHash = "sha256-/knBr0l7dZ6lX9QpohyPNrFEi4WQpNM01zOE5bCIB2E=";
+  k3sVersion = "1.28.14+k3s1";
+  k3sCommit = "3ef2bdb1e5ba667b735a65cbfa43229fd49230ef";
+  k3sRepoSha256 = "146xxpldp7bffn8sigfp9xjj8hw793ybp1xrfyb9s0bd85yxiw4x";
+  k3sVendorHash = "sha256-Y5s5lPP2bVGPHQPma3DJYYP91I3HQQoi+KbjEZpTr6w=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.14.0";
   k3sRootSha256 = "15cs9faw3jishsb5nhgmb5ldjc47hkwf7hz2126fp8ahf80m0fcl";
-  k3sCNIVersion = "1.4.0-k3s2";
-  k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
-  containerdVersion = "1.7.20-k3s2.28";
-  containerdSha256 = "0jqqa9202d94qd7g8d5zy161snlsc42cdjpmp50w4j3pnp2i1cki";
+  k3sCNIVersion = "1.5.1-k3s1";
+  k3sCNISha256 = "1bkz78p77aiw64hdvmlgc5zir9x8zha8qprfaab48jxbcsj3dfi7";
+  containerdVersion = "1.7.21-k3s2.28";
+  containerdSha256 = "00gdmd617mxf246m3mfz8if8snaciib4zdb7fm12mdhf52w031a6";
   criCtlVersion = "1.26.0-rc.0-k3s1";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_29/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_29/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.8%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "1v3vyrb86xijyvljs0s0skhxpjbarjqg2sx9m40332dfq9din7xq"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.9%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "0z3k4pc5cg75krk391d9h74ankv20mfcswrhwhhfv208rcndd9w9"
   },
   "airgap-images-arm": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.8%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "0yifpx6vix5bjzkz81i5rsn89hkpp0rhk77ndl1lgy66pq4csbmm"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.9%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "0iy0xz8ypmgn48jh3b4hbnwl8iszdb35c2f6an115z86lnl7a9a3"
   },
   "airgap-images-arm64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.8%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "1p8zf47pghhjqhrcvmzdbcfxxy78pjpqwvmhm3wdidsa8xyy375a"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.9%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "1bjfd63jd7a1yhh796nmdh7jvw9mabsw5gajcx8ssqcxd4wwrdxb"
   },
   "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.8%2Bk3s1/k3s-images.txt",
-    "sha256": "1f1d33jn4g5b6zmzdzzm4ffwfrmjwh60v9gnph0ysxjwsq1k0pxp"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.9%2Bk3s1/k3s-images.txt",
+    "sha256": "1l71xhcj2z9fz3mn89iyyxznrgk59qgng549iq3zc8w3l0hl0qry"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
@@ -1,15 +1,15 @@
 {
-  k3sVersion = "1.29.8+k3s1";
-  k3sCommit = "33fdc35dd67cf6c07989327e992fd26ed89b2449";
-  k3sRepoSha256 = "0ky5f039nkhdj6y5v9yr6lk875l29c67j6kqc2dzdb3iqbwskcbr";
-  k3sVendorHash = "sha256-VxVGBvpeKf/nuw09Llf85d4P8oCD2GvD1f0Mxt6fMj8=";
+  k3sVersion = "1.29.9+k3s1";
+  k3sCommit = "e92d3b3ba7a4810e82e38a3d5c6091a3e18caad5";
+  k3sRepoSha256 = "1i4881nv41dpvxmh20qy121d45431xbhkzlywx1rfwqla8wq6bwh";
+  k3sVendorHash = "sha256-JeX9SJw6U1/FMbv9fVQeQvAZKq+Z99ZrLC2bAy1vUkA=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.14.0";
   k3sRootSha256 = "15cs9faw3jishsb5nhgmb5ldjc47hkwf7hz2126fp8ahf80m0fcl";
-  k3sCNIVersion = "1.4.0-k3s2";
-  k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
-  containerdVersion = "1.7.20-k3s1";
-  containerdSha256 = "12ihr3z8vcglv5b0v9ris29zkkkdvjbcp3bf7ym71a0xdbg83s8i";
+  k3sCNIVersion = "1.5.1-k3s1";
+  k3sCNISha256 = "1bkz78p77aiw64hdvmlgc5zir9x8zha8qprfaab48jxbcsj3dfi7";
+  containerdVersion = "1.7.21-k3s2";
+  containerdSha256 = "0kp93fhmw2kiy46hw3ag05z8xwhw7kqp4wcbhsxshsdf0929g539";
   criCtlVersion = "1.29.0-k3s1";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.4%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "145sj4gpwdjvfv3bphpdg6db1d83bbwl0shbnsqpjizsm3ifvmm9"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.5%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "1fcdhhixxcbqxd8varz3vwz1qrkjpmxmwq74g14z7qafr7nqm757"
   },
   "airgap-images-arm": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.4%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "0sdkfsjxxi5sq0nxjw7g7r1p7711l74r39y5ss12q85q4sla0m7l"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.5%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "04d79m0lp8l53lgrpvhl6drn5jzdgjvaj32mcjq9y175f4knhiaw"
   },
   "airgap-images-arm64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.4%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "1kw85g79rywk6n3wda7ffvjhf030wwj8g3x8n73rgiprvksw4p7j"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.5%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "1grhh38x3mpj86fn487dfmhgdvbjf61mz8fg8sc9dcqhvpi8rr3w"
   },
   "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.4%2Bk3s1/k3s-images.txt",
-    "sha256": "1f1d33jn4g5b6zmzdzzm4ffwfrmjwh60v9gnph0ysxjwsq1k0pxp"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.5%2Bk3s1/k3s-images.txt",
+    "sha256": "1l71xhcj2z9fz3mn89iyyxznrgk59qgng549iq3zc8w3l0hl0qry"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_30/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_30/versions.nix
@@ -1,15 +1,15 @@
 {
-  k3sVersion = "1.30.4+k3s1";
-  k3sCommit = "98262b5dee29fe5ac849a0cef90b5d50292b020b";
-  k3sRepoSha256 = "1iwg7j0divbh41dx40kz69qkvscvppqb37dqvxayw3ha1yja4sq6";
-  k3sVendorHash = "sha256-EovTZ3DvDqWFR9vxhtjgcZcPXVk1C0PYNCxEV5XA6wg=";
+  k3sVersion = "1.30.5+k3s1";
+  k3sCommit = "9b586704a211264ca86b22f2a0b4617b00412235";
+  k3sRepoSha256 = "1fzpkfbk2x9xw9js9ns15g84c7q93knwx7fdmdj4af3830kplnnr";
+  k3sVendorHash = "sha256-fs9p6ywS5XCeJSF5ovDG40o+H4p4QmEJ0cvU5T9hwuA=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.14.0";
   k3sRootSha256 = "15cs9faw3jishsb5nhgmb5ldjc47hkwf7hz2126fp8ahf80m0fcl";
-  k3sCNIVersion = "1.4.0-k3s2";
-  k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
-  containerdVersion = "1.7.20-k3s1";
-  containerdSha256 = "12ihr3z8vcglv5b0v9ris29zkkkdvjbcp3bf7ym71a0xdbg83s8i";
+  k3sCNIVersion = "1.5.1-k3s1";
+  k3sCNISha256 = "1bkz78p77aiw64hdvmlgc5zir9x8zha8qprfaab48jxbcsj3dfi7";
+  containerdVersion = "1.7.21-k3s2";
+  containerdSha256 = "0kp93fhmw2kiy46hw3ag05z8xwhw7kqp4wcbhsxshsdf0929g539";
   criCtlVersion = "1.29.0-k3s1";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_31/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_31/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.0%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "13pakr8nxlbqhqcz40gyjncw4bghk7x7ryb2ynmr5airspqcdrl6"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.1%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "1hq8bj2hlzbq9rhpx9ifidfkrzy1pknizksq641kazl7kv44wldy"
   },
   "airgap-images-arm": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.0%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "0vc2v89qy9gbzfbmfrdb0l5yzyprk7yma5ps0yfj60jd9av07qvh"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.1%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "1mp8k98mzzn7fpyqjyvia13v2jri37nn3fdqdq3gmxrbcqvkh15g"
   },
   "airgap-images-arm64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.0%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "10ffa45pm1scavcd5cimdaw29rlc55c9i40qzh3n3451g1yqlmmk"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.1%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "1gg30iln9grrw3qdwlqwcb0k1zafiwr2lj7vd64mmsm1fj057skw"
   },
   "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.0%2Bk3s1/k3s-images.txt",
-    "sha256": "0y4x02fj1iysghq6s88wsiqfpsajrrwrg89m59qk431cii23nrza"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.1%2Bk3s1/k3s-images.txt",
+    "sha256": "1l71xhcj2z9fz3mn89iyyxznrgk59qgng549iq3zc8w3l0hl0qry"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_31/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_31/versions.nix
@@ -1,15 +1,15 @@
 {
-  k3sVersion = "1.31.0+k3s1";
-  k3sCommit = "34be6d96d17d8d65fda86272b62b752cb0e9c45e";
-  k3sRepoSha256 = "16yzsx56jmca07jdnzjvy4pcfrvvibv987l1mzdaws1vkm3xqfnw";
-  k3sVendorHash = "sha256-1uYlvGkW6n4aiUVX/2OjppczdobY/fk1ZaK6j3AEwvM=";
+  k3sVersion = "1.31.1+k3s1";
+  k3sCommit = "452dbbc14c747a0070fdf007ef2239a6e5d8d934";
+  k3sRepoSha256 = "012j78bxhmjq7d0z0yzxzbvlhgzx9qi254cpk6s6mi3k60ay6bx2";
+  k3sVendorHash = "sha256-CnfnyqrBQ9W1G6NORGSA5jB75Dvd1Hgu+KVITYrb6Mc=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.14.0";
   k3sRootSha256 = "15cs9faw3jishsb5nhgmb5ldjc47hkwf7hz2126fp8ahf80m0fcl";
-  k3sCNIVersion = "1.4.0-k3s2";
-  k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
-  containerdVersion = "1.7.20-k3s1";
-  containerdSha256 = "12ihr3z8vcglv5b0v9ris29zkkkdvjbcp3bf7ym71a0xdbg83s8i";
+  k3sCNIVersion = "1.5.1-k3s1";
+  k3sCNISha256 = "1bkz78p77aiw64hdvmlgc5zir9x8zha8qprfaab48jxbcsj3dfi7";
+  containerdVersion = "1.7.21-k3s2";
+  containerdSha256 = "0kp93fhmw2kiy46hw3ag05z8xwhw7kqp4wcbhsxshsdf0929g539";
   criCtlVersion = "1.31.0-k3s2";
 }


### PR DESCRIPTION
## Things done

Updated k3s_1_28, k3s_1_29, k3s_1_30, and k3s_1_31 (k3s). 

https://github.com/k3s-io/k3s/releases/tag/v1.28.14%2Bk3s1
https://github.com/k3s-io/k3s/releases/tag/v1.29.9%2Bk3s1
https://github.com/k3s-io/k3s/releases/tag/v1.30.5%2Bk3s1
https://github.com/k3s-io/k3s/releases/tag/v1.31.1%2Bk3s1

r-ryantm seems to be having trouble updating still, issue with finding the previous version, perhaps due to our alias: https://r.ryantm.com/log/k3s/2024-10-02.log

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc: @NixOS/k3s 


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
