### PR TITLE
buildFHSEnv: Allow using bwrap rootful arguments

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -35,6 +35,7 @@ let
     concatStringsSep
     escapeShellArgs
     filter
+    getExe
     optionalString
     splitString
     ;
@@ -125,6 +126,9 @@ let
   '';
 
   indentLines = str: concatLines (map (s: "  " + s) (filter (s: s != "") (splitString "\n" str)));
+  bubblewrapPatched = bubblewrap.overrideAttrs (oldAttrs: {
+    patches = (oldAttrs.patches or []) ++ [ ./disable_setuid_security_boundary.patch ];
+  });
   bwrapCmd = { initArgs ? "" }: ''
     ${extraPreBwrapCmds}
     ignored=(/nix /dev /proc /etc ${optionalString privateTmp "/tmp"})
@@ -226,7 +230,7 @@ let
     ''}
 
     cmd=(
-      ${bubblewrap}/bin/bwrap
+      ${getExe bubblewrapPatched}
       --dev-bind /dev /dev
       --proc /proc
       --chdir "$(pwd)"

--- a/pkgs/build-support/build-fhsenv-bubblewrap/disable_setuid_security_boundary.patch
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/disable_setuid_security_boundary.patch
@@ -1,0 +1,24 @@
+diff --git a/bubblewrap.c b/bubblewrap.c
+index 9f87e90..62c9a5c 100644
+--- a/bubblewrap.c
++++ b/bubblewrap.c
+@@ -35,6 +35,7 @@
+ #include <linux/sched.h>
+ #include <linux/seccomp.h>
+ #include <linux/filter.h>
++#include <unistd.h>
+ 
+ #include "utils.h"
+ #include "network.h"
+@@ -2722,6 +2723,11 @@ main (int    argc,
+   int intermediate_pids_sockets[2] = {-1, -1};
+   const char *exec_path = NULL;
+ 
++  // Set real UID to effective UID to trick bubblewrap into thinking it is root
++  if (setreuid(geteuid(), -1) != 0) {
++    die_with_error ("seretuid failed");
++  }
++
+   /* Handle --version early on before we try to acquire/drop
+    * any capabilities so it works in a build environment;
+    * right now flatpak's build runs bubblewrap --version.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
