### PR TITLE
pgmq: init at 1.4.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20711,6 +20711,12 @@
     githubId = 18656090;
     name = "Yuki Takagi";
   };
+  takeda = {
+    name = "Derek Kuliński";
+    email = "d@kulinski.us";
+    github = "takeda";
+    githubId = 411978;
+  };
   taketwo = {
     email = "alexandrov88@gmail.com";
     github = "taketwo";

--- a/pkgs/servers/sql/postgresql/ext/default.nix
+++ b/pkgs/servers/sql/postgresql/ext/default.nix
@@ -42,6 +42,8 @@ self: super: {
 
     pgaudit = super.callPackage ./pgaudit.nix { };
 
+    pgmq = super.callPackage ./pgmq.nix { };
+
     pgroonga = super.callPackage ./pgroonga.nix { };
 
     pgsodium = super.callPackage ./pgsodium.nix { };

--- a/pkgs/servers/sql/postgresql/ext/pgmq.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgmq.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  postgresql,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pgmq";
+  version = "1.4.4";
+
+  src = fetchFromGitHub {
+    owner = "tembo-io";
+    repo = "pgmq";
+    rev = "v${version}";
+    hash = "sha256-z+8/BqIlHwlMnuIzMz6eylmYbSmhtsNt7TJf/CxbdVw=";
+  };
+
+  sourceRoot = "${src.name}/pgmq-extension";
+
+  dontConfigure = true;
+
+  buildInputs = [ postgresql ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -t $out/share/postgresql/extension sql/*.sql
+    install -D -t $out/share/postgresql/extension *.control
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Lightweight message queue like AWS SQS and RSMQ but on Postgres";
+    homepage = "https://tembo.io/pgmq";
+    changelog = "https://github.com/tembo-io/pgmq/releases/tag/v${version}";
+    maintainers = with lib.maintainers; [ takeda ];
+    platforms = postgresql.meta.platforms;
+    license = lib.licenses.postgresql;
+  };
+}


### PR DESCRIPTION

PGMQ is a message queue extension that allows to implement similar queuing that's available on AWS SQS or RSMQ.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
