### PR TITLE
[Backport release-24.05] mozillavpn: 2.24.0 → 2.24.1, add updateScript

### DIFF
--- a/pkgs/by-name/mo/mozillavpn/package.nix
+++ b/pkgs/by-name/mo/mozillavpn/package.nix
@@ -31,17 +31,16 @@ stdenv.mkDerivation (finalAttrs: {
   };
   patches = [ ];
 
-  netfilterGoModules =
-    (buildGoModule {
-      inherit (finalAttrs)
-        pname
-        version
-        src
-        patches
-        ;
-      modRoot = "linux/netfilter";
-      vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
-    }).goModules;
+  netfilter = buildGoModule {
+    pname = "${finalAttrs.pname}-netfilter";
+    inherit (finalAttrs)
+      version
+      src
+      patches
+      ;
+    modRoot = "linux/netfilter";
+    vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
+  };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit (finalAttrs) src patches;
@@ -84,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace extension/CMakeLists.txt \
       --replace '/etc' "$out/etc"
 
-    ln -s '${finalAttrs.netfilterGoModules}' linux/netfilter/vendor
+    ln -s '${finalAttrs.netfilter.goModules}' linux/netfilter/vendor
   '';
 
   cmakeFlags = [

--- a/pkgs/by-name/mo/mozillavpn/package.nix
+++ b/pkgs/by-name/mo/mozillavpn/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mozillavpn";
-  version = "2.24.0";
+  version = "2.24.1";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-iTnwx+KPZ5b8qT0fEMUCGQx1UyGVM4VCzooZqslGWtw=";
+    hash = "sha256-X2rtHAZ9vbWjuOmD3B/uPasUQ1Q+b4SkNqk4MqGMaYo=";
   };
   patches = [ ];
 

--- a/pkgs/by-name/mo/mozillavpn/package.nix
+++ b/pkgs/by-name/mo/mozillavpn/package.nix
@@ -1,4 +1,5 @@
 {
+  _experimental-update-script-combinators,
   buildGoModule,
   cargo,
   cmake,
@@ -9,6 +10,7 @@
   libgcrypt,
   libgpg-error,
   libsecret,
+  nix-update-script,
   pkg-config,
   polkit,
   python3,
@@ -98,6 +100,14 @@ stdenv.mkDerivation (finalAttrs: {
     "PATH"
     ":"
     (lib.makeBinPath [ wireguard-tools ])
+  ];
+
+  passthru.updateScript = _experimental-update-script-combinators.sequence [
+    (nix-update-script { })
+    (nix-update-script {
+      attrPath = "mozillavpn.netfilter";
+      extraArgs = [ "--version=skip" ];
+    })
   ];
 
   meta = {


### PR DESCRIPTION
Backport to `release-24.05`:

- #345790 

Update the Mozilla VPN client from 2.24.0 to 2.24.1. Also add an `updateScript` to automate future updates.

https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.24.1
https://github.com/mozilla-mobile/mozilla-vpn-client/compare/v2.24.0...v2.24.1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
