### PR TITLE
git: move credential helpers to exec path

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -157,12 +157,12 @@ stdenv.mkDerivation (finalAttrs: {
   installFlags = [ "NO_INSTALL_HARDLINKS=1" ];
 
   preInstall = (lib.optionalString osxkeychainSupport ''
-    mkdir -p $out/bin
-    ln -s $out/share/git/contrib/credential/osxkeychain/git-credential-osxkeychain $out/bin/
+    mkdir -p $out/libexec/git-core
+    ln -s $out/share/git/contrib/credential/osxkeychain/git-credential-osxkeychain $out/libexec/git-core/
     rm -f $PWD/contrib/credential/osxkeychain/git-credential-osxkeychain.o
   '') + (lib.optionalString withLibsecret ''
-    mkdir -p $out/bin
-    ln -s $out/share/git/contrib/credential/libsecret/git-credential-libsecret $out/bin/
+    mkdir -p $out/libexec/git-core
+    ln -s $out/share/git/contrib/credential/libsecret/git-credential-libsecret $out/libexec/git-core/
     rm -f $PWD/contrib/credential/libsecret/git-credential-libsecret.o
   '');
 
@@ -221,7 +221,7 @@ stdenv.mkDerivation (finalAttrs: {
       ln -s $out/share/git/contrib/git-jump/git-jump $out/bin/git-jump
     '' + lib.optionalString perlSupport ''
       # wrap perl commands
-      makeWrapper "$out/share/git/contrib/credential/netrc/git-credential-netrc.perl" $out/bin/git-credential-netrc \
+      makeWrapper "$out/share/git/contrib/credential/netrc/git-credential-netrc.perl" $out/libexec/git-core/git-credential-netrc \
                   --set PERL5LIB   "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
       wrapProgram $out/libexec/git-core/git-cvsimport \
                   --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"


### PR DESCRIPTION
If git-credential-osxkeychain isn't on your PATH, git will fail to find it. Moving it to git's exec path[^1] allows it to be located more reliably. In other distributions such as Fedora[^2] and Homebrew[^3], credential helpers are not added to the user's PATH unless they are supplied by another package (e.g. git-credential-gcloud).

If there are concerns that people may be relying on referencing these binaries directly we can add symlinks in bin for backwards compatibility, but that's unlikely and easy to address.

This unfortunately affects a lot of packages so I haven't ran `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` to completion, but since this only affects credential helpers it's unlikely to impact other packages.

[^1]: https://git-scm.com/docs/git/2.46.0#Documentation/git.txt---exec-pathltpathgt
[^2]: https://src.fedoraproject.org/rpms/git/blob/rawhide/f/git.spec#_651
[^3]: https://github.com/Homebrew/homebrew-core/blob/12120ff79ce009489b958d8271af686d74403859/Formula/g/git.rb#L112


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
