### PR TITLE
buckets: init at 0.75.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11315,6 +11315,11 @@
     github = "kmicklas";
     githubId = 929096;
   };
+  kmogged = {
+    name = "Kevin";
+    github = "kmogged";
+    githubId = 22965352;
+  };
   knairda = {
     email = "adrian@kummerlaender.eu";
     name = "Adrian Kummerlaender";

--- a/pkgs/by-name/bu/buckets/package.nix
+++ b/pkgs/by-name/bu/buckets/package.nix
@@ -1,0 +1,63 @@
+{
+  fetchurl,
+  appimageTools,
+  lib,
+  makeWrapper,
+  stdenv,
+}:
+
+let
+
+  inherit (stdenv.hostPlatform) system;
+
+  platform =
+    {
+      x86_64-linux = "amd64";
+      aarch64-linux = "arm64";
+    }
+    .${system};
+
+  # Get hash in sri format
+  # nix-prefetch-url <url> | xargs nix hash to-sri --type sha256 --extra-experimental-features nix-command
+  hash =
+    {
+      x86_64-linux = "sha256-Gj/VDsV+ks8bhsFwU47+oBmsYOa0lQMHZeqQ3/IHm9E=";
+      aarch64-linux = "sha256-9pIT7iiarHBtHRdX5lqdfmJLJLMkugqZdprBZm5g1A8=";
+    }
+    .${system};
+
+  pname = "buckets";
+  version = "0.75.0";
+  src = fetchurl {
+    url = "https://github.com/buckets/application/releases/download/v${version}/Buckets-linux-latest-${platform}-${version}.AppImage";
+    inherit hash;
+  };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.libsodium ];
+  extraInstallCommands = ''
+    source "${makeWrapper}/nix-support/setup-hook"
+    wrapProgram $out/bin/buckets
+    install -m 444 -D ${appimageContents}/buckets.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/buckets.desktop \
+        --replace-fail 'Exec=AppRun' 'Exec=buckets'
+    for size in 16 32 48 64 128 256 512; do
+        install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/buckets.png \
+          $out/share/icons/hicolor/''${size}x''${size}/apps/buckets.png
+    done
+  '';
+
+  meta = {
+    description = "Private family budgeting app";
+    homepage = "https://www.budgetwithbuckets.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ kmogged ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "buckets";
+  };
+}


### PR DESCRIPTION
Adds initial package for the financial applications buckets (https://www.budgetwithbuckets.com/)

I have updated the maintainers file with my info and have added myself as the maintainer. I use this software daily and have been using this particular nix definition for a few months now and I think the project is mature enough to be included in the nixpkgs. I have had the most success wrapping the AppImage. I am open to improvements, but the software is stable on NixOS.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
