### PR TITLE
nim: 2.0.8 -> 2.2.0; nim: init updatescript;

### DIFF
--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -76,12 +76,12 @@ in {
 
   nim-unwrapped-2 = stdenv.mkDerivation (finalAttrs: {
     pname = "nim-unwrapped";
-    version = "2.0.8";
+    version = "2.2.0";
     strictDeps = true;
 
     src = fetchurl {
       url = "https://nim-lang.org/download/nim-${finalAttrs.version}.tar.xz";
-      hash = "sha256-VwLahEcA0xKdtzFwtcYGrb37h+grgWwNkRB+ogpl3xY=";
+      hash = "sha256-zphChJyXYOSH7N0c2t98DyhEyvrmBUAcfHKuJXZEiTw=";
     };
 
     buildInputs = [ boehmgc openssl pcre readline sqlite ]
@@ -94,7 +94,7 @@ in {
       ./nixbuild.patch
       # Load libraries at runtime by absolute path
 
-      ./extra-mangling.patch
+      ./extra-mangling-2.patch
       # Mangle store paths of modules to prevent runtime dependence.
 
       ./openssl.patch
@@ -151,12 +151,16 @@ in {
       runHook postInstall
     '';
 
+    passthru = {
+      updateScript.command = [ ./update.sh ];
+    };
+
     meta = with lib; {
       description = "Statically typed, imperative programming language";
       homepage = "https://nim-lang.org/";
       license = licenses.mit;
       mainProgram = "nim";
-      maintainers = with maintainers; [ ehmry ];
+      maintainers = with maintainers; [ ehmry eveeifyeve ];
     };
   });
 

--- a/pkgs/development/compilers/nim/extra-mangling-2.patch
+++ b/pkgs/development/compilers/nim/extra-mangling-2.patch
@@ -1,0 +1,48 @@
+diff --git a/compiler/modulepaths.nim b/compiler/modulepaths.nim
+index c9e6060e5..acb289498 100644
+--- a/compiler/modulepaths.nim
++++ b/compiler/modulepaths.nim
+@@ -79,6 +79,13 @@ proc checkModuleName*(conf: ConfigRef; n: PNode; doLocalError=true): FileIndex =
+   else:
+     result = fileInfoIdx(conf, fullPath)
+ 
++proc rot13(result: var string) =
++  for i, c in result:
++    case c
++    of 'a'..'m', 'A'..'M': result[i] = char(c.uint8 + 13)
++    of 'n'..'z', 'N'..'Z': result[i] = char(c.uint8 - 13)
++    else: discard
++
+ proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
+   ## Mangle a relative module path to avoid path and symbol collisions.
+   ##
+@@ -87,9 +94,11 @@ proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
+   ##
+   ## Example:
+   ## `foo-#head/../bar` becomes `@foo-@hhead@s..@sbar`
+-  "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
++  result = "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
+     {$os.DirSep: "@s", $os.AltSep: "@s", "#": "@h", "@": "@@", ":": "@c"})
++  rot13(result)
+ 
+ proc demangleModuleName*(path: string): string =
+   ## Demangle a relative module path.
+   result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@c": ":"})
++  rot13(result)
+diff --git a/compiler/modulegraphs.nim b/compiler/modulegraphs.nim
+index 77762d23a..59dd8903a 100644
+--- a/compiler/modulegraphs.nim
++++ b/compiler/modulegraphs.nim
+@@ -503,7 +503,11 @@ proc uniqueModuleName*(conf: ConfigRef; m: PSym): string =
+   for i in 0..<trunc:
+     let c = rel[i]
+     case c
+-    of 'a'..'z', '0'..'9':
++    of 'a'..'m':
++      result.add char(c.uint8 + 13)
++    of 'n'..'z':
++      result.add char(c.uint8 - 13)
++    of '0'..'9':
+       result.add c
+     of {os.DirSep, os.AltSep}:
+       result.add 'Z' # because it looks a bit like '/'

--- a/pkgs/development/compilers/nim/update.sh
+++ b/pkgs/development/compilers/nim/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash nix-update curl coreutils jq
+
+set -ex
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+curl_github() {
+  curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} "$@"
+}
+
+
+case "$UPDATE_NIX_ATTR_PATH" in
+nim)
+  latestTag=$(curl_github https://api.github.com/repos/nim-lang/Nim/releases/latest | jq -r ".tag_name")
+  latestVersion="$(expr "$latestTag" : 'v\(.*\)')"
+
+  echo "Updating Nim"
+  nix-update --version "$latestVersion" \
+    --override-filename "$SCRIPT_DIR/default.nix" \
+  nim
+*)
+  echo "Unknown attr path $UPDATE_NIX_ATTR_PATH"
+  ;;
+esac


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[changeLog v2.0.8...v2.2.0](https://github.com/nim-lang/Nim/compare/v2.0.8...v2.2.0)

Adds an update script to nim.

Fixes: #346530 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
