### PR TITLE
ruby-modules/gem-config: Add support for rjb, ruby-magic, webp-ffi

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -27,6 +27,8 @@
 , bison, flex, pango, python3, patchelf, binutils, freetds, wrapGAppsHook3, atk
 , bundler, libsass, dart-sass, libexif, libselinux, libsepol, shared-mime-info, libthai, libdatrie
 , CoreServices, DarwinTools, cctools, libtool, discount, exiv2, libepoxy, libxkbcommon, libmaxminddb, libyaml
+, substituteAll, jdk
+, libjpeg, libpng, libtiff, libwebp
 , cargo, rustc, rustPlatform
 , autoSignDarwinBinariesHook
 }@args:
@@ -734,6 +736,17 @@ in
     meta.mainProgram = "restclient";
   };
 
+  rjb = attrs: {
+    dontBuild = false;
+    buildInputs = [ jdk ];
+    patches = [
+      (substituteAll {
+        src = ./rjb-set-java-home.patch;
+        javaHome = jdk.home;
+      })
+    ];
+  };
+
   rmagick = attrs: {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ imagemagick which ];
@@ -762,6 +775,15 @@ in
 
   ruby-lxc = attrs: {
     buildInputs = [ lxc ];
+  };
+
+  ruby-magic = attrs: {
+    buildInputs = [ file ];
+    buildFlags = [
+      "--use-system-libraries"
+      "--with-magic-include=${file.dev}/include"
+      "--with-magic-lib=${file.out}/lib"
+    ];
   };
 
   ruby-terminfo = attrs: {
@@ -895,6 +917,10 @@ in
 
   uuid4r = attrs: {
     buildInputs = [ which libossp_uuid ];
+  };
+
+  webp-ffi = attrs: {
+    buildInputs = [ libjpeg libpng libtiff libwebp ];
   };
 
   whois = attrs: {

--- a/pkgs/development/ruby-modules/gem-config/rjb-set-java-home.patch
+++ b/pkgs/development/ruby-modules/gem-config/rjb-set-java-home.patch
@@ -1,0 +1,52 @@
+diff --git a/ext/extconf.rb b/ext/extconf.rb
+index a660d25..1cc6813 100644
+--- a/ext/extconf.rb
++++ b/ext/extconf.rb
+@@ -29,7 +29,7 @@ class Path
+ 
+ end
+ 
+-javahome = ENV['JAVA_HOME']
++javahome = "@javaHome@"
+ if javahome.nil? && RUBY_PLATFORM =~ /darwin/
+   javahome = `/usr/libexec/java_home`.strip
+ end
+diff --git a/ext/load.c b/ext/load.c
+index ce678c7..50cd81f 100644
+--- a/ext/load.c
++++ b/ext/load.c
+@@ -103,6 +103,8 @@
+  #define GETDEFAULTJVMINITARGS "JNI_GetDefaultJavaVMInitArgs"
+ #endif
+ 
++# define DEFAULT_HOME "@javaHome@"
++
+ typedef int (JNICALL *GETDEFAULTJAVAVMINITARGS)(void*);
+ typedef int (JNICALL *CREATEJAVAVM)(JavaVM**, JNIEnv**, void*);
+ 
+@@ -238,11 +240,7 @@ static int load_jvm(const char* jvmtype)
+ #endif
+     if (!jh)
+     {
+-        if (RTEST(ruby_verbose))
+-        {
+-            fprintf(stderr, "no JAVA_HOME environment\n");
+-        }
+-        return 0;
++        jh = DEFAULT_HOME;
+     }
+ #if defined(_WIN32)
+     if (*jh == '"' && *(jh + strlen(jh) - 1) == '"')
+diff --git a/lib/rjb.rb b/lib/rjb.rb
+index dcfb320..9d0fd17 100644
+--- a/lib/rjb.rb
++++ b/lib/rjb.rb
+@@ -37,7 +37,7 @@ module RjbConf
+   if /darwin/ =~ RUBY_PLATFORM
+     if ENV['JVM_LIB'].nil? || ENV['JVM_LIB'] == ''
+       if ENV['JAVA_HOME'].nil? || ENV['JAVA_HOME'] == ''
+-        jvms = Dir.glob("#{`/usr/libexec/java_home`.strip}/**/libjvm.dylib")
++        jvms = Dir.glob("@javaHome@/**/libjvm.dylib")
+       else
+         jvms = Dir.glob("#{ENV['JAVA_HOME']}/**/libjvm.dylib")
+       end


### PR DESCRIPTION
As I mentioned [here](https://discourse.nixos.org/t/ruby-on-rails-gem-collisions/40645/4?u=amiryal) before, I would like to submit the `gemConfig`s that I use in the project I am working on.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
