### PR TITLE
nixos/google-compute-config: avoid IFD

### DIFF
--- a/nixos/modules/virtualisation/google-compute-config.nix
+++ b/nixos/modules/virtualisation/google-compute-config.nix
@@ -90,7 +90,7 @@ in
 
   users.groups.google-sudoers = mkIf config.users.mutableUsers { };
 
-  boot.extraModprobeConfig = readFile "${pkgs.google-guest-configs}/etc/modprobe.d/gce-blacklist.conf";
+  boot.initrd.extraFiles."/etc/modprobe.d/gce-blacklist.conf".source = pkgs.copyPathToStore "${pkgs.google-guest-configs}/etc/modprobe.d/gce-blacklist.conf";
 
   environment.etc."sysctl.d/60-gce-network-security.conf".source = "${pkgs.google-guest-configs}/etc/sysctl.d/60-gce-network-security.conf";
 


### PR DESCRIPTION
the GCE image nixos module currently involves an import from derivation:
```
[illustris@illustris-thinkpad:~/src/gcp-terranix-minimal]$ nix flake show
warning: updating lock file '/home/illustris/src/gcp-terranix-minimal/flake.lock':
• Updated input 'nixpkgs':
    'github:illustris/nixpkgs/241f73f91699ec138fa01c75d1e6db267d685831?narHash=sha256-iTsBnBiEFfUX0NYXQzPv/kh//Mhf%2BAmI8/EQapT%2BwzQ%3D' (2024-10-05)
  → 'github:nixos/nixpkgs/bc947f541ae55e999ffdb4013441347d83b00feb?narHash=sha256-NOiTvBbRLIOe5F6RbHaAh6%2B%2BBNjsb149fGZd1T4%2BKBg%3D' (2024-10-04)
path:/home/illustris/src/gcp-terranix-minimal?lastModified=1728231944&narHash=sha256-0Tj986jFv6nN2c4vNZX4Q0FvO9gpsA1LXxXbwBKs%2B5U%3D
├───apps
│   └───x86_64-linux
│       ├───apply: app
│       ├───destroy: app
│       ├───plan: app
│       ├───shell: app
│       └───show: app
├───nixosConfigurations
│   └───default: NixOS configuration
└───packages
    └───x86_64-linux
evaluation warning: system.stateVersion is not set, defaulting to 24.11. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
error:
       … while calling the 'head' builtin
         at /nix/store/sdzpqjwx7pdx6lsq6llyfqqf7hspp83c-source/lib/attrsets.nix:1575:11:
         1574|         || pred here (elemAt values 1) (head values) then
         1575|           head values
             |           ^
         1576|         else

       … while evaluating the attribute 'value'
         at /nix/store/sdzpqjwx7pdx6lsq6llyfqqf7hspp83c-source/lib/modules.nix:816:9:
          815|     in warnDeprecation opt //
          816|       { value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          817|         inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/sdzpqjwx7pdx6lsq6llyfqqf7hspp83c-source/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `system.systemBuilderArgs':

       … while evaluating definitions from `/nix/store/sdzpqjwx7pdx6lsq6llyfqqf7hspp83c-source/nixos/modules/system/activation/activatable-system.nix':

       … while evaluating the option `system.activationScripts.etc.text':

       … while evaluating definitions from `/nix/store/sdzpqjwx7pdx6lsq6llyfqqf7hspp83c-source/nixos/modules/system/etc/etc-activation.nix':

       … while evaluating definitions from `/nix/store/sdzpqjwx7pdx6lsq6llyfqqf7hspp83c-source/nixos/modules/system/etc/etc.nix':

       … while evaluating the option `environment.etc."modprobe.d/nixos.conf".source':

       … while evaluating definitions from `/nix/store/sdzpqjwx7pdx6lsq6llyfqqf7hspp83c-source/nixos/modules/system/etc/etc.nix':

       … while evaluating the option `environment.etc."modprobe.d/nixos.conf".text':

       … while evaluating definitions from `/nix/store/sdzpqjwx7pdx6lsq6llyfqqf7hspp83c-source/nixos/modules/system/boot/modprobe.nix':

       … while evaluating the option `boot.extraModprobeConfig':

       … while evaluating definitions from `/nix/store/sdzpqjwx7pdx6lsq6llyfqqf7hspp83c-source/nixos/modules/virtualisation/google-compute-config.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: cannot build '/nix/store/gyfbxzx1gg20y1gbzf6syh4qxv5plqx1-google-guest-configs-20211116.00.drv^out' during evaluation because the option 'allow-import-from-derivation' is disabled
```

With this change applied, nix flake show works:
```
[illustris@illustris-thinkpad:~/src/gcp-terranix-minimal]$ nix flake show
warning: updating lock file '/home/illustris/src/gcp-terranix-minimal/flake.lock':
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/bc947f541ae55e999ffdb4013441347d83b00feb?narHash=sha256-NOiTvBbRLIOe5F6RbHaAh6%2B%2BBNjsb149fGZd1T4%2BKBg%3D' (2024-10-04)
  → 'github:illustris/nixpkgs/241f73f91699ec138fa01c75d1e6db267d685831?narHash=sha256-iTsBnBiEFfUX0NYXQzPv/kh//Mhf%2BAmI8/EQapT%2BwzQ%3D' (2024-10-05)
path:/home/illustris/src/gcp-terranix-minimal?lastModified=1728231917&narHash=sha256-A8YnfzvxkaFDv2uBOO0cy%2BqSBNAfTt0RLdKtmbRruoU%3D
├───apps
│   └───x86_64-linux
│       ├───apply: app
│       ├───destroy: app
│       ├───plan: app
│       ├───shell: app
│       └───show: app
├───nixosConfigurations
│   └───default: NixOS configuration
└───packages
    └───x86_64-linux
evaluation warning: system.stateVersion is not set, defaulting to 24.11. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
        ├───default: package 'nixos-system-unnamed-24.11.20241005.241f73f'
        ├───image: package 'google-compute-image'
        └───tf: package 'config.tf.json'
```

The modprobe rules are present on the VM as expected:
```
[root@bvzvgywzuzzavwxs:~]# grep -o /nix/store/.*initrd /boot/grub/grub.cfg | xargs cat | zstd -d | cpio -i
50789 blocks

[root@bvzvgywzuzzavwxs:~]# ls
dev  etc  init  lib  nix  proc  sys

[root@bvzvgywzuzzavwxs:~]# ls etc/modprobe.d/
debian.conf  gce-blacklist.conf  nixos.conf  ubuntu.conf

[root@bvzvgywzuzzavwxs:~]# cat etc/modprobe.d/gce-blacklist.conf 
# nouveau does not work with GCE GPU's.
blacklist nouveau

# GCE does not have a floppy device.
blacklist floppy

[root@bvzvgywzuzzavwxs:~]#
```

You can test it out by running `nix run github:illustris/gcp-ifd-poc#apply`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
