### PR TITLE
apko: 0.14.1 -> 0.19.1, fix go tests

### DIFF
--- a/pkgs/development/tools/apko/default.nix
+++ b/pkgs/development/tools/apko/default.nix
@@ -6,13 +6,13 @@
 
 buildGoModule rec {
   pname = "apko";
-  version = "0.14.1";
+  version = "0.19.1";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-O1lU3b3dNmFcV0Dfkpw63Eu6AgLSLBi7MbF47OsjgL4=";
+    hash = "sha256-uUsNYQPW2MtXxohdenXbNWfikp8TW0chJ5SDYU8ayV4=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -24,7 +24,7 @@ buildGoModule rec {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-shnVJ6TcqWxUu1Ib2ewaz2VK4mi1Rt3R0Cmof9ilDJ4=";
+  vendorHash = "sha256-2Tuhya70R++Nv5KEd+4vjxiTTansraSXQtGm/FqRktk=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -50,6 +50,11 @@ buildGoModule rec {
     export SOURCE_DATE_EPOCH=0
     ldflags=
   '';
+
+  checkFlags = [
+    # requires networking (apk.chainreg.biz)
+    "-skip=TestInitDB_ChainguardDiscovery"
+  ];
 
   postInstall = ''
     installShellCompletion --cmd apko \

--- a/pkgs/development/tools/apko/default.nix
+++ b/pkgs/development/tools/apko/default.nix
@@ -41,10 +41,15 @@ buildGoModule rec {
     ldflags+=" -X sigs.k8s.io/release-utils/version.buildDate=$(cat SOURCE_DATE_EPOCH)"
   '';
 
-  checkFlags = [
-    # fails to run on read-only filesystem
-    "-skip=(TestPublish|TestBuild|TestTarFS)"
-  ];
+  preCheck = ''
+    # some tests require a writable HOME
+    export HOME=$(mktemp -d)
+
+    # some test data include SOURCE_DATE_EPOCH (which is different from our default)
+    # and the default version info which we get by unsetting our ldflags
+    export SOURCE_DATE_EPOCH=0
+    ldflags=
+  '';
 
   postInstall = ''
     installShellCompletion --cmd apko \

--- a/pkgs/development/tools/apko/default.nix
+++ b/pkgs/development/tools/apko/default.nix
@@ -74,6 +74,6 @@ buildGoModule rec {
     description = "Build OCI images using APK directly without Dockerfile";
     mainProgram = "apko";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jk developer-guy ];
+    maintainers = with maintainers; [ jk developer-guy emilylange ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -283,7 +283,9 @@ with pkgs;
 
   fission = callPackage ../development/tools/fission { };
 
-  apko = callPackage ../development/tools/apko { };
+  apko = callPackage ../development/tools/apko {
+    buildGoModule = buildGo123Module;
+  };
 
   melange = callPackage ../development/tools/melange { };
 


### PR DESCRIPTION
- https://github.com/chainguard-dev/apko/releases/tag/v0.19.1
- https://github.com/chainguard-dev/apko/releases/tag/v0.19.0
- https://github.com/chainguard-dev/apko/releases/tag/v0.18.1
- https://github.com/chainguard-dev/apko/releases/tag/v0.18.0
- https://github.com/chainguard-dev/apko/releases/tag/v0.17.0
- https://github.com/chainguard-dev/apko/releases/tag/v0.16.0
- https://github.com/chainguard-dev/apko/releases/tag/v0.15.0
- https://github.com/chainguard-dev/apko/releases/tag/v0.14.9
- https://github.com/chainguard-dev/apko/releases/tag/v0.14.8
- https://github.com/chainguard-dev/apko/releases/tag/v0.14.7
- https://github.com/chainguard-dev/apko/releases/tag/v0.14.6
- https://github.com/chainguard-dev/apko/releases/tag/v0.14.5
- https://github.com/chainguard-dev/apko/releases/tag/v0.14.4
- https://github.com/chainguard-dev/apko/releases/tag/v0.14.3
- https://github.com/chainguard-dev/apko/releases/tag/v0.14.2
- diff: https://github.com/chainguard-dev/apko/compare/v0.14.1...v0.19.1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).