### PR TITLE
lib.types: add mergeTypes, a commutative type merger

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -749,7 +749,7 @@ let
     foldl' (res: opt:
       let t  = res.type;
           t' = opt.options.type;
-          mergedType = t.typeMerge t'.functor;
+          mergedType = types.mergeTypes t t';
           typesMergeable = mergedType != null;
           typeSet = if (bothHave "type") && typesMergeable
                        then { type = mergedType; }

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -687,6 +687,9 @@ The only required parameter is `name`.
     Note: There is a generic `defaultTypeMerge` that work with most of
     value and composed types.
 
+    Note: This is to define the type merge behavior. To merge types, use
+    `lib.types.mergeTypes`.
+
 `functor`
 
 :   An attribute set representing the type. It is used for type


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I worked on this change while trying to make `lib.types.coercedTo` mergeable by "propagating" a type merge to its final type (e.g. allowing to merge `coercedTo … … (submodule …)` with `submodule …`), which is way more easy to implement if the `coercedTo.typeMerge` function gets always called. Before this change, this was not guranteed, making `coercedTo` mergeable really hard, as discussed [here](https://github.com/NixOS/nixpkgs/pull/21875#issuecomment-276533560).

While researching, I did not find any reason which was already discussed on GitHub, why the type merging mechanism should not attempt to behave commutative. To be precise, I only found the discussion mentioned earlier and [this PR where one reviewer avoided to answer the question if type merging should behave commutative or not](https://github.com/NixOS/nixpkgs/pull/18380#discussion_r78278248).

So I propose this change as it seems to me as a rather obvious solution to the problem of commutative. To be more precise, this emulates the same behavior implemented in some programming languages which support operator overlading. E.g. Python supports operator overloading with [special method names](https://docs.python.org/3/reference/datamodel.html#special-method-names) where, for the case of binary operators, [one can return `NotImplemented`](https://docs.python.org/3/reference/datamodel.html#object.__lt__) to make Python to attempt to call the respective reflective operator of the other argument. My implementation here leverages that `typeMerge` is already expected to return `null` when type merging is not supported.

## Things done

This PR adds the new helper method `lib.types.mergeTypes`.

This helper method establishes type merging to be more commutative by probing both types’ typeMerge functions. The first non-null result is returned.
This makes typeMerge more to a internal implementation detail.

All obvious calls to typeMerge in nixpkgs are also replaced with calls to mergeTypes, to establish this more commutative behavior in the module system.

As of now, all typeMerge implementations already behaved commutative, so this does not introduce new functionality by itself. But this improvement makes it possible to introduce one-sided type merging capabilities in the future.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

I ran following tests for verifying that this change does not break the module system:
- `nix-build lib/tests/release.nix` (to ensure basic functionality of the module system)
- `nix build .#nixosTests.acme` (as an exemplary NixOS test)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
