### PR TITLE
nak: init at 0.7.6

### DIFF
--- a/pkgs/by-name/na/nak/package.nix
+++ b/pkgs/by-name/na/nak/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGo123Module,
+  fetchFromGitHub,
+}:
+buildGo123Module rec {
+  pname = "nak";
+  version = "0.7.6";
+
+  src = fetchFromGitHub {
+    owner = "fiatjaf";
+    repo = "nak";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-VUSBCvDW53Z+mdAx0bUQIgcsiEwxOnm/FnnMcSC0iks=";
+  };
+
+  vendorHash = "sha256-alex1YEkviR5O0KLGZlOsf1i7s6m1C4LxHdJCogDCng=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  # Integration tests fail (requires connection to relays)
+  doCheck = false;
+
+  meta = {
+    description = "Command-line tool for Nostr things";
+    homepage = "https://github.com/fiatjaf/nak";
+    changelog = "https://github.com/fiatjaf/nak/releases/tag/${version}";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ nartsiss ];
+    mainProgram = "nak";
+  };
+}


### PR DESCRIPTION
## Things done

New [nak](https://github.com/fiatjaf/nak) package - nostr army knife command-line tool
Closes #346668

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
