### PR TITLE
nix-plugin-pijul.tests: fix the eval

### DIFF
--- a/pkgs/by-name/ni/nix-plugin-pijul/package.nix
+++ b/pkgs/by-name/ni/nix-plugin-pijul/package.nix
@@ -11,9 +11,11 @@
   runCommand,
   pijul,
   nixVersions,
+  nixOverride ? null,
   nix-plugin-pijul,
 }:
-stdenv.mkDerivation (finalAttrs: {
+let nix = if nixOverride != null then nixOverride else nixVersions.nix_2_18;
+in stdenv.mkDerivation (finalAttrs: {
   pname = "nix-plugin-pijul";
   version = "0.1.4";
 
@@ -30,12 +32,12 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     boost
     howard-hinnant-date
-    nixVersions.nix_2_18
+    nix
   ];
 
   passthru.tests = let
-    localRepoCheck = nix:
-      runCommand "localRepoCheck-${nix.name}"
+    localRepoCheck = nixOverride:
+      runCommand "localRepoCheck-${nixOverride.name}"
       {
         nativeBuildInputs = [
           pijul
@@ -56,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
 
         output=$(
           nix \
-            --option plugin-files ${nix-plugin-pijul.override {inherit nix;}}/lib/nix/plugins/pijul.so \
+            --option plugin-files ${nix-plugin-pijul.override {inherit nixOverride;}}/lib/nix/plugins/pijul.so \
             --extra-experimental-features 'nix-command flakes' \
             eval --impure --raw --expr "builtins.readFile ((builtins.fetchTree \"pijul+file://$PWD\") + \"/foo\")"
         )


### PR DESCRIPTION
Without the change the eval fails as:

    $ nix build --no-link -f. nix-plugin-pijul.tests
    error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'localRepoCheck-nix-2.25.0pre20240920_ca3fc169'
         whose name attribute is located at pkgs/stdenv/generic/make-derivation.nix:336:7

       … while evaluating attribute 'buildCommand' of derivation 'localRepoCheck-nix-2.25.0pre20240920_ca3fc169'
         at pkgs/build-support/trivial-builders/default.nix:59:17:
           58|         enableParallelBuilding = true;
           59|         inherit buildCommand name;
             |                 ^
           60|         passAsFile = [ "buildCommand" ]

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: function 'anonymous lambda' called with unexpected argument 'nix'
       at pkgs/by-name/ni/nix-plugin-pijul/package.nix:1:1:
            1| {
             | ^
            2|   lib,
       Did you mean lib?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
