### PR TITLE
mathematica: fix incorrect matchesDoc with #343491

### DIFF
--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -51,10 +51,7 @@ let versions = callPackage ./versions.nix { };
           sublist = l: lib.sublist 0 n l;
       in lib.compareLists lib.compare (sublist as) (sublist bs) == 0;
 
-    matchesDoc = v:
-      builtins.match (if webdoc
-                      then ".*[0-9]_LIN(UX)?.sh"
-                      else ".*_B[Nn][Dd][Ll].sh") v.src.name != null;
+    matchesDoc = v: (builtins.match ".*[0-9]_LIN(UX)?.sh" v.src.name != null) == webdoc;
 
 in
 


### PR DESCRIPTION
With mathematica 14.1 came into nixpkgs with #343491, there are two types of file names of local-doc installer, `Wolfram_*_LIN_Bndl.sh` and `Mathematica_*_BNDL_LINUX.sh`. However, the modified matchesDoc implementation failed to match the later type, causing evaluation errors.

```console
$ NIXPKGS_ALLOW_UNFREE=1 nix eval --impure .#mathematica --apply 'p: (p.override { version = "13.2.0"; }).outPath' -L
warning: Git tree '/home/sharzy/ws/dev/contrib/nixpkgs' is dirty
error:
       … while evaluating the attribute 'src.outPath'

         at /nix/store/ppsywc1wrw5gm88lflxwncyprjlf0sya-source/pkgs/applications/science/math/mathematica/generic.nix:67:10:

           66| in stdenv.mkDerivation {
           67|   inherit meta name src version;
             |          ^
           68|

       … while calling the 'throw' builtin

         at /nix/store/ppsywc1wrw5gm88lflxwncyprjlf0sya-source/pkgs/applications/science/math/mathematica/default.nix:40:12:

           39|       if matching-versions == []
           40|       then throw ("No registered Mathematica version found to match"
             |            ^
           41|                   + " version=${toString version} and language=${lang},"

       error: No registered Mathematica version found to match version=13.2.0 and language=en, and with local documentation
```

Since an installer is either webdoc or localdoc, I suggest not writing regex for both types, which is error-prone and harder to override.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
