### PR TITLE
nixos/sdrplay: disable telemetry

### DIFF
--- a/nixos/modules/services/misc/sdrplay.nix
+++ b/nixos/modules/services/misc/sdrplay.nix
@@ -30,6 +30,7 @@ with lib;
       };
     };
     services.udev.packages = [ pkgs.sdrplay ];
-
+    # Disable telemetry
+    networking.hosts = { "0.0.0.0" = [ "api.sdrplay.com" ]; };
   };
 }


### PR DESCRIPTION
The proprietary SDRPlay API server sends unencrypted "registration" HTTP requests to `http://api.sdrplay.com/regdevice3.php`, containing the serial number of an attached SDRPlay device among other data. By extension this also allows the collection of IP (approximate location) and Timestamp information, all without user consent. After a successful telemetry request, the software creates a hidden file in `/etc`, similar to a cookie.

## Things done

Disable telemetry by blocking DNS resolution of `api.sdrplay.com`
Tested with sdrplay 3.15.2 (updated myself, before seeing #334459)

The SDRPlay API server does not need an internet connection to work, ~~so another solution would be to run the service in a separate network namespace. However, I have not researched whether that would block access from the client library to the service.~~ RFC.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
