### PR TITLE
python312Packages.pynitrokey: 0.4.50 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/pynitrokey/default.nix
+++ b/pkgs/development/python-modules/pynitrokey/default.nix
@@ -16,21 +16,21 @@
   python-dateutil,
   pyusb,
   requests,
-  spsdk,
   tqdm,
   tlv8,
   typing-extensions,
-  pyserial,
-  protobuf,
   click-aliases,
   semver,
   nethsm,
   importlib-metadata,
+  nitrokey,
+  pyscard,
+  asn1crypto,
 }:
 
 let
   pname = "pynitrokey";
-  version = "0.4.50";
+  version = "0.6.0";
   mainProgram = "nitropy";
 in
 
@@ -40,10 +40,14 @@ buildPythonPackage {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-BIBwIYxoUcK7E69REcu/qmrpNlyYwnA7Im3iRSsWlnA=";
+    hash = "sha256-pY6ATORZDPGRnkN6dse1s/DzQRpplDbPAGUHU4E7U9M=";
   };
 
-  propagatedBuildInputs = [
+  nativeBuildInputs = [ installShellFiles ];
+
+  build-system = [ flit-core ];
+
+  dependencies = [
     certifi
     cffi
     click
@@ -55,21 +59,16 @@ buildPythonPackage {
     python-dateutil
     pyusb
     requests
-    spsdk
     tqdm
     tlv8
     typing-extensions
-    pyserial
-    protobuf
     click-aliases
     semver
     nethsm
     importlib-metadata
-  ];
-
-  nativeBuildInputs = [
-    flit-core
-    installShellFiles
+    nitrokey
+    pyscard
+    asn1crypto
   ];
 
   pythonRelaxDeps = true;


### PR DESCRIPTION
## Things done

https://github.com/Nitrokey/pynitrokey/releases/tag/v0.5.0
https://github.com/Nitrokey/pynitrokey/releases/tag/v0.6.0

Diff: https://github.com/Nitrokey/pynitrokey/compare/v0.4.50...v0.6.0

Due to the refactoring in v0.5.0 by upstream, #346706 must be merged first. I will rebase this PR and mark it as ready when that has happened.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>7 packages built:</summary>
  <ul>
    <li>nitrokey-app2</li>
    <li>nitrokey-app2.dist</li>
    <li>nitrokey-fido2-firmware</li>
    <li>pynitrokey (python312Packages.pynitrokey)</li>
    <li>pynitrokey.dist (python312Packages.pynitrokey.dist)</li>
    <li>python311Packages.pynitrokey</li>
    <li>python311Packages.pynitrokey.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
