### PR TITLE
lilv: add meson options to include Nix and NixOS specific paths for the default lv2 plugin search

### DIFF
--- a/pkgs/development/libraries/audio/lilv/default.nix
+++ b/pkgs/development/libraries/audio/lilv/default.nix
@@ -44,8 +44,7 @@ stdenv.mkDerivation rec {
       + "~/.nix-profile/lib/lv2")
     ++ lib.optional stdenv.isLinux  (lib.mesonOption "default_lv2_path"
       "~/.lv2:/usr/local/lib/lv2:/usr/lib/lv2:"
-      + "~/.nix-profile/lib/lv2:/run/current-system/sw/lib/lv2:"
-      + "/etc/profiles/per-user/$USER/lib/lv2");
+      + "~/.nix-profile/lib/lv2:/run/current-system/sw/lib/lv2");
 
   passthru = {
     tests = {

--- a/pkgs/development/libraries/audio/lilv/default.nix
+++ b/pkgs/development/libraries/audio/lilv/default.nix
@@ -32,10 +32,20 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ lv2 ];
 
   mesonFlags = [
-    "-Ddocs=disabled"
+    (lib.mesonOption "docs" "disabled")
     # Tests require building a shared library.
     (lib.mesonEnable "tests" (!stdenv.hostPlatform.isStatic))
-  ];
+  ] # Add nix and NixOS specific lv2 paths
+    # The default values are from: https://github.com/lv2/lilv/blob/master/src/lilv_config.h
+    ++ lib.optional stdenv.isDarwin  (lib.mesonOption "default_lv2_path"
+      "~/.lv2:~/Library/Audio/Plug-Ins/LV2:"
+      + "/usr/local/lib/lv2:/usr/lib/lv2:"
+      + "/Library/Audio/Plug-Ins/LV2:"
+      + "~/.nix-profile/lib/lv2")
+    ++ lib.optional stdenv.isLinux  (lib.mesonOption "default_lv2_path"
+      "~/.lv2:/usr/local/lib/lv2:/usr/lib/lv2:"
+      + "~/.nix-profile/lib/lv2:/run/current-system/sw/lib/lv2:"
+      + "/etc/profiles/per-user/$USER/lib/lv2");
 
   passthru = {
     tests = {


### PR DESCRIPTION
Currently applications that use lilv will miss LV2 plugins installed in Nix and NixOS.

The lilv meson build already exposes options that can be filled.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
