### PR TITLE
google-chat-linux: init at 5.29.23-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4606,6 +4606,12 @@
     githubId = 490965;
     name = "Craig Swank";
   };
+  cterence = {
+    email = "terence.chateigne@posteo.net";
+    github = "cterence";
+    githubId = 25285508;
+    name = "Térence Chateigné";
+  };
   ctron = {
     email = "ctron@dentrassi.de";
     github = "ctron";

--- a/pkgs/by-name/go/google-chat-linux/package.nix
+++ b/pkgs/by-name/go/google-chat-linux/package.nix
@@ -1,0 +1,71 @@
+{
+  buildNpmPackage,
+  copyDesktopItems,
+  electron,
+  fetchFromGitHub,
+  lib,
+  makeDesktopItem,
+}:
+
+buildNpmPackage rec {
+  pname = "google-chat-linux";
+  version = "5.29.23-1";
+
+  src = fetchFromGitHub {
+    owner = "squalou";
+    repo = "google-chat-linux";
+    rev = "refs/tags/${version}";
+    hash = "sha256-JBjxZUs0HUgAkJJBYhNv2SHjpBtAcP09Ah4ATPwpZsQ=";
+  };
+
+  npmDepsHash = "sha256-7lKWbXyDpYh1sP9LAV/oA7rfpckSbIucwKT21vBrJ3Y=";
+  dontNpmBuild = true;
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  # npm install will error when electron tries to download its binary
+  # we don't need it anyways since we wrap the program with our nixpkgs electron
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  postPatch = ''
+    # https://github.com/electron/electron/issues/31121
+    substituteInPlace src/paths.js \
+      --replace-fail "process.resourcesPath" "'$out/lib/node_modules/${pname}/assets'"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/icons
+    ln -s $out/lib/node_modules/${pname}/build/icons/icon.png $out/share/icons/${pname}.png
+    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
+      --add-flags $out/lib/node_modules/${pname}/
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "google-chat-linux";
+      exec = "google-chat-linux";
+      icon = "google-chat-linux";
+      desktopName = "Google Chat";
+      comment = meta.description;
+      categories = [
+        "Network"
+        "InstantMessaging"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Electron-base client for Google Hangouts Chat";
+    homepage = "https://github.com/squalou/google-chat-linux";
+    downloadPage = "https://github.com/squalou/google-chat-linux/releases";
+    changelog = "https://github.com/squalou/google-chat-linux/releases/tag/${version}";
+    license = lib.licenses.wtfpl;
+    mainProgram = "google-chat-linux";
+    maintainers = with lib.maintainers; [
+      cterence
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Add google-chat-linux, an electron-base client for Google Hangouts Chat. Link: https://github.com/squalou/google-chat-linux
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
