### PR TITLE
grafana-to-ntfy: init at 0-unstable-2024-10-04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9879,6 +9879,12 @@
     githubId = 110620;
     name = "Jevin Maltais";
   };
+  jeyemwey = {
+    name = "Jannik";
+    email = "jannik@outlook.com";
+    github = "jeyemwey";
+    githubId = 2796271;
+  };
   jfb = {
     email = "james@yamtime.com";
     github = "tftio";

--- a/pkgs/by-name/gr/grafana-to-ntfy/package.nix
+++ b/pkgs/by-name/gr/grafana-to-ntfy/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  darwin,
+  ...
+}:
+rustPlatform.buildRustPackage {
+  pname = "grafana-to-ntfy";
+  version = "0-unstable-2024-10-04";
+
+  src = fetchFromGitHub {
+    owner = "kittyandrew";
+    repo = "grafana-to-ntfy";
+    rev = "325337f4dc2fe44427262f063f2a594cc226f55f";
+    sha256 = "sha256-zEm06aq44IcUXIrm9Upovmifu4INpLjE3dMXahHppwk=";
+  };
+
+  cargoHash = "sha256-IdONQaAgUBeuz5GNnJ0fSFG6X686QJsT7AiGUrLztt0=";
+
+  nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isLinux) [ pkg-config ];
+
+  buildInputs =
+    lib.optionals (stdenv.hostPlatform.isLinux) [ openssl ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ darwin.apple_sdk.frameworks.Security ];
+
+  meta = {
+    description = "Bridge to bring Grafana Webhook alerts to ntfy.sh";
+    homepage = "https://github.com/kittyandrew/grafana-to-ntfy";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ jeyemwey ];
+    mainProgram = "grafana-to-ntfy";
+  };
+}


### PR DESCRIPTION
Initialise package `grafana-to-ntfy` since the project recently got a License by its maintainer (compare https://github.com/kittyandrew/grafana-to-ntfy/issues/12). 


## Things done

The package does not have releases not many recent commits to it, so I set `version=0.1.0` as described in the Cargo.toml of the project.

On the rest, its a very basic rust project that creates a single binary  which is a webserver.

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
