### PR TITLE
Runtimedep update for Ryujinx

### DIFF
--- a/pkgs/by-name/ry/ryujinx/package.nix
+++ b/pkgs/by-name/ry/ryujinx/package.nix
@@ -21,6 +21,7 @@
 , udev
 , SDL2
 , SDL2_mixer
+, fontconfig
 }:
 
 buildDotnetModule rec {
@@ -50,6 +51,7 @@ buildDotnetModule rec {
     vulkan-loader
     ffmpeg
     udev
+    fontconfig
 
     # Avalonia UI
     glew


### PR DESCRIPTION
Added fontconfig as runtime dependency for Ryujinx, since otherwise ryujinx won't launch stating that libSkiaSharp shared library or one of its dependencies is not able to load (libfontconfig.so.1 is missing).

Tested locally by adding this runtime dependency and running on my nixos install.

## Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  
- [x] Tested, as applicable:
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
