### PR TITLE
freecad: work around https://github.com/FreeCAD/FreeCAD/issues/10514

### DIFF
--- a/pkgs/by-name/fr/freecad/0003-freecad-font-issue-10514.patch
+++ b/pkgs/by-name/fr/freecad/0003-freecad-font-issue-10514.patch
@@ -1,0 +1,61 @@
+diff --git a/src/Gui/PreferencePages/DlgSettingsEditor.cpp b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+index 5f92058c18..b00104497b 100644
+--- a/src/Gui/PreferencePages/DlgSettingsEditor.cpp
++++ b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+@@ -56,27 +56,34 @@ namespace
+  *
+  * Based on
+  * https://stackoverflow.com/questions/18896933/qt-qfont-selection-of-a-monospace-font-doesnt-work
++ * Local fix to based on comment in
++ * https://github.com/FreeCAD/FreeCAD/issues/10514#issuecomment-1849176386
+  */
++bool hasFixedPitch(const QFont& font)
++{
++    return QFontInfo(font).fixedPitch();
++}
++
+ QFont getMonospaceFont()
+ {
+-    QFont font(QString::fromLatin1("monospace"));
+-    if (font.fixedPitch()) {
+-        return font;
+-    }
+-    font.setStyleHint(QFont::Monospace);
+-    if (font.fixedPitch()) {
+-        return font;
++    if (QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); hasFixedPitch(font)) {
++        return font;  // should typically work.
+     }
+-    font.setStyleHint(QFont::TypeWriter);
+-    if (font.fixedPitch()) {
++
++    QFont font;                         // default QApplication font
++    font.setStyleHint(QFont::Courier);  // may not work
++    if (hasFixedPitch(font)) {
+         return font;
+     }
+-    font.setFamily(QString::fromLatin1("courier"));
+-    if (font.fixedPitch()) {
+-        return font;
++    for (const char* family : {"Monospace", "Courier"}) {
++        font.setFamily(QString::fromLatin1(family));
++        if (hasFixedPitch(font)) {
++            return font;
++        }
+     }
+-    return font;  // We failed, but return whatever we have anyway
++    return font;
+ }
++
+ }  // namespace
+ 
+ /* TRANSLATOR Gui::Dialog::DlgSettingsEditor */
+@@ -302,7 +309,7 @@ void DlgSettingsEditor::loadSettings()
+     ui->fontSize->setValue(10);
+     ui->fontSize->setValue(hGrp->GetInt("FontSize", ui->fontSize->value()));
+ 
+-    QByteArray defaultMonospaceFont = getMonospaceFont().family().toLatin1();
++    QByteArray defaultMonospaceFont = QFontInfo(getMonospaceFont()).family().toLatin1();
+ 
+ #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+     QStringList familyNames = QFontDatabase().families(QFontDatabase::Any);

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -131,6 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
     ./0002-FreeCad-OndselSolver-pkgconfig.patch
+    ./0003-freecad-font-issue-10514.patch
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
  * Fixes #284880
  * Also discussed on https://discourse.nixos.org/t/freecad-failed-to-compute-left-right-minimum-bearings-for-cursor-pcf/35266

Symptom is that failure to load a fixed font is followed by a flood of
 'Failed to compute left/right minimum bearings for "cursor.pcf"'
messages that can freeze up the machine.

Isssue FreeCAD issue tracker https://github.com/FreeCAD/FreeCAD/issues/10514

Is not yet fixed, but with a working solution, which has not made it into the repo yet: https://github.com/FreeCAD/FreeCAD/issues/10514#issuecomment-1849176386 The hotfix from that comment is added here slightly edited as freecad-font-10514.patch


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
