### PR TITLE
doc: overhaul interactive shell helpers section

### DIFF
--- a/doc/packages/shell-helpers.section.md
+++ b/doc/packages/shell-helpers.section.md
@@ -1,12 +1,82 @@
 # Interactive shell helpers {#sec-shell-helpers}
 
-Some packages provide the shell integration to be more useful. But unlike other systems, nix doesn't have a standard `share` directory location. This is why a bunch `PACKAGE-share` scripts are shipped that print the location of the corresponding shared folder. Current list of such packages is as following:
+Some packages contain shell integration files, but unlike other systems Nix doesn't have a standard `share` directory location.
+There are several approaches for dealing with this depending on the package and the user's setup.
 
-- `fzf` : `fzf-share`
+## Sourcing with `-share` scripts {#sec-shell-helpers-share-scripts}
 
-E.g. `fzf` can then be used in the `.bashrc` like this:
+Some packages ship `-share` scripts that print the location of the corresponding shared folder, including:
+
+- `blesh` : {command}`blesh-share`
+- `fzf` : {command}`fzf-share`
+- `gitstatus` : {command}`gitstatus-share`
+- `skim` : {command}`sk-share`
+- `zsh-autoenv` : {command}`zsh-autoenv-share`
+
+E.g. {command}`fzf` can then be used like this:
 
 ```bash
-source "$(fzf-share)/completion.bash"
-source "$(fzf-share)/key-bindings.bash"
+# ~/.bashrc
+source "$(fzf-share)/completion.bash";
+source "$(fzf-share)/key-bindings.bash";
+```
+
+## Sourcing with parameter expansion {#sec-shell-helpers-sourcing-expansion}
+
+When a `-share` script isn't packaged, Nix can expand paramaters in the format `${pkgs.pname}` using the `pkgs` attribute:
+
+```nix
+# NixOS configuration
+programs.bash.interactiveShellInit = ''
+  source "${pkgs.fzf}/share/fzf/completion.bash";
+  source "${pkgs.fzf}/share/fzf/key-bindings.bash";
+'';
+```
+
+This will ensure the package is added to your store even if it's not installed to your environment.
+
+## Sourcing with {command}`nix-eval` {#sec-shell-helpers-sourcing-nix-eval}
+
+If you aren't using Nix for configuration or otherwise need to reference a share directory from outside it, you can also evaluate at runtime:
+
+```bash
+# ~/.bashrc
+source "$(nix eval --raw --read-only nixpkgs#fzf.outPath)/share/fzf/completion.bash";
+source "$(nix eval --raw --read-only nixpkgs#fzf.outPath)/share/fzf/key-bindings.bash";
+```
+
+::: {.warning}
+{command}`nix eval` returns the path where a derivation would go under Nix's latest configuration, not necessarily where one is currently present.
+If there's a mismatch between your booted system and the latest configuration (for example before you run {command}`sudo nixos-rebuild switch`) it may return a directory that doesn't exist.
+
+Additionally, {command}`nix-eval` takes hundreds of milliseconds to complete.
+
+[Sourcing with variables](#sec-shell-helpers-sourcing-variables) should be preferred for these reasons.
+:::
+
+## Sourcing with share path variables {#sec-shell-helpers-sourcing-variables}
+
+Another option is to take advantage of parameter expansion to create an environment variable:
+
+```nix
+# NixOS configuration
+environment.variables.FZF_SHARE_PATH = "${pkgs.fzf}/share/fzf";
+```
+
+As mentioned in [sourcing with parameter expansion](#sec-shell-helpers-sourcing-expansion), this will ensure the package is added to the store.
+If you don't use Nix for configuration, you can at least limit the time spent on {command}`nix eval` by running it at login:
+
+```bash
+# ~/.bash_profile
+FZF_SHARE_PATH = "$(nix eval --raw --read-only nixpkgs#fzf.outPath)/share/fzf";
+export FZF_SHARE_PATH;
+```
+
+Running {command}`nix eval` at login also means the value will remain the same for the length of your session.
+The environment variable can then be sourced from an unmanaged {file}`~/.bashrc`:
+
+```bash
+# ~/.bashrc
+source "${FZF_SHARE_PATH}/completion.bash";
+source "${FZF_SHARE_PATH}/key-bindings.bash";
 ```


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage. 
-->

Expands the documentation on interactive shell helpers to cover scenarios where a `-share` helper script may not be available. As of now only 5 packages include this type of helper, I've edited the list to include all of them but other solutions are needed for the rest of the package collection. Both Nix parameter expansion and `nix eval` approaches are documented, open to any feedback on scope and whether this would be more appropriate somewhere other than the reference.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[@NixOS/documentation-team](https://github.com/orgs/NixOS/teams/documentation-team)