### PR TITLE
coroot: init at 1.5.8

### DIFF
--- a/pkgs/by-name/co/coroot/package.nix
+++ b/pkgs/by-name/co/coroot/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  fetchpatch,
+  pkg-config,
+  nodejs,
+  npmHooks,
+  lz4,
+}:
+
+buildGoModule rec {
+  pname = "coroot";
+  version = "1.5.8";
+
+  src = fetchFromGitHub {
+    owner = "coroot";
+    repo = "coroot";
+    rev = "v${version}";
+    hash = "sha256-c8i+JtmUzq8lsRU8NpR4p1EXtIljYs1uZAq3O5fMqa4=";
+  };
+  # github.com/grafana/pyroscope-go/godeltaprof 0.1.6 is broken on go 1.23
+  # use patch from https://github.com/coroot/coroot/pull/357 until it gets fixed
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/coroot/coroot/commit/9bf6ac0ad4dfaa7f13e6d9b5ce5e331d1478aafc.patch";
+      hash = "sha256-5otqdYyQ57sNjF84CRgx0wcztsRdTdsNuhEkvGyw7UE=";
+    })
+  ];
+
+  vendorHash = "sha256-W0UNw8FEIHDKQDCjBryDSJB/UhNyAtMxC6A/9lr79sg=";
+  npmDeps = fetchNpmDeps {
+    src = "${src}/front";
+    hash = "sha256-inZV+iv837+7ntBae/oLSNLxpzoqEcJNPNdBE+osJHQ=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+  buildInputs = [ lz4 ];
+
+  overrideModAttrs = oldAttrs: {
+    nativeBuildInputs = lib.remove npmHooks.npmConfigHook oldAttrs.nativeBuildInputs;
+    preBuild = null;
+  };
+
+  npmRoot = "front";
+  preBuild = ''
+    npm --prefix="$npmRoot" run build-prod
+  '';
+
+  meta = {
+    description = "Open-source APM & Observability tool";
+    homepage = "https://coroot.com";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ errnoh ];
+    mainProgram = "coroot";
+  };
+}


### PR DESCRIPTION
Adding package for [coroot](https://github.com/coroot/coroot), the server part of Coroot monitoring tool. I'll add the client version in a separate PR.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
