### PR TITLE
libblocksruntime: unstable-2014-06-24 -> unstable-2017-10-28 and modernize

### DIFF
--- a/pkgs/development/libraries/libblocksruntime/default.nix
+++ b/pkgs/development/libraries/libblocksruntime/default.nix
@@ -1,30 +1,41 @@
-{ lib, stdenv, fetchFromGitHub, clang }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
 
 stdenv.mkDerivation {
   pname = "blocksruntime";
-  version = "unstable-2014-06-24";
+  version = "unstable-2017-10-28";
 
   src = fetchFromGitHub {
     owner = "mackyle";
     repo = "blocksruntime";
-    rev = "b5c5274daf1e0e46ecc9ad8f6f69889bce0a0a5d";
-    sha256 = "0ic4lagagkylcvwgf10mg0s1i57h4i25ds2fzvms22xj4zwzk1sd";
+    rev = "9cc93ae2b58676c23fd02cf0c686fa15b7a3ff81";
+    sha256 = "sha256-pQMNZBgkF4uADOVCWXB5J3qQt8JMe8vo6ZmbtSVA5Xo=";
   };
 
-  buildInputs = [ clang ];
-
-  configurePhase = ''
-    export CC=clang
-    export CXX=clang++
+  buildPhase = ''
+    runHook preBuild
+    ./buildlib ${lib.optionalString (!stdenv.hostPlatform.isStatic) "-shared"}
+    runHook postBuild
   '';
 
-  buildPhase = "./buildlib";
+  installPhase = ''
+    runHook preInstall
+    prefix="/" DESTDIR=$out ./installlib ${
+      if stdenv.hostPlatform.isStatic then "-static" else "-shared"
+    }
+    runHook postInstall
+  '';
 
-  checkPhase = "./checktests";
+  checkPhase = ''
+    runHook preCheck
+    ./checktests
+    runHook postChck
+  '';
 
   doCheck = false; # hasdescriptor.c test fails, hrm.
-
-  installPhase = ''prefix="/" DESTDIR=$out ./installlib'';
 
   meta = with lib; {
     description = "Installs the BlocksRuntime library from the compiler-rt";


### PR DESCRIPTION
Build and install the shared library if not static static library is built even with `-shared` specified but what is installed can be specified during install.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
