### PR TITLE
ghbackup: init at 1.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12193,6 +12193,11 @@
     github = "lenivaya";
     githubId = 49302467;
   };
+  lenny = {
+    name = "Lenny.";
+    matrix = "lenny@flipdot.org";
+    keys = [ { fingerprint = "6D63 2D4D 0CFE 8D53 F5FD  C7ED 738F C800 6E9E A634"; } ];
+  };
   leo248 = {
     github = "leo248";
     githubId = 95365184;

--- a/pkgs/by-name/gh/ghbackup/package.nix
+++ b/pkgs/by-name/gh/ghbackup/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  git,
+  makeWrapper,
+}:
+
+buildGoModule rec {
+  pname = "ghbackup";
+  version = "1.13.0";
+
+  src = fetchFromGitHub {
+    owner = "qvl";
+    repo = "ghbackup";
+    rev = "v${version}";
+    hash = "sha256-3LSe805VrbUGjqjnhTJD2KBVZ4rq+4Z3l4d0I1MrBMA=";
+  };
+
+  patches = [ ./patches/fix-next-page-logic.patch ];
+
+  postPatch = ''
+    go mod init qvl.io/ghbackup
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  vendorHash = null;
+
+  postFixup = ''
+    wrapProgram $out/bin/${meta.mainProgram} \
+      --prefix PATH : "${lib.makeBinPath [ git ]}"
+  '';
+
+  doCheck = false; # tests want to actually download from github
+
+  meta = with lib; {
+    description = "Backup your GitHub repositories with a simple command-line application written in Go.";
+    homepage = "https://github.com/qvl/ghbackup";
+    license = licenses.mit;
+    mainProgram = "ghbackup";
+    maintainers = with maintainers; [ lenny ];
+  };
+}

--- a/pkgs/by-name/gh/ghbackup/patches/fix-next-page-logic.patch
+++ b/pkgs/by-name/gh/ghbackup/patches/fix-next-page-logic.patch
@@ -1,0 +1,66 @@
+From 9825efc51387fef14fdb184e7061b313a54fcb86 Mon Sep 17 00:00:00 2001
+From: Ronan Barrett <ronan.barrett@voiapp.io>
+Date: Mon, 8 May 2023 15:54:39 +0200
+Subject: [PATCH 1/2] fix next page logic
+
+---
+ ghbackup/fetch.go | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/ghbackup/fetch.go b/ghbackup/fetch.go
+index 93cce1c..bcef8ad 100644
+--- a/ghbackup/fetch.go
++++ b/ghbackup/fetch.go
+@@ -126,11 +126,17 @@ func getNextURL(header http.Header) string {
+ 	if len(parts) == 0 {
+ 		return ""
+ 	}
+-	firstLink := parts[0]
+-	if !strings.Contains(firstLink, "rel=\"next\"") {
++	var nextLink string
++	for _, v := range parts {
++		if strings.Contains(v, "rel=\"next\"") {
++			nextLink = strings.TrimSpace(v)
++		}
++	}
++	if nextLink == "" {
+ 		return ""
+ 	}
+-	parts = strings.Split(firstLink, ";")
++
++	parts = strings.Split(nextLink, ";")
+ 	if len(parts) == 0 {
+ 		return ""
+ 	}
+@@ -140,3 +146,4 @@ func getNextURL(header http.Header) string {
+ 	}
+ 	return urlInBrackets[1 : len(urlInBrackets)-1]
+ }
++
+
+From 5f696939f668cd88c59c05fd8e0d6ad9f236dea5 Mon Sep 17 00:00:00 2001
+From: Ronan Barrett <ronan.barrett@voiapp.io>
+Date: Mon, 8 May 2023 16:44:47 +0200
+Subject: [PATCH 2/2] add break
+
+---
+ ghbackup/fetch.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ghbackup/fetch.go b/ghbackup/fetch.go
+index bcef8ad..b045c38 100644
+--- a/ghbackup/fetch.go
++++ b/ghbackup/fetch.go
+@@ -130,6 +130,7 @@ func getNextURL(header http.Header) string {
+ 	for _, v := range parts {
+ 		if strings.Contains(v, "rel=\"next\"") {
+ 			nextLink = strings.TrimSpace(v)
++			break
+ 		}
+ 	}
+ 	if nextLink == "" {
+@@ -146,4 +147,3 @@ func getNextURL(header http.Header) string {
+ 	}
+ 	return urlInBrackets[1 : len(urlInBrackets)-1]
+ }
+-


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added a package for [ghbackup](https://github.com/qvl/ghbackup), a simple cli tool for backing up your github repos. Supports personal access tokens to get private repos. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
