### PR TITLE
redis: refactor

### DIFF
--- a/pkgs/by-name/re/redis/package.nix
+++ b/pkgs/by-name/re/redis/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  fetchpatch2,
   lua,
   jemalloc,
   pkg-config,
@@ -10,12 +11,12 @@
   which,
   ps,
   getconf,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   systemd,
-  # dependency ordering is broken at the moment when building with openssl
-  tlsSupport ? !stdenv.hostPlatform.isStatic,
   openssl,
+  python3,
 
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  tlsSupport ? true,
   # Using system jemalloc fixes cross-compilation and various setups.
   # However the experimental 'active defragmentation' feature of redis requires
   # their custom patched version of jemalloc.
@@ -26,30 +27,29 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "redis";
   version = "7.2.7";
 
-  src = fetchurl {
-    url = "https://download.redis.io/releases/redis-${finalAttrs.version}.tar.gz";
-    hash = "sha256-csCB47jPrnFEJz0m12c28IMZAAr0bAFRXK1dKXZc6tU=";
+  src = fetchFromGitHub {
+    owner = "redis";
+    repo = "redis";
+    rev = finalAttrs.version;
+    hash = "sha256-WZ89BUm3zz6n0dZKyODHCyMGExbqaPJJ1qxLvJKUSDI=";
   };
 
-  patches = lib.optionals useSystemJemalloc [
-    # use system jemalloc
-    (fetchurl {
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/redis/-/raw/102cc861713c796756abd541bf341a4512eb06e6/redis-5.0-use-system-jemalloc.patch";
-      hash = "sha256-VPRfoSnctkkkzLrXEWQX3Lh5HmZaCXoJafyOG007KzM=";
-    })
-  ];
+  patches = lib.optional useSystemJemalloc (fetchpatch2 {
+    url = "https://gitlab.archlinux.org/archlinux/packaging/packages/redis/-/raw/102cc861713c796756abd541bf341a4512eb06e6/redis-5.0-use-system-jemalloc.patch";
+    hash = "sha256-A9qp+PWQRuNy/xmv9KLM7/XAyL7Tzkyn0scpVCGngcc=";
+  });
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    which
+    python3
+  ];
 
   buildInputs =
     [ lua ]
     ++ lib.optional useSystemJemalloc jemalloc
     ++ lib.optional withSystemd systemd
-    ++ lib.optionals tlsSupport [ openssl ];
-
-  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace src/Makefile --replace "-flto" ""
-  '';
+    ++ lib.optional tlsSupport openssl;
 
   # More cross-compiling fixes.
   makeFlags =
@@ -101,13 +101,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests.redis = nixosTests.redis;
   passthru.serverBin = "redis-server";
 
-  meta = with lib; {
+  meta = {
     homepage = "https://redis.io";
     description = "Open source, advanced key-value store";
-    license = licenses.bsd3;
-    platforms = platforms.all;
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
     changelog = "https://github.com/redis/redis/raw/${finalAttrs.version}/00-RELEASENOTES";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       berdario
       globin
     ];


### PR DESCRIPTION
- use `fetchFromGitHub` instead of downloading from redis.io
- use `fetchpatch2` instead of `fetchurl` and `fetchpatch`
- use `optional` instead of `optionals` in several places
- remove `with lib;`
- enable `tlsSupport` by default
- format with `nixfmt-rfc-style`
- remove `preBuild` which does not have any motivation behind
- add `which` and `python3` to `nativeBuildInputs`



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
