### PR TITLE
python3Packages.materialx: enable MSL support on x86_64-darwin

### DIFF
--- a/pkgs/development/python-modules/materialx/default.nix
+++ b/pkgs/development/python-modules/materialx/default.nix
@@ -5,13 +5,14 @@
   fetchFromGitHub,
   cmake,
   setuptools,
-  darwin,
   libX11,
   libXt,
   libGL,
   openimageio,
   imath,
   python,
+  darwinMinVersionHook,
+  apple-sdk_14,
 }:
 
 buildPythonPackage rec {
@@ -37,13 +38,10 @@ buildPythonPackage rec {
       openimageio
       imath
     ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (
-      with darwin.apple_sdk.frameworks;
-      [
-        OpenGL
-        Cocoa
-      ]
-    )
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      apple-sdk_14
+      (darwinMinVersionHook "10.15")
+    ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       libX11
       libXt
@@ -53,9 +51,8 @@ buildPythonPackage rec {
   cmakeFlags = [
     (lib.cmakeBool "MATERIALX_BUILD_OIIO" true)
     (lib.cmakeBool "MATERIALX_BUILD_PYTHON" true)
-    # don't build MSL shader back-end on x86_x64-darwin, as it requires a newer SDK with metal support
     (lib.cmakeBool "MATERIALX_BUILD_GEN_MSL" (
-      stdenv.hostPlatform.isLinux || (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin)
+      stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isDarwin
     ))
   ];
 


### PR DESCRIPTION
After https://github.com/NixOS/nixpkgs/pull/346043, it is possible to enable MSL support on x86_64-darwin. The 10.15 deployment target is based on upstream’s [README][1], which states 10.15.7 is the oldest tested version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[1]: https://github.com/AcademySoftwareFoundation/MaterialX/blob/8357e1402bd875c8204ad8e8ac970ff6c1638cd6/source/MaterialXTest/README.md?plain=1#L74