### PR TITLE
nixos/image/amazon: introduce

### DIFF
--- a/nixos/modules/image/amazon.nix
+++ b/nixos/modules/image/amazon.nix
@@ -110,10 +110,7 @@ in
           mkdir -p $mountPoint/boot
           mount /dev/vda1 $mountPoint/boot
 
-          export HOME=$TMPDIR
-          ls -la $mountPoint/nix/var/nix/profiles
-
-          NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- ${config.system.build.toplevel}/bin/switch-to-configuration boot
+          HOME=$TMPDIR NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- ${config.system.build.toplevel}/bin/switch-to-configuration boot
         ''
     );
   };

--- a/nixos/modules/image/amazon.nix
+++ b/nixos/modules/image/amazon.nix
@@ -1,0 +1,121 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.image.amazon;
+in
+{
+  imports = [ ./repart.nix ];
+  options = {
+    image.amazon = {
+      bootMode = lib.mkOption {
+        type = lib.types.enum [
+          "uefi-preferred"
+          "uefi"
+        ];
+        default = if pkgs.hostPlatform.isAarch64 then "uefi" else "uefi-preferred";
+      };
+    };
+
+  };
+  config = {
+    boot.loader.grub = {
+      enable = true;
+      efiSupport = true;
+      efiInstallAsRemovable = true;
+      device = if cfg.bootMode == "uefi-preferred" then "/dev/vda" else "nodev";
+    };
+    fileSystems."/" = {
+      fsType = "ext4";
+      device = "/dev/disk/by-partlabel/root";
+    };
+    # Grows on first boot
+    systemd.repart.partitions = {
+      "10-root".repartConfig.Type = "root";
+    };
+    systemd.services.nix-store-load-db = {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "nix-daemon.socket" ];
+      unitConfig.ConditionFirstBoot = true;
+      serviceConfig.ExecStart = "nix-store --load-db < /nix/store/.registration";
+    };
+    system.image.id = config.system.name;
+    system.image.version = config.system.nixos.version;
+    image.repart = {
+      name = config.system.name;
+      partitions = {
+        "00-esp" = {
+          repartConfig = {
+            Type = "esp";
+            Format = "vfat";
+            SizeMinBytes = "1G";
+            SizeMaxBytes = "1G";
+          };
+        };
+        "05-bios" = lib.mkIf (config.image.amazon.bootMode == "uefi-preferred") {
+          repartConfig = {
+            Type = "21686148-6449-6e6f-744e-656564454649";
+            SizeMinBytes = "1M";
+            SizeMaxBytes = "1M";
+          };
+        };
+        "10-root" = {
+          storePaths = [ config.system.build.toplevel ];
+          contents = {
+            # This is needed for nixos-enter to work
+            "/etc/NIXOS".source = pkgs.writeText "NIXOS" "";
+            "/nix/var/nix/profiles".source = pkgs.runCommand "profiles" { } ''
+              mkdir -p $out
+              ln -s ${config.system.build.toplevel} $out/system-1-link
+              ln -s /nix/var/nix/profiles/system-1-link $out/system
+            '';
+          };
+          repartConfig = {
+            Type = "root";
+            Label = "root";
+            Format = config.fileSystems."/".fsType;
+            Minimize = "guess";
+          };
+        };
+      };
+    };
+
+    system.build.amazonImage = pkgs.vmTools.runInLinuxVM (
+      pkgs.runCommand config.system.build.image.name
+        {
+          preVM = ''
+            cp ${config.system.build.image}/${config.image.repart.imageFile} ${config.image.repart.imageFile}
+            chmod u+w ${config.image.repart.imageFile}
+            diskImage=${config.image.repart.imageFile}
+          '';
+          postVM = ''
+            mkdir -p $out
+            cp $diskImage $out/${config.image.repart.imageFile}
+          '';
+          buildInputs = with pkgs; [
+            nixos-enter
+            util-linux
+          ];
+        }
+        ''
+          rootDisk=/dev/vda3
+          mkdir /dev/block
+          ln -s /dev/vda1 /dev/block/254:1
+          mountPoint=/mnt
+          mkdir $mountPoint
+          mount $rootDisk $mountPoint
+          mkdir -p $mountPoint/boot
+          mount /dev/vda1 $mountPoint/boot
+
+          export HOME=$TMPDIR
+          ls -la $mountPoint/nix/var/nix/profiles
+
+          NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- ${config.system.build.toplevel}/bin/switch-to-configuration boot
+        ''
+    );
+  };
+
+}

--- a/nixos/modules/image/images.nix
+++ b/nixos/modules/image/images.nix
@@ -9,7 +9,7 @@ let
   inherit (lib) types;
 
   imageModules = {
-    amazon = ../../maintainers/scripts/ec2/amazon-image.nix;
+    amazon = ./amazon.nix;
     azure = ../virtualisation/azure-image.nix;
     digital-ocean = ../virtualisation/digital-ocean-image.nix;
     google-compute = ../virtualisation/google-compute-image.nix;

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -315,7 +315,7 @@ rec {
         modules = [
           configuration
           versionModule
-          ./maintainers/scripts/ec2/amazon-image.nix
+          ({modulesPath,...}: { imports = [ "${modulesPath}/image/amazon.nix" ]; })
         ];
       }).config.system.build.amazonImage
     )

--- a/nixos/tests/amazon-image.nix
+++ b/nixos/tests/amazon-image.nix
@@ -1,0 +1,60 @@
+# Tests building and running a GUID Partition Table (GPT) appliance image.
+# "Appliance" here means that the image does not contain the normal NixOS
+# infrastructure of a system profile and cannot be re-built via
+# `nixos-rebuild`.
+
+{ lib, ... }:
+
+let rootPartitionLabel = "root";
+in {
+  name = "appliance-gpt-image";
+
+  meta.maintainers = with lib.maintainers; [ arianvp ];
+
+  defaults = { lib, ... }: {
+    imports = [ ../modules/image/amazon.nix ];
+
+    virtualisation.directBoot.enable = false;
+    virtualisation.mountHostNixStore = false;
+    virtualisation.installBootLoader = true;
+
+    virtualisation.fileSystems = lib.mkForce {
+      "/" = {
+        device = "/dev/disk/by-partlabel/root";
+        fsType = "ext4";
+      };
+    };
+
+    image.repart = {
+      # OVMF does not work with the default repart sector size of 4096
+      sectorSize = 512;
+    };
+  };
+
+  nodes.uefi = { virtualisation.useEFIBoot = true; };
+  nodes.bios = { virtualisation.useEFIBoot = false; };
+
+  testScript = { nodes, ... }: ''
+    import os
+    import subprocess
+    import tempfile
+
+    tmp_disk_image = tempfile.NamedTemporaryFile()
+
+    subprocess.run([
+      "${nodes.uefi.virtualisation.qemu.package}/bin/qemu-img",
+      "create",
+      "-f",
+      "qcow2",
+      "-b",
+      "${nodes.uefi.system.build.finalImage}/${nodes.uefi.image.repart.imageFile}",
+      "-F",
+      "raw",
+      tmp_disk_image.name,
+    ])
+
+    # Set NIX_DISK_IMAGE so that the qemu script finds the right disk image.
+    os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
+    uefi.wait_for_unit("default.target")
+  '';
+}


### PR DESCRIPTION
Use repart to build a hybridg GPT/BIOS image

Uses `runInLinuxVM` to install grub. We can probably skip that if we install systemd-boot on UEFI-only systems

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
