### PR TITLE
lowdown: add flag to disable the Darwin sandbox

### DIFF
--- a/pkgs/applications/blockchains/clightning/default.nix
+++ b/pkgs/applications/blockchains/clightning/default.nix
@@ -8,7 +8,7 @@
 , automake
 , gettext
 , libtool
-, lowdown
+, lowdown-unsandboxed
 , protobuf
 , unzip
 , which
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   # when building on darwin we need cctools to provide the correct libtool
   # as libwally-core detects the host as darwin and tries to add the -static
   # option to libtool, also we have to add the modified gsed package.
-  nativeBuildInputs = [ autoconf autogen automake gettext libtool lowdown protobuf py3 unzip which ]
+  nativeBuildInputs = [ autoconf autogen automake gettext libtool lowdown-unsandboxed protobuf py3 unzip which ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools darwin.autoSignDarwinBinariesHook ];
 
   buildInputs = [ gmp libsodium sqlite zlib jq ];

--- a/pkgs/by-name/ce/certspotter/package.nix
+++ b/pkgs/by-name/ce/certspotter/package.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildGoModule
-, lowdown
+, lowdown-unsandboxed
 }:
 
 buildGoModule rec {
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  nativeBuildInputs = [ lowdown ];
+  nativeBuildInputs = [ lowdown-unsandboxed ];
 
   postInstall = ''
     cd man

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -39,6 +39,7 @@ assert (hash == null) -> (src != null);
   libcpuid,
   libsodium,
   lowdown,
+  lowdown-unsandboxed,
   lsof,
   mercurial,
   mdbook,
@@ -119,7 +120,7 @@ stdenv.mkDerivation {
     ]
     ++ lib.optionals isLegacyParser [ bison ]
     ++ lib.optionals enableDocumentation [
-      (lib.getBin lowdown)
+      (lib.getBin lowdown-unsandboxed)
       mdbook
       mdbook-linkcheck
       doxygen

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -59,6 +59,7 @@ in
 , libxml2
 , libxslt
 , lowdown
+, lowdown-unsandboxed
 , toml11
 , man
 , mdbook
@@ -122,7 +123,7 @@ self = stdenv.mkDerivation {
     docbook_xsl_ns
     docbook5
   ] ++ lib.optionals (enableDocumentation && atLeast24) [
-    (lib.getBin lowdown)
+    (lib.getBin lowdown-unsandboxed)
     mdbook
   ] ++ lib.optionals (atLeast213 && enableDocumentation) [
     mdbook-linkcheck

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5434,6 +5434,11 @@ with pkgs;
 
   lowdown = callPackage ../tools/typesetting/lowdown { };
 
+  # Less secure variant of lowdown for use inside Nix builds.
+  lowdown-unsandboxed = lowdown.override {
+    enableDarwinSandbox = false;
+  };
+
   numatop = callPackage ../os-specific/linux/numatop { };
 
   numworks-udev-rules = callPackage ../os-specific/linux/numworks-udev-rules { };


### PR DESCRIPTION
This is a program written in a memory‐unsafe language that processes potentially‐untrusted user input. We shouldn’t disable upstream’s sandboxing mechanisms for all downstream consumers without good reason.

Although the sandbox API is officially marked as deprecated, it is used as the basis for the supported App Sandbox and it is extremely unlikely to ever be removed as it is used extensively throughout the OS for service hardening and by third parties like the Chrome sandbox. Nix itself uses it to sandbox builds, and its lack of support for nesting is why this caused problems in the first place. Instead, introduce a `lowdown-unsandboxed` package that can be used in the `nativeBuildInputs` of Nix builds, while keeping the sandboxed version of the program for general use. The name might not be ideal, as it remains identical to `lowdown` on non‐Darwin platforms, but I couldn’t think of a better one.

See: #125004
Closes: #346933

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
