### PR TITLE
swift: fix build with the new SDK pattern

### DIFF
--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -511,12 +511,6 @@ in stdenv.mkDerivation {
     # which requires a special signature.
     #
     # CMAKE_BUILD_WITH_INSTALL_NAME_DIR ensures we don't use rpath on Darwin.
-    #
-    # NOTE: On Darwin, we only want ncurses in the linker search path, because
-    # headers are part of libsystem. Adding its headers to the search path
-    # causes strange mixing and errors. Note that libedit propagates ncurses,
-    # so we add both manually here, instead of relying on setup hooks.
-    # TODO: Find a better way to prevent this conflict.
     cmakeFlags="
       -GNinja
       -DLLDB_SWIFTC=$SWIFT_BUILD_ROOT/swift/bin/swiftc
@@ -534,11 +528,11 @@ in stdenv.mkDerivation {
       ${lib.optionalString stdenv.hostPlatform.isDarwin ''
       -DLLDB_USE_SYSTEM_DEBUGSERVER=ON
       ''}
-      -DLibEdit_INCLUDE_DIRS=${libedit.dev}/include
-      -DLibEdit_LIBRARIES=${libedit}/lib/libedit${stdenv.hostPlatform.extensions.sharedLibrary}
-      -DCURSES_INCLUDE_DIRS=${if stdenv.hostPlatform.isDarwin then "/var/empty" else ncurses.dev}/include
-      -DCURSES_LIBRARIES=${ncurses}/lib/libncurses${stdenv.hostPlatform.extensions.sharedLibrary}
-      -DPANEL_LIBRARIES=${ncurses}/lib/libpanel${stdenv.hostPlatform.extensions.sharedLibrary}
+      -DLibEdit_INCLUDE_DIRS=${lib.getInclude libedit}/include
+      -DLibEdit_LIBRARIES=${lib.getLib libedit}/lib/libedit${stdenv.hostPlatform.extensions.sharedLibrary}
+      -DCURSES_INCLUDE_DIRS=${lib.getInclude ncurses}/include
+      -DCURSES_LIBRARIES=${lib.getLib ncurses}/lib/libncurses${stdenv.hostPlatform.extensions.sharedLibrary}
+      -DPANEL_LIBRARIES=${lib.getLib ncurses}/lib/libpanel${stdenv.hostPlatform.extensions.sharedLibrary}
     ";
     buildProject lldb llvm-project/lldb
 

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -219,6 +219,7 @@ in stdenv.mkDerivation {
       sigtool # codesign
       DarwinTools # sw_vers
       fixDarwinDylibNames
+      cctools.libtool
     ];
 
   buildInputs = [

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -668,12 +668,6 @@ in stdenv.mkDerivation {
     # just copying the 3 symlinks inside to smaller closures.
     mkdir $lib/lib/swift/clang
     cp -P ${clang}/resource-root/* $lib/lib/swift/clang/
-
-    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # Install required library for ObjC interop.
-    # TODO: Is there no source code for this available?
-    cp -r ${CLTools_Executables}/usr/lib/arc $out/lib/arc
-    ''}
   '';
 
   preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -47,18 +47,6 @@ let
     # packaging with `swiftPackages.callPackage`.
     inherit (clang) bintools;
     stdenv = overrideCC pkgs.stdenv clang;
-    darwin = pkgs.darwin.overrideScope (_: prev: {
-      inherit apple_sdk;
-      inherit (apple_sdk) Libsystem LibsystemCross libcharset libunwind objc4 configd IOKit Security;
-      CF = apple_sdk.CoreFoundation // { __attrsFailEvaluation = true; };
-      __attrsFailEvaluation = true;
-    });
-    xcodebuild = pkgs.xcbuild.override {
-      inherit (apple_sdk.frameworks) CoreServices CoreGraphics ImageIO;
-      inherit stdenv;
-      sdkVer = "10.15";
-    };
-    xcbuild = xcodebuild;
 
     swift-unwrapped = callPackage ./compiler {
       inherit (darwin) DarwinTools sigtool;

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -15,7 +15,11 @@ let
     callPackage = newScope self;
 
     # Current versions of Swift on Darwin require macOS SDK 10.15 at least.
-    # Re-export this so we can rely on the minimum Swift SDK elsewhere.
+    # The Swift compiler propagates the 13.3 SDK and a 10.15 deployment target.
+    # Packages that need a newer version can add it to their build inputs
+    # to use it (as normal).
+
+    # This SDK is included for compatibility with existing packages.
     apple_sdk = pkgs.darwin.apple_sdk_11_0;
 
     # Swift builds its own Clang for internal use. We wrap that clang with a
@@ -40,8 +44,7 @@ let
         swiftLlvmPackages.clang;
 
     # Overrides that create a useful environment for swift packages, allowing
-    # packaging with `swiftPackages.callPackage`. These are similar to
-    # `apple_sdk_11_0.callPackage`, with our clang on top.
+    # packaging with `swiftPackages.callPackage`.
     inherit (clang) bintools;
     stdenv = overrideCC pkgs.stdenv clang;
     darwin = pkgs.darwin.overrideScope (_: prev: {
@@ -67,7 +70,7 @@ let
     };
 
     Dispatch = if stdenv.hostPlatform.isDarwin
-      then null # part of libsystem
+      then null # part of apple-sdk
       else callPackage ./libdispatch { swift = swiftNoSwiftDriver; };
 
     Foundation = if stdenv.hostPlatform.isDarwin

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -59,7 +59,7 @@ let
       else callPackage ./libdispatch { swift = swiftNoSwiftDriver; };
 
     Foundation = if stdenv.hostPlatform.isDarwin
-      then apple_sdk.frameworks.Foundation
+      then null # part of apple-sdk
       else callPackage ./foundation { swift = swiftNoSwiftDriver; };
 
     # TODO: Apple distributes a binary XCTest with Xcode, but it is not part of

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -59,8 +59,6 @@ let
 
     swift-unwrapped = callPackage ./compiler {
       inherit (darwin) DarwinTools sigtool;
-      inherit (apple_sdk) MacOSX-SDK CLTools_Executables;
-      inherit (apple_sdk.frameworks) CoreServices Foundation Combine;
     };
 
     swiftNoSwiftDriver = callPackage ./wrapper {

--- a/pkgs/development/compilers/swift/wrapper/wrapper.sh
+++ b/pkgs/development/compilers/swift/wrapper/wrapper.sh
@@ -156,6 +156,14 @@ if [ -z "${NIX_CC_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source $cc_wrapper/nix-support/add-flags.sh
 fi
 
+# Only add darwin min version flag and set up `DEVELOPER_DIR` if a default darwin min version is set,
+# which is a signal that we're targeting darwin. (Copied from add-flags in libc but tailored for Swift).
+if [ "@darwinMinVersion@" ]; then
+    # Make sure the wrapped Swift compiler can find the overlays in the SDK.
+    NIX_SWIFTFLAGS_COMPILE+=" -I $SDKROOT/usr/lib/swift"
+    NIX_LDFLAGS_@suffixSalt@+=" -L $SDKROOT/usr/lib/swift"
+fi
+
 if [[ "$isCxx" = 1 ]]; then
     if [[ "$cxxInclude" = 1 ]]; then
         NIX_CFLAGS_COMPILE_@suffixSalt@+=" $NIX_CXXSTDLIB_COMPILE_@suffixSalt@"


### PR DESCRIPTION
Swift depends on how the old SDK pattern was implemented (e.g., that only the requested framework dependencies would be available). This PR updates Swift to build in a way that’s compatible with the new pattern, uses the same SDK that Swift 5.8 expects to use, and propagates it to make sure packages using Swift have at least the right SDK version. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
