### PR TITLE
gcc: fix build with new SDK pattern

### DIFF
--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -7,13 +7,6 @@
 let
   forceLibgccToBuildCrtStuff =
     import ./libgcc-buildstuff.nix { inherit lib stdenv; };
-
-  # todo(@reckenrode) Remove in staging. This is ugly, but it avoid unwanted rebuilds on Darwin and Linux.
-  enableDarwinFixesForStagingNext =
-    version:
-    stdenv.buildPlatform.isDarwin
-    && stdenv.buildPlatform.isx86_64
-    && lib.versionOlder version "10";
 in
 
 originalAttrs: (stdenv.mkDerivation (finalAttrs: originalAttrs // {
@@ -27,20 +20,11 @@ originalAttrs: (stdenv.mkDerivation (finalAttrs: originalAttrs // {
 
     if test "$staticCompiler" = "1"; then
         EXTRA_LDFLAGS="-static"
-    ${
-      if enableDarwinFixesForStagingNext finalAttrs.version then
-        ''
-          elif test "''${NIX_DONT_SET_RPATH-}" != "1"; then
-              EXTRA_LDFLAGS="-Wl,-rpath,''${!outputLib}/lib"
-          else
-              EXTRA_LDFLAGS=""
-        ''
-      else
-        ''
-          else
-              EXTRA_LDFLAGS="-Wl,-rpath,''${!outputLib}/lib"
-        ''
-    }fi
+    elif test "''${NIX_DONT_SET_RPATH-}" != "1"; then
+        EXTRA_LDFLAGS="-Wl,-rpath,''${!outputLib}/lib"
+    else
+        EXTRA_LDFLAGS=""
+    fi
 
     # GCC interprets empty paths as ".", which we don't want.
     if test -z "''${CPATH-}"; then unset CPATH; fi
@@ -74,24 +58,13 @@ originalAttrs: (stdenv.mkDerivation (finalAttrs: originalAttrs // {
                 extraLDFlags=("-L/usr/lib64" "-L/usr/lib")
                 libc_libdir="/usr/lib"
             fi
-            ${
-              if enableDarwinFixesForStagingNext finalAttrs.version then
-                ''
-                  extraLDFlags=("-L$libc_libdir")
-                          nixDontSetRpathVar=NIX_DONT_SET_RPATH''${post}
-                          if test "''${!nixDontSetRpathVar-}" != "1"; then
-                              extraLDFlags+=("-rpath" "$libc_libdir")
-                          fi
-                          extraLDFlags+=("''${extraLDFlags[@]}")
-                ''
-              else
-                ''
-                  extraLDFlags=("-L$libc_libdir" "-rpath" "$libc_libdir"
-                                        "''${extraLDFlags[@]}")
-                ''
-# The strange indentation with the next line is to ensure the string renders the same when the condition is false,
-# which is necessary to prevent unwanted rebuilds in staging-next.
-}        for i in "''${extraLDFlags[@]}"; do
+            extraLDFlags=("-L$libc_libdir")
+            nixDontSetRpathVar=NIX_DONT_SET_RPATH''${post}
+            if test "''${!nixDontSetRpathVar-}" != "1"; then
+                extraLDFlags+=("-rpath" "$libc_libdir")
+            fi
+            extraLDFlags+=("''${extraLDFlags[@]}")
+            for i in "''${extraLDFlags[@]}"; do
                 declare -g EXTRA_LDFLAGS''${post}+=" -Wl,$i"
             done
         done

--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -58,12 +58,13 @@ originalAttrs: (stdenv.mkDerivation (finalAttrs: originalAttrs // {
                 extraLDFlags=("-L/usr/lib64" "-L/usr/lib")
                 libc_libdir="/usr/lib"
             fi
-            extraLDFlags=("-L$libc_libdir")
+            declare -a prefixExtraLDFlags=()
+            prefixExtraLDFlags=("-L$libc_libdir")
             nixDontSetRpathVar=NIX_DONT_SET_RPATH''${post}
             if test "''${!nixDontSetRpathVar-}" != "1"; then
-                extraLDFlags+=("-rpath" "$libc_libdir")
+                prefixExtraLDFlags+=("-rpath" "$libc_libdir")
             fi
-            extraLDFlags+=("''${extraLDFlags[@]}")
+            extraLDFlags=("''${prefixExtraLDFlags[@]}" "''${extraLDFlags[@]}")
             for i in "''${extraLDFlags[@]}"; do
                 declare -g EXTRA_LDFLAGS''${post}+=" -Wl,$i"
             done

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -34,6 +34,7 @@
 , nukeReferences
 , callPackage
 , majorMinorVersion
+, apple-sdk
 , cctools
 , darwin
 }:
@@ -105,6 +106,7 @@ let
       ;
       # inherit generated with 'nix eval --json --impure --expr "with import ./. {}; lib.attrNames (lib.functionArgs gcc${majorVersion}.cc.override)" | jq '.[]' --raw-output'
       inherit
+        apple-sdk
         binutils
         buildPackages
         cargo


### PR DESCRIPTION
GCC’s bootstrap uses GCC unwrapped. It needs to be able to find the SDK at sysroot to bootstrap properly on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
