### PR TITLE
steamtinkerlaunch: add steamcompattool output

### DIFF
--- a/pkgs/tools/games/steamtinkerlaunch/default.nix
+++ b/pkgs/tools/games/steamtinkerlaunch/default.nix
@@ -25,7 +25,19 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-CGtSGAm+52t2zFsPJEsm76w+FEHhbOd9NYuerGa31tc=";
   };
 
+  outputs = [ "out" "steamcompattool" ];
+
   installFlags = [ "PREFIX=\${out}" ];
+
+  nativeBuildInputs = let
+    # We need a `steam` command in order to install the compat tool
+    fakeSteam = writeShellApplication {
+      name = "steam";
+      text = "exit 0";
+    };
+  in [
+    fakeSteam
+  ];
 
   postInstall =
     let
@@ -52,11 +64,31 @@ stdenvNoCC.mkDerivation {
         text = "";
         bashOptions = [ ];
       };
+      fakeYad = writeShellApplication {
+        name = "yad";
+        text = "echo ${yad.version} FAKE";
+      };
     in
     ''
       cp $out/bin/steamtinkerlaunch $TMPDIR/steamtinkerlaunch
       install ${lib.getExe header} -T $out/bin/steamtinkerlaunch
       tail -n +2 $TMPDIR/steamtinkerlaunch >> $out/bin/steamtinkerlaunch
+
+      # Create a fake steam dir, it checks this and reads a few values
+      steamdir=$TMPDIR/.local/share/Steam/
+      mkdir -p $steamdir/config/
+      echo \"path\" \"$steamdir\" > $steamdir/config/config.vdf
+      mkdir $TMPDIR/.steam/
+      ln -s $steamdir $TMPDIR/.steam/steam
+
+      cp -a $out/bin/steamtinkerlaunch $TMPDIR/steamtinkerlaunch
+      # yad cannot print its version without a graphical session https://github.com/v1cont/yad/issues/277
+      substituteInPlace $TMPDIR/steamtinkerlaunch --replace ${yad} ${fakeYad}
+      HOME=$TMPDIR $TMPDIR/steamtinkerlaunch compat add
+
+      cp -a $steamdir/compatibilitytools.d/SteamTinkerLaunch $steamcompattool
+      # It creates this symlink but it points to $TMPDIR
+      ln -sfn $out/bin/steamtinkerlaunch $steamcompattool/
     '';
 
   meta = with lib; {

--- a/pkgs/tools/games/steamtinkerlaunch/default.nix
+++ b/pkgs/tools/games/steamtinkerlaunch/default.nix
@@ -3,7 +3,6 @@
 , gawk
 , git
 , lib
-, makeWrapper
 , procps
 , stdenvNoCC
 , unixtools
@@ -12,6 +11,7 @@
 , xdotool
 , xorg
 , yad
+, writeShellApplication
 }:
 
 stdenvNoCC.mkDerivation {
@@ -25,31 +25,39 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-CGtSGAm+52t2zFsPJEsm76w+FEHhbOd9NYuerGa31tc=";
   };
 
-  # hardcode PROGCMD because #150841
-  postPatch = ''
-    substituteInPlace steamtinkerlaunch --replace 'PROGCMD="''${0##*/}"' 'PROGCMD="steamtinkerlaunch"'
-  '';
-
-  nativeBuildInputs = [ makeWrapper ];
-
   installFlags = [ "PREFIX=\${out}" ];
 
-  postInstall = ''
-    wrapProgram $out/bin/steamtinkerlaunch --prefix PATH : ${lib.makeBinPath [
-      bash
-      gawk
-      git
-      procps
-      unixtools.xxd
-      unzip
-      wget
-      xdotool
-      xorg.xprop
-      xorg.xrandr
-      xorg.xwininfo
-      yad
-    ]}
-  '';
+  postInstall =
+    let
+      # We (ab)use writeShellApplication to produce a header for a shell script
+      # here in order to add the runtimePath to the original script. We cannot
+      # wrap here as that always corrupts $0 in bash scripts which STL uses to
+      # install its compat tool.
+      header = writeShellApplication {
+        runtimeInputs = [
+          bash
+          gawk
+          git
+          procps
+          unixtools.xxd
+          unzip
+          wget
+          xdotool
+          xorg.xprop
+          xorg.xrandr
+          xorg.xwininfo
+          yad
+        ];
+        name = "stl-head";
+        text = "";
+        bashOptions = [ ];
+      };
+    in
+    ''
+      cp $out/bin/steamtinkerlaunch $TMPDIR/steamtinkerlaunch
+      install ${lib.getExe header} -T $out/bin/steamtinkerlaunch
+      tail -n +2 $TMPDIR/steamtinkerlaunch >> $out/bin/steamtinkerlaunch
+    '';
 
   meta = with lib; {
     description = "Linux wrapper tool for use with the Steam client for custom launch options and 3rd party programs";


### PR DESCRIPTION
This makes it possible to integrate this into our steam derivation's
extraCompatPackages

While I was at it, I've also made it so we don't wrap in order to preserve $0 which fixes https://github.com/NixOS/nixpkgs/issues/295902. If you'd prefer that in a separate PR, I could do that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
