### PR TITLE
nixos/networkd: support systemd-creds in WireGuard

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -17,6 +17,7 @@ let
     filterAttrs
     flatten
     flip
+    hasPrefix
     head
     isInt
     isFloat
@@ -195,6 +196,10 @@ in rec {
   assertRemoved = name: see: group: attr:
     optional (attr ? ${name})
       "Systemd ${group} field `${name}' has been removed. See ${see}";
+
+  assertKeyIsSystemdCredential = name: group: attr:
+    optional (attr ? ${name} && !(hasPrefix "@" attr.${name}))
+      "Systemd ${group} field `${name}' is not a systemd credential";
 
   checkUnitConfig = group: checks: attrs: let
     # We're applied at the top-level type (attrsOf unitOption), so the actual

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -411,11 +411,14 @@ let
         (assertValueOneOf "Layer2SpecificHeader" [ "none" "default" ])
       ];
 
-      # NOTE The PrivateKey directive is missing on purpose here, please
-      # do not add it to this list. The nix store is world-readable let's
-      # refrain ourselves from providing a footgun.
+      # NOTE Check whether the key starts with an @, in which case it is
+      # interpreted as the name of the credential from which the actual key
+      # shall be read by systemd-creds.
+      # Do not remove this check as the nix store is world-readable.
       sectionWireGuard = checkUnitConfig "WireGuard" [
+        (assertKeyIsSystemdCredential "PrivateKey")
         (assertOnlyFields [
+          "PrivateKey"
           "PrivateKeyFile"
           "ListenPort"
           "FirewallMark"
@@ -426,12 +429,15 @@ let
         (assertRange "FirewallMark" 1 4294967295)
       ];
 
-      # NOTE The PresharedKey directive is missing on purpose here, please
-      # do not add it to this list. The nix store is world-readable,let's
-      # refrain ourselves from providing a footgun.
+      # NOTE Check whether the key starts with an @, in which case it is
+      # interpreted as the name of the credential from which the actual key
+      # shall be read by systemd-creds.
+      # Do not remove this check as the nix store is world-readable.
       sectionWireGuardPeer = checkUnitConfigWithLegacyKey "wireguardPeerConfig" "WireGuardPeer" [
+        (assertKeyIsSystemdCredential "PresharedKey")
         (assertOnlyFields [
           "PublicKey"
+          "PresharedKey"
           "PresharedKeyFile"
           "AllowedIPs"
           "Endpoint"


### PR DESCRIPTION
systemd 256 supports `network.wireguard.*` credentials (https://www.freedesktop.org/software/systemd/man/latest/systemd.netdev.html#PrivateKey=).

To avoid putting secrets into the Nix store, check whether PrivateKey / PresharedKey starts with an @. If so it is a credential. Else throw an assertion.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
