### PR TITLE
mongodb-7_0: fix avxSupport

### DIFF
--- a/pkgs/servers/nosql/mongodb/7.0.nix
+++ b/pkgs/servers/nosql/mongodb/7.0.nix
@@ -8,6 +8,7 @@
   cctools,
   avxSupport ? stdenv.hostPlatform.avxSupport,
   nixosTests,
+  lib,
 }:
 
 let
@@ -34,7 +35,11 @@ buildMongoDB {
 
     # Fix building with python 3.12 since the imp module was removed
     ./mongodb-python312.patch
-  ];
+
+    # mongodb-7_0's mozjs uses avx2 instructions
+    # https://github.com/GermanAizek/mongodb-without-avx/issues/16
+  ] ++ lib.optionals (!avxSupport) [ ./mozjs-noavx.patch ];
+
   passthru.tests = {
     inherit (nixosTests) mongodb;
   };

--- a/pkgs/servers/nosql/mongodb/mozjs-noavx.patch
+++ b/pkgs/servers/nosql/mongodb/mozjs-noavx.patch
@@ -1,0 +1,25 @@
+--- a/src/third_party/mozjs/SConscript
++++ b/src/third_party/mozjs/SConscript
+@@ -145,8 +145,7 @@ sources = [
+ ]
+ 
+ if env['TARGET_ARCH'] == 'x86_64' and not env.TargetOSIs('windows'):
+-    env.Append(CCFLAGS=['-mavx2'])
+-    sources.extend(["extract/mozglue/misc/SIMD_avx2.cpp", "extract/mozglue/misc/SSE.cpp"])
++    sources.extend(["extract/mozglue/misc/SSE.cpp"])
+ 
+ if env.TargetOSIs('windows'):
+     sources.extend([
+diff --git a/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp b/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp
+index 3893de57b32..4ea0a657fbb 100644
+--- a/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp
++++ b/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp
+@@ -448,7 +448,7 @@ const char* SIMD::memchr8SSE2(const char* ptr, char value, size_t length) {
+ // assertion failure. Accordingly, we just don't allow that to happen. We
+ // are not particularly concerned about ensuring that newer 32 bit processors
+ // get access to the AVX2 functions exposed here.
+-#  if defined(MOZILLA_MAY_SUPPORT_AVX2) && defined(__x86_64__)
++#  if 0
+ 
+ bool SupportsAVX2() { return supports_avx2(); }
+ 


### PR DESCRIPTION
`mongodb-7_0`'s mozjs uses avx2 instructions which aren't disabled when removing the sandybridge optimization.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
