### PR TITLE
magic-wormhole: 0.15.0 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -36,12 +36,12 @@
 
 buildPythonPackage rec {
   pname = "magic-wormhole";
-  version = "0.15.0";
+  version = "0.16.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-viVjtcVUe6MzvGYI8EgATI821VYTm/L/49n0HaJ5cAY=";
+    hash = "sha256-FObBRomNvaem0ZAmJiOmlBmVU2Pn5DTWSq0tIz1tlMk=";
   };
 
   postPatch =
@@ -57,10 +57,6 @@ buildPythonPackage rec {
     '';
 
   build-system = [ setuptools ];
-
-  pythonRelaxDeps = [
-    "spake2"
-  ];
 
   dependencies = [
     attrs


### PR DESCRIPTION
## Description of changes

https://github.com/magic-wormhole/magic-wormhole/blob/0.16.0/NEWS.md
https://github.com/magic-wormhole/magic-wormhole/compare/refs/tags/0.15.0...refs/tags/0.16.0

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

`tahoe-lafs` is already broken on master

<details>
  <summary>4 packages failed to build:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>
<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc