### PR TITLE
k3s: set meta.position to respective version file

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -23,7 +23,7 @@ lib:
   # run `grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}'` in the k3s repo at the tag
   criCtlVersion,
   updateScript ? null,
-}:
+}@attrs:
 
 # builder.nix contains a "builder" expression that, given k3s version and hash
 # variables, creates a package for that version.
@@ -325,6 +325,7 @@ in
 buildGoModule rec {
   pname = "k3s";
   version = k3sVersion;
+  pos = builtins.unsafeGetAttrPos "k3sVersion" attrs;
 
   tags = [
     "libsqlite3"


### PR DESCRIPTION
This tries to enable automatic update PRs for k3s packages. We previously noticed that [nixpkgs-update](https://github.com/nix-community/nixpkgs-update) fails when updating any k3s package, for example in:

- https://github.com/NixOS/nixpkgs/pull/339264
- https://github.com/NixOS/nixpkgs/pull/346479

The updates failed because `meta.position` points to the generic builder script for all k3s packages and the version strings are maintained in specific `version.nix` files. This error is also listed in the [FAQs of nixpkgs-update](https://nix-community.github.io/nixpkgs-update/nixpkgs-maintainer-faq/) (topic `Can't find derivation file`) and matches the error message in the logs: `Old version 1.28.13+k3s1" not present in master derivation file with contents...` (e.g. [here](https://r.ryantm.com/log/k3s_1_28/2024-10-07.log)). 

This commit explicitly sets `meta.position` to the position of the `k3sVersion` attribute, which points to the version file of the respective version (e.g. pkgs/applications/networking/cluster/k3s/1_28/versions.nix). This solves problems during automatic updates and provides version-specific information in `meta.position`.

With this change, I can run `nixpkgs-update` locally without errors.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @NixOS/k3s 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
