### PR TITLE
mkPythonPackage, mkPythonApplication: handle `passthru` with `stdenv.mkDerivation` instead of `lib.extendDerivation`

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -215,23 +215,6 @@ let
 
   isSetuptoolsDependency = isSetuptoolsDependency' (attrs.pname or null);
 
-  passthru =
-    attrs.passthru or { }
-    // {
-      updateScript = let
-        filename = head (splitString ":" self.meta.position);
-      in attrs.passthru.updateScript or [ update-python-libraries filename ];
-    }
-    // optionalAttrs (dependencies != []) {
-      inherit dependencies;
-    }
-    // optionalAttrs (optional-dependencies != {}) {
-      inherit optional-dependencies;
-    }
-    // optionalAttrs (build-system != []) {
-      inherit build-system;
-    };
-
   # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
   self = toPythonModule (stdenv.mkDerivation ((cleanAttrs attrs) // {
 
@@ -324,7 +307,21 @@ let
 
     outputs = outputs ++ optional withDistOutput "dist";
 
-    inherit passthru;
+    passthru = attrs.passthru or { }
+    // {
+      updateScript = let
+        filename = head (splitString ":" self.meta.position);
+      in attrs.passthru.updateScript or [ update-python-libraries filename ];
+    }
+    // optionalAttrs (dependencies != []) {
+      inherit dependencies;
+    }
+    // optionalAttrs (optional-dependencies != {}) {
+      inherit optional-dependencies;
+    }
+    // optionalAttrs (build-system != []) {
+      inherit build-system;
+    };
 
     meta = {
       # default to python's platforms
@@ -341,5 +338,5 @@ let
 
 in extendDerivation
   (disabled -> throw "${name} not supported for interpreter ${python.executable}")
-  passthru
+  { }
   self


### PR DESCRIPTION
The `passthru` specification of `buildPythonPackage` and `buildPythonApplication` was initially implemented via `lib.extendDerivation` instead of passing to `stdenv.mkDerivation`. In b9138b7c072f55dcfd7b8c0747c3c4291bd0b28e (as part of #271597), `passthru` is also passed down to `mkDerivation`, but the effect of `lib.extendDerivation` still shadows the `passthru` attributes from the result derivation returned by `mkDerivation`.

This PR simplifies the implementation and only passes `passthru` to `mkDerivation` but not to `lib.extendDerivation`. This change keeps the evaluation result unchanged but simplifies the code a bit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (no rebuild)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
