### PR TITLE
android-unpinner: init at 2bc31d9

### DIFF
--- a/pkgs/by-name/an/android-unpinner/package.nix
+++ b/pkgs/by-name/an/android-unpinner/package.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, rich
+, rich-click
+, android-tools
+, aapt
+, apksigner
+, androidenv
+}:
+let
+  buildToolsVersion = "33.0.2";
+  build-tools = androidenv.composeAndroidPackages {
+    buildToolsVersions = [ buildToolsVersion ];
+  };
+  zipalign = "${build-tools.androidsdk}/libexec/android-sdk/build-tools/${buildToolsVersion}/zipalign";
+in
+buildPythonPackage rec {
+  pname = "android-unpinner";
+  version = "2bc31d94c3fe296457e2d7bf2120220de16ca839";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "mitmproxy";
+    repo = "android-unpinner";
+    rev = version;
+    hash = "sha256-6EHd0CkJ1zlnjWUjDvYaehv3IfqlryKzOsxglPoZiog=";
+  };
+
+  propagatedBuildInputs = [ rich rich-click ];
+
+  patchPhase = ''
+    runHook prePatch
+
+    # use nixpkgs adb as opposed to vendored platform_tools adb
+    substituteInPlace android_unpinner/vendor/platform_tools/__init__.py \
+      --replace "{adb_binary}" ${lib.getExe' android-tools "adb"}
+
+    # replace build_tools too
+    substituteInPlace android_unpinner/vendor/build_tools/__init__.py \
+      --replace "aapt2_binary," "'${lib.getExe aapt}'," \
+      --replace "apksigner_binary," "'${lib.getExe apksigner}'," \
+      --replace "zipalign_binary," "'${zipalign}'," \
+      --replace 'here / "android-unpinner.jks"' "'${src}/android_unpinner/vendor/build_tools/android-unpinner.jks'"
+
+    # vendored gadgets
+    substituteInPlace android_unpinner/vendor/__init__.py \
+      --replace "Path(__file__).absolute().parent" "Path('${src}/android_unpinner/vendor')"
+
+    # vendored scripts
+    substituteInPlace android_unpinner/__main__.py \
+      --replace "Path(__file__).absolute().parent" "Path('${src}/android_unpinner')"
+
+    runHook postPatch
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/mitmproxy/android-unpinner";
+    description = "Android Certificate Pinning Unpinner";
+    longDescription = ''
+      Tool that removes certificate pinning from APKs without requiring root.
+    '';
+    license = with licenses; mit;
+    maintainers = with maintainers; [ mib ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1625,6 +1625,8 @@ with pkgs;
 
   amidst = callPackage ../tools/games/minecraft/amidst { };
 
+  android-unpinner = pkgs.python3Packages.callPackage ../by-name/an/android-unpinner/package.nix { };
+
   asar = callPackage ../tools/compression/asar { };
 
   askalono = callPackage ../tools/misc/askalono { };


### PR DESCRIPTION
Tool to remove certificate pinning from android apps.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Patched to use nixpkgs' adb, not the vendored, but that's it (not sure if done optimally though, but hey, it works ;)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
