### PR TITLE
collectd: bring back xencpu plugin

### DIFF
--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -111,6 +111,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.optional ((cfg.plugins ? xencpu) || cfg.user == "root") ''
+      The xencpu plugin for collectd typically requires root privileges. You
+      have enabled the xencpu plugin but collectd is not configured to run as
+      root. If you're running in a Xen dom0 environment and want to collect
+      metrics of hardware CPU load, you may need
+      `services.collectd.user = "root"`;
+    '';
+
     # 1200 is after the default (1000) but before mkAfter (1500).
     services.collectd.extraConfig = lib.mkOrder 1200 ''
       ${baseDirLine}

--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -42,8 +42,8 @@
   varnish,
   xen,
   yajl,
-  # Defaults to `null` for all supported plugins (except xen, which is marked as
-  # insecure), otherwise a list of plugin names for a custom build
+  # Defaults to `null` for all supported plugins, otherwise a list of plugin
+  # names for a custom build
   enabledPlugins ? null,
   ...
 }:
@@ -195,7 +195,9 @@ let
   buildInputs =
     if enabledPlugins == null then
       builtins.concatMap pluginBuildInputs (
-        builtins.attrNames (builtins.removeAttrs plugins [ "xencpu" ])
+        builtins.attrNames (
+          builtins.removeAttrs plugins (lib.optional (!lib.meta.availableOn stdenv.hostPlatform xen) "xencpu")
+        )
       )
     else
       builtins.concatMap pluginBuildInputs enabledPlugins;


### PR DESCRIPTION
Xen is no longer in a broken/unmaintained status, so we can bring the `xencpu` plugin back easily.
 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
