### PR TITLE
mpsolve: switch to GitHub repository as source

### DIFF
--- a/pkgs/applications/science/math/mpsolve/default.nix
+++ b/pkgs/applications/science/math/mpsolve/default.nix
@@ -1,23 +1,32 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitHub
+, autoreconfHook
+, bison
+, flex
+, gitUpdater
 , gmp
+, gtk3
 , pkg-config
 , qtbase
 , wrapQtAppsHook
-, gtk3
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mpsolve";
   version = "3.2.1";
 
-  src = fetchurl {
-    url = "https://numpi.dm.unipi.it/_media/software/mpsolve/mpsolve-${finalAttrs.version}.tar.gz";
-    hash = "sha256-PRFCiumrLgIPJMq/vNnk2bIuxXLPcK8NRP6Nrh1R544=";
+  src = fetchFromGitHub {
+    owner = "robol";
+    repo = "MPSolve";
+    rev = finalAttrs.version;
+    hash = "sha256-7lYwInodKj02G76xqhp/6e9MCzPY80gsAW3vTMNsfdA=";
   };
 
   nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
     pkg-config
     wrapQtAppsHook
   ];
@@ -27,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
     gtk3
     qtbase
   ];
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     homepage = "https://numpi.dm.unipi.it/scientific-computing-libraries/mpsolve/";


### PR DESCRIPTION
## Things done
This pull request updates the source for mpsolve, switching from the tarball hosted on the project's homepage to their GitHub repository. Since the GitHub repo doesn't include the `configure` script (unlike the tarball), I've added `autoreconfHook` to handle that. This change also allows us to use `gitUpdater` for easier future updates.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
