### PR TITLE
cups-filters: remove support for legacy CUPS browsing and for LDAP

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -494,6 +494,8 @@
 
 - The `xdg.portal.gtkUsePortal` option has been removed, as it had been deprecated for over 2 years. Using the `GTK_USE_PORTAL` environment variable in this manner is not intended nor encouraged by the GTK developers, but can still be done manually via `environment.sessionVariables`.
 
+- Support for the legacy CUPS browsing and LDAP have been removed from `services.printing`. If `cups` or `ldap` are in the `BrowseRemoteProtocols` setting in `services.printing.browsedConf`, it needs to be removed.
+
 - The `services.trust-dns` module has been renamed to `services.hickory-dns`.
 
 - The option `services.prometheus.exporters.pgbouncer.connectionStringFile` has been removed since

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -184,8 +184,8 @@ in
         type = types.bool;
         default = false;
         description = ''
-          Whether to open the firewall for TCP/UDP ports specified in
-          listenAdrresses option.
+          Whether to open the firewall for TCP ports specified in
+          listenAddresses option.
         '';
       };
 
@@ -493,7 +493,6 @@ in
       listenPorts = parsePorts cfg.listenAddresses;
     in mkIf cfg.openFirewall {
       allowedTCPPorts = listenPorts;
-      allowedUDPPorts = listenPorts;
     };
 
   };

--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -18,6 +18,7 @@
 , liblouis
 , libpng
 , makeWrapper
+, autoreconfHook
 , mupdf
 , perl
 , pkg-config
@@ -53,9 +54,14 @@ stdenv.mkDerivation rec {
       url = "https://github.com/OpenPrinting/libcupsfilters/commit/95576ec3d20c109332d14672a807353cdc551018.patch";
       hash = "sha256-MXWllrdWt8n7zqvumQNg34dBgWMwMTwf9lrD+ZZP8Wk=";
     })
+    (fetchpatch {
+      name = "remove-cups-ldap-browse-protocols_CVE-2024-47176_CVE-2024-47850.patch";
+      url = "https://github.com/OpenPrinting/cups-filters/commit/6fd2bdfbdce76149af531ce9fca9062304238451.patch";
+      hash = "sha256-XS1ODy7i7ilgEjsKuEvOUiRN9pqsj+bOktKoshKcg8Q=";
+    })
   ];
 
-  nativeBuildInputs = [ pkg-config makeWrapper ];
+  nativeBuildInputs = [ pkg-config makeWrapper autoreconfHook ];
 
   buildInputs = [
     cups


### PR DESCRIPTION
Fixes CVE-2024-47176 / https://github.com/OpenPrinting/cups-browsed/security/advisories/GHSA-rj88-6mr5-rcw8 and CVE-2024-47850 / https://github.com/OpenPrinting/cups-filters/security/advisories/GHSA-rq86-c7g6-r2h8.

NixOS is not affected by these security issues by default because we do not ship the default configuration file so it fallbacks to `BrowseRemoteProtocols dnssd`.

631/udp is removed from the open firewall ports, it was by the CUPS browsing protocol.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Result of `nixpkgs-review pr 347168` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>rcu</li>
  </ul>
</details>
<details>
  <summary>13 packages built:</summary>
  <ul>
    <li>cups-filters</li>
    <li>foomatic-db</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
    <li>ocsinventory-agent</li>
    <li>ocsinventory-agent.devdoc</li>
    <li>perl536Packages.NetCUPS</li>
    <li>perl536Packages.NetCUPS.devdoc</li>
    <li>perl538Packages.NetCUPS</li>
    <li>perl538Packages.NetCUPS.devdoc</li>
    <li>ptouch-driver</li>
    <li>splix</li>
    <li>system-config-printer</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
