### PR TITLE
pmars: init at 0.9.4

### DIFF
--- a/pkgs/by-name/pm/pmars/0001-fix-round-redefinition.patch
+++ b/pkgs/by-name/pm/pmars/0001-fix-round-redefinition.patch
@@ -1,0 +1,92 @@
+diff '--color=auto' -ruN a/src/cdb.c b/src/cdb.c
+--- a/src/cdb.c	1970-01-01 01:00:01.000000000 +0100
++++ b/src/cdb.c	2024-10-08 11:28:57.892951658 +0200
+@@ -1564,7 +1564,7 @@
+             (warriorsLeft ? warriorsLeft : 1));
+     substitute(buf[bi1], "CYCLE", outs, buf[bi2]);
+     SWITCHBI;
+-    sprintf(outs, "%d", round);
++    sprintf(outs, "%d", roundCounter);
+     substitute(buf[bi1], "ROUND", outs, buf[bi2]);
+ 
+     SWITCHBI;
+@@ -1875,7 +1875,7 @@
+ #endif
+   int     nFuture, nPast, count, taskHalf = (coreSize <= 10000 ? 7 : 5);
+ 
+-  sprintf(outs, roundOfCycle, round, rounds,
++  sprintf(outs, roundOfCycle, roundCounter, rounds,
+           (cycle + (warriorsLeft ? warriorsLeft : 1) - 1) /
+           (warriorsLeft ? warriorsLeft : 1));
+   cdb_fputs(outs, COND);
+diff '--color=auto' -ruN a/src/curdisp.c b/src/curdisp.c
+--- a/src/curdisp.c	1970-01-01 01:00:01.000000000 +0100
++++ b/src/curdisp.c	2024-10-08 11:29:52.129955266 +0200
+@@ -156,7 +156,7 @@
+       wstandend(corewin);
+       if (!--refreshCounter) {
+         refreshCounter = refreshInterval;
+-        update_statusline(round);
++        update_statusline(roundCounter);
+         wrefresh(corewin);
+       }
+     }
+@@ -542,7 +542,7 @@
+ text_display_close()
+ {
+   if (displayLevel) {
+-    update_statusline(round - 1);
++    update_statusline(roundCounter - 1);
+     wstandout(corewin);
+     mvwaddstr(corewin, 0, 0, pressAnyKey);
+     wrefresh(corewin);
+diff '--color=auto' -ruN a/src/sim.c b/src/sim.c
+--- a/src/sim.c	1970-01-01 01:00:01.000000000 +0100
++++ b/src/sim.c	2024-10-08 11:28:21.848284678 +0200
+@@ -173,7 +173,7 @@
+ mem_struct FAR *memory;
+ 
+ long    cycle;
+-int     round;
++int     roundCounter;
+ 
+ char    alloc_p = 0;                /* indicate whether memory has been allocated */
+ int     warriorsLeft;                /* number of warriors still left in core */
+@@ -328,7 +328,7 @@
+ #endif
+ 
+   display_init();
+-  round = 1;
++  roundCounter = 1;
+   do {                                /* each round */
+ #if defined(DOS16) && !defined(SERVER) && !defined(DOSTXTGRAPHX) && !defined(DOSGRXGRAPHX) && !defined(DJGPP)
+     fputc('\r', stdout);        /* enable interruption by Ctrl-C */
+@@ -1421,13 +1421,13 @@
+ #ifndef SERVER
+     if (debugState == BREAK) {
+       if (warriorsLeft == 1 && warriors != 1)
+-	sprintf(outs, warriorTerminatedEndOfRound, W - warrior, W->name, round);
++	sprintf(outs, warriorTerminatedEndOfRound, W - warrior, W->name, roundCounter);
+       else
+-	sprintf(outs, endOfRound, round);
++	sprintf(outs, endOfRound, roundCounter);
+       debugState = cdb(outs);
+     }
+ #endif
+-  } while (++round <= rounds);
++  } while (++roundCounter <= rounds);
+ 
+   display_close();
+ #ifdef PERMUTATE
+diff '--color=auto' -ruN a/src/sim.h b/src/sim.h
+--- a/src/sim.h	1970-01-01 01:00:01.000000000 +0100
++++ b/src/sim.h	2024-10-08 11:27:46.730634854 +0200
+@@ -89,7 +89,7 @@
+ #define FAR
+ #endif
+ 
+-extern int round;
++extern int roundCounter;
+ extern long cycle;
+ extern ADDR_T progCnt;                /* program counter */
+ extern warrior_struct *W;        /* indicate which warrior is running */

--- a/pkgs/by-name/pm/pmars/0002-fix-sighandler.patch
+++ b/pkgs/by-name/pm/pmars/0002-fix-sighandler.patch
@@ -1,0 +1,52 @@
+diff '--color=auto' -ruN a/src/pmars.c b/src/pmars.c
+--- a/src/pmars.c	2024-11-12 20:36:28.142766807 +0100
++++ b/src/pmars.c	2024-11-12 20:39:48.096710063 +0100
+@@ -72,7 +72,7 @@
+ #ifdef PSPACE
+ void    pspace_init(void);
+ #endif
+-#if defined(unix) || defined(__MSDOS__) || defined(VMS)
++#if defined(unix) || defined(__MSDOS__) || defined(VMS) || defined(__MACH__)
+ void    sighandler(int dummy);
+ #endif
+ #if defined(CURSESGRAPHX)
+@@ -87,7 +87,7 @@
+ #ifdef PSPACE
+ void    pspace_init();
+ #endif
+-#if defined(unix) || defined(__MSDOS__)
++#if defined(unix) || defined(__MSDOS__) || defined(__MACH__)
+ void    sighandler();
+ #endif
+ #if defined(CURSESGRAPHX)
+@@ -224,7 +224,7 @@
+ }
+ 
+ /* called when ctrl-c is pressed; prepares for debugger entry */
+-#if defined(unix) || defined(__MSDOS__) || defined (__OS2__)
++#if defined(unix) || defined(__MSDOS__) || defined (__OS2__) || defined(__MACH__)
+ void
+ #ifdef __OS2__
+         _cdecl
+@@ -290,7 +290,7 @@
+   int     argc;
+   char  **argv;
+ {
+-#if defined(unix) && !defined(DJGPP)
++#if (defined(unix) && !defined(DJGPP)) || defined(__MACH__)
+ #ifdef SIGINT
+   signal(SIGINT, sighandler);
+ #endif
+diff '--color=auto' -ruN a/src/xwindisp.c b/src/xwindisp.c
+--- a/src/xwindisp.c	2024-11-12 20:36:28.143766827 +0100
++++ b/src/xwindisp.c	2024-11-12 20:37:39.708178145 +0100
+@@ -61,6 +61,9 @@
+ #define YELLOW                        14
+ #define WHITE                         15
+ 
++/* defined in pmars.c */
++extern void sighandler(int dummy);
++
+  /* X names of the colors we allocate */
+ static char *xColorNames[MAXXCOLOR] = {
+   "black", "blue3", "green3", "cyan3",

--- a/pkgs/by-name/pm/pmars/package.nix
+++ b/pkgs/by-name/pm/pmars/package.nix
@@ -1,0 +1,106 @@
+{
+  stdenv,
+  lib,
+  fetchzip,
+  installShellFiles,
+  libX11,
+  ncurses,
+  pkg-config,
+  enableXwinGraphics ? false,
+}:
+
+let
+  options = [
+    "${if enableXwinGraphics then "XWIN" else "CURSES"}GRAPHX"
+    "EXT94"
+    "PERMUTATE"
+    "RWLIMIT"
+  ];
+  pkgConfigLibs =
+    lib.optionals enableXwinGraphics [ "x11" ]
+    ++ lib.optionals (!enableXwinGraphics) [ "ncurses" ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pmars";
+  version = "0.9.4";
+
+  src = fetchzip {
+    url = "http://www.koth.org/pmars/pmars-${finalAttrs.version}.zip";
+    hash = "sha256-68zsH9HWWp13pozjMajayS/VhY8iTosUp1CvcAmj/dE=";
+  };
+
+  patches = [
+    # Error under Clang due to global "round" variable: redefinition of 'round' as different kind of symbol
+    ./0001-fix-round-redefinition.patch
+
+    # call to undeclared function 'sighandler' & undefined sighandler on Darwin
+    ./0002-fix-sighandler.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace src/Makefile \
+      --replace-fail 'CC = gcc' "CC = $CC" \
+      --replace-fail '@strip' "@$STRIP" \
+      --replace-fail 'CFLAGS = -O -DEXT94 -DXWINGRAPHX -DPERMUTATE -DRWLIMIT' "CFLAGS = ${
+        lib.concatMapStringsSep " " (opt: "-D${opt}") options
+      } ${
+        lib.optionalString (
+          pkgConfigLibs != [ ]
+        ) "$($PKG_CONFIG --cflags ${lib.strings.concatStringsSep " " pkgConfigLibs})"
+      }" \
+      --replace-fail 'LIB = -L/usr/X11R6/lib -lX11' "LIB = ${
+        lib.optionalString (
+          pkgConfigLibs != [ ]
+        ) "$($PKG_CONFIG --libs ${lib.strings.concatStringsSep " " pkgConfigLibs})"
+      }"
+  '';
+
+  nativeBuildInputs = [ installShellFiles ] ++ lib.optionals (pkgConfigLibs != [ ]) [ pkg-config ];
+
+  buildInputs =
+    lib.optionals enableXwinGraphics [ libX11 ]
+    ++ lib.optionals (!enableXwinGraphics) [ ncurses ];
+
+  preConfigure = ''
+    cd src
+  '';
+
+  hardeningDisable = [ "format" ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 pmars $out/bin/pmars
+
+    mkdir -p $out/share/pmars
+    cp -R -t $out/share/pmars/ ../{AUTHORS,COPYING,README,config,warriors}
+
+    installManPage ../doc/pmars.6
+
+    mkdir -p $out/share/doc/pmars
+    cp -t $out/share/doc/pmars/ ../doc/{primer.*,redcode.ref}
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit options;
+  };
+
+  meta = {
+    description = "Official Core War simulator";
+    longDescription = ''
+      Portable MARS is the official Core War simulator of the ICWS and the rec.games.corewar newsgroup. pMARS serves as
+      a test bed for new Redcode standards and tournament styles. It has also been used in genetic algorithm experiments
+      and as an assembly language teaching aid. pMARS is under active development by a group of Core War enthusiasts who
+      put a lot of time into this project.
+    '';
+    homepage = "http://www.koth.org/pmars/";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "pmars";
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16929,6 +16929,8 @@ with pkgs;
 
   heroic = callPackage ../games/heroic/fhsenv.nix { };
 
+  pmars-x11 = pmars.override { enableXwinGraphics = true; };
+
   wipeout-rewrite = callPackage ../games/wipeout-rewrite {
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };


### PR DESCRIPTION
[pMARS](http://www.koth.org/pmars/), a simulator for [Core War](https://en.wikipedia.org/wiki/Core_War).

A recreation of the match-up from the Wikipedia image:
![image](https://github.com/user-attachments/assets/2376f20d-7bcf-4958-802f-60931710290c)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
