### PR TITLE
nixos-anywhere: update owner to `nix-community`

### DIFF
--- a/pkgs/by-name/ni/nixos-anywhere/package.nix
+++ b/pkgs/by-name/ni/nixos-anywhere/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "nixos-anywhere";
   version = "1.4.0";
   src = fetchFromGitHub {
-    owner = "numtide";
+    owner = "nix-community";
     repo = "nixos-anywhere";
     rev = finalAttrs.version;
     hash = "sha256-ssx6Y665uoOO3PX6Mp9NAF8sqoGb7Ezfw+bTY69aGlE=";
@@ -43,14 +43,14 @@ stdenv.mkDerivation (finalAttrs: {
     install -D -m 0755 src/get-facts.sh $out/bin/get-facts.sh
 
     # We prefer the system's openssh over our own, since it might come with features not present in ours:
-    # https://github.com/numtide/nixos-anywhere/issues/62
+    # https://github.com/nix-community/nixos-anywhere/issues/62
     wrapProgram $out/bin/nixos-anywhere \
       --prefix PATH : ${lib.makeBinPath runtimeDeps} --suffix PATH : ${lib.makeBinPath [ openssh ]}
   '';
 
   meta = with lib; {
     description = "Install nixos everywhere via ssh";
-    homepage = "https://github.com/numtide/nixos-anywhere";
+    homepage = "https://github.com/nix-community/nixos-anywhere";
     mainProgram = "nixos-anywhere";
     license = licenses.mit;
     platforms = platforms.all;


### PR DESCRIPTION
Reflect the repo being moved to `nix-community/nixos-anywhere`

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @Mic92 @Lassulus @phaer @zimbatm 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
