### PR TITLE
nixos/localtimed: set `time.timeZone` to `null` to avoid silent overriding

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -653,6 +653,9 @@
 
 - ZFS now imports its pools in `postResumeCommands` rather than `postDeviceCommands`. If you had `postDeviceCommands` scripts that depended on ZFS pools being imported, those now need to be in `postResumeCommands`.
 
+- `services.localtimed.enable = true` will now set `time.timeZone = null`.
+  This is to avoid silently shadowing a user's explicitly defined timezone without recognition on the user's part.
+
 ## Detailed migration information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}

--- a/nixos/modules/services/system/localtimed.nix
+++ b/nixos/modules/services/system/localtimed.nix
@@ -16,6 +16,11 @@ in {
           Enable `localtimed`, a simple daemon for keeping the
           system timezone up-to-date based on the current location. It uses
           geoclue2 to determine the current location.
+
+          To avoid silent overriding by the service, if you have explicitly set a
+          timezone, either remove it or ensure that it is set with a lower priority
+          than the default value using `lib.mkDefault` or `lib.mkOverride`. This is
+          to make the choice deliberate. An error will be presented otherwise.
         '';
       };
       package = mkPackageOption pkgs "localtime" { };
@@ -24,6 +29,10 @@ in {
   };
 
   config = mkIf cfg.enable {
+    # This will give users an error if they have set an explicit time
+    # zone, rather than having the service silently override it.
+    time.timeZone = null;
+
     services.geoclue2.appConfig.localtimed = {
       isAllowed = true;
       isSystem = true;


### PR DESCRIPTION
Currently if a timezone was selected explicitly, the service will silently override the value, essentially ignoring what is meant to be a a deliberate choice of option. This may cause confusion as to why the option is not doing anything when this service is enabled, particularly in more complex set-ups after some time.

This will simply make the choice deliberate from the user's part, either by having to remove the option or lowering its priority as a recognition that it may be ignored.

This change was inspired by the [`services.tzupdate`][services.tzupdate] module, which does the same.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[services.tzupdate]: https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/misc/tzupdate.nix#L24
[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc