### PR TITLE
zen-browser: init at 1.0.1-a.22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13738,7 +13738,6 @@
     github = "matthewpi";
     githubId = 26559841;
     name = "Matthew Penner";
-    keys = [ { fingerprint = "5118 F1CC B7B0 6C17 4DD1  5267 3131 1906 AD4C F6D6"; } ];
   };
   matthiasbenaets = {
     email = "matthias.benaets@gmail.com";

--- a/pkgs/by-name/ze/zen-browser-unwrapped/package.nix
+++ b/pkgs/by-name/ze/zen-browser-unwrapped/package.nix
@@ -1,0 +1,436 @@
+{
+  buildNpmPackage,
+  buildPackages,
+  fetchFromGitHub,
+  fetchurl,
+  lib,
+  overrideCC,
+  stdenv,
+
+  # build time
+  autoconf,
+  cargo,
+  dump_syms,
+  git,
+  gnum4,
+  nodejs,
+  patchelf,
+  pkg-config,
+  pkgsBuildBuild,
+  pkgsCross,
+  python3,
+  runCommand,
+  rsync,
+  rustc,
+  rust-cbindgen,
+  rustPlatform,
+  unzip,
+  vips,
+  wrapGAppsHook3,
+  writeShellScript,
+
+  # runtime
+  alsa-lib,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  dbus-glib,
+  ffmpeg,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  gtk3,
+  glib,
+  icu73,
+  jemalloc,
+  libGL,
+  libGLU,
+  libdrm,
+  libevent,
+  libffi,
+  libglvnd,
+  libjack2,
+  libjpeg,
+  libkrb5,
+  libnotify,
+  libpng,
+  libpulseaudio,
+  libstartup_notification,
+  libva,
+  libvpx,
+  libwebp,
+  libxkbcommon,
+  libxml2,
+  makeWrapper,
+  mesa,
+  nasm,
+  nspr,
+  nss_latest,
+  pango,
+  pciutils,
+  pipewire,
+  sndio,
+  udev,
+  xcb-util-cursor,
+  xorg,
+  zlib,
+
+  # Generic changes the compatibility mode of the final binaries.
+  #
+  # Enabling generic will make the browser compatible with more devices at the
+  # cost of disabling hardware-specific optimizations. It is highly recommended
+  # to leave `generic` disabled.
+  generic ? false,
+  debugBuild ? false,
+
+  # On 32bit platforms, we disable adding "-g" for easier linking.
+  enableDebugSymbols ? !stdenv.hostPlatform.is32bit,
+  alsaSupport ? stdenv.hostPlatform.isLinux,
+  ffmpegSupport ? true,
+  gssSupport ? true,
+  jackSupport ? stdenv.hostPlatform.isLinux,
+  jemallocSupport ? !stdenv.hostPlatform.isMusl,
+  pipewireSupport ? waylandSupport && webrtcSupport,
+  pulseaudioSupport ? stdenv.hostPlatform.isLinux,
+  sndioSupport ? stdenv.hostPlatform.isLinux,
+  waylandSupport ? true,
+
+  privacySupport ? false,
+
+  # WARNING: NEVER set any of the options below to `true` by default.
+  # Set to `!privacySupport` or `false`.
+  crashreporterSupport ?
+    !privacySupport && !stdenv.hostPlatform.isRiscV && !stdenv.hostPlatform.isMusl,
+  geolocationSupport ? !privacySupport,
+  webrtcSupport ? !privacySupport,
+}:
+let
+  surfer = buildNpmPackage {
+    pname = "surfer";
+    version = "1.5.0";
+
+    src = fetchFromGitHub {
+      owner = "zen-browser";
+      repo = "surfer";
+      rev = "50af7094ede6e9f0910f010c531f8447876a6464";
+      hash = "sha256-wmAWg6hoICNHfoXJifYFHmyFQS6H22u3GSuRW4alexw=";
+    };
+
+    patches = [ ./surfer-dont-check-update.patch ];
+
+    npmDepsHash = "sha256-p0RVqn0Yfe0jxBcBa/hYj5g9XSVMFhnnZT+au+bMs18=";
+    makeCacheWritable = true;
+
+    SHARP_IGNORE_GLOBAL_LIBVIPS = false;
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ vips ];
+  };
+
+  llvmPackages0 = rustc.llvmPackages;
+  llvmPackagesBuildBuild0 = pkgsBuildBuild.rustc.llvmPackages;
+
+  llvmPackages = llvmPackages0.override {
+    bootBintoolsNoLibc = null;
+    bootBintools = null;
+  };
+  llvmPackagesBuildBuild = llvmPackagesBuildBuild0.override {
+    bootBintoolsNoLibc = null;
+    bootBintools = null;
+  };
+
+  buildStdenv = overrideCC llvmPackages.stdenv (
+    llvmPackages.stdenv.cc.override { bintools = buildPackages.rustc.llvmPackages.bintools; }
+  );
+
+  inherit (pkgsCross) wasi32;
+
+  wasiSysRoot = runCommand "wasi-sysroot" { } ''
+    mkdir -p "$out"/lib/wasm32-wasi
+    for lib in ${wasi32.llvmPackages.libcxx}/lib/*; do
+      ln -s "$lib" "$out"/lib/wasm32-wasi
+    done
+  '';
+
+  firefox-l10n = fetchFromGitHub {
+    owner = "mozilla-l10n";
+    repo = "firefox-l10n";
+    rev = "9d639cd79d6b73081fadb3474dd7d73b89732e7b";
+    hash = "sha256-+2JCaPp+c2BRM60xFCeY0pixIyo2a3rpTPaSt1kTfDw=";
+  };
+in
+buildStdenv.mkDerivation (finalAttrs: {
+  pname = "zen-browser-unwrapped";
+  version = "1.0.1-a.22";
+
+  src = fetchFromGitHub {
+    owner = "zen-browser";
+    repo = "desktop";
+    rev = finalAttrs.version;
+    hash = "sha256-5O0qrCyS1EIRCiSLtxK6WqCMB2LZzuPmiP1qT4wO85k=";
+    fetchSubmodules = true;
+  };
+
+  # DO NOT UPDATE THE FIREFOX VERSION MANUALLY!
+  #
+  # Both `firefoxVersion` and `firefoxSrc` are managed by the `update.sh` script.
+  # The Firefox version is specified by `zen-browser` in the `surfer.json` file.
+  #
+  # We need to manually set the version here to avoid IFD.
+  firefoxVersion = "132.0.1";
+  firefoxSrc = fetchurl {
+    url = "mirror://mozilla/firefox/releases/${finalAttrs.firefoxVersion}/source/firefox-${finalAttrs.firefoxVersion}.source.tar.xz";
+    hash = "sha256-XAMbVywdpyZnfi/5e2rVp+OyM4em/DljORy1YvgKXkg=";
+  };
+
+  SURFER_COMPAT = generic;
+
+  nativeBuildInputs =
+    [
+      autoconf
+      cargo
+      git
+      gnum4
+      llvmPackagesBuildBuild.bintools
+      makeWrapper
+      nasm
+      nodejs
+      pkg-config
+      python3
+      rsync
+      rust-cbindgen
+      rustPlatform.bindgenHook
+      rustc
+      surfer
+      unzip
+      wrapGAppsHook3
+      xorg.xvfb
+    ]
+    ++ lib.optionals crashreporterSupport [
+      dump_syms
+      patchelf
+    ];
+
+  buildInputs =
+    [
+      atk
+      cairo
+      cups
+      dbus
+      dbus-glib
+      ffmpeg
+      fontconfig
+      freetype
+      gdk-pixbuf
+      gtk3
+      glib
+      icu73
+      libGL
+      libGLU
+      libevent
+      libffi
+      libglvnd
+      libjpeg
+      libnotify
+      libpng
+      libstartup_notification
+      libva
+      libvpx
+      libwebp
+      libxml2
+      mesa
+      nspr
+      nss_latest
+      pango
+      pciutils
+      pipewire
+      udev
+      xcb-util-cursor
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXft
+      xorg.libXi
+      xorg.libXrender
+      xorg.libXt
+      xorg.libXtst
+      xorg.pixman
+      xorg.xorgproto
+      xorg.libxcb
+      xorg.libXrandr
+      xorg.libXcomposite
+      xorg.libXfixes
+      xorg.libXScrnSaver
+      zlib
+    ]
+    ++ lib.optional alsaSupport alsa-lib
+    ++ lib.optional jackSupport libjack2
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional sndioSupport sndio
+    ++ lib.optional gssSupport libkrb5
+    ++ lib.optional jemallocSupport jemalloc
+    ++ lib.optionals waylandSupport [
+      libdrm
+      libxkbcommon
+    ];
+
+  configureFlags = [
+    "--disable-bootstrap"
+    "--disable-updater"
+    "--enable-default-toolkit=cairo-gtk3${lib.optionalString waylandSupport "-wayland"}"
+    "--enable-system-pixman"
+    "--with-distribution-id=org.nixos"
+    "--with-libclang-path=${llvmPackagesBuildBuild.libclang.lib}/lib"
+    "--with-system-ffi"
+    "--with-system-icu"
+    "--with-system-jpeg"
+    "--with-system-libevent"
+    "--with-system-libvpx"
+    "--with-system-nspr"
+    "--with-system-nss"
+    "--with-system-png" # needs APNG support
+    "--with-system-webp"
+    "--with-system-zlib"
+    "--with-wasi-sysroot=${wasiSysRoot}"
+    "--host=${buildStdenv.buildPlatform.config}"
+    "--target=${buildStdenv.hostPlatform.config}"
+    (lib.enableFeature alsaSupport "alsa")
+    (lib.enableFeature ffmpegSupport "ffmpeg")
+    (lib.enableFeature geolocationSupport "necko-wifi")
+    (lib.enableFeature gssSupport "negotiateauth")
+    (lib.enableFeature jackSupport "jack")
+    (lib.enableFeature jemallocSupport "jemalloc")
+    (lib.enableFeature pulseaudioSupport "pulseaudio")
+    (lib.enableFeature sndioSupport "sndio")
+    (lib.enableFeature webrtcSupport "webrtc")
+    # --enable-release adds -ffunction-sections & LTO that require a big amount
+    # of RAM, and the 32-bit memory space cannot handle that linking
+    (lib.enableFeature (!debugBuild && !stdenv.hostPlatform.is32bit) "release")
+    (lib.enableFeature enableDebugSymbols "debug-symbols")
+  ] ++ lib.optional stdenv.hostPlatform.isAarch "--disable-wasm-avx";
+
+  configureScript = writeShellScript "configureMozconfig" (
+    (lib.optionalString stdenv.hostPlatform.isAarch ''
+      echo "ac_add_options --with-libclang-path=/usr/lib64" >> ./configs/linux/mozconfig
+
+      # linux mozconfig
+      sed -i 's/x86-\(64\|64-v3\)/native/g' ./configs/linux/mozconfig
+      sed -i 's/x86_64-pc-linux/aarch64-linux-gnu/g' ./configs/linux/mozconfig
+
+      # eme/widevine must be disabled on arm64 (thx google)
+      sed -i '/--enable-eme/s/^/# /' ./configs/common/mozconfig
+      sed -i 's/-msse3//g' ./configs/linux/mozconfig
+      sed -i 's/-mssse3//g' ./configs/linux/mozconfig
+      sed -i 's/-msse4.1//g' ./configs/linux/mozconfig
+      sed -i 's/-msse4.2//g' ./configs/linux/mozconfig
+      sed -i 's/-mavx2//g' ./configs/linux/mozconfig
+      sed -i 's/-mavx//g' ./configs/linux/mozconfig
+      sed -i 's/-mfma//g' ./configs/linux/mozconfig
+      sed -i 's/-maes//g' ./configs/linux/mozconfig
+      sed -i 's/-mpopcnt//g' ./configs/linux/mozconfig
+      sed -i 's/-mpclmul//g' ./configs/linux/mozconfig
+      sed -i 's/+avx2//g' ./configs/linux/mozconfig
+      sed -i 's/+sse4.1//g' ./configs/linux/mozconfig
+
+    '')
+    + ''
+      for flag in $@; do
+        echo "ac_add_options $flag" >> mozconfig
+      done
+    ''
+  );
+
+  # To the person reading this wondering what is going on here, this is what
+  # happens when a build process relies on Git. Normally you would use `fetchgit`
+  # with `leaveDotGit = true`, however that leads to reproducibility issues, so
+  # instead we create our own Git repo with a single commit.
+  #
+  # `surfer` (the build tool made for zen-browser) uses git to read the latest
+  # HEAD commit, `git apply`, and likely a few other operations.
+  preConfigure = ''
+    export HOME="$TMPDIR"
+    git config --global user.email "nixbld@localhost"
+    git config --global user.name "nixbld"
+    git init
+    git add --all
+    git commit -m 'nixpkgs'
+
+    export LLVM_PROFDATA=llvm-profdata
+    export MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=system
+    export WASM_CC=${wasi32.stdenv.cc}/bin/${wasi32.stdenv.cc.targetPrefix}cc
+    export WASM_CXX=${wasi32.stdenv.cc}/bin/${wasi32.stdenv.cc.targetPrefix}c++
+
+    export ZEN_RELEASE=1
+    surfer ci --brand alpha --display-version ${finalAttrs.version}
+
+    install -D ${finalAttrs.firefoxSrc} .surfer/engine/firefox-${finalAttrs.firefoxVersion}.source.tar.xz
+    surfer download
+    surfer import
+    patchShebangs engine/mach engine/build engine/tools
+  '';
+
+  preBuild = ''
+    cp -r ${firefox-l10n} l10n/firefox-l10n
+
+    for lang in $(cat ./l10n/supported-languages); do
+      rsync -av --progress l10n/firefox-l10n/"$lang"/ l10n/"$lang" --exclude .git
+    done
+
+    sh scripts/copy-language-pack.sh en-US
+
+    for lang in $(cat ./l10n/supported-languages); do
+      sh scripts/copy-language-pack.sh "$lang"
+    done
+
+    Xvfb :2 -screen 0 1024x768x24 &
+    export DISPLAY=:2
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    surfer build
+
+    runHook postBuild
+  '';
+
+  preInstall = ''
+    cd engine/obj-*
+  '';
+
+  meta = {
+    mainProgram = "zen";
+    description = "Firefox based browser with a focus on privacy and customization";
+    homepage = "https://www.zen-browser.app/";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      matthewpi
+      titaniumtown
+    ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+
+  enableParallelBuilding = true;
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  passthru = {
+    updateScript = ./update.sh;
+
+    # These values are used by `wrapFirefox`.
+    # ref; `pkgs/applications/networking/browsers/firefox/wrapper.nix'
+    binaryName = finalAttrs.meta.mainProgram;
+    inherit alsaSupport;
+    inherit jackSupport;
+    inherit pipewireSupport;
+    inherit sndioSupport;
+    inherit nspr;
+    inherit ffmpegSupport;
+    inherit gssSupport;
+    inherit gtk3;
+    inherit wasiSysRoot;
+  };
+})

--- a/pkgs/by-name/ze/zen-browser-unwrapped/surfer-dont-check-update.patch
+++ b/pkgs/by-name/ze/zen-browser-unwrapped/surfer-dont-check-update.patch
@@ -1,0 +1,19 @@
+diff --git a/src/index.ts b/src/index.ts
+index 3d41389..f6bfb95 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -19,7 +19,6 @@ import { resolve } from 'node:path'
+ import { errorHandler, config as configInited, versionFormatter } from './utils'
+ import { commands } from './cmds'
+ import { BIN_NAME, ENGINE_DIR } from './constants'
+-import { updateCheck } from './middleware/update-check'
+ import { registerCommand } from './middleware/register-command'
+ import { log } from './log'
+
+@@ -83,7 +82,6 @@ async function middleware(command: commander.Command) {
+   // If the program is verbose, store that fact within the logger
+   log.isDebug = program.opts().verbose
+
+-  await updateCheck()
+   registerCommand(command.name())
+ }

--- a/pkgs/by-name/ze/zen-browser-unwrapped/update.sh
+++ b/pkgs/by-name/ze/zen-browser-unwrapped/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -eou pipefail
+
+PACKAGE_PATH=./pkgs/by-name/ze/zen-browser-unwrapped
+PACKAGE_NIX="$PACKAGE_PATH"/package.nix
+
+version="$(curl --silent 'https://api.github.com/repos/zen-browser/desktop/releases/latest' | jq --raw-output '.tag_name')"
+update-source-version zen-browser-unwrapped "${version}" --file="$PACKAGE_NIX"
+
+# Get the extracted src for zen-browser, we need to read the `surfer.json` file
+# to get the Firefox version.
+src="$(nix-build -A zen-browser-unwrapped.src --no-out-link)"
+
+# Get the Firefox version from the `surfer.json` file.
+firefoxVersion=$(cat "$src"/surfer.json | jq --raw-output '.version.version')
+
+# Update the Firefox version for the derivation.
+update-source-version zen-browser-unwrapped "$firefoxVersion" --version-key=firefoxVersion --source-key=firefoxSrc --file="$PACKAGE_NIX"

--- a/pkgs/by-name/ze/zen-browser/package.nix
+++ b/pkgs/by-name/ze/zen-browser/package.nix
@@ -1,0 +1,8 @@
+{
+  wrapFirefox,
+  zen-browser-unwrapped,
+}:
+wrapFirefox zen-browser-unwrapped {
+  pname = "zen-browser";
+  libName = "zen";
+}


### PR DESCRIPTION
<https://zen-browser.app/>

Closes https://github.com/NixOS/nixpkgs/issues/327982

NOTE: This package takes quite a lot of resources to build.  On my desktop (7900X) and on my build server (5950X) the build takes upwards of about 30-35 minutes. This is not a package you want to compile yourself if you can avoid it.

If anyone wants to be added as a maintainer to this package, please leave a comment and I will add you.

@Zh40Le1ZOOB thanks for doing the legwork to get this packaged.  I based this package on the one you linked in the associated package request, but merged in a bunch of the options from the `firefox` package already in nixpkgs.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
