### PR TITLE
lib.oldestSupportedReleaseIsAtLeast: rename from bad name

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -5,7 +5,7 @@
 
 let
   inherit (builtins) head length;
-  inherit (lib.trivial) isInOldestRelease mergeAttrs warn warnIf;
+  inherit (lib.trivial) oldestSupportedReleaseIsAtLeast mergeAttrs warn warnIf;
   inherit (lib.strings) concatStringsSep concatMapStringsSep escapeNixIdentifier sanitizeDerivationName;
   inherit (lib.lists) foldr foldl' concatMap elemAt all partition groupBy take foldl;
 in
@@ -2137,6 +2137,6 @@ rec {
     "lib.zip is a deprecated alias of lib.zipAttrsWith." zipAttrsWith;
 
   # DEPRECATED
-  cartesianProductOfSets = warnIf (isInOldestRelease 2405)
+  cartesianProductOfSets = warnIf (oldestSupportedReleaseIsAtLeast 2405)
     "lib.cartesianProductOfSets is a deprecated alias of lib.cartesianProduct." cartesianProduct;
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -73,7 +73,7 @@ let
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
-      info showWarnings nixpkgsVersion version isInOldestRelease
+      info showWarnings nixpkgsVersion version isInOldestRelease oldestSupportedReleaseIsAtLeast
       mod compare splitByAndCompare seq deepSeq lessThan add sub
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
       fromHexString toHexString toBaseDigits inPureEvalMode isBool isInt pathExists

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -23,7 +23,7 @@ let
     isAttrs
     isBool
     isFunction
-    isInOldestRelease
+    oldestSupportedReleaseIsAtLeast
     isList
     isString
     length
@@ -1030,7 +1030,7 @@ let
   mkForce = mkOverride 50;
   mkVMOverride = mkOverride 10; # used by ‘nixos-rebuild build-vm’
 
-  defaultPriority = warnIf (isInOldestRelease 2305) "lib.modules.defaultPriority is deprecated, please use lib.modules.defaultOverridePriority instead." defaultOverridePriority;
+  defaultPriority = warnIf (oldestSupportedReleaseIsAtLeast 2305) "lib.modules.defaultPriority is deprecated, please use lib.modules.defaultOverridePriority instead." defaultOverridePriority;
 
   mkFixStrictness = warn "lib.mkFixStrictness has no effect and will be removed. It returns its argument unmodified, so you can just remove any calls." id;
 
@@ -1146,8 +1146,8 @@ let
   }: doRename {
     inherit from to;
     visible = false;
-    warn = isInOldestRelease sinceRelease;
-    use = warnIf (isInOldestRelease sinceRelease)
+    warn = oldestSupportedReleaseIsAtLeast sinceRelease;
+    use = warnIf (oldestSupportedReleaseIsAtLeast sinceRelease)
       "Obsolete option `${showOption from}' is used. It was renamed to `${showOption to}'.";
   };
 

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -256,15 +256,15 @@ let
 
 in {
 
-  pathType = lib.warnIf (lib.isInOldestRelease 2305)
+  pathType = lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2305)
     "lib.sources.pathType has been moved to lib.filesystem.pathType."
     lib.filesystem.pathType;
 
-  pathIsDirectory = lib.warnIf (lib.isInOldestRelease 2305)
+  pathIsDirectory = lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2305)
     "lib.sources.pathIsDirectory has been moved to lib.filesystem.pathIsDirectory."
     lib.filesystem.pathIsDirectory;
 
-  pathIsRegularFile = lib.warnIf (lib.isInOldestRelease 2305)
+  pathIsRegularFile = lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2305)
     "lib.sources.pathIsRegularFile has been moved to lib.filesystem.pathIsRegularFile."
     lib.filesystem.pathIsRegularFile;
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -2272,7 +2272,7 @@ rec {
     isCoercibleToString :: a -> bool
     ```
   */
-  isCoercibleToString = lib.warnIf (lib.isInOldestRelease 2305)
+  isCoercibleToString = lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2305)
     "lib.strings.isCoercibleToString is deprecated in favor of either isStringLike or isConvertibleWithToString. Only use the latter if it needs to return true for null, numbers, booleans and list of similarly coercibles."
     isConvertibleWithToString;
 

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -397,6 +397,15 @@ in {
     Set it to the upcoming release, matching the nixpkgs/.version file.
   */
   isInOldestRelease =
+    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2411)
+      "lib.isInOldestRelease is deprecated. Use lib.oldestSupportedReleaseIsAtLeast instead."
+    lib.oldestSupportedReleaseIsAtLeast;
+
+  /**
+    Alias for `isInOldestRelease` introduced in 24.11.
+    Use `isInOldestRelease` in expressions outside of Nixpkgs for greater compatibility.
+   */
+  oldestSupportedReleaseIsAtLeast =
     release:
       release <= lib.trivial.oldestSupportedRelease;
 

--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -151,7 +151,7 @@ in
     nodesCompat =
       mapAttrs
         (name: config: config // {
-          config = lib.warnIf (lib.isInOldestRelease 2211)
+          config = lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2211)
             "Module argument `nodes.${name}.config` is deprecated. Use `nodes.${name}` instead."
             config;
         })

--- a/pkgs/build-support/substitute/substitute.nix
+++ b/pkgs/build-support/substitute/substitute.nix
@@ -39,7 +39,7 @@ let
   optionalDeprecationWarning =
     # substitutions is only available starting 24.05.
     # TODO: Remove support for replacements sometime after the next release
-    lib.warnIf (args ? replacements && lib.isInOldestRelease 2405) ''
+    lib.warnIf (args ? replacements && lib.oldestSupportedReleaseIsAtLeast 2405) ''
       pkgs.substitute: For "${name}", `replacements` is used, which is deprecated since it doesn't support arguments with spaces. Use `substitutions` instead:
         substitutions = [ ${deprecationReplacement} ];'';
 in

--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -466,7 +466,7 @@ rec {
     which is cross aware instead.
   */
   generateOptparseApplicativeCompletions = commands: pkg:
-    lib.warnIf (lib.isInOldestRelease 2211) "haskellLib.generateOptparseApplicativeCompletions is deprecated in favor of haskellPackages.generateOptparseApplicativeCompletions. Please change ${pkg.name} to use the latter and make sure it uses its matching haskell.packages set!"
+    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2211) "haskellLib.generateOptparseApplicativeCompletions is deprecated in favor of haskellPackages.generateOptparseApplicativeCompletions. Please change ${pkg.name} to use the latter and make sure it uses its matching haskell.packages set!"
       (pkgs.lib.foldr __generateOptparseApplicativeCompletion pkg commands);
 
   /*
@@ -475,7 +475,7 @@ rec {
     which is cross aware instead.
   */
   generateOptparseApplicativeCompletion = command: pkg:
-    lib.warnIf (lib.isInOldestRelease 2211) "haskellLib.generateOptparseApplicativeCompletion is deprecated in favor of haskellPackages.generateOptparseApplicativeCompletions (plural!). Please change ${pkg.name} to use the latter and make sure it uses its matching haskell.packages set!"
+    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2211) "haskellLib.generateOptparseApplicativeCompletion is deprecated in favor of haskellPackages.generateOptparseApplicativeCompletions (plural!). Please change ${pkg.name} to use the latter and make sure it uses its matching haskell.packages set!"
       (__generateOptparseApplicativeCompletion command pkg);
 
   # Don't fail at configure time if there are multiple versions of the

--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -93,7 +93,7 @@ in rec {
     inherit hasDistutilsCxxPatch;
     # Remove after 24.11 is released.
     pythonForBuild =
-      lib.warnIf (lib.isInOldestRelease 2311) "`pythonForBuild` (from `python*`) has been renamed to `pythonOnBuildForHost`"
+      lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2311) "`pythonForBuild` (from `python*`) has been renamed to `pythonOnBuildForHost`"
         pythonOnBuildForHost_overridden;
     pythonOnBuildForHost = pythonOnBuildForHost_overridden;
 


### PR DESCRIPTION
…and deprecate after 24.11

It seems impossible to describe this condition more concisely without making it incomprehensible.

I've considered removing the old end-of-life gates, but they're still useful as "comments" that describe when an alias was deprecated, and we could instead remove the aliases altogether. We could set a policy for that, but I'd like to do one thing at a time.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
