### PR TITLE
vtsls: init at 0.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11627,6 +11627,13 @@
     name = "André Kugland";
     keys = [ { fingerprint = "6A62 5E60 E3FF FCAE B3AA  50DC 1DA9 3817 80CD D833"; } ];
   };
+  kuglimon = {
+    name = "Tatu Argillander";
+    email = "tatu.argillander@kouralabs.com";
+    github = "kuglimon";
+    githubId = 629430;
+    keys = [ { fingerprint = "2843 750C B1AB E256 94BE  40E2 D843 D30B 42CA 0E2D"; } ];
+  };
   kupac = {
     github = "Kupac";
     githubId = 8224569;

--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -1,0 +1,93 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nodejs_22,
+  gitMinimal,
+  pnpm_8,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vtsls";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "yioneko";
+    repo = "vtsls";
+    rev = "server-v${finalAttrs.version}";
+    hash = "sha256-HCi9WLh4IEfhgkQNUVk6IGkQfYagg805Rix78zG6xt0=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    nodejs_22
+    # patches are applied with git during build
+    gitMinimal
+    pnpm_8.configHook
+  ];
+
+  buildInputs = [ nodejs_22 ];
+
+  pnpmWorkspaces = [ "@vtsls/language-server" ];
+
+  pnpmDeps = pnpm_8.fetchDeps {
+    inherit (finalAttrs)
+      pnpmWorkspaces
+      pname
+      src
+      version
+      ;
+    hash = "sha256-4XxQ0Z2atTBItrD9iY7q5rJaCmb1EeDBvQ5+L3ceRXI=";
+  };
+
+  # Patches to get submodule sha from file instead of 'git submodule status'
+  patches = [ ./vtsls-build-patch.patch ];
+
+  # Skips manual confirmations during build
+  CI = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    # During build vtsls needs a working git installation.
+    git config --global user.name nixbld
+    git config --global user.email nixbld@example.com
+
+    # during build this sha is used as a marker to skip applying patches and
+    # copying files, which doesn't matter in this case
+    echo "dummysha" > ./packages/service/HEAD
+
+    # Requires a git repository during build
+    git init packages/service/vscode
+
+    # Depends on the @vtsls/language-service workspace
+    # '--workspace-concurrency=1' helps debug failing builds.
+    pnpm --filter "@vtsls/language-server..." build
+
+    # These trash deterministic builds. During build the whole directory is
+    # copied to another path.
+    rm -rf packages/service/vscode/.git
+    rm -rf packages/service/src/typescript-language-features/.git
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/vtsls-language-server}
+    cp -r {packages,node_modules} $out/lib/vtsls-language-server
+    ln -s $out/lib/vtsls-language-server/packages/server/bin/vtsls.js $out/bin/vtsls
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "LSP wrapper for typescript extension of vscode.";
+    homepage = "https://github.com/yioneko/vtsls";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kuglimon ];
+    mainProgram = "vtsls";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/vt/vtsls/vtsls-build-patch.patch
+++ b/pkgs/by-name/vt/vtsls/vtsls-build-patch.patch
@@ -1,0 +1,18 @@
+diff --git a/packages/service/scripts/patch.js b/packages/service/scripts/patch.js
+index 2d01f3a..f26c216 100644
+--- a/packages/service/scripts/patch.js
++++ b/packages/service/scripts/patch.js
+@@ -13,11 +13,7 @@ const vscTsExtPath = path.resolve(__dirname, "../vscode/extensions/typescript-la
+ const tsExtPath = path.resolve(__dirname, "../src/typescript-language-features");
+
+ async function getVscodeSha() {
+-  const { stdout } = await exec("git", ["submodule", "status", "vscode"], {
+-    cwd: path.resolve(__dirname, "../"),
+-  });
+-  const commit = stdout.match(/^\s*([^\s]+)\s/)[1];
+-  return commit;
++  return await fs.readFile('./HEAD', { encoding: 'utf8' });
+ }
+
+ /**
+


### PR DESCRIPTION
Provides [vtsls](https://github.com/yioneko/vtsls), a typescript language server.

I've lightly used this for a couple of weeks on NixOS and nix-darwin.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
