### PR TITLE
sogo: 5.11.0 -> 5.11.1

### DIFF
--- a/pkgs/servers/web-apps/sogo/default.nix
+++ b/pkgs/servers/web-apps/sogo/default.nix
@@ -5,14 +5,14 @@
 , libwbxml }:
 gnustep.stdenv.mkDerivation rec {
   pname = "sogo";
-  version = "5.11.0";
+  version = "5.11.1";
 
   # always update the sope package as well, when updating sogo
   src = fetchFromGitHub {
     owner = "Alinto";
     repo = pname;
     rev = "SOGo-${version}";
-    hash = "sha256-2/0OaCAQkdnDPGOVERZs2Oz+bCpQN3MTLzp2pz0WB08=";
+    hash = "sha256-oCJNEsYSK/wiWOmRRl9QPcGtf/h0IcSfwKijsOyiKjs=";
   };
 
   nativeBuildInputs = [ gnustep.make makeWrapper python3 pkg-config ];


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
