### PR TITLE
LogSeq: Pin electron 27 until upstream is updated

### DIFF
--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -4,16 +4,17 @@
 , appimageTools
 , unzip
 , makeWrapper
-# Notice: graphs will not sync without matching upstream's major electron version
-#         the specific electron version is set at top-level file to preserve override interface.
-#         whenever updating this package also sync electron version at top-level file.
-, electron
+  # Notice: graphs will not sync without matching upstream's major electron version
+  #         the specific electron version is set at top-level file to preserve override interface.
+  #         whenever updating this package also sync electron version at top-level file.
+, electron_27
 , autoPatchelfHook
 , git
 , nix-update-script
 }:
 
-stdenv.mkDerivation (finalAttrs: let
+stdenv.mkDerivation (finalAttrs:
+let
   inherit (finalAttrs) pname version src;
   inherit (stdenv.hostPlatform) system;
   selectSystem = attrs: attrs.${system} or (throw "Unsupported system: ${system}");
@@ -27,7 +28,8 @@ stdenv.mkDerivation (finalAttrs: let
     x86_64-darwin = "sha256-0i9ozqBSeV/y8v+YEmQkbY0V6JHOv6tKub4O5Fdx2fQ=";
     aarch64-darwin = "sha256-Uvv96XWxpFj14wPH0DwPT+mlf3Z2dy1g/z8iBt5Te7Q=";
   };
-in {
+in
+{
   pname = "logseq";
   version = "0.10.9";
   src = fetchurl {
@@ -48,27 +50,28 @@ in {
   installPhase = ''
     runHook preInstall
   '' + lib.optionalString stdenv.hostPlatform.isLinux (
-  let
-   appimageContents = appimageTools.extract { inherit pname src version; };
-  in
-  ''
-    mkdir -p $out/bin $out/share/logseq $out/share/applications
-    cp -a ${appimageContents}/{locales,resources} $out/share/logseq
-    cp -a ${appimageContents}/Logseq.desktop $out/share/applications/logseq.desktop
+    let
+      appimageContents = appimageTools.extract { inherit pname src version; };
+    in
+    ''
+      mkdir -p $out/bin $out/share/logseq $out/share/applications
+      cp -a ${appimageContents}/{locales,resources} $out/share/logseq
+      cp -a ${appimageContents}/Logseq.desktop $out/share/applications/logseq.desktop
 
-    # remove the `git` in `dugite` because we want the `git` in `nixpkgs`
-    chmod +w -R $out/share/logseq/resources/app/node_modules/dugite/git
-    chmod +w $out/share/logseq/resources/app/node_modules/dugite
-    rm -rf $out/share/logseq/resources/app/node_modules/dugite/git
-    chmod -w $out/share/logseq/resources/app/node_modules/dugite
+      # remove the `git` in `dugite` because we want the `git` in `nixpkgs`
+      chmod +w -R $out/share/logseq/resources/app/node_modules/dugite/git
+      chmod +w $out/share/logseq/resources/app/node_modules/dugite
+      rm -rf $out/share/logseq/resources/app/node_modules/dugite/git
+      chmod -w $out/share/logseq/resources/app/node_modules/dugite
 
-    mkdir -p $out/share/pixmaps
-    ln -s $out/share/logseq/resources/app/icons/logseq.png $out/share/pixmaps/logseq.png
+      mkdir -p $out/share/pixmaps
+      ln -s $out/share/logseq/resources/app/icons/logseq.png $out/share/pixmaps/logseq.png
 
-    substituteInPlace $out/share/applications/logseq.desktop \
-      --replace Exec=Logseq Exec=logseq \
-      --replace Icon=Logseq Icon=logseq
-  '') + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace $out/share/applications/logseq.desktop \
+        --replace Exec=Logseq Exec=logseq \
+        --replace Icon=Logseq Icon=logseq
+    ''
+  ) + lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/{Applications/Logseq.app,bin}
     cp -R . $out/Applications/Logseq.app
     makeWrapper $out/Applications/Logseq.app/Contents/MacOS/Logseq $out/bin/logseq
@@ -78,7 +81,7 @@ in {
 
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     # set the env "LOCAL_GIT_DIRECTORY" for dugite so that we can use the git in nixpkgs
-    makeWrapper ${electron}/bin/electron $out/bin/logseq \
+    makeWrapper ${electron_27}/bin/electron $out/bin/logseq \
       --set "LOCAL_GIT_DIRECTORY" ${git} \
       --add-flags $out/share/logseq/resources/app \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"


### PR DESCRIPTION
Linked to #341683

The current version of LogSeq still uses Electron 27. The newer versions have issues with the better_sqlite3 library, raising warnings on each file save. This pull request pins the electron version to 27, while we wait for upstream to update their dependencies. This way, none of the previous errors are showing in the GUI and in the logs.

> [!WARNING] 
> Notice that Electron 27 is marked as insecure, so this may not be the best option for all NixOS users.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
