### PR TITLE
liboqs: 0.10.1 -> 0.11.0, oqs-provider: 0.6.1 -> 0.7.0

### DIFF
--- a/pkgs/by-name/li/liboqs/fix-openssl-detection.patch
+++ b/pkgs/by-name/li/liboqs/fix-openssl-detection.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Do not forcibly set OPENSSL_ROOT_DIR.
 CMake can already find OpenSSL via pkg-config. Setting OPENSSL_ROOT_DIR
 forcibly to "/usr" breaks this.
 ---
- CMakeLists.txt | 11 -----------
- 1 file changed, 11 deletions(-)
+ CMakeLists.txt | 9 ---------
+ 1 file changed, 9 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 288bcbe8..9750fae6 100644
+index 0564bc8e..7b4c7f47 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -119,17 +119,6 @@ include(.CMake/compiler_opts.cmake)
+@@ -144,15 +144,6 @@ include(.CMake/compiler_opts.cmake)
  include(.CMake/alg_support.cmake)
  
  if(${OQS_USE_OPENSSL})
@@ -24,13 +24,12 @@ index 288bcbe8..9750fae6 100644
 -            elseif(EXISTS "/opt/homebrew/opt/openssl@1.1")
 -                set(OPENSSL_ROOT_DIR "/opt/homebrew/opt/openssl@1.1")
 -            endif()
--        elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux")
--            set(OPENSSL_ROOT_DIR "/usr")
 -        endif()
 -    endif()
      find_package(OpenSSL 1.1.1 REQUIRED)
- endif()
  
+     if(OQS_DLOPEN_OPENSSL)
+
 -- 
 2.42.0
 

--- a/pkgs/by-name/li/liboqs/package.nix
+++ b/pkgs/by-name/li/liboqs/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "liboqs";
-  version = "0.10.1";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "open-quantum-safe";
     repo = "liboqs";
     rev = finalAttrs.version;
-    hash = "sha256-zsSKFUs75K0Byxh3KVCZ8lIOf/vpbyMJXfk6fa2u+aE=";
+    hash = "sha256-+Gx1JPrJoeMix9DIF0rJQTivxN1lgaCIYFvJ1pnYZzM=";
   };
 
   patches = [

--- a/pkgs/by-name/oq/oqs-provider/package.nix
+++ b/pkgs/by-name/oq/oqs-provider/package.nix
@@ -8,13 +8,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   name = "oqs-provider";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "open-quantum-safe";
     repo  = "oqs-provider";
     rev = finalAttrs.version;
-    hash = "sha256-AW0rOszXm9Hy55b2fQ2mpZulhXjYwvztwL6DIFgIzjA=";
+    hash = "sha256-2+TpYpZwC8vx6tGgS2waD/BQDfnbq0PJIwvX5wDDBEg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (`lib/ossl-modules/oqsprovider.so`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
