### PR TITLE
cbqn: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/development/interpreters/bqn/cbqn/sources.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/sources.nix
@@ -10,13 +10,13 @@
   cbqn = let
     self = {
       pname = "cbqn";
-      version = "0.7.0";
+      version = "0.8.0";
 
       src = fetchFromGitHub {
         owner = "dzaima";
         repo = "CBQN";
         rev = "v${self.version}";
-        hash = "sha256-TUK0HrJ1IyiVi9Y3S1IrK/d4/EZxdRdWyxsAwj79KEc=";
+        hash = "sha256-vmd7CX0jgozysmjKK0p5GM4Qd3vY71q1kcKwfr+6fkw=";
       };
     };
   in
@@ -24,13 +24,13 @@
 
   cbqn-bytecode = {
     pname = "cbqn-bytecode";
-    version = "0-unstable-2024-05-22";
+    version = "0-unstable-2024-09-15";
 
     src = fetchFromGitHub {
       owner = "dzaima";
       repo = "cbqnBytecode";
-      rev = "c5674783c11d7569e5a4d166600ffcde2409331d";
-      hash = "sha256-y7gqHzUxVUUVryutlq3Upuso8r3ZRSyF7ydMg1OVlwA=";
+      rev = "c7d83937710889591bad3525077afc30a21e5148";
+      hash = "sha256-bEHyiJusddBuTk7MZX1NGvkj66WeOJv5qxBQV6Uhs1E=";
     };
   };
 
@@ -48,13 +48,13 @@
 
   singeli = {
     pname = "singeli";
-    version = "0-unstable-2024-02-26";
+    version = "0-unstable-2024-09-29";
 
     src = fetchFromGitHub {
       owner = "mlochbaum";
       repo = "Singeli";
-      rev = "ce6ef5d06d35777f0016bbfe0c6c1cf6a9c1b48e";
-      hash = "sha256-dDoWoq4LYMD2CKyPxXDAwoeH2E+f0FDyvngtWPEr67w=";
+      rev = "b43f3999b0c5a40b43ceee258fbe6bb8245d06af";
+      hash = "sha256-tf5mYIV368Y2cgYJ0U4OZQxuN6kldHUKi9oSjAHbA4Y=";
     };
   };
 }


### PR DESCRIPTION
Also other sources were updated:
- cbqn-bytecode: 0-unstable-2024-05-22 -> 0-unstable-2024-09-15
- replxx: didn't change
- singeli: 0-unstable-2024-02-26 -> 0-unstable-2024-09-29

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
