### PR TITLE
xlockmore: set mainprogram to xlock

### DIFF
--- a/pkgs/misc/screensavers/xlockmore/default.nix
+++ b/pkgs/misc/screensavers/xlockmore/default.nix
@@ -38,5 +38,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ pSub ];
     platforms = platforms.linux;
+    mainProgram = "xlock";
   };
 }


### PR DESCRIPTION
This allows using `nix run nixpkgs#xlockmore`.
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
