### PR TITLE
mpvScripts.mpv-image-viewer: init at 0-unstable-2023-03-03

### DIFF
--- a/pkgs/applications/video/mpv/scripts/mpv-image-viewer.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-image-viewer.nix
@@ -1,0 +1,58 @@
+{
+  buildLua,
+  fetchFromGitHub,
+  lib,
+  unstableGitUpdater,
+}:
+let
+  mkScript =
+    pname: args:
+    let
+      self = {
+        inherit pname;
+        version = "0-unstable-2023-03-03";
+        src = fetchFromGitHub {
+          owner = "occivink";
+          repo = "mpv-image-viewer";
+          rev = "efc82147cba4809f22e9afae6ed7a41ad9794ffd";
+          hash = "sha256-H7uBwrIb5uNEr3m+rHED/hO2CHypGu7hbcRpC30am2Q=";
+        };
+
+        sourceRoot = "source/scripts";
+
+        passthru = {
+          updateScript = unstableGitUpdater { };
+        };
+
+        meta = {
+          description = "Configuration, scripts and tips for using mpv as an image viewer";
+          longDescription = ''
+            ${pname} is a component of mpv-image-viewer.
+
+            mpv-image-viewer aggregates configurations, scripts and tips for using
+            mpv as an image viewer. The affectionate nickname mvi is given to mpv in
+            such case.
+
+            Each mpv-image-viewer script can be used on its own without depending on
+            any of the others. Refer to the README and script-opts/ directory for
+            additional configuration tips or examples.
+          '';
+          homepage = "https://github.com/occivink/mpv-image-viewer";
+          license = lib.licenses.unlicense;
+          maintainers = with lib.maintainers; [ colinsane ];
+        };
+      };
+    in
+    buildLua (lib.attrsets.recursiveUpdate self args);
+in
+lib.recurseIntoAttrs (
+  lib.mapAttrs (name: lib.makeOverridable (mkScript name)) {
+    detect-image.meta.description = "Allows you to run specific commands when images are being displayed. Does not do anything by default, needs to be configured through detect_image.conf";
+    equalizer = { };
+    freeze-window.meta.description = "By default, mpv automatically resizes the window when the current file changes to fit its size. This script freezes the window so that this does not happen. There is no configuration";
+    image-positioning.meta.description = "Adds several high-level commands to zoom and pan";
+    minimap.meta.description = "Adds a minimap that displays the position of the image relative to the view";
+    ruler.meta.description = "Adds a ruler command that lets you measure positions, distances and angles in the image. Can be configured through ruler.conf";
+    status-line.meta.description = "Adds a status line that can show different properties in the corner of the window. By default it shows filename [positon/total] in the bottom left";
+  }
+)


### PR DESCRIPTION
packages [mpv-image-viewer](https://github.com/occivink/mpv-image-viewer). these are all independent, managed under one umbrella project. example usage:

```sh
$ nix-shell -E 'mpv.override { scripts = [ mpvScripts.mpv-image-viewer.image-positioning ]; }'
[nix-shell]$ echo 'CTRL+MBTN_LEFT script-binding drag-to-pan' | mpv --input-conf=/dev/stdin --pause 'https://github.com/NixOS/nixos-artwork/blob/master/wallpapers/NixOS-Gradient-grey.png?raw=true'

# zoom the image with default mpv controls (control + mouse wheel)
# and observe that holding control + left mouse button now allows to pan when zoomed in,
# whereas stock `mpv` does not implement any panning function
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
