### PR TITLE
libvpl: 2.10.1 -> 2.13.0

### DIFF
--- a/pkgs/by-name/li/libvpl/package.nix
+++ b/pkgs/by-name/li/libvpl/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libvpl";
-  version = "2.10.1";
+  version = "2.13.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "libvpl";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-2yfJo4iwI/h0CJ+mJJ3cAyG5S7KksUibwJHebF3MR+E=";
+    hash = "sha256-H+pRdpk1B/QgsXaTxhQfm3JW5Plgz4esrUV1kKfjY1s=";
   };
 
   nativeBuildInputs = [
@@ -24,13 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-      "-DENABLE_DRI3=ON"
-      "-DENABLE_DRM=ON"
-      "-DENABLE_VA=ON"
-      "-DENABLE_WAYLAND=ON"
-      "-DENABLE_X11=ON"
-      "-DINSTALL_EXAMPLE_CODE=OFF"
-      "-DBUILD_TOOLS=OFF"
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   patches = [
@@ -39,6 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
       inherit (addDriverRunpath) driverLink;
     })
   ];
+
+  doCheck = true;
 
   meta = with lib; {
     description = "Intel Video Processing Library";


### PR DESCRIPTION
## Things done

* https://github.com/intel/libvpl/releases/tag/v2.10.2
* https://github.com/intel/libvpl/releases/tag/v2.11.0
* https://github.com/intel/libvpl/releases/tag/v2.12.0
* https://github.com/intel/libvpl/releases/tag/v2.13.0

There were many changes, including the refactoring of tools into a separate repository in v2.11.0, which changed some flags.
> Removed
>    Command line tools. They have been moved to a separate repository
    (https://github.com/intel/libvpl-tools)

Upstream also created tags like v2023.4.0, but these are older than the 2.x.y. releases. This confuses repology and r-ryantm.

Closes #281079 which is indeed a downgrade. But since r-ryantm remains confused about the versions, it could well be that it will generate another downgrade soon again.

Enabled unit tests.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>obs-studio-plugins.advanced-scene-switcher</li>
  </ul>
</details>
<details>
  <summary>39 packages built:</summary>
  <ul>
    <li>libvpl</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.droidcam-obs</li>
    <li>obs-studio-plugins.input-overlay</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-3d-effect</li>
    <li>obs-studio-plugins.obs-backgroundremoval</li>
    <li>obs-studio-plugins.obs-command-source</li>
    <li>obs-studio-plugins.obs-composite-blur</li>
    <li>obs-studio-plugins.obs-freeze-filter</li>
    <li>obs-studio-plugins.obs-gradient-source</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-hyperion</li>
    <li>obs-studio-plugins.obs-livesplit-one</li>
    <li>obs-studio-plugins.obs-move-transition</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-mute-filter</li>
    <li>obs-studio-plugins.obs-ndi</li>
    <li>obs-studio-plugins.obs-nvfbc</li>
    <li>obs-studio-plugins.obs-pipewire-audio-capture</li>
    <li>obs-studio-plugins.obs-replay-source</li>
    <li>obs-studio-plugins.obs-rgb-levels-filter</li>
    <li>obs-studio-plugins.obs-scale-to-sound</li>
    <li>obs-studio-plugins.obs-shaderfilter</li>
    <li>obs-studio-plugins.obs-source-clone</li>
    <li>obs-studio-plugins.obs-source-record</li>
    <li>obs-studio-plugins.obs-source-switcher</li>
    <li>obs-studio-plugins.obs-teleport</li>
    <li>obs-studio-plugins.obs-text-pthread</li>
    <li>obs-studio-plugins.obs-transition-table</li>
    <li>obs-studio-plugins.obs-tuna</li>
    <li>obs-studio-plugins.obs-vaapi</li>
    <li>obs-studio-plugins.obs-vertical-canvas</li>
    <li>obs-studio-plugins.obs-vintage-filter</li>
    <li>obs-studio-plugins.obs-vkcapture</li>
    <li>obs-studio-plugins.obs-webkitgtk</li>
    <li>obs-studio-plugins.obs-websocket</li>
    <li>obs-studio-plugins.waveform</li>
    <li>obs-studio-plugins.wlrobs</li>
  </ul>
</details>

advanced-scene-switcher currently [fails on Hydra](https://hydra.nixos.org/build/273947613) and seems unrelated to this change.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
