### PR TITLE
unixODBCDrivers.mdb: init as mdbtools alias

### DIFF
--- a/pkgs/by-name/md/mdbtools/package.nix
+++ b/pkgs/by-name/md/mdbtools/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       gpl2Plus
       lgpl2
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ geoffreyfrogeye ];
     platforms = platforms.unix;
     inherit (src.meta) homepage;
   };

--- a/pkgs/by-name/md/mdbtools/package.nix
+++ b/pkgs/by-name/md/mdbtools/package.nix
@@ -53,6 +53,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  passthru = lib.optionalAttrs withUnixODBC {
+    fancyName = "MDBTools";
+    driver = "lib/odbc/libmdbodbc.so";
+  };
+
   meta = with lib; {
     description = ".mdb (MS Access) format tools";
     license = with licenses; [

--- a/pkgs/by-name/md/mdbtools/package.nix
+++ b/pkgs/by-name/md/mdbtools/package.nix
@@ -10,6 +10,10 @@
   autoreconfHook,
   txt2man,
   which,
+  withLibiodbc ? false,
+  libiodbc,
+  withUnixODBC ? true,
+  unixODBC,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,18 +27,24 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-XWkFgQZKx9/pjVNEqfp9BwgR7w3fVxQ/bkJEYUvCXPs=";
   };
 
-  configureFlags = [ "--disable-scrollkeeper" ];
+  configureFlags =
+    [ "--disable-scrollkeeper" ]
+    ++ lib.optional withUnixODBC "--with-unixodbc=${unixODBC}"
+    ++ lib.optional withLibiodbc "--with-iodbc=${libiodbc}";
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=unused-but-set-variable";
 
-  nativeBuildInputs = [
-    pkg-config
-    bison
-    flex
-    autoreconfHook
-    txt2man
-    which
-  ];
+  nativeBuildInputs =
+    [
+      pkg-config
+      bison
+      flex
+      autoreconfHook
+      txt2man
+      which
+    ]
+    ++ lib.optional withLibiodbc libiodbc
+    ++ lib.optional withUnixODBC unixODBC;
 
   buildInputs = [
     glib

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -17,6 +17,7 @@
   fixDarwinDylibNames,
   fetchFromGitHub,
   psqlodbc,
+  mdbtools,
 }:
 
 # Each of these ODBC drivers can be configured in your odbcinst.ini file using
@@ -375,5 +376,10 @@
       platforms = platforms.linux;
       maintainers = with maintainers; [ sir4ur0n ];
     };
+  };
+
+  mdb = mdbtools.override {
+    withUnixODBC = true;
+    withLibiodbc = false;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

mdbtools, allows building a OCBD driver compatible with both unixOBCD and libiodbc. While it is in nixpkgs already, it doesn't allow to do so. This changes allows just that, and also adds unixODBCDrivers.mdb as an alias, and me as a maintainer, because why not.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
