### PR TITLE
CODEOWNERS: Fix non-matching patterns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 /lib/cli.nix                @infinisil @Profpatsch
 /lib/debug.nix              @infinisil @Profpatsch
 /lib/asserts.nix            @infinisil @Profpatsch
-/lib/path.*                 @infinisil
+/lib/path/*                 @infinisil
 /lib/fileset                @infinisil
 ## Libraries / Module system
 /lib/modules.nix            @infinisil @roberth
@@ -107,7 +107,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 /nixos/lib/test-driver  @tfc
 
 # NixOS QEMU virtualisation
-/nixos/virtualisation/qemu-vm.nix           @raitobezarius
+/nixos/modules/virtualisation/qemu-vm.nix           @raitobezarius
 
 # ACME
 /nixos/modules/security/acme                @arianvp @flokli @aanderse @emilazy # no merge permission: @m1cr0man
@@ -172,7 +172,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 # Audio
 /nixos/modules/services/audio/botamusique.nix @mweinelt
 /nixos/modules/services/audio/snapserver.nix @mweinelt
-/nixos/tests/modules/services/audio/botamusique.nix @mweinelt
+/nixos/tests/botamusique.nix @mweinelt
 /nixos/tests/snapcast.nix @mweinelt
 
 # Browsers
@@ -206,21 +206,20 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 
 # PostgreSQL and related stuff
 /pkgs/servers/sql/postgresql @thoughtpolice
-/nixos/modules/services/databases/postgresql.xml @thoughtpolice
+/nixos/modules/services/databases/postgresql.md @thoughtpolice
 /nixos/modules/services/databases/postgresql.nix @thoughtpolice
 /nixos/tests/postgresql.nix @thoughtpolice
 
 # Hardened profile & related modules
 /nixos/modules/profiles/hardened.nix @joachifm
-/nixos/modules/security/hidepid.nix @joachifm
 /nixos/modules/security/lock-kernel-modules.nix @joachifm
 /nixos/modules/security/misc.nix @joachifm
 /nixos/tests/hardened.nix @joachifm
-/pkgs/os-specific/linux/kernel/hardened-config.nix @joachifm
+/pkgs/os-specific/linux/kernel/hardened/config.nix @joachifm
 
 # Home Automation
-/nixos/modules/services/misc/home-assistant.nix @mweinelt
-/nixos/modules/services/misc/zigbee2mqtt.nix @mweinelt
+/nixos/modules/services/home-automation/home-assistant.nix @mweinelt
+/nixos/modules/services/home-automation/zigbee2mqtt.nix @mweinelt
 /nixos/tests/home-assistant.nix @mweinelt
 /nixos/tests/zigbee2mqtt.nix @mweinelt
 /pkgs/servers/home-assistant @mweinelt
@@ -318,8 +317,6 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 
 # nim
 /pkgs/development/compilers/nim   @ehmry
-/pkgs/development/nim-packages    @ehmry
-/pkgs/top-level/nim-packages.nix  @ehmry
 
 # terraform providers
 /pkgs/applications/networking/cluster/terraform-providers @zowoq


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/336261 we have CI that checks that the codeowners file is valid:

https://github.com/NixOS/nixpkgs/actions/runs/11243668280/job/31260095472#step:7:34

Which files are correct (or whether they were removed) was determined using the Git history and some grepping

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
