### PR TITLE
python3Packages.plover-lapwing-aio: init at 1.3.4

### DIFF
--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -1,37 +1,65 @@
-{ lib, fetchFromGitHub, python3Packages, wmctrl, qtbase, mkDerivationWith }:
-
 {
-  stable = throw "plover.stable was removed because it used Python 2. Use plover.dev instead."; # added 2022-06-05
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  wmctrl,
+  buildPythonPackage,
+  pytest,
+  mock,
+  babel,
+  pyqt5,
+  xlib,
+  pyserial,
+  appdirs,
+  wcwidth,
+  setuptools,
+  rtf-tokenize,
+  plover-stroke,
+  wrapQtAppsHook,
+}:
+buildPythonPackage rec {
+  pname = "plover";
+  version = "4.0.0rc2";
 
-  dev = with python3Packages; mkDerivationWith buildPythonPackage rec {
-    pname = "plover";
-    version = "4.0.0.dev10";
-
-    meta = with lib; {
-      broken = stdenv.hostPlatform.isDarwin;
-      description = "OpenSteno Plover stenography software";
-      maintainers = with maintainers; [ twey kovirobi ];
-      license     = licenses.gpl2;
-    };
-
-    src = fetchFromGitHub {
-      owner = "openstenoproject";
-      repo = "plover";
-      rev = "v${version}";
-      sha256 = "sha256-oJ7+R3ZWhUbNTTAw1AfMg2ur8vW1XEbsa5FgSTam1Ns=";
-    };
-
-    # I'm not sure why we don't find PyQt5 here but there's a similar
-    # sed on many of the platforms Plover builds for
-    postPatch = "sed -i /PyQt5/d setup.cfg";
-
-    nativeCheckInputs           = [ pytest mock ];
-    propagatedBuildInputs = [ babel pyqt5 xlib pyserial appdirs wcwidth setuptools ];
-
-    dontWrapQtApps = true;
-
-    preFixup = ''
-      makeWrapperArgs+=("''${qtWrapperArgs[@]}")
-    '';
+  meta = with lib; {
+    broken = stdenv.hostPlatform.isDarwin;
+    description = "OpenSteno Plover stenography software";
+    maintainers = with maintainers; [
+      twey
+      kovirobi
+    ];
+    license = licenses.gpl2;
   };
+
+  src = fetchFromGitHub {
+    owner = "openstenoproject";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-rmMec/BbvOJ92u8Tmp3Kv2YezzJxB/L8UrDntTDSKj4=";
+  };
+
+  # I'm not sure why we don't find PyQt5 here but there's a similar
+  # sed on many of the platforms Plover builds for
+  postPatch = "sed -i /PyQt5/d setup.cfg";
+
+  nativeCheckInputs = [
+    pytest
+    mock
+  ];
+  nativeBuildInputs = [ wrapQtAppsHook ];
+  propagatedBuildInputs = [
+    babel
+    pyqt5
+    xlib
+    pyserial
+    appdirs
+    wcwidth
+    setuptools
+    rtf-tokenize
+    plover-stroke
+  ];
+
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
 }

--- a/pkgs/development/python-modules/plover-dict-commands/default.nix
+++ b/pkgs/development/python-modules/plover-dict-commands/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  plover,
+  setuptools,
+  setuptools-scm,
+  pythonImportsCheckHook,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "plover-dict-commands";
+  version = "0.2.5";
+  pyproject = true;
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  meta = with lib; {
+    description = "Plugin for enabling, disabling, and changing the priority of dictionaries in Plover";
+    maintainers = with maintainers; [ twey ];
+    license = licenses.gpl2Plus;
+  };
+
+  src = fetchPypi {
+    pname = "plover_dict_commands";
+    inherit version;
+    hash = "sha256-ki/M5V106YbQMjZQmkTNyBzFboVYi/x0hkLAXqPyk8Q=";
+  };
+
+  nativeCheckInputs = [
+    pythonImportsCheckHook
+  ];
+
+  propagatedBuildInputs = [ plover ];
+}

--- a/pkgs/development/python-modules/plover-lapwing-aio/default.nix
+++ b/pkgs/development/python-modules/plover-lapwing-aio/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  plover,
+  plover-dict-commands,
+  plover-last-translation,
+  plover-modal-dictionary,
+  plover-python-dictionary,
+  plover-stitching,
+  setuptools,
+  pythonImportsCheckHook,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "plover-lapwing-aio";
+  version = "1.3.4";
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  meta = with lib; {
+    description = "Automatically installs all the necessary plugins and dictionaries for using Lapwing theory with Plover";
+    maintainers = with maintainers; [ twey ];
+    license = licenses.gpl2Plus;
+  };
+
+  src = fetchPypi {
+    pname = "plover_lapwing_aio";
+    inherit version;
+    hash = "sha256-0GqmWGe5uN2JfnH/XMWrIH5As3xueREBU6nk3gGi3Vw=";
+  };
+
+  nativeCheckInputs = [
+    pythonImportsCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    plover
+    plover-dict-commands
+    plover-last-translation
+    plover-modal-dictionary
+    plover-python-dictionary
+    plover-stitching
+  ];
+}

--- a/pkgs/development/python-modules/plover-last-translation/default.nix
+++ b/pkgs/development/python-modules/plover-last-translation/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  plover,
+  setuptools,
+  pythonImportsCheckHook,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "plover-last-translation";
+  version = "0.0.2";
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  meta = with lib; {
+    description = "Macro plugins for Plover to repeat output";
+    maintainers = with maintainers; [ twey ];
+    license = licenses.gpl2Plus;
+  };
+
+  src = fetchPypi {
+    pname = "plover_last_translation";
+    inherit version;
+    hash = "sha256-lmgjbuwdqZ8eeU4m/d1akFwwj5CmliEaLmXEKAubjdk=";
+  };
+
+  nativeCheckInputs = [
+    pythonImportsCheckHook
+  ];
+
+  propagatedBuildInputs = [ plover ];
+}

--- a/pkgs/development/python-modules/plover-modal-dictionary/default.nix
+++ b/pkgs/development/python-modules/plover-modal-dictionary/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  plover,
+  setuptools,
+  pythonImportsCheckHook,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "plover-modal-dictionary";
+  version = "0.0.3";
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  meta = with lib; {
+    description = "Modal Dictionaries for Plover";
+    maintainers = with maintainers; [ twey ];
+    license = licenses.gpl2Plus;
+  };
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-qLr5H6ZvPhzG4Wa6dK45iReABO0EvA5+2afp2ctnc1A=";
+  };
+
+  nativeCheckInputs = [
+    pythonImportsCheckHook
+  ];
+
+  propagatedBuildInputs = [ plover ];
+}

--- a/pkgs/development/python-modules/plover-python-dictionary/default.nix
+++ b/pkgs/development/python-modules/plover-python-dictionary/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  plover,
+  setuptools,
+  pytestCheckHook,
+  pythonImportsCheckHook,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "plover-python-dictionary";
+  version = "1.1.0";
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  meta = with lib; {
+    description = "Add support for Python dictionaries to Plover.";
+    maintainers = with maintainers; [ twey ];
+    license = licenses.gpl2Plus;
+  };
+
+  src = fetchPypi {
+    pname = "plover_python_dictionary";
+    inherit version;
+    hash = "sha256-YlHTmMtKWUadObGbsrsF+PUspCB4Kr+amy57DQ4eCQs=";
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pythonImportsCheckHook
+  ];
+
+  propagatedBuildInputs = [ plover ];
+}

--- a/pkgs/development/python-modules/plover-stitching/default.nix
+++ b/pkgs/development/python-modules/plover-stitching/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  plover,
+  setuptools,
+  pythonImportsCheckHook,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "plover-stitching";
+  version = "0.1.0";
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  meta = with lib; {
+    description = "Write stitched words like T-H-I-S or define stitched sequences like heh-heh-heh";
+    maintainers = with maintainers; [ twey ];
+    license = licenses.gpl2Plus;
+  };
+
+  src = fetchPypi {
+    pname = "plover_stitching";
+    inherit version;
+    hash = "sha256-08wsVTf89kKattOM0Uj/R/heW9zSX7JQBcza8aJJwxc=";
+  };
+
+  # pytestCheckHook disabled because tests rely on an old Plover
+  # testing API
+  nativeCheckInputs = [
+    pythonImportsCheckHook
+  ];
+
+  propagatedBuildInputs = [ plover ];
+}

--- a/pkgs/development/python-modules/plover-stroke/default.nix
+++ b/pkgs/development/python-modules/plover-stroke/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  setuptools,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "plover-stroke";
+  version = "1.1.0";
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  meta = with lib; {
+    description = "Helper class for working with steno strokes";
+    maintainers = with maintainers; [ twey ];
+    license = licenses.gpl2Plus;
+  };
+
+  src = fetchPypi {
+    pname = "plover_stroke";
+    inherit version;
+    hash = "sha256-3gOyP0ruZrZfaffU7MQjNoG0NUFQLYa/FP3inqpy0VM=";
+  };
+}

--- a/pkgs/development/python-modules/plover/default.nix
+++ b/pkgs/development/python-modules/plover/default.nix
@@ -24,11 +24,8 @@ buildPythonPackage rec {
   meta = with lib; {
     broken = stdenv.hostPlatform.isDarwin;
     description = "OpenSteno Plover stenography software";
-    maintainers = with maintainers; [
-      twey
-      kovirobi
-    ];
-    license = licenses.gpl2;
+    maintainers = with maintainers; [ twey kovirobi ];
+    license     = licenses.gpl2;
   };
 
   src = fetchFromGitHub {
@@ -42,22 +39,9 @@ buildPythonPackage rec {
   # sed on many of the platforms Plover builds for
   postPatch = "sed -i /PyQt5/d setup.cfg";
 
-  nativeCheckInputs = [
-    pytest
-    mock
-  ];
+  nativeCheckInputs = [ pytest mock ];
   nativeBuildInputs = [ wrapQtAppsHook ];
-  propagatedBuildInputs = [
-    babel
-    pyqt5
-    xlib
-    pyserial
-    appdirs
-    wcwidth
-    setuptools
-    rtf-tokenize
-    plover-stroke
-  ];
+  propagatedBuildInputs = [ babel pyqt5 xlib pyserial appdirs wcwidth setuptools rtf-tokenize plover-stroke ];
 
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")

--- a/pkgs/development/python-modules/plover/default.nix
+++ b/pkgs/development/python-modules/plover/default.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   wmctrl,
+  python3Packages,
   buildPythonPackage,
   pytest,
   mock,
@@ -17,33 +18,63 @@
   plover-stroke,
   wrapQtAppsHook,
 }:
-buildPythonPackage rec {
-  pname = "plover";
-  version = "4.0.0rc2";
+let
+  plover = python3Packages.buildPythonPackage rec {
+    pname = "plover";
+    version = "4.0.0rc2";
+    pyproject = true;
+    build-system = [ setuptools ];
 
-  meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
-    description = "OpenSteno Plover stenography software";
-    maintainers = with maintainers; [ twey kovirobi ];
-    license     = licenses.gpl2;
+    meta = with lib; {
+      broken = stdenv.hostPlatform.isDarwin;
+      description = "OpenSteno Plover stenography software";
+      maintainers = with maintainers; [
+        twey
+        kovirobi
+      ];
+      license = licenses.gpl2;
+    };
+
+    src = fetchFromGitHub {
+      owner = "openstenoproject";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "sha256-rmMec/BbvOJ92u8Tmp3Kv2YezzJxB/L8UrDntTDSKj4=";
+    };
+
+    # I'm not sure why we don't find PyQt5 here but there's a similar
+    # sed on many of the platforms Plover builds for
+    postPatch = "sed -i /PyQt5/d setup.cfg";
+
+    nativeCheckInputs = [
+      pytest
+      mock
+    ];
+    nativeBuildInputs = [ wrapQtAppsHook ];
+    propagatedBuildInputs = [
+      babel
+      pyqt5
+      xlib
+      pyserial
+      appdirs
+      wcwidth
+      setuptools
+      rtf-tokenize
+      plover-stroke
+    ];
+
+    preFixup = ''
+      makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+    '';
   };
 
-  src = fetchFromGitHub {
-    owner = "openstenoproject";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-rmMec/BbvOJ92u8Tmp3Kv2YezzJxB/L8UrDntTDSKj4=";
-  };
-
-  # I'm not sure why we don't find PyQt5 here but there's a similar
-  # sed on many of the platforms Plover builds for
-  postPatch = "sed -i /PyQt5/d setup.cfg";
-
-  nativeCheckInputs = [ pytest mock ];
-  nativeBuildInputs = [ wrapQtAppsHook ];
-  propagatedBuildInputs = [ babel pyqt5 xlib pyserial appdirs wcwidth setuptools rtf-tokenize plover-stroke ];
-
-  preFixup = ''
-    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
-  '';
+  plugins = lib.attrsets.mapAttrs' (name: value: {
+    name = builtins.substring 7 (builtins.stringLength name) name;
+    inherit value;
+  }) (lib.attrsets.filterAttrs (k: v: lib.strings.hasPrefix "plover-" k) python3Packages);
+in
+plover
+// {
+  inherit plugins;
+  withPlugins = ps: python3Packages.python.withPackages (_: ps plugins);
 }

--- a/pkgs/development/python-modules/rtf-tokenize/default.nix
+++ b/pkgs/development/python-modules/rtf-tokenize/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "rtf-tokenize";
+  version = "1.0.0";
+
+  meta = with lib; {
+    description = "A simple RTF tokenizer";
+    maintainers = with maintainers; [ twey ];
+    license = licenses.gpl2Plus;
+  };
+
+  src = fetchPypi {
+    pname = "rtf_tokenize";
+    inherit version;
+    hash = "sha256-XD3zkNAEeb12N8gjv81v37Id3RuWroFUY95+HtOS1gg=";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31986,9 +31986,7 @@ with pkgs;
 
   plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };
 
-  plover = python3Packages.callPackage ../applications/misc/plover {
-    inherit (libsForQt5) wrapQtAppsHook;
-  };
+  plover = python3Packages.plover;
 
   plugdata = callPackage ../applications/audio/plugdata { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31986,7 +31986,9 @@ with pkgs;
 
   plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };
 
-  plover = recurseIntoAttrs (libsForQt5.callPackage ../applications/misc/plover { });
+  plover = python3Packages.callPackage ../applications/misc/plover {
+    inherit (libsForQt5) wrapQtAppsHook;
+  };
 
   plugdata = callPackage ../applications/audio/plugdata { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9898,6 +9898,8 @@ self: super: with self; {
 
   plover-dict-commands = callPackage ../development/python-modules/plover-dict-commands { };
 
+  plover-lapwing-aio = callPackage ../development/python-modules/plover-lapwing-aio { };
+
   plover-last-translation = callPackage ../development/python-modules/plover-last-translation { };
 
   plover-modal-dictionary = callPackage ../development/python-modules/plover-modal-dictionary { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9896,6 +9896,8 @@ self: super: with self; {
     inherit (pkgs.libsForQt5) wrapQtAppsHook;
   };
 
+  plover-dict-commands = callPackage ../development/python-modules/plover-dict-commands { };
+
   plover-stitching = callPackage ../development/python-modules/plover-stitching { };
 
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9896,6 +9896,8 @@ self: super: with self; {
     inherit (pkgs.libsForQt5) wrapQtAppsHook;
   };
 
+  plover-stitching = callPackage ../development/python-modules/plover-stitching { };
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   micloud = callPackage ../development/python-modules/micloud { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9902,6 +9902,8 @@ self: super: with self; {
 
   plover-modal-dictionary = callPackage ../development/python-modules/plover-modal-dictionary { };
 
+  plover-python-dictionary = callPackage ../development/python-modules/plover-python-dictionary { };
+
   plover-stitching = callPackage ../development/python-modules/plover-stitching { };
 
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9892,6 +9892,10 @@ self: super: with self; {
 
   pkg-about = callPackage ../development/python-modules/pkg-about { };
 
+  plover = callPackage ../development/python-modules/plover {
+    inherit (pkgs.libsForQt5) wrapQtAppsHook;
+  };
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   micloud = callPackage ../development/python-modules/micloud { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9900,6 +9900,8 @@ self: super: with self; {
 
   plover-last-translation = callPackage ../development/python-modules/plover-last-translation { };
 
+  plover-modal-dictionary = callPackage ../development/python-modules/plover-modal-dictionary { };
+
   plover-stitching = callPackage ../development/python-modules/plover-stitching { };
 
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9898,6 +9898,8 @@ self: super: with self; {
 
   plover-dict-commands = callPackage ../development/python-modules/plover-dict-commands { };
 
+  plover-last-translation = callPackage ../development/python-modules/plover-last-translation { };
+
   plover-stitching = callPackage ../development/python-modules/plover-stitching { };
 
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13837,6 +13837,8 @@ self: super: with self; {
 
   rstr = callPackage ../development/python-modules/rstr { };
 
+  rtf-tokenize = callPackage ../development/python-modules/rtf-tokenize { };
+
   rtmidi-python = callPackage ../development/python-modules/rtmidi-python {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreAudio CoreMIDI CoreServices;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9892,6 +9892,8 @@ self: super: with self; {
 
   pkg-about = callPackage ../development/python-modules/pkg-about { };
 
+  plover-stroke = callPackage ../development/python-modules/plover-stroke { };
+
   micloud = callPackage ../development/python-modules/micloud { };
 
   mqtt2influxdb = callPackage ../development/python-modules/mqtt2influxdb { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is the last PR in a series of PRs that:

- updates `plover` from `4.0.0.dev10` to the more recent `4.0.0rc2`
- adds a couple of new dependencies to `pythonPackages`
- moves `plover` from `applications/misc` to `development/python-modules` to allow using it as a dependency for the plugins
- adds a `withPlugins` function to `plover`
- adds the `plover-lapwing-aio` plugin and its dependencies

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
