### PR TITLE
tomato-c: 2023-8-21 → 2024-4-19

### DIFF
--- a/pkgs/by-name/to/tomato-c/package.nix
+++ b/pkgs/by-name/to/tomato-c/package.nix
@@ -1,39 +1,29 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, fetchpatch
-, libnotify
-, makeWrapper
-, mpv
-, ncurses
-, pkg-config
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  libnotify,
+  makeWrapper,
+  mpv,
+  ncurses,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tomato-c";
-  version = "unstable-2023-08-21";
+  version = "0-unstable-2024-04-19";
 
   src = fetchFromGitHub {
     owner = "gabrielzschmitz";
     repo = "Tomato.C";
-    rev = "6e43e85aa15f3d96811311a3950eba8ce9715634";
-    hash = "sha256-RpKkQ7xhM2XqfZdXra0ju0cTBL3Al9NMVQ/oleFydDs=";
+    rev = "b3b85764362a7c120f3312f5b618102a4eac9f01";
+    hash = "sha256-7i+vn1dAK+bAGpBlKTnSBUpyJyRiPc7AiUF/tz+RyTI=";
   };
-
-  patches = [
-    # Adds missing function declarations required by newer versions of clang.
-    (fetchpatch {
-      url = "https://github.com/gabrielzschmitz/Tomato.C/commit/ad6d4c385ae39d655a716850653cd92431c1f31e.patch";
-      hash = "sha256-3ormv59Ce4rOmeyL30QET3CCUIOrRYMquub+eIQsMW8=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace Makefile \
       --replace-fail "sudo " ""
-    # Need to define _ISOC99_SOURCE to use `snprintf` on Darwin
-    substituteInPlace config.mk \
-      --replace-fail -D_POSIX_C_SOURCE -D_ISOC99_SOURCE
     substituteInPlace notify.c \
       --replace-fail "/usr/local" "${placeholder "out"}"
     substituteInPlace util.c \
@@ -65,7 +55,12 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     for file in $out/bin/*; do
       wrapProgram $file \
-        --prefix PATH : ${lib.makeBinPath [ libnotify mpv ]}
+        --prefix PATH : ${
+          lib.makeBinPath [
+            libnotify
+            mpv
+          ]
+        }
     done
   '';
 


### PR DESCRIPTION
Requested in #346890

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
