### PR TITLE
cvs: use ssh instead of rsh.

### DIFF
--- a/pkgs/applications/version-management/cvs/default.nix
+++ b/pkgs/applications/version-management/cvs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, nano }:
+{ lib, stdenv, fetchurl, fetchpatch, nano, runCommand }:
 
 stdenv.mkDerivation rec {
   pname = "cvs";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "mirror://savannah/cvs/source/feature/${version}/cvs-${version}.tar.bz2";
     sha256 = "0pjir8cwn0087mxszzbsi1gyfc6373vif96cw4q3m1x6p49kd1bq";
   };
+
+  fake-ssh = runCommand "fakeSsh" {} ''
+    mkdir -p $out/bin
+    touch $out/bin/ssh
+    chmod +x $out/bin/ssh
+  '';
+
+  buildInputs = [fake-ssh];
 
   patches = [
     ./getcwd-chroot.patch


### PR DESCRIPTION
If no ssh executable can be found during the configure phase, CVS defaults to using rsh for remote connections instead. This seems undesirable in 2024.

## Things done

- Added the `openssh` package to the build inputs so that the `ssh` executable is found by configure.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
