### PR TITLE
llvmPackages.stdenv: make Darwin a “system” libc++ platform

### DIFF
--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -12,6 +12,7 @@
   fetchpatch,
   fetchpatch2,
   overrideCC,
+  overrideLibcxx,
   wrapCCWith,
   wrapBintoolsWith,
   buildLlvmTools, # tools, but from the previous stage, for cross
@@ -1097,7 +1098,19 @@ let
         else
           libraries.compiler-rt-libc;
 
-      stdenv = overrideCC stdenv buildLlvmTools.clang;
+      stdenv =
+        let
+          stdenv' = overrideCC stdenv buildLlvmTools.clang;
+        in
+        # Treat libc++ as a “system” library on Darwin where all versions use the same underlying libc++.
+        # Use libcxxStdenv to use a specific version of LLVM and libc++ regardless.
+        if
+          stdenv.targetPlatform.isDarwin
+          && lib.versionOlder metadata.release_version (lib.getVersion stdenv.cc.libcxx)
+        then
+          overrideLibcxx stdenv'
+        else
+          stdenv';
 
       libcxxStdenv = overrideCC stdenv buildLlvmTools.libcxxClang;
 

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -75,8 +75,15 @@ rec {
         ln -s '${lib.getDev llvmLibcxx}/include' "$dev/include"
       '';
     in
+    # Return the stdenv libc++ in case it’s the same version as the LLVM version. This can happen on Darwin
+    # when `overrideLibcxx` is used with an LLVM stdenv version that matches the default LLVM version.
+    if stdenvLibcxxVersion == llvmLibcxxVersion then
+      overrideCC stdenv (stdenv.cc.override {
+        libcxx = stdenvLibcxx;
+        extraPackages = [ pkgs.buildPackages.targetPackages.llvmPackages.compiler-rt ];
+      })
     # Check the version for the stdenv’s libc++ version to avoid trying to override it multiple times.
-    if lib.hasPrefix stdenvLibcxxVersion llvmLibcxxVersion then
+    else if lib.hasPrefix stdenvLibcxxVersion llvmLibcxxVersion then
       stdenv
     else
       overrideCC stdenv (stdenv.cc.override {

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -56,8 +56,8 @@ rec {
     assert stdenv.cc.libcxx != null;
     assert pkgs.stdenv.cc.libcxx != null;
     # only unified libcxx / libcxxabi stdenv's are supported
-    assert lib.versionAtLeast pkgs.stdenv.cc.libcxx.version "12";
-    assert lib.versionAtLeast stdenv.cc.libcxx.version "12";
+    assert lib.versionAtLeast (lib.getVersion pkgs.stdenv.cc.libcxx) "12";
+    assert lib.versionAtLeast (lib.getVersion stdenv.cc.libcxx) "12";
     let
       llvmLibcxxVersion = lib.getVersion llvmLibcxx;
       stdenvLibcxxVersion = lib.getVersion stdenvLibcxx;


### PR DESCRIPTION
This was split off from https://github.com/NixOS/nixpkgs/pull/346043. It updates `overrideLibcxx` to use `tapi` to restrict symbols and updates LLVM to always apply the adapter on Darwin. This aligns Darwin’s behavior regarding LLVM with Linux, which always uses libstdc++ unless you use llvmPackages.libcxxStdenv.

Whether to apply this to pkgsLLVM is an open question. It makes sense to do that there as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
