### PR TITLE
[staging] CODEOWNERS: Fix auto-patchelf path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,7 @@
 /pkgs/build-support/bintools-wrapper             @Ericson2314
 /pkgs/build-support/setup-hooks                  @Ericson2314
 /pkgs/build-support/setup-hooks/auto-patchelf.sh @layus
-/pkgs/build-support/setup-hooks/auto-patchelf.py @layus
+/pkgs/by-name/au/auto-patchelf                   @layus
 /pkgs/pkgs-lib                                   @infinisil
 ## Format generators/serializers
 /pkgs/pkgs-lib/formats/libconfig                 @h7x4


### PR DESCRIPTION
After https://github.com/NixOS/nixpkgs/pull/340162 and https://github.com/NixOS/nixpkgs/pull/336261 it [started failing](https://github.com/NixOS/nixpkgs/actions/runs/11246996195/job/31269748379):

```
[err] line 59: "/pkgs/build-support/setup-hooks/auto-patchelf.py" does not match any files in repository
```

This fixes that.

Ping @layus @philiptaron @Scrumplex 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
