### PR TITLE
draft: nixos/ceph: init ceph-exporter

### DIFF
--- a/nixos/modules/services/network-filesystems/ceph.nix
+++ b/nixos/modules/services/network-filesystems/ceph.nix
@@ -24,7 +24,12 @@ let
     path = [ pkgs.getopt ];
 
     # Don't start services that are not yet initialized
-    unitConfig.ConditionPathExists = "/var/lib/${stateDirectory}/keyring";
+    unitConfig.ConditionPathExists = {
+      # keep the default keyring location for exporters as they are
+      # "client."-type keyring users, and these live in /etc/ceph.
+      "exporter" = "/etc/ceph/${clusterName}.client.${daemonId}.keyring";
+    }.${daemonType} or "/var/lib/${stateDirectory}/keyring";
+
     startLimitBurst =
       if daemonType == "osd" then 30 else if lib.elem daemonType ["mgr" "mds"] then 3 else 5;
     startLimitIntervalSec = 60 * 30;  # 30 mins
@@ -321,6 +326,20 @@ in
         '';
       };
     };
+
+    exporter = {
+      enable = lib.mkEnableOption "Ceph metrics exporter daemon";
+      package = lib.mkPackageOption pkgs "ceph" { };
+      daemons = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [];
+        example = [ "name1" "name2" ];
+        description = ''
+          A list of ceph exporter daemons that should have a service created. The names correspond
+          to the id part in ceph i.e. [ "name1" ] would result in client.name1.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf config.services.ceph.enable {
@@ -339,6 +358,9 @@ in
       }
       { assertion = cfg.mgr.enable -> cfg.mgr.daemons != [];
         message = "have to set id of atleast one MGR if you're going to enable MGR";
+      }
+      { assertion = cfg.exporter.enable -> cfg.exporter.daemons != [];
+        message = "have to set id of atleast one exporter if you're going to enable exporter";
       }
     ];
 
@@ -376,7 +398,8 @@ in
         ++ lib.optional cfg.mds.enable (makeServices "mds" cfg.mds.daemons)
         ++ lib.optional cfg.osd.enable (makeServices "osd" cfg.osd.daemons)
         ++ lib.optional cfg.rgw.enable (makeServices "rgw" cfg.rgw.daemons)
-        ++ lib.optional cfg.mgr.enable (makeServices "mgr" cfg.mgr.daemons);
+        ++ lib.optional cfg.mgr.enable (makeServices "mgr" cfg.mgr.daemons)
+        ++ lib.optional cfg.exporter.enable (makeServices "exporter" cfg.exporter.daemons);
       in
         lib.mkMerge services;
 
@@ -391,7 +414,8 @@ in
         ++ lib.optional cfg.mds.enable (makeTarget "mds")
         ++ lib.optional cfg.osd.enable (makeTarget "osd")
         ++ lib.optional cfg.rgw.enable (makeTarget "rgw")
-        ++ lib.optional cfg.mgr.enable (makeTarget "mgr");
+        ++ lib.optional cfg.mgr.enable (makeTarget "mgr")
+        ++ lib.optional cfg.exporter.enable (makeTarget "exporter");
       in
         lib.mkMerge targets;
 


### PR DESCRIPTION
Add initial support for the ceph-exporter. I'm not too sure of how this turned out, so some discussion would be helpful to crystallize this.

For one, I'm not even certain that cargo-culting the "multi-daemon-per-type approach" makes sense here -- it would at the very least need more switches in the module to control which sockets the daemon has access to, and I'm also not certain it would work in a sane way with multiple clusters (though I suppose that's only really a keyring issue)

Maybe we should forgo this and simply allow a single statically named unit for this service?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
