### PR TITLE
nushellPlugins.units: init at 0.1.2

### DIFF
--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -7,4 +7,5 @@ lib.makeScope newScope (self: with self; {
   query = callPackage ./query.nix { inherit IOKit CoreFoundation; };
   regex = throw "`nu_plugin_regex` is no longer compatible with the current Nushell release.";
   net = callPackage ./net.nix { inherit IOKit CoreFoundation; };
+  units = callPackage ./units.nix { };
 })

--- a/pkgs/shells/nushell/plugins/units.nix
+++ b/pkgs/shells/nushell/plugins/units.nix
@@ -1,0 +1,36 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  pkg-config,
+  nix-update-script,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nushell_plugin_units";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    repo = "nu_plugin_units";
+    owner = "JosephTLyons";
+    rev = "v${version}";
+    hash = "sha256-PS16n4j/dg5/+RaliYA18bStNpAecv9aaY2YKXsgLWY=";
+  };
+  cargoHash = "sha256-pxA+6E5luFHq/N0K/8Xk2LapwDnPqDUEpTYqP/jcc3s=";
+
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+  buildInputs = [ ];
+  cargoBuildFlags = [ "--package nu_plugin_units" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "A nushell plugin for easily converting between common units.";
+    mainProgram = "nu_plugin_units";
+    homepage = "https://github.com/JosephTLyons/nu_plugin_units";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mgttlinger ];
+    platforms = with platforms; all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added nushell plugin units (https://github.com/JosephTLyons/nu_plugin_units) for converting units in the shell.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
