### PR TITLE
deno: 1.46.3 -> 2.0.0, deno_1: init at 1.46.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -205,7 +205,7 @@
 
 - `grafana` has been updated to version 11.1. This version doesn't support setting `http_addr` to a hostname anymore, an IP address is expected.
 
-- `deno` has been updated to v2 which has breaking changes.
+- `deno` has been updated to v2 which has breaking changes. Upstream will be abandoning v1 soon but for now you can use `deno_1` if you are yet to migrate (will be removed prior to cutting a final 24.11 release).
 
 - `knot-dns` has been updated to version 3.4.x. Check the [migration guide](https://www.knot-dns.cz/docs/latest/html/migration.html#upgrade-3-3-x-to-3-4-x) for breaking changes.
 

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -205,6 +205,8 @@
 
 - `grafana` has been updated to version 11.1. This version doesn't support setting `http_addr` to a hostname anymore, an IP address is expected.
 
+- `deno` has been updated to v2 which has breaking changes.
+
 - `knot-dns` has been updated to version 3.4.x. Check the [migration guide](https://www.knot-dns.cz/docs/latest/html/migration.html#upgrade-3-3-x-to-3-4-x) for breaking changes.
 
 - `services.kubernetes.kubelet.clusterDns` now accepts a list of DNS resolvers rather than a single string, bringing the module more in line with the upstream Kubelet configuration schema.

--- a/pkgs/by-name/de/deno/1/librusty_v8.nix
+++ b/pkgs/by-name/de/deno/1/librusty_v8.nix
@@ -1,0 +1,12 @@
+# auto-generated file -- DO NOT EDIT!
+{ fetchLibrustyV8 }:
+
+fetchLibrustyV8 {
+  version = "0.105.0";
+  shas = {
+    x86_64-linux = "sha256-9yON4DNPxm4IUZSLZp9VZtzSRPPWX1tEuQLVJmN8cLs=";
+    aarch64-linux = "sha256-5vAjw2vimjCHKPxjIp5vcwMCWUUDYVlk4QyOeEI0DLY=";
+    x86_64-darwin = "sha256-o4WRkg4ptiJTNMkorn5K+P8xOJwpChM5PqkZCjP076g=";
+    aarch64-darwin = "sha256-ZuWBnvxu1PgDtjtguxtj3BhFO01AChlbjAS0kZUws3A=";
+  };
+}

--- a/pkgs/by-name/de/deno/1/package.nix
+++ b/pkgs/by-name/de/deno/1/package.nix
@@ -1,0 +1,118 @@
+{
+  stdenv,
+  lib,
+  callPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  cmake,
+  protobuf,
+  installShellFiles,
+  libiconv,
+  darwin,
+  librusty_v8 ? callPackage ./librusty_v8.nix {
+    inherit (callPackage ../fetchers.nix { }) fetchLibrustyV8;
+  },
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "deno";
+  version = "1.46.3";
+
+  src = fetchFromGitHub {
+    owner = "denoland";
+    repo = "deno";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-AM6SjcIHo6Koxcnznhkv3cXoKaMy2TEVpiWe/bczDuA=";
+  };
+
+  cargoHash = "sha256-D+CZpb6OTzM5Il0k8GQB7qSONy4myE5yKlaSkLLqHT8=";
+
+  postPatch = ''
+    # upstream uses lld on aarch64-darwin for faster builds
+    # within nix lld looks for CoreFoundation rather than CoreFoundation.tbd and fails
+    substituteInPlace .cargo/config.toml --replace "-fuse-ld=lld " ""
+  '';
+
+  # uses zlib-ng but can't dynamically link yet
+  # https://github.com/rust-lang/libz-sys/issues/158
+  nativeBuildInputs = [
+    # required by libz-ng-sys crate
+    cmake
+    # required by deno_kv crate
+    protobuf
+    installShellFiles
+  ];
+  buildInputs = lib.optionals stdenv.isDarwin (
+    [
+      libiconv
+      darwin.libobjc
+    ]
+    ++ (with darwin.apple_sdk_11_0.frameworks; [
+      Security
+      CoreServices
+      Metal
+      MetalPerformanceShaders
+      Foundation
+      QuartzCore
+    ])
+  );
+
+  buildAndTestSubdir = "cli";
+
+  # work around "error: unknown warning group '-Wunused-but-set-parameter'"
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-unknown-warning-option";
+  # The v8 package will try to download a `librusty_v8.a` release at build time to our read-only filesystem
+  # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
+  env.RUSTY_V8_ARCHIVE = librusty_v8;
+
+  # Tests have some inconsistencies between runs with output integration tests
+  # Skipping until resolved
+  doCheck = false;
+
+  preInstall = ''
+    find ./target -name libswc_common${stdenv.hostPlatform.extensions.sharedLibrary} -delete
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd deno \
+      --bash <($out/bin/deno completions bash) \
+      --fish <($out/bin/deno completions fish) \
+      --zsh <($out/bin/deno completions zsh)
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/deno --help
+    $out/bin/deno --version | grep "deno ${version}"
+    runHook postInstallCheck
+  '';
+
+  passthru.tests = callPackage ./tests { };
+
+  meta = with lib; {
+    homepage = "https://deno.land/";
+    changelog = "https://github.com/denoland/deno/releases/tag/v${version}";
+    description = "Secure runtime for JavaScript and TypeScript";
+    longDescription = ''
+      Deno aims to be a productive and secure scripting environment for the modern programmer.
+      Deno will always be distributed as a single executable.
+      Given a URL to a Deno program, it is runnable with nothing more than the ~15 megabyte zipped executable.
+      Deno explicitly takes on the role of both runtime and package manager.
+      It uses a standard browser-compatible protocol for loading modules: URLs.
+      Among other things, Deno is a great replacement for utility scripts that may have been historically written with
+      bash or python.
+    '';
+    license = licenses.mit;
+    mainProgram = "deno";
+    maintainers = with maintainers; [ jk ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    # NOTE: `aligned_alloc` error on darwin SDK < 10.15. Can't do usual overrideSDK with rust toolchain in current implementation.
+    # Should be fixed with darwin SDK refactor and can be revisited.
+    badPlatforms = [ "x86_64-darwin" ];
+  };
+}

--- a/pkgs/by-name/de/deno/1/tests/basic.ts
+++ b/pkgs/by-name/de/deno/1/tests/basic.ts
@@ -1,0 +1,1 @@
+console.log(1 + 1)

--- a/pkgs/by-name/de/deno/1/tests/default.nix
+++ b/pkgs/by-name/de/deno/1/tests/default.nix
@@ -1,0 +1,79 @@
+{
+  deno,
+  runCommand,
+  lib,
+  testers,
+}:
+let
+  testDenoRun =
+    name:
+    {
+      args ? "",
+      dir ? ./. + "/${name}",
+      file ? "index.ts",
+      expected ? "",
+      expectFailure ? false,
+    }:
+    let
+      command = "deno run ${args} ${dir}/${file}";
+    in
+    runCommand "deno-test-${name}"
+      {
+        nativeBuildInputs = [ deno ];
+        meta.timeout = 60;
+      }
+      ''
+        HOME=$(mktemp -d)
+        if output=$(${command} 2>&1); then
+          if [[ $output =~ '${expected}' ]]; then
+            echo "Test '${name}' passed"
+            touch $out
+          else
+            echo -n ${lib.escapeShellArg command} >&2
+            echo " output did not match what was expected." >&2
+            echo "The expected was:" >&2
+            echo '${expected}' >&2
+            echo "The output was:" >&2
+            echo "$output" >&2
+            exit 1
+          fi
+        else
+          if [[ "${toString expectFailure}" == "1" ]]; then
+            echo "Test '${name}' failed as expected"
+            touch $out
+            exit 0
+          fi
+          echo -n ${lib.escapeShellArg command} >&2
+          echo " returned a non-zero exit code." >&2
+          echo "$output" >&2
+          exit 1
+        fi
+      '';
+in
+(lib.mapAttrs testDenoRun {
+  basic = {
+    dir = ./.;
+    file = "basic.ts";
+    expected = "2";
+  };
+  import-json = {
+    expected = "hello from JSON";
+  };
+  import-ts = {
+    expected = "hello from ts";
+  };
+  read-file = {
+    args = "--allow-read";
+    expected = "hello from a file";
+  };
+  fail-read-file = {
+    expectFailure = true;
+    dir = ./read-file;
+  };
+})
+// {
+  version = testers.testVersion {
+    package = deno;
+    command = "deno --version";
+  };
+}

--- a/pkgs/by-name/de/deno/1/tests/import-json/data.json
+++ b/pkgs/by-name/de/deno/1/tests/import-json/data.json
@@ -1,0 +1,1 @@
+{ "msg": "hello from JSON" }

--- a/pkgs/by-name/de/deno/1/tests/import-json/index.ts
+++ b/pkgs/by-name/de/deno/1/tests/import-json/index.ts
@@ -1,0 +1,2 @@
+import file from "./data.json" assert { type: "json" };
+console.log(file.msg);

--- a/pkgs/by-name/de/deno/1/tests/import-ts/index.ts
+++ b/pkgs/by-name/de/deno/1/tests/import-ts/index.ts
@@ -1,0 +1,3 @@
+import { sayHello } from "./lib.ts"
+
+sayHello("ts")

--- a/pkgs/by-name/de/deno/1/tests/import-ts/lib.ts
+++ b/pkgs/by-name/de/deno/1/tests/import-ts/lib.ts
@@ -1,0 +1,3 @@
+export function sayHello(thing: string) {
+  console.log(`hello from ${thing}`);
+}

--- a/pkgs/by-name/de/deno/1/tests/read-file/data.txt
+++ b/pkgs/by-name/de/deno/1/tests/read-file/data.txt
@@ -1,0 +1,1 @@
+hello from a file

--- a/pkgs/by-name/de/deno/1/tests/read-file/index.ts
+++ b/pkgs/by-name/de/deno/1/tests/read-file/index.ts
@@ -1,0 +1,5 @@
+// trim 'file://' prefix
+const thisDir = Deno.mainModule.substring(7, Deno.mainModule.length);
+const getParent = (path: string) => path.substring(0, path.lastIndexOf("/"))
+const text = await Deno.readTextFile(getParent(thisDir) + "/data.txt");
+console.log(text);

--- a/pkgs/by-name/de/deno/fetchers.nix
+++ b/pkgs/by-name/de/deno/fetchers.nix
@@ -1,0 +1,21 @@
+# not a stable interface, do not reference outside the deno package but make a
+# copy if you need
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+{
+  fetchLibrustyV8 =
+    args:
+    fetchurl {
+      name = "librusty_v8-${args.version}";
+      url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+      sha256 = args.shas.${stdenv.hostPlatform.system};
+      meta = {
+        inherit (args) version;
+        sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      };
+    };
+}

--- a/pkgs/by-name/de/deno/librusty_v8.nix
+++ b/pkgs/by-name/de/deno/librusty_v8.nix
@@ -1,23 +1,12 @@
 # auto-generated file -- DO NOT EDIT!
-{ lib, stdenv, fetchurl }:
+{ fetchLibrustyV8 }:
 
-let
-  fetch_librusty_v8 = args: fetchurl {
-    name = "librusty_v8-${args.version}";
-    url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
-    sha256 = args.shas.${stdenv.hostPlatform.system};
-    meta = {
-      inherit (args) version;
-      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    };
-  };
-in
-fetch_librusty_v8 {
-  version = "0.105.0";
+fetchLibrustyV8 {
+  version = "0.106.0";
   shas = {
-    x86_64-linux = "sha256-9yON4DNPxm4IUZSLZp9VZtzSRPPWX1tEuQLVJmN8cLs=";
-    aarch64-linux = "sha256-5vAjw2vimjCHKPxjIp5vcwMCWUUDYVlk4QyOeEI0DLY=";
-    x86_64-darwin = "sha256-o4WRkg4ptiJTNMkorn5K+P8xOJwpChM5PqkZCjP076g=";
-    aarch64-darwin = "sha256-ZuWBnvxu1PgDtjtguxtj3BhFO01AChlbjAS0kZUws3A=";
+    x86_64-linux = "sha256-jLYl/CJp2Z+Ut6qZlh6u+CtR8KN+ToNTB+72QnVbIKM=";
+    aarch64-linux = "sha256-uAkBMg6JXA+aILd8TzDtuaEdM3Axiw43Ad5tZzxNt5w=";
+    x86_64-darwin = "sha256-60aR0YvQT8KyacY8J3fWKZcf9vny51VUB19NVpurS/A=";
+    aarch64-darwin = "sha256-pd/I6Mclj2/r/uJTIywnolPKYzeLu1c28d/6D56vkzQ=";
   };
 }

--- a/pkgs/by-name/de/deno/tests/default.nix
+++ b/pkgs/by-name/de/deno/tests/default.nix
@@ -1,43 +1,54 @@
-{ deno, runCommand, lib, testers }:
+{
+  deno,
+  runCommand,
+  lib,
+  testers,
+}:
 let
   testDenoRun =
     name:
-    { args ? ""
-    , dir ? ./. + "/${name}"
-    , file ? "index.ts"
-    , expected ? ""
-    , expectFailure ? false
+    {
+      args ? "",
+      dir ? ./. + "/${name}",
+      file ? "index.ts",
+      expected ? "",
+      expectFailure ? false,
     }:
     let
       command = "deno run ${args} ${dir}/${file}";
     in
-    runCommand "deno-test-${name}" { nativeBuildInputs = [ deno ]; meta.timeout = 60; } ''
-      HOME=$(mktemp -d)
-      if output=$(${command} 2>&1); then
-        if [[ $output =~ '${expected}' ]]; then
-          echo "Test '${name}' passed"
-          touch $out
+    runCommand "deno-test-${name}"
+      {
+        nativeBuildInputs = [ deno ];
+        meta.timeout = 60;
+      }
+      ''
+        HOME=$(mktemp -d)
+        if output=$(${command} 2>&1); then
+          if [[ $output =~ '${expected}' ]]; then
+            echo "Test '${name}' passed"
+            touch $out
+          else
+            echo -n ${lib.escapeShellArg command} >&2
+            echo " output did not match what was expected." >&2
+            echo "The expected was:" >&2
+            echo '${expected}' >&2
+            echo "The output was:" >&2
+            echo "$output" >&2
+            exit 1
+          fi
         else
+          if [[ "${toString expectFailure}" == "1" ]]; then
+            echo "Test '${name}' failed as expected"
+            touch $out
+            exit 0
+          fi
           echo -n ${lib.escapeShellArg command} >&2
-          echo " output did not match what was expected." >&2
-          echo "The expected was:" >&2
-          echo '${expected}' >&2
-          echo "The output was:" >&2
+          echo " returned a non-zero exit code." >&2
           echo "$output" >&2
           exit 1
         fi
-      else
-        if [[ "${toString expectFailure}" == "1" ]]; then
-          echo "Test '${name}' failed as expected"
-          touch $out
-          exit 0
-        fi
-        echo -n ${lib.escapeShellArg command} >&2
-        echo " returned a non-zero exit code." >&2
-        echo "$output" >&2
-        exit 1
-      fi
-    '';
+      '';
 in
 (lib.mapAttrs testDenoRun {
   basic = {
@@ -59,8 +70,8 @@ in
     expectFailure = true;
     dir = ./read-file;
   };
-}) //
-{
+})
+// {
   version = testers.testVersion {
     package = deno;
     command = "deno --version";

--- a/pkgs/by-name/de/deno/tests/import-json/index.ts
+++ b/pkgs/by-name/de/deno/tests/import-json/index.ts
@@ -1,2 +1,2 @@
-import file from "./data.json" assert { type: "json" };
+import file from "./data.json" with { type: "json" };
 console.log(file.msg);

--- a/pkgs/by-name/de/deno/update/librusty_v8.ts
+++ b/pkgs/by-name/de/deno/update/librusty_v8.ts
@@ -1,4 +1,4 @@
-import * as toml from "https://deno.land/std@0.202.0/toml/mod.ts";
+import * as toml from "jsr:@std/toml@1.0.1";
 import { getExistingVersion, logger, run, write } from "./common.ts";
 
 const log = logger("librusty_v8");
@@ -40,22 +40,15 @@ fetchurl {
 
 const templateDeps = (version: string, deps: PrefetchResult[]) =>
   `# auto-generated file -- DO NOT EDIT!
-{ lib, stdenv, fetchurl }:
+{ fetchLibrustyV8 }:
 
-let
-  fetch_librusty_v8 = args: fetchurl {
-    name = "librusty_v8-\${args.version}";
-    url = "https://github.com/denoland/rusty_v8/releases/download/v\${args.version}/librusty_v8_release_\${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
-    sha256 = args.shas.\${stdenv.hostPlatform.system};
-    meta = {
-      inherit (args) version;
-      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    };
-  };
-in
-fetch_librusty_v8 {
+fetchLibrustyV8 {
   version = "${version}";
   shas = {
+    x86_64-linux = "sha256-jLYl/CJp2Z+Ut6qZlh6u+CtR8KN+ToNTB+72QnVbIKM=";
+    aarch64-linux = "sha256-uAkBMg6JXA+aILd8TzDtuaEdM3Axiw43Ad5tZzxNt5w=";
+    x86_64-darwin = "sha256-60aR0YvQT8KyacY8J3fWKZcf9vny51VUB19NVpurS/A=";
+    aarch64-darwin = "sha256-pd/I6Mclj2/r/uJTIywnolPKYzeLu1c28d/6D56vkzQ=";
 ${deps.map(({ arch, sha256 }) => `    ${arch.nix} = "${sha256}";`).join("\n")}
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6839,6 +6839,8 @@ with pkgs;
 
   deer = callPackage ../shells/zsh/zsh-deer { };
 
+  deno_1 = callPackage ../by-name/de/deno/1/package.nix { };
+
   deqp-runner = callPackage ../tools/graphics/deqp-runner { };
 
   detox = callPackage ../tools/misc/detox { };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updates `deno` to v2
Adds a `deno_1` to hold v1 for now.
Depending on deno's support plans v1 may be removed just before the 24.11 release.

Updated the update scripts to use new Deno v2 interfaces and pull latest
toml dependency from jsr rather than the deno.land registry.


Note: need to double check it's ok to put `deno_1` inside `pkgs/by-name/deno/v1/package.nix`

Note: might wait a bit for the deno v2 announcement blog

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
