### PR TITLE
mupen64plus: 2.5.9 -> 2.6.0

### DIFF
--- a/pkgs/by-name/mu/mupen64plus/package.nix
+++ b/pkgs/by-name/mu/mupen64plus/package.nix
@@ -1,29 +1,45 @@
-{lib, stdenv, fetchurl, fetchpatch, boost, dash, freetype, libpng, pkg-config, SDL, which, zlib, nasm }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  boost,
+  dash,
+  freetype,
+  libpng,
+  libGLU,
+  pkg-config,
+  SDL2,
+  which,
+  zlib,
+  nasm,
+  vulkan-loader,
+}:
 
 stdenv.mkDerivation rec {
   pname = "mupen64plus";
-  version = "2.5.9";
+  version = "2.6.0";
 
   src = fetchurl {
     url = "https://github.com/mupen64plus/mupen64plus-core/releases/download/${version}/mupen64plus-bundle-src-${version}.tar.gz";
-    sha256 = "1a21n4gqdvag6krwcjm5bnyw5phrlxw6m0mk73jy53iq03f3s96m";
+    sha256 = "sha256-KX4XGAzXanuOqAnRob4smO1cc1LccWllqA3rWYsh4TE=";
   };
 
-  patches = [
-    # Pull upstream fix for -fno-common toolchains:
-    #  https://github.com/mupen64plus/mupen64plus-core/pull/736
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/mupen64plus/mupen64plus-core/commit/39975200ad4926cfc79c96609b64696289065502.patch";
-      sha256 = "0kdshp9xdkharn3d1g1pvxhh761pa1v5w07iq0wf9l380r2m6gbv";
-      # a/something -> a/source/mupen64plus-core/something
-      stripLen = 1;
-      extraPrefix = "source/mupen64plus-core/";
-    })
+  nativeBuildInputs = [
+    pkg-config
+    nasm
   ];
-
-  nativeBuildInputs = [ pkg-config nasm ];
-  buildInputs = [ boost dash freetype libpng SDL which zlib ];
+  buildInputs = [
+    boost
+    dash
+    freetype
+    libpng
+    libGLU
+    SDL2
+    which
+    zlib
+    vulkan-loader
+  ];
 
   buildPhase = ''
     dash m64p_build.sh PREFIX="$out" COREDIR="$out/lib/" PLUGINDIR="$out/lib/mupen64plus" SHAREDIR="$out/share/mupen64plus"


### PR DESCRIPTION
## Changes
Removed patch as that is now merged in this release.

Dependency changed: SDL -> SDL2
fails to build with SDL and other distro's are using SDL2.

Dependencies added: vulkan-loader and libGLU are now required to build.

https://github.com/mupen64plus/mupen64plus-core/blob/2.6.0/RELEASE

CC @svanderburg 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
