### PR TITLE
git: move credential helpers to exec path

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -265,13 +265,23 @@ stdenv.mkDerivation (finalAttrs: {
 
   preInstall =
     lib.optionalString osxkeychainSupport ''
+      mkdir -p $out/libexec/git-core
+      ln -s $out/share/git/contrib/credential/osxkeychain/git-credential-osxkeychain $out/libexec/git-core/
+
+      # ideally unneeded, but added for backwards compatibility
       mkdir -p $out/bin
-      ln -s $out/share/git/contrib/credential/osxkeychain/git-credential-osxkeychain $out/bin/
+      ln -s $out/libexec/git-core/git-credential-osxkeychain $out/bin/
+
       rm -f $PWD/contrib/credential/osxkeychain/git-credential-osxkeychain.o
     ''
     + lib.optionalString withLibsecret ''
+      mkdir -p $out/libexec/git-core
+      ln -s $out/share/git/contrib/credential/libsecret/git-credential-libsecret $out/libexec/git-core/
+
+      # ideally unneeded, but added for backwards compatibility
       mkdir -p $out/bin
-      ln -s $out/share/git/contrib/credential/libsecret/git-credential-libsecret $out/bin/
+      ln -s $out/libexec/git-core/git-credential-libsecret $out/bin/
+
       rm -f $PWD/contrib/credential/libsecret/git-credential-libsecret.o
     '';
 
@@ -340,8 +350,11 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     + lib.optionalString perlSupport ''
       # wrap perl commands
-      makeWrapper "$out/share/git/contrib/credential/netrc/git-credential-netrc.perl" $out/bin/git-credential-netrc \
+      makeWrapper "$out/share/git/contrib/credential/netrc/git-credential-netrc.perl" $out/libexec/git-core/git-credential-netrc \
                   --set PERL5LIB   "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
+      # ideally unneeded, but added for backwards compatibility
+      ln -s $out/libexec/git-core/git-credential-netrc $out/bin/
+
       wrapProgram $out/libexec/git-core/git-cvsimport \
                   --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
       wrapProgram $out/libexec/git-core/git-archimport \
@@ -419,7 +432,6 @@ stdenv.mkDerivation (finalAttrs: {
         ''
     )
     + lib.optionalString osxkeychainSupport ''
-      ln -s $out/share/git/contrib/credential/osxkeychain/git-credential-osxkeychain $out/libexec/git-core/
       # enable git-credential-osxkeychain on darwin if desired (default)
       mkdir -p $out/etc
       cat > $out/etc/gitconfig << EOF


### PR DESCRIPTION
Currently if the credential helpers packaged with git aren't on your PATH, git will fail to locate them. This most notably affects git maintanence[^1] which generates systemd units / launchd agents that invoke git directly without setting PATH. Home Manager is also able to generate maintanence units for systemd and does not set PATH[^2], meaning credential helpers will not work without additional configuration.

Moving the credential helpers to git's exec path[^3] allows git to locate them regardless of how PATH is set, and matches the packaging of Fedora[^4] and Homebrew[^5]. Typically credential helpers are not added to PATH unless they are provided by another package separate from git (e.g. git-credential-gcloud).

I opted to create symlinks at the old bin paths in case some users were relying on invoking them directly. In practice I doubt this is done much. If we want to slim down git's bin dir I think the symlinks could be removed, and in doing so we'd better match the packaging done in other distributions.

[^1]: https://git-scm.com/docs/git-maintenance/2.47.1
[^2]: https://github.com/nix-community/home-manager/blob/b6fd653ef8fbeccfd4958650757e91767a65506d/modules/programs/git.nix#L619
[^3]: https://git-scm.com/docs/git/2.47.1#Documentation/git.txt---exec-pathltpathgt
[^4]: https://src.fedoraproject.org/rpms/git/blob/rawhide/f/git.spec#_651
[^5]: https://github.com/Homebrew/homebrew-core/blob/12120ff79ce009489b958d8271af686d74403859/Formula/g/git.rb#L112

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
