### PR TITLE
fetchPypi: if the computed URL doesn't exist, fetch metadata to find …

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -106,7 +106,7 @@ tryHashedMirrors() {
 set -o noglob
 
 urls2=
-for url in $urls; do
+for url in $urls $(eval " $urlScript"); do
     if test "${url:0:9}" != "mirror://"; then
         urls2="$urls2 $url"
     else

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -57,6 +57,11 @@ in
   # locations.  They are tried in order.
   urls ? [ ],
 
+  # In addition to `url` and `urls`, a bash script that outputs URLs
+  # on its standard output (one URL per line). They are tried in
+  # order.
+  urlScript ? "",
+
   # Additional curl options needed for the download to succeed.
   # Warning: Each space (no matter the escaping) will start a new argument.
   # If you wish to pass arguments with spaces, use `curlOptsList`
@@ -127,8 +132,9 @@ let
       (if lib.isList urls then urls else throw "`urls` is not a list")
     else if urls == [ ] && url != "" then
       (if lib.isString url then [ url ] else throw "`url` is not a string")
-    else
-      throw "fetchurl requires either `url` or `urls` to be set";
+    else if urlScript == "" then
+      throw "fetchurl requires either `url` or `urls` to be set"
+    else [];
 
   hash_ =
     if
@@ -212,6 +218,8 @@ stdenvNoCC.mkDerivation (
     nativeBuildInputs = [ curl ] ++ nativeBuildInputs;
 
     urls = urls_;
+
+    inherit urlScript;
 
     # If set, prefer the content-addressable mirrors
     # (http://tarballs.nixos.org) over the original URLs.


### PR DESCRIPTION
Some packages on pypi.org aren't accessible via the URL computed by the previous version of fetchPypi. In that case, their URL is given by the blake2b hash of their content, which would have to be fetched from pypi.org manually.

This commit solves this by fetching the metadata from pypi.org and find one ore more correct URLs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
