### PR TITLE
sleek-todo: init at 2.0.14

### DIFF
--- a/pkgs/by-name/sl/sleek-todo/package.nix
+++ b/pkgs/by-name/sl/sleek-todo/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  undmg,
+  appimageTools,
+
+}:
+
+let
+
+  pname = "sleek-todo";
+  version = "2.0.14";
+
+  src =
+    fetchurl
+      {
+        x86_64-darwin = {
+          url = "https://github.com/ransome1/sleek/releases/download/v${version}/sleek-2.0.14-mac-x64.dmg";
+          hash = "sha256-f5mMSRa+gAoakOy9TSZeALqCylGLd0nUJIh8o+LWAro=";
+        };
+        x86_64-linux = {
+          url = "https://github.com/ransome1/sleek/releases/download/v${version}/sleek-2.0.14.AppImage";
+          hash = "sha256-d2fLsCI7peuNBtjgHs1qumgPAF9eJeBYiIIffoSv9Jk=";
+        };
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.system}");
+
+  meta = {
+    description = "Todo manager based on todo.txt syntax";
+    homepage = "https://github.com/ransome1/sleek";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ByteSudoer ];
+    mainProgram = "sleek-todo";
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+if stdenv.hostPlatform.isDarwin then
+  stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+
+    sourceRoot = ".";
+    nativeBuildInputs = [ undmg ];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications/
+      runHook postInstall
+    '';
+  }
+else
+  appimageTools.wrapType2 {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+
+    extraInstallCommands = ''
+      mkdir -p $out/share/{applications,sleek}
+      cp -a ${appimageContents}/{locales,resources} $out/share/sleek
+      cp -a ${appimageContents}/usr/share/icons $out/share
+      install -Dm 444 ${appimageContents}/sleek.desktop $out/share/applications
+      substituteInPlace $out/share/applications/sleek.desktop \
+      --replace-warn 'Exec=AppRun' 'Exec=${pname}'
+    '';
+
+  }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


## Things done
Packaging Sleek: todo.txt manager for Linux, Windows and MacOS, free and open-source (FOSS)
Metadata
- homepage URL: https://github.com/ransome1/sleek/wiki
- source URL: https://github.com/ransome1/sleek
- license: mit
- platforms: unix, linux, darwin
Note: This package was called `sleek-todo` because another package wit the name `sleek` already exists.

Closes https://github.com/NixOS/nixpkgs/issues/347108
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
