### PR TITLE
snapweb: init at 0.8.0

### DIFF
--- a/nixos/modules/services/audio/snapserver.nix
+++ b/nixos/modules/services/audio/snapserver.nix
@@ -186,7 +186,8 @@ in {
 
       http.docRoot = lib.mkOption {
         type = with lib.types; nullOr path;
-        default = null;
+        default = pkgs.snapweb;
+        defaultText = lib.literalExpression "pkgs.snapweb";
         description = ''
           Path to serve from the HTTP servers root.
         '';

--- a/pkgs/by-name/sn/snapweb/package.nix
+++ b/pkgs/by-name/sn/snapweb/package.nix
@@ -1,0 +1,40 @@
+{
+  buildNpmPackage,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  vips,
+}:
+
+buildNpmPackage rec {
+  pname = "snapweb";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "badaix";
+    repo = "snapweb";
+    rev = "v${version}";
+    hash = "sha256-rrJmuTFk2dC+GqYmBZ+hu5hx1iknAgSWjr22S7bfmEE=";
+  };
+
+  npmDepsHash = "sha256-n1MmU9zHyuEqtQSfYpQ+0hDM0z6ongcFsGyikPMyNSU=";
+
+  # For 'sharp' dependency, otherwise it will try to build it
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ vips ];
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Web client for Snapcast";
+    homepage = "https://github.com/badaix/snapweb";
+    maintainers = with maintainers; [ ettom ];
+    license = licenses.gpl3Plus;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add package for [Snapweb](https://github.com/badaix/snapweb), the web client for Snapcast. Additionally, set it as the default for `services.snapserver.http.docRoot`. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
