### PR TITLE
workflows/codeowners: Dry mode for now

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -15,11 +15,12 @@ on:
 env:
   # TODO: Once confirmed that this works by seeing that the action would request
   # reviews from the same people (or refuse for wrong base branches),
-  # move all entries from CODEOWNERS to OWNERS and change this value here
-  # OWNERS_FILE: .github/OWNERS
+  # move all entries from CODEOWNERS to OWNERS, remove these two lines and uncomment the ones below
   OWNERS_FILE: .github/CODEOWNERS
-  # Also remove this
   DRY_MODE: 1
+  # OWNERS_FILE: .github/OWNERS
+  # # Don't do anything on draft PRs
+  # DRY_MODE: ${{ github.event.pull_request.draft && '1' || '' }}
 
 jobs:
   # Check that code owners is valid
@@ -84,5 +85,3 @@ jobs:
       run: result/bin/request-reviews.sh ${{ github.repository }} ${{ github.event.number }} "$OWNERS_FILE"
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        # Don't do anything on draft PRs
-        DRY_MODE: ${{ github.event.pull_request.draft && '1' || '' }}


### PR DESCRIPTION
Apparently it started requesting reviews from code owners already because the DRY_MODE from the global env was overridden in the local job declaration: https://github.com/NixOS/nixpkgs/pull/347354#event-14570645380

The intention when introduced in https://github.com/NixOS/nixpkgs/pull/336261 was to still run it in full dry mode for now.

This change fixes the behavior, making sure it always runs in dry mode.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
