### PR TITLE
nixos: add `system.build.toplevelFor.<system>`

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1596,6 +1596,7 @@
   ./services/x11/xserver.nix
   ./system/activation/activatable-system.nix
   ./system/activation/activation-script.nix
+  ./system/activation/alternate-system.nix
   ./system/activation/specialisation.nix
   ./system/activation/switchable-system.nix
   ./system/activation/bootspec.nix

--- a/nixos/modules/system/activation/alternate-system.nix
+++ b/nixos/modules/system/activation/alternate-system.nix
@@ -1,0 +1,32 @@
+{
+  config,
+  lib,
+  extendModules,
+  ...
+}:
+
+let
+  forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+in
+{
+  options = {
+    system = forAllSystems (
+      system:
+      lib.mkOption {
+        description = ''
+          Extra configuration when using `system.build.toplevelFor.${system}`
+        '';
+        inherit (extendModules { modules = [ { nixpkgs.system = lib.mkOverride 0 system; } ]; }) type;
+        default = { };
+        visible = "shallow";
+      }
+    );
+  };
+
+  config = {
+    system.build.toplevelFor = forAllSystems (system: config.system.${system}.system.build.toplevel);
+  };
+
+  # uses extendModules to generate a type
+  meta.buildDocsInSandbox = false;
+}


### PR DESCRIPTION
Added `system.build.toplevelFor.<system>` and corresponding `system.<system>` options for customizing them

I'm not sure if there's a list of doubles that NixOS supports, so I'm using `lib.systems.flakeExposed` for now even though that also contains macOS

cc @roberth 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
