### PR TITLE
openwebrxplus: init at 1.2.70

### DIFF
--- a/pkgs/applications/radio/openwebrx/default.nix
+++ b/pkgs/applications/radio/openwebrx/default.nix
@@ -1,20 +1,18 @@
 { stdenv, lib, buildPythonPackage, buildPythonApplication, fetchFromGitHub
-, pkg-config, cmake, setuptools
-, libsamplerate, fftwFloat
-, rtl-sdr, soapysdr-with-plugins, csdr, pycsdr, pydigiham, direwolf, sox, wsjtx, codecserver
-}:
+, pkg-config, cmake, setuptools, libsamplerate, fftwFloat, rtl-sdr
+, soapysdr-with-plugins, csdr, pycsdr, pydigiham, direwolf, sox, wsjtx
+, codecserver }:
 
 let
-
   js8py = buildPythonPackage rec {
     pname = "js8py";
-    version = "0.1.1";
+    version = "0.1.2";
 
     src = fetchFromGitHub {
       owner = "jketterl";
       repo = pname;
       rev = version;
-      sha256 = "1j80zclg1cl5clqd00qqa16prz7cyc32bvxqz2mh540cirygq24w";
+      sha256 = "sha256-06ilrMowapJRqBdAkoWkoM00kq/36uin1bBESVN3JdI=";
     };
 
     pythonImportsCheck = [ "js8py" "test" ];
@@ -29,13 +27,13 @@ let
 
   owrx_connector = stdenv.mkDerivation rec {
     pname = "owrx_connector";
-    version = "0.6.0";
+    version = "0.6.2";
 
     src = fetchFromGitHub {
       owner = "jketterl";
       repo = pname;
       rev = version;
-      sha256 = "sha256-1H0TJ8QN3b6Lof5TWvyokhCeN+dN7ITwzRvEo2X8OWc=";
+      sha256 = "sha256-2gGfEj5LkeQmPxX0vaSTX7sWdjHncqmLHY83/yFBwO8=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/op/openwebrxplus/package.nix
+++ b/pkgs/by-name/op/openwebrxplus/package.nix
@@ -1,0 +1,279 @@
+{
+  stdenv,
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  ninja,
+  libsamplerate,
+  fftwFloat,
+  rtl-sdr,
+  soapysdr-with-plugins,
+  direwolf,
+  sox,
+  wsjtx,
+  codecserver,
+  openwebrx,
+  dablin,
+  dump1090,
+  hamlib,
+  imagemagick,
+  multimon-ng,
+  nrsc5,
+  rtl_433,
+}:
+let
+  inherit (python3Packages)
+    buildPythonPackage
+    buildPythonApplication
+    pydigiham
+    setuptools
+    python
+    ;
+
+  inherit (openwebrx.passthru) js8py;
+
+  csdr-eti = stdenv.mkDerivation rec {
+    pname = "csdr-eti";
+    version = "0.0.11";
+
+    src = fetchFromGitHub {
+      owner = "luarvique";
+      repo = "csdr-eti";
+      rev = version;
+      hash = "sha256-jft4zi1mLU6zZ+2gsym/3Xu8zkKL0MeoztcyMPM0RYI=";
+    };
+
+    nativeBuildInputs = [
+      cmake
+      ninja
+      pkg-config
+    ];
+
+    propagatedBuildInputs = [
+      fftwFloat
+      libsamplerate
+    ];
+    buildInputs = [ csdr ];
+
+    hardeningDisable = lib.optional stdenv.isAarch64 "format";
+
+    meta = with lib; {
+      homepage = "https://github.com/jketterl/csdr";
+      description = "Simple DSP library and command-line tool for Software Defined Radio";
+      license = licenses.gpl3Only;
+      platforms = platforms.unix;
+      broken = stdenv.isDarwin;
+      maintainers = teams.c3d2.members;
+    };
+  };
+
+  csdr = stdenv.mkDerivation rec {
+    pname = "csdr";
+    version = "0.18.23";
+
+    src = fetchFromGitHub {
+      owner = "luarvique";
+      repo = "csdr";
+      rev = version;
+      hash = "sha256-Q7g1OqfpAP6u78zyHjLP2ASGYKNKCAVv8cgGwytZ+cE=";
+    };
+
+    nativeBuildInputs = [
+      cmake
+      ninja
+      pkg-config
+    ];
+
+    propagatedBuildInputs = [
+      fftwFloat
+      libsamplerate
+    ];
+
+    hardeningDisable = lib.optional stdenv.isAarch64 "format";
+
+    postFixup = ''
+      substituteInPlace "$out"/lib/pkgconfig/csdr.pc \
+        --replace-fail '=''${prefix}//' '=/' \
+        --replace-fail '=''${exec_prefix}//' '=/'
+    '';
+
+    meta = with lib; {
+      homepage = "https://github.com/jketterl/csdr";
+      description = "Simple DSP library and command-line tool for Software Defined Radio";
+      license = licenses.gpl3Only;
+      platforms = platforms.unix;
+      broken = stdenv.isDarwin;
+      maintainers = teams.c3d2.members;
+    };
+  };
+
+  pycsdr-eti = buildPythonPackage rec {
+    pname = "pycsdr-eti";
+    version = "0.0.11";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "luarvique";
+      repo = "pycsdr-eti";
+      rev = version;
+      hash = "sha256-pjY5sxHvuDTUDxpdhWk8U7ibwxHznyywEqj1btAyXBE=";
+    };
+
+    postPatch = ''
+      substituteInPlace setup.py \
+        --replace-fail ', "fftw3"' ""
+    '';
+
+    build-system = [ setuptools ];
+    dependencies = [ pycsdr ];
+    buildInputs = [
+      csdr-eti
+      csdr
+    ];
+    NIX_CFLAGS_COMPILE = [ "-I${pycsdr}/include/${python.libPrefix}" ];
+
+    # has no tests
+    doCheck = false;
+    pythonImportsCheck = [ "csdreti" ];
+
+    meta = {
+      homepage = "https://github.com/jketterl/pycsdr-eti";
+      description = "Bindings for csdr-eti";
+      license = lib.licenses.gpl3Only;
+      maintainers = lib.teams.c3d2.members;
+    };
+  };
+
+  pycsdr = buildPythonPackage rec {
+    pname = "pycsdr";
+    version = "0.18.23";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "luarvique";
+      repo = "pycsdr";
+      rev = version;
+      hash = "sha256-NjRBC7bhq2bMlRI0Q8bcGcneD/HlAO6l/0As3/lk4e8=";
+    };
+
+    build-system = [ setuptools ];
+
+    buildInputs = [ csdr ];
+
+    # has no tests
+    doCheck = false;
+    pythonImportsCheck = [ "pycsdr" ];
+
+    meta = {
+      homepage = "https://github.com/jketterl/pycsdr";
+      description = "Bindings for the csdr library";
+      license = lib.licenses.gpl3Only;
+      maintainers = lib.teams.c3d2.members;
+    };
+  };
+
+  owrx_connector = stdenv.mkDerivation rec {
+    pname = "owrx-connector";
+    version = "0.6.5";
+
+    src = fetchFromGitHub {
+      owner = "luarvique";
+      repo = "owrx_connector";
+      rev = version;
+      sha256 = "sha256-e0VEv9t4gVDxJEbDJm1aKSJeqlmhT/QimC3x4JJ6ke8=";
+    };
+
+    nativeBuildInputs = [
+      cmake
+      ninja
+      pkg-config
+    ];
+
+    buildInputs = [
+      libsamplerate
+      fftwFloat
+      csdr
+      rtl-sdr
+      soapysdr-with-plugins
+    ];
+
+    meta = with lib; {
+      homepage = "https://github.com/jketterl/owrx_connector";
+      description = "Set of connectors that are used by OpenWebRX to interface with SDR hardware";
+      license = licenses.gpl3Only;
+      platforms = platforms.unix;
+      maintainers = teams.c3d2.members;
+    };
+  };
+in
+buildPythonApplication rec {
+  pname = "openwebrxplus";
+  version = "1.2.70";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "luarvique";
+    repo = "openwebrx";
+    rev = version;
+    sha256 = "sha256-17Ug3xZ2tUMvwn3SUZqz8Y1Dd7UQrEsa5YQ7XV+FId0=";
+  };
+
+  build-dependencies = [ setuptools ];
+
+  dependencies = [
+    dablin
+    direwolf
+    dump1090
+    hamlib
+    imagemagick
+    multimon-ng
+    nrsc5
+    rtl_433
+    wsjtx
+    setuptools
+    pycsdr
+    pycsdr-eti
+    pydigiham
+    js8py
+    owrx_connector
+    soapysdr-with-plugins
+  ];
+
+  buildInputs = [
+    direwolf
+    sox
+    wsjtx
+    codecserver
+  ];
+
+  pythonImportsCheck = [
+    "pycsdr"
+    "owrx"
+    "test"
+  ];
+
+  passthru = {
+    inherit
+      js8py
+      owrx_connector
+      pycsdr
+      csdr
+      ;
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/luarvique/openwebrx";
+    description = "Simple DSP library and command-line tool for Software Defined Radio";
+    mainProgram = "openwebrx";
+    license = licenses.gpl3Only;
+    maintainers =
+      with maintainers;
+      [
+        arcnmx
+        kittywitch
+      ]
+      ++ teams.c3d2.members;
+  };
+}


### PR DESCRIPTION
Provides many more decoders than openwebrx. Can be used by setting `services.openwebrx.package`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
