### PR TITLE
Avoid rerequesting reviews with the new codeowners mechanism

### DIFF
--- a/ci/request-reviews/get-reviewers.sh
+++ b/ci/request-reviews/get-reviewers.sh
@@ -10,16 +10,18 @@ log() {
     echo "$@" >&2
 }
 
-if (( "$#" < 5 )); then
-    log "Usage: $0 GIT_REPO BASE_REF HEAD_REF OWNERS_FILE PR_AUTHOR"
+if (( "$#" < 7 )); then
+    log "Usage: $0 GIT_REPO OWNERS_FILE BASE_REPO BASE_REF HEAD_REF PR_NUMBER PR_AUTHOR"
     exit 1
 fi
 
 gitRepo=$1
-baseRef=$2
-headRef=$3
-ownersFile=$4
-prAuthor=$5
+ownersFile=$2
+baseRepo=$3
+baseRef=$4
+headRef=$5
+prNumber=$6
+prAuthor=$7
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' exit
@@ -76,6 +78,20 @@ if [[ -v users[$prAuthor] ]]; then
     log "One or more files are owned by the PR author, ignoring"
     unset 'users[$prAuthor]'
 fi
+
+gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$baseRepo/pulls/$prNumber/reviews" \
+    --jq '.[].user.login' > "$tmp/already-reviewed-by"
+
+# And we don't want to rerequest reviews from people who already reviewed
+while read -r user; do
+    if [[ -v users[$user] ]]; then
+        log "User $user is a code owner but has already left a review, ignoring"
+        unset 'users[$user]'
+    fi
+done < "$tmp/already-reviewed-by"
 
 # Turn it into a JSON for the GitHub API call to request PR reviewers
 jq -n \

--- a/ci/request-reviews/request-reviews.sh
+++ b/ci/request-reviews/request-reviews.sh
@@ -80,7 +80,7 @@ if ! "$SCRIPT_DIR"/verify-base-branch.sh "$tmp/nixpkgs.git" "$headRef" "$baseRep
 fi
 
 log "Getting code owners to request reviews from"
-"$SCRIPT_DIR"/get-reviewers.sh "$tmp/nixpkgs.git" "$baseBranch" "$headRef" "$ownersFile" "$prAuthor" > "$tmp/reviewers.json"
+"$SCRIPT_DIR"/get-reviewers.sh "$tmp/nixpkgs.git" "$ownersFile" "$baseRepo" "$baseBranch" "$headRef" "$prNumber" "$prAuthor" > "$tmp/reviewers.json"
 
 log "Requesting reviews from: $(<"$tmp/reviewers.json")"
 


### PR DESCRIPTION
As a follow-up to https://github.com/NixOS/nixpkgs/pull/336261, the automation should never rerequest reviews from users that already reviewed the changes, which is what was happening before this change: https://github.com/NixOS/nixpkgs/pull/347354#event-14570645380

Furthermore, request reviews from individual team members. This makes this alternate codeowner mechanism behave differently than the native GitHub one, but there's no other way to avoid rerequesting reviews from teams when a member already reviewed the PR.

## Things done

- [x] Tested that reviews aren't rerequested: https://github.com/Infinisil-s-Test-Organization/nixpkgs/pull/24 (retriggered CI after the review was requested)

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
