### PR TITLE
Flatpak: NixOS-integrated Flatpak package management

### DIFF
--- a/nixos/modules/services/desktops/flatpak.md
+++ b/nixos/modules/services/desktops/flatpak.md
@@ -44,6 +44,7 @@ Flatpak packages to be installed or removed through your {file}`configuration.ni
     ];
     packages = [ "org.blender.Blender" "net.ankiweb.Anki" ];
     removeUnmanagedPackages = true;
+    removeUnmanagedRemotes = true;
     update = {
       auto = {
         enable = true;
@@ -60,12 +61,14 @@ This example configuration will:
 - Add the specified Flatpak remotes (Flathub and GNOME nightly in this example)
 - Ensure the specified packages are installed (Blender and Anki in this example)
 - Remove any Flatpak packages not listed in the `packages` option (if `removeUnmanagedPackages` is true)
+- Remove any Flatpak remotes not listed in the `remotes` option (if `removeUnmanagedRemotes` is true)
 - Enable automatic weekly updates of Flatpak packages
 - Disable package updates when building your system
 
 Important notes:
 - Package versions are managed by Flatpak's servers, not nixpkgs.
 - The `removeUnmanagedPackages` option defaults to `false`.
+- The `removeUnmanagedRemotes` option defaults to `false`.
 - The `update.auto.enable` option defaults to `false`. When set to `true`, it allows automatic updates of installed Flatpak packages.
 - The `update.auto.onCalendar` option uses systemd calendar syntax. If not set, no timer will be created even if `update.auto.enable` is `true`.
 - The `update.duringBuild` option defaults to `false`. When set to `true`, it updates Flatpak packages during system rebuild.
@@ -101,4 +104,7 @@ $ flatpak run org.freedesktop.Bustle
 
 GNOME Software and KDE Discover offer a graphical interface for these tasks.
 
-Note: When using NixOS-integrated package management, manually installed packages may be removed if `removeUnmanagedPackages` is set to `true` and the package is not listed in the `packages` option. If automatic updates are disabled, you will need to manually update your Flatpak packages using the `flatpak update` command.
+Note: When using NixOS-integrated package management:
+- Manually installed packages may be removed if `removeUnmanagedPackages` is set to `true` and the package is not listed in the `packages` option.
+- Manually added remotes may be removed if `removeUnmanagedRemotes` is set to `true` and the remote is not listed in the `remotes` option.
+- If automatic updates are disabled, you will need to manually update your Flatpak packages using the `flatpak update` command.

--- a/nixos/modules/services/desktops/flatpak.md
+++ b/nixos/modules/services/desktops/flatpak.md
@@ -25,9 +25,59 @@ in other cases, you will need to add something like the following to your
 }
 ```
 
-Then, you will need to add a repository, for example,
+## NixOS-integrated Flatpak Package Management {#nixos-integrated-flatpak-package-management}
+NixOS now supports integrated management of Flatpak packages. You can specify
+Flatpak packages to be installed or removed through your {file}`configuration.nix`:
+```nix
+{
+  services.flatpak = {
+    enable = true;
+    packages = [ "org.blender.Blender" "net.ankiweb.Anki" ];
+    removeUnmanagedPackages = true;
+    update = {
+      auto = {
+        enable = true;
+        onCalendar = "weekly";
+      };
+      duringBuild = false;
+    };
+    remote = {
+      name = "flathub";
+      url = "https://flathub.org/repo/flathub.flatpakrepo";
+    };
+  };
+}
+```
+
+This example configuration will:
+- Enable Flatpak
+- Ensure the specified packages are installed (Blender and Anki in this example)
+- Remove any Flatpak packages not listed in the `packages` option (if `removeUnmanagedPackages` is true)
+- Enable automatic weekly updates of Flatpak packages
+- Disable package updates when building your system
+- Add the Flathub remote repository
+
+Important notes:
+- Package versions are managed by Flatpak's servers, not nixpkgs.
+- The `removeUnmanagedPackages` option defaults to `false`.
+- The `update.auto.enable` option defaults to `false`. When set to `true`, it allows automatic updates of installed Flatpak packages.
+- The `update.auto.onCalendar` option uses systemd calendar syntax. If not set, no timer will be created even if `update.auto.enable` is `true`.
+- The `update.duringBuild` option defaults to `false`. When set to `true`, it updates Flatpak packages during system rebuild.
+- The `remote` option is `null` by default. If set, it adds the specified Flatpak remote repository. If `null`, no remote will be added automatically.
+
+Be aware that while Flatpak packages are managed through NixOS, they operate in a somewhat separate environment. If you encounter issues with a Flatpak package:
+- First, check if the issue is related to NixOS configuration, such as missing portals or system dependencies.
+- If the problem seems to be with the Flatpak package itself, then it's best to check with the upstream project.
+
+Remember that the NixOS Flatpak integration might also have its own quirks, so consider if the problem could be related to how NixOS is managing Flatpak when troubleshooting.
+
+## Manual Package Management {#manual-package-management}
+If you prefer to manage Flatpak packages manually, you can still do so.
+
+First, you will need to add a repository, for example,
 [Flathub](https://github.com/flatpak/flatpak/wiki),
 either using the following commands:
+
 ```ShellSession
 $ flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 $ flatpak update
@@ -35,10 +85,14 @@ $ flatpak update
 or by opening the
 [repository file](https://flathub.org/repo/flathub.flatpakrepo) in GNOME Software.
 
-Finally, you can search and install programs:
+Then, you can search and install programs:
+
 ```ShellSession
 $ flatpak search bustle
 $ flatpak install flathub org.freedesktop.Bustle
 $ flatpak run org.freedesktop.Bustle
 ```
-Again, GNOME Software offers graphical interface for these tasks.
+
+GNOME Software and KDE Discover offer a graphical interface for these tasks.
+
+Note: When using NixOS-integrated package management, manually installed packages may be removed if `removeUnmanagedPackages` is set to `true` and the package is not listed in the `packages` option. If automatic updates are disabled, you will need to manually update your Flatpak packages using the `flatpak update` command.

--- a/nixos/modules/services/desktops/flatpak.md
+++ b/nixos/modules/services/desktops/flatpak.md
@@ -69,6 +69,7 @@ Important notes:
 - The `update.auto.enable` option defaults to `false`. When set to `true`, it allows automatic updates of installed Flatpak packages.
 - The `update.auto.onCalendar` option uses systemd calendar syntax. If not set, no timer will be created even if `update.auto.enable` is `true`.
 - The `update.duringBuild` option defaults to `false`. When set to `true`, it updates Flatpak packages during system rebuild.
+- The `remotes` option defaults to including Flathub, the main repository for Flatpak applications.
 
 Be aware that while Flatpak packages are managed through NixOS, they operate in a somewhat separate environment. If you encounter issues with a Flatpak package:
 - First, check if the issue is related to NixOS configuration, such as missing portals or system dependencies.

--- a/nixos/modules/services/desktops/flatpak.md
+++ b/nixos/modules/services/desktops/flatpak.md
@@ -71,7 +71,7 @@ Be aware that while Flatpak packages are managed through NixOS, they operate in 
 
 Remember that the NixOS Flatpak integration might also have its own quirks, so consider if the problem could be related to how NixOS is managing Flatpak when troubleshooting.
 
-## Manual Package Management {#manual-package-management}
+## Manual Flatpak management {#module-services-flatpak-manual-manage}
 If you prefer to manage Flatpak packages manually, you can still do so.
 
 First, you will need to add a repository, for example,

--- a/nixos/modules/services/desktops/flatpak.md
+++ b/nixos/modules/services/desktops/flatpak.md
@@ -32,6 +32,16 @@ Flatpak packages to be installed or removed through your {file}`configuration.ni
 {
   services.flatpak = {
     enable = true;
+    remotes = [
+      {
+        name = "flathub";
+        url = "https://flathub.org/repo/flathub.flatpakrepo";
+      }
+      {
+        name = "gnome";
+        url = "https://sdk.gnome.org/repo/flatpak/gnome-nightly.flatpakrepo";
+      }
+    ];
     packages = [ "org.blender.Blender" "net.ankiweb.Anki" ];
     removeUnmanagedPackages = true;
     update = {
@@ -41,21 +51,17 @@ Flatpak packages to be installed or removed through your {file}`configuration.ni
       };
       duringBuild = false;
     };
-    remote = {
-      name = "flathub";
-      url = "https://flathub.org/repo/flathub.flatpakrepo";
-    };
   };
 }
 ```
 
 This example configuration will:
 - Enable Flatpak
+- Add the specified Flatpak remotes (Flathub and GNOME nightly in this example)
 - Ensure the specified packages are installed (Blender and Anki in this example)
 - Remove any Flatpak packages not listed in the `packages` option (if `removeUnmanagedPackages` is true)
 - Enable automatic weekly updates of Flatpak packages
 - Disable package updates when building your system
-- Add the Flathub remote repository
 
 Important notes:
 - Package versions are managed by Flatpak's servers, not nixpkgs.
@@ -63,7 +69,6 @@ Important notes:
 - The `update.auto.enable` option defaults to `false`. When set to `true`, it allows automatic updates of installed Flatpak packages.
 - The `update.auto.onCalendar` option uses systemd calendar syntax. If not set, no timer will be created even if `update.auto.enable` is `true`.
 - The `update.duringBuild` option defaults to `false`. When set to `true`, it updates Flatpak packages during system rebuild.
-- The `remote` option is `null` by default. If set, it adds the specified Flatpak remote repository. If `null`, no remote will be added automatically.
 
 Be aware that while Flatpak packages are managed through NixOS, they operate in a somewhat separate environment. If you encounter issues with a Flatpak package:
 - First, check if the issue is related to NixOS configuration, such as missing portals or system dependencies.

--- a/nixos/modules/services/desktops/flatpak.md
+++ b/nixos/modules/services/desktops/flatpak.md
@@ -25,7 +25,7 @@ in other cases, you will need to add something like the following to your
 }
 ```
 
-## NixOS-integrated Flatpak Package Management {#nixos-integrated-flatpak-package-management}
+## Declarative Flatpak management {#module-services-flatpak-declarative-manage}
 NixOS now supports integrated management of Flatpak packages. You can specify
 Flatpak packages to be installed or removed through your {file}`configuration.nix`:
 ```nix

--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -118,7 +118,12 @@ in
             };
           }
         );
-        default = [ ];
+        default = [
+          {
+            name = "flathub";
+            url = "https://flathub.org/repo/flathub.flatpakrepo";
+          }
+        ];
         example = [
           {
             name = "flathub";
@@ -129,7 +134,7 @@ in
             url = "https://sdk.gnome.org/repo/flatpak/gnome-nightly.flatpakrepo";
           }
         ];
-        description = "List of Flatpak remotes to add.";
+        description = "List of Flatpak remotes to add. By default, includes Flathub.";
       };
     };
   };

--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -1,4 +1,3 @@
-# flatpak service.
 {
   config,
   lib,
@@ -8,8 +7,49 @@
 
 let
   cfg = config.services.flatpak;
-in
 
+  flatpakCommand = "${cfg.package}/bin/flatpak";
+
+  manageFlatpaks = pkgs.writeShellScript "manage-flatpaks" ''
+    set -eou pipefail
+
+    ${lib.optionalString (cfg.remote != null) ''
+      if ! ${flatpakCommand} remotes | grep -q "^${cfg.remote.name}"; then
+        echo "Adding Flatpak remote: ${cfg.remote.name}"
+        ${flatpakCommand} remote-add --if-not-exists "${cfg.remote.name}" "${cfg.remote.url}"
+      else
+        echo "Flatpak remote already exists: ${cfg.remote.name}"
+      fi
+    ''}
+
+    echo "Installing specified Flatpak packages..."
+    for pkg in ${toString cfg.packages}; do
+      if ! ${flatpakCommand} info "$pkg" &>/dev/null; then
+        echo "Installing Flatpak package: $pkg"
+        ${flatpakCommand} install --assumeyes "$pkg"
+      else
+        echo "Flatpak package already installed: $pkg"
+      fi
+    done
+
+    ${lib.optionalString cfg.removeUnmanagedPackages ''
+      echo "Removing unmanaged Flatpak packages..."
+      installed_pkgs=$(${flatpakCommand} list --app --columns=application)
+      for pkg in $installed_pkgs; do
+        if ! echo "${toString cfg.packages}" | grep -q "$pkg"; then
+          echo "Removing Flatpak package: $pkg"
+          ${flatpakCommand} uninstall --assumeyes "$pkg"
+        fi
+      done
+    ''}
+
+    ${lib.optionalString cfg.update.duringBuild ''
+      echo "Updating all Flatpak packages..."
+      ${flatpakCommand} update --assumeyes
+    ''}
+  '';
+
+in
 {
   meta = {
     doc = ./flatpak.md;
@@ -22,12 +62,73 @@ in
       enable = lib.mkEnableOption "flatpak";
 
       package = lib.mkPackageOption pkgs "flatpak" { };
+
+      packages = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [
+          "org.blender.Blender"
+          "net.ankiweb.Anki"
+        ];
+        description = "List of Flatpak packages to install or update.";
+      };
+
+      removeUnmanagedPackages = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to remove Flatpak packages not listed in 'packages'.";
+      };
+
+      update = {
+        auto = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Whether to automatically update Flatpak packages.";
+          };
+          onCalendar = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "weekly";
+            description = ''
+              When to perform automatic updates. Uses systemd calendar format. If null, no timer will be created.
+              See systemd.time for more information on the calendar event syntax.
+            '';
+          };
+        };
+        duringBuild = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to update Flatpak packages during system rebuild.";
+        };
+      };
+
+      remote = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.submodule {
+            options = {
+              name = lib.mkOption {
+                type = lib.types.str;
+                description = "Name of the Flatpak remote.";
+              };
+              url = lib.mkOption {
+                type = lib.types.str;
+                description = "URL of the Flatpak remote.";
+              };
+            };
+          }
+        );
+        default = null;
+        example = {
+          name = "flathub";
+          url = "https://flathub.org/repo/flathub.flatpakrepo";
+        };
+        description = "Flatpak remote to add. If null, no remote will be added automatically.";
+      };
     };
   };
 
-  ###### implementation
   config = lib.mkIf cfg.enable {
-
     assertions = [
       {
         assertion = (config.xdg.portal.enable == true);
@@ -53,6 +154,39 @@ in
       "$HOME/.local/share/flatpak/exports"
       "/var/lib/flatpak/exports"
     ];
+
+    # Activation script for installation and optionally updating during build
+    system.activationScripts.flatpak-setup = ''
+      echo "Managing Flatpak packages..."
+      ${manageFlatpaks}
+    '';
+
+    # Systemd service for automatic updates
+    systemd.services.flatpak-update = lib.mkIf cfg.update.auto.enable {
+      description = "Flatpak package updates";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      path = [ cfg.package ];
+      script = ''
+        ${flatpakCommand} update --assumeyes
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+    };
+
+    systemd.timers.flatpak-update =
+      lib.mkIf (cfg.update.auto.enable && cfg.update.auto.onCalendar != null)
+        {
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = cfg.update.auto.onCalendar;
+            Persistent = true;
+            Unit = "flatpak-update.service";
+          };
+        };
 
     # It has been possible since https://github.com/flatpak/flatpak/releases/tag/1.3.2
     # to build a SELinux policy module.


### PR DESCRIPTION
## Description
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR integrates Flatpak package management into NixOS configuration. It allows users to specify Flatpak packages in their NixOS configuration, which will be installed, updated, or removed during the system activation phase. There are more options available as shown in the example config.

### New features:
- `services.flatpak.packages`: A list of Flatpak packages to install or update.
- `services.flatpak.removeUnmanagedPackages`: An option to remove Flatpak packages not listed in `packages`.
- `services.flatpak.update.duringBuild`: An option to update Flatpak packages during build.
- `services.flatpak.update.auto`: A set of options for automatic Flatpak packages  update.
- `services.flatpak.remote`: A set of options for setting remote Flatpak repository.

### Example usage:
```nix
{
  services.flatpak = {
    enable = true;
    packages = [ "org.blender.Blender" "net.ankiweb.Anki" ];
    removeUnmanagedPackages = true;
    update = {
      auto = {
        enable = true;
        onCalendar = "weekly";
      };
      duringBuild = false;
    };
    remote = {
      name = "flathub";
      url = "https://flathub.org/repo/flathub.flatpakrepo";
    };
  };
}
```

### Note:
This feature is implemented during the system configuration activation phase rather than the build phase. Initial attempts to implement it in the build phase encountered difficulties due to the fact that Flatpak operations requiring system resources (like D-Bus) not available during the build phase.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
