### PR TITLE
firefox-gnome-theme: init at 131

### DIFF
--- a/pkgs/by-name/fi/firefox-gnome-theme/package.nix
+++ b/pkgs/by-name/fi/firefox-gnome-theme/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttr: {
+  pname = "firefox-gnome-theme";
+  version = "131";
+
+  src = fetchFromGitHub {
+    owner = "rafaelmardojai";
+    repo = "firefox-gnome-theme";
+    rev = "refs/tags/v${finalAttr.version}";
+    hash = "sha256-nf+0/UR5TZArp3Dn3NS3nB+ZGqecTOTOZRCFM3a1veM=";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  strictDeps = true;
+
+  # Only copy necessary files
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out
+    cp -ra ./configuration ./theme ./icon.svg ./userChrome.css ./userContent.css -t $out
+    install -Dm 644 ./README.md -t $doc/share/doc/firefox-gnome-theme/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "GNOME theme for Firefox";
+    longDescription = ''
+      A GNOME theme for Firefox.
+      This theme follows latest GNOME Adwaita style.
+    '';
+    homepage = "https://github.com/rafaelmardojai/firefox-gnome-theme";
+    downloadPage = "https://github.com/rafaelmardojai/firefox-gnome-theme/releases";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ ashgoldofficial ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Copy of #314231, because I messed up previous branch. Couldn't figure how to solve in any better way.

## Package info
**Project description**

A GNOME theme for Firefox

This theme follows latest GNOME Adwaita style.

**Metadata**

* homepage URL: https://github.com/rafaelmardojai/firefox-gnome-theme
* license: unlicense
* platforms: all

**Screenshot**
![Screenshot from 2024-05-24 13-31-12](https://github.com/NixOS/nixpkgs/assets/104313094/ec5c27e7-dd85-40cc-af18-b854f2ba8e3c)


## Basic usage (home-manager)
I don't know how to use it system wide without overlays, wrappers and overrides. 
```nix
programs.firefox.profiles.<name> = {
  settings = {
    # Needed
    # https://github.com/rafaelmardojai/firefox-gnome-theme?tab=readme-ov-file#required-firefox-preferences
    "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
    "svg.context-properties.content.enabled" = true;
    
    # Non essential
    "browser.theme.dark-private-windows" = false;
    "browser.uidensity" = 0;
    "widget.gtk.rounded-bottom-corners.enabled" = true;

    # Theme options can be found at
    # https://github.com/rafaelmardojai/firefox-gnome-theme?tab=readme-ov-file#enabling-optional-features
  };
  userChrome = ''
    @import "${pkgs.firefox-gnome-theme}/userChrome.css";
  '';
  userContent = ''
    @import "${pkgs.firefox-gnome-theme}/userContent.css";
  '';
};
```
For theme to automatically swich between light/dark variants based on GNOME's "Dark Style" option you need to use "System theme — auto" theme in Firefox.


## Questions and what can be done
- Should install scripts be added as well? I think they only affect home directory.
- Maybe add `version` and `hash` arguments for easier override (in case someone need other version of the theme for an older Firefox). Please give me your opinion.
- There are different themes in this package (standard Adwaita and some maia theme), user can choose one in install script. So should there be a `theme` argument for an easier override?
- Maybe there should be home-manager module (`programs.firefox-gnome-theme`) for easier usage. I don't know what can be done via system configuration, so give me your opinion.
- Just a question: `cp` and `install` are used during the `installPhase` so can this package's platforms be set to all? Or should the `installPhase` be moved to `buildPhase`?


## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
