### PR TITLE
qemu-vm: fix case-hack appearing in store image

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -141,6 +141,7 @@ let
           --absolute-names \
           --verbatim-files-from \
           --transform 'flags=rSh;s|/nix/store/||' \
+          --transform 'flags=rSh;s|~nix~case~hack~[[:digit:]]\+||g' \
           --files-from ${hostPkgs.closureInfo { rootPaths = [ config.system.build.toplevel regInfo ]; }}/store-paths \
           | ${hostPkgs.erofs-utils}/bin/mkfs.erofs \
             --quiet \


### PR DESCRIPTION
When using `darwin.linux-builder` after #241373, the Nix case hack suffix doesn't get removed and is present in the `linux-builder`'s store:

```
$ tree -L 1 /nix/store/sy6029qwc2a379081zriyq8hly31nrvh-ncurses-6.4.20221231/share/terminfo
/nix/store/sy6029qwc2a379081zriyq8hly31nrvh-ncurses-6.4.20221231/share/terminfo
├── 1
├── 2
├── 3
├── 4
├── 5
├── 6
├── 7
├── 8
├── 9
├── A
├── E
├── L
├── M
├── N
├── P
├── Q
├── X
├── a~nix~case~hack~1
├── b
├── c
├── d
├── e~nix~case~hack~1
├── f
├── g
├── h
├── i
├── j
├── k
├── l~nix~case~hack~1
├── m~nix~case~hack~1
├── n~nix~case~hack~1
├── o
├── p~nix~case~hack~1
├── q~nix~case~hack~1
├── r
├── s
├── t
├── u
├── v
├── w
├── x~nix~case~hack~1
└── z
```

This leads to issues when building a derivation like:

```nix
pkgs.buildEnv {
  name = "system-path";
  paths = [ pkgs.alacritty.terminfo pkgs.ncurses ];
  ignoreCollisions = true;
  pathsToLink = [ "/share/terminfo" ];
};
```

`pkgs.alacritty.terminfo`:

```
$ tree /nix/store/r0ljq2kgfvchnaa7a9ifjjjjj1dd45fc-alacritty-0.13.2-terminfo/share/terminfo
/nix/store/r0ljq2kgfvchnaa7a9ifjjjjj1dd45fc-alacritty-0.13.2-terminfo/share/terminfo
└── a
    ├── alacritty
    └── alacritty-direct
```

The derivation will successfully build on `aarch64-linux` but the two `a` directories won't get correctly merged and the store path will look like:
```
$ tree -L 1 /nix/store/ba93lbk52rvzgx6k8al8yg5kh4sk7g3l-system-path/share/terminfo
/nix/store/ba93lbk52rvzgx6k8al8yg5kh4sk7g3l-system-path/share/terminfo
├── A
├── a
└── a~nix~case~hack~1
```

Which will fail to get copied to `aarch64-darwin`:

```
building '/nix/store/3lmhyv6abflzr1x4zp60qr0pifkw7xcc-system-path.drv'...
system-path> warning: collision between `/nix/store/zwwfyrswrgv6akmsqhr3n1f917g7drwr-xwayland-24.1.2/share/man/man1/Xserver.1.gz' and `/nix/store/lilzagdmycrraggzfwyg0plavs4kdhrl-xorg-server-21.1.13/share/man/man1/Xserver.1.gz'
system-path> warning: collision between `/nix/store/zwwfyrswrgv6akmsqhr3n1f917g7drwr-xwayland-24.1.2/lib/xorg/protocol.txt' and `/nix/store/lilzagdmycrraggzfwyg0plavs4kdhrl-xorg-server-21.1.13/lib/xorg/protocol.txt'
system-path> created 8030 symlinks in user environment
system-path> gtk-update-icon-cache: Cache file created successfully.
copying 1 paths...
copying path '/nix/store/ba93lbk52rvzgx6k8al8yg5kh4sk7g3l-system-path' from 'ssh-ng://'...
error: filesystem error: in create_symlink: File exists ["/nix/store/sy6029qwc2a379081zriyq8hly31nrvh-ncurses-6.4.20221231/share/terminfo/a~nix~case~hack~1"] ["/nix/store/ba93lbk52rvzgx6k8al8yg5kh4sk7g3l-system-path/share/terminfo/a~nix~case~hack~1"]
error: builder for '/nix/store/3lmhyv6abflzr1x4zp60qr0pifkw7xcc-system-path.drv' failed with exit code 1
```

cc @roberth @emilazy @nikstur 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
