### PR TITLE
git-sim: init at 0.3.5

### DIFF
--- a/pkgs/by-name/gi/git-sim/package.nix
+++ b/pkgs/by-name/gi/git-sim/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  python3Packages,
+}:
+let
+  inherit (python3Packages)
+    buildPythonApplication
+    gitpython
+    manim
+    opencv4
+    typer
+    pydantic
+    fonttools
+    git-dummy
+    pytestCheckHook
+    ;
+
+  version = "0.3.5";
+in
+
+buildPythonApplication {
+  pname = "git-sim";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "initialcommit-com";
+    repo = "git-sim";
+    rev = "v${version}";
+    hash = "sha256-4jHkAlF2SAzHjBi8pmAJ0TKkcLxw+6EdGsXnHZUMILw=";
+  };
+
+  patches = [ ./tests.patch ];
+
+  build-system = [ ];
+
+  pythonRemoveDeps = [ "opencv-python-headless" ];
+
+  dependencies = [
+    gitpython
+    manim
+    opencv4
+    typer
+    pydantic
+    fonttools
+    git-dummy
+  ];
+
+  # https://github.com/NixOS/nixpkgs/commit/8033561015355dd3c3cf419d81ead31e534d2138
+  makeWrapperArgs = [ "--prefix PYTHONWARNINGS , ignore:::pydub.utils:" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall =
+    # https://github.com/NixOS/nixpkgs/issues/308283
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd git-sim \
+        --bash <($out/bin/git-sim --show-completion bash) \
+        --fish <($out/bin/git-sim --show-completion fish) \
+        --zsh <($out/bin/git-sim --show-completion zsh)
+    ''
+    + "ln -s ${git-dummy}/bin/git-dummy $out/bin/";
+
+  preCheck = ''
+    PATH=$PATH:$out/bin
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    git-dummy
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Visually simulate Git operations in your own repos with a single terminal command";
+    homepage = "https://initialcommit.com/tools/git-sim";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ mathiassven ];
+  };
+}

--- a/pkgs/by-name/gi/git-sim/tests.patch
+++ b/pkgs/by-name/gi/git-sim/tests.patch
@@ -1,0 +1,33 @@
+diff --git a/tests/e2e_tests/conftest.py b/tests/e2e_tests/conftest.py
+index 310197a..9e82a1e 100644
+--- a/tests/e2e_tests/conftest.py
++++ b/tests/e2e_tests/conftest.py
+@@ -22,9 +22,7 @@ def tmp_repo(tmp_path_factory):
+     # Create the sample repo for testing.
+     os.chdir(tmp_repo_dir)
+ 
+-    # When defining cmd, as_posix() is required for Windows compatibility.
+-    git_dummy_path = utils.get_venv_path() / "git-dummy"
+-    cmd = f"{git_dummy_path.as_posix()} --commits=10 --branches=4 --merge=1 --constant-sha --name=sample_repo --diverge-at=2"
++    cmd = "git-dummy --commits=10 --branches=4 --merge=1 --constant-sha --name=sample_repo --diverge-at=2"
+     cmd_parts = split(cmd)
+     subprocess.run(cmd_parts)
+ 
+diff --git a/tests/e2e_tests/utils.py b/tests/e2e_tests/utils.py
+index 8dfc623..41a4cf6 100644
+--- a/tests/e2e_tests/utils.py
++++ b/tests/e2e_tests/utils.py
+@@ -69,13 +69,6 @@ def get_cmd_parts(raw_command):
+         f"git-sim -d --output-only-path --img-format=png --font='{font_path}'",
+     )
+ 
+-    # Replace `git-sim` with the full path to the binary.
+-    #   as_posix() is needed for Windows compatibility.
+-    # The space is included in "git-sim " to avoid replacing any occurrences
+-    #   of git-sim in a font path.
+-    git_sim_path = get_venv_path() / "git-sim"
+-    cmd = cmd.replace("git-sim ", f"{git_sim_path.as_posix()} ")
+-
+     # Show full test command when run in diagnostic mode.
+     print(f"  Test command: {cmd}")
+ 

--- a/pkgs/development/python-modules/git-dummy/default.nix
+++ b/pkgs/development/python-modules/git-dummy/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  installShellFiles,
+  setuptools,
+  gitpython,
+  typer,
+  pydantic-settings,
+}:
+
+buildPythonPackage rec {
+  pname = "git-dummy";
+  version = "0.1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "initialcommit-com";
+    repo = "git-dummy";
+    rev = "v${version}";
+    hash = "sha256-viybxn2J7SO7NgSvjwlP+tgtm+H6QrACafIy82d9XEk=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    gitpython
+    typer
+    pydantic-settings
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall =
+    # https://github.com/NixOS/nixpkgs/issues/308283
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd git-dummy \
+        --bash <($out/bin/git-dummy --show-completion bash) \
+        --fish <($out/bin/git-dummy --show-completion fish) \
+        --zsh <($out/bin/git-dummy --show-completion zsh)
+    '';
+
+  meta = {
+    homepage = "https://github.com/initialcommit-com/git-dummy";
+    description = "Generate dummy Git repositories populated with the desired number of commits, branches, and structure";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ mathiassven ];
+  };
+}

--- a/pkgs/development/python-modules/manim/default.nix
+++ b/pkgs/development/python-modules/manim/default.nix
@@ -205,6 +205,9 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace "--no-cov-on-fail --cov=manim --cov-report xml --cov-report term" ""
+
+    substituteInPlace manim/_config/default.cfg \
+      --replace "ffmpeg_executable = ffmpeg" "ffmpeg_executable = ${lib.getExe ffmpeg}"
   '';
 
   buildInputs = [ cairo ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5071,6 +5071,8 @@ self: super: with self; {
 
   git-url-parse = callPackage ../development/python-modules/git-url-parse { };
 
+  git-dummy = callPackage ../development/python-modules/git-dummy { };
+
   gitdb = callPackage ../development/python-modules/gitdb { };
 
   githubkit = callPackage ../development/python-modules/githubkit { };


### PR DESCRIPTION
Closes: #212680 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
