### PR TITLE
treewide: fix typo chown -> chmod

### DIFF
--- a/nixos/modules/services/networking/shorewall.nix
+++ b/nixos/modules/services/networking/shorewall.nix
@@ -58,7 +58,7 @@ in {
         install -D -d -m 750 /var/lib/shorewall
         install -D -d -m 755 /var/lock/subsys
         touch                /var/log/shorewall.log
-        chown 750            /var/log/shorewall.log
+        chmod 750            /var/log/shorewall.log
       '';
     };
     environment = {

--- a/nixos/modules/services/networking/shorewall6.nix
+++ b/nixos/modules/services/networking/shorewall6.nix
@@ -58,7 +58,7 @@ in {
         install -D -d -m 750 /var/lib/shorewall6
         install -D -d -m 755 /var/lock/subsys
         touch                /var/log/shorewall6.log
-        chown 750            /var/log/shorewall6.log
+        chmod 750            /var/log/shorewall6.log
       '';
     };
     environment = {

--- a/nixos/modules/virtualisation/ec2-data.nix
+++ b/nixos/modules/virtualisation/ec2-data.nix
@@ -34,7 +34,7 @@ with lib;
             if ! [ -e /root/.ssh/authorized_keys ]; then
                 echo "obtaining SSH key..."
                 mkdir -p /root/.ssh
-                chown 0700 /root/.ssh
+                chmod 0700 /root/.ssh
                 if [ -s /etc/ec2-metadata/public-keys-0-openssh-key ]; then
                     (umask 177; cat /etc/ec2-metadata/public-keys-0-openssh-key >> /root/.ssh/authorized_keys)
                     echo "new key added to authorized_keys"
@@ -47,7 +47,7 @@ with lib;
             userData=/etc/ec2-metadata/user-data
 
             mkdir -p /etc/ssh
-            chown 0755 /etc/ssh
+            chmod 0755 /etc/ssh
 
             if [ -s "$userData" ]; then
               key="$(sed 's/|/\n/g; s/SSH_HOST_DSA_KEY://; t; d' $userData)"

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -1,6 +1,6 @@
 metaDir=/etc/ec2-metadata
 mkdir -p "$metaDir"
-chown 0755 "$metaDir"
+chmod 0755 "$metaDir"
 rm -f "$metaDir/*"
 
 get_imds_token() {

--- a/nixos/tests/nebula.nix
+++ b/nixos/tests/nebula.nix
@@ -136,9 +136,9 @@ in
       ${name}.start()
       ${name}.succeed(
           "mkdir -p /root/.ssh",
-          "chown 700 /root/.ssh",
+          "chmod 700 /root/.ssh",
           "cat '${snakeOilPrivateKey}' > /root/.ssh/id_snakeoil",
-          "chown 600 /root/.ssh/id_snakeoil",
+          "chmod 600 /root/.ssh/id_snakeoil",
           "mkdir -p /root"
       )
     '';

--- a/nixos/tests/tmate-ssh-server.nix
+++ b/nixos/tests/tmate-ssh-server.nix
@@ -6,9 +6,9 @@ let
   setUpPrivateKey = name: ''
     ${name}.succeed(
         "mkdir -p /root/.ssh",
-        "chown 700 /root/.ssh",
+        "chmod 700 /root/.ssh",
         "cat '${snakeOilPrivateKey}' > /root/.ssh/id_snakeoil",
-        "chown 600 /root/.ssh/id_snakeoil",
+        "chmod 600 /root/.ssh/id_snakeoil",
     )
     ${name}.wait_for_file("/root/.ssh/id_snakeoil")
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Fixes https://github.com/NixOS/nixpkgs/issues/347672

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
