### PR TITLE
Rizin/Cutter: Add patch to disable PCRE2 JIT.

### DIFF
--- a/pkgs/development/tools/analysis/rizin/0002-disable-pcre2-jit.patch
+++ b/pkgs/development/tools/analysis/rizin/0002-disable-pcre2-jit.patch
@@ -1,0 +1,36 @@
+diff --git a/meson.build b/meson.build
+index a8153a2ee5..787cbfae06 100644
+--- a/meson.build
++++ b/meson.build
+@@ -197,7 +197,7 @@ endif
+ 
+ # Handle PCRE2
+ cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv32', 'riscv64', 's390x', 'x86', 'x86_64' ]
+-pcre2_jit_supported = target_machine.cpu_family() in cpu_jit_supported and cc.get_id() != 'tcc' and target_machine.system() != 'darwin'
++pcre2_jit_supported = false
+ if pcre2_jit_supported
+   add_project_arguments(['-DSUPPORTS_PCRE2_JIT'], language: 'c')
+ endif
+diff --git a/subprojects/packagefiles/pcre2/meson.build b/subprojects/packagefiles/pcre2/meson.build
+index b40ea85740..f3ee7a02ed 100644
+--- a/subprojects/packagefiles/pcre2/meson.build
++++ b/subprojects/packagefiles/pcre2/meson.build
+@@ -60,18 +60,6 @@ cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv
+ # tcc doesn't support the MSVC asm syntax PCRE2 uses (`__asm { ... }`).
+ # Darwin kernel not as well, because of forbidden wx memory.
+ # It is used in the JIT compiler code.
+-if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported and target_machine.system() != 'darwin'
+-  libpcre2_c_args += ['-DSUPPORT_JIT']
+-  pcre2_files += ['src/pcre2_jit_compile.c']
+-endif
+-
+-if target_machine.system() == 'openbsd'
+-  # jit compilation fails with "no more memory" if wx allocations are allowed.
+-  libpcre2_c_args += ['-DSLJIT_WX_EXECUTABLE_ALLOCATOR']
+-elif target_machine.system() == 'netbsd'
+-  # jit compilation fails with "no more memory" if wx allocations are allowed.
+-  libpcre2_c_args += ['-DSLJIT_PROT_EXECUTABLE_ALLOCATOR']
+-endif
+ 
+ pcre2_includes = [
+   include_directories('.'),

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -60,6 +60,7 @@ let rizin = stdenv.mkDerivation rec {
     ./librz-wrapper-support.patch
 
     ./0001-fix-compilation-with-clang.patch
+    # Can be dropped when upstream fixes this: https://github.com/NixOS/nixpkgs/issues/300056
     ./0002-disable-pcre2-jit.patch
   ];
 

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -60,6 +60,7 @@ let rizin = stdenv.mkDerivation rec {
     ./librz-wrapper-support.patch
 
     ./0001-fix-compilation-with-clang.patch
+    ./0002-disable-pcre2-jit.patch
   ];
 
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc @Mic92

Multiple users reported problems **likely** related to PCRE2 JIT.

See: https://github.com/rizinorg/cutter/issues/3220 https://github.com/rizinorg/cutter/issues/3328

It seems to be related to:
- https://github.com/NixOS/nixpkgs/issues/300056
- https://github.com/NixOS/nixpkgs/pull/300565 

The thing is, I cannot not test it. Because a simple build fails due to some dependency issues as it looks like. And I struggle to find time for it. Is there an easy fix? Then I can try it again.

```
> nix-build -E 'with import <nixpkgs> {}; callPackage ./nixpkgs-rizin-pcre2-jit/pkgs/development/tools/analysis/rizin/cutter.nix {}'
error:
       … while calling the 'abort' builtin
 
         at /nix/var/nix/profiles/per-user/root/channels/nixos/lib/customisation.nix:269:13:
 
          268|        # which is especially relevant with allowAliases = false
          269|        else abort "lib.customisation.callPackageWith: ${error}";
             |             ^
          270|
 
       error: evaluation aborted with the following error message: 'lib.customisation.callPackageWith: Function called without required argument "qt5compat" at /home/user/nixpkgs-rizin-pcre2-jit/pkgs/development/tools/analysis/rizin/cutter.nix:11'
```

Rizin was updated to PCRE 10.44 directly after the release though. But I think it is not yet part of Cutter 2.3.4.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
