### PR TITLE
argyllcms: clean up; fix static

### DIFF
--- a/pkgs/by-name/ar/argyllcms/package.nix
+++ b/pkgs/by-name/ar/argyllcms/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   fetchzip,
   jam,
+  pkg-config,
   unzip,
   libX11,
   libXxf86vm,
@@ -37,6 +38,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     jam
+    pkg-config
     unzip
   ];
 
@@ -70,7 +72,10 @@ stdenv.mkDerivation rec {
       -s HAVE_PNG=true
       -s HAVE_Z=true
       -s HAVE_SSL=true
-      -s LINKFLAGS="-ljpeg -ltiff -lpng -lz -lssl"
+      -s LINKFLAGS="$($PKG_CONFIG --libs libjpeg libtiff-4 libpng zlib libssl)"
+      -s GUILINKFLAGS="$($PKG_CONFIG --libs x11 xext xxf86vm xinerama xrandr xau xdmcp xscrnsaver)"
+    )
+
     export AR="$AR rusc"
   '';
 

--- a/pkgs/by-name/ar/argyllcms/package.nix
+++ b/pkgs/by-name/ar/argyllcms/package.nix
@@ -16,6 +16,7 @@
   writeText,
   libXdmcp,
   libXau,
+  xorgproto,
   lib,
   openssl,
   buildPackages,
@@ -51,84 +52,27 @@ stdenv.mkDerivation rec {
       --replace "-m64" ""
   '';
 
-  preConfigure =
-    let
-      # The contents of this file comes from the Jamtop file from the
-      # root of the ArgyllCMS distribution, rewritten to pick up Nixpkgs
-      # library paths. When ArgyllCMS is updated, make sure that changes
-      # in that file is reflected here.
-      jamTop = writeText "argyllcms_jamtop" ''
-        DESTDIR = "/" ;
-        REFSUBDIR = "share/argyllcms" ;
+  preConfigure = ''
+    # Remove tiff, jpg and png to be sure the nixpkgs-provided ones are used
+    rm -rf tiff jpg png
 
-        # Keep this DESTDIR anchored to Jamtop. PREFIX is used literally
-        ANCHORED_PATH_VARS = DESTDIR ;
+    substituteInPlace Jamtop \
+      --replace-fail /usr/X11R6/include ${lib.getDev xorgproto}/include \
+      --replace-fail /usr/X11R6/lib ${lib.getLib libX11}/lib
 
-        # Tell standalone libraries that they are part of Argyll:
-        DEFINES += ARGYLLCMS ;
-
-        # enable serial instruments & support
-        USE_SERIAL = true ;
-
-        # enable fast serial instruments & support
-        USE_FAST_SERIAL = true ;                # (Implicit in USE_SERIAL too)
-
-        # enable USB instruments & support
-        USE_USB = true ;
-
-        # enable dummy Demo Instrument (only if code is available)
-        USE_DEMOINST = true ;
-
-        # enable Video Test Patch Generator and 3DLUT device support
-        # (V2.0.0 and above)
-        USE_VTPGLUT = false ;
-
-        # enable Printer device support
-        USE_PRINTER = false ;
-
-        # enable CMF Measurement device and accessory support (if present)
-        USE_CMFM = false ;
-
-        # Use ArgyllCMS version of libusb (deprecated - don't use)
-        USE_LIBUSB = false ;
-
-        # Compile in graph plotting code (Not fully implemented)
-        USE_PLOT = true ;		# [true]
-
-        JPEGLIB = ;
-        JPEGINC = ;
-        HAVE_JPEG = true ;
-
-        TIFFLIB = ;
-        TIFFINC = ;
-        HAVE_TIFF = true ;
-
-        PNGLIB = ;
-        PNGINC = ;
-        HAVE_PNG = true ;
-
-        ZLIB = ;
-        ZINC = ;
-        HAVE_Z = true ;
-
-        SSLLIB = ;
-        SSLINC = ;
-        HAVE_SSL = true ;
-
-        LINKFLAGS +=
-          ${lib.concatStringsSep " " (map (x: "-L${x}/lib") buildInputs)}
-          -lrt -lX11 -lXext -lXxf86vm -lXinerama -lXrandr -lXau -lXdmcp -lXss
-          -ljpeg -ltiff -lpng -lssl ;
-      '';
-    in
-    ''
-      cp ${jamTop} Jamtop
-      substituteInPlace Makefile --replace "-j 3" "-j $NIX_BUILD_CORES"
-      # Remove tiff, jpg and png to be sure the nixpkgs-provided ones are used
-      rm -rf tiff jpg png
-
-      export AR="$AR rusc"
-    '';
+    jamFlagsArray=(
+      -q -fJambase -j "$NIX_BUILD_CORES"
+      -s DESTDIR=/
+      -s REFSUBDIR=share/argyllcms
+      -s PREFIX="$out"
+      -s HAVE_JPEG=true
+      -s HAVE_TIFF=true
+      -s HAVE_PNG=true
+      -s HAVE_Z=true
+      -s HAVE_SSL=true
+      -s LINKFLAGS="-ljpeg -ltiff -lpng -lz -lssl"
+    export AR="$AR rusc"
+  '';
 
   buildInputs = [
     libtiff
@@ -146,15 +90,21 @@ stdenv.mkDerivation rec {
     openssl
   ];
 
-  buildFlags = [ "all" ];
+  buildPhase = ''
+    runHook preBuild
 
-  makeFlags = [
-    "PREFIX=${placeholder "out"}"
-  ];
+    jam "''${jamFlagsArray[@]}"
 
-  # Install udev rules, but remove lines that set up the udev-acl
-  # stuff, since that is handled by udev's own rules (70-udev-acl.rules)
-  postInstall = ''
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    jam "''${jamFlagsArray[@]}" install
+
+    # Install udev rules, but remove lines that set up the udev-acl
+    # stuff, since that is handled by udev's own rules (70-udev-acl.rules)
     rm -v $out/bin/License.txt
     mkdir -p $out/etc/udev/rules.d
     sed -i '/udev-acl/d' usb/55-Argyll.rules
@@ -162,6 +112,7 @@ stdenv.mkDerivation rec {
 
     sed -i -e 's/^CREATED .*/CREATED "'"$(date -d @$SOURCE_DATE_EPOCH)"'"/g' $out/share/argyllcms/RefMediumGamut.gam
 
+    runHook postInstall
   '';
 
   passthru = {


### PR DESCRIPTION
Almost everything in the default Jamtop (apart from the X11 paths) is overridable.  This moves us closer to upstream by using the build system's override functionality rather than including our own replacement copy of Jamtop.  This will mean less churn when updating, and possibly also better portability as the base Jamtop has stuff to handle different OSes in it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
