### PR TITLE
ndcurves: init at 1.4.1

### DIFF
--- a/pkgs/by-name/nd/ndcurves/package.nix
+++ b/pkgs/by-name/nd/ndcurves/package.nix
@@ -1,0 +1,76 @@
+{
+  cmake,
+  doxygen,
+  fetchFromGitHub,
+  jrl-cmakemodules,
+  lib,
+  pinocchio,
+  pkg-config,
+  python3Packages,
+  pythonSupport ? false,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ndcurves";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "loco-3d";
+    repo = "ndcurves";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-XJ3VSSGKSJ+x3jc4408PGHTYg3nC7o/EeFnbKBELefs=";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs =
+    [
+      cmake
+      doxygen
+      pkg-config
+    ]
+    ++ lib.optionals pythonSupport [
+      python3Packages.python
+      python3Packages.pythonImportsCheckHook
+    ];
+  propagatedBuildInputs =
+    [ jrl-cmakemodules ]
+    ++ lib.optionals pythonSupport [
+      python3Packages.eigenpy
+      python3Packages.pinocchio
+    ]
+    ++ lib.optional (!pythonSupport) pinocchio;
+
+  cmakeFlags =
+    [
+      (lib.cmakeBool "BUILD_PYTHON_INTERFACE" pythonSupport)
+      (lib.cmakeBool "CURVES_WITH_PINOCCHIO_SUPPORT" true)
+    ]
+    ++ lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) (
+      lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'curves_tests|python-curves'"
+    )
+    ++ lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) (
+      lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'test-so3-smooth'"
+    )
+    ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) (
+      lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'curves_tests'"
+    );
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "ndcurves" ];
+
+  meta = {
+    description = "Library for creating smooth cubic splines";
+    homepage = "https://github.com/loco-3d/ndcurves";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.nim65s ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/nd/ndcurves/package.nix
+++ b/pkgs/by-name/nd/ndcurves/package.nix
@@ -52,14 +52,11 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" pythonSupport)
       (lib.cmakeBool "CURVES_WITH_PINOCCHIO_SUPPORT" true)
     ]
-    ++ lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) (
+    ++ lib.optional stdenv.hostPlatform.isAarch64 (
       lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'curves_tests|python-curves'"
     )
     ++ lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) (
       lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'test-so3-smooth'"
-    )
-    ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) (
-      lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'curves_tests'"
     );
 
   doCheck = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8926,6 +8926,8 @@ self: super: with self; {
 
   natural = callPackage ../development/python-modules/natural { };
 
+  ndcurves = toPythonModule (pkgs.ndcurves.override { python3Packages = self; pythonSupport = true; });
+
   nomadnet = callPackage ../development/python-modules/nomadnet { };
 
   noneprompt = callPackage ../development/python-modules/noneprompt {  };


### PR DESCRIPTION
Hi,

This add the [ndcurves](https://github.com/loco-3d/ndcurves) library,  for creating smooth cubic splines. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
