### PR TITLE
libspatialite: added patch to wrap call to xmlNanoHTTPCleanup()

### DIFF
--- a/pkgs/development/libraries/libspatialite/default.nix
+++ b/pkgs/development/libraries/libspatialite/default.nix
@@ -25,6 +25,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-Q74t00na/+AW3RQAxdEShYKMIv6jXKUQnyHz7VBgUIA=";
   };
 
+  patches = [
+    # Drop use of deprecated libxml2 HTTP API.
+    # From: https://www.gaia-gis.it/fossil/libspatialite/info/7c452740fe
+    # see also: https://github.com/NixOS/nixpkgs/issues/347085
+    ./xmlNanoHTTPCleanup.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     validatePkgConfig
@@ -35,7 +42,7 @@ stdenv.mkDerivation rec {
     freexl
     geos
     librttopo
-    (libxml2.override { enableHttp = true; })
+    libxml2
     minizip
     proj
     sqlite

--- a/pkgs/development/libraries/libspatialite/xmlNanoHTTPCleanup.patch
+++ b/pkgs/development/libraries/libspatialite/xmlNanoHTTPCleanup.patch
@@ -1,0 +1,26 @@
+diff --git a/src/wfs/wfs_in.c b/src/wfs/wfs_in.c
+index fe07a0d..7f2557d 100644
+--- a/src/wfs/wfs_in.c
++++ b/src/wfs/wfs_in.c
+@@ -76,7 +76,10 @@ Regione Toscana - Settore Sistema Informativo Territoriale ed Ambientale
+ #ifdef ENABLE_LIBXML2		/* LIBXML2 enabled: supporting XML documents */
+ 
+ #include <libxml/parser.h>
+-#include <libxml/nanohttp.h>
++
++#ifdef LIBXML_HTTP_ENABLED
++  #include <libxml/nanohttp.h>
++#endif
+ 
+ #define MAX_GTYPES	28
+ 
+@@ -4637,7 +4640,9 @@ SPATIALITE_DECLARE void
+ reset_wfs_http_connection (void)
+ {
+ /* Resets the libxml2 "nano HTTP": useful when changing the HTTP_PROXY settings */
++#ifdef LIBXML_HTTP_ENABLED
+     xmlNanoHTTPCleanup ();
++#endif
+ }
+ 
+ #else /* LIBXML2 isn't enabled */


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/347085

Added patch to wrap the call to `xmlNanoHTTPCleanup()` as described here: https://www.gaia-gis.it/fossil/libspatialite/info/7c452740fe

This is enough to successfully build `rPackages.icosa`, but more generally it is likely that other packages could have issues due to re-enabling HTTP support in `libxml2` through an override in their buildInputs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
