### PR TITLE
python312Packages.plotly: 5.24.0 -> 5.24.1

### DIFF
--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -2,37 +2,43 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
+
+  # dependencies
+  kaleido,
   packaging,
   tenacity,
-  kaleido,
-  pytestCheckHook,
-  pandas,
-  requests,
-  matplotlib,
-  xarray,
-  pillow,
-  scipy,
-  psutil,
-  statsmodels,
+
+  # tests
   ipython,
   ipywidgets,
-  which,
-  orca,
+  matplotlib,
   nbformat,
+  orca,
+  pandas,
+  pillow,
+  psutil,
+  pytestCheckHook,
+  requests,
   scikit-image,
+  scipy,
+  statsmodels,
+  which,
+  xarray,
 }:
 
 buildPythonPackage rec {
   pname = "plotly";
-  version = "5.24.0";
+  version = "5.24.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "plotly";
     repo = "plotly.py";
     rev = "refs/tags/v${version}";
-    hash = "sha256-frSUybQxst4wG8g8U43Nay9dYCUXuR3dBealwPVyFdI=";
+    hash = "sha256-ONuX5/GlirPF8+7bZtib1Xsv5llcXcSelFfGyeTc5L8=";
   };
 
   sourceRoot = "${src.name}/packages/python/plotly";
@@ -47,30 +53,34 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
+    kaleido
     packaging
     tenacity
-    kaleido
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-    pandas
-    requests
-    matplotlib
-    xarray
-    pillow
-    scipy
-    psutil
-    statsmodels
     ipython
     ipywidgets
-    which
-    orca
+    matplotlib
     nbformat
+    orca
+    pandas
+    pillow
+    psutil
+    pytestCheckHook
+    requests
     scikit-image
+    scipy
+    statsmodels
+    which
+    xarray
   ];
 
   disabledTests = [
+    # Require unpackaged `vaex`
+    "test_build_df_with_hover_data_from_vaex_and_polars"
+    "test_build_df_from_vaex_and_polars"
+
     # FAILED plotly/matplotlylib/mplexporter/tests/test_basic.py::test_legend_dots - AssertionError: assert '3' == '2'
     "test_legend_dots"
     # FAILED plotly/matplotlylib/mplexporter/tests/test_utils.py::test_linestyle - AssertionError:


### PR DESCRIPTION
## Things done

This PR also fixes `plotly` which is currently broken.

Changelog: https://github.com/plotly/plotly.py/blob/master/CHANGELOG.md

cc @Pandapip1

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
