### PR TITLE
colord: add enableSystemd option

### DIFF
--- a/pkgs/by-name/eu/eudev/package.nix
+++ b/pkgs/by-name/eu/eudev/package.nix
@@ -6,6 +6,7 @@
 , kmod
 , pkg-config
 , util-linux
+, testers
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -56,6 +57,10 @@ stdenv.mkDerivation (finalAttrs: {
     "udevrulesdir=$(out)/var/lib/udev/rules.d"
   ];
 
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
   meta = {
     homepage = "https://github.com/eudev-project/eudev";
     description = "Fork of udev with the aim of isolating it from init";
@@ -80,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/eudev-project/eudev/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ raskin AndersonTorres ];
+    pkgConfigModules = [ "libudev" "udev" ];
     inherit (kmod.meta) platforms;
   };
 })

--- a/pkgs/development/libraries/libudev-zero/default.nix
+++ b/pkgs/development/libraries/libudev-zero/default.nix
@@ -1,13 +1,13 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub, testers }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libudev-zero";
   version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "illiliti";
     repo = "libudev-zero";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-NXDof1tfr66ywYhCBDlPa+8DUfFj6YH0dvSaxHFqsXI=";
   };
 
@@ -19,12 +19,17 @@ stdenv.mkDerivation rec {
 
   installTargets = lib.optionals stdenv.hostPlatform.isStatic "install-static";
 
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
   meta = with lib; {
     homepage = "https://github.com/illiliti/libudev-zero";
     description = "Daemonless replacement for libudev";
     changelog = "https://github.com/illiliti/libudev-zero/releases/tag/${version}";
     maintainers = with maintainers; [ qyliss shamilton ];
     license = licenses.isc;
+    pkgConfigModules = [ "libudev" ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -4,6 +4,7 @@
 , lib
 , nixosTests
 , pkgsCross
+, testers
 , fetchFromGitHub
 , fetchzip
 , fetchpatch2
@@ -795,6 +796,7 @@ stdenv.mkDerivation (finalAttrs: {
             else "aarch64-multiplatform";
         in
         pkgsCross.${systemString}.systemd;
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     };
   };
 
@@ -830,6 +832,7 @@ stdenv.mkDerivation (finalAttrs: {
       publicDomain
     ];
     maintainers = with lib.maintainers; [ flokli kloenk ];
+    pkgConfigModules = [ "libsystemd" "libudev" "systemd" "udev" ];
     # See src/basic/missing_syscall_def.h
     platforms = with lib.platforms; lib.intersectLists linux
       (aarch ++ x86 ++ loongarch64 ++ m68k ++ mips ++ power ++ riscv ++ s390);

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -10,7 +10,9 @@
 , gusb
 , lcms2
 , sqlite
+, udev
 , systemd
+, enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
 , dbus
 , gobject-introspection
 , argyllcms
@@ -60,6 +62,11 @@ stdenv.mkDerivation rec {
     "-Dvapi=true"
     "-Ddaemon=${lib.boolToString enableDaemon}"
     "-Ddaemon_user=colord"
+    (lib.mesonBool "systemd" enableSystemd)
+
+    # The presence of the "udev" pkg-config module (as opposed to "libudev")
+    # indicates whether rules are supported.
+    (lib.mesonBool "udev_rules" (lib.elem "udev" udev.meta.pkgConfigModules))
   ];
 
   nativeBuildInputs = [
@@ -90,6 +97,8 @@ stdenv.mkDerivation rec {
     libgudev
     sane-backends
     sqlite
+    udev
+  ] ++ lib.optionals enableSystemd [
     systemd
   ] ++ lib.optionals enableDaemon [
     polkit


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/345979, building colord is necessary to build xdg-desktop-portal-gtk, but it wasn't possible for systems that can't use systemd.

I've called the option "enableSystemd" for consistency with the existing "enableDaemon" option.

As usual in Nixpkgs, the user is responsible for also overriding udev
to a non-systemd implementation if necessary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
