### PR TITLE
jfrog-cli: 2.56.1 -> 2.70.0, update go version

### DIFF
--- a/pkgs/tools/misc/jfrog-cli/default.nix
+++ b/pkgs/tools/misc/jfrog-cli/default.nix
@@ -1,37 +1,22 @@
 { lib
-, buildGoModule
+, buildGo123Module
 , fetchFromGitHub
 , nodejs
 , nix-update-script
 }:
 
-buildGoModule rec {
+buildGo123Module rec {
   pname = "jfrog-cli";
-  version = "2.56.1";
+  version = "2.70.0";
 
   src = fetchFromGitHub {
     owner = "jfrog";
     repo = "jfrog-cli";
     rev = "refs/tags/v${version}";
-    hash = "sha256-oUICnpVHRNCauWEplz7xH6AdP6CbbYX/Uy/QUPjwGHc=";
+    hash = "sha256-ddwGmXb616kDNNNTNUykiEWX/2ihUpgetZ/va943RiQ=";
   };
 
-  vendorHash = "sha256-zQjOOUlqL0Mj2DKHiG9rOfu41SKMO7C99JBJDycXAs4=";
-
-  # Upgrade the Go version during the vendoring FOD build because it fails otherwise.
-  overrideModAttrs = _: {
-    preBuild = ''
-      substituteInPlace go.mod --replace-fail 'go 1.20' 'go 1.21'
-    '';
-    postInstall = ''
-      cp go.mod "$out/go.mod"
-    '';
-  };
-
-  # Copy the modified go.mod we got from the vendoring process.
-  preBuild = ''
-    cp vendor/go.mod go.mod
-  '';
+  vendorHash = "sha256-CT+flwvPC9IRWBMyCHtj25F/szeeno9OHMs3+D0J58g=";
 
   postPatch = ''
     # Patch out broken test cleanup.

--- a/pkgs/tools/misc/jfrog-cli/default.nix
+++ b/pkgs/tools/misc/jfrog-cli/default.nix
@@ -16,7 +16,8 @@ buildGo123Module rec {
     hash = "sha256-ddwGmXb616kDNNNTNUykiEWX/2ihUpgetZ/va943RiQ=";
   };
 
-  vendorHash = "sha256-CT+flwvPC9IRWBMyCHtj25F/szeeno9OHMs3+D0J58g=";
+  proxyVendor = true;
+  vendorHash = "sha256-1xUCQF2UDHAmzibixv9pR6G2gvXxIStCyBuz608UpIQ=";
 
   postPatch = ''
     # Patch out broken test cleanup.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- https://github.com/jfrog/jfrog-cli/releases/tag/v2.70.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.69.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.68.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.67.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.66.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.65.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.64.1
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.64.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.63.2
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.63.1
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.63.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.62.2
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.62.1
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.62.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.61.2
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.61.1
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.61.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.60.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.59.1
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.59.0
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.58.2
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.58.1
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.57.1
- https://github.com/jfrog/jfrog-cli/releases/tag/v2.57.0
- diff: https://github.com/jfrog/jfrog-cli/compare/v2.56.1...v2.70.0

The upstream repo has updated to use go 1.23, so we no longer need to update during build time. This was causing the automated version updates to fail.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
