### PR TITLE
tree-sitter-grammars: add river

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/generated.nix
@@ -2364,6 +2364,17 @@
     };
     meta.homepage = "https://github.com/rescript-lang/tree-sitter-rescript";
   };
+  river = buildGrammar {
+    language = "river";
+    version = "0.0.0+rev=eafcdc5";
+    src = fetchFromGitHub {
+      owner = "grafana";
+      repo = "tree-sitter-river";
+      rev = "eafcdc5147f985fea120feb670f1df7babb2f79e";
+      hash = "sha256-fhuIO++hLr5DqqwgFXgg8QGmcheTpYaYLMo7117rjyk=";
+    };
+    meta.homepage = "https://github.com/grafana/tree-sitter-river";
+  };
   rnoweb = buildGrammar {
     language = "rnoweb";
     version = "0.0.0+rev=1a74dc0";

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -82,6 +82,7 @@
   tree-sitter-r = lib.importJSON ./tree-sitter-r.json;
   tree-sitter-regex = lib.importJSON ./tree-sitter-regex.json;
   tree-sitter-rego = lib.importJSON ./tree-sitter-rego.json;
+  tree-sitter-river = lib.importJSON ./tree-sitter-river.json;
   tree-sitter-rst = lib.importJSON ./tree-sitter-rst.json;
   tree-sitter-ruby = lib.importJSON ./tree-sitter-ruby.json;
   tree-sitter-rust = lib.importJSON ./tree-sitter-rust.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-river.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-river.json
@@ -1,0 +1,12 @@
+{
+  "url": "https://github.com/grafana/tree-sitter-river",
+  "rev": "eafcdc5147f985fea120feb670f1df7babb2f79e",
+  "date": "2023-11-22T14:48:13+01:00",
+  "path": "/nix/store/6wwv45dv3lgyzng2hryadamp061yzx4i-tree-sitter-river",
+  "sha256": "0acgxdgdffya5jc8d9ck2xrac0gi41w1a85cm91vwbm1xwxqh6vy",
+  "hash": "sha256-fhuIO++hLr5DqqwgFXgg8QGmcheTpYaYLMo7117rjyk=",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -439,6 +439,10 @@ let
       orga = "glehmann";
       repo = "tree-sitter-earthfile";
     };
+    "tree-sitter-river" = {
+      orga = "grafana";
+      repo = "tree-sitter-river";
+    };
   };
 
   allGrammars =


### PR DESCRIPTION
https://github.com/grafana/tree-sitter-river

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

tested in nvim