### PR TITLE
python312Packages.plotly: cleanup, enable checks on darwin

### DIFF
--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -20,6 +20,8 @@
   which,
   nbformat,
   scikit-image,
+  orca,
+  psutil,
 }:
 
 buildPythonPackage rec {
@@ -50,6 +52,15 @@ buildPythonPackage rec {
     tenacity
     kaleido
   ];
+
+  # packages/python/plotly/optional-requirements.txt
+  optional-dependencies = {
+    orca = [
+      orca
+      requests
+      psutil
+    ];
+  };
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -14,12 +14,10 @@
   xarray,
   pillow,
   scipy,
-  psutil,
   statsmodels,
   ipython,
   ipywidgets,
   which,
-  orca,
   nbformat,
   scikit-image,
 }:
@@ -61,69 +59,39 @@ buildPythonPackage rec {
     xarray
     pillow
     scipy
-    psutil
     statsmodels
     ipython
     ipywidgets
     which
-    orca
     nbformat
     scikit-image
   ];
 
-  # the check inputs are broken on darwin
-  doCheck = !stdenv.hostPlatform.isDarwin;
-
   disabledTests = [
-    # FAILED plotly/matplotlylib/mplexporter/tests/test_basic.py::test_legend_dots - AssertionError: assert '3' == '2'
+    # failed pinning test, sensitive to dep versions
     "test_legend_dots"
-    # FAILED plotly/matplotlylib/mplexporter/tests/test_utils.py::test_linestyle - AssertionError:
     "test_linestyle"
-    # FAILED plotly/tests/test_io/test_to_from_plotly_json.py::test_sanitize_json[auto] - KeyError: 'template'
-    # FAILED plotly/tests/test_io/test_to_from_plotly_json.py::test_sanitize_json[json] - KeyError: 'template'
+    # test bug, i assume sensitive to dep versions
     "test_sanitize_json"
-    # FAILED plotly/tests/test_orca/test_orca_server.py::test_validate_orca - ValueError:
-    "test_validate_orca"
-    # FAILED plotly/tests/test_orca/test_orca_server.py::test_orca_executable_path - ValueError:
-    "test_orca_executable_path"
-    # FAILED plotly/tests/test_orca/test_orca_server.py::test_orca_version_number - ValueError:
-    "test_orca_version_number"
-    # FAILED plotly/tests/test_orca/test_orca_server.py::test_ensure_orca_ping_and_proc - ValueError:
-    "test_ensure_orca_ping_and_proc"
-    # FAILED plotly/tests/test_orca/test_orca_server.py::test_server_timeout_shutdown - ValueError:
-    "test_server_timeout_shutdown"
-    # FAILED plotly/tests/test_orca/test_orca_server.py::test_external_server_url - ValueError:
-    "test_external_server_url"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_simple_to_image[eps] - ValueError:
-    "test_simple_to_image"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_to_image_default[eps] - ValueError:
-    "test_to_image_default"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_write_image_string[eps] - ValueError:
-    "test_write_image_string"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_write_image_writeable[eps] - ValueError:
-    "test_write_image_writeable"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_write_image_string_format_inference[eps] - ValueError:
-    "test_write_image_string_format_inference"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_write_image_string_bad_extension_failure - assert 'must be specified as one of the followi...
-    "test_write_image_string_bad_extension_failure"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_write_image_string_bad_extension_override - ValueError:
-    "test_write_image_string_bad_extension_override"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_topojson_fig_to_image[eps] - ValueError:
-    "test_topojson_fig_to_image"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_latex_fig_to_image[eps] - ValueError:
-    "test_latex_fig_to_image"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_problematic_environment_variables[eps] - ValueError:
-    "test_problematic_environment_variables"
-    # FAILED plotly/tests/test_orca/test_to_image.py::test_invalid_figure_json - assert 'Invalid' in "\nThe orca executable is required in order to e...
-    "test_invalid_figure_json"
-    # FAILED test_init/test_dependencies_not_imported.py::test_dependencies_not_imported - AssertionError: assert 'plotly' not in {'IPython': <module>
-    "test_dependencies_not_imported"
-    # FAILED test_init/test_lazy_imports.py::test_lazy_imports - AssertionError: assert 'plotly' not in {'IPython': <module 'IPython' from '...
-    "test_lazy_imports"
     # requires vaex and polars, vaex is not packaged
     "test_build_df_from_vaex_and_polars"
     "test_build_df_with_hover_data_from_vaex_and_polars"
+    # lazy loading error, could it be the sandbox PYTHONPATH?
+    # AssertionError: assert "plotly" not in sys.modules
+    "test_dependencies_not_imported"
+    "test_lazy_imports"
   ];
+  disabledTestPaths =
+    [
+      # unable to locate orca binary, adding the package does not fix it
+      "plotly/tests/test_orca/"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # requires local networking
+      "plotly/tests/test_io/test_renderers.py"
+      # fails to launch kaleido subprocess
+      "plotly/tests/test_optional/test_kaleido"
+    ];
 
   pythonImportsCheck = [ "plotly" ];
 


### PR DESCRIPTION
this are fixes i made for https://github.com/NixOS/nixpkgs/pull/347567, but i did not push it due to the eval backlog
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
