### PR TITLE
freecad: make customizable

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -878,6 +878,8 @@
 
 - `virtualisation.incus` module gained new `incus-user.service` and `incus-user.socket` systemd units. It is now possible to add a user to `incus` group instead of `incus-admin` for increased security.
 
+- `freecad` now supports addons and custom configuration in nix-way, which can be used by calling `freecad.customize`.
+
 ## Detailed Migration Information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}

--- a/pkgs/by-name/fr/freecad/0003-Gui-take-in-account-module-path-argument.patch
+++ b/pkgs/by-name/fr/freecad/0003-Gui-take-in-account-module-path-argument.patch
@@ -1,0 +1,149 @@
+From 23ddb6ff148ec5c27da050ba0eb7a2e449b8450b Mon Sep 17 00:00:00 2001
+From: Yury Shvedov <yury.shvedov@kaspersky.com>
+Date: Mon, 4 Nov 2024 14:22:22 +0300
+Subject: [PATCH] Gui: take in account module-path argument
+
+Use paths passed with `--module-path` argument to search for preference
+packs
+
+Change-Id: If168dbd99a826757290ee6b918f5b712305fe2bb
+---
+ src/Gui/DlgPreferencePackManagementImp.cpp | 16 +++++----
+ src/Gui/PreferencePackManager.cpp          | 39 +++++++++++++++++-----
+ src/Gui/PreferencePackManager.h            |  5 +++
+ 3 files changed, 44 insertions(+), 16 deletions(-)
+
+diff --git a/src/Gui/DlgPreferencePackManagementImp.cpp b/src/Gui/DlgPreferencePackManagementImp.cpp
+index a1a0dad41a..50f3982f21 100644
+--- a/src/Gui/DlgPreferencePackManagementImp.cpp
++++ b/src/Gui/DlgPreferencePackManagementImp.cpp
+@@ -54,7 +54,7 @@ void DlgPreferencePackManagementImp::showEvent(QShowEvent* event)
+     // but can only disable individual installed packs (though we can completely uninstall the pack's
+     // containing Addon by redirecting to the Addon Manager).
+     auto savedPreferencePacksDirectory = fs::path(App::Application::getUserAppDataDir()) / "SavedPreferencePacks";
+-    auto modDirectory = fs::path(App::Application::getUserAppDataDir()) / "Mod";
++    auto modDirectories = Application::Instance->prefPackManager()->modPaths();
+     auto resourcePath = fs::path(App::Application::getResourceDir()) / "Gui" / "PreferencePacks";
+ 
+     // The displayed tree has two levels: at the toplevel is either "User-Saved Packs" or the name
+@@ -66,12 +66,14 @@ void DlgPreferencePackManagementImp::showEvent(QShowEvent* event)
+     auto builtinPacks = getPacksFromDirectory(resourcePath);
+ 
+     std::map<std::string, std::vector<std::string>> installedPacks;
+-    if (fs::exists(modDirectory) && fs::is_directory(modDirectory)) {
+-        for (const auto& mod : fs::directory_iterator(modDirectory)) {
+-            auto packs = getPacksFromDirectory(mod);
+-            if (!packs.empty()) {
+-                auto modName = mod.path().filename().string();
+-                installedPacks.emplace(modName, packs);
++    for (const auto& modDirectory : modDirectories) {
++        if (fs::exists(modDirectory) && fs::is_directory(modDirectory)) {
++            for (const auto& mod : fs::directory_iterator(modDirectory)) {
++                auto packs = getPacksFromDirectory(mod);
++                if (!packs.empty()) {
++                    auto modName = mod.path().filename().string();
++                    installedPacks.emplace(modName, packs);
++                }
+             }
+         }
+     }
+diff --git a/src/Gui/PreferencePackManager.cpp b/src/Gui/PreferencePackManager.cpp
+index dfc54240c0..83e32fa05e 100644
+--- a/src/Gui/PreferencePackManager.cpp
++++ b/src/Gui/PreferencePackManager.cpp
+@@ -30,6 +30,7 @@
+ #endif
+ 
+ #include <boost/filesystem.hpp>
++#include <boost/algorithm/string.hpp>
+ #include <QDir>
+ 
+ #include "PreferencePackManager.h"
+@@ -134,12 +135,11 @@ void PreferencePack::applyConfigChanges() const
+ }
+ 
+ PreferencePackManager::PreferencePackManager()
++    : _preferencePackPaths(modPaths())
+ {
+-    auto modPath = fs::path(App::Application::getUserAppDataDir()) / "Mod";
+     auto savedPath = fs::path(App::Application::getUserAppDataDir()) / "SavedPreferencePacks";
+     auto resourcePath = fs::path(App::Application::getResourceDir()) / "Gui" / "PreferencePacks";
+-    _preferencePackPaths.push_back(resourcePath);
+-    _preferencePackPaths.push_back(modPath);
++    _preferencePackPaths.insert(_preferencePackPaths.begin(), resourcePath);
+     _preferencePackPaths.push_back(savedPath);
+     rescan();
+ 
+@@ -232,6 +232,26 @@ void Gui::PreferencePackManager::importConfig(const std::string& packName,
+     rescan();
+ }
+ 
++// TODO(Shvedov): Is this suitable place for this method? It is more generic,
++// and maybe more suitable place at Application?
++std::vector<boost::filesystem::path> Gui::PreferencePackManager::modPaths() const
++{
++    auto userModPath = fs::path(App::Application::getUserAppDataDir()) / "Mod";
++
++    auto& config = App::Application::Config();
++    auto additionalModules = config.find("AdditionalModulePaths");
++    std::vector<boost::filesystem::path> result;
++
++    if (additionalModules != config.end()) {
++        boost::split(result,
++                     additionalModules->second,
++                     boost::is_any_of(";"),
++                     boost::token_compress_on);
++    }
++    result.emplace_back(userModPath);
++    return result;
++}
++
+ void Gui::PreferencePackManager::FindPreferencePacksInPackage(const fs::path &mod)
+ {
+     try {
+@@ -528,7 +548,6 @@ std::vector<PreferencePackManager::TemplateFile> PreferencePackManager::template
+     // (alternate spellings are provided for packages using CamelCase and snake_case, and both major English dialects)
+ 
+     auto resourcePath = fs::path(App::Application::getResourceDir()) / "Gui";
+-    auto modPath = fs::path(App::Application::getUserAppDataDir()) / "Mod";
+ 
+     std::string group = "Built-In";
+     if (fs::exists(resourcePath) && fs::is_directory(resourcePath)) {
+@@ -536,11 +555,13 @@ std::vector<PreferencePackManager::TemplateFile> PreferencePackManager::template
+         std::copy(localFiles.begin(), localFiles.end(), std::back_inserter(_templateFiles));
+     }
+ 
+-    if (fs::exists(modPath) && fs::is_directory(modPath)) {
+-        for (const auto& mod : fs::directory_iterator(modPath)) {
+-            group = mod.path().filename().string();
+-            const auto localFiles = scanForTemplateFiles(group, mod);
+-            std::copy(localFiles.begin(), localFiles.end(), std::back_inserter(_templateFiles));
++    for (const auto& modPath : modPaths()) {
++        if (fs::exists(modPath) && fs::is_directory(modPath)) {
++            for (const auto& mod : fs::directory_iterator(modPath)) {
++                group = mod.path().filename().string();
++                const auto localFiles = scanForTemplateFiles(group, mod);
++                std::copy(localFiles.begin(), localFiles.end(), std::back_inserter(_templateFiles));
++            }
+         }
+     }
+ 
+diff --git a/src/Gui/PreferencePackManager.h b/src/Gui/PreferencePackManager.h
+index 301e160df2..e5776e47a0 100644
+--- a/src/Gui/PreferencePackManager.h
++++ b/src/Gui/PreferencePackManager.h
+@@ -191,6 +191,11 @@ namespace Gui {
+          */
+         void importConfig(const std::string &packName, const boost::filesystem::path &path);
+ 
++        /**
++         * Get a list of all mod directories.
++         */
++        std::vector<boost::filesystem::path> modPaths() const;
++
+     private:
+ 
+         void FindPreferencePacksInPackage(const boost::filesystem::path& mod);
+-- 
+2.44.1
+

--- a/pkgs/by-name/fr/freecad/freecad-utils.nix
+++ b/pkgs/by-name/fr/freecad/freecad-utils.nix
@@ -1,0 +1,98 @@
+{
+  runCommand,
+  buildEnv,
+  makeWrapper,
+  lib,
+  python311,
+  writeShellScript,
+}:
+let
+  wrapPathsStr =
+    flag: values:
+    builtins.concatStringsSep " " (
+      builtins.concatMap (p: [
+        "--add-flags"
+        flag
+        "--add-flags"
+        p
+      ]) values
+    );
+
+  wrapCfgStr =
+    typ: val:
+    let
+      installer = writeShellScript "insteller-${typ}" ''
+        dst="$HOME/.config/FreeCAD/${typ}.cfg"
+        if [ ! -f "$dst" ]; then
+          mkdir -p "$(dirname "$dst")"
+          cp --no-preserve=mode,ownership '${val}' "$dst"
+        fi
+      '';
+    in
+    lib.optionalString (val != null) "--run ${installer}";
+
+  pythonsProcessed = builtins.map (
+    pyt:
+    if builtins.isString pyt then
+      pyt
+    else if builtins.isFunction pyt then
+      "${(python311.withPackages pyt)}/lib/python3.11/site-packages"
+    else
+      throw "Expected string or function as python paths for freecad"
+  );
+
+  makeCustomizable =
+    freecad:
+    freecad
+    // {
+      customize =
+        {
+          name ? freecad.name,
+          modules ? [ ],
+          pythons ? [ ],
+          makeWrapperFlags ? [ ],
+          userCfg ? null,
+          systemCfg ? null,
+        }:
+        let
+          modulesStr = wrapPathsStr "--module-path" modules;
+          pythonsStr = wrapPathsStr "--python-path" (pythonsProcessed pythons);
+          makeWrapperFlagsStr = builtins.concatStringsSep " " (builtins.map (f: "'${f}'") makeWrapperFlags);
+
+          userCfgStr = wrapCfgStr "user" userCfg;
+          systemCfgStr = wrapCfgStr "system" systemCfg;
+
+          bin = runCommand "${name}-bin" { nativeBuildInputs = [ makeWrapper ]; } ''
+            mkdir -p "$out/bin"
+            for exe in FreeCAD{,Cmd}; do
+              if [[ ! -e ${freecad}/bin/$exe ]]; then
+                echo "No binary $exe in freecad package"
+                false
+              fi
+              dest="$out/bin/$exe";
+              makeWrapper "${freecad}/bin/$exe" "$dest" \
+                --inherit-argv0                         \
+                ${modulesStr}                           \
+                ${pythonsStr}                           \
+                ${userCfgStr}                           \
+                ${systemCfgStr}                         \
+                ${makeWrapperFlagsStr}
+            done
+            ln -s FreeCAD $out/bin/freecad
+            ln -s FreeCADCmd $out/bin/freecadcmd
+          '';
+        in
+        makeCustomizable (buildEnv {
+          inherit name;
+          paths = [
+            (lib.lowPrio freecad)
+            bin
+          ];
+        });
+      override = f: makeCustomizable (freecad.override f);
+      overrideAttrs = f: makeCustomizable (freecad.overrideAttrs f);
+    };
+in
+{
+  inherit makeCustomizable;
+}

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -1,4 +1,5 @@
 { lib
+, callPackage
 , cmake
 , coin3d
 , doxygen
@@ -60,8 +61,9 @@ let
     scipy
     shiboken2
     ;
+  freecad-utils = callPackage ./freecad-utils.nix { };
 in
-stdenv.mkDerivation (finalAttrs: {
+freecad-utils.makeCustomizable (stdenv.mkDerivation (finalAttrs: {
   pname = "freecad";
   version = "1.0rc4";
 
@@ -215,4 +217,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ gebner srounce ];
     platforms = lib.platforms.linux;
   };
-})
+}))

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -6,7 +6,6 @@
 , eigen
 , fetchFromGitHub
 , fmt
-, freecad
 , gfortran
 , gts
 , hdf5
@@ -23,7 +22,6 @@
 , opencascade-occt_7_6
 , pkg-config
 , python311Packages
-, runCommand  # for passthru.tests
 , spaceNavSupport ? stdenv.hostPlatform.isLinux
 , stdenv
 , swig
@@ -177,22 +175,7 @@ freecad-utils.makeCustomizable (stdenv.mkDerivation (finalAttrs: {
     ln -s $out/bin/FreeCADCmd $out/bin/freecadcmd
   '';
 
-  passthru.tests = {
-    # Check that things such as argument parsing still work correctly with
-    # the above PYTHONPATH patch. Previously the patch used above changed
-    # the `PyConfig_InitIsolatedConfig` to `PyConfig_InitPythonConfig`,
-    # which caused the built-in interpreter to attempt (and fail) to doubly
-    # parse argv. This should catch if that ever regresses and also ensures
-    # that PYTHONPATH is still respected enough for the FreeCAD console to
-    # successfully run and check that it was included in `sys.path`.
-    python-path =
-      runCommand "freecad-test-console"
-        {
-          nativeBuildInputs = [ freecad ];
-        } ''
-        HOME="$(mktemp -d)" PYTHONPATH="$(pwd)/test" FreeCADCmd --log-file $out -c "if not '$(pwd)/test' in sys.path: sys.exit(1)" </dev/null
-      '';
-  };
+  passthru.tests = callPackage ./tests {};
 
   meta = {
     homepage = "https://www.freecad.org";

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -131,6 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
     ./0002-FreeCad-OndselSolver-pkgconfig.patch
+    ./0003-Gui-take-in-account-module-path-argument.patch
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/fr/freecad/tests/default.nix
+++ b/pkgs/by-name/fr/freecad/tests/default.nix
@@ -1,0 +1,7 @@
+{
+  callPackage,
+}:
+{
+  python-path = callPackage ./python-path.nix { };
+  modules = callPackage ./modules.nix { };
+}

--- a/pkgs/by-name/fr/freecad/tests/modules.nix
+++ b/pkgs/by-name/fr/freecad/tests/modules.nix
@@ -1,0 +1,42 @@
+{
+  freecad,
+  runCommand,
+  writeTextFile,
+}:
+let
+  mkModule =
+    n:
+    writeTextFile {
+      name = "module-${n}";
+      destination = "/Init.py";
+      text = ''
+        import sys
+        import os
+
+        out = os.environ['out']
+        f = open(out + "/module-${n}.touch", "w")
+        f.write("module-${n}");
+        f.close()
+      '';
+    };
+  module-1 = mkModule "1";
+  module-2 = mkModule "2";
+  freecad-customized = freecad.customize {
+    modules = [
+      module-1
+      module-2
+    ];
+  };
+in
+runCommand "freecad-test-modules"
+  {
+    nativeBuildInputs = [ freecad-customized ];
+  }
+  ''
+    mkdir $out
+    HOME="$(mktemp -d)" FreeCADCmd --log-file $out/freecad.log -c "sys.exit(0)" </dev/null
+    test -f $out/module-1.touch
+    test -f $out/module-2.touch
+    grep -q 'Initializing ${module-1}... done' $out/freecad.log
+    grep -q 'Initializing ${module-2}... done' $out/freecad.log
+  ''

--- a/pkgs/by-name/fr/freecad/tests/python-path.nix
+++ b/pkgs/by-name/fr/freecad/tests/python-path.nix
@@ -1,0 +1,18 @@
+{
+  freecad,
+  runCommand,
+}:
+# Check that things such as argument parsing still work correctly with
+# the above PYTHONPATH patch. Previously the patch used above changed
+# the `PyConfig_InitIsolatedConfig` to `PyConfig_InitPythonConfig`,
+# which caused the built-in interpreter to attempt (and fail) to doubly
+# parse argv. This should catch if that ever regresses and also ensures
+# that PYTHONPATH is still respected enough for the FreeCAD console to
+# successfully run and check that it was included in `sys.path`.
+runCommand "freecad-test-console"
+  {
+    nativeBuildInputs = [ freecad ];
+  }
+  ''
+    HOME="$(mktemp -d)" PYTHONPATH="$(pwd)/test" FreeCADCmd --log-file $out -c "if not '$(pwd)/test' in sys.path: sys.exit(1)" </dev/null
+  ''


### PR DESCRIPTION
FreeCad has addon system with various addons around the net.

It has an addon-manager which allows to browse through registered addons and install them in runtime. But this is not nix-way, because you have to install addons again after system configuration moving.

Additionally freecad allows you to manually install addons and put them to common folder or specify with command arguments.

This patch introduces extra `customize` method to FreeCad derivation attrset (inspired from vim) which allows you to inject addons from nix configuration.

```nix
{ freecad
, fetchFromGitHub
}:
let
  cad-exchanger = fetchFromGitHub {
    owner = "yorikvanhavre";
    repo = "CADExchanger";
    rev = "5c2cd792ddc4581b917ebe7add5ef960bf6c3e2a";
    hash = "sha256-AST5bwhgMbvW3m8V1cv5PqKjJi2eSE1lbXpVLvRVzM8=";
  };
  open-theme = fetchFromGitHub {
    owner = "obelisk79";
    repo = "OpenTheme";
    rev = "80399168ab27c660a9a14812b67492f412f3148f";
    hash = "sha256-NgrBvP+wRNED3JI8zG9JMT//xfZfivQC8yy4m2GsujM=";
  };

  freecad-customized = freecad.customize {
    modules = [ cad-exchanger open-theme ];
    pythons = [
      (ps: with ps; [ requests pyjwt tzlocal ])
    ];
    makeWrapperFlags = [ "--set-default" "QT_FONT_DPI" "85" ];
    userCfg = ./my-default-config.cfg;
  };
in
freecad-customized
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
