### PR TITLE
nix-search-cli: unstable-2023-09-12 -> v0.2.0+commit.7d6b4c5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16469,6 +16469,12 @@
     githubId = 722550;
     name = "Peter Hoeg";
   };
+  peterldowns = {
+    name = "Peter Downs";
+    email = "github@peterdowns.com";
+    github = "peterldowns";
+    githubId = 824173;
+  };
   peterromfeldhk = {
     email = "peter.romfeld.hk@gmail.com";
     github = "peterromfeldhk";

--- a/pkgs/by-name/ni/nix-search-cli/package.nix
+++ b/pkgs/by-name/ni/nix-search-cli/package.nix
@@ -1,33 +1,46 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, unstableGitUpdater
 }:
 
-buildGoModule {
+let
+  # latest release version, without "v" prefix and "+commit" build metadata
+  # semver information:
+  # https://github.com/peterldowns/nix-search-cli/releases/tag/v0.2%2Bcommit.7d6b4c5
+  version = "0.2.0";
+  commit = "7d6b4c5";
+  srcHash = "sha256-0Zms/QVCUKxILLLJYsaodSW64DJrVr/yB13SnNL8+Wg=";
+  vendorHash = "sha256-RZuB0aRiMSccPhX30cGKBBEMCSvmC6r53dWaqDYbmyA=";
+in buildGoModule {
   pname = "nix-search-cli";
-  version = "0-unstable-2023-09-12";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "peterldowns";
     repo = "nix-search-cli";
-    rev = "f3f1c53c72dadac06472a7112aeb486ab5dda695";
-    hash = "sha256-YM1Lf7py79rU8aJE0PfQaMr5JWx5J1covUf1aCjRkc8=";
+    rev = "7d6b4c501ee448dc2e5c123aa4c6d9db44a6dd12";
+    hash = srcHash;
   };
+  inherit vendorHash;
 
-  vendorHash = "sha256-JDOu7YdX9ztMZt0EFAMz++gD7n+Mn1VOe5g6XwrgS5M=";
-
-  passthru.updateScript = unstableGitUpdater {
-    # Almost every commit is tagged as "release-<unix-time>-<commit>", software doesn't keep track of its version
-    # Using 0 feels closer to what the tagging is trying to express
-    hardcodeZeroVersion = true;
-  };
+  # These should match the options defined in the upstream repo:
+  # https://github.com/peterldowns/nix-search-cli/blob/main/flake.nix
+  ldflags = [
+    "-X main.Version=${version}"
+    "-X main.Commit=${commit}"
+  ];
+  GOWORK = "off";
+  modRoot = ".";
+  doCheck = false;
+  subPackages = [
+    "cmd/nix-search"
+  ];
 
   meta = with lib; {
     description = "CLI for searching packages on search.nixos.org";
     homepage = "https://github.com/peterldowns/nix-search-cli";
     license = licenses.mit;
-    maintainers = with maintainers; [ donovanglover ];
+    maintainers = with maintainers; [ donovanglover peterldowns ];
     platforms = platforms.all;
     mainProgram = "nix-search";
   };


### PR DESCRIPTION
Upgrades `nix-search` to the latest version, with the following changes since 2023-09-12:

- `--help` has more useful information, including version info and a link to the github docs
- new `-r / --reverse` flag allows printing search results in reverse order, for making it easier to see relevant results

All changes are backwards compatible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true` (unset, [defaults to true](https://nix.dev/manual/nix/2.18/command-ref/conf-file.html#conf-sandbox))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - `nix run nixpkgs#nixpkgs-review -- pr --post-result 37242` ~hangs indefinitely~ took forever and succeeded!
  -  From `rg`, there are no other packages in nixpkgs that depend on `nix-search-cli`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - `./result/bin/nix-search --help` shoes the version/commit message and the appropriate options.
  - `./result/bin/nix-search -p 'python3'` returned search results as expected
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
    - unnecessary, all changes are backwards-compatible
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
  - I think so, this is my first time. I added myself to `maintainers`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
