### PR TITLE
Improve PR merge check for CI

### DIFF
--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -26,52 +26,22 @@ jobs:
     # This should take 1 minute at most, but let's be generous. The default of 6 hours is definitely too long.
     timeout-minutes: 10
     steps:
-      # This step has to be in this file, because it's needed to determine which revision of the repository to fetch, and we can only use other files from the repository once it's fetched.
+      # This checks out the base branch because of pull_request_target
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          path: base
+          sparse-checkout: ci
       - name: Resolving the merge commit
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # This checks for mergeability of a pull request as recommended in
-          # https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests
-
-          # Retry the API query this many times
-          retryCount=5
-          # Start with 5 seconds, but double every retry
-          retryInterval=5
-          while true; do
-            echo "Checking whether the pull request can be merged"
-            prInfo=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/"$GITHUB_REPOSITORY"/pulls/${{ github.event.pull_request.number }})
-            mergeable=$(jq -r .mergeable <<< "$prInfo")
-            mergedSha=$(jq -r .merge_commit_sha <<< "$prInfo")
-
-            if [[ "$mergeable" == "null" ]]; then
-              if (( retryCount == 0 )); then
-                echo "Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com/"
-                exit 1
-              else
-                (( retryCount -= 1 )) || true
-
-                # null indicates that GitHub is still computing whether it's mergeable
-                # Wait a couple seconds before trying again
-                echo "GitHub is still computing whether this PR can be merged, waiting $retryInterval seconds before trying again ($retryCount retries left)"
-                sleep "$retryInterval"
-
-                (( retryInterval *= 2 )) || true
-              fi
-            else
-              break
-            fi
-          done
-
-          if [[ "$mergeable" == "true" ]]; then
-            echo "The PR can be merged, checking the merge commit $mergedSha"
+          if mergedSha=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
+            echo "Checking the merge commit $mergedSha"
             echo "mergedSha=$mergedSha" >> "$GITHUB_ENV"
           else
-            echo "The PR cannot be merged, it has a merge conflict, skipping the rest.."
+            echo "Skipping the rest..."
           fi
+          rm -rf base
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         if: env.mergedSha
         with:

--- a/ci/README.md
+++ b/ci/README.md
@@ -41,3 +41,58 @@ Why not just build the tooling right from the PRs Nixpkgs version?
 - Because it improves security, since we don't have to build potentially untrusted code from PRs.
   The tool only needs a very minimal Nix evaluation at runtime, which can work with [readonly-mode](https://nixos.org/manual/nix/stable/command-ref/opt-common.html#opt-readonly-mode) and [restrict-eval](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-restrict-eval).
 
+## `get-merge-commit.sh GITHUB_REPO PR_NUMBER`
+
+Check whether a PR is mergeable and return the test merge commit as
+[computed by GitHub](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests).
+
+Arguments:
+- `GITHUB_REPO`: The repository of the PR, e.g. `NixOS/nixpkgs`
+- `PR_NUMBER`: The PR number, e.g. `1234`
+
+Exit codes:
+- 0: The PR can be merged, the test merge commit hash is returned on stdout
+- 1: The PR cannot be merged because it's not open anymore
+- 2: The PR cannot be merged because it has a merge conflict
+- 3: The merge commit isn't being computed, GitHub is likely having internal issues, unknown if the PR is mergeable
+
+### Usage
+
+This script can be used in GitHub Actions workflows as follows:
+
+```yaml
+on: pull_request_target
+
+# We need a token to query the API, but it doesn't need any special permissions
+permissions: {}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      # Important: Because of `pull_request_target`, this doesn't check out the PR,
+      # but rather the base branch of the PR, which is needed so we don't run untrusted code
+      - uses: actions/checkout@<VERSION>
+        with:
+          path: base
+          sparse-checkout: ci
+      - name: Resolving the merge commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if mergedSha=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
+            echo "Checking the merge commit $mergedSha"
+            echo "mergedSha=$mergedSha" >> "$GITHUB_ENV"
+          else
+            # Skipping so that no notifications are sent
+            echo "Skipping the rest..."
+          fi
+          rm -rf base
+      - uses: actions/checkout@<VERSION>
+        # Add this to _all_ subsequent steps to skip them
+        if: env.mergedSha
+        with:
+          ref: ${{ env.mergedSha }}
+      - ...
+```

--- a/ci/get-merge-commit.sh
+++ b/ci/get-merge-commit.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# This checks for mergeability of a pull request as recommended in
+# https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests
+
+set -euo pipefail
+
+log() {
+    echo "$@" >&2
+}
+
+if (( $# < 2 )); then
+    log "Usage: $0 GITHUB_REPO PR_NUMBER"
+    exit 99
+fi
+repo=$1
+prNumber=$2
+
+# Retry the API query this many times
+retryCount=5
+# Start with 5 seconds, but double every retry
+retryInterval=5
+
+while true; do
+    log "Checking whether the pull request can be merged"
+    prInfo=$(gh api \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "/repos/$repo/pulls/$prNumber")
+    mergeable=$(jq -r .mergeable <<< "$prInfo")
+    if [[ "$mergeable" == "null" ]]; then
+        if (( retryCount == 0 )); then
+            log "Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com/"
+            exit 1
+        else
+            (( retryCount -= 1 )) || true
+
+            # null indicates that GitHub is still computing whether it's mergeable
+            # Wait a couple seconds before trying again
+            log "GitHub is still computing whether this PR can be merged, waiting $retryInterval seconds before trying again ($retryCount retries left)"
+            sleep "$retryInterval"
+
+            (( retryInterval *= 2 )) || true
+        fi
+    else
+        break
+    fi
+done
+
+if [[ "$mergeable" == "true" ]]; then
+    log "The PR can be merged"
+    jq -r .merge_commit_sha <<< "$prInfo"
+else
+    log "The PR has a merge conflict"
+    exit 1
+fi

--- a/ci/get-merge-commit.sh
+++ b/ci/get-merge-commit.sh
@@ -26,6 +26,14 @@ while true; do
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         "/repos/$repo/pulls/$prNumber")
+
+    # Non-open PRs won't have their mergeability computed no matter what
+    state=$(jq -r .state <<< "$prInfo")
+    if [[ "$state" != open ]]; then
+        log "PR is not open anymore"
+        exit 2
+    fi
+
     mergeable=$(jq -r .mergeable <<< "$prInfo")
     if [[ "$mergeable" == "null" ]]; then
         if (( retryCount == 0 )); then

--- a/ci/get-merge-commit.sh
+++ b/ci/get-merge-commit.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# This checks for mergeability of a pull request as recommended in
-# https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests
+# See ./README.md for docs
 
 set -euo pipefail
 
@@ -31,14 +30,14 @@ while true; do
     state=$(jq -r .state <<< "$prInfo")
     if [[ "$state" != open ]]; then
         log "PR is not open anymore"
-        exit 2
+        exit 1
     fi
 
     mergeable=$(jq -r .mergeable <<< "$prInfo")
     if [[ "$mergeable" == "null" ]]; then
         if (( retryCount == 0 )); then
             log "Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com/"
-            exit 1
+            exit 3
         else
             (( retryCount -= 1 )) || true
 
@@ -59,5 +58,5 @@ if [[ "$mergeable" == "true" ]]; then
     jq -r .merge_commit_sha <<< "$prInfo"
 else
     log "The PR has a merge conflict"
-    exit 1
+    exit 2
 fi


### PR DESCRIPTION
The Nixpkgs-vet workflow has been using a script to check whether the PR to check is mergeable and abort the check if it's not. This PR improves the script by:
- Making it reusable for other workflows. It can be used for any workflow checking out the PR really.
- Handle PRs that are not open anymore, fixing [this kind of misleading error](https://github.com/NixOS/nixpkgs/actions/runs/11279197077/job/31369348101#step:2:59):
  ```
  Checking whether the pull request can be merged
  GitHub is still computing whether this PR can be merged, waiting 5 seconds before trying again (4 retries left)
  [...]
  GitHub is still computing whether this PR can be merged, waiting 80 seconds before trying again (0 retries left)
  Checking whether the pull request can be merged
  Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com/
  ```
- Write some documentation for this script and how it can be used in workflows

### Things done

- [x] Tested that it works: https://github.com/tweag/nixpkgs/actions/runs/11280488261/job/31373578194?pr=97
- [x] Tested that it detects closed PRs: https://github.com/tweag/nixpkgs/actions/runs/11280512693/job/31373655841

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
