### PR TITLE
workflows/codeowners: Cache codeowner validator build

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -25,6 +25,13 @@ jobs:
     steps:
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 
+    - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
+      if: github.repository_owner == 'NixOS'
+      with:
+        # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
+        name: nixpkgs-ci
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
     # Important: Because we use pull_request_target, this checks out the base branch of the PR, not the PR itself.
     # We later build and run code from the base branch with access to secrets,
     # so it's important this is not the PRs code.


### PR DESCRIPTION
The codeowner-validator build declared in ci/codeowners-validator was not cached before and needed to be built for every PR, which is slow and wasteful: https://github.com/NixOS/nixpkgs/actions/runs/11280533037/job/31373720922

This is hard to test, but I'm using the exact same code as in e.g. [`basic-eval.yml`](https://github.com/NixOS/nixpkgs/blob/1017ec59861b97a339f23e253f1fc9cb25330aa2/.github/workflows/basic-eval.yml#L24-L28), so it should work.

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
