### PR TITLE
nixos/vpp: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -64,6 +64,8 @@
 
 - [tuwunel](https://matrix-construct.github.io/tuwunel/), a federated chat server implementing the Matrix protocol, forked from Conduwuit. Available as [services.matrix-tuwunel](#opt-services.matrix-tuwunel.enable).
 
+- [FD.io's Vector Packet Processor](https://fd.io/docs/vpp/master/), a userland network stack for high-performance routing and switching on general purpose computers. Available as [services.vpp](#opt-services.vpp.instances).
+
 - [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).
 
 - [boot.kernel.sysfs](options.html#opt-boot.kernel.sysfs) allows setting of sysfs attributes.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1391,6 +1391,7 @@
   ./services/networking/v2raya.nix
   ./services/networking/vdirsyncer.nix
   ./services/networking/veilid.nix
+  ./services/networking/vpp.nix
   ./services/networking/vsftpd.nix
   ./services/networking/vwifi.nix
   ./services/networking/wasabibackend.nix

--- a/nixos/modules/services/networking/vpp.nix
+++ b/nixos/modules/services/networking/vpp.nix
@@ -1,0 +1,517 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    ;
+  cfg = config.services.vpp;
+
+  # Converts the settings option to a string
+  #
+  # Top-level attrsets, lists and primitives get parsed as expected, i.e. `foo = { bar = true; };`
+  # becomes `foo { bar }` in the final config file. Nested attrsets on the other hand, such as
+  # {option}`dpdk.dev`, get parsed differently. For example, this config:
+  # ```nix
+  # settings = {
+  #   dpdk = {
+  #     dev = {
+  #       "foo".name = "bar";
+  #       "baz".name = "qux";
+  #     };
+  #   };
+  # };
+  # ```
+  # Would get parsed into the following:
+  # ```
+  # dpdk {
+  #   dev foo { name bar }
+  #   dev baz { name qux }
+  # }
+  # ```
+  # Notice how `dev.foo` becomes `dev foo { }` instead of `dev { foo { } }`.
+  parseConfig =
+    cfg:
+    let
+      inherit (lib) concatMap;
+
+      # Specifies an attrset that encodes the value according to its type
+      encode =
+        name: value:
+        {
+          null = [ ];
+          bool = lib.optional value name;
+          int = [ "${name} ${toString value}" ];
+          string = [ "${name} ${value}" ];
+
+          # Values like `foo = [ "bar" "baz" ];` should be transformed into
+          #   foo bar
+          #   foo baz
+          list = concatMap (encode name) value;
+
+          # Values like `foo = { bar = { baz = true; }; bar2 = { baz2 = true; }; };` should be transformed into
+          #   foo bar {
+          #     baz
+          #   }
+          #   foo bar2 {
+          #     baz2
+          #   }
+          set = concatMap (
+            subname:
+            lib.optionals (value.${subname} != null) (
+              [ "${name} ${subname} {" ] ++ (map (line: "  ${line}") (toLines value.${subname})) ++ [ "}" ]
+            )
+          ) (lib.filter (v: v != null) (builtins.attrNames value));
+        }
+        .${builtins.typeOf value};
+
+      # One level "above" encode, acts upon a set and uses encode on each name,value pair
+      toLines = set: concatMap (name: encode name set.${name}) (builtins.attrNames set);
+
+      # Moves top-level attrsets into a dummy "" value, so that `section = {...}` is transformed to `section  {...}`
+      parseSections =
+        set:
+        builtins.mapAttrs (name: value: {
+          "" = value;
+        }) set;
+    in
+    lib.strings.concatStringsSep "\n" (toLines (parseSections cfg));
+
+  semanticTypes = with types; rec {
+    vppAtom = nullOr (oneOf [
+      int
+      bool
+      str
+    ]);
+    vppAttr = attrsOf vppAll;
+    vppAll =
+      (oneOf [
+        vppAtom
+        (listOf vppAtom)
+        vppAttr
+      ])
+      // {
+        # Since this is a recursive type and the description by default contains
+        # the description of its subtypes, infinite recursion would occur without
+        # explicitly breaking this cycle
+        description = "vpp values (atoms (null, str, int, bool), list of atoms, or attrsets of vpp values)";
+      };
+  };
+
+  vppOpts =
+    { name, ... }:
+    {
+      options = {
+        enable = mkEnableOption "FD.io's Vector Packet Processor, a high-performance userspace network stack";
+
+        name = mkOption {
+          type = types.str;
+          default = name;
+          description = ''
+            Name is used as a suffix for the service name.
+            By default it takes the value you use for `<name>` in:
+            {option}`services.vpp.instances.<name>`
+          '';
+        };
+
+        package = mkPackageOption pkgs "vpp" { };
+
+        kernelModule = mkOption {
+          type = types.nullOr types.str;
+          default = "uio_pci_generic";
+          example = "vfio-pci";
+          description = "Kernel driver module to load before starting this VPP instance. Set to `null` to disable this functionality.";
+        };
+
+        group = mkOption {
+          type = types.str;
+          default = "vpp";
+          example = "vpp-main";
+          description = "Group that grants users in it privileges to control this instance via {command}`vppctl`.";
+        };
+
+        settings = mkOption {
+          description = ''
+            Configuration for VPP, see <https://fd.io/docs/vpp/master/configuration/reference.html> for details.
+
+            Nix value declared here will be translated directly to the config format VPP uses.
+          '';
+          defaultText = ''
+            unix = {
+              nodaemon = true;
+              nosyslog = true;
+              cli-listen = "/run/vpp/\${name}-cli.sock";
+              gid = config.services.vpp.instances.\${name}.group;
+              startup-config = config.services.vpp.instances.\${name}.startupConfigFile;
+              cli-prompt = "vpp-\${name}";
+            };
+            api-segment = {
+              prefix = "\${name}";
+              gid = config.services.vpp.instances.\${name}.group;
+            };
+          '';
+          example = lib.literalExpression ''
+            {
+              unix.cli-listen = "/run/vpp/cli.sock";
+
+              plugins.plugin."rdma_plugin.so".disable = true;
+              dpdk = {
+                dev."0000:01:00.0" = {
+                  name = "sfp0";
+                  num-rx-queues = 4;
+                };
+                dev."0000:01:00.1" = { };
+
+                ## In the case of many devices that don't need special config, they can also be defined in a list:
+                # dev = [ "0000:01:00.0" "0000:01:00.1" ];
+                ## And, since `x = [ y ];` is functionally identical to `x = y;`, this is also possible:
+                # dev = [
+                #   {
+                #     default.num-rx-queues = 4;
+                #     "0000:01:00.0".name = "uplink";
+                #   }
+                #   [ "0000:02:00.0" "0000:02:00.1" ]
+                # ];
+              };
+            }
+          '';
+          type = types.submodule {
+            freeformType = semanticTypes.vppAttr;
+            options =
+              let
+                # Most of the defaults don't need to be changed except under very specific circumstances and
+                # all have their values documented in defaultText, so they're not visible to reduce clutter
+                mkOptionWithDefault =
+                  value:
+                  mkOption {
+                    default = value;
+                    type = semanticTypes.vppAll;
+                    visible = false;
+                  };
+              in
+              {
+                ## Config defaults
+                api-segment = {
+                  prefix = mkOptionWithDefault name;
+                  gid = mkOptionWithDefault cfg.instances.${name}.group;
+                };
+
+                unix = {
+                  nodaemon = mkOptionWithDefault true;
+                  nosyslog = mkOptionWithDefault true;
+                  gid = mkOptionWithDefault cfg.instances.${name}.group;
+                  startup-config = mkOptionWithDefault (toString cfg.instances.${name}.startupConfigFile);
+
+                  cli-prompt = mkOptionWithDefault "vpp-${name}";
+                  cli-listen = mkOption {
+                    # Visible in documentation unlike other defaults, since changing this
+                    # setting will likely be pretty common on single-instance configs
+                    type = types.str;
+                    default = "/run/vpp/${name}-cli.sock";
+                    example = "localhost:5002";
+                    description = ''
+                      Address in the format IPADDR:PORT or a socket path the CLI should listen on. If you only run
+                      a single instance of VPP, it's recommended to change this to `/run/vpp/cli.sock` so
+                      {command}`vppctl` can be used without specifying this path using the `-s` argument.
+                    '';
+                  };
+                };
+
+                ## User-facing option documentation
+                plugins.plugin = mkOption {
+                  type = types.attrsOf (
+                    types.submodule {
+                      freeformType = semanticTypes.vppAll;
+                      options.enable = mkOption {
+                        type = types.nullOr types.bool;
+                        example = true;
+                        default = null;
+                        description = ''
+                          Whether to enable this plugin. Because of how the config is parsed, `false`
+                          has no effect. If you want to explicitly turn a plugin off use {option}`disable`.
+                        '';
+                      };
+                      options.disable = mkOption {
+                        type = types.nullOr types.bool;
+                        example = true;
+                        default = null;
+                        description = ''
+                          Whether to disable this plugin. Because of how the config is parsed, `false`
+                          has no effect. If you want to explicitly turn a plugin on use {option}`enable`.
+                        '';
+                      };
+                    }
+                  );
+                  example = {
+                    default.disable = true;
+                    "dpdk_plugin.so".enable = true;
+                  };
+                  default = { };
+                  description = ''
+                    Configuration for specific plugins, usually used to turn a plugin on or off.
+                    Special value `default` applies to all plugins.
+                  '';
+                };
+
+                dpdk = {
+                  dev = mkOption {
+                    type = types.attrsOf (
+                      types.submodule {
+                        freeformType = semanticTypes.vppAll;
+
+                        options.name = mkOption {
+                          type = types.nullOr types.str;
+                          example = "eth0";
+                          default = null;
+                          description = "Override the name of this interface as seen from the CLI.";
+                        };
+                        options.num-rx-queues = mkOption {
+                          type = types.nullOr types.ints.positive;
+                          example = 4;
+                          default = null;
+                          description = ''
+                            Number of receive queues on this interface. Useful for multi-threaded operation.
+                            Use the `cpu.*` options to setup workers if you want to use this option.
+                          '';
+                        };
+                      }
+                    );
+                    example = {
+                      "0000:01:00.0".name = "eth0";
+                    };
+                    default = { };
+                    description = ''
+                      Which DPDK network interfaces VPP should bind to, can also be specified as a list if no
+                      per-device configuration is needed. Special value `default` applies to all interfaces.
+                    '';
+                  };
+
+                  blacklist = mkOption {
+                    type = types.oneOf [
+                      types.str
+                      (types.listOf types.str)
+                    ];
+                    example = "8086:10fb";
+                    default = [ ];
+                    description = "Device types to blacklist, using PCI vendor:device syntax.";
+                  };
+                };
+
+                cpu = {
+                  main-core = mkOption {
+                    type = types.nullOr types.ints.unsigned;
+                    example = 0;
+                    default = null;
+                    description = ''
+                      Logical CPU core where the main thread runs, if unset VPP will use core 1 if available.
+                    '';
+                  };
+
+                  corelist-workers = mkOption {
+                    type = types.nullOr types.str;
+                    example = "2-3,18-19";
+                    default = null;
+                    description = ''
+                      Explicitly set logical CPUs on which VPP worker threads will run.
+
+                      {option}`skip-cores` and {option}`workers` are incompatible with {option}`corelist-workers`.
+                    '';
+                  };
+
+                  skip-cores = mkOption {
+                    type = types.nullOr types.ints.positive;
+                    example = 8;
+                    default = null;
+                    description = ''
+                      Set number of logical CPU cores to skip when using the {option}`workers` option.
+
+                      {option}`skip-cores` and {option}`workers` are incompatible with {option}`corelist-workers`.
+                    '';
+                  };
+                  workers = mkOption {
+                    type = types.nullOr types.ints.positive;
+                    example = 4;
+                    default = null;
+                    description = ''
+                      Set number of workers to be created and automatically assigned. Workers will be pinned to
+                      N consecutive CPU cores while skipping {option}`skip-cores` CPU core(s) and main thread's core.
+
+                      {option}`skip-cores` and {option}`workers` are incompatible with {option}`corelist-workers`.
+                    '';
+                  };
+                };
+              };
+          };
+        };
+
+        extraConfig = mkOption {
+          type = types.lines;
+          default = "";
+          description = ''
+            Extra configuration to append to the configuration file.
+          '';
+        };
+
+        settingsFile = mkOption {
+          type = types.path;
+          example = "/etc/vpp/settings.conf";
+          default =
+            let
+              inherit (cfg.instances.${name}) settings extraConfig;
+            in
+            pkgs.writeText "vpp-${name}.conf" ((parseConfig settings) + extraConfig);
+          defaultText = lib.literalExpression ''pkgs.writeText "vpp-\${name}.conf" ((parseConfig settings) + extraConfig)'';
+          description = ''
+            Configuration file passed to {command}`vpp -c`.
+            It is recommended to use the {option}`settings` option instead.
+
+            Setting this option will override the config file
+            auto-generated from the {option}`settings` and {option}`extraConfig` options.
+          '';
+        };
+
+        startupConfig = mkOption {
+          type = types.lines;
+          default = "";
+          example = ''
+            set interface state TenGigabitEthernet1/0/0 up
+            set interface state TenGigabitEthernet1/0/1 up
+            set interface ip address TenGigabitEthernet1/0/0 2001:db8::1/64
+            set interface ip address TenGigabitEthernet1/0/1 2001:db8:1234::1/64
+          '';
+          description = ''
+            Script to run on startup in {command}`vppctl`, passed to
+            VPP's `startup-config` option in the `unix` section as a file.
+
+            This is used to configure things like IP addresses and routes. To configure
+            interfaces, plugins, etc., see the {option}`settings` option.
+          '';
+        };
+
+        startupConfigFile = mkOption {
+          type = types.path;
+          example = "/etc/vpp/startup.conf";
+          default = pkgs.writeText "vpp-${name}-startup.conf" cfg.instances.${name}.startupConfig;
+          defaultText = lib.literalExpression ''pkgs.writeText "vpp-\${name}-startup.conf" config.services.vpp.instances.\${name}.startupConfig'';
+          description = ''
+            File to run as a script on startup in {command}`vppctl`, passed
+            to VPP's `startup-config` option in the `unix` section.
+
+            Setting this option will override {option}`startupConfig`.
+          '';
+        };
+      };
+    };
+in
+{
+  options.services.vpp = {
+    hugepages = {
+      autoSetup = mkOption {
+        default = false;
+        example = true;
+        description = ''
+          Whether to automatically setup 2MB hugepages for use with FD.io's Vector Packet Processor.
+
+          If any programs other than VPP use hugepages or you want to use 1GB hugepages, it's recommended
+          to keep this `false` and set them up manually using {option}`boot.kernel.sysctl` or {option}`boot.kernelParams`.
+        '';
+      };
+
+      count = mkOption {
+        type = types.ints.positive;
+        default = 1024;
+        example = 2048;
+        description = "Number of 2MB hugepages to setup on the system if {option}`services.vpp.hugepages.autoSetup` is enabled.";
+      };
+    };
+
+    instances = mkOption {
+      default = { };
+      type = types.attrsOf (types.submodule vppOpts);
+      description = ''
+        VPP supports multiple instances for testing or other purposes.
+        If you don't require multiple instances of VPP you can define just the one.
+      '';
+      example = lib.literalExpression ''
+        {
+          "main" = {
+            enable = true;
+            group = "vpp-main";
+            settings = { };
+          };
+          "test" = {
+            enable = false;
+            group = "vpp-test";
+            settings = { };
+          };
+        };
+      '';
+    };
+  };
+
+  config =
+    let
+      #TODO: systemd hardening
+      mkInstanceServiceConfig = instance: {
+        description = "Vector Packet Processing Process";
+        after = [
+          "syslog.target"
+          "network.target"
+          "auditd.service"
+        ];
+        serviceConfig = {
+          ExecStartPre = [
+            "-${pkgs.coreutils}/bin/rm -f /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api"
+          ]
+          ++ (lib.optional (
+            instance.kernelModule != null
+          ) "-${pkgs.kmod}/bin/modprobe ${instance.kernelModule}");
+          ExecStart = "${instance.package}/bin/vpp -c ${instance.settingsFile}";
+          Type = "simple";
+          Restart = "on-failure";
+          RestartSec = "5s";
+          RuntimeDirectory = "vpp";
+        };
+        wantedBy = [ "multi-user.target" ];
+      };
+      instances = lib.attrValues cfg.instances;
+    in
+    lib.mkIf (lib.any (v: v.enable) instances) {
+      environment.systemPackages = [
+        pkgs.vpp # for the vppctl tool
+      ];
+
+      boot.kernel.sysctl = lib.mkIf cfg.hugepages.autoSetup {
+        # defaults for 2MB hugepages, see https://fd.io/docs/vpp/master/gettingstarted/running/index.html#huge-pages
+        "vm.nr_hugepages" = cfg.hugepages.count;
+        "vm.max_map_count" = cfg.hugepages.count * 2;
+        "kernel.shmmax" = cfg.hugepages.count * 2097152; # * 2 * 1024 * 1024
+      };
+
+      users.groups = lib.mkMerge (
+        map (
+          instance:
+          lib.mkIf instance.enable {
+            ${instance.group} = { };
+          }
+        ) instances
+      );
+
+      systemd.services = lib.mkMerge (
+        map (
+          instance:
+          lib.mkIf instance.enable {
+            "vpp-${instance.name}" = mkInstanceServiceConfig instance;
+          }
+        ) instances
+      );
+
+      meta.maintainers = with lib.maintainers; [ azey7f ];
+    };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1588,6 +1588,7 @@ in
   vikunja = runTest ./vikunja.nix;
   virtualbox = handleTestOn [ "x86_64-linux" ] ./virtualbox.nix { };
   vm-variant = handleTest ./vm-variant.nix { };
+  vpp = handleTest ./vpp.nix { };
   vscode-remote-ssh = handleTestOn [ "x86_64-linux" ] ./vscode-remote-ssh.nix { };
   vscodium = import ./vscodium.nix { inherit runTest; };
   vsftpd = runTest ./vsftpd.nix;

--- a/nixos/tests/vpp.nix
+++ b/nixos/tests/vpp.nix
@@ -1,0 +1,131 @@
+# This test runs FD.io's VPP and tests routing between two virtual networks.
+# Topology is similar to the `nat` test, with a client on one network, a server
+# on another, and a VPP-powered router inbetween connecting the two.
+
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+  {
+    name = "vpp";
+
+    meta.maintainers = with lib.maintainers; [ azey7f ];
+
+    nodes = {
+      client =
+        { ... }:
+        {
+          virtualisation.vlans = [ 1 ];
+          networking.interfaces = lib.mkForce {
+            eth1.ipv6.addresses = [
+              {
+                address = "fd01::2";
+                prefixLength = 64;
+              }
+            ];
+          };
+          networking.defaultGateway6 = "fd01::1";
+          networking.useDHCP = false;
+        };
+      server =
+        { ... }:
+        {
+          virtualisation.vlans = [ 2 ];
+          networking.interfaces = lib.mkForce {
+            eth1.ipv6.addresses = [
+              {
+                address = "fd02::2";
+                prefixLength = 64;
+              }
+            ];
+          };
+          networking.defaultGateway6 = "fd02::1";
+          networking.useDHCP = false;
+
+          services.nginx.enable = true;
+          services.nginx.statusPage = true;
+
+          networking.firewall.allowedTCPPorts = [ 80 ];
+        };
+      router =
+        { config, ... }:
+        {
+          virtualisation.vlans = [
+            1
+            2
+          ];
+
+          # Disable netdevs so VPP can take over them
+          networking.useDHCP = false;
+          networking.interfaces = lib.mkForce { };
+
+          # install igb_uio driver
+          boot.extraModulePackages = [ config.boot.kernelPackages.dpdk-kmods ];
+
+          virtualisation.memorySize = 4096;
+          services.vpp.hugepages = {
+            autoSetup = true;
+            count = 1024;
+          };
+
+          services.vpp.instances.main = {
+            enable = true;
+            kernelModule = "igb_uio";
+            settings = {
+              unix.cli-listen = "/run/vpp/cli.sock"; # override a default value
+
+              plugins = {
+                # Selectively enable only necessary plugins
+                plugin.default.disable = true;
+                plugin."dpdk_plugin.so".enable = true;
+              };
+
+              dpdk.dev."0000:00:09.0".name = "vlan1";
+              dpdk.dev."0000:00:0a.0".name = "vlan2";
+            };
+            startupConfig = ''
+              set int state vlan1 up
+              set int state vlan2 up
+              set int ip addr vlan1 fd01::1/64
+              set int ip addr vlan2 fd02::1/64
+            '';
+          };
+        };
+    };
+
+    testScript = ''
+      start_all()
+
+      # wait for router
+      router.wait_for_unit("vpp-main.service")
+      router.wait_for_file("/run/vpp/cli.sock")
+
+      # make sure VPP initialized correctly
+      # wait_until_succeeds is necessary since startupConfig executes *after* the service starts
+      router.wait_until_succeeds("vppctl show int addr | grep -A1 vlan1 | grep -q fd01::1/64")
+      router.succeed("vppctl show int addr | grep -A1 vlan2 | grep -q fd02::1/64")
+
+      # wait for server, make sure nginx is reachable
+      server.wait_for_unit("nginx.service")
+      server.succeed("curl --fail http://[::1]")
+
+      # wait for client, make sure it can connect to the server through the router
+      client.wait_for_unit("network.target")
+      client.succeed("curl --fail http://[fd02::2]")
+
+      # test ICMP
+      server.succeed("ping -c 1 fd01::2")
+      client.succeed("ping -c 1 fd02::2")
+
+      # disable interfaces in VPP, make sure server isn't reachable
+      router.succeed("vppctl set int state vlan1 down")
+      router.succeed("vppctl set int state vlan2 down")
+      client.fail("curl --fail --connect-timeout 5 http://[fd02::2]")
+      client.fail("ping -c 1 fd02::2")
+
+      # restart VPP, make sure it restores its config & server becomes reachable again
+      router.succeed("systemctl restart vpp-main")
+      router.wait_for_unit("vpp-main.service")
+      client.succeed("curl --fail http://[fd02::2]")
+      client.succeed("ping -c 1 fd02::2")
+    '';
+  }
+)

--- a/pkgs/by-name/vp/vpp/package.nix
+++ b/pkgs/by-name/vp/vpp/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
+  nixosTests,
   cmake,
   pkg-config,
   check,
@@ -120,6 +121,10 @@ stdenv.mkDerivation rec {
   ];
 
   passthru.updateScript = nix-update-script { };
+
+  passthru.tests = {
+    inherit (nixosTests) vpp;
+  };
 
   meta = {
     description = "Fast, scalable layer 2-4 multi-platform network stack running in user space";


### PR DESCRIPTION
## Description of changes

Module & associated tests for #346281.

Includes an RFC42 `settings` option using a custom parser based on [znc](https://github.com/NixOS/nixpkgs/blob/c636130b369ff944bb1c3560c8bb9377e6082975/nixos/modules/services/networking/znc/default.nix)'s and support for multiple instances similar to authelia's module. The test is pretty basic and verifies routing functionality between 2 hosts with VPP acting as the router.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
