### PR TITLE
upower: fix disabling introspection, systemd

### DIFF
--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -34,8 +34,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "upower";
   version = "1.90.4";
 
-  outputs = [ "out" "dev" "installedTests" ]
-    ++ lib.optionals withDocs [ "devdoc" ];
+  outputs = [ "out" "dev" ]
+    ++ lib.optionals withDocs [ "devdoc" ]
+    ++ lib.optionals withIntrospection [ "installedTests" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -82,6 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     libusb1
     udev
     systemd
+  ] ++ lib.optionals withIntrospection [
     # Duplicate from nativeCheckInputs until https://github.com/NixOS/nixpkgs/issues/161570 is solved
     umockdev
 
@@ -97,12 +99,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeCheckInputs = [
+    libeatmydata
+  ] ++ lib.optionals withIntrospection [
     python3.pkgs.dbus-python
     python3.pkgs.python-dbusmock
     python3.pkgs.pygobject3
     dbus
     umockdev
-    libeatmydata
     python3.pkgs.packaging
   ];
 
@@ -180,7 +183,7 @@ stdenv.mkDerivation (finalAttrs: {
     ! test -e "$DESTDIR"
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString withIntrospection ''
     wrapProgram "$installedTests/libexec/upower/integration-test.py" \
       --prefix GI_TYPELIB_PATH : "${lib.makeSearchPath "lib/girepository-1.0" [
         "$out"

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -17,7 +17,6 @@
 , libusb1
 , glib
 , gettext
-, systemd
 , nixosTests
 , useIMobileDevice ? true
 , libimobiledevice
@@ -26,6 +25,8 @@
 , withIntrospection ? lib.meta.availableOn stdenv.hostPlatform gobject-introspection && stdenv.hostPlatform.emulatorAvailable buildPackages
 , buildPackages
 , gobject-introspection
+, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
+, systemd
 }:
 
 assert withDocs -> withIntrospection;
@@ -82,7 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
     libgudev
     libusb1
     udev
-    systemd
   ] ++ lib.optionals withIntrospection [
     # Duplicate from nativeCheckInputs until https://github.com/NixOS/nixpkgs/issues/161570 is solved
     umockdev
@@ -94,6 +94,8 @@ stdenv.mkDerivation (finalAttrs: {
       pp.pygobject3
       pp.packaging
     ]))
+  ] ++ lib.optionals withSystemd [
+    systemd
   ] ++ lib.optionals useIMobileDevice [
     libimobiledevice
   ];


### PR DESCRIPTION
Since #345979, building upower is necessary to build xdg-desktop-portal-gtk, but it wasn't possible for systems that can't use systemd.

I've called the option "withSystemd" as it's the most common name for this kind of option in Nixpkgs, and it's consistent with the package's "withIntrospection" argument (though not "useIMobileDevice").

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
