### PR TITLE
nixos/zapret: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22608,6 +22608,13 @@
     githubId = 144771550;
     name = "Luca Uricariu";
   };
+  voronind = {
+    email = "hi@voronind.com";
+    name = "Dmitry Voronin";
+    github = "voronind-com";
+    githubId = 22127600;
+    keys = [ { fingerprint = "3241 FDAD 82A7 E22D 4279  F405 913F 3267 9278 2E1C"; } ];
+  };
   votava = {
     email = "votava@gmail.com";
     github = "janvotava";

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -181,6 +181,8 @@
 
 - [Fedimint](https://github.com/fedimint/fedimint), a module based system for building federated applications (Federated E-Cash Mint). Available as [services.fedimintd](#opt-services.fedimintd).
 
+- [Zapret](https://github.com/bol-van/zapret), a DPI bypass tool. Available as [services.zapret](option.html#opt-services.zapret).
+
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}
 
 - The `sound` options have been removed or renamed, as they had a lot of unintended side effects. See [below](#sec-release-24.11-migration-sound) for details.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1276,6 +1276,7 @@
   ./services/networking/xray.nix
   ./services/networking/xrdp.nix
   ./services/networking/yggdrasil.nix
+  ./services/networking/zapret.nix
   ./services/networking/zerobin.nix
   ./services/networking/zeronet.nix
   ./services/networking/zerotierone.nix

--- a/nixos/modules/services/networking/zapret.nix
+++ b/nixos/modules/services/networking/zapret.nix
@@ -1,0 +1,159 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.zapret;
+
+  whitelist = lib.optionalString (
+    cfg.whitelist != null
+  ) "--hostlist ${pkgs.writeText "zapret-whitelist" (lib.concatStringsSep "\n" cfg.whitelist)}";
+
+  blacklist =
+    lib.optionalString (cfg.blacklist != null)
+      "--hostlist-exclude ${pkgs.writeText "zapret-blacklist" (lib.concatStringsSep "\n" cfg.blacklist)}";
+
+  ports = if cfg.httpSupport then "80,443" else "443";
+in
+{
+  options.services.zapret = {
+    enable = lib.mkEnableOption "the Zapret DPI bypass service.";
+    package = lib.mkPackageOption pkgs "zapret" { };
+    params = lib.mkOption {
+      default = [ ];
+      type = with lib.types; listOf str;
+      example = ''
+        [
+          "--dpi-desync=fake,disorder2"
+          "--dpi-desync-ttl=1"
+          "--dpi-desync-autottl=2"
+        ];
+      '';
+      description = ''
+        Specify the bypass parameters for Zapret binary.
+        There are no universal parameters as they vary between different networks, so you'll have to find them yourself.
+
+        This can be done by running the `blockcheck` binary from zapret package, i.e. `nix-shell -p zapret --command blockcheck`.
+        It'll try different params and then tell you which params are working for your network.
+      '';
+    };
+    whitelist = lib.mkOption {
+      default = null;
+      type = with lib.types; nullOr (listOf str);
+      example = ''
+        [
+          "youtube.com"
+          "googlevideo.com"
+          "ytimg.com"
+          "youtu.be"
+        ]
+      '';
+      description = ''
+        Specify a list of domains to bypass. All other domains will be ignored.
+        You can specify either whitelist or blacklist, but not both.
+        If neither are specified, then bypass all domains.
+
+        It is recommended to specify the whitelist. This will make sure that other resources won't be affected by this service.
+      '';
+    };
+    blacklist = lib.mkOption {
+      default = null;
+      type = with lib.types; nullOr (listOf str);
+      example = ''
+        [
+          "example.com"
+        ]
+      '';
+      description = ''
+        Specify a list of domains NOT to bypass. All other domains will be bypassed.
+        You can specify either whitelist or blacklist, but not both.
+        If neither are specified, then bypass all domains.
+      '';
+    };
+    qnum = lib.mkOption {
+      default = 200;
+      type = lib.types.int;
+      description = ''
+        Routing queue number.
+        Only change this if you already use the default queue number somewhere else.
+      '';
+    };
+    configureFirewall = lib.mkOption {
+      default = true;
+      type = lib.types.bool;
+      description = ''
+        Whether to setup firewall routing so that system http(s) traffic is forwarded via this service.
+        Disable if you want to set it up manually.
+      '';
+    };
+    httpSupport = lib.mkOption {
+      default = true;
+      type = lib.types.bool;
+      description = ''
+        Whether to route http traffic on port 80.
+        Http bypass rarely works and you might want to disable it if you don't utilise http connections.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = (cfg.whitelist == null) || (cfg.blacklist == null);
+            message = "Can't specify both whitelist and blacklist.";
+          }
+          {
+            assertion = (builtins.length cfg.params) != 0;
+            message = "You have to specify zapret parameters. See the params option's description.";
+          }
+        ];
+
+        systemd.services.zapret = {
+          description = "DPI bypass service";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network.target" ];
+          serviceConfig = {
+            ExecStart = "${cfg.package}/bin/nfqws --pidfile=/run/nfqws.pid ${lib.concatStringsSep " " cfg.params} ${whitelist} ${blacklist} --qnum=${toString cfg.qnum}";
+            Type = "simple";
+            PIDFile = "/run/nfqws.pid";
+            Restart = "always";
+            RuntimeMaxSec = "1h"; # This service loves to crash silently or cause network slowdowns. It also restarts instantly. In my experience restarting it hourly provided the best experience.
+
+            # hardening
+            DevicePolicy = "closed";
+            KeyringMode = "private";
+            PrivateTmp = true;
+            PrivateMounts = true;
+            ProtectHome = true;
+            ProtectHostname = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectSystem = "strict";
+            ProtectProc = "invisible";
+            RemoveIPC = true;
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            SystemCallArchitectures = "native";
+          };
+        };
+      }
+
+      # Route system traffic via service for specified ports.
+      (lib.mkIf cfg.configureFirewall {
+        networking.firewall.extraCommands = ''
+          iptables -t mangle -I POSTROUTING -p tcp -m multiport --dports ${ports} -m connbytes --connbytes-dir=original --connbytes-mode=packets --connbytes 1:6 -m mark ! --mark 0x40000000/0x40000000 -j NFQUEUE --queue-num ${toString cfg.qnum} --queue-bypass
+        '';
+      })
+    ]
+  );
+
+  meta.maintainers = with lib.maintainers; [
+    voronind
+    nishimara
+  ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Implement a systemd service for NixOS that enables Zapret package system-wide.
I've been using it for a while now.

Compared to https://github.com/NixOS/nixpkgs/pull/327903 this module has whitelist/blacklist support as well as some other configurations. Also after running this for a while, I solved some pain-points like repetitive network slowdowns. And no "dirty" parts.

Also this is my first contribution. I'd really appreciate assistance with making things right this first time. Please tell me all your thoughts. Thanks!

Example configuration:
```nix
services.zapret = {
  enable = true;
  package = pkgs.zapret;
  params = [
    "--dpi-desync=fake,disorder2"
    "--dpi-desync-ttl=1"
    "--dpi-desync-autottl=2"
  ];
  whitelist = [
    "youtube.com"
    "googlevideo.com"
    "ytimg.com"
    "youtu.be"
  ];
  # blacklist = [ ];
  qnum = 200;
  configureFirewall = true;
  httpSupport = true;
};
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
