### PR TITLE
python312Packages.pylitejet: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/pylitejet/default.nix
+++ b/pkgs/development/python-modules/pylitejet/default.nix
@@ -4,12 +4,12 @@
   fetchFromGitHub,
   pyserial,
   pythonOlder,
-  setuptools,
+  setuptools-scm,
 }:
 
 buildPythonPackage rec {
   pname = "pylitejet";
-  version = "0.3.0";
+  version = "0.6.3";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -17,11 +17,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "joncar";
     repo = "pylitejet";
-    rev = "refs/tags/${version}";
-    hash = "sha256-fgsAb8zvmIKtitgAQbAPfTzbEGGaj3dU6FXzlSyy4Dk=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-LHNMKU7aMDtSi4K+pZqRF9vAL3EKOFRFFNXKsQJVP2Y=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools-scm ];
 
   dependencies = [ pyserial ];
 
@@ -33,6 +33,7 @@ buildPythonPackage rec {
   meta = {
     description = "Library for interfacing with the LiteJet lighting system";
     homepage = "https://github.com/joncar/pylitejet";
+    changelog = "https://github.com/joncar/pylitejet/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/pylitejet/default.nix
+++ b/pkgs/development/python-modules/pylitejet/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pyserial,
+  pythonOlder,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pylitejet";
+  version = "0.3.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "joncar";
+    repo = "pylitejet";
+    rev = "refs/tags/${version}";
+    hash = "sha256-fgsAb8zvmIKtitgAQbAPfTzbEGGaj3dU6FXzlSyy4Dk=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pyserial ];
+
+  # Only custom tests which uses the CLi are available
+  doCheck = false;
+
+  pythonImportsCheck = [ "pylitejet" ];
+
+  meta = {
+    description = "Library for interfacing with the LiteJet lighting system";
+    homepage = "https://github.com/joncar/pylitejet";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2414,7 +2414,8 @@
     "lirc" = ps: with ps; [
     ]; # missing inputs: python-lirc
     "litejet" = ps: with ps; [
-    ]; # missing inputs: pylitejet
+      pylitejet
+    ];
     "litterrobot" = ps: with ps; [
       pylitterbot
     ];
@@ -5404,6 +5405,7 @@
     "light"
     "linear_garage_door"
     "linkplay"
+    "litejet"
     "litterrobot"
     "livisi"
     "local_calendar"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11615,6 +11615,8 @@ self: super: with self; {
 
   pylion = callPackage ../development/python-modules/pylion { };
 
+  pylitejet = callPackage ../development/python-modules/pylitejet { };
+
   pylitterbot = callPackage ../development/python-modules/pylitterbot { };
 
   py-libzfs = callPackage ../development/python-modules/py-libzfs { };


### PR DESCRIPTION
Library for interfacing with the LiteJet lighting system

https://github.com/joncar/pylitejet

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
