### PR TITLE
xen: make the EFI build mandatory, fix XSA 462 description

### DIFF
--- a/pkgs/build-support/xen/default.nix
+++ b/pkgs/build-support/xen/default.nix
@@ -60,7 +60,6 @@
   branch ? lib.versions.majorMinor version,
   version,
   vendor ? "nixos",
-  withEFI ? true,
   withFlask ? false,
   withSeaBIOS ? true,
   withOVMF ? true,
@@ -280,8 +279,6 @@ stdenv.mkDerivation (finalAttrs: {
 
       "GIT=${coreutils}/bin/false"
       "WGET=${coreutils}/bin/false"
-    ]
-    ++ optionals withEFI [
       "EFI_VENDOR=${vendor}"
       "INSTALL_EFI_STRIP=1"
       "LD=${getExe' binutils-unwrapped-all-targets "ld"}"
@@ -386,8 +383,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   passthru = {
-    efi =
-      if withEFI then "boot/xen-${version}.efi" else throw "This Xen was compiled without an EFI binary.";
+    efi = "boot/xen-${version}.efi";
     flaskPolicy =
       if withFlask then
         "boot/xenpolicy-${version}"
@@ -434,18 +430,11 @@ stdenv.mkDerivation (finalAttrs: {
 
         Use with the `qemu_xen` package.
       ''
-      # Then, if any of the optional with* components are being built, add the "Includes:" string.
-      + optionalString (withEFI || withFlask) (
-        "\nIncludes:"
-        # Originally, this was a call for the complicated withPrefetchedSources. Since there aren't
-        # that many optional components, we just use lib.strings.optionalString, because it's simpler.
-        # Optional components that aren't being built are automatically hidden.
-        + optionalString withEFI "\n* `xen.efi`: The Xen Project's [EFI binary](https://xenbits.xenproject.org/docs/${branch}-testing/misc/efi.html), available on the `boot` output of this package."
-        + optionalString withFlask "\n* `xsm-flask`: The [FLASK Xen Security Module](https://wiki.xenproject.org/wiki/Xen_Security_Modules_:_XSM-FLASK). The `xenpolicy-${version}` file is available on the `boot` output of this package."
-        + optionalString withSeaBIOS "\n* `seabios`: Support for the SeaBIOS boot firmware on HVM domains."
-        + optionalString withOVMF "\n* `ovmf`: Support for the OVMF UEFI boot firmware on HVM domains."
-        + optionalString withIPXE "\n* `ipxe`: Support for the iPXE boot firmware on HVM domains."
-      )
+      + "\nIncludes:\n* `xen.efi`: The Xen Project's [EFI binary](https://xenbits.xenproject.org/docs/${branch}-testing/misc/efi.html), available on the `boot` output of this package."
+      + optionalString withFlask "\n* `xsm-flask`: The [FLASK Xen Security Module](https://wiki.xenproject.org/wiki/Xen_Security_Modules_:_XSM-FLASK). The `xenpolicy-${version}` file is available on the `boot` output of this package."
+      + optionalString withSeaBIOS "\n* `seabios`: Support for the SeaBIOS boot firmware on HVM domains."
+      + optionalString withOVMF "\n* `ovmf`: Support for the OVMF UEFI boot firmware on HVM domains."
+      + optionalString withIPXE "\n* `ipxe`: Support for the iPXE boot firmware on HVM domains."
       # Finally, we write a notice explaining which vulnerabilities this Xen is NOT vulnerable to.
       # This will hopefully give users the peace of mind that their Xen is secure, without needing
       # to search the source code for the XSA patches.

--- a/pkgs/build-support/xen/patches.nix
+++ b/pkgs/build-support/xen/patches.nix
@@ -142,14 +142,11 @@ in
       In x86's APIC (Advanced Programmable Interrupt Controller) architecture,
       error conditions are reported in a status register.  Furthermore, the OS
       can opt to receive an interrupt when a new error occurs.
-
       It is possible to configure the error interrupt with an illegal vector,
       which generates an error when an error interrupt is raised.
-
       This case causes Xen to recurse through vlapic_error().  The recursion
       itself is bounded; errors accumulate in the the status register and only
       generate an interrupt when a new status bit becomes set.
-
       However, the lock protecting this state in Xen will try to be taken
       recursively, and deadlock.
     '';


### PR DESCRIPTION
As binutils-efi no longer exists, there's no longer any reason to have the withEFI flag. All supported builds should also build xen.efi.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] No rebuilds: we're already building with EFI enabled and the description is only appended to a `meta` attribute.
- [x] No release notes: change is minor.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
