### PR TITLE
darwin.locale: restore locale data

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/package.nix
@@ -35,7 +35,6 @@ mkAppleDerivation {
 
   outputs = [
     "out"
-    "locale"
     "ps"
     "man"
   ];
@@ -86,15 +85,9 @@ mkAppleDerivation {
     (lib.mesonOption "sdk_version" (lib.getVersion apple-sdk))
   ];
 
-  postBuild = ''
-    # Build the locales TODO
-  '';
-
   postInstall = ''
-    moveToOutput share/locale "$locale"
     moveToOutput bin/ps "$ps"
     ln -s "$ps/bin/ps" "$out/bin/ps"
-    mkdir -p "$locale/share/locale"
   '';
 
   meta = {

--- a/pkgs/os-specific/darwin/apple-source-releases/locale/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/locale/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  adv_cmds,
+  bmake,
+  fetchFromGitHub,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "locale";
+  version = "118";
+
+  # This data is old, but it’s closer to what macOS has than FreeBSD. Trying to use the FreeBSD data
+  # results in test failures due to different behavior (e.g., with zh_CN and spaces in gnulib’s `trim` test).
+  # TODO(@reckenrode) Update locale data using https://cldr.unicode.org to match current macOS locale data.
+  src = fetchFromGitHub {
+    owner = "apple-oss-distributions";
+    repo = "adv_cmds";
+    rev = "adv_cmds-118";
+    hash = "sha256-KzaAlqXqfJW2s31qmA0D7qteaZY57Va2o86aZrwyR74=";
+  };
+
+  sourceRoot = "source/usr-share-locale.tproj";
+
+  postPatch = ''
+    # bmake expects `Makefile` not `BSDmakefile`.
+    find . -name Makefile -exec rm {} \; -exec ln -s BSDmakefile {} \;
+
+    # Update `Makefile`s to: get commands from `PATH`, and install to the correct location.
+    # Note: not every `Makefile` has `rsync` or the project name in it.
+    for subproject in colldef mklocale monetdef msgdef numericdef timedef; do
+      substituteInPlace "$subproject/BSDmakefile" \
+        --replace-warn "../../$subproject.tproj/" "" \
+        --replace-fail /usr/share/locale /share/locale \
+        --replace-fail '-o ''${BINOWN} -g ''${BINGRP}' "" \
+        --replace-warn "rsync -a" "cp -r"
+    done
+
+    # Update `bsdmake` references to `bmake`
+    substituteInPlace Makefile \
+      --replace-fail bsdmake bmake
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    adv_cmds
+    bmake
+  ];
+
+  enableParallelInstalling = true;
+
+  installFlags = [ "DESTDIR=${placeholder "out"}" ];
+
+  meta = {
+    description = "Locale data for Darwin";
+    license = [
+      lib.licenses.apsl10
+      lib.licenses.apsl20
+    ];
+    maintainers = lib.teams.darwin.members;
+  };
+}

--- a/pkgs/os-specific/darwin/apple-source-releases/update-source-releases.sh
+++ b/pkgs/os-specific/darwin/apple-source-releases/update-source-releases.sh
@@ -25,6 +25,7 @@ tag="macos-${sdkVersion//.}"
 
 declare -A ignoredPackages=(
     [libsbuf]=1
+    [locale]=1
     [mkAppleDerivation]=1
     [update-source-releases.sh]=1
     [versions.json]=1

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -238,6 +238,7 @@ let
       autoconf
       automake
       bison
+      bmake
       brotli
       cmake
       cpio

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -289,9 +289,14 @@ let
       ;
   };
 
-  darwinPackages = prevStage: { inherit (prevStage.darwin) locale sigtool; };
+  darwinPackages = prevStage: { inherit (prevStage.darwin) sigtool; };
   darwinPackagesNoCC = prevStage: {
-    inherit (prevStage.darwin) binutils binutils-unwrapped libSystem;
+    inherit (prevStage.darwin)
+      binutils
+      binutils-unwrapped
+      libSystem
+      locale
+      ;
   };
 
   # These packages are not allowed to be used in the Darwin bootstrap

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -118,7 +118,7 @@ impure-cmds // apple-source-packages // apple-source-headers // stubs // {
     extraBuildInputs = [];
   };
 
-  inherit (self.adv_cmds) locale ps;
+  inherit (self.adv_cmds) ps;
 
   binutils-unwrapped = callPackage ../os-specific/darwin/binutils {
     inherit (pkgs) cctools;


### PR DESCRIPTION
This is a follow up to https://github.com/NixOS/nixpkgs/pull/346043 to add the missing locale data. It’s not exactly the same as the data used on macOS, but it’s close. This is being done separately in case the PR is rejected.

Replacement for https://github.com/NixOS/nixpkgs/pull/347642.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
