### PR TITLE
nixos/bonsaid: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -20,6 +20,8 @@
 
 - [Bazecor](https://github.com/Dygmalab/Bazecor), the graphical configurator for Dygma Products.
 
+- [Bonsai](https://git.sr.ht/~stacyharper/bonsai), a general-purpose event mapper/state machine primarily used to create complex key shortcuts, and as part of the [SXMO](https://sxmo.org/) desktop environment. Available as [services.bonsaid](#opt-services.bonsaid.enable).
+
 - [scanservjs](https://github.com/sbs20/scanservjs/), a web UI for SANE scanners. Available at [services.scanservjs](#opt-services.scanservjs.enable).
 
 - [Kimai](https://www.kimai.org/), a web-based multi-user time-tracking application. Available as [services.kimai](options.html#opt-services.kimai).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -509,6 +509,7 @@
   ./services/desktops/ayatana-indicators.nix
   ./services/desktops/bamf.nix
   ./services/desktops/blueman.nix
+  ./services/desktops/bonsaid.nix
   ./services/desktops/cpupower-gui.nix
   ./services/desktops/deepin/deepin-anything.nix
   ./services/desktops/deepin/dde-api.nix

--- a/nixos/modules/services/desktops/bonsaid.nix
+++ b/nixos/modules/services/desktops/bonsaid.nix
@@ -1,0 +1,168 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  json = pkgs.formats.json { };
+  transitionType = lib.types.submodule {
+    freeformType = json.type;
+    options.type = lib.mkOption {
+      type = lib.types.enum [
+        "delay"
+        "event"
+        "exec"
+      ];
+      description = ''
+        Type of transition. Determines how bonsaid interprets the other options in this transition.
+      '';
+    };
+    options.command = lib.mkOption {
+      type = lib.types.nullOr (lib.types.listOf lib.types.str);
+      default = null;
+      description = ''
+        Command to run when this transition is taken.
+        This is executed inline by `bonsaid` and blocks handling of any other events until completion.
+        To perform the command asynchronously, specify it like `[ "setsid" "-f" "my-command" ]`.
+
+        Only effects transitions with `type = "exec"`.
+      '';
+    };
+    options.delay_duration = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      description = ''
+        Nanoseconds to wait after the previous state change before performing this transition.
+        This can be placed at the same level as a `type = "event"` transition to achieve a
+        timeout mechanism.
+
+        Only effects transitions with `type = "delay"`.
+      '';
+    };
+    options.event_name = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Name of the event which should trigger this transition when received by `bonsaid`.
+        Events are sent to `bonsaid` by running `bonsaictl -e <event_name>`.
+
+        Only effects transitions with `type = "event"`.
+      '';
+    };
+    options.transitions = lib.mkOption {
+      type = lib.types.listOf transitionType;
+      default = [ ];
+      description = ''
+        List of transitions out of this state.
+        If left empty, then this state is considered a terminal state and entering it will
+        trigger an immediate transition back to the root state (after processing side effects).
+      '';
+      visible = "shallow";
+    };
+  };
+  cfg = config.services.bonsaid;
+in
+{
+  meta.maintainers = [ lib.maintainers.colinsane ];
+
+  options.services.bonsaid = {
+    enable = lib.mkEnableOption "bonsaid";
+    package = lib.mkPackageOption pkgs "bonsai" { };
+    extraFlags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Extra flags to pass to `bonsaid`, such as `[ "-v" ]` to enable verbose logging.
+      '';
+    };
+    settings = lib.mkOption {
+      type = lib.types.listOf transitionType;
+      description = ''
+        State transition definitions. See the upstream [README](https://git.sr.ht/~stacyharper/bonsai)
+        for extended documentation and a more complete example.
+      '';
+      example = [
+        {
+          type = "event";
+          event_name = "power_button_pressed";
+          transitions = [
+            {
+              # Hold power button for 600ms to trigger a command
+              type = "delay";
+              delay_duration = 600000000;
+              transitions = [
+                {
+                  type = "exec";
+                  command = [
+                    "swaymsg"
+                    "--"
+                    "output"
+                    "*"
+                    "power"
+                    "off"
+                  ];
+                  # `transitions = []` marks this as a terminal state,
+                  # so bonsai will return to the root state immediately after executing the above command.
+                  transitions = [ ];
+                }
+              ];
+            }
+            {
+              # If the power button is released before the 600ms elapses, return to the root state.
+              type = "event";
+              event_name = "power_button_released";
+              transitions = [ ];
+            }
+          ];
+        }
+      ];
+    };
+    configFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path to a .json file specifying the state transitions.
+        You don't need to set this unless you prefer to provide the json file
+        yourself instead of using the `settings` option.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.bonsaid.configFile =
+      let
+        filterNulls =
+          v:
+          if lib.isAttrs v then
+            lib.mapAttrs (_: filterNulls) (lib.filterAttrs (_: a: a != null) v)
+          else if lib.isList v then
+            lib.map filterNulls (lib.filter (a: a != null) v)
+          else
+            v;
+      in
+      lib.mkDefault (json.generate "bonsai_tree.json" (filterNulls cfg.settings));
+
+    # bonsaid is controlled by bonsaictl, so place the latter in the environment by default.
+    # bonsaictl is typically invoked by scripts or a DE so this isn't strictly necesssary,
+    # but it's helpful while administering the service generally.
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.user.services.bonsaid = {
+      description = "Bonsai Finite State Machine daemon";
+      documentation = [ "https://git.sr.ht/~stacyharper/bonsai" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe' cfg.package "bonsaid")
+            "-t"
+            cfg.configFile
+          ]
+          ++ cfg.extraFlags
+        );
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+  };
+}


### PR DESCRIPTION
[bonsai](https://git.sr.ht/~stacyharper/bonsai) project.

nixpkgs already has the package for bonsai, which is _only_ usable as a client + daemon setup. until now, bonsai package users were presumably all configuring their own services. this provides that service component, generally.

i chose to implement this as a user service. that's because both the daemon and client components -- `bonsaid` and `bonsaictl`  coordinate on a socket by using the `XDG_RUNTIME_DIR` environment variable. so, if either one is invoked by a different user, they fail to connect. one can't run `bonsaid` as root and `bonsaictl` as an ordinary user, for example. the only thing that made sense was to attach `bonsaid` to the user's service manager.

@MatthewCroughan has graciously agreed to test this module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
