### PR TITLE
nixos/immich: add doc & test for listen to all interfaces

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -137,7 +137,15 @@ in
     host = mkOption {
       type = types.str;
       default = "localhost";
-      description = "The host that immich will listen on.";
+      example = ""; # all interfaces
+      # hint: the use of "" for IMMICH_HOST is not documented
+      # see https://docs.immich.app/install/environment-variables/#ports
+      # or https://github.com/immich-app/immich/blob/767caf9bfec2ec74ebdef6f58643ee9505da8550/docs/docs/install/environment-variables.md?plain=1#L70
+      # impl: https://github.com/immich-app/immich/blob/60f4dedb2991c8356d2977f1dc9cfa2cf666788c/server/src/app.common.ts#L90
+      description = ''
+        The host that immich will listen on.
+        Set to `""` to listen on all interfaces.
+      '';
     };
     port = mkOption {
       type = types.port;

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -137,7 +137,15 @@ in
     host = mkOption {
       type = types.str;
       default = "localhost";
-      description = "The host that immich will listen on.";
+      example = ""; # all interfaces
+      # hint: the use of "" for IMMICH_HOST is not documented
+      # see https://docs.immich.app/install/environment-variables/#ports
+      # or https://github.com/immich-app/immich/blob/767caf9bfec2ec74ebdef6f58643ee9505da8550/docs/docs/install/environment-variables.md?plain=1#L70
+      # impl: https://github.com/immich-app/immich/blob/60f4dedb2991c8356d2977f1dc9cfa2cf666788c/server/src/app.common.ts#L90
+      description = ''
+        The host that immich will listen on.
+        Set to an empty string (`""`) to listen on all interfaces.
+      '';
     };
     port = mkOption {
       type = types.port;

--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -17,6 +17,7 @@
       services.immich = {
         enable = true;
         environment.IMMICH_LOG_LEVEL = "verbose";
+        host = ""; # all interfaces (example from module option)
         settings = {
           backup.database = {
             enabled = true;
@@ -45,6 +46,9 @@
     machine.wait_for_open_port(2283) # Server
     machine.wait_for_open_port(3003) # Machine learning
     machine.succeed("curl --fail http://localhost:2283/")
+
+    with subtest("verify listening to any IP (i.e. v4 & v6)"):
+      machine.succeed("ss -tln | grep -F '*:2283'")
 
     machine.succeed("""
       curl -f --json '{ "email": "test@example.com", "name": "Admin", "password": "admin" }' http://localhost:2283/api/auth/admin-sign-up


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- adds a hint to the description of `services.immich.host`
  explaining how to enable listening to all interfaces
- in code, add hint that setting IMMICH_HOST="" does trigger Immich to
  listen on both IPv4 & IPv6 is an undocumented feature
  (at least no documentation of that parameter could be found)
- extend NixOS test to check for the undocumented env var to work

Motivation was my experience on getting Immich to listen on all interfaces, which started by discovering that `0.0.0.0` & `::` do not work & concluded into the invalid PR #347815 until I got it finally working properly now.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
