### PR TITLE
Fix codeowner workflow for branches starting with "pr"

### DIFF
--- a/ci/request-reviews/request-reviews.sh
+++ b/ci/request-reviews/request-reviews.sh
@@ -60,10 +60,9 @@ git -C "$tmp/nixpkgs.git" remote add fork https://github.com/"$prRepo".git
 git -C "$tmp/nixpkgs.git" config remote.fork.partialclonefilter tree:0
 git -C "$tmp/nixpkgs.git" config remote.fork.promisor true
 
-# This should not conflict with any refs in Nixpkgs
-headRef=refs/remotes/fork/pr
-# Only fetch into a remote ref, because the local ref namespace is used by Nixpkgs, don't want any conflicts
-git -C "$tmp/nixpkgs.git" fetch --no-tags fork "$prBranch":"$headRef"
+# Our local branches mirror Nixpkgs, so make sure to not try to update any to avoid conflicts
+git -C "$tmp/nixpkgs.git" fetch --no-tags fork "$prBranch"
+headRef=$(git -C "$tmp/nixpkgs.git" rev-parse HEAD)
 
 log "Checking correctness of the base branch"
 if ! "$SCRIPT_DIR"/verify-base-branch.sh "$tmp/nixpkgs.git" "$headRef" "$baseRepo" "$baseBranch" "$prRepo" "$prBranch" | tee "$tmp/invalid-base-error" >&2; then


### PR DESCRIPTION
Turns out if :<something> is passed, a local branch is updated, which can conflict if the PR branch starts with "pr". I tried to avoid that with the original code but apparently that didn't work!

https://github.com/NixOS/nixpkgs/actions/runs/11284183639/job/31384967152?pr=347822

    Fetching the PR commit history
    From https://github.com/linj-fork/nixpkgs
     * [new branch]            pr/kanata-add-version-check -> fork/pr
    error: cannot lock ref 'refs/remotes/fork/pr/kanata-add-version-check': 'refs/remotes/fork/pr' exists; cannot create 'refs/remotes/fork/pr/kanata-add-version-check'
     ! [new branch]            pr/kanata-add-version-check -> fork/pr/kanata-add-version-check  (unable to update local ref)
    error: some local refs could not be updated; try running


Thanks for [the report](https://github.com/NixOS/nixpkgs/pull/347610#issuecomment-2406314033), @jian-lin!

## Things done

Successfully ran it locally with dry mode:
```
$ nix-build ci -A requestReviews
$ DRY_MODE=1 result/bin/request-reviews.sh NixOS/nixpkgs 347822 ci/OWNERS
[...]
Fetching the PR commit history
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 1 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (1/1), 395 bytes | 395.00 KiB/s, done.
From https://github.com/linj-fork/nixpkgs
 * branch                      pr/kanata-add-version-check -> FETCH_HEAD
 * [new branch]                pr/kanata-add-version-check -> fork/pr/kanata-add-version-check
Checking correctness of the base branch
[...]
```

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
