### PR TITLE
deepin.dtk: fix build on qt 6.8

### DIFF
--- a/pkgs/desktops/deepin/library/dtk6core/default.nix
+++ b/pkgs/desktops/deepin/library/dtk6core/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   pkg-config,
   doxygen,
@@ -26,6 +27,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./fix-pkgconfig-path.patch
     ./fix-pri-path.patch
+    (fetchpatch {
+      name = "fix-build-on-qt-6.8.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/dtk6core/-/raw/d2e991f96b2940e8533b7e944bab5a7dd6aa0fb7/qt-6.8.patch";
+      hash = "sha256-HZxUrtUmVwnNUwcBoU7ewb+McsRkALQglPBbJU8HTkk=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/deepin/library/dtk6declarative/default.nix
+++ b/pkgs/desktops/deepin/library/dtk6declarative/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./fix-pkgconfig-path.patch
     ./fix-pri-path.patch
+    ./fix-build-on-qt-6.8.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/library/dtk6declarative/fix-build-on-qt-6.8.patch
+++ b/pkgs/desktops/deepin/library/dtk6declarative/fix-build-on-qt-6.8.patch
@@ -1,0 +1,135 @@
+diff --git a/qt6/src/CMakeLists.txt b/qt6/src/CMakeLists.txt
+index 4314b72..a7ecaf1 100644
+--- a/qt6/src/CMakeLists.txt
++++ b/qt6/src/CMakeLists.txt
+@@ -25,6 +25,7 @@ dtk_extend_target(${PLUGIN_NAME} EnableCov ${ENABLE_COV})
+ qt_add_translations(${LIB_NAME}
+     TS_FILES ${TS_FILES}
+     QM_FILES_OUTPUT_VARIABLE QM_FILES
++    IMMEDIATE_CALL
+ )
+ 
+ set_target_properties(${LIB_NAME} PROPERTIES
+diff --git a/src/private/dbackdropnode.cpp b/src/private/dbackdropnode.cpp
+index 91c398a..1ed0ad8 100644
+--- a/src/private/dbackdropnode.cpp
++++ b/src/private/dbackdropnode.cpp
+@@ -320,8 +320,8 @@ public:
+             renderer->setDevicePixelRatio(base->devicePixelRatio());
+             renderer->setDeviceRect(base->deviceRect());
+             renderer->setViewportRect(base->viewportRect());
+-            renderer->setProjectionMatrix(base->projectionMatrix());
+-            renderer->setProjectionMatrixWithNativeNDC(base->projectionMatrixWithNativeNDC());
++            renderer->setProjectionMatrix(base->projectionMatrix(0));
++            renderer->setProjectionMatrixWithNativeNDC(base->projectionMatrixWithNativeNDC(0));
+         } else {
+             renderer->setDevicePixelRatio(1.0);
+             renderer->setDeviceRect(QRect(QPoint(0, 0), pixelSize));
+@@ -336,8 +336,8 @@ public:
+         }
+ 
+         if (Q_UNLIKELY(!matrix.isIdentity())) {
+-            renderer->setProjectionMatrix(renderer->projectionMatrix() * matrix);
+-            renderer->setProjectionMatrixWithNativeNDC(renderer->projectionMatrixWithNativeNDC() * matrix);
++            renderer->setProjectionMatrix(renderer->projectionMatrix(0) * matrix);
++            renderer->setProjectionMatrixWithNativeNDC(renderer->projectionMatrixWithNativeNDC(0) * matrix);
+         }
+ 
+         renderer->setRootNode(rootNode);
+diff --git a/src/private/dmaskeffectnode.cpp b/src/private/dmaskeffectnode.cpp
+index c4db07d..da1e4ce 100644
+--- a/src/private/dmaskeffectnode.cpp
++++ b/src/private/dmaskeffectnode.cpp
+@@ -35,7 +35,7 @@ protected:
+ class OpaqueTextureMaterialShader : public QSGOpaqueTextureMaterialRhiShader
+ {
+ public:
+-    OpaqueTextureMaterialShader();
++    OpaqueTextureMaterialShader(int viewCount);
+ 
+     bool updateUniformData(RenderState &state, QSGMaterial *newMaterial, QSGMaterial *oldMaterial)  override;
+ 
+@@ -48,7 +48,7 @@ public:
+ class TextureMaterialShader : public OpaqueTextureMaterialShader
+ {
+ public:
+-    TextureMaterialShader();
++    TextureMaterialShader(int viewCount);
+ 
+ #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+     void updateState(const RenderState &state, QSGMaterial *newEffect, QSGMaterial *oldEffect) override;
+@@ -61,7 +61,8 @@ protected:
+ #endif
+ };
+ 
+-OpaqueTextureMaterialShader::OpaqueTextureMaterialShader()
++OpaqueTextureMaterialShader::OpaqueTextureMaterialShader(int viewCount)
++ : QSGOpaqueTextureMaterialRhiShader(viewCount)
+ {
+ #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+ #if QT_CONFIG(opengl)
+@@ -236,8 +237,8 @@ bool OpaqueTextureMaterialShader::updateGraphicsPipelineState(RenderState &state
+ }
+ #endif
+ 
+-TextureMaterialShader::TextureMaterialShader()
+-    : OpaqueTextureMaterialShader()
++TextureMaterialShader::TextureMaterialShader(int viewCount)
++    : OpaqueTextureMaterialShader(viewCount)
+ {
+ #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // TODO qt6
+ #if QT_CONFIG(opengl)
+@@ -529,7 +530,7 @@ QSGMaterialShader *TextureMaterial::createShader() const
+ QSGMaterialShader *TextureMaterial::createShader(QSGRendererInterface::RenderMode renderMode) const
+ {
+     Q_UNUSED(renderMode)
+-    return new TextureMaterialShader;
++    return new TextureMaterialShader(viewCount());
+ }
+ #endif
+ 
+@@ -553,7 +554,7 @@ QSGMaterialShader *OpaqueTextureMaterial::createShader() const
+ QSGMaterialShader *OpaqueTextureMaterial::createShader(QSGRendererInterface::RenderMode renderMode) const
+ {
+     Q_UNUSED(renderMode)
+-    return new OpaqueTextureMaterialShader;
++    return new OpaqueTextureMaterialShader(viewCount());
+ }
+ #endif
+ 
+diff --git a/src/private/drectanglenode.cpp b/src/private/drectanglenode.cpp
+index efeeab6..b961588 100644
+--- a/src/private/drectanglenode.cpp
++++ b/src/private/drectanglenode.cpp
+@@ -72,7 +72,8 @@ void CornerColorShader::initialize()
+     m_idQtOpacity = program->uniformLocation("qt_Opacity");
+ }
+ #else
+-CornerColorShader::CornerColorShader()
++CornerColorShader::CornerColorShader(int viewCount)
++    : QSGOpaqueTextureMaterialRhiShader(viewCount)
+ {
+     setShaderFileName(QSGMaterialShader::VertexStage, QStringLiteral(":/dtk/declarative/shaders_ng/cornerscolorshader.vert.qsb"));
+     setShaderFileName(QSGMaterialShader::FragmentStage, QStringLiteral(":/dtk/declarative/shaders_ng/cornerscolorshader.frag.qsb"));
+@@ -128,7 +129,7 @@ QSGMaterialShader *CornerColorMaterial::createShader() const
+ QSGMaterialShader *CornerColorMaterial::createShader(QSGRendererInterface::RenderMode renderMode) const
+ {
+     Q_UNUSED(renderMode)
+-    return new CornerColorShader;
++    return new CornerColorShader(viewCount());
+ }
+ #endif
+ 
+diff --git a/src/private/drectanglenode_p.h b/src/private/drectanglenode_p.h
+index aee5a7c..7962154 100644
+--- a/src/private/drectanglenode_p.h
++++ b/src/private/drectanglenode_p.h
+@@ -37,7 +37,7 @@ private:
+ class CornerColorShader : public QSGOpaqueTextureMaterialRhiShader
+ {
+ public:
+-    CornerColorShader();
++    CornerColorShader(int viewCount);
+     bool updateUniformData(RenderState &state, QSGMaterial *newMaterial, QSGMaterial *oldMaterial);
+ };
+ #endif

--- a/pkgs/desktops/deepin/library/dtk6gui/default.nix
+++ b/pkgs/desktops/deepin/library/dtk6gui/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   pkg-config,
   doxygen,
@@ -24,6 +25,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./fix-pkgconfig-path.patch
     ./fix-pri-path.patch
+    (fetchpatch {
+      name = "fix-build-on-qt-6.8.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/dtk6gui/-/raw/b6b8521fd69c28dbca5f6e8d1d8258c904b6caf1/qt-6.8.patch";
+      hash = "sha256-Fu5vwvKJGMW94JYoIPvDCeXs8WrAskQlVRX/3FYQFGY=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/deepin/library/dtk6widget/default.nix
+++ b/pkgs/desktops/deepin/library/dtk6widget/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   pkg-config,
   doxygen,
@@ -25,6 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./fix-pkgconfig-path.patch
     ./fix-pri-path.patch
+    (fetchpatch {
+      name = "fix-build-on-qt-6.8.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/dtk6widget/-/raw/c4ac094715daa4ec319dc4d55bbca9d818845f82/qt-6.8.patch";
+      hash = "sha256-XEgtAV0mF1+C26wCaukjuv4WNbP4ISGgXt/eav7h9ko=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Fix DDE build on qt 6.8,  Most of the patches from archlinux maintainers


dtkgui(qt5) also need https://github.com/NixOS/nixpkgs/pull/348029
 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
