### PR TITLE
apple-sdk_15: init at 15.0

### DIFF
--- a/pkgs/by-name/ap/apple-sdk/metadata/apple-oss-lockfile.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/apple-oss-lockfile.json
@@ -1422,5 +1422,183 @@
       "hash": "sha256-j5Ep1RX5DTJqTGszrF4d/JtzUqZ6nA6XoExqcIQ0RVQ=",
       "version": "10063.101.15"
     }
+  },
+  "15.0": {
+    "CarbonHeaders": {
+      "hash": "sha256-nIPXnLr21yVnpBhx9K5q3l/nPARA6JL/dED08MeyhP8=",
+      "version": "18.1"
+    },
+    "CommonCrypto": {
+      "hash": "sha256-qwQEFoycAw+YLwqpZgJB1Ppg8mrWFnRPDj4I5f2Ggns=",
+      "version": "600032"
+    },
+    "IOAudioFamily": {
+      "hash": "sha256-VSk3jvsITJugtL67Qt0m4qJ879i7Fj6B/NGBFVCwpiU=",
+      "version": "600.2"
+    },
+    "IOBDStorageFamily": {
+      "hash": "sha256-s8hTwX0jq2iPULfBLUwpzqtszWuvJrrLGbmrKa/fY4U=",
+      "version": "24"
+    },
+    "IOCDStorageFamily": {
+      "hash": "sha256-p/2qM5zjXFDRb/DISpEHxQEdvmuLlRGt/Ygc71Yu2rI=",
+      "version": "62"
+    },
+    "IODVDStorageFamily": {
+      "hash": "sha256-1Sa8aZBGNtqJBNHva+YXxET6Wcdm2PgVrTzYT/8qrN4=",
+      "version": "46"
+    },
+    "IOFWDVComponents": {
+      "hash": "sha256-WkfkWnzRupEh20U7vjsTta89clhus6GTkOpXQWXw/bM=",
+      "version": "208"
+    },
+    "IOFireWireAVC": {
+      "hash": "sha256-qR9lSTa7PN5Z9Nis4tfuXlcZGMIU48dete/NPD0UBbE=",
+      "version": "434"
+    },
+    "IOFireWireFamily": {
+      "hash": "sha256-hmErAXjLWIelqJaCrB8J4IiIxyB7S6EHFY+AY9YhmKQ=",
+      "version": "490"
+    },
+    "IOFireWireSBP2": {
+      "hash": "sha256-Xk+PDnUaO9q46nQwHwTKf/QXtGclfs0wTWiUbcV7e4s=",
+      "version": "452"
+    },
+    "IOFireWireSerialBusProtocolTransport": {
+      "hash": "sha256-P7egeaD9SSa+YyrIRzM44gILKbIL7vezXK3M6q3MBOI=",
+      "version": "261"
+    },
+    "IOGraphics": {
+      "hash": "sha256-Ag37fd3tZJLXLVq1yzHOCWGOYYfwwTkC8hnvNaTEaWg=",
+      "version": "598"
+    },
+    "IOHIDFamily": {
+      "hash": "sha256-4hIztdbKpoC0VrRVwZkoCZuByyTGw02lrrcFDBAXyko=",
+      "version": "2102.0.6"
+    },
+    "IOKitUser": {
+      "hash": "sha256-ytMma1ft1fKjCvP0SKdwnVonPEixzthoCR7ML94/pLE=",
+      "version": "100140.0.6"
+    },
+    "IONetworkingFamily": {
+      "hash": "sha256-gZ7Dkk4Iu7AV9K2ioqSeJ1W7bTNxv77bmT18iv3ljLg=",
+      "version": "185"
+    },
+    "IOSerialFamily": {
+      "hash": "sha256-wVS4QTx6MBOS0VrwyCZ3s5Usezwaf8rWzmNnfdDTXTU=",
+      "version": "93"
+    },
+    "IOStorageFamily": {
+      "hash": "sha256-W9H3jzaXLvAb0cziHBpNo5Iom7c7H5bg4MxQIhIsefc=",
+      "version": "317"
+    },
+    "IOUSBFamily": {
+      "hash": "sha256-Z0E3TfKP49toYo1Fo9kElRap8CZ+mVDHy5RIexgJTpA=",
+      "version": "630.4.5"
+    },
+    "Libc": {
+      "hash": "sha256-1t+e8DQUmsrmr1f6QUU4uUm/el3G7EOL+vUO28srPAM=",
+      "version": "1669.0.4"
+    },
+    "Libinfo": {
+      "hash": "sha256-D7JMCakQVCQ9j2zUHQSGB8zZcHD6azwYY3bsJU0JfEE=",
+      "version": "592"
+    },
+    "Libm": {
+      "hash": "sha256-p4BndAag9d0XSMYWQ+c4myGv5qXbKx5E1VghudSbpTk=",
+      "version": "2026"
+    },
+    "Libnotify": {
+      "hash": "sha256-qYox9iQUnU0AGVfPK2p61/2zlNAJmixCE5K7WojMQ3I=",
+      "version": "327.0.5"
+    },
+    "Librpcsvc": {
+      "hash": "sha256-UWYdCQ9QsBqwM01bWr+igINAHSdSluB/FrOclC5AjTI=",
+      "version": "31"
+    },
+    "Libsystem": {
+      "hash": "sha256-nawWJiu2IJ34ek5iOX6CrlqMzev7TuJpUkvDp30ZQ/U=",
+      "version": "1351"
+    },
+    "OpenDirectory": {
+      "hash": "sha256-6fSl8PasCZSBfe0ftaePcBuSEO3syb6kK+mfDI6iR7A=",
+      "version": "146"
+    },
+    "Security": {
+      "hash": "sha256-ptS/IESkJmbcO3H+v6mmN2jvH2mfLXi+fMQfGCLSt7M=",
+      "version": "61439.1.1"
+    },
+    "architecture": {
+      "hash": "sha256-PRNUrhzSOrwmxSPkKmV0LV7yEIik65sdkfKdBqcwFhU=",
+      "version": "282"
+    },
+    "configd": {
+      "hash": "sha256-Wks7d0Kere6YYPJar593ZSC5bbkyKcaTxrHK6Ah6u0c=",
+      "version": "1345"
+    },
+    "copyfile": {
+      "hash": "sha256-lIhl5sr1gewIHkh10hD+H/I7MVPzlHlONGRMOO7OZuA=",
+      "version": "213"
+    },
+    "dtrace": {
+      "hash": "sha256-S0gI+9eTcuZkh0FWmTmZ+AhZ4qoSdnUb5GTp1melk9A=",
+      "version": "409"
+    },
+    "dyld": {
+      "hash": "sha256-q0GN5+4mW8Yxer0XxhlLK7JRM4JDoxeSFDRzbZ738lw=",
+      "version": "1231.3"
+    },
+    "eap8021x": {
+      "hash": "sha256-2FdEb76KBbCAl2iwly4c1Xstar53O8qgGdN/3WXO23U=",
+      "version": "364"
+    },
+    "hfs": {
+      "hash": "sha256-utmIFAW7Gdbbj71oZnHSaTUse9cIN3ZSfXyFTmuxnc4=",
+      "version": "672"
+    },
+    "launchd": {
+      "hash": "sha256-8mW9bnuHmRXCx9py8Wy28C5b2QPICW0rlAps5njYa00=",
+      "version": "842.1.4"
+    },
+    "libclosure": {
+      "hash": "sha256-21OuQearKTN75OgHN+RPLR1VGdf3ZffPYpV51Kj6LYE=",
+      "version": "94"
+    },
+    "libdispatch": {
+      "hash": "sha256-q2oyaEdt8clVLjLwBjAAvLKodpuYThscK3VcQotCmIM=",
+      "version": "1502.0.1"
+    },
+    "libmalloc": {
+      "hash": "sha256-tFaYSvebk4uIIPu/46eMp6QnwiO/SmShjUoFnJjnmsc=",
+      "version": "646.0.13"
+    },
+    "libplatform": {
+      "hash": "sha256-U3TRUGBxuspEPfzdsd+53Kh8E9GmceMhsxxXuQbcdcc=",
+      "version": "340"
+    },
+    "libpthread": {
+      "hash": "sha256-eYHDAt2wNk7hJZJxsC7Y9w4ASKdexidu613kPo7TAKs=",
+      "version": "535"
+    },
+    "mDNSResponder": {
+      "hash": "sha256-w+Pw/VsHl8hkDiS7EEEYKp9P2NVwu8NSVPSn2U15vHM=",
+      "version": "2559.1.1"
+    },
+    "objc4": {
+      "hash": "sha256-Z9UAm/hjjO2K0c7ag/ws4e/Y2nKOWnObPgp4HUZe+W4=",
+      "version": "928.2"
+    },
+    "ppp": {
+      "hash": "sha256-8+QUA79sHf85yvGSPE9qCmGsrZDT3NZnbgZVroJw/Hg=",
+      "version": "1016"
+    },
+    "removefile": {
+      "hash": "sha256-h1jb4DcgDHwi9eiUguc2e5OLP8ZHxCN3B4Myp/DFDBg=",
+      "version": "75"
+    },
+    "xnu": {
+      "hash": "sha256-9cFPrWtTpCb02YrvKX1KWoExoH2VjPdOBU4dscmKL4A=",
+      "version": "11215.1.10"
+    }
   }
 }

--- a/pkgs/by-name/ap/apple-sdk/metadata/versions.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/versions.json
@@ -38,5 +38,10 @@
     "url": "https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg",
     "version": "14.4",
     "hash": "sha256-QozDiwY0Czc0g45vPD7G4v4Ra+3DujCJbSads3fJjjM="
+  },
+  "15": {
+    "url": "https://swcdn.apple.com/content/downloads/33/46/042-32691-A_3MH7S3118O/3dblccqo9ws17dc5lk3hojfbt3s74q0ql6/CLTools_macOSNMOS_SDK.pkg",
+    "version": "15.0",
+    "hash": "sha256-JhaAPyfX46D+9sematdAYAORw40JP3xvleWRz7Hj/1s="
   }
 }

--- a/pkgs/by-name/ap/apple-sdk/scripts/lock-sdk-deps.sh
+++ b/pkgs/by-name/ap/apple-sdk/scripts/lock-sdk-deps.sh
@@ -60,7 +60,7 @@ for package in "${packages[@]}"; do
 
     packageHash=$(nix --extra-experimental-features nix-command hash path "$package-$packageTag")
 
-    pkgsjson="{\"$package\": {\"version\": \"$packageVersion\", \"hash\": \"$packageHash\"}}"
+    pkgsjson="{\"$sdkVersion\": {\"$package\": {\"version\": \"$packageVersion\", \"hash\": \"$packageHash\"}}}"
 
     echo "   - Locking $package to version $packageVersion with hash '$packageHash'"
     jq --argjson pkg "$pkgsjson" -S '. * $pkg' "$lockfile" | sponge "$lockfile"

--- a/pkgs/os-specific/darwin/apple-source-releases/libpcap/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libpcap/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   apple-sdk_11,
-  #  apple-sdk_15,
+  apple-sdk_15,
   bison,
   bluez,
   fetchFromGitHub,
@@ -16,15 +16,7 @@
 }:
 
 let
-  # Get it from the SDK once the 15.0 SDK is available in nixpkgs.
-  #  xnu = apple-sdk_15.sourceRelease "xnu";
-
-  xnu = fetchFromGitHub {
-    owner = "apple-oss-distributions";
-    repo = "xnu";
-    rev = "xnu-11215.1.10";
-    hash = "sha256-9cFPrWtTpCb02YrvKX1KWoExoH2VjPdOBU4dscmKL4A=";
-  };
+  xnu = apple-sdk_15.sourceRelease "xnu";
 
   privateHeaders = stdenvNoCC.mkDerivation {
     name = "libpcap-deps-private-headers";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23789,6 +23789,7 @@ with pkgs;
   apple-sdk_12 = callPackage ../by-name/ap/apple-sdk/package.nix { darwinSdkMajorVersion = "12"; };
   apple-sdk_13 = callPackage ../by-name/ap/apple-sdk/package.nix { darwinSdkMajorVersion = "13"; };
   apple-sdk_14 = callPackage ../by-name/ap/apple-sdk/package.nix { darwinSdkMajorVersion = "14"; };
+  apple-sdk_15 = callPackage ../by-name/ap/apple-sdk/package.nix { darwinSdkMajorVersion = "15"; };
 
   darwinMinVersionHook =
     deploymentTarget:


### PR DESCRIPTION
In Nixpkgs, we’ve become used to the idea that adding a new macOS SDK version is a major undertaking that can take weeks or months. Indeed, before July we hadn’t added any in years (though shout‐outs to @ConnorBaker for https://github.com/NixOS/nixpkgs/pull/229210). As https://github.com/NixOS/nixpkgs/pull/346043 was being worked on, I set myself a challenge in coordination with @reckenrode: after it was merged, I would try to add the new macOS 15 SDK to Nixpkgs by myself, with no assistance from Randy, and see how long it took.

The answer is 70 minutes to have it working, tested, and used in the tree, and most of that was avoidable. That’s huge. I had an unfair advantage, of course, having been following the process from the beginning and having read the PR in full, but I had never tried to run one of the scripts, there is not yet any documentation to help me when it goes wrong, and I’m also pretty tired after a long day getting the rework PR tested and merged. The bulk of my time was spent waiting on unnecessary downloads that I had to restart, fixing my own silly mistakes, and getting confused by minor bugs and infelicities in the update scripts; I think that when it comes time to add the macOS 16 SDK in a year’s time, the same process should take no more than 10 minutes. Read on if you’d like a play‐by‐play and my takeaways.

### Experience report

Before I started, I knew I’d need a program that used a macOS 15 API to test with, so I assembled the following basic package that computes √2 as a half‐precision float, using the new `__sqrtf16` API:

```patch
diff --git a/pkgs/by-name/ap/apple-sdk_15-test/package.nix b/pkgs/by-name/ap/apple-sdk_15-test/package.nix
new file mode 100644
index 0000000000..331646920c
--- /dev/null
+++ b/pkgs/by-name/ap/apple-sdk_15-test/package.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  stdenv,
+  meson,
+  ninja,
+}:
+
+stdenv.mkDerivation {
+  name = "apple-sdk_15-test";
+
+  src = ./src;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  meta.mainProgram = "apple-sdk_15-test";
+}
diff --git a/pkgs/by-name/ap/apple-sdk_15-test/src/apple-sdk_15-test.m b/pkgs/by-name/ap/apple-sdk_15-test/src/apple-sdk_15-test.m
new file mode 100644
index 0000000000..c2c0d93601
--- /dev/null
+++ b/pkgs/by-name/ap/apple-sdk_15-test/src/apple-sdk_15-test.m
@@ -1,0 +1,10 @@
+#include <math.h>
+#include <stdio.h>
+
+int main() {
+	if (@available(macOS 15, *)) {
+		printf("%f\n", (double) __sqrtf16(2));
+	} else {
+		printf(":(\n");
+	}
+}
diff --git a/pkgs/by-name/ap/apple-sdk_15-test/src/meson.build b/pkgs/by-name/ap/apple-sdk_15-test/src/meson.build
new file mode 100644
index 0000000000..c2d56fd595
--- /dev/null
+++ b/pkgs/by-name/ap/apple-sdk_15-test/src/meson.build
@@ -1,0 +1,2 @@
+project('apple-sdk_15-test', 'objc')
+executable('apple-sdk_15-test', 'apple-sdk_15-test.m', install : true)
```

I confirmed that it build and ran as expected with the Xcode toolchain. As expected, the Nix package failed to build with the default SDK version (currently 10.12 on `x86_64-darwin`):

```
[1/2] Compiling Objective-C object apple-sdk_15-test.p/apple-sdk_15-test.m.o
FAILED: apple-sdk_15-test.p/apple-sdk_15-test.m.o 
clang -Iapple-sdk_15-test.p -I. -I.. -fdiagnostics-color=always -Wall -Winvalid-pch -MD -MQ apple-sdk_15-test.p/apple-sdk_15-test.m.o -MF apple-sdk_15-test.p/apple-sdk_15-test.m.o.d -o apple-sdk_15-test.p/apple-sdk_15-test.m.o -c ../apple-sdk_15-test.m
../apple-sdk_15-test.m:6:40: error: call to undeclared function '__sqrtf16'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
               printf("%f\n", (double) __sqrtf16(2));
                                       ^
1 error generated.
ninja: build stopped: subcommand failed.
```

So I had my shiny new software that wants fresh SDK features; my goal was to add the new SDK and get it building in as little time as possible. I started the clock and went looking in `pkgs/by-name/ap/apple-sdk` for the appropriate scripts. There’s a `scripts` directory with `get-sdks-from-catalog.sh`, `lock-sdk-deps.sh`, and `regenerate-lockfile.sh`, and after a glance at all three, it seemed like `get-sdks-from-catalog.sh` was a good starting point.

It wanted to be fed an Apple software update catalogue file; I looked again at the other two scripts since I figured there would be something to automatically download that for me, but nope. I remembered that swscan.apple.com is famously hard to find things in and that Randy had mentioned a Gist where he found the URLs for stuff in the past. A quick search of the Matrix room logs brought up https://gist.github.com/meyer/b14c87d162366f0428a99cd2ff0d0b8b, with a comment helpfully pointing to the correct link for macOS 15. I downloaded the catalogue and gave it to the script.

It gave me the following output:

```
Package URL: https://swcdn.apple.com/content/downloads/02/62/071-54303-A_EU2CL1YVT7/943i95dpeyi2ghlnj2mgyq3t202t5gf18b/CLTools_macOSNMOS_SDK.pkg
  Xcode Ver: 12.5.1 (12.5.1.0.1.1623191612)

Package URL: https://swcdn.apple.com/content/downloads/24/42/002-83793-A_74JRE8GVAT/rlnkct919wgc5c0pjq986z5bb9h62uvni2/CLTools_macOSNMOS_SDK.pkg
  Xcode Ver: 13.4.0 (13.4.0.0.1.1651278267)

Package URL: https://swcdn.apple.com/content/downloads/15/62/032-84673-A_7A1TG1RF8Z/xpc8q44ggn2pkn82iwr0fi1zeb9cxi8ath/CLTools_macOSNMOS_SDK.pkg
  Xcode Ver: 14.3.1 (14.3.1.0.1.1683849156)

Package URL: https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg
  Xcode Ver: 15.3.0 (15.3.0.0.1.1708646388)

Package URL: https://swcdn.apple.com/content/downloads/33/46/042-32691-A_3MH7S3118O/3dblccqo9ws17dc5lk3hojfbt3s74q0ql6/CLTools_macOSNMOS_SDK.pkg
  Xcode Ver: 16.0.0 (16.0.0.0.1.1724870825)
```

Okay, clearly the 15.3 SDK is at https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg, that looks great. (A twinge of doubt in my head: didn’t macOS 15.0 just come out? Are we really on the 15.3 SDK already? But I could worry about that later; the clock is ticking.)

I remembered that the SDK versions were all stored in a JSON file. I looked around briefly for tooling to automatically add the new one, but couldn’t find any. No matter – a quick `nix store prefetch-file` and I had the new 15.3 SDK version manually added to `metadata/versions.json`. I then added the `apple-sdk_15` line to `all-packages.nix`. At this point it was about 8 minutes since I started.

Okay, job done, right? Well, no; there’s those other two scripts. Looking at them revealed that they were there to handle pinning the corresponding source releases. `regenerate-lockfile.sh` is a wrapper around `lock-sdk-deps.sh` that automates running it over all the SDK versions and a bunch of packages, so that seemed like the thing to run. It took about ten minutes redownloading the source releases for all the previous SDK versions.

At that point the script failed because apparently the `macos-153` tag in https://github.com/apple-oss-distributions/distribution-macOS doesn’t exist, which indeed it doesn’t. Uh oh – I know that Apple are often slow to release corresponding source releases. There’s a `macos-150` tag, though, so maybe we can just use that? It seemed like the only way to override it was to adjust the version in `metadata/versions.json` and run the script again; another ten minutes down the drain. About half‐way through, I looked at the `metadata/apple-oss-lockfile.json` file it was writing to, and saw that it had removed the outer layer of SDK versions from the JSON structure. I remembered being an annoying pedant about Randy’s `jq` use in these scripts – did it break in the process of responding to that review feedback? Yep, it did. I fixed the script to add the SDK version back to the JSON structure and ran it again. Success! A quick switch of the SDK version back to 15.3 and the packaging should be done.

Now for the moment of truth: I added the new SDK to the build inputs and hoped for the best.

```diff
diff --git a/pkgs/by-name/ap/apple-sdk_15-test/package.nix b/pkgs/by-name/ap/apple-sdk_15-test/package.nix
index 331646920c..6fd99ee30c 100644
--- a/pkgs/by-name/ap/apple-sdk_15-test/package.nix
+++ b/pkgs/by-name/ap/apple-sdk_15-test/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   meson,
   ninja,
+  apple-sdk_15,
 }:
 
 stdenv.mkDerivation {
@@ -15,5 +16,9 @@
     ninja
   ];
 
+  buildInputs = [
+    apple-sdk_15
+  ];
+
   meta.mainProgram = "apple-sdk_15-test";
 }
```

…and it failed with an arcane message about `cp: missing destination file operand after '/nix/store/65ifh4l4h4vpiv85nsv6w77js32rhrks-macOS-SDK-15.3'`. Um, a messed up glob, maybe? Consulting the derivation told me that it was extracting the package and looking for the appropriate versioned SDK inside it. I downloaded and extracted it manually to look at and… uh, it’s the 14.3 SDK?

Did I misread the output of that catalogue‐reading script? Maybe that’s why it’s 15.3 instead of 15.0? The answer is yes, I misread the output, but no, that doesn’t explain the version thing. I thought the output was grouped like this:

```
Package URL: https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg
  Xcode Ver: 15.3.0 (15.3.0.0.1.1708646388)
```

but it’s actually like this:

```
  Xcode Ver: 15.3.0 (15.3.0.0.1.1708646388)

Package URL: https://swcdn.apple.com/content/downloads/33/46/042-32691-A_3MH7S3118O/3dblccqo9ws17dc5lk3hojfbt3s74q0ql6/CLTools_macOSNMOS_SDK.pkg
```

I replaced the URL with the correct one and, after a slight mishap with the hash (because `nix store prefetch-file` doesn’t name its store path `source` like the Nixpkgs fetchers do), started building the SDK again. It failed with the same error. I downloaded and extracted the new `.pkg`, and… the SDK version inside is actually 15.0? I still don’t really understand where the 15.3 is coming from. I know Xcode and SDK versions aren’t the same, but it doesn’t look like Xcode 15.3 shipped with the macOS 15 SDK. So, I don’t know; I’ll need to wait for Randy to explain that one to me. But I put the version back to 15.0, and the SDK started *actually* building this time. Yay! I was getting impatient at this point because of this taking longer than I expected, and it made me think dangerous thoughts about how I should parallelize the `.tbd` conversion process. But, just over an hour in, it successfully built my test package, and I ran it on the community builder I was using to do the builds (because it already had the `stdenv` for `x86_64-darwin` cached from my earlier testing of the rework PR):

```
emily@darwin01 ~/nixpkgs (git)-[a7dc7ea2533f] % ./result/bin/apple-sdk_15-test 
:(
```

I’ve never been so happy to see a frowning face. This is the correct result: the community builder is running 14.7, and the SDK to build with is decoupled from the minimum deployment target we require at runtime (currently 10.12 for `x86_64-darwin` and 11.0 for `aarch64-darwin`), so this is the runtime check I wrote being handled correctly. I downloaded the binary locally, and successfully computed the world’s most accurate approximation of the square root of two:

```
emily@yuyuko ~/Downloads> ./apple-sdk_15-test
1.414062
```

Now I wanted to test the hook to set the deployment target, which is required for software that doesn’t do dynamic checks or unconditionally requires newer APIs. Thankfully, that’s also really easy with the new scheme:

```diff
diff --git a/pkgs/by-name/ap/apple-sdk_15-test/package.nix b/pkgs/by-name/ap/apple-sdk_15-test/package.nix
index 6fd99ee30c..07f0de5762 100644
--- a/pkgs/by-name/ap/apple-sdk_15-test/package.nix
+++ b/pkgs/by-name/ap/apple-sdk_15-test/package.nix
@@ -4,6 +4,7 @@
   meson,
   ninja,
   apple-sdk_15,
+  darwinMinVersionHook,
 }:
 
 stdenv.mkDerivation {
@@ -18,6 +19,7 @@
 
   buildInputs = [
     apple-sdk_15
+    (darwinMinVersionHook "15.0")
   ];
 
   meta.mainProgram = "apple-sdk_15-test";
```

The resulting binary continued to work on my local 15.0 machine, but correctly failed to load in spectacular fashion when run on the too‐old community builder:

```
emily@darwin01 ~/nixpkgs (git)-[374daa9e3926] % ./result/bin/apple-sdk_15-test 
dyld[81506]: Symbol not found: ___sqrtf16
  Referenced from: <D4B67B64-E1CF-3DC5-B8A9-AD232A2D5FD5> /nix/store/p74qqhqmdxda7nnd1f2krssh105pr2vy-apple-sdk_15-test/bin/apple-sdk_15-test (built for macOS 15.0 which is newer than running OS)
  Expected in:     <0240FF42-6851-34BD-B251-3C4704DE26AA> /usr/lib/libSystem.B.dylib
[2]    81506 abort      ./result/bin/apple-sdk_15-test
```

At that point, the job was done, but I remembered from reviewing the PR that there was one package of an Apple source release that was currently fetching a private header version from GitHub because of not yet having the macOS 15 SDK packaged. A quick ripgrep and I edited `pkgs/os-specific/darwin/apple-source-releases/libpcap/package.nix` to comment out the `apple-sdk_15.sourceRelease` line that was waiting for me. I built the resulting package, and around 70 minutes from when I started, the job was done.

Well, except for reorganizing the commits and writing this extremely long pull request message, of course.

### Conclusion

70 minutes is incredible! Thanks to Randy, we should never again be in a position where we need a newer SDK but don’t have it. The fact that the diff here is so tiny (seriously – go look at it!) and most of the 70 minutes were spent waiting for downloads and dealing with the scripts not yet being fully polished is a massive vindication of the general approach. So I don’t at all want to seem critical here, especially given that we had to rush all of this right before the release, but I think it’s helpful to note down areas for future improvement here.

* The URLs to the software catalogues are very predictable; our tooling should automatically compute and download them, rather than relying on people to look up Gists.
* Similarly, downloading the new SDK and adding it to the versions file should be automated, or at least the output from the catalogue script should be formatted in a less confusing way.
* I don’t know what went on with the weird 15.3 version thing, but if there’s any way we can avoid the confusion I went through and report the correct SDK version automatically that would be great. The SDK build error wasn’t really that helpful, either.
* The script to pin the source releases redownloads everything every time; that’s slow and seems unnecessary, if we instead record enough information for the script to know what hasn’t changed.
* This is really minor, but it’d be nice if the `.tbd` conversion process was parallelized so that the SDKs built faster. (It still only takes a few minutes, though.)

Hopefully I can tackle some of these soon, and possibly just rewrite the scripts in something other than Bash. But when you consider how much toil and suffering past attempts to package new macOS SDKs have resulted in, it’s incredible how minor these nitpicks are. The process is almost entirely automated now, and as soon as I got the correct SDK URL downloading with the correct version recorded, the SDK package built and worked the very first time. The future looks bright.

I only tested this on `x86_64-darwin` since I didn’t want to build another `stdenv`. I’m counting on you to test `aarch64-darwin` and tell me what I messed up, Randy :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
