### PR TITLE
llvmPackages_13: build from filtered monorepoSrc

### DIFF
--- a/pkgs/development/compilers/llvm/common/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/common/bolt/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   llvm_meta,
   monorepoSrc,
+  release_version,
   runCommand,
   cmake,
   libxml2,
@@ -20,16 +21,22 @@ stdenv.mkDerivation (finalAttrs: {
   inherit version patches;
 
   # Blank llvm dir just so relative path works
-  src = runCommand "bolt-src-${finalAttrs.version}" { } ''
-    mkdir $out
-    cp -r ${monorepoSrc}/cmake "$out"
-    cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"
-    cp -r ${monorepoSrc}/third-party "$out"
+  src = runCommand "bolt-src-${finalAttrs.version}" { } (
+    ''
+      mkdir $out
+    ''
+    + lib.optionalString (lib.versionAtLeast release_version "14") ''
+      cp -r ${monorepoSrc}/cmake "$out"
+    ''
+    + ''
+      cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"
+      cp -r ${monorepoSrc}/third-party "$out"
 
-    # tablegen stuff, probably not the best way but it works...
-    cp -r ${monorepoSrc}/llvm/ "$out"
-    chmod -R +w $out/llvm
-  '';
+      # tablegen stuff, probably not the best way but it works...
+      cp -r ${monorepoSrc}/llvm/ "$out"
+      chmod -R +w $out/llvm
+    ''
+  );
 
   sourceRoot = "${finalAttrs.src.name}/bolt";
 

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -24,12 +24,14 @@ let
   pname = "clang";
 
   src' = if monorepoSrc != null then
-    runCommand "${pname}-src-${version}" {} ''
+    runCommand "${pname}-src-${version}" {} (''
       mkdir -p "$out"
+    '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
       cp -r ${monorepoSrc}/cmake "$out"
+    '' + ''
       cp -r ${monorepoSrc}/${pname} "$out"
       cp -r ${monorepoSrc}/clang-tools-extra "$out"
-    '' else src;
+    '') else src;
 
   self = stdenv.mkDerivation (finalAttrs: rec {
     inherit pname version patches;

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -47,11 +47,13 @@ let
   pname = baseName + lib.optionalString (haveLibc) "-libc";
 
   src' = if monorepoSrc != null then
-    runCommand "${baseName}-src-${version}" {} ''
+    runCommand "${baseName}-src-${version}" {} (''
       mkdir -p "$out"
+    '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
       cp -r ${monorepoSrc}/cmake "$out"
+    '' + ''
       cp -r ${monorepoSrc}/${baseName} "$out"
-    '' else src;
+    '') else src;
 
   preConfigure = lib.optionalString (!haveLibc) ''
     cmakeFlagsArray+=(-DCMAKE_C_FLAGS="-nodefaultlibs -ffreestanding")

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -331,13 +331,7 @@ let
   tools = lib.makeExtensible (
     tools:
     let
-      callPackage = newScope (
-        tools
-        // args
-        // metadata
-        # Previously monorepoSrc was erroneously not being passed through.
-        // lib.optionalAttrs (lib.versionOlder metadata.release_version "14") { monorepoSrc = null; } # Preserve a bug during #307211, TODO: remove; causes llvm 13 rebuild.
-      );
+      callPackage = newScope (tools // args // metadata);
       clangVersion =
         if (lib.versionOlder metadata.release_version "16") then
           metadata.release_version

--- a/pkgs/development/compilers/llvm/common/libclc.nix
+++ b/pkgs/development/compilers/llvm/common/libclc.nix
@@ -22,11 +22,17 @@ stdenv.mkDerivation rec {
   pname = "libclc";
   inherit version;
 
-  src = runCommand "${pname}-src-${version}" { } ''
-    mkdir -p "$out"
-    cp -r ${monorepoSrc}/cmake "$out"
-    cp -r ${monorepoSrc}/${pname} "$out"
-  '';
+  src = runCommand "${pname}-src-${version}" { } (
+    ''
+      mkdir -p "$out"
+    ''
+    + lib.optionalString (lib.versionAtLeast release_version "14") ''
+      cp -r ${monorepoSrc}/cmake "$out"
+    ''
+    + ''
+      cp -r ${monorepoSrc}/${pname} "$out"
+    ''
+  );
 
   sourceRoot = "${src.name}/${pname}";
 

--- a/pkgs/development/compilers/llvm/common/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/common/libunwind/default.nix
@@ -19,7 +19,9 @@ let
   src' = if monorepoSrc != null then
     runCommand "${pname}-src-${version}" {} (''
       mkdir -p "$out"
+    '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
       cp -r ${monorepoSrc}/cmake "$out"
+    '' + ''
       cp -r ${monorepoSrc}/${pname} "$out"
       mkdir -p "$out/libcxx"
       cp -r ${monorepoSrc}/libcxx/cmake "$out/libcxx"

--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -32,7 +32,9 @@ let
     if monorepoSrc != null then
       runCommand "lldb-src-${version}" { } (''
         mkdir -p "$out"
+      '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
         cp -r ${monorepoSrc}/cmake "$out"
+      '' + ''
         cp -r ${monorepoSrc}/lldb "$out"
       '' + lib.optionalString (lib.versionAtLeast release_version "19" && enableManpages) ''
         mkdir -p "$out/llvm"

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -77,11 +77,15 @@ let
 
   pname = "llvm";
 
+  # TODO: simplify versionAtLeast condition for cmake and third-party via rebuild
   src' = if monorepoSrc != null then
     runCommand "${pname}-src-${version}" {} (''
       mkdir -p "$out"
+    '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
       cp -r ${monorepoSrc}/cmake "$out"
+    '' + ''
       cp -r ${monorepoSrc}/${pname} "$out"
+    '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
       cp -r ${monorepoSrc}/third-party "$out"
     '' + lib.optionalString enablePolly ''
       chmod u+w "$out/${pname}/tools"

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , llvm_meta
+, release_version
 , buildLlvmTools
 , monorepoSrc
 , runCommand
@@ -18,14 +19,16 @@ stdenv.mkDerivation rec {
   inherit version doCheck;
 
   # Blank llvm dir just so relative path works
-  src = runCommand "${pname}-src-${version}" { } ''
+  src = runCommand "${pname}-src-${version}" { } (''
     mkdir -p "$out"
+  '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
     cp -r ${monorepoSrc}/cmake "$out"
+  '' + ''
     cp -r ${monorepoSrc}/mlir "$out"
     cp -r ${monorepoSrc}/third-party "$out/third-party"
 
     mkdir -p "$out/llvm"
-  '';
+  '');
 
   sourceRoot = "${src.name}/mlir";
 

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -21,11 +21,13 @@ let
   pname = "openmp";
   src' =
     if monorepoSrc != null then
-      runCommand "${pname}-src-${version}" {} ''
+      runCommand "${pname}-src-${version}" {} (''
         mkdir -p "$out"
+      '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
         cp -r ${monorepoSrc}/cmake "$out"
+      '' + ''
         cp -r ${monorepoSrc}/${pname} "$out"
-      '' else src;
+      '') else src;
 in
 stdenv.mkDerivation (rec {
   inherit pname version patches;


### PR DESCRIPTION
This change implements a leftover task from #307211, namely passing monorepoSrc to the different llvmPackages_13 package expressions. Before this change, all packages llvmPackages_13 would be built from a subdirectory of the full LLVM monorepo tree. After this change only the relevant directories are made available at build time. This

- reduces the size of the source that needs to be made available to the builder.
- prevents LLVM from sidestepping our instructions and including extra sources from other directories it shouldn't.

Since LLVM 12 and 13 don't have the `cmake` directory at the top level, the runCommand expressions filtering the source need to be adjusted, but this causes no rebuild for any other LLVM version (ofborg should confirm this).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
