### PR TITLE
valkey: 7.2.7 -> 8.0.1

### DIFF
--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withSystemd systemd
     ++ lib.optional tlsSupport openssl;
 
+  strictDeps = true;
+
   preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace src/Makefile --replace-fail "-flto" ""
   '';
@@ -55,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     # disable test "Connect multiple replicas at the same time": even
     # upstream find this test too timing-sensitive
     substituteInPlace tests/integration/replication.tcl \
-      --replace-fail 'foreach mdl {no yes}' 'foreach mdl {}'
+      --replace-fail 'foreach mdl {no yes} dualchannel {no yes}' 'foreach mdl {} dualchannel {}'
 
     substituteInPlace tests/support/server.tcl \
       --replace-fail 'exec /usr/bin/env' 'exec env'

--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "valkey";
-  version = "7.2.7";
+  version = "8.0.1";
 
   src = fetchFromGitHub {
     owner = "valkey-io";
     repo = "valkey";
     rev = finalAttrs.version;
-    hash = "sha256-2kbhUg+rNuIUF/Bna6jFLI6Vhg9TlSi+OZEy6jKl2X0=";
+    hash = "sha256-WB0blQLxQOTkK8UGsH6WISZAisUAtGIDfjoc4RnPSew=";
   };
 
   patches = lib.optional useSystemJemalloc ./use_system_jemalloc.patch;


### PR DESCRIPTION
Fixes #344898

cc @Astralchroma

There is a test failure when building:
```
[exception]: Executing test client: ERR CONFIG SET failed (possibly related to argument 'repl-diskless-sync') - argument must be 'yes' or 'no'.
ERR CONFIG SET failed (possibly related to argument 'repl-diskless-sync') - argument must be 'yes' or 'no'
    while executing
"$master config set repl-diskless-sync $mdl"
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc