### PR TITLE
moltenvk: 1.2.10 -> 1.2.11

### DIFF
--- a/pkgs/by-name/mo/moltenvk/package.nix
+++ b/pkgs/by-name/mo/moltenvk/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "MoltenVK";
-  version = "1.2.10";
+  version = "1.2.11";
 
   strictDeps = true;
 
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "KhronosGroup";
     repo = "MoltenVK";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-5hc+bnsyc8Am9My2kzsU7fv+1CePCHgxL82Mxz/zJRo=";
+    hash = "sha256-24qQnJ0RnJP2M4zSlSlQ4c4dVZtHutNiCvjrsCDw6wY=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/mo/moltenvk/package.nix
+++ b/pkgs/by-name/mo/moltenvk/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   gitUpdater,
-  apple-sdk_14,
+  apple-sdk_15,
   darwinMinVersionHook,
   cereal,
   libcxx,
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   buildInputs = [
-    apple-sdk_14
+    apple-sdk_15
     cereal
     (darwinMinVersionHook "10.15")
     glslang

--- a/pkgs/by-name/mo/moltenvk/package.nix
+++ b/pkgs/by-name/mo/moltenvk/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   gitUpdater,
   apple-sdk_15,
   darwinMinVersionHook,
@@ -53,6 +54,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-24qQnJ0RnJP2M4zSlSlQ4c4dVZtHutNiCvjrsCDw6wY=";
   };
 
+  patches = [
+    # Cherry-pick patch to fix build failure due to a hardcoded SPIRV-Cross namespace.
+    # This can be dropped for MoltenVK 1.2.12.
+    (fetchpatch2 {
+      url = "https://github.com/KhronosGroup/MoltenVK/commit/856c8237ac3b32178caae3408effc35bedfdffa1.patch?full_index=1";
+      hash = "sha256-dVTop8sU19Swdb3ajbI+6S715NaxTqd7d0yQ/FDqxqY=";
+    })
+  ];
+
   postPatch = ''
     # Move `mvkGitRevDerived.h` to a stable location
     substituteInPlace Scripts/gen_moltenvk_rev_hdr.sh \
@@ -91,10 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Link glslang source because MoltenVK needs non-public headers to build.
     mkdir -p build/include
     ln -s "${glslang.src}" "build/include/glslang"
-
-    # MoltenVK should be using SPIRV_CROSS_NAMESPACE instead of hardcoding the namespace.
-    substituteInPlace MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm \
-      --replace-fail MVK_spirv_cross SPIRV_CROSS_NAMESPACE
   '';
 
   env.NIX_CFLAGS_COMPILE = toString (


### PR DESCRIPTION
https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.11

This PR also switches MoltenVK to build with the 15.0 SDK, which is supported by upstream; and cherry-picks an upstream patch for the SPIRV-Cross namespace issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
