### PR TITLE
vmware-guest: allow the user to override the open-vm-tools package

### DIFF
--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -1,50 +1,58 @@
 { config, lib, pkgs, ... }:
 let
+  inherit (lib) getExe' literalExpression mkEnableOption mkIf mkOption mkRenamedOptionModule optionals optionalString types;
   cfg = config.virtualisation.vmware.guest;
-  open-vm-tools = if cfg.headless then pkgs.open-vm-tools-headless else pkgs.open-vm-tools;
   xf86inputvmmouse = pkgs.xorg.xf86inputvmmouse;
 in
 {
   imports = [
-    (lib.mkRenamedOptionModule [ "services" "vmwareGuest" ] [ "virtualisation" "vmware" "guest" ])
+    (mkRenamedOptionModule [ "services" "vmwareGuest" ] [ "virtualisation" "vmware" "guest" ])
   ];
 
   options.virtualisation.vmware.guest = {
-    enable = lib.mkEnableOption "VMWare Guest Support";
-    headless = lib.mkOption {
-      type = lib.types.bool;
+    enable = mkEnableOption "VMWare Guest Support";
+    headless = mkOption {
+      type = types.bool;
       default = !config.services.xserver.enable;
-      defaultText = "!config.services.xserver.enable";
+      defaultText = literalExpression "!config.services.xserver.enable";
       description = "Whether to disable X11-related features.";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = if cfg.headless then pkgs.open-vm-tools-headless else pkgs.open-vm-tools;
+      defaultText = literalExpression  "if config.virtualisation.vmware.headless then pkgs.open-vm-tools-headless else pkgs.open-vm-tools;";
+      example = literalExpression "pkgs.open-vm-tools";
+      description = "Package providing open-vm-tools.";
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = mkIf cfg.enable {
     assertions = [ {
       assertion = pkgs.stdenv.hostPlatform.isx86 || pkgs.stdenv.hostPlatform.isAarch64;
       message = "VMWare guest is not currently supported on ${pkgs.stdenv.hostPlatform.system}";
     } ];
 
     boot.initrd.availableKernelModules = [ "mptspi" ];
-    boot.initrd.kernelModules = lib.optionals pkgs.stdenv.hostPlatform.isx86 [ "vmw_pvscsi" ];
+    boot.initrd.kernelModules = optionals pkgs.stdenv.hostPlatform.isx86 [ "vmw_pvscsi" ];
 
-    environment.systemPackages = [ open-vm-tools ];
+    environment.systemPackages = [ cfg.package ];
 
     systemd.services.vmware =
       { description = "VMWare Guest Service";
         wantedBy = [ "multi-user.target" ];
         after = [ "display-manager.service" ];
         unitConfig.ConditionVirtualization = "vmware";
-        serviceConfig.ExecStart = "${open-vm-tools}/bin/vmtoolsd";
+        serviceConfig.ExecStart = getExe' cfg.package "vmtoolsd";
       };
 
     # Mount the vmblock for drag-and-drop and copy-and-paste.
-    systemd.mounts = lib.mkIf (!cfg.headless) [
+    systemd.mounts = mkIf (!cfg.headless) [
       {
         description = "VMware vmblock fuse mount";
         documentation = [ "https://github.com/vmware/open-vm-tools/blob/master/open-vm-tools/vmblock-fuse/design.txt" ];
         unitConfig.ConditionVirtualization = "vmware";
-        what = "${open-vm-tools}/bin/vmware-vmblock-fuse";
+        what = getExe' cfg.package "vmware-vmblock-fuse";
         where = "/run/vmblock-fuse";
         type = "fuse";
         options = "subtype=vmware-vmblock,default_permissions,allow_other";
@@ -52,19 +60,19 @@ in
       }
     ];
 
-    security.wrappers.vmware-user-suid-wrapper = lib.mkIf (!cfg.headless) {
+    security.wrappers.vmware-user-suid-wrapper = mkIf (!cfg.headless) {
         setuid = true;
         owner = "root";
         group = "root";
-        source = "${open-vm-tools}/bin/vmware-user-suid-wrapper";
+        source = getExe' cfg.package "vmware-user-suid-wrapper";
       };
 
-    environment.etc.vmware-tools.source = "${open-vm-tools}/etc/vmware-tools/*";
+    environment.etc.vmware-tools.source = "${cfg.package}/etc/vmware-tools/*";
 
-    services.xserver = lib.mkIf (!cfg.headless) {
-      modules = lib.optionals pkgs.stdenv.hostPlatform.isx86 [ xf86inputvmmouse ];
+    services.xserver = mkIf (!cfg.headless) {
+      modules = optionals pkgs.stdenv.hostPlatform.isx86 [ xf86inputvmmouse ];
 
-      config = lib.optionalString (pkgs.stdenv.hostPlatform.isx86) ''
+      config = optionalString (pkgs.stdenv.hostPlatform.isx86) ''
           Section "InputClass"
             Identifier "VMMouse"
             MatchDevicePath "/dev/input/event*"
@@ -74,10 +82,10 @@ in
         '';
 
       displayManager.sessionCommands = ''
-          ${open-vm-tools}/bin/vmware-user-suid-wrapper
+          ${getExe' cfg.package "vmware-user-suid-wrapper"}
         '';
     };
 
-    services.udev.packages = [ open-vm-tools ];
+    services.udev.packages = [ cfg.package ];
   };
 }

--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -9,6 +9,10 @@ in
     (mkRenamedOptionModule [ "services" "vmwareGuest" ] [ "virtualisation" "vmware" "guest" ])
   ];
 
+  meta = {
+    maintainers = [ lib.maintainers.kjeremy ];
+  };
+
   options.virtualisation.vmware.guest = {
     enable = mkEnableOption "VMWare Guest Support";
     headless = mkOption {


### PR DESCRIPTION
Expose  `virtualisation.vmware-guest.package` for easier testing of updates.

Some cleanup

Adds me as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
