### PR TITLE
nixos/tests/pam: Check against absolute module paths

### DIFF
--- a/nixos/tests/pam/pam-file-contents.nix
+++ b/nixos/tests/pam/pam-file-contents.nix
@@ -25,8 +25,8 @@ import ../make-test-python.nix (
 
     testScript =
       builtins.replaceStrings
-        [ "@@pam_ccreds@@" "@@pam_krb5@@" ]
-        [ pkgs.pam_ccreds.outPath pkgs.pam_krb5.outPath ]
+        [ "@@linux-pam@@" "@@pam_ccreds@@" "@@pam_krb5@@" ]
+        [ pkgs.linux-pam.outPath pkgs.pam_ccreds.outPath pkgs.pam_krb5.outPath ]
         (builtins.readFile ./test_chfn.py);
   }
 )

--- a/nixos/tests/pam/test_chfn.py
+++ b/nixos/tests/pam/test_chfn.py
@@ -1,17 +1,17 @@
 expected_lines = {
-    "account required pam_unix.so",
+    "account required @@linux-pam@@/lib/security/pam_unix.so",
     "account sufficient @@pam_krb5@@/lib/security/pam_krb5.so",
     "auth [default=die success=done] @@pam_ccreds@@/lib/security/pam_ccreds.so action=validate use_first_pass",
     "auth [default=ignore success=1 service_err=reset] @@pam_krb5@@/lib/security/pam_krb5.so use_first_pass",
-    "auth required pam_deny.so",
+    "auth required @@linux-pam@@/lib/security/pam_deny.so",
     "auth sufficient @@pam_ccreds@@/lib/security/pam_ccreds.so action=store use_first_pass",
-    "auth sufficient pam_rootok.so",
-    "auth sufficient pam_unix.so likeauth try_first_pass",
+    "auth sufficient @@linux-pam@@/lib/security/pam_rootok.so",
+    "auth sufficient @@linux-pam@@/lib/security/pam_unix.so likeauth try_first_pass",
     "password sufficient @@pam_krb5@@/lib/security/pam_krb5.so use_first_pass",
-    "password sufficient pam_unix.so nullok yescrypt",
+    "password sufficient @@linux-pam@@/lib/security/pam_unix.so nullok yescrypt",
     "session optional @@pam_krb5@@/lib/security/pam_krb5.so",
-    "session required pam_env.so conffile=/etc/pam/environment readenv=0",
-    "session required pam_unix.so",
+    "session required @@linux-pam@@/lib/security/pam_env.so conffile=/etc/pam/environment readenv=0",
+    "session required @@linux-pam@@/lib/security/pam_unix.so",
 }
 actual_lines = set(machine.succeed("cat /etc/pam.d/chfn").splitlines())
 


### PR DESCRIPTION
`nixosTests.pam-file-contents` fails because it expects relative paths for PAM modules from `pkgs.linux-pam`, while the NixOS module generates absolute paths (cf. https://github.com/NixOS/nixpkgs/pull/347937#issuecomment-2407655591).

This modifies the test to check against absolute paths.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
