### PR TITLE
Revert "kops: 1.29.2 -> 1.30.1"

### DIFF
--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -62,8 +62,8 @@ rec {
   };
 
   kops_1_29 = mkKops rec {
-    version = "1.30.1";
-    sha256 = "sha256-aj2OnjkXlBEH830RoJiAlhiFfS1zjVoX38PrsgAaB7A=";
+    version = "1.29.2";
+    sha256 = "sha256-SRj0x9N+yfTG/UL/hu1ds46Zt6d5SUYU0PA9lPHO6jQ=";
     rev = "v${version}";
   };
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#344817 which mistakenly pointed `kops_1_29` to kOps v1.30.1