### PR TITLE
glibc: fix locale fallback on non-nixos systems

### DIFF
--- a/pkgs/development/libraries/glibc/nix-locale-archive.patch
+++ b/pkgs/development/libraries/glibc/nix-locale-archive.patch
@@ -17,9 +17,9 @@ index 512769eaec..171dbb4ad9 100644
 +  if (path && fd < 0)
 +    fd = __open_nocancel (path, O_RDONLY|O_LARGEFILE|O_CLOEXEC);
 +  if (fd < 0)
-+    fd = __open_nocancel (archfname, O_RDONLY|O_LARGEFILE|O_CLOEXEC);
-+  if (fd < 0)
 +    fd = __open_nocancel ("/usr/lib/locale/locale-archive", O_RDONLY|O_LARGEFILE|O_CLOEXEC);
++  if (fd < 0)
++    fd = __open_nocancel (archfname, O_RDONLY|O_LARGEFILE|O_CLOEXEC);
 +  return fd;
 +}
 +
@@ -64,9 +64,9 @@ index ca0a95be99..e484783402 100644
 +  if (path && fd < 0)
 +    fd = open64 (path, O_RDONLY);
 +  if (fd < 0)
-+    fd = open64 (ARCHIVE_NAME, O_RDONLY);
-+  if (fd < 0)
 +    fd = open64 ("/usr/lib/locale/locale-archive", O_RDONLY);
++  if (fd < 0)
++    fd = open64 (ARCHIVE_NAME, O_RDONLY);
 +  return fd;
 +}
 +


### PR DESCRIPTION
    glibc: fix locale fallback on non-nixos systems
    
    There is a nixpkgs' glibc patch that makes it look at environment variables to
    locate the locale-archive. It has a fallback to /usr/lib/locale/locale-archive,
    which is a pretty good one since nearly all non-nixos systems use that exact
    path since glibc hard codes it looking at PREFIX/lib/locale/locale-archive. IE
    debian/EL/Arch/Gentoo and others all use the same path for locale-archive. That
    hard coding in glibc is why nixpkgs even has this patch in the first place.
    Other wise you would need to rebuild every single package whenever you wanted to
    change the locale-archive at runtime.
    
    The problem with that final fallback is that glibc in nixpkgs includes a minimal
    locale-archive with just C.UTF-8. It does this so tests that require UTF-8
    support can work in nixpkgs. The current patch will _always_ find the minimal
    locale-archive and never actually fall back to the system one.
    
    This can be very confusing, especially when looking at the patch and wondering
    why your CI system is throwing locale errors. Eventually you realize that some
    test sanitizes the environment, but still confused since it should fall back to
    the system's locale-archive.
    
    On systems that do not set LOCALE_ARCHIVE and do not have
    /usr/lib/locale/locale-archive then we fall back to that super minimal
    locale-archive included with the default nixpkgs' glibc.
    
    Testing:
    == Before ==
    % env -u LOCALE_ARCHIVE_2_27 -u LOCALE_ARCHIVE LANG=en_US.UTF-8 /nix/store/gdq185xa4cmka46nv67vkmjlmkd9yr1k-cowsay-3.8.3/bin/cowsay hello
    perl: warning: Setting locale failed.
    perl: warning: Please check that your locale settings:
            LANGUAGE = "",
            LC_ALL = (unset),
            LANG = "en_US.UTF-8"
        are supported and installed on your system.
    perl: warning: Falling back to the standard locale ("C").
     _______
    < hello >
     -------
            \   ^__^
             \  (oo)\_______
                (__)\       )\/\
                    ||----w |
                    ||     ||
    
    == After ==
    % env -u LOCALE_ARCHIVE_2_27 -u LOCALE_ARCHIVE LANG=en_US.UTF-8 /nix/store/hhc2gzs6gax4frk8985w2ada2ra35zyw-cowsay-3.8.3/bin/cowsay hello
     _______
    < hello >
     -------
            \   ^__^
             \  (oo)\_______
                (__)\       )\/\
                    ||----w |
                    ||     ||
    
    === On NixOS ===
    % env -u LOCALE_ARCHIVE_2_27 -u LOCALE_ARCHIVE LANG=en_US.UTF-8 /nix/store/hhc2gzs6gax4frk8985w2ada2ra35zyw-cowsay-3.8.3/bin/cowsay hello
    perl: warning: Setting locale failed.
    perl: warning: Please check that your locale settings:
            LANGUAGE = (unset),
            LC_ALL = (unset),
            LC_CTYPE = (unset),
            LC_NUMERIC = (unset),
            LC_COLLATE = (unset),
            LC_TIME = (unset),
            LC_MESSAGES = (unset),
            LC_MONETARY = (unset),
            LC_ADDRESS = (unset),
            LC_IDENTIFICATION = (unset),
            LC_MEASUREMENT = (unset),
            LC_PAPER = (unset),
            LC_TELEPHONE = (unset),
            LC_NAME = (unset),
            LANG = "en_US.UTF-8"
        are supported and installed on your system.
    perl: warning: Falling back to the standard locale ("C").
     _______
    < hello >
     -------
            \   ^__^
             \  (oo)\_______
                (__)\       )\/\
                    ||----w |
                    ||     ||
    
    === Still can get the minimal locale-archive included with glibc ===
    % env -u LOCALE_ARCHIVE_2_27 -u LOCALE_ARCHIVE LANG=C.UTF-8 /nix/store/hhc2gzs6gax4frk8985w2ada2ra35zyw-cowsay-3.8.3/bin/cowsay hello
     _______
    < hello >
     -------
            \   ^__^
             \  (oo)\_______
                (__)\       )\/\
                    ||----w |
                    ||     ||



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
