### PR TITLE
gaucheBootstrap: unbreak on darwin platform

### DIFF
--- a/pkgs/development/interpreters/gauche/boot.nix
+++ b/pkgs/development/interpreters/gauche/boot.nix
@@ -10,6 +10,7 @@
   zlib,
   mbedtls,
   cacert,
+  CoreServices,
 }:
 
 stdenv.mkDerivation rec {
@@ -35,7 +36,7 @@ stdenv.mkDerivation rec {
     zlib
     mbedtls
     cacert
-  ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29202,7 +29202,9 @@ with pkgs;
     };
   };
 
-  gaucheBootstrap = darwin.apple_sdk_11_0.callPackage ../development/interpreters/gauche/boot.nix { };
+  gaucheBootstrap = darwin.apple_sdk_11_0.callPackage ../development/interpreters/gauche/boot.nix {
+    inherit (darwin.apple_sdk_11_0.frameworks) CoreServices;
+  };
 
   gauche = darwin.apple_sdk_11_0.callPackage ../development/interpreters/gauche {
     inherit (darwin.apple_sdk_11_0.frameworks) CoreServices;


### PR DESCRIPTION
Building `gaucheBootstrap` results in following compile error:

```
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c libproc.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c librx.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c libsrfis.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c libstr.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c libsym.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c libsys.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c libthr.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c libtype.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c libvec.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c main.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c gauche-config.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c test-extra.c
clang -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`  -no-cpp-precomp -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -c libextra.c
TARGETLIB="`pwd`" ./link-dylib clang -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -L.  -o gauche-config gauche-config.o -lmbedtls -lproc -lm  -lpthread
TARGETLIB="`pwd`" ./link-dylib clang -g -O2 -Wall -Wextra -Wno-unused-label -no-cpp-precomp -fPIC -fno-common  -L.   -framework CoreServices -framework CoreFoundation -dynamiclib -o libgauche-0.98.dylib box.o core.o vm.o compaux.o macro.o connection.o code.o class.o dispatch.o error.o execenv.o prof.o collection.o boolean.o char.o string.o list.o hash.o dws32hash.o dwsiphash.o treemap.o bits.o native.o port.o write.o read.o vector.o weak.o symbol.o gloc.o compare.o regexp.o signal.o parameter.o module.o proc.o memo.o mmap.o net.o netaddr.o netdb.o number.o bignum.o load.o lazy.o repl.o autoloads.o system.o mutex.o thread.o threadlocal.o compile.o libalpha.o libbool.o libbox.o libchar.o libcode.o libcmp.o libdict.o libeval.o libexc.o libfmt.o libio.o liblazy.o liblist.o libmacbase.o libmacro.o libmemo.o libmisc.o libmod.o libnative.o libnet.o libnum.o libobj.o libomega.o libparam.o libproc.o librx.o libsrfis.o libstr.o libsym.o libsys.o libthr.o libtype.o libvec.o libgc_pic.a `./get-atomic-ops-flags.sh .. .. --libs` -lmbedtls -lproc -lm  -lpthread
ld: framework not found CoreServices
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [Makefile:409: libgauche-0.98.dylib] Error 1
make[1]: Leaving directory '/private/tmp/nix-build-gauche-bootstrap-0.9.15.drv-0/Gauche-0.9.15/src'
make: *** [Makefile:47: all] Error 1
```

In the process unbreak `gauche` on darwin platforms.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
