### PR TITLE
fop: apply patch for CVE-2024-28168

### DIFF
--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , ant
 , jdk
 , jre
@@ -16,6 +17,14 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://apache/xmlgraphics/fop/fop-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-b7Av17wu6Ar/npKOiwYqzlvBFSIuXTpqTacM1sxtBvc=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2024-28168.patch";
+      url = "https://github.com/apache/xmlgraphics-fop/commit/d96ba9a11710d02716b6f4f6107ebfa9ccec7134.patch";
+      hash = "sha256-zmUA1Tq6iZtvNECCiXebXodp6AikBn10NTZnVHpPMlw=";
+    })
+  ];
 
   nativeBuildInputs = [
     ant


### PR DESCRIPTION
https://www.openwall.com/lists/oss-security/2024/10/09/1

Bumping to 2.10 implies some build changes that I'm not comfortable
dealing with to pull a security fix.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 347972`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>spring</li>
    <li>springLobby</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 57 packages built:</summary>
  <ul>
    <li>asciidoc-full</li>
    <li>asciidoc-full-with-plugins</li>
    <li>asciidoc-full-with-plugins.dist</li>
    <li>asciidoc-full.dist</li>
    <li>checkov</li>
    <li>checkov.dist</li>
    <li>clevis</li>
    <li>clevis.man</li>
    <li>disorderfs</li>
    <li>fop</li>
    <li>gpsbabel-gui</li>
    <li>gpsbabel-gui.doc</li>
    <li>hal-hardware-analyzer</li>
    <li>igraph</li>
    <li>igraph.dev</li>
    <li>igraph.doc</li>
    <li>kakounePlugins.rep</li>
    <li>libleidenalg</li>
    <li>luksmeta</li>
    <li>python311Packages.explorerscript</li>
    <li>python311Packages.explorerscript.dist</li>
    <li>python311Packages.igraph</li>
    <li>python311Packages.igraph.dist</li>
    <li>python311Packages.kmapper</li>
    <li>python311Packages.kmapper.dist</li>
    <li>python311Packages.leidenalg</li>
    <li>python311Packages.leidenalg.dist</li>
    <li>python311Packages.scikit-tda</li>
    <li>python311Packages.scikit-tda.dist</li>
    <li>python311Packages.skytemple-dtef</li>
    <li>python311Packages.skytemple-dtef.dist</li>
    <li>python311Packages.skytemple-files</li>
    <li>python311Packages.skytemple-files.dist</li>
    <li>python311Packages.skytemple-ssb-debugger</li>
    <li>python311Packages.skytemple-ssb-debugger.dist</li>
    <li>python311Packages.textnets</li>
    <li>python311Packages.textnets.dist</li>
    <li>python312Packages.explorerscript</li>
    <li>python312Packages.explorerscript.dist</li>
    <li>python312Packages.igraph</li>
    <li>python312Packages.igraph.dist</li>
    <li>python312Packages.kmapper</li>
    <li>python312Packages.kmapper.dist</li>
    <li>python312Packages.leidenalg</li>
    <li>python312Packages.leidenalg.dist</li>
    <li>python312Packages.scikit-tda</li>
    <li>python312Packages.scikit-tda.dist</li>
    <li>python312Packages.skytemple-dtef</li>
    <li>python312Packages.skytemple-dtef.dist</li>
    <li>python312Packages.skytemple-files</li>
    <li>python312Packages.skytemple-files.dist</li>
    <li>python312Packages.skytemple-ssb-debugger</li>
    <li>python312Packages.skytemple-ssb-debugger.dist</li>
    <li>skytemple</li>
    <li>skytemple.dist</li>
    <li>tang</li>
    <li>tang.man</li>
  </ul>
</details>
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
