### PR TITLE
ocamlPackages.mirage-crypto: 0.11.3 → 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/asn1-combinators/default.nix
+++ b/pkgs/development/ocaml-modules/asn1-combinators/default.nix
@@ -1,20 +1,20 @@
 { lib, buildDunePackage, fetchurl
-, cstruct, zarith, bigarray-compat, stdlib-shims, ptime, alcotest
+, ptime
+, alcotest
 }:
 
 buildDunePackage rec {
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   pname = "asn1-combinators";
-  version = "0.2.6";
+  version = "0.3.1";
 
   src = fetchurl {
-    url = "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v${version}/asn1-combinators-v${version}.tbz";
-    sha256 = "sha256-ASreDYhp72IQY3UsHPjqAm9rxwL+0Q35r1ZojikbGpE=";
+    url = "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v${version}/asn1-combinators-${version}.tbz";
+    hash = "sha256-+imExupuHhxP4gM/AWWvYRljwkAM4roFEAS3ffxVfE4=";
   };
 
-  propagatedBuildInputs = [ cstruct zarith bigarray-compat stdlib-shims ptime ];
+  propagatedBuildInputs = [ ptime ];
 
   doCheck = true;
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/awa/default.nix
+++ b/pkgs/development/ocaml-modules/awa/default.nix
@@ -1,31 +1,26 @@
 { lib, buildDunePackage, fetchurl
-, ppx_sexp_conv
 , mirage-crypto, mirage-crypto-ec, mirage-crypto-rng, mirage-crypto-pk
-, x509, cstruct, cstruct-unix, cstruct-sexp, sexplib, eqaf-cstruct
+, x509, cstruct, cstruct-unix, eqaf
 , mtime, logs, fmt, cmdliner, base64
 , zarith
 }:
 
 buildDunePackage rec {
   pname = "awa";
-  version = "0.3.1";
+  version = "0.4.0";
 
   minimalOCamlVersion = "4.10";
 
   src = fetchurl {
     url = "https://github.com/mirage/awa-ssh/releases/download/v${version}/awa-${version}.tbz";
-    hash = "sha256-VejHFn07B/zoEG4LjLaen24ig9kAXtERl/pRo6UZCQk=";
+    hash = "sha256-uATKGr+J18jBx5vErB93Q9+BCR7ezi1Q+ueQGolpybQ=";
   };
-
-  postPatch = ''
-    substituteInPlace lib/dune --replace-warn eqaf.cstruct eqaf-cstruct
-  '';
 
   propagatedBuildInputs = [
     mirage-crypto mirage-crypto-ec mirage-crypto-rng mirage-crypto-pk x509
-    cstruct cstruct-sexp sexplib mtime
+    cstruct mtime
     logs base64 zarith
-    ppx_sexp_conv eqaf-cstruct
+    eqaf
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/awa/mirage.nix
+++ b/pkgs/development/ocaml-modules/awa/mirage.nix
@@ -8,8 +8,6 @@ buildDunePackage {
 
   inherit (awa) version src;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     awa cstruct mtime lwt mirage-flow mirage-clock logs
     duration mirage-time

--- a/pkgs/development/ocaml-modules/ca-certs-nss/default.nix
+++ b/pkgs/development/ocaml-modules/ca-certs-nss/default.nix
@@ -7,20 +7,19 @@
 , logs
 , fmt
 , bos
-, astring
 , cmdliner
 , alcotest
 }:
 
 buildDunePackage rec {
   pname = "ca-certs-nss";
-  version = "3.101";
+  version = "3.103";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/ca-certs-nss/releases/download/v${version}/ca-certs-nss-${version}.tbz";
-    hash = "sha256-XE3201P5JXWMRLhCwAa6zwMHEwZjg3ORIKii7tmx/hI=";
+    hash = "sha256-ZBwPBUwYuBBuzukgocEHBoqorotLmzHkjUYCmWRqYAw=";
   };
 
   propagatedBuildInputs = [
@@ -33,7 +32,6 @@ buildDunePackage rec {
     logs
     fmt
     bos
-    astring
     cmdliner
   ];
 

--- a/pkgs/development/ocaml-modules/ca-certs/default.nix
+++ b/pkgs/development/ocaml-modules/ca-certs/default.nix
@@ -5,16 +5,14 @@
 
 buildDunePackage rec {
   pname = "ca-certs";
-  version = "0.2.3";
+  version = "1.0.0";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/ca-certs/releases/download/v${version}/ca-certs-${version}.tbz";
-    hash = "sha256-0tjWRX2RXvbXg974Lzvl7C9W+S4gIU9Y7dY8nC/GDpw=";
+    hash = "sha256-hpDyMSNGckeZ8tihtoTsFrYnsCfUFkgDoOK34kYsCnI=";
   };
-
-  duneVersion = "3";
 
   propagatedBuildInputs = [ bos fpath ptime mirage-crypto x509 astring logs ];
 

--- a/pkgs/development/ocaml-modules/chacha/default.nix
+++ b/pkgs/development/ocaml-modules/chacha/default.nix
@@ -26,9 +26,6 @@ buildDunePackage rec {
     sha256 = "sha256-y7X9toFDrgdv3qmFmUs7K7QS+Gy45rRLulKy48m7uqc=";
   })];
 
-  minimalOCamlVersion = "4.02";
-  duneVersion = "3";
-
   propagatedBuildInputs = [ cstruct mirage-crypto ];
 
   # alcotest isn't available for OCaml < 4.05 due to fmt
@@ -45,5 +42,6 @@ buildDunePackage rec {
     '';
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ fufexan ];
+    broken = true; # Not compatible with mirage-crypto ≥ 1.0
   };
 }

--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -1,5 +1,5 @@
-{ buildDunePackage, async, async_ssl ? null, ppx_sexp_conv, ppx_here, uri, conduit
-, core, ipaddr, ipaddr-sexp, sexplib
+{ buildDunePackage, async, ppx_sexp_conv, ppx_here, uri, conduit
+, core, ipaddr, ipaddr-sexp, sexplib0
 }:
 
 buildDunePackage {
@@ -13,13 +13,12 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     async
-    async_ssl
     conduit
     uri
     ipaddr
     ipaddr-sexp
     core
-    sexplib
+    sexplib0
   ];
 
   meta = conduit.meta // {

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -1,20 +1,20 @@
 { lib, fetchurl, buildDunePackage
-, ppx_sexp_conv, sexplib, astring, uri
+, ppx_sexp_conv, sexplib0, astring, uri
 , ipaddr, ipaddr-sexp
 }:
 
 buildDunePackage rec {
   pname = "conduit";
-  version = "6.2.3";
+  version = "7.0.0";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.13";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-conduit/releases/download/v${version}/conduit-${version}.tbz";
-    hash = "sha256-OkaEuxSFsfJH1ghN0KNW4QJ+ksLNRns1yr1Zp2RCPnk=";
+    hash = "sha256-Pg7ChIlqldF42NE1eS56Rssk+csK8OqWTQXO4avLEhg=";
   };
 
-  propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib uri ppx_sexp_conv ];
+  propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib0 uri ppx_sexp_conv ];
 
   meta = {
     description = "Network connection establishment library";

--- a/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
@@ -1,6 +1,6 @@
 { buildDunePackage
 , conduit-lwt, ppx_sexp_conv, lwt, uri, ipaddr, ipaddr-sexp, ca-certs, logs
-, lwt_ssl, tls, lwt_log, ssl
+, lwt_ssl, lwt_log, ssl
 }:
 
 buildDunePackage {
@@ -15,7 +15,6 @@ buildDunePackage {
     uri
     ipaddr
     ipaddr-sexp
-    tls
     ca-certs
     logs
     lwt_ssl

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, ppx_sexp_conv, conduit, lwt, sexplib }:
+{ buildDunePackage, ppx_sexp_conv, conduit, lwt, sexplib0 }:
 
 buildDunePackage {
   pname = "conduit-lwt";
@@ -6,7 +6,7 @@ buildDunePackage {
 
   buildInputs = [ ppx_sexp_conv ];
 
-  propagatedBuildInputs = [ conduit lwt sexplib ];
+  propagatedBuildInputs = [ conduit lwt sexplib0 ];
 
   meta = conduit.meta // {
     description = "Network connection establishment library for Lwt";

--- a/pkgs/development/ocaml-modules/conduit/mirage.nix
+++ b/pkgs/development/ocaml-modules/conduit/mirage.nix
@@ -1,6 +1,6 @@
 { buildDunePackage, conduit-lwt
-, ppx_sexp_conv, sexplib, uri, cstruct, mirage-flow
-, mirage-flow-combinators, mirage-random, mirage-time, mirage-clock
+, ppx_sexp_conv, sexplib0, uri, cstruct, mirage-flow
+, mirage-flow-combinators, mirage-crypto-rng-mirage, mirage-time, mirage-clock
 , dns-client-mirage, vchan, xenstore, tls, tls-mirage, ipaddr, ipaddr-sexp
 , tcpip, ca-certs-nss
 }:
@@ -13,8 +13,8 @@ buildDunePackage {
   nativeBuildInputs = [ ppx_sexp_conv ];
 
   propagatedBuildInputs = [
-    sexplib uri cstruct mirage-clock mirage-flow
-    mirage-flow-combinators mirage-random mirage-time
+    sexplib0 uri cstruct mirage-clock mirage-flow
+    mirage-flow-combinators mirage-crypto-rng-mirage mirage-time
     dns-client-mirage conduit-lwt vchan xenstore tls tls-mirage
     ipaddr ipaddr-sexp tcpip ca-certs-nss
   ];

--- a/pkgs/development/ocaml-modules/dns/certify.nix
+++ b/pkgs/development/ocaml-modules/dns/certify.nix
@@ -1,6 +1,6 @@
 { buildDunePackage, dns, dns-tsig, dns-mirage, randomconv, x509
-, mirage-random, mirage-time, mirage-clock
-, logs, mirage-crypto-pk, mirage-crypto-rng, mirage-crypto-ec, lwt
+, mirage-time, mirage-clock
+, logs, mirage-crypto-pk, mirage-crypto-rng-mirage, mirage-crypto-ec, lwt
 , tcpip
 }:
 
@@ -8,7 +8,6 @@ buildDunePackage {
   pname = "dns-certify";
 
   inherit (dns) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns
@@ -16,12 +15,11 @@ buildDunePackage {
     dns-mirage
     randomconv
     x509
-    mirage-random
     mirage-time
     mirage-clock
     logs
     mirage-crypto-pk
-    mirage-crypto-rng
+    mirage-crypto-rng-mirage
     mirage-crypto-ec
     lwt
     tcpip

--- a/pkgs/development/ocaml-modules/dns/cli.nix
+++ b/pkgs/development/ocaml-modules/dns/cli.nix
@@ -1,6 +1,6 @@
 { buildDunePackage, dns, dns-tsig, dns-client-lwt, dns-server, dns-certify, dnssec
 , bos, cmdliner, fpath, x509, mirage-crypto, mirage-crypto-pk
-, mirage-crypto-rng, hex, ptime, mtime, logs, fmt, ipaddr, lwt
+, mirage-crypto-rng, ohex, ptime, mtime, logs, fmt, ipaddr, lwt
 , randomconv, alcotest
 }:
 
@@ -10,7 +10,6 @@ buildDunePackage {
   minimalOCamlVersion = "4.08";
 
   inherit (dns) version src;
-  duneVersion = "3";
 
   # no need to propagate as this is primarily
   # an executable package
@@ -28,7 +27,7 @@ buildDunePackage {
     mirage-crypto
     mirage-crypto-pk
     mirage-crypto-rng
-    hex
+    ohex
     ptime
     mtime
     logs

--- a/pkgs/development/ocaml-modules/dns/client-lwt.nix
+++ b/pkgs/development/ocaml-modules/dns/client-lwt.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, dns, dns-client, lwt
-, mirage-crypto-rng, mtime
+, mirage-crypto-rng-lwt, mtime
 , ipaddr, alcotest
 , ca-certs
 , happy-eyeballs
@@ -21,7 +21,7 @@ buildDunePackage {
     happy-eyeballs-lwt
     tls-lwt
     mtime
-    mirage-crypto-rng
+    mirage-crypto-rng-lwt
   ];
   checkInputs = [ alcotest ];
   doCheck = true;

--- a/pkgs/development/ocaml-modules/dns/client-mirage.nix
+++ b/pkgs/development/ocaml-modules/dns/client-mirage.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, dns, dns-client, lwt, mirage-clock, mirage-time
-, mirage-random
+, mirage-crypto-rng-mirage
 , domain-name, ipaddr
 , ca-certs-nss
 , happy-eyeballs
@@ -17,7 +17,7 @@ buildDunePackage {
     domain-name
     ipaddr
     lwt
-    mirage-random
+    mirage-crypto-rng-mirage
     mirage-time
     mirage-clock
     ca-certs-nss

--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -2,7 +2,6 @@
 , buildDunePackage
 , fetchurl
 , alcotest
-, cstruct
 , domain-name
 , duration
 , gmap
@@ -13,20 +12,21 @@
 , ptime
 , fmt
 , base64
+, ohex
 }:
 
 buildDunePackage rec {
   pname = "dns";
-  version = "8.0.0";
+  version = "9.0.0";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.13";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-${version}.tbz";
-    hash = "sha256-CIIGG8W/p1FasmyEyoBiMjrFkxs/iuKVJ5SwySfYhU4=";
+    hash = "sha256-HvXwTLVKw0wHV+xftL/z+yNA6UjxUTSdo/cC+s3qy/Y=";
   };
 
-  propagatedBuildInputs = [ fmt logs ptime domain-name gmap cstruct ipaddr lru duration metrics base64 ];
+  propagatedBuildInputs = [ fmt logs ptime domain-name gmap ipaddr lru duration metrics base64 ohex ];
 
   doCheck = true;
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/dns/dnssec.nix
+++ b/pkgs/development/ocaml-modules/dns/dnssec.nix
@@ -1,5 +1,4 @@
 { buildDunePackage
-, cstruct
 , dns
 , mirage-crypto
 , mirage-crypto-pk
@@ -14,10 +13,8 @@ buildDunePackage {
   pname = "dnssec";
 
   inherit (dns) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
-    cstruct
     dns
     mirage-crypto
     mirage-crypto-pk

--- a/pkgs/development/ocaml-modules/dns/mirage.nix
+++ b/pkgs/development/ocaml-modules/dns/mirage.nix
@@ -4,7 +4,6 @@ buildDunePackage {
   pname = "dns-mirage";
 
   inherit (dns) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns

--- a/pkgs/development/ocaml-modules/dns/resolver.nix
+++ b/pkgs/development/ocaml-modules/dns/resolver.nix
@@ -20,7 +20,6 @@ buildDunePackage {
   pname = "dns-resolver";
 
   inherit (dns) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns

--- a/pkgs/development/ocaml-modules/dns/server.nix
+++ b/pkgs/development/ocaml-modules/dns/server.nix
@@ -17,7 +17,6 @@ buildDunePackage {
   pname = "dns-server";
 
   inherit (dns) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns

--- a/pkgs/development/ocaml-modules/dns/stub.nix
+++ b/pkgs/development/ocaml-modules/dns/stub.nix
@@ -1,13 +1,12 @@
 { buildDunePackage, dns, dns-client-mirage, dns-mirage, dns-resolver, dns-tsig
 , dns-server, duration, randomconv, lwt, mirage-time, mirage-clock
-, mirage-random, tcpip, metrics
+, mirage-crypto-rng-mirage, tcpip, metrics
 }:
 
 buildDunePackage {
   pname = "dns-stub";
 
   inherit (dns) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns
@@ -21,7 +20,7 @@ buildDunePackage {
     lwt
     mirage-time
     mirage-clock
-    mirage-random
+    mirage-crypto-rng-mirage
     tcpip
     metrics
   ];

--- a/pkgs/development/ocaml-modules/dns/tsig.nix
+++ b/pkgs/development/ocaml-modules/dns/tsig.nix
@@ -1,13 +1,12 @@
-{ buildDunePackage, dns, mirage-crypto, base64, alcotest }:
+{ buildDunePackage, dns, digestif, base64, alcotest }:
 
 buildDunePackage {
   pname = "dns-tsig";
 
   inherit (dns) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
-    mirage-crypto
+    digestif
     dns
     base64
   ];

--- a/pkgs/development/ocaml-modules/erm_xmpp/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/default.nix
@@ -1,21 +1,21 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, camlp4, ocamlbuild
-, erm_xml, mirage-crypto, mirage-crypto-rng, base64
+, erm_xml, mirage-crypto, mirage-crypto-rng, base64, digestif
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.3+20220404";
+  version = "0.3+20241009";
   pname = "ocaml${ocaml.version}-erm_xmpp";
 
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "xmpp";
-    rev    = "e54d54e142ac9770c37e144693473692bf473530";
-    sha256 = "sha256-Ize8Em4LI54Cy1Xuzr9BjQGV7JMr3W6KI1YzI8G1q/U=";
+    rev    = "54418f77abf47b175e9c1b68a4f745a12b640d6a";
+    sha256 = "sha256-AbzZjNkW1VH/FOnzNruvelZeo3IYg/Usr3enQEknTQs=";
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild camlp4 ];
   buildInputs = [ camlp4 ];
-  propagatedBuildInputs = [ erm_xml mirage-crypto mirage-crypto-rng base64 ];
+  propagatedBuildInputs = [ erm_xml mirage-crypto mirage-crypto-rng base64 digestif ];
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -2,19 +2,19 @@
 , alcotest, mirage-crypto-rng, git-binary
 , angstrom, astring, cstruct, decompress, digestif, encore, fmt, checkseum
 , ke, logs, lwt, ocamlgraph, uri, rresult, base64, hxd
-, result, bigstringaf, optint, mirage-flow, domain-name, emile
+, bigstringaf, optint, mirage-flow, domain-name, emile
 , mimic, carton, carton-lwt, carton-git, ipaddr, psq, crowbar, alcotest-lwt, cmdliner
 }:
 
 buildDunePackage rec {
   pname = "git";
-  version = "3.16.1";
+  version = "3.17.0";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${version}/git-${version}.tbz";
-    hash = "sha256-wDW9zM2eTS9IxtnNxl5h/BCDjs8dim8qN2riCoqSSAM=";
+    hash = "sha256-7yANBBLtGlOFJdBQEpiJDguJPgIFKAlNajrhI1n9AmU=";
   };
 
   buildInputs = [
@@ -22,7 +22,7 @@ buildDunePackage rec {
   ];
   propagatedBuildInputs = [
     angstrom astring checkseum cstruct decompress digestif encore fmt
-    ke logs lwt ocamlgraph uri rresult result bigstringaf optint mirage-flow
+    ke logs lwt ocamlgraph uri rresult bigstringaf optint mirage-flow
     domain-name emile mimic carton carton-lwt carton-git ipaddr psq hxd
   ];
   nativeCheckInputs = [

--- a/pkgs/development/ocaml-modules/git/paf.nix
+++ b/pkgs/development/ocaml-modules/git/paf.nix
@@ -9,7 +9,6 @@
 , lwt
 , mirage-clock
 , mirage-time
-, result
 , rresult
 , tls
 , uri
@@ -34,7 +33,6 @@ buildDunePackage {
     ca-certs-nss
     fmt
     lwt
-    result
     rresult
     ipaddr
     logs

--- a/pkgs/development/ocaml-modules/git/unix.nix
+++ b/pkgs/development/ocaml-modules/git/unix.nix
@@ -1,12 +1,12 @@
 { buildDunePackage, git
-, rresult, result, bigstringaf
+, rresult, bigstringaf
 , fmt, bos, fpath, uri, digestif, logs, lwt
-, mirage-clock, mirage-clock-unix, astring, awa, cmdliner
+, mirage-clock, mirage-clock-unix, astring, cmdliner
 , decompress, domain-name, ipaddr, mtime
-, tcpip, awa-mirage, mirage-flow, mirage-unix
+, tcpip, mirage-flow, mirage-unix
 , alcotest, alcotest-lwt, base64, cstruct
 , ke, mirage-crypto-rng, git-binary
-, ptime, mimic, ca-certs-nss, tls, tls-mirage
+, mimic, tls
 , cacert, happy-eyeballs-lwt, git-mirage
 }:
 
@@ -17,19 +17,17 @@ buildDunePackage {
   minimalOCamlVersion = "4.08";
 
   buildInputs = [
-    awa
-    awa-mirage
     cmdliner
     mirage-clock
     tcpip
   ];
   propagatedBuildInputs = [
-    rresult result bigstringaf
+    rresult bigstringaf
     fmt bos fpath digestif logs lwt
     astring decompress
     domain-name ipaddr mirage-flow mirage-unix
-    cstruct ptime mimic ca-certs-nss
-    tls tls-mirage git happy-eyeballs-lwt
+    cstruct mimic
+    tls git happy-eyeballs-lwt
     git-mirage mirage-clock-unix
   ];
   checkInputs = [

--- a/pkgs/development/ocaml-modules/hkdf/default.nix
+++ b/pkgs/development/ocaml-modules/hkdf/default.nix
@@ -1,19 +1,18 @@
-{ lib, buildDunePackage, fetchurl, cstruct, mirage-crypto, alcotest }:
+{ lib, buildDunePackage, fetchurl, digestif, alcotest, ohex }:
 
 buildDunePackage rec {
   pname = "hkdf";
-  version = "1.0.4";
+  version = "2.0.0";
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/hannesm/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    hash = "sha256-uSbW2krEWquZlzXdK7/R91ETFnENeRr6NhAGtv42/Vs=";
+    url = "https://github.com/hannesm/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    hash = "sha256-VLBxJ5viTTn1nK0QNIAGq/8961x0/RGHZN/C/7ITWNM=";
   };
 
-  propagatedBuildInputs = [ cstruct mirage-crypto ];
-  checkInputs = [ alcotest ];
+  propagatedBuildInputs = [ digestif ];
+  checkInputs = [ alcotest ohex ];
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/http-mirage-client/default.nix
+++ b/pkgs/development/ocaml-modules/http-mirage-client/default.nix
@@ -16,13 +16,13 @@
 
 buildDunePackage rec {
   pname = "http-mirage-client";
-  version = "0.0.6";
+  version = "0.0.7";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/roburio/http-mirage-client/releases/download/v${version}/http-mirage-client-${version}.tbz";
-    hash = "sha256-rtl76NJRYwSRNgN57v0KwUlcDsGQ2MR+y5ZDVf4Otjs=";
+    hash = "sha256-GKPJKVtHEbt8L922y/G1oewqGVBO4f313XadzImMtFM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -246,7 +246,7 @@ with self;
     pname = "cohttp_async_websocket";
     hash = "0d0smavnxpnwrmhlcf3b5a3cm3n9kz1y8fh6l28xv6zrn4sc7ik8";
     meta.description = "Websocket library for use with cohttp and async";
-    propagatedBuildInputs = [ async_websocket cohttp-async ppx_jane uri-sexp ];
+    propagatedBuildInputs = [ async_ssl async_websocket cohttp-async ppx_jane uri-sexp ];
   };
 
   cohttp_static_handler = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.16.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.16.nix
@@ -264,7 +264,7 @@ with self;
     pname = "cohttp_async_websocket";
     hash = "sha256-OBtyKMyvfz0KNG4SWmvoTMVPnVTpO12N38q+kEbegJE=";
     meta.description = "Websocket library for use with cohttp and async";
-    propagatedBuildInputs = [ async_websocket cohttp-async ppx_jane uri-sexp ];
+    propagatedBuildInputs = [ async_ssl async_websocket cohttp-async ppx_jane uri-sexp ];
   };
 
   cohttp_static_handler = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -402,6 +402,7 @@ with self;
     hash = "sha256-0InGCF34LWQes9S4OgbR6w+6cylThYuj1Dj0aQyTnuY=";
     meta.description = "Websocket library for use with cohttp and async";
     propagatedBuildInputs = [
+      async_ssl
       async_websocket
       cohttp-async
       ppx_jane

--- a/pkgs/development/ocaml-modules/letsencrypt/app.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/app.nix
@@ -11,12 +11,10 @@
 , bos
 , fpath
 , randomconv
-, cstruct
 }:
 
 buildDunePackage {
   pname = "letsencrypt-app";
-  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   inherit (letsencrypt)
@@ -37,7 +35,6 @@ buildDunePackage {
     bos
     fpath
     randomconv
-    cstruct
   ];
 
   meta = letsencrypt.meta // {

--- a/pkgs/development/ocaml-modules/letsencrypt/default.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/default.nix
@@ -1,9 +1,9 @@
 { buildDunePackage
 , lib
 , fetchurl
-, asn1-combinators
 , uri
 , base64
+, digestif
 , logs
 , fmt
 , lwt
@@ -12,23 +12,21 @@
 , mirage-crypto-pk
 , x509
 , yojson
-, ounit
+, ounit2
 , ptime
 , domain-name
-, cstruct
 }:
 
 buildDunePackage rec {
   pname = "letsencrypt";
-  version = "0.5.1";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v${version}/letsencrypt-${version}.tbz";
-    hash = "sha256-uQOHpdyPg5kms+negxpQMxfhow6auZ0ipt5ksoXYo1w=";
+    hash = "sha256-koNG19aoLY28Hb7GyuPuJUyrCAE59n2vjbH4z0ykGvA=";
   };
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   buildInputs = [
     fmt
@@ -41,17 +39,16 @@ buildDunePackage rec {
     yojson
     lwt
     base64
+    digestif
     mirage-crypto
     mirage-crypto-ec
     mirage-crypto-pk
-    asn1-combinators
     x509
     uri
-    cstruct
   ];
 
   doCheck = true;
-  checkInputs = [ ounit ];
+  checkInputs = [ ounit2 ];
 
   meta = {
     description = "ACME implementation in OCaml";

--- a/pkgs/development/ocaml-modules/letsencrypt/dns.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/dns.nix
@@ -10,7 +10,6 @@
 
 buildDunePackage {
   pname = "letsencrypt-dns";
-  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   inherit (letsencrypt)

--- a/pkgs/development/ocaml-modules/letsencrypt/mirage.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/mirage.nix
@@ -10,8 +10,6 @@ buildDunePackage {
 
   inherit (letsencrypt) version src;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [ emile http-mirage-client letsencrypt paf ];
 
   meta = letsencrypt.meta // {

--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -1,34 +1,28 @@
-{ lib, fetchurl, buildDunePackage, ounit2, dune-configurator, eqaf-cstruct, pkg-config
+{ lib, fetchurl, buildDunePackage, ohex, ounit2, dune-configurator, eqaf-cstruct
 , withFreestanding ? false
 , ocaml-freestanding
 }:
 
 buildDunePackage rec {
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.13";
 
   pname = "mirage-crypto";
-  version = "0.11.3";
+  version = "1.1.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-${version}.tbz";
-    sha256 = "sha256-v7Uw+hac2QXrx+JEnzQHz71nAjrAspG4tvShQ3pdlbE=";
+    hash = "sha256-xxiXZ6fq1UkjyrAg85zQw0r31LBId2k52U8Cir9TY1M=";
   };
 
   doCheck = true;
-  checkInputs = [ ounit2 ];
+  checkInputs = [ ohex ounit2 ];
 
-  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator  ];
   propagatedBuildInputs = [
     eqaf-cstruct
   ] ++ lib.optionals withFreestanding [
     ocaml-freestanding
   ];
-
-  # Compatibility with eqaf 0.10
-  postPatch = ''
-    substituteInPlace src/dune --replace-warn eqaf.cstruct eqaf-cstruct
-  '';
 
   meta = with lib; {
     homepage = "https://github.com/mirage/mirage-crypto";

--- a/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
@@ -3,12 +3,12 @@
 , mirage-crypto
 , dune-configurator
 , pkg-config
-, cstruct
 , mirage-crypto-rng
 , mirage-crypto-pk
-, hex
 , alcotest
 , asn1-combinators
+, ohex
+, ounit2
 , ppx_deriving_yojson
 , ppx_deriving
 , yojson
@@ -23,14 +23,11 @@ buildDunePackage rec {
     src
     version;
 
-  duneVersion = "3";
-
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     dune-configurator
   ];
   propagatedBuildInputs = [
-    cstruct
     mirage-crypto
     mirage-crypto-rng
   ] ++ lib.optionals withFreestanding [
@@ -41,9 +38,10 @@ buildDunePackage rec {
 
   doCheck = true;
   checkInputs = [
-    hex
     alcotest
     asn1-combinators
+    ohex
+    ounit2
     ppx_deriving_yojson
     ppx_deriving
     yojson

--- a/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
@@ -1,21 +1,17 @@
-{ buildDunePackage, ounit2, randomconv, mirage-crypto, mirage-crypto-rng
-, cstruct, sexplib0, zarith, eqaf-cstruct, gmp }:
+{ buildDunePackage, ohex, ounit2, randomconv, mirage-crypto, mirage-crypto-rng
+, sexplib0, zarith, gmp }:
 
 buildDunePackage rec {
   pname = "mirage-crypto-pk";
 
   inherit (mirage-crypto) version src;
 
-  postPatch = ''
-    substituteInPlace pk/dune --replace-warn eqaf.cstruct eqaf-cstruct
-  '';
-
   buildInputs = [ gmp ];
-  propagatedBuildInputs = [ cstruct mirage-crypto mirage-crypto-rng
-                            zarith eqaf-cstruct sexplib0 ];
+  propagatedBuildInputs = [ mirage-crypto mirage-crypto-rng
+                            zarith sexplib0 ];
 
   doCheck = true;
-  checkInputs = [ ounit2 randomconv ];
+  checkInputs = [ ohex ounit2 randomconv ];
 
   meta = mirage-crypto.meta // {
     description = "Simple public-key cryptography for the modern age";

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
@@ -1,18 +1,18 @@
-{ buildDunePackage, mirage-crypto-rng, duration, cstruct, mirage-runtime
+{ buildDunePackage, mirage-crypto-rng, duration, mirage-runtime
 , mirage-time, mirage-clock, mirage-unix, mirage-time-unix, mirage-clock-unix
 , logs, lwt
+, ohex
 }:
 
 buildDunePackage rec {
   pname = "mirage-crypto-rng-mirage";
 
   inherit (mirage-crypto-rng) version src;
-  duneVersion = "3";
 
   doCheck = true;
-  checkInputs = [ mirage-unix mirage-clock-unix mirage-time-unix ];
+  checkInputs = [ mirage-unix mirage-clock-unix mirage-time-unix ohex ];
 
-  propagatedBuildInputs = [ duration cstruct mirage-crypto-rng mirage-runtime
+  propagatedBuildInputs = [ duration mirage-crypto-rng mirage-runtime
                             mirage-time mirage-clock logs lwt ];
 
   meta = mirage-crypto-rng.meta // {

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
@@ -1,5 +1,5 @@
-{ buildDunePackage, mirage-crypto, ounit2, randomconv, dune-configurator
-, cstruct, duration, logs }:
+{ buildDunePackage, mirage-crypto, ohex, ounit2, randomconv, dune-configurator
+, digestif, duration, logs }:
 
 buildDunePackage rec {
   pname = "mirage-crypto-rng";
@@ -7,12 +7,10 @@ buildDunePackage rec {
   inherit (mirage-crypto) version src;
 
   doCheck = true;
-  checkInputs = [ ounit2 randomconv ];
+  checkInputs = [ ohex ounit2 randomconv ];
 
   buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ cstruct mirage-crypto duration logs ];
-
-  strictDeps = true;
+  propagatedBuildInputs = [ digestif mirage-crypto duration logs ];
 
   meta = mirage-crypto.meta // {
     description = "Cryptographically secure PRNG";

--- a/pkgs/development/ocaml-modules/mrmime/default.nix
+++ b/pkgs/development/ocaml-modules/mrmime/default.nix
@@ -57,7 +57,8 @@ buildDunePackage rec {
     jsonm
     mirage-crypto-rng
   ];
-  doCheck = true;
+  # Checks are not compatible with mirage-crypto-rng ≥ 1.0
+  doCheck = false;
 
   meta = {
     description = "Parser and generator of mail in OCaml";

--- a/pkgs/development/ocaml-modules/ohex/default.nix
+++ b/pkgs/development/ocaml-modules/ohex/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  alcotest,
+}:
+
+buildDunePackage rec {
+  pname = "ohex";
+  version = "0.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml/opam-source-archives/raw/main/ohex-${version}.tar.gz";
+    hash = "sha256-prV7rbo0sAx3S2t4YtjniJEVq43uLXK8ZMsqoMzn2Ow=";
+  };
+
+  doCheck = true;
+  checkInputs = [ alcotest ];
+
+  meta = {
+    description = "Hexadecimal encoding and decoding";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/opium/default.nix
+++ b/pkgs/development/ocaml-modules/opium/default.nix
@@ -23,7 +23,6 @@
 buildDunePackage rec {
   pname = "opium";
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   inherit (rock) src version;
 
@@ -57,5 +56,6 @@ buildDunePackage rec {
     homepage = "https://github.com/rgrinberg/opium";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.pmahoney ];
+    broken = true; # Not compatible with mirage-crypto ≥ 1.0
   };
 }

--- a/pkgs/development/ocaml-modules/otr/default.nix
+++ b/pkgs/development/ocaml-modules/otr/default.nix
@@ -13,8 +13,6 @@ buildDunePackage rec {
     hash = "sha256:0dssc7p6s7z53n0mddyipjghzr8ld8bb7alaxqrx9gdpspwab1gq";
   };
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [ cstruct sexplib0 mirage-crypto mirage-crypto-pk
                             astring base64 ];
 
@@ -25,5 +23,6 @@ buildDunePackage rec {
     description = "Off-the-record messaging protocol, purely in OCaml";
     license = licenses.bsd2;
     maintainers = with maintainers; [ sternenseemann ];
+    broken = true; # Not compatible with mirage-crypto ≥ 1.0
   };
 }

--- a/pkgs/development/ocaml-modules/paf/default.nix
+++ b/pkgs/development/ocaml-modules/paf/default.nix
@@ -24,11 +24,11 @@
 
 buildDunePackage rec {
   pname = "paf";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchurl {
     url = "https://github.com/dinosaure/paf-le-chien/releases/download/${version}/paf-${version}.tbz";
-    hash = "sha256-uvNezux0V4mwbxU07zCfCYXOgCYKPxshOKiiAjLef9k=";
+    hash = "sha256-w2lGs+DYY08BUKumWFxPFTLQKvdRPu7H1FdQOIjDQyE=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/pbkdf/default.nix
+++ b/pkgs/development/ocaml-modules/pbkdf/default.nix
@@ -1,25 +1,24 @@
 { lib
 , buildDunePackage
 , fetchzip
-, cstruct
+, digestif
 , mirage-crypto
 , alcotest
+, ohex
 }:
 
 buildDunePackage rec {
   pname = "pbkdf";
-  version = "1.2.0";
-
-  duneVersion = "3";
+  version = "2.0.0";
 
   src = fetchzip {
     url = "https://github.com/abeaumont/ocaml-pbkdf/archive/${version}.tar.gz";
-    sha256 = "sha256-dGi4Vw+7VBpK/NpJ6zdpogm+E6G/oJovXCksJBSmqjI=";
+    hash = "sha256-D2dXpf1D/wsJrcajU3If37tuLYjahoA/+QoXZKr1vQs=";
   };
 
   minimalOCamlVersion = "4.08";
-  propagatedBuildInputs = [ cstruct mirage-crypto ];
-  checkInputs = [ alcotest ];
+  propagatedBuildInputs = [ digestif mirage-crypto ];
+  checkInputs = [ alcotest ohex ];
   doCheck = true;
 
   meta = {

--- a/pkgs/development/ocaml-modules/randomconv/default.nix
+++ b/pkgs/development/ocaml-modules/randomconv/default.nix
@@ -1,17 +1,15 @@
-{ lib, buildDunePackage, fetchurl, cstruct }:
+{ lib, buildDunePackage, fetchurl }:
 
 buildDunePackage rec {
   pname = "randomconv";
-  version = "0.1.3";
+  version = "0.2.0";
 
-  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
-    url = "https://github.com/hannesm/randomconv/releases/download/v${version}/randomconv-v${version}.tbz";
-    sha256 = "1iv3r0s5kqxs893b0d55f0r62k777haiahfkkvvfbqwgqsm6la4v";
+    url = "https://github.com/hannesm/randomconv/releases/download/v${version}/randomconv-${version}.tbz";
+    hash = "sha256-sxce3wfjQaRGj5L/wh4qiGO4LtXDb3R3zJja8F1bY+o=";
   };
-
-  propagatedBuildInputs = [ cstruct ];
 
   meta = {
     homepage = "https://github.com/hannesm/randomconv";

--- a/pkgs/development/ocaml-modules/riot/default.nix
+++ b/pkgs/development/ocaml-modules/riot/default.nix
@@ -47,5 +47,6 @@ buildDunePackage rec {
     changelog = "https://github.com/leostera/riot/blob/${version}/CHANGES.md";
     license = lib.licenses.mit;
     maintainers = [ ];
+    broken = true; # Not compatible with mirage-crypto ≥ 1.0
   };
 }

--- a/pkgs/development/ocaml-modules/tcpip/default.nix
+++ b/pkgs/development/ocaml-modules/tcpip/default.nix
@@ -1,7 +1,7 @@
 { lib, buildDunePackage, fetchurl
 , pkg-config
 , cstruct, cstruct-lwt, mirage-net, mirage-clock
-, mirage-random, mirage-time
+, mirage-crypto-rng-mirage, mirage-time
 , macaddr, macaddr-cstruct, fmt
 , lwt, lwt-dllist, logs, duration, randomconv, ethernet
 , alcotest, mirage-flow, mirage-vnetif, pcap-format
@@ -13,11 +13,11 @@
 
 buildDunePackage rec {
   pname = "tcpip";
-  version = "8.1.0";
+  version = "8.2.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    hash = "sha256-hrpdkvkHi93GUxL2O19M40/SVw12VDOyOiJquE11qcA=";
+    hash = "sha256-kW5oirqJdnbERNuBKfSWOtc5+NG+Yx2eAJxiKLS31u0=";
   };
 
   nativeBuildInputs = [
@@ -29,7 +29,7 @@ buildDunePackage rec {
     cstruct-lwt
     mirage-net
     mirage-clock
-    mirage-random
+    mirage-crypto-rng-mirage
     mirage-time
     ipaddr-cstruct
     macaddr

--- a/pkgs/development/ocaml-modules/tls/async.nix
+++ b/pkgs/development/ocaml-modules/tls/async.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, tls, async, cstruct-async, core, cstruct, mirage-crypto-rng-async }:
+{ buildDunePackage, tls, async, cstruct-async, core, mirage-crypto-rng-async }:
 
 buildDunePackage rec {
   pname = "tls-async";
@@ -12,7 +12,6 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     async
     core
-    cstruct
     cstruct-async
     mirage-crypto-rng-async
     tls

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -1,22 +1,21 @@
 { lib, fetchurl, buildDunePackage
-, cstruct, domain-name, fmt, logs, hkdf, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk, mirage-crypto-rng, ptime, x509
+, domain-name, fmt, logs, hkdf, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk, mirage-crypto-rng, ptime, x509
 , ipaddr
-, alcotest, cstruct-unix, ounit2
+, alcotest, ounit2
 }:
 
 buildDunePackage rec {
   pname = "tls";
-  version = "0.17.5";
+  version = "1.0.1";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-${version}.tbz";
-    hash = "sha256-iRCIV786b4VyKSWo1KP1nCkdY4wPLi/EXw/a+JKuSBk=";
+    hash = "sha256-2uS1/8gD6ILphIBCWP+KrKe4N9hVbeaEABldpccKjYM=";
   };
 
   minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [
-    cstruct
     domain-name
     fmt
     logs
@@ -33,7 +32,6 @@ buildDunePackage rec {
   doCheck = true;
   checkInputs = [
     alcotest
-    cstruct-unix
     ounit2
   ];
 

--- a/pkgs/development/ocaml-modules/tls/lwt.nix
+++ b/pkgs/development/ocaml-modules/tls/lwt.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, tls, lwt, mirage-crypto-rng-lwt, x509 }:
+{ buildDunePackage, tls, lwt, mirage-crypto-rng-lwt }:
 
 buildDunePackage rec {
   pname = "tls-lwt";
@@ -13,6 +13,5 @@ buildDunePackage rec {
     lwt
     mirage-crypto-rng-lwt
     tls
-    x509
   ];
 }

--- a/pkgs/development/ocaml-modules/tls/mirage.nix
+++ b/pkgs/development/ocaml-modules/tls/mirage.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, tls
-, fmt, lwt, mirage-clock, mirage-crypto, mirage-crypto-pk, mirage-flow, mirage-kv, ptime, x509
+, fmt, lwt, mirage-clock, mirage-crypto, mirage-crypto-pk, mirage-flow, mirage-kv, ptime
 }:
 
 buildDunePackage {
@@ -16,7 +16,6 @@ buildDunePackage {
     mirage-kv
     ptime
     tls
-    x509
   ];
 
   meta = tls.meta // {

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -1,24 +1,22 @@
 { lib, fetchurl, buildDunePackage
-, alcotest, cstruct-unix
+, alcotest
 , asn1-combinators, domain-name, fmt, gmap, pbkdf, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk, ipaddr
-, logs, base64
+, logs, base64, ohex
 }:
 
 buildDunePackage rec {
   minimalOCamlVersion = "4.08";
 
   pname = "x509";
-  version = "0.16.5";
-
-  duneVersion = "3";
+  version = "1.0.2";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-x509/releases/download/v${version}/x509-${version}.tbz";
-    hash = "sha256-FJ4lpf6jf2GfsmkL7lwA8BydzzHTNfj/yqs5p1OMzZk=";
+    hash = "sha256-LrUYbLLJTNCWvEZtRXUv5LHdEya2oNTtAbrfm7EE2Bg=";
   };
 
-  checkInputs = [ alcotest cstruct-unix ];
-  propagatedBuildInputs = [ asn1-combinators domain-name fmt gmap mirage-crypto mirage-crypto-pk mirage-crypto-ec pbkdf logs base64 ipaddr ];
+  checkInputs = [ alcotest ];
+  propagatedBuildInputs = [ asn1-combinators domain-name fmt gmap mirage-crypto mirage-crypto-pk mirage-crypto-ec pbkdf logs base64 ipaddr ohex ];
 
   doCheck = true;
 

--- a/pkgs/development/tools/comby/default.nix
+++ b/pkgs/development/tools/comby/default.nix
@@ -79,7 +79,6 @@ mkCombyPackage {
     ocamlPackages.patience_diff
     ocamlPackages.toml
     ocamlPackages.cohttp-lwt-unix
-    ocamlPackages.opium
     ocamlPackages.textutils
     ocamlPackages.jst-config
     ocamlPackages.parany

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1407,6 +1407,8 @@ let
 
     ogg = callPackage ../development/ocaml-modules/ogg { };
 
+    ohex = callPackage ../development/ocaml-modules/ohex { };
+
     ojs = callPackage ../development/ocaml-modules/gen_js_api/ojs.nix { };
 
     omd = callPackage ../development/ocaml-modules/omd { };


### PR DESCRIPTION
Updates `mirage-crypto` and related packages.

This breaks a few packages (`chacha`, `opium`, `otr`, `riot`), some of which are not maintained upstream so it might not be a source for concern. They are not used in `nixpkgs` apart in `jackline` which gets broken: I don’t know what are upstream plans.

cc @Zimmi48.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
