### PR TITLE
xp-pen-artist-pro-14-gen-2-driver: init at 4.0.4-240815

### DIFF
--- a/pkgs/by-name/xp/xp-pen-artist-pro-14-gen-2-driver/package.nix
+++ b/pkgs/by-name/xp/xp-pen-artist-pro-14-gen-2-driver/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  libusb1,
+  qt5,
+}:
+
+let
+  dataDir = "var/lib/xppenap14";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xp-pen-artist-pro-14-gen-2-driver";
+  version = "4.0.4-240815";
+
+  src = fetchurl {
+    url = "https://download01.xp-pen.com/file/2024/08/XPPenLinux${finalAttrs.version}.tar.gz";
+    hash = "sha256-Fd3Q3Z6UTmxU0DPfeyvf2hiNbiesIcl305NHmsjh1pk=";
+  };
+
+  buildInputs = [
+    libusb1
+    qt5.qtbase
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    qt5.wrapQtAppsHook
+    makeWrapper
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{opt,bin}
+
+    cp -r App/usr/lib/pentablet/{PenTablet,conf,doc,UI} $out/opt
+    cp -r App/lib $out/lib
+
+    sed -i 's#usr/lib/pentablet#${dataDir}#g' $out/opt/PenTablet
+
+    makeWrapper $out/opt/PenTablet $out/bin/PenTablet \
+      "''${qtWrapperArgs[@]}" \
+      --run 'if [ "$EUID" -ne 0 ]; then echo "Please run as root."; exit 1; fi' \
+      --run 'if [ ! -d /${dataDir} ]; then mkdir -p /${dataDir}; cp -r '$out'/opt/conf /${dataDir}; chmod u+w -R /${dataDir}; fi'
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://www.xp-pen.com/product/artist-pro-14-gen-2.html";
+    description = "Driver for XP-PEN Artist Pro 14 (Gen 2) drawing tablet";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ gepbird ];
+    license = lib.licenses.unfree;
+    mainProgram = "PenTablet";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/347116

@HangedFool please test how it works, I saw the GUI open but don't have a tablet for it. You can run this and the GUI should open: `NIXPKGS_ALLOW_UNFREE=1 nix run github:gepbird/nixpkgs/xp-pen-init#xp-pen-artist-pro-14-gen-2-driver --impure`

Postponed to an upcoming follow up PR: ~~If the latest xp-pen driver is backwards compatible with all the previously released tablets, we could merge all the 2 old (`xp-pen-deco-01-v2-driver` and `xp-pen-g430-driver`) and this (`xp-pen-artist-pro-14-gen-2-driver)` package into a single one called `xp-pen-driver`. What do you think about it @virchau13 ?~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
