### PR TITLE
nixos/headscale: don't set deprecated options in config 

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -20,6 +20,11 @@
   settingsFormat = pkgs.formats.yaml {};
   configFile = settingsFormat.generate "headscale.yaml" cfg.settings;
   cliConfigFile = settingsFormat.generate "headscale.yaml" cliConfig;
+
+  assertRemovedOption = option: message: {
+    assertion = !lib.hasAttrByPath option cfg;
+    message = "The option `services.headscale.${lib.options.showOption option}` was removed. " + message;
+  };
 in {
   options = {
     services.headscale = {
@@ -81,21 +86,6 @@ in {
         '';
         type = lib.types.submodule {
           freeformType = settingsFormat.type;
-
-          imports = with lib; [
-            (mkAliasOptionModule ["acl_policy_path"] ["policy" "path"])
-            (mkAliasOptionModule ["db_host"] ["database" "postgres" "host"])
-            (mkAliasOptionModule ["db_name"] ["database" "postgres" "name"])
-            (mkAliasOptionModule ["db_password_file"] ["database" "postgres" "password_file"])
-            (mkAliasOptionModule ["db_path"] ["database" "sqlite" "path"])
-            (mkAliasOptionModule ["db_port"] ["database" "postgres" "port"])
-            (mkAliasOptionModule ["db_type"] ["database" "type"])
-            (mkAliasOptionModule ["db_user"] ["database" "postgres" "user"])
-            (mkAliasOptionModule ["dns_config" "base_domain"] ["dns" "base_domain"])
-            (mkAliasOptionModule ["dns_config" "domains"] ["dns" "search_domains"])
-            (mkAliasOptionModule ["dns_config" "magic_dns"] ["dns" "magic_dns"])
-            (mkAliasOptionModule ["dns_config" "nameservers"] ["dns" "nameservers" "global"])
-          ];
 
           options = {
             server_url = lib.mkOption {
@@ -507,6 +497,17 @@ in {
         assertion = with cfg.settings; dns.use_username_in_magic_dns or false || dns.base_domain == "" || !lib.hasInfix dns.base_domain server_url;
         message = "server_url cannot contain the base_domain, this will cause the headscale server and embedded DERP to become unreachable from the Tailscale node.";
       }
+      (assertRemovedOption ["settings" "acl_policy_path"] "Use `policy.path` instead.")
+      (assertRemovedOption ["settings" "db_host"] "Use `database.postgres.host` instead.")
+      (assertRemovedOption ["settings" "db_name"] "Use `database.postgres.name` instead.")
+      (assertRemovedOption ["settings" "db_password_file"] "Use `database.postgres.password_file` instead.")
+      (assertRemovedOption ["settings" "db_path"] "Use `database.sqlite.path` instead.")
+      (assertRemovedOption ["settings" "db_port"] "Use `database.postgres.port` instead.")
+      (assertRemovedOption ["settings" "db_type"] "Use `database.type` instead.")
+      (assertRemovedOption ["settings" "db_user"] "Use `database.postgres.user` instead.")
+      (assertRemovedOption ["settings" "dns_config"] "Use `dns` instead.")
+      (assertRemovedOption ["settings" "dns_config" "domains"] "Use `dns.search_domains` instead.")
+      (assertRemovedOption ["settings" "dns_config" "nameservers"] "Use `dns.nameservers.global` instead.")
     ];
 
     services.headscale.settings = lib.mkMerge [

--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -289,7 +289,6 @@ in {
                 default = true;
                 description = ''
                   Whether to use [MagicDNS](https://tailscale.com/kb/1081/magicdns/).
-                  Only works if there is at least a nameserver defined.
                 '';
                 example = false;
               };
@@ -299,11 +298,13 @@ in {
                 default = "";
                 description = ''
                   Defines the base domain to create the hostnames for MagicDNS.
-                  {option}`baseDomain` must be a FQDNs, without the trailing dot.
-                  The FQDN of the hosts will be
-                  `hostname.namespace.base_domain` (e.g.
-                  `myhost.mynamespace.example.com`).
+                  This domain must be different from the {option}`server_url`
+                  domain.
+                  {option}`base_domain` must be a FQDN, without the trailing dot.
+                  The FQDN of the hosts will be `hostname.base_domain` (e.g.
+                  `myhost.tailnet.example.com`).
                 '';
+                example = "tailnet.example.com";
               };
 
               nameservers = {

--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -498,6 +498,10 @@ in {
         assertion = with cfg.settings; dns.use_username_in_magic_dns or false || dns.base_domain == "" || !lib.hasInfix dns.base_domain server_url;
         message = "server_url cannot contain the base_domain, this will cause the headscale server and embedded DERP to become unreachable from the Tailscale node.";
       }
+      {
+        assertion = with cfg.settings; dns.magic_dns -> dns.base_domain != "";
+        message = "dns.base_domain must be set when using MagicDNS";
+      }
       (assertRemovedOption ["settings" "acl_policy_path"] "Use `policy.path` instead.")
       (assertRemovedOption ["settings" "db_host"] "Use `database.postgres.host` instead.")
       (assertRemovedOption ["settings" "db_name"] "Use `database.postgres.name` instead.")

--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -500,6 +500,15 @@ in {
   ];
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        # This is stricter than it needs to be but is exactly what upstream does:
+        # https://github.com/kradalby/headscale/blob/adc084f20f843d7963c999764fa83939668d2d2c/hscontrol/types/config.go#L799
+        assertion = with cfg.settings; dns.use_username_in_magic_dns or false || dns.base_domain == "" || !lib.hasInfix dns.base_domain server_url;
+        message = "server_url cannot contain the base_domain, this will cause the headscale server and embedded DERP to become unreachable from the Tailscale node.";
+      }
+    ];
+
     services.headscale.settings = lib.mkMerge [
       cliConfig
       {

--- a/nixos/tests/headscale.nix
+++ b/nixos/tests/headscale.nix
@@ -38,6 +38,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
                 region_id = 999;
                 stun_listen_addr = "0.0.0.0:${toString stunPort}";
               };
+              dns.base_domain = "tailnet";
             };
           };
           nginx = {
@@ -77,6 +78,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
 
       # Check that they are reachable from the tailnet
       peer1.wait_until_succeeds("tailscale ping peer2")
-      peer2.wait_until_succeeds("tailscale ping peer1")
+      peer2.wait_until_succeeds("tailscale ping peer1.tailnet")
     '';
   })


### PR DESCRIPTION
We cannot use `mkRenamedOptionModule` or `mkRemovedOptionModule` inside a freeform option. Thus we have to manually assert these deprecated options aren't used rather than aliasing them to their replacement.
See https://github.com/NixOS/nixpkgs/pull/340054#discussion_r1796110820.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
