### PR TITLE
freshBootstrapTools.bootstrapTools: update for new SDK pattern

### DIFF
--- a/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
@@ -18,20 +18,22 @@
   gnused,
   gnutar,
   gzip,
+  jq,
   ld64,
   libffi,
   libiconv,
+  libtapi,
   libxml2,
-  libyaml,
   llvmPackages,
   ncurses,
   nukeReferences,
+  oniguruma,
   openssl,
   patch,
   pbzx,
   runCommand,
   writeText,
-  xar,
+  xarMinimal,
   xz,
   zlib,
 }:
@@ -113,21 +115,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     in
     ''
-      mkdir -p $out/bin $out/lib $out/lib/darwin
+      mkdir -p $out/bin $out/include $out/lib $out/lib/darwin
 
-      ${lib.optionalString stdenv.targetPlatform.isx86_64 ''
-        # Copy libSystem's .o files for various low-level boot stuff.
-        cp -d ${getLib darwin.Libsystem}/lib/*.o $out/lib
-
-        # Resolv is actually a link to another package, so let's copy it properly
-        cp -L ${getLib darwin.Libsystem}/lib/libresolv.9.dylib $out/lib
-      ''}
-
-      cp -rL ${getDev darwin.Libsystem}/include $out
       chmod -R u+w $out/include
       cp -rL ${getDev libiconv}/include/* $out/include
       cp -rL ${getDev gnugrep.pcre2}/include/* $out/include
-      mv $out/include $out/include-Libsystem
 
       # Copy binutils.
       for i in as ld ar ranlib nm strip otool install_name_tool lipo codesign_allocate; do
@@ -163,7 +155,7 @@ stdenv.mkDerivation (finalAttrs: {
       cp ${getBin xz}/bin/xz $out/bin
       cp -d ${getLib bzip2}/lib/libbz2*.dylib $out/lib
       cp -d ${getLib gmpxx}/lib/libgmp*.dylib $out/lib
-      cp -d ${getLib xar}/lib/libxar*.dylib $out/lib
+      cp -d ${getLib xarMinimal}/lib/libxar*.dylib $out/lib
       cp -d ${getLib xz}/lib/liblzma*.dylib $out/lib
       cp -d ${getLib zlib}/lib/libz*.dylib $out/lib
 
@@ -185,17 +177,18 @@ stdenv.mkDerivation (finalAttrs: {
       cp -d ${getLib llvmPackages.llvm}/lib/libLLVM.dylib $out/lib
       cp -d ${getLib libffi}/lib/libffi*.dylib $out/lib
 
-      mkdir $out/include
       cp -rd ${getDev llvmPackages.libcxx}/include/c++ $out/include
 
-      # copy .tbd assembly utils
-      cp ${getBin darwin.rewrite-tbd}/bin/rewrite-tbd $out/bin
-      cp -d ${getLib libyaml}/lib/libyaml*.dylib $out/lib
+      # Copy tools needed to build the SDK
+      cp -d ${getBin jq}/bin/* $out/bin
+      cp -d ${getBin libtapi}/bin/* $out/bin
+
+      cp -d ${getLib jq}/lib/lib*.dylib $out/lib
+      cp -d ${getLib oniguruma}/lib/lib*.dylib $out/lib
+      cp -d ${getLib libtapi}/lib/libtapi*.dylib $out/lib
 
       # copy sigtool
       cp -d ${getBin darwin.sigtool}/bin/{codesign,sigtool} $out/bin
-
-      cp -d ${getLib darwin.libtapi}/lib/libtapi*.dylib $out/lib
 
       # tools needed to unpack bootstrap archive
       mkdir -p unpack/bin unpack/lib


### PR DESCRIPTION
- Drop libSystem. It’s no longer needed. The SDK can be downloaded and built with existing tools.
- Add jq and tapi. Adding these allows the stdenv bootstrap to stop special-casing stage 0.
- Update tests for updated ld64. It handles code-signing properly, so the signatures aren’t broken.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
