### PR TITLE
python3{11,12}Packages.uncompyle6: use `pyproject`, relax spark-parser dependency, remove nose dependency

### DIFF
--- a/pkgs/development/python-modules/uncompyle6/default.nix
+++ b/pkgs/development/python-modules/uncompyle6/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
+  setuptools,
   spark-parser,
   xdis,
   nose,
@@ -14,14 +15,16 @@
 buildPythonPackage rec {
   pname = "uncompyle6";
   version = "3.9.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-b3CYD/4IpksRS2hxgy/QLYbJkDX4l2qPH4Eh2tb8pCU=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     spark-parser
     xdis
   ];

--- a/pkgs/development/python-modules/uncompyle6/default.nix
+++ b/pkgs/development/python-modules/uncompyle6/default.nix
@@ -29,6 +29,8 @@ buildPythonPackage rec {
     xdis
   ];
 
+  pythonRelaxDeps = [ "spark-parser" ];
+
   nativeCheckInputs = [
     nose
     pytestCheckHook

--- a/pkgs/development/python-modules/uncompyle6/default.nix
+++ b/pkgs/development/python-modules/uncompyle6/default.nix
@@ -2,11 +2,9 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   setuptools,
   spark-parser,
   xdis,
-  nose,
   pytestCheckHook,
   hypothesis,
   six,
@@ -32,7 +30,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "spark-parser" ];
 
   nativeCheckInputs = [
-    nose
     pytestCheckHook
     hypothesis
     six
@@ -40,7 +37,7 @@ buildPythonPackage rec {
 
   # No tests are provided for versions past 3.8,
   # as the project only targets bytecode of versions <= 3.8
-  doCheck = pythonOlder "3.9";
+  doCheck = false;
 
   meta = {
     description = "A bytecode decompiler for Python versions 3.8 and below";


### PR DESCRIPTION
Upstream tests don’t use nose and we can’t run them anyway.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
