### PR TITLE
darwin.libiconv: update patch for static build; curl: don’t skip `passthru.tests.static` on `x86_64-darwin`

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/libiconv/patches/0001-Support-static-module-loading.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/libiconv/patches/0001-Support-static-module-loading.patch
@@ -1,17 +1,17 @@
-From a3e945c630180e9aa182603207238302e58fe8fe Mon Sep 17 00:00:00 2001
+From cf3bcbf4444d73cb3d1a9369c569338ae0fcb668 Mon Sep 17 00:00:00 2001
 From: Randy Eckenrode <randy@largeandhighquality.com>
 Date: Sat, 25 May 2024 19:03:58 -0400
 Subject: [PATCH 1/2] Support static module loading
 
 ---
- citrus/citrus_module.c | 21 ++++++++++++++++++---
- 1 file changed, 18 insertions(+), 3 deletions(-)
+ citrus/citrus_module.c | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
 
 diff --git a/citrus/citrus_module.c b/citrus/citrus_module.c
-index 5103d30..c22c9da 100644
+index 8ca4702..7667868 100644
 --- a/citrus/citrus_module.c
 +++ b/citrus/citrus_module.c
-@@ -324,22 +324,36 @@ out:
+@@ -324,16 +324,24 @@ out:
  	return (path[0] ? path : NULL);
  }
  
@@ -37,9 +37,10 @@ index 5103d30..c22c9da 100644
  	return (p);
  }
  
- int
- _citrus_load_module(_citrus_module_t *rhandle, const char *encname)
- {
+@@ -345,6 +353,12 @@ _citrus_load_module(_citrus_module_t *rhandle, const char *encname)
+ 	return (0);
+ #else
+ 
 +#if defined(ENABLE_STATIC)
 +	if (is_known_encoding(encname, strnlen(encname, MAX_WORD_LENGTH)) > MAX_HASH_VALUE) {
 +		return (EINVAL);
@@ -49,24 +50,24 @@ index 5103d30..c22c9da 100644
  	const char *p;
  	char path[PATH_MAX];
  	void *handle;
-@@ -368,14 +382,15 @@ _citrus_load_module(_citrus_module_t *rhandle, const char *encname)
+@@ -373,7 +387,7 @@ _citrus_load_module(_citrus_module_t *rhandle, const char *encname)
  	}
  
  	*rhandle = (_citrus_module_t)handle;
 -
 +#endif
  	return (0);
+ #endif
  }
- 
- void
- _citrus_unload_module(_citrus_module_t handle)
- {
--
+@@ -390,6 +404,8 @@ _citrus_unload_module(_citrus_module_t handle)
+ 	assert(handle != RTLD_SELF);
+ #endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
+ #endif /* __APPLE__ */
 +#if !defined(ENABLE_STATIC)
  	if (handle)
  		dlclose((void *)handle);
 +#endif
  }
 -- 
-2.44.1
+2.46.0
 

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -219,7 +219,6 @@ stdenv.mkDerivation (finalAttrs: {
       # nginx-http3 = useThisCurl nixosTests.nginx-http3;
       nginx-http3 = nixosTests.nginx-http3;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    } // lib.optionalAttrs (stdenv.hostPlatform.system != "x86_64-darwin") {
       static = pkgsStatic.curl;
     } // lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
       fetchpatch = tests.fetchpatch.simple.override { fetchpatch = (fetchpatch.override { fetchurl = useThisCurl fetchurl; }) // { version = 1; }; };


### PR DESCRIPTION
This works since <https://github.com/NixOS/nixpkgs/pull/346950>.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
