### PR TITLE
OWNERS: Only request @infinisil for OWNERS changes

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -19,7 +19,7 @@
 /.github/workflows/nixpkgs-vet.yml @infinisil @philiptaron
 /.github/workflows/codeowners-v2.yml @infinisil
 /ci @infinisil @philiptaron @NixOS/Security
-/ci/OWNERS @infinisil
+/ci/OWNERS @infinisil @philiptaron
 
 # Development support
 /.editorconfig @Mic92 @zowoq

--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -18,8 +18,8 @@
 /.github/workflows/check-nix-format.yml @infinisil
 /.github/workflows/nixpkgs-vet.yml @infinisil @philiptaron
 /.github/workflows/codeowners-v2.yml @infinisil
-/ci/OWNERS @infinisil
 /ci @infinisil @philiptaron @NixOS/Security
+/ci/OWNERS @infinisil
 
 # Development support
 /.editorconfig @Mic92 @zowoq


### PR DESCRIPTION
This was the original intention, but lower matching entries take precedence, so it never worked!

Note that before the move to ci/OWNERS, .github/CODEOWNERS had no owner itself, and I might also remove myself again if it turns out to be too much noise.

Ping @mweinelt 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
