### PR TITLE
qt6.qtbase: build with `apple-sdk_15`, propagate `apple-sdk_12`

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -10,7 +10,9 @@
 , gst_all_1
 , libglvnd
 , darwin
-, overrideSDK
+, apple-sdk_15
+, apple-sdk_12
+, darwinMinVersionHook
 , buildPackages
 , python3
 , config
@@ -28,15 +30,27 @@ let
         inherit (self) qtModule;
         inherit srcs python3 stdenv;
       });
+
+      # Per <https://doc.qt.io/qt-6/macos.html#supported-versions>.
+      # This should reflect the lowest “Target Platform” and the
+      # highest “Build Environment”.
+      apple-sdk_qt = apple-sdk_15;
+      darwinDeploymentTargetDeps = [
+        apple-sdk_12
+        (darwinMinVersionHook "12.0")
+      ];
     in
     {
 
       inherit callPackage srcs;
 
-      qtModule = callPackage ./qtModule.nix { };
+      qtModule = callPackage ./qtModule.nix {
+        inherit apple-sdk_qt;
+      };
 
       qtbase = callPackage ./modules/qtbase.nix {
         withGtk3 = !stdenv.hostPlatform.isMinGW;
+        inherit apple-sdk_qt darwinDeploymentTargetDeps;
         inherit (srcs.qtbase) src version;
         patches = [
           ./patches/0001-qtbase-qmake-always-use-libname-instead-of-absolute-.patch

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -67,9 +67,8 @@
 , unixODBCDrivers
   # darwin
 , moveBuildTree
-, apple-sdk_11
-, apple-sdk_14
-, darwinMinVersionHook
+, apple-sdk_qt
+, darwinDeploymentTargetDeps
 , xcbuild
   # mingw
 , pkgsBuildBuild
@@ -156,10 +155,8 @@ stdenv.mkDerivation rec {
     xorg.libXtst
     xorg.xcbutilcursor
     libepoxy
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    apple-sdk_14
-    (darwinMinVersionHook "11.0")
-  ] ++ lib.optionals libGLSupported [
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin darwinDeploymentTargetDeps
+  ++ lib.optionals libGLSupported [
     libGL
   ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
     vulkan-headers
@@ -171,8 +168,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform libinput) [
     libinput
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    apple-sdk_11
-    (darwinMinVersionHook "11.0")
+    apple-sdk_qt
   ]
   ++ lib.optional withGtk3 gtk3
   ++ lib.optional (libmysqlclient != null && !stdenv.hostPlatform.isMinGW) libmysqlclient

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, apple-sdk_14
+, apple-sdk_qt
 , cmake
 , ninja
 , perl
@@ -22,8 +22,7 @@ stdenv.mkDerivation (args // {
 
   buildInputs =
     args.buildInputs or [ ]
-    # Per https://doc.qt.io/qt-6/macos.html#supported-versions
-    ++ lib.optionals stdenv.isDarwin [ apple-sdk_14 ];
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_qt ];
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cmake ninja perl ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ moveBuildTree ];
   propagatedBuildInputs =


### PR DESCRIPTION
As of Qt 6.8, the macOS 15 SDK is supported for building, and support for targeting macOS 11 has been dropped. (Another good reason for supporting only 3 to 4 macOS releases.)

Previously the build and target SDKs were swapped, probably because the dependency lists are in a confusing order. Move them into a central place to reduce duplication and keep macOS platform support in one prominent location.

Fixes: 830b9fe572fa374c4b7c31aac506003f1d8dfd5c

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
