### PR TITLE
rust-cbindgen: fix test failures due to env vars

### DIFF
--- a/pkgs/development/tools/rust/cbindgen/1010-fix-test-failures-due-to-CARGO_BUILD_TARGET.patch
+++ b/pkgs/development/tools/rust/cbindgen/1010-fix-test-failures-due-to-CARGO_BUILD_TARGET.patch
@@ -1,0 +1,56 @@
+diff --git a/tests/profile.rs b/tests/profile.rs
+index 69433a2..596829d 100644
+--- a/tests/profile.rs
++++ b/tests/profile.rs
+@@ -1,6 +1,7 @@
+ use cbindgen::*;
+ 
+ use serial_test::serial;
++use std::env;
+ use std::path::{Path, PathBuf};
+ use std::process::Command;
+ 
+@@ -17,7 +18,12 @@ fn build_using_lib(config: fn(Builder) -> Builder) -> tempfile::TempDir {
+         .tempdir()
+         .expect("Creating tmp dir failed");
+ 
+-    std::env::set_var("CARGO_EXPAND_TARGET_DIR", tmp_dir.path());
++    unsafe {
++        env::set_var("CARGO_EXPAND_TARGET_DIR", tmp_dir.path());
++        env::remove_var("CARGO_BUILD_TARGET");
++        // ^ avoid unexpected change of layout of the target directory;
++        // ... see: https://doc.rust-lang.org/cargo/guide/build-cache.html
++    }
+     let builder = Builder::new()
+         .with_config(Config::from_file(expand_dep_test_dir.join("cbindgen.toml")).unwrap())
+         .with_crate(expand_dep_test_dir);
+@@ -45,6 +51,9 @@ fn build_using_bin(extra_args: &[&str]) -> tempfile::TempDir {
+     Command::new(cbindgen_path)
+         .current_dir(expand_dep_test_dir)
+         .env("CARGO_EXPAND_TARGET_DIR", tmp_dir.path())
++        .env_remove("CARGO_BUILD_TARGET")
++        // ^ avoid unexpected change of layout of the target directory;
++        // ... see: https://doc.rust-lang.org/cargo/guide/build-cache.html
+         .args(extra_args)
+         .output()
+         .expect("build should succeed");
+@@ -87,6 +96,19 @@ fn bin_default_uses_debug_build() {
+     assert_eq!(get_contents_of_dir(target_dir.path()), &["debug"]);
+ }
+ 
++#[test]
++fn bin_ignore_cargo_build_target_in_tests() {
++    unsafe {
++        env::set_var("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu");
++    }
++    assert_eq!(
++        env::var("CARGO_BUILD_TARGET"),
++        Ok("x86_64-unknown-linux-gnu".into())
++    );
++    // ^ this env var should be ignored:
++    bin_default_uses_debug_build();
++}
++
+ #[test]
+ fn bin_explicit_debug_build() {
+     let target_dir = build_using_bin(&["--profile", "debug"]);

--- a/pkgs/development/tools/rust/cbindgen/default.nix
+++ b/pkgs/development/tools/rust/cbindgen/default.nix
@@ -23,6 +23,12 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-XTGHHD5Qw3mr+lkPKOXyqb0K3sEENW8Sf0n9mtrFFXI=";
   };
 
+  patches = [
+    # open PR: https://github.com/mozilla/cbindgen/pull/1010
+    # see also: https://github.com/NixOS/nixpkgs/pull/298108
+    ./1010-fix-test-failures-due-to-CARGO_BUILD_TARGET.patch
+  ];
+
   cargoHash = "sha256-l4FgwXdibek4BAnqjWd1rLxpEwuMNjYgvo6X3SS3fRo=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
@@ -45,10 +51,6 @@ rustPlatform.buildRustPackage rec {
     # https://github.com/eqrion/cbindgen/issues/628
     "--skip test_body"
   ];
-
-  # tests currently fail, waiting on upstream
-  # Related: https://github.com/NixOS/nixpkgs/pull/348031
-  doCheck = false;
 
   passthru.tests = {
     inherit


### PR DESCRIPTION
... specifically, it's the `CARGO_BUILD_TARGET` env var introduced in commit: 683f97e3781356b3e8251d0ab5e5906c4cdd4ded. See: https://github.com/NixOS/nixpkgs/pull/298108.

Targeted `master` but tested against a cherry-picked 683f97e3781356b3e8251d0ab5e5906c4cdd4ded (which is currently `staging`).

Upstream PR is linked in the code; not linking here to avoid excessive notifications to upstream.
cc @trofi for testing :rocket: 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
