### PR TITLE
nixos/bees: sync service configuration with upstream

### DIFF
--- a/nixos/modules/services/misc/bees.nix
+++ b/nixos/modules/services/misc/bees.nix
@@ -97,42 +97,29 @@ in
       '';
     };
   };
-  config = {
+  config = lib.mkIf (cfg.filesystems != { }) {
+    systemd.packages = [ pkgs.bees ];
     systemd.services = lib.mapAttrs' (
       name: fs:
       lib.nameValuePair "beesd@${name}" {
-        description = "Block-level BTRFS deduplication for %i";
-        after = [ "sysinit.target" ];
-
-        serviceConfig =
-          let
-            configOpts = [
-              fs.spec
-              "verbosity=${toString fs.verbosity}"
-              "idxSizeMB=${toString fs.hashTableSizeMB}"
-              "workDir=${fs.workDir}"
+        overrideStrategy = "asDropin";
+        serviceConfig = {
+          ExecStart =
+            let
+              configOpts = [
+                fs.spec
+                "verbosity=${toString fs.verbosity}"
+                "idxSizeMB=${toString fs.hashTableSizeMB}"
+                "workDir=${fs.workDir}"
+              ];
+              configOptsStr = lib.escapeShellArgs configOpts;
+            in
+            [
+              ""
+              "${pkgs.bees}/bin/bees-service-wrapper run ${configOptsStr} -- --no-timestamps ${lib.escapeShellArgs fs.extraOptions}"
             ];
-            configOptsStr = lib.escapeShellArgs configOpts;
-          in
-          {
-            # Values from https://github.com/Zygo/bees/blob/v0.6.5/scripts/beesd@.service.in
-            ExecStart = "${pkgs.bees}/bin/bees-service-wrapper run ${configOptsStr} -- --no-timestamps ${lib.escapeShellArgs fs.extraOptions}";
-            ExecStopPost = "${pkgs.bees}/bin/bees-service-wrapper cleanup ${configOptsStr}";
-            CPUAccounting = true;
-            CPUSchedulingPolicy = "batch";
-            CPUWeight = 12;
-            IOSchedulingClass = "idle";
-            IOSchedulingPriority = 7;
-            IOWeight = 10;
-            KillMode = "control-group";
-            KillSignal = "SIGTERM";
-            MemoryAccounting = true;
-            Nice = 19;
-            Restart = "on-abnormal";
-            StartupCPUWeight = 25;
-            StartupIOWeight = 25;
-            SyslogIdentifier = "beesd"; # would otherwise be "bees-service-wrapper"
-          };
+          SyslogIdentifier = "beesd"; # would otherwise be "bees-service-wrapper"
+        };
         unitConfig.RequiresMountsFor = lib.mkIf (lib.hasPrefix "/" fs.spec) fs.spec;
         wantedBy = [ "multi-user.target" ];
       }


### PR DESCRIPTION
Several hardening options have been added to the upstream service file since it has last been synchronised. Perhaps most importantly, its mount is not globally visible any more, so that it can't be used for bypassing nosuid and the like.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
