### PR TITLE
warp-terminal: 0.2024.10.08.08.02.stable_01 -> 0.2024.10.08.08.02.stable_02

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-Awr2NvXsWaEeJpdCA94q7kxQ04IDpwNxnm7GxB4J09w=",
-    "version": "0.2024.10.08.08.02.stable_01"
+    "hash": "sha256-LPH9JbOXOBjT4vMWNGMvQYDVnTE6p2tFTlOe8HOFsk0=",
+    "version": "0.2024.10.08.08.02.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-fNY+wXqlqUSdRVptDNuk1ouddSlIKQrBFPIij9Qa0jM=",
-    "version": "0.2024.10.08.08.02.stable_01"
+    "hash": "sha256-jwbwRgQ7WR04zCki7PQuuMZD7v2tFl3Gm1olZ28FAp8=",
+    "version": "0.2024.10.08.08.02.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-EdQjc8uXG4cpkgnIYRaBXLeuYqhbN7rs4bU+L/Cc7XA=",
-    "version": "0.2024.10.08.08.02.stable_01"
+    "hash": "sha256-Ticn8OMYHWQT88WQSpgcT/kBVnHyoDHNhTk0m4T45bQ=",
+    "version": "0.2024.10.08.08.02.stable_02"
   }
 }


### PR DESCRIPTION
Changelog: https://docs.warp.dev/getting-started/changelog#id-2024.10.08-v0.2024.10.08.08.02

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
