### PR TITLE
release-unfree-redistributable: init

### DIFF
--- a/pkgs/top-level/release-unfree-redistributable.nix
+++ b/pkgs/top-level/release-unfree-redistributable.nix
@@ -1,0 +1,122 @@
+/*
+  Nixpkgs unfree+redistributable packages.
+
+  NOTE: This file is used by the sister nix-community project.
+
+  The official Hydra instance only builds and provides binary caches for free
+  packages (as in OSI-approved).
+
+  Some unfree packages such as MongoDB, ZeroTier, ... take a while to be
+  built. While their license is not free, they allow redistribution of
+  build artefacts.
+
+  The sister project nix-community will build and distribute those packages
+  for a subset of the channels to <https://nix-community.cachix.org>.
+
+  See also:
+
+  * <https://hydra.nix-community.org/jobset/nixpkgs/unfree-redistributable>
+  * <https://github.com/nix-community/infra/pull/1406>
+
+  Test for example like this:
+
+    $ hydra-eval-jobs pkgs/top-level/release-unfree-redistributable.nix -I .
+*/
+
+{
+  # The platforms for which we build Nixpkgs.
+  supportedSystems ? [
+    "x86_64-linux"
+    "aarch64-linux"
+  ],
+  # Attributes passed to nixpkgs.
+  nixpkgsArgs ? {
+    config = {
+      allowAliases = false;
+      allowUnfree = true;
+      cudaSupport = true;
+      inHydra = true;
+    };
+  },
+  # We only build the full package set on infrequently releasing channels.
+  full ? false,
+}:
+
+let
+  release-lib = import ./release-lib.nix {
+    inherit supportedSystems nixpkgsArgs;
+  };
+
+  inherit (release-lib)
+    lib
+    mapTestOn
+    pkgs
+    ;
+
+  # similar to release-lib.packagePlatforms, but also includes some condition for which package to pick
+  packagesWith =
+    prefix: cond:
+    lib.mapAttrs (
+      name: value:
+      let
+        attrPath = if prefix == "" then name else "${prefix}.${name}";
+        res = builtins.tryEval (
+          if lib.isDerivation value then
+            lib.optionals (cond attrPath value) (
+              # logic copied from release-lib packagePlatforms
+              value.meta.hydraPlatforms
+                or (lib.subtractLists (value.meta.badPlatforms or [ ]) (value.meta.platforms or [ "x86_64-linux" ]))
+            )
+          else if
+            value.recurseForDerivations or false
+            || value.recurseForRelease or false
+            || value.__recurseIntoDerivationForReleaseJobs or false
+          then
+            # Recurse
+            packagesWith attrPath cond value
+          else
+            [ ]
+        );
+      in
+      lib.optionals res.success res.value
+    );
+
+  # Unfree is any license not OSI-approved.
+  isUnfree = pkg: lib.lists.any (l: !(l.free or true)) (lib.lists.toList (pkg.meta.license or [ ]));
+
+  # Whenever the license allows re-distribution of the binaries
+  isRedistributable =
+    pkg: lib.lists.any (l: l.redistributable or false) (lib.lists.toList (pkg.meta.license or [ ]));
+
+  isSource =
+    pkg: !lib.lists.any (x: !(x.isSource)) (lib.lists.toList (pkg.meta.sourceProvenance or [ ]));
+
+  isNotLinuxKernel =
+    attrPath: !(lib.hasPrefix "linuxKernel" attrPath || lib.hasPrefix "linuxPackages" attrPath);
+
+  # This is handled by release-cuda.nix
+  isNotCudaPackage = attrPath: !(lib.hasPrefix "cuda" attrPath);
+
+  canSubstituteSrc =
+    pkg:
+    # requireFile don't allow using substituters and are therefor skipped
+    pkg.src.allowSubstitutes or true;
+
+  cond =
+    attrPath: pkg:
+    (isUnfree pkg)
+    && (isRedistributable pkg)
+    && (isSource pkg)
+    && (canSubstituteSrc pkg)
+    && (
+      full
+      ||
+        # We only build these heavy packages on releases
+        ((isNotCudaPackage attrPath) && (isNotLinuxKernel attrPath))
+    );
+
+  packages = packagesWith "" cond pkgs;
+
+  jobs = mapTestOn packages;
+in
+jobs


### PR DESCRIPTION
## Motivation

NixOS's current policy is to only build free (as in OSI-approved licenses) packages. This leaves a whole set of packages that are part of nixpkgs, and whose code doesn't get exercised. We don't know if those packages are broken, and the users each have to compile it by themselves instead of benefiting for the binary cache. The latter is particularly annoying for large packages such as Linux kernel modules and MongoDB.

My observation in the field is that `nixpkgs.config.allowUnfree` is causing all sorts of frictions. It prevents users from using `nix run` on all the packages, leads users to create more instances of nixpkgs with that specialization. This leads me to believe that we should either allow those packages to be built by Hydra, or move them to another "unfree" repository.

In the unfree package category, we have two sub-categories: redistributable and non-redistributable. It's an attribute of the license that allows re-distributing the resulting binaries or not.

In this release file, we only build and publish the unfree+redistributable packages.

At the moment, this is built by the sister nix-community project. See <https://github.com/nix-community/infra/pull/1406> where we started building those packages. The build results then get pushed to <https://nix-community.cachix.org> (which you're welcome to use).

Ideally over time, a decision will be made on updating the NixOS policy.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
