### PR TITLE
depotdownloader: 2.5.0 -> 2.7.2

### DIFF
--- a/pkgs/tools/misc/depotdownloader/default.nix
+++ b/pkgs/tools/misc/depotdownloader/default.nix
@@ -1,21 +1,24 @@
 { lib
 , buildDotnetModule
 , fetchFromGitHub
+, dotnetCorePackages
 }:
 
 buildDotnetModule rec {
   pname = "depotdownloader";
-  version = "2.5.0";
+  version = "2.7.2";
 
   src = fetchFromGitHub {
     owner = "SteamRE";
     repo = "DepotDownloader";
     rev = "DepotDownloader_${version}";
-    sha256 = "Kgi0u+H5BIAhrjk9e+8H1h0p5Edm3+2twYBPY3JQGps=";
+    sha256 = "c8hgeFTgOjRTjaOSrUazko74GdTW5p9i7+YJIqR28hw=";
   };
 
   projectFile = "DepotDownloader.sln";
   nugetDeps = ./deps.nix;
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
+  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/tools/misc/depotdownloader/deps.nix
+++ b/pkgs/tools/misc/depotdownloader/deps.nix
@@ -2,14 +2,18 @@
 # Please dont edit it manually, your changes might get overwritten!
 
 { fetchNuGet }: [
-  (fetchNuGet { pname = "Microsoft.NETCore.Platforms"; version = "5.0.0"; sha256 = "0mwpwdflidzgzfx2dlpkvvnkgkr2ayaf0s80737h4wa35gaj11rc"; })
-  (fetchNuGet { pname = "Microsoft.Win32.Registry"; version = "5.0.0"; sha256 = "102hvhq2gmlcbq8y2cb7hdr2dnmjzfp2k3asr1ycwrfacwyaak7n"; })
-  (fetchNuGet { pname = "protobuf-net"; version = "3.2.16"; sha256 = "0pwlqlq2p8my2sr8b0cvdav5cm8wpwf3s4gy7s1ba701ac2zyb9y"; })
-  (fetchNuGet { pname = "protobuf-net.Core"; version = "3.2.16"; sha256 = "00znhikq7valr3jaxg66cwli9hf75wkmmpf6rf8p790hf8lxq0c5"; })
-  (fetchNuGet { pname = "QRCoder"; version = "1.4.3"; sha256 = "1hmlqbdyq5n9bsmns5h0dwcxpd2jvqr9a2y6dyc9kbjmc8j1dpla"; })
-  (fetchNuGet { pname = "SteamKit2"; version = "2.5.0-beta.1"; sha256 = "0691285g4z12hv5kpv72l36h45086n14rw56x3dnixcvrjzg2q01"; })
-  (fetchNuGet { pname = "System.Collections.Immutable"; version = "7.0.0"; sha256 = "1n9122cy6v3qhsisc9lzwa1m1j62b8pi2678nsmnlyvfpk0zdagm"; })
-  (fetchNuGet { pname = "System.Runtime.CompilerServices.Unsafe"; version = "6.0.0"; sha256 = "0qm741kh4rh57wky16sq4m0v05fxmkjjr87krycf5vp9f0zbahbc"; })
-  (fetchNuGet { pname = "System.Security.AccessControl"; version = "5.0.0"; sha256 = "17n3lrrl6vahkqmhlpn3w20afgz09n7i6rv0r3qypngwi7wqdr5r"; })
-  (fetchNuGet { pname = "System.Security.Principal.Windows"; version = "5.0.0"; sha256 = "1mpk7xj76lxgz97a5yg93wi8lj0l8p157a5d50mmjy3gbz1904q8"; })
+  (fetchNuGet { pname = "Microsoft.NETCore.Platforms"; version = "5.0.0"; hash = "sha256-LIcg1StDcQLPOABp4JRXIs837d7z0ia6+++3SF3jl1c="; })
+  (fetchNuGet { pname = "Microsoft.Win32.Registry"; version = "5.0.0"; hash = "sha256-9kylPGfKZc58yFqNKa77stomcoNnMeERXozWJzDcUIA="; })
+  (fetchNuGet { pname = "Microsoft.Windows.CsWin32"; version = "0.3.106"; hash = "sha256-S1uQa684taPb6uh69784ebVpXoirMoX+pxBRA+Rrzlg="; })
+  (fetchNuGet { pname = "Microsoft.Windows.SDK.Win32Docs"; version = "0.1.42-alpha"; hash = "sha256-6DvzmNzrGVfWmNJNqooj+Ya+7bAQlyeg7pmyKaUlIws="; })
+  (fetchNuGet { pname = "Microsoft.Windows.SDK.Win32Metadata"; version = "60.0.34-preview"; hash = "sha256-KdRe73sXipzMvm2BLmwwBZGh+l9isZDC9l8WFyUR1zM="; })
+  (fetchNuGet { pname = "Microsoft.Windows.WDK.Win32Metadata"; version = "0.11.4-experimental"; hash = "sha256-b3oKUKbr+3Udfl7RWzUY9BR/XWNsN+VmEkBxk6KiFo0="; })
+  (fetchNuGet { pname = "protobuf-net"; version = "3.2.30"; hash = "sha256-keRy5OWT+/tlZt3D7x+9PEdjTvEJcZdYsf/i1ZBtciE="; })
+  (fetchNuGet { pname = "protobuf-net.Core"; version = "3.2.30"; hash = "sha256-GMpJNecoBfrV2VgpYOhcZnKZaLFDObNLcX2LBTThrwY="; })
+  (fetchNuGet { pname = "QRCoder"; version = "1.6.0"; hash = "sha256-2Ev/6d7PH6K4dVYQQHlZ+ZggkCnDtrlaGygs65mDo28="; })
+  (fetchNuGet { pname = "SteamKit2"; version = "3.0.0-beta.3"; hash = "sha256-G3Apy5g0TT273Ake6/4DnrJGY4lWrTbyHDJMntiSuzE="; })
+  (fetchNuGet { pname = "System.Collections.Immutable"; version = "7.0.0"; hash = "sha256-9an2wbxue2qrtugYES9awshQg+KfJqajhnhs45kQIdk="; })
+  (fetchNuGet { pname = "System.IO.Hashing"; version = "8.0.0"; hash = "sha256-szOGt0TNBo6dEdC3gf6H+e9YW3Nw0woa6UnCGGGK5cE="; })
+  (fetchNuGet { pname = "System.Security.AccessControl"; version = "5.0.0"; hash = "sha256-ueSG+Yn82evxyGBnE49N4D+ngODDXgornlBtQ3Omw54="; })
+  (fetchNuGet { pname = "System.Security.Principal.Windows"; version = "5.0.0"; hash = "sha256-CBOQwl9veFkrKK2oU8JFFEiKIh/p+aJO+q9Tc2Q/89Y="; })
 ]


### PR DESCRIPTION
* Updated SteamKit (allows using websocket servers to fix connections)
* Updated to .NET 8.0

see full changelog [here](https://github.com/SteamRE/DepotDownloader/compare/DepotDownloader_2.5.0...DepotDownloader_2.7.2) @babbaj 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
