### PR TITLE
nixos/tests/docker-tools-overlay: fix test

### DIFF
--- a/nixos/tests/docker-tools-overlay.nix
+++ b/nixos/tests/docker-tools-overlay.nix
@@ -12,7 +12,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
       { ... }:
       {
         virtualisation.docker.enable = true;
-        virtualisation.docker.storageDriver = "overlay";  # defaults to overlay2
+        virtualisation.docker.storageDriver = "overlay2";
       };
   };
 


### PR DESCRIPTION
- change `virtualisation.docker.storageDriver` from deprecated `overlay` to `overlay2`. Using `overlay` dockerd fails to start with error: `ERROR: the overlay storage-driver has been deprecated and removed`
https://docs.docker.com/engine/deprecated/#legacy-overlay-storage-driver

---
Fixes build of `nixosTests.docker-tools-overlay` (fails since `2023-11-14`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.docker-tools-overlay.x86_64-linux
https://hydra.nixos.org/build/274675056

Log:
```text
docker # [   27.585476] dockerd[970]: failed to start daemon: error initializing graphdriver: [graphdriver] ERROR: the overlay storage-driver has been deprecated and removed; visit https://docs.docker.com/go/storage-driver/ for more information: overlay
docker # [   27.598244] systemd[1]: docker.service: Main process exited, code=exited, status=1/FAILURE
docker # [   27.600730] systemd[1]: docker.service: Failed with result 'exit-code'.
docker # [   27.604406] systemd[1]: Failed to start Docker Application Container Engine.
docker # [   29.779517] systemd[1]: docker.service: Scheduled restart job, restart counter is at 3.
docker # [   29.783500] systemd[1]: docker.service: Start request repeated too quickly.
docker # [   29.787914] systemd[1]: docker.service: Failed with result 'exit-code'.
docker # [   29.793353] systemd[1]: Failed to start Docker Application Container Engine.
docker # [   29.797414] systemd[1]: docker.socket: Failed with result 'service-start-limit-hit'.
docker # Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
docker: output: 
cleanup
kill machine (pid 8)
```

First failed after https://github.com/NixOS/nixpkgs/pull/264461 (docker: move default from 20.10 to 24) was merged
According to https://docs.docker.com/engine/deprecated/#legacy-overlay-storage-driver that was the version in which `overlay` was removed:
> Legacy overlay storage driver
Deprecated in Release: v18.09 Removed in Release: v24.0

---

Listed test maintainers:
@lnl7
@roberth

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
