### PR TITLE
python312Packages.pysnmp: 6.2.5 -> 7.1.5

### DIFF
--- a/pkgs/development/python-modules/pysnmp/default.nix
+++ b/pkgs/development/python-modules/pysnmp/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "pysnmp";
-  version = "6.2.6";
+  version = "7.1.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lextudio";
     repo = "pysnmp";
     rev = "refs/tags/v${version}";
-    hash = "sha256-+FfXvsfn8XzliaGUKZlzqbozoo6vDxUkgC87JOoVasY=";
+    hash = "sha256-6KrJfYorC0NDIeoYbtaf5NK+v1YaCdckB1Jjm8BKPdQ=";
   };
 
   pythonRemoveDeps = [ "pytest-cov" ];
@@ -54,7 +54,15 @@ buildPythonPackage rec {
     "test_v1_get"
     "test_v1_next"
     "test_v1_set"
+    #  pysnmp.error.PySnmpError: Bad IPv4/UDP transport address demo.pysnmp.com@161: [Errno -3] Temporary failure in name resolution
     "test_v2c_bulk"
+    "test_v2c_get_table_bulk"
+    "test_v2c_get_table_bulk_0_7"
+    "test_v2c_get_table_bulk_0_8"
+    "test_v2c_get_table_bulk_0_31"
+    "test_v2c_get_table_bulk_0_60"
+    "test_v2c_get_table_bulk_0_5_subtree"
+    "test_v2c_get_table_bulk_0_6_subtree"
     # pysnmp.smi.error.MibNotFoundError
     "test_send_v3_trap_notification"
     "test_addAsn1MibSource"

--- a/pkgs/development/python-modules/pysnmpcrypto/default.nix
+++ b/pkgs/development/python-modules/pysnmpcrypto/default.nix
@@ -1,42 +1,30 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-
-  # build-system
-  setuptools,
-
-  # dependencies
   cryptography,
-  pycryptodomex,
-
-  # tests
+  fetchFromGitHub,
+  poetry-core,
   pytestCheckHook,
+  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "pysnmpcrypto";
-  version = "0.0.4";
+  version = "0.1.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-tjX7Ox7GY3uaADP1BQYhThbrhFdLHSWrAnu95MqlUSk=";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "lextudio";
+    repo = "pysnmpcrypto";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-gNRD8mSWVVLXwJjb3nT7IKnjTdwTutFDnQybgZTY2b0=";
   };
 
-  postPatch = ''
-    # ValueError: invalid literal for int() with base 10: 'post0' in File "<string>", line 104, in <listcomp>
-    substituteInPlace setup.py --replace \
-      "observed_version = [int(x) for x in setuptools.__version__.split('.')]" \
-      "observed_version = [36, 2, 0]"
-  '';
+  build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = [
-    cryptography
-    pycryptodomex
-  ];
+  dependencies = [ cryptography ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -44,8 +32,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Strong crypto support for Python SNMP library";
-    homepage = "https://github.com/etingof/pysnmpcrypto";
-    changelog = "https://github.com/etingof/pysnmpcrypto/blob/${version}/CHANGES.txt";
+    homepage = "https://github.com/lextudio/pysnmpcrypto";
+    changelog = "https://github.com/lextudio/pysnmpcrypto/blob/v${version}/CHANGES.txt";
     license = licenses.bsd2;
     maintainers = [ ];
   };


### PR DESCRIPTION
https://github.com/lextudio/pysnmp/blob/refs/tags/v7.1.5/CHANGES.rst

waiting for python3.pkgs.brother compat


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
