### PR TITLE
nixos/swraid: enable it by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -268,6 +268,9 @@
   Processes also now run as a dynamically allocated user by default instead of
   root.
 
+- Software raid is enabled by default now, and is controlled by `boot.swraid.enable`.
+  This was previously disabled in 23.11.
+
 - The `mautrix-signal` module was adapted to incorporate the configuration rearrangement that resulted from the update to the mautrix bridgev2 architecture. Pre-0.7.0 configurations should continue to work.
   In case you want to update your configuration make sure to check the NixOS manual.
 

--- a/nixos/modules/tasks/swraid.nix
+++ b/nixos/modules/tasks/swraid.nix
@@ -4,8 +4,6 @@
 
   mdadm_conf = config.environment.etc."mdadm.conf";
 
-  enable_implicitly_for_old_state_versions = lib.versionOlder config.system.stateVersion "23.11";
-
   minimum_config_is_set = config_text:
     (builtins.match ".*(MAILADDR|PROGRAM).*" mdadm_conf.text) != null;
 
@@ -31,7 +29,7 @@ in {
         should detect it correctly in the standard installation
         procedure.
       '';
-      default = enable_implicitly_for_old_state_versions;
+      default = true;
       defaultText = "`true` if stateVersion is older than 23.11";
     };
 
@@ -43,8 +41,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    warnings = lib.mkIf
-        ( !enable_implicitly_for_old_state_versions && !minimum_config_is_set mdadm_conf)
+    warnings = lib.mkIf (!minimum_config_is_set mdadm_conf)
         [ "mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash." ];
 
     environment.systemPackages = [ pkgs.mdadm ];


### PR DESCRIPTION
It is detected automatically now according to https://github.com/NixOS/nixpkgs/pull/343760#issuecomment-2366875162, so enable it by default


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
