### PR TITLE
cosmic-wallpapers: init at 0-unstable-2024-09-27

### DIFF
--- a/pkgs/by-name/co/cosmic-wallpapers/package.nix
+++ b/pkgs/by-name/co/cosmic-wallpapers/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchpatch,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "cosmic-wallpapers";
+  version = "1.0.0-alpha.2";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "cosmic-wallpapers";
+    rev = "epoch-${finalAttrs.version}";
+    forceFetchGit = true;
+    fetchLFS = true;
+    hash = "sha256-9abkb9dECE7qVq547DkpIUvaYLXLGfkRlTgLCbQtSPw=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/pop-os/cosmic-wallpapers/pull/2/commits/4d17ebe69335f8ffa80fd1c48baa7f3d3efa4dbe.patch";
+      hash = "sha256-4QRtX5dbN6C/ZKU3pvV7mTT7EDrMWvRCFB4004RMylM=";
+    })
+  ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "epoch-(.*)"
+    ];
+  };
+
+  meta = {
+    description = "Wallpapers for the COSMIC Desktop Environment";
+    homepage = "https://system76.com/cosmic";
+    license = with lib.licenses; [
+      unfree # https://github.com/pop-os/cosmic-wallpapers/issues/1 https://github.com/pop-os/cosmic-wallpapers/issues/3 https://github.com/pop-os/cosmic-wallpapers/issues/4
+      cc-by-40 # https://www.esa.int/ESA_Multimedia/Images/2017/06/A_stormy_stellar_nursery (A_stormy_stellar_nursery_esa_379309.jpg)
+      publicDomain # https://earthobservatory.nasa.gov/image-use-policy (otherworldly_earth_nasa_ISS064-E-29444.jpg, phytoplankton_bloom_nasa_oli2_20240121.jpg); https://hubblesite.org/copyright (orion_nebula_nasa_heic0601a.jpg); https://webbtelescope.org/copyright (tarantula_nebula_nasa_PIA23646.jpg)
+    ];
+    maintainers = with lib.maintainers; [ pandapip1 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Copied from https://github.com/lilyinstarlight/nixos-cosmic

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
