### PR TITLE
zsh-abbr: adding completions + removing redudant bin directory

### DIFF
--- a/pkgs/shells/zsh/zsh-abbr/default.nix
+++ b/pkgs/shells/zsh/zsh-abbr/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  installShellFiles,
 }:
 stdenv.mkDerivation rec {
   pname = "zsh-abbr";
@@ -15,12 +16,18 @@ stdenv.mkDerivation rec {
   };
 
   strictDeps = true;
+  nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
-    install -D zsh-abbr.zsh $out/share/zsh/${pname}/abbr.plugin.zsh
-    # Needed so that `man` can find the manpage, since it looks via PATH
-    mkdir -p $out/bin
-    mv man $out/share/man
+    runHook preInstall
+
+    install zsh-abbr.plugin.zsh zsh-abbr.zsh -Dt $out/share/zsh/zsh-abbr/
+    install completions/_abbr -Dt $out/share/zsh/zsh-abbr/completions/
+
+    # Required for `man` to find the manpage of abbr, since it looks via PATH
+    installManPage man/man1/*
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

1. Renamed the installed plugin to `zsh-abbr.plugin.zsh` because most plugins share that structure and automating the installation process would be kinder if we omit this exception.
2. Install `completions/_abbr`, which allows completions for the `abbr` command in zsh. Only benefits people who are not creating their abbreviation file through nix.
3. Rewrite comment a little. (unnecessary but I think it is better written this way? (subjective I know))
4. Remove the `$out/bin` because it only contains the changelog file. Not necessary for using the package.

Also, it should resolve #348110.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
