### PR TITLE
maintainers/team-list: establish the Darwin team

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -393,3 +393,8 @@ pkgs/by-name/lx/lxc*                    @adamcstephens
 /pkgs/by-name/in/installShellFiles/*     @Ericson2314
 /pkgs/test/install-shell-files/*         @Ericson2314
 /doc/hooks/installShellFiles.section.md  @Ericson2314
+
+# Darwin
+/pkgs/by-name/ap/apple-sdk                     @NixOS/darwin-core
+/pkgs/os-specific/darwin/apple-source-releases @NixOS/darwin-core
+/pkgs/stdenv/darwin                            @NixOS/darwin-core

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -198,8 +198,8 @@ with lib.maintainers;
       reckenrode
       toonn
     ];
-    githubTeams = [ "darwin-maintainers" ];
-    scope = "Maintain Darwin compatibility of packages and Darwin-only packages.";
+    githubTeams = [ "darwin-core" ];
+    scope = "Maintain core platform support and packages for macOS and other Apple platforms.";
     shortName = "Darwin";
     enableFeatureFreezePing = true;
   };

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -195,6 +195,7 @@ with lib.maintainers;
 
   darwin = {
     members = [
+      emily
       reckenrode
       toonn
     ];


### PR DESCRIPTION
macOS support in Nixpkgs goes back a long time; I’m not sure exactly when it was first added, but some degree of support was around in 2004, with a revival in 2009 with the addition of `x86_64-darwin` support.  Being able to build packages and development environments across platforms is a big value‐add for Nixpkgs and has gained us many users and contributors that we otherwise wouldn’t have had, but its path from fun experiment to officially‐supported platform used in production by many people has been a rocky one. People who have looked at PRs from years ago will recognize names like @copumpkin and @matthewbauer that put in tons of incredible work to establish the pure Darwin build environment that we’ve been using since, but they moved on to other things, and the platform suffered for a long time from a lack of active maintainers with the ability to keep up with changes in both Nixpkgs and macOS.

When the first Apple Silicon Macs were released, @thefloweringash went to great lengths to establish support in Nixpkgs for the new platform, finally adding the macOS 11 SDK and making a lot of tooling and improvements. For the past three years, thanks to @domenkozar and @toonn, we’ve been calling for people to join @NixOS/darwin-maintainers, which has made an immense difference to the state of macOS support in Nixpkgs thanks to helping out with porting derivations, testing packages, and fixing builds. However, the bedrock of platform support that work has built upon hasn’t fared so well – I’m sure everyone involved knows the pain of packages needing a newer SDK than we’ve had available, or having to tell people to clutter their derivations with baroque framework dependencies and `overrideSDK` noise, not to mention the pain of Rust packages that need a newer SDK or the state of ofborg Darwin builds.

That’s finally starting to change, and we’re now at a point where the core Nixpkgs Darwin infrastructure is seeing great renovations and improvements. @reckenrode’s long‐awaited [SDK rework] has [finally landed]; it adds the missing SDK versions, makes them much easier to use, gives us a build environment more like Xcode’s, and means we’ll never have to specify explicit framework dependency lists again. It will vastly simplify the experience of building packages for macOS, and far more things should just build out of the box. It’ll be available in time for 24.11 after the next `staging` cycle; documentation is being worked on, but take a look at <https://github.com/NixOS/nixpkgs/pull/346043#issuecomment-2395751368> and <https://github.com/NixOS/nixpkgs/pull/347216> for examples of what a difference it makes. We’re also going to [raise the minimum macOS version] for 25.05 and track closer to what Apple and other FOSS projects support in future, so `x86_64-darwin` will stop being such a problem. (And I plan to try and solve the Darwin ofborg problems soon.)

[SDK rework]: https://discourse.nixos.org/t/on-the-future-of-darwin-sdks-or-how-you-can-stop-worrying-and-put-the-sdk-in-build-inputs/50574
[finally landed]: https://github.com/NixOS/nixpkgs/pull/346043
[raise the minimum macOS version]: https://github.com/NixOS/nixpkgs/pull/338695

As a result of all this activity, it makes sense to establish a fully‐fledged Darwin team to take responsibility for the core platform support infrastructure: the standard environment based on LLVM and cctools, SDK packages, Apple source releases, and other critical components that are used across the tree on macOS. I’m really happy that we’ve managed to get people pinging @NixOS/darwin-maintainers when they need help, but of course, not everyone who signed up to help out with packaging software on Darwin wants to be held responsible for maintaining arcane internals like these, and not everyone who would be interested in maintaining this infrastructure wants to get the volume of pings that the existing GitHub team gets.

It makes sense, therefore, to decouple this new Darwin team from the existing @NixOS/darwin-maintainers and assign a new GitHub team to `lib.teams.darwin`, which hasn’t corresponded to the GitHub team member list for years anyway. I’ve created @NixOS/darwin-core for the purpose, added it to the teams and codeowners files in this PR, and will request the organization owners assign it to the Nixpkgs repository. I want to be clear, though, that this isn’t a matter of creating a hierarchy. If anything, we’re here to serve @NixOS/darwin-maintainers, by maintaining the core infrastructure to make creating and maintaining Darwin packages as smooth as possible. We had some discussion about potential names for the new GitHub team and even possibly renaming the existing GitHub team, but we didn’t come up with anything that I thought was clearly better, and I don’t want to throw away the work we’ve done teaching people to ping @NixOS/darwin-maintainers if they have a Darwin problem. I’m happy to bikeshed further if anyone can think of better names that more clearly delineate the roles of the two.

We’d also love for more people to get involved! I’m only adding myself in this PR, but I talked with @paparodeo who also expressed potential interest in joining, and I know there are other people who have done work on Darwin platform support who I think would be a great fit. If you’re interested in doing and reviewing work like the following to improve the fundamentals of macOS support, it’d be great to have you:

* <https://github.com/NixOS/nixpkgs/pull/346043>
* <https://github.com/NixOS/nixpkgs/pull/307880>
* <https://github.com/NixOS/nixpkgs/pull/347862>
* <https://github.com/NixOS/nixpkgs/pull/338695>
* <https://github.com/NixOS/nixpkgs/pull/348000>
* <https://github.com/NixOS/nixpkgs/pull/347388>
* <https://github.com/NixOS/nixpkgs/pull/329721>
* <https://github.com/NixOS/nixpkgs/pull/126411>
* <https://github.com/NixOS/nixpkgs/pull/324155>

(Although hopefully we’ve done enough foundational work by now that the PRs won’t be *quite* as big as some of these going forward!)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
