### PR TITLE
prometheus-klipper-exporter: init at v0.11.2

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -50,6 +50,7 @@ let
     "junos-czerwonk"
     "kea"
     "keylight"
+    "klipper"
     "knot"
     "lnd"
     "mail"

--- a/nixos/modules/services/monitoring/prometheus/exporters/klipper.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/klipper.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.klipper;
+  inherit (lib)
+    mkOption
+    mkMerge
+    mkIf
+    types
+    concatStringsSep
+    any
+    optionalString
+    ;
+  moonraker = config.services.moonraker;
+in
+{
+  port = 9101;
+  extraOpts = {
+    package = lib.mkPackageOption pkgs "prometheus-klipper-exporter" { };
+
+    moonrakerApiKey = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        API Key to authenticate with the Moonraker APIs.
+        Only needed if the host running the exporter is not a trusted client to Moonraker.
+      '';
+    };
+  };
+  serviceOpts = mkMerge (
+    [
+      {
+        serviceConfig = {
+          ExecStart = concatStringsSep " " [
+            "${cfg.package}/bin/prometheus-klipper-exporter"
+            (optionalString (cfg.moonrakerApiKey != "") "--moonraker.apikey ${cfg.moonrakerApiKey}")
+            "--web.listen-address ${cfg.listenAddress}:${toString cfg.port}"
+            "${concatStringsSep " " cfg.extraFlags}"
+          ];
+        };
+      }
+    ]
+    ++ [
+      (mkIf config.services.moonraker.enable {
+        after = [ "moonraker.service" ];
+        requires = [ "moonraker.service" ];
+      })
+    ]
+  );
+}

--- a/pkgs/by-name/pr/prometheus-klipper-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-klipper-exporter/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+}:
+
+buildGoModule rec {
+  pname = "prometheus-klipper-exporter";
+  version = "0.11.2";
+
+  src = fetchFromGitHub {
+    owner = "scross01";
+    repo = "prometheus-klipper-exporter";
+    rev = "v${version}";
+    sha256 = "sha256-ow7bzgaY4pYccslITlkNBKfZBJv9uwPk25I1Y3bnjbU=";
+  };
+
+  vendorHash = "sha256-0nbLHZ2WMLMK0zKZuUYz355K01Xspn9svmlFCtQjed0=";
+
+  doCheck = true;
+
+  passthru.tests = {
+    inherit (nixosTests.prometheus-exporters) process;
+  };
+
+  meta = with lib; {
+    description = " Prometheus Exporter for Klipper ";
+    homepage = "https://github.com/scross01/prometheus-klipper-exporter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wulfsta ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds [prometheus-klipper-exporter](https://github.com/scross01/prometheus-klipper-exporter) and a related service. This can be used by adding a relatively simple snippet to `/etc/nixos/configuration.nix`:
```
...
  services.prometheus = {
      exporters = {
        klipper = {
          enable = true;
          port = 9101;
        };
      };
    };
...
```
Since it follows the [Multi-Target Exporter Pattern](https://prometheus.io/docs/guides/multi-target-exporter/), scraping it is a bit more complicated - here is a sample, supposing the machine running the exporter is at `10.0.0.1`, the Moonraker port is `7125`, and Moonraker is running on the same machine as the exporter:
```
...
  services.prometheus.scrapeConfigs = [
        {
          job_name = "prometheus-klipper-voron";
          static_configs = [{
            targets = [ "127.0.0.1:7125" ];
          }];
          metrics_path = "/probe";
          params = {
            modules = [
              "process_stats"
              "job_queue"
              "system_info"
              "network_stats"
              "directory_info"
              "printer_objects"
              "history"
            ];
          };
          relabel_configs = [
            {
              source_labels = [ "__address__" ];
              target_label = "__param_target";
            }
            {
              source_labels = [ "__param_target" ];
              target_label = "instance";
            }
            {
              target_label = "__address__";
              replacement = "10.0.0.1:9101";
            }
          ];
        }
      ];
    };

...
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
