### PR TITLE
lib.meta.platformMatch: expand to partial systems without parsed & change some packages to using meta.badPlatforms

### DIFF
--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -174,6 +174,7 @@ This means that `broken` can be used to express constraints, for example:
   ```
 
 This makes `broken` strictly more powerful than `meta.badPlatforms`.
+It is recommended to use `meta.badPlatforms` when only checking for the platforms.
 However `meta.availableOn` currently examines only `meta.platforms` and `meta.badPlatforms`, so `meta.broken` does not influence the default values for optional dependencies.
 
 ## Licenses {#sec-meta-license}

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -211,6 +211,8 @@ rec {
 
     3. (modern) a pattern for the platform `parsed` field (see `lib.systems.inspect.patterns`).
 
+    4. (modern) a partial attribute set of the platform structure.
+
     We can inject these into a pattern for the whole of a structured platform,
     and then match that.
 
@@ -249,7 +251,8 @@ rec {
     else matchAttrs (
       # Normalize platform attrset.
       if elem ? parsed then elem
-      else { parsed = elem; }
+      else if elem ? _type && elem._type == "system" then { parsed = elem; }
+      else elem
     ) platform
   );
 

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -29,7 +29,9 @@ in
 
 rec {
   # these patterns are to be matched against {host,build,target}Platform.parsed
-  patterns = rec {
+  patterns = mapAttrs (_: pattern:
+    if isList pattern then map (pattern: pattern // { _type = "system"; }) pattern
+    else pattern // { _type = "system"; }) (rec {
     # The patterns below are lists in sum-of-products form.
     #
     # Each attribute is list of product conditions; non-list values are treated
@@ -124,7 +126,7 @@ rec {
 
     isElf          = { kernel.execFormat = execFormats.elf; };
     isMacho        = { kernel.execFormat = execFormats.macho; };
-  };
+  });
 
   # given two patterns, return a pattern which is their logical AND.
   # Since a pattern is a list-of-disjuncts, this needs to
@@ -163,7 +165,7 @@ rec {
   # that `lib.meta.availableOn` can distinguish them from the patterns which
   # apply only to the `parsed` field.
 
-  platformPatterns = mapAttrs (_: p: { parsed = {}; } // p) {
+  platformPatterns = {
     isStatic = { isStatic = true; };
   };
 }

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -141,7 +141,8 @@ rec {
         map (attr2:
           recursiveUpdateUntil
             (path: subattr1: subattr2:
-              if (builtins.intersectAttrs subattr1 subattr2) == {} || subattr1 == subattr2
+              if (builtins.isString subattr2) then true
+              else if (builtins.intersectAttrs subattr1 subattr2) == {} || subattr1 == subattr2
               then true
               else throw ''
                 pattern conflict at path ${toString path}:

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -499,6 +499,8 @@ rec {
     getAbi    = name:     abis.${name} or (throw "Unknown ABI: ${name}");
 
     parsed = {
+      # Required so predicates match correctly
+      _type = "system";
       cpu = getCpu args.cpu;
       vendor =
         /**/ if args ? vendor    then getVendor args.vendor
@@ -521,7 +523,7 @@ rec {
         else                     abis.unknown;
     };
 
-  in mkSystem parsed;
+  in mkSystem (removeAttrs parsed [ "_type" ]);
 
   mkSystemFromString = s: mkSystemFromSkeleton (mkSkeletonFromList (splitString "-" s));
 

--- a/pkgs/by-name/cd/cdogs-sdl/package.nix
+++ b/pkgs/by-name/cd/cdogs-sdl/package.nix
@@ -59,6 +59,9 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ nixinator ];
     platforms = platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/cdogs-sdl.x86_64-darwin
+    badPlatforms = [
+      # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/cdogs-sdl.x86_64-darwin
+      { isDarwin = true; }
+    ];
   };
 }

--- a/pkgs/by-name/en/enigma/package.nix
+++ b/pkgs/by-name/en/enigma/package.nix
@@ -40,7 +40,9 @@ stdenv.mkDerivation rec {
     mainProgram = "enigma";
     license = with licenses; [ gpl2Plus free ]; # source + bundles libs + art
     platforms = platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin;
+    badPlatforms = [
+      { isDarwin = true; }
+    ];
     maintainers = with maintainers; [ iblech ];
     homepage = "https://www.nongnu.org/enigma/";
   };

--- a/pkgs/by-name/jf/jfsw/package.nix
+++ b/pkgs/by-name/jf/jfsw/package.nix
@@ -51,7 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     mainProgram = "sw";
     maintainers = with lib.maintainers; [ moody ];
-    broken = stdenv.hostPlatform.isDarwin;
+    badPlatforms = [
+      { isDarwin = true; }
+    ];
     inherit (SDL2.meta) platforms;
   };
 })

--- a/pkgs/by-name/sn/snipes/package.nix
+++ b/pkgs/by-name/sn/snipes/package.nix
@@ -37,11 +37,14 @@ in stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "Modern port of the classic 1982 text-mode game Snipes";
-    mainProgram = "snipes";
-    homepage    = "https://www.vogons.org/viewtopic.php?f=7&t=49073";
-    license     = licenses.free; # This reverse-engineered source code is released with the original authors' permission.
-    maintainers = with maintainers; [ peterhoeg cybershadow ];
-    broken      = stdenv.hostPlatform.isDarwin; # not supported upstream - https://github.com/Davidebyzero/Snipes/issues/8#issuecomment-433720046
+    description  = "Modern port of the classic 1982 text-mode game Snipes";
+    mainProgram  = "snipes";
+    homepage     = "https://www.vogons.org/viewtopic.php?f=7&t=49073";
+    license      = licenses.free; # This reverse-engineered source code is released with the original authors' permission.
+    maintainers  = with maintainers; [ peterhoeg cybershadow ];
+    badPlatforms = [
+      # not supported upstream - https://github.com/Davidebyzero/Snipes/issues/8#issuecomment-433720046
+      { isDarwin = true; }
+    ];
   };
 }

--- a/pkgs/by-name/sp/space-orbit/package.nix
+++ b/pkgs/by-name/sp/space-orbit/package.nix
@@ -38,10 +38,12 @@ EOF
   '';
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Space combat simulator";
     mainProgram = "space-orbit";
     license = licenses.gpl2Plus;
     platforms = platforms.all;
+    badPlatforms = [
+      { isDarwin = true; }
+    ];
   };
 }

--- a/pkgs/by-name/vo/voxelands/package.nix
+++ b/pkgs/by-name/vo/voxelands/package.nix
@@ -69,6 +69,9 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = [ ];
-    broken = stdenv.hostPlatform.isAarch64;  # build fails with "libIrrlicht.so: undefined reference to `png_init_filter_functions_neon'"
+    badPlatforms = [
+      # build fails with "libIrrlicht.so: undefined reference to `png_init_filter_functions_neon'"
+      { isAarch64 = true; }
+    ];
   };
 }

--- a/pkgs/games/openspades/default.nix
+++ b/pkgs/games/openspades/default.nix
@@ -64,7 +64,13 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl3;
     platforms   = platforms.all;
     maintainers = with maintainers; [ abbradar azahi ];
-    # never built on aarch64-linux since first introduction in nixpkgs
-    broken = stdenv.hostPlatform.isDarwin || (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
+    badPlatforms = [
+      { isDarwin = true; }
+      # never built on aarch64-linux since first introduction in nixpkgs
+      {
+        isAarch64 = true;
+        isLinux = true;
+      }
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Many packages use `meta.broken` and just check `stdenv` whether the package is not supported. However, we should be using `meta.badPlatforms`. The idea is this can make meta easier to serialize. I've adjusted `lib.meta.platformMatch` to handle a partial system without requiring `parsed` to be present. I've updated the documentation to try and note people shouldn't be using `meta.broken` for simple checks. Some adjustments were necessary to `lib.systems.mkSystemFromSkeleton` and `lib.systems.inspect` in order to handle the new behavior, however the existing behavior is still intact. Some packages have been switched from `meta.broken` to `meta.badPlatforms` to showcase this. Rebuild count should be 0.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
