### PR TITLE
postgresqlPackages.timescaledb: 2.14.2 -> 2.17.2; adopt, nixfmt; postgresqlPackages.timescaledb_toolkit: 1.18.0 -> 1.19.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -22,6 +22,10 @@
 
 - `buildGoPackage` has been removed. Use `buildGoModule` instead. See the [Go section in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-language-go) for details.
 
+- `timescaledb` requires manual upgrade steps.
+    After you run ALTER EXTENSION, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull requests [#6797](https://github.com/timescale/timescaledb/pull/6797).
+    PostgreSQL 13 is no longer supported in TimescaleDB v2.16.
+
 - `kanata` was updated to v1.7.0, which introduces several breaking changes.
   See the release notes of
   [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0)

--- a/pkgs/development/tools/rust/cargo-pgrx/default.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/default.nix
@@ -77,4 +77,11 @@ in
     hash = "sha256-0m9oaqjU42RYyttkTihADDrRMjr2WoK/8sInZALeHws=";
     cargoHash = "sha256-9XTIcpoCnROP63ZTDgMMMmj0kPggiTazKlKQfCgXKzk=";
   };
+
+  cargo-pgrx_0_12_6 = generic {
+    version = "0.12.6";
+    hash = "sha256-7aQkrApALZe6EoQGVShGBj0UIATnfOy2DytFj9IWdEA=";
+    cargoHash = "sha256-Di4UldQwAt3xVyvgQT1gUhdvYUVp7n/a72pnX45kP0w=";
+  };
+
 }

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -1,11 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, cmake, postgresql, openssl, libkrb5, nixosTests, enableUnfree ? true, buildPostgresqlExtension }:
+{
+  buildPostgresqlExtension,
+  cmake,
+  enableUnfree ? true,
+  fetchFromGitHub,
+  lib,
+  libkrb5,
+  nixosTests,
+  openssl,
+  postgresql,
+  stdenv,
+}:
 
 buildPostgresqlExtension rec {
   pname = "timescaledb${lib.optionalString (!enableUnfree) "-apache"}";
   version = "2.17.2";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ openssl libkrb5 ];
+  buildInputs = [
+    openssl
+    libkrb5
+  ];
 
   src = fetchFromGitHub {
     owner = "timescale";
@@ -14,7 +28,12 @@ buildPostgresqlExtension rec {
     hash = "sha256-gPsAebMUBuAwP6Hoi9/vrc2IFsmTbL0wQH1g6/2k2d4=";
   };
 
-  cmakeFlags = [ "-DSEND_TELEMETRY_DEFAULT=OFF" "-DREGRESS_CHECKS=OFF" "-DTAP_CHECKS=OFF" ]
+  cmakeFlags =
+    [
+      "-DSEND_TELEMETRY_DEFAULT=OFF"
+      "-DREGRESS_CHECKS=OFF"
+      "-DTAP_CHECKS=OFF"
+    ]
     ++ lib.optionals (!enableUnfree) [ "-DAPACHE_ONLY=ON" ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ "-DLINTER=OFF" ];
 

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -2,7 +2,7 @@
 
 buildPostgresqlExtension rec {
   pname = "timescaledb${lib.optionalString (!enableUnfree) "-apache"}";
-  version = "2.14.2";
+  version = "2.17.2";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ openssl libkrb5 ];
@@ -11,7 +11,7 @@ buildPostgresqlExtension rec {
     owner = "timescale";
     repo = "timescaledb";
     rev = version;
-    hash = "sha256-gJViEWHtIczvIiQKuvvuwCfWJMxAYoBhCHhD75no6r0=";
+    hash = "sha256-gPsAebMUBuAwP6Hoi9/vrc2IFsmTbL0wQH1g6/2k2d4=";
   };
 
   cmakeFlags = [ "-DSEND_TELEMETRY_DEFAULT=OFF" "-DREGRESS_CHECKS=OFF" "-DTAP_CHECKS=OFF" ]
@@ -41,11 +41,6 @@ buildPostgresqlExtension rec {
     maintainers = [ maintainers.kirillrdy ];
     platforms = postgresql.meta.platforms;
     license = with licenses; if enableUnfree then tsl else asl20;
-    broken = versionOlder postgresql.version "13" ||
-      # timescaledb supports PostgreSQL 17 from 2.17.0 on:
-      # https://github.com/timescale/timescaledb/releases/tag/2.17.0
-      # We can't upgrade to it, yet, because this would imply dropping support for
-      # PostgreSQL 13, which is a breaking change.
-      (versionAtLeast postgresql.version "17" && version == "2.14.2");
+    broken = versionOlder postgresql.version "14";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -38,7 +38,7 @@ buildPostgresqlExtension rec {
     description = "Scales PostgreSQL for time-series data via automatic partitioning across time and space";
     homepage = "https://www.timescale.com/";
     changelog = "https://github.com/timescale/timescaledb/blob/${version}/CHANGELOG.md";
-    maintainers = [ ];
+    maintainers = [ maintainers.kirillrdy ];
     platforms = postgresql.meta.platforms;
     license = with licenses; if enableUnfree then tsl else asl20;
     broken = versionOlder postgresql.version "13" ||

--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -3,24 +3,24 @@
 , buildPgrxExtension
 , postgresql
 , nixosTests
-, cargo-pgrx_0_10_2
+, cargo-pgrx_0_12_0_alpha_1
 , nix-update-script
 }:
 
-(buildPgrxExtension.override { cargo-pgrx = cargo-pgrx_0_10_2; }) rec {
+(buildPgrxExtension.override { cargo-pgrx = cargo-pgrx_0_12_0_alpha_1; }) rec {
   inherit postgresql;
 
   pname = "timescaledb_toolkit";
-  version = "1.18.0";
+  version = "1.19.0";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = "timescaledb-toolkit";
     rev = version;
-    hash = "sha256-Lm/LFBkG91GeWlJL9RBqP8W0tlhBEeGQ6kXUzzv4xRE=";
+    hash = "sha256-7yUbtWbYL4AnuUX8OXG4OVqYCY2Lf0pISSTlcFdPqog=";
   };
 
-  cargoHash = "sha256-LME8oftHmmiN8GU3eTBTSB6m0CE+KtDFRssL1g2Cjm8=";
+  cargoHash = "sha256-+uD4UU7QwNISQZ7a2kDkY/y3fQWk/K0fFcrFq4yq6RU=";
   buildAndTestSubdir = "extension";
 
   passthru = {
@@ -37,8 +37,5 @@
     maintainers = with maintainers; [ typetetris ];
     platforms = postgresql.meta.platforms;
     license = licenses.tsl;
-    # PostgreSQL 17 support issue upstream: https://github.com/timescale/timescaledb-toolkit/issues/813
-    # Check after next package update.
-    broken = versionAtLeast postgresql.version "17" && version == "1.18.0";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -3,11 +3,11 @@
 , buildPgrxExtension
 , postgresql
 , nixosTests
-, cargo-pgrx_0_12_0_alpha_1
+, cargo-pgrx_0_12_6
 , nix-update-script
 }:
 
-(buildPgrxExtension.override { cargo-pgrx = cargo-pgrx_0_12_0_alpha_1; }) rec {
+(buildPgrxExtension.override { cargo-pgrx = cargo-pgrx_0_12_6; }) rec {
   inherit postgresql;
 
   pname = "timescaledb_toolkit";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7007,6 +7007,7 @@ with pkgs;
     cargo-pgrx_0_11_2
     cargo-pgrx_0_11_3
     cargo-pgrx_0_12_0_alpha_1
+    cargo-pgrx_0_12_6
     ;
   cargo-pgrx = cargo-pgrx_0_11_2;
 


### PR DESCRIPTION
Changes:
-  https://github.com/timescale/timescaledb/releases/tag/2.17.2
-  https://github.com/timescale/timescaledb/releases/tag/2.17.1
 - https://github.com/timescale/timescaledb/releases/tag/2.17.0
 - https://github.com/timescale/timescaledb/releases/tag/2.16.1
 - https://github.com/timescale/timescaledb/releases/tag/2.16.0
 - https://github.com/timescale/timescaledb/releases/tag/2.15.3
 - https://github.com/timescale/timescaledb/releases/tag/2.15.2
 - https://github.com/timescale/timescaledb/releases/tag/2.15.1
 - https://github.com/timescale/timescaledb/releases/tag/2.15.0
 - https://github.com/timescale/timescaledb-toolkit/releases/tag/1.19.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
