### PR TITLE
openjdk23: init at 23-ga

### DIFF
--- a/pkgs/development/compilers/openjdk/23.nix
+++ b/pkgs/development/compilers/openjdk/23.nix
@@ -1,0 +1,274 @@
+{ stdenv
+, lib
+, fetchurl
+, fetchpatch
+, fetchFromGitHub
+, pkg-config
+, autoconf
+, cpio
+, file
+, which
+, unzip
+, zip
+, perl
+, cups
+, freetype
+, alsa-lib
+, libjpeg
+, giflib
+, libpng
+, zlib
+, lcms2
+, libX11
+, libICE
+, libXrender
+, libXext
+, libXt
+, libXtst
+, libXi
+, libXinerama
+, libXcursor
+, libXrandr
+, fontconfig
+, openjdk23-bootstrap
+, ensureNewerSourcesForZipFilesHook
+, setJavaClassPath
+  # TODO(@sternenseemann): gtk3 fails to evaluate in pkgsCross.ghcjs.buildPackages
+  # which should be fixable, this is a no-rebuild workaround for GHC.
+, headless ? stdenv.targetPlatform.isGhcjs
+, enableJavaFX ? false
+, openjfx
+, enableGtk ? true
+, gtk3
+, glib
+, writeShellScript
+, versionCheckHook
+}:
+
+let
+
+  # Java version format:
+  # $FEATURE.$INTERIM.$UPDATE.$PATCH
+  # See
+  # https://openjdk.org/jeps/223
+  # https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/Runtime.Version.html
+  featureVersion = "23";
+  info = builtins.getAttr featureVersion (lib.importJSON ./info.json);
+  version = info.version;
+
+  # when building a headless jdk, also bootstrap it with a headless jdk
+  openjdk-bootstrap = openjdk23-bootstrap.override { gtkSupport = !headless; };
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openjdk" + lib.optionalString headless "-headless";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "openjdk";
+    repo = info.repo;
+    rev = "jdk-${version}";
+    hash = info.hash;
+  };
+
+  nativeBuildInputs = [ pkg-config autoconf unzip ensureNewerSourcesForZipFilesHook ];
+  buildInputs = [
+    cpio
+    file
+    which
+    zip
+    perl
+    zlib
+    cups
+    freetype
+    alsa-lib
+    libjpeg
+    giflib
+    libpng
+    zlib
+    lcms2
+    libX11
+    libICE
+    libXrender
+    libXext
+    libXtst
+    libXt
+    libXtst
+    libXi
+    libXinerama
+    libXcursor
+    libXrandr
+    fontconfig
+    openjdk-bootstrap
+  ] ++ lib.optionals (!headless && enableGtk) [
+    gtk3
+    glib
+  ];
+
+  patches = [
+    ./fix-java-home-jdk21.patch
+    ./read-truststore-from-env-jdk10.patch
+    ./increase-javadoc-heap-jdk13.patch
+    ./ignore-LegalNoticeFilePlugin-jdk18.patch
+
+    # Fix build for gnumake-4.4.1:
+    #   https://github.com/openjdk/jdk/pull/12992
+    (fetchpatch {
+      name = "gnumake-4.4.1";
+      url = "https://github.com/openjdk/jdk/commit/9341d135b855cc208d48e47d30cd90aafa354c36.patch";
+      hash = "sha256-Qcm3ZmGCOYLZcskNjj7DYR85R4v07vYvvavrVOYL8vg=";
+    })
+  ] ++ lib.optionals (!headless && enableGtk) [
+    ./swing-use-gtk-jdk13.patch
+  ];
+
+  postPatch = ''
+    chmod +x configure
+    patchShebangs --build configure
+  '';
+
+  # JDK's build system attempts to specifically detect
+  # and special-case WSL, and we don't want it to do that,
+  # so pass the correct platform names explicitly
+  configurePlatforms = [ "build" "host" ];
+
+
+  # https://openjdk.org/groups/build/doc/building.html
+  configureFlags = [
+    "--with-boot-jdk=${openjdk-bootstrap.home}"
+    "--with-version-string=${version}"
+    "--with-vendor-version-string=(nix)"
+    "--enable-unlimited-crypto"
+    "--with-native-debug-symbols=internal"
+    "--with-libjpeg=system"
+    "--with-giflib=system"
+    "--with-libpng=system"
+    "--with-zlib=system"
+    "--with-lcms=system"
+    "--with-stdc++lib=dynamic"
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    "--with-toolchain-type=clang"
+    # Explicitly tell Clang to compile C++ files as C++, see
+    # https://github.com/NixOS/nixpkgs/issues/150655#issuecomment-1935304859
+    "--with-extra-cxxflags=-xc++"
+  ]
+  ++ lib.optional headless "--enable-headless-only"
+  ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+
+  separateDebugInfo = true;
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  NIX_LDFLAGS = toString (lib.optionals (!headless) [
+    "-lfontconfig"
+    "-lcups"
+    "-lXinerama"
+    "-lXrandr"
+    "-lmagic"
+  ] ++ lib.optionals (!headless && enableGtk) [
+    "-lgtk-3"
+    "-lgio-2.0"
+  ]);
+
+  # -j flag is explicitly rejected by the build system:
+  #     Error: 'make -jN' is not supported, use 'make JOBS=N'
+  # Note: it does not make build sequential. Build system
+  # still runs in parallel.
+  enableParallelBuilding = false;
+
+  buildFlags = [ "images" ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+
+    mv build/*/images/jdk $out/lib/openjdk
+
+    # Remove some broken manpages.
+    rm -rf $out/lib/openjdk/man/ja*
+
+    # Mirror some stuff in top-level.
+    mkdir -p $out/share
+    ln -s $out/lib/openjdk/include $out/include
+    ln -s $out/lib/openjdk/man $out/share/man
+
+    # IDEs use the provided src.zip to navigate the Java codebase (https://github.com/NixOS/nixpkgs/pull/95081)
+    ln -s $out/lib/openjdk/lib/src.zip $out/lib/src.zip
+
+    # jni.h expects jni_md.h to be in the header search path.
+    ln -s $out/include/linux/*_md.h $out/include/
+
+    # Remove crap from the installation.
+    rm -rf $out/lib/openjdk/demo
+    ${lib.optionalString headless ''
+      rm $out/lib/openjdk/lib/{libjsound,libfontmanager}.so
+    ''}
+
+    ln -s $out/lib/openjdk/bin $out/bin
+  '';
+
+  preFixup = ''
+    # Propagate the setJavaClassPath setup hook so that any package
+    # that depends on the JDK has $CLASSPATH set up properly.
+    mkdir -p $out/nix-support
+    #TODO or printWords?  cf https://github.com/NixOS/nixpkgs/pull/27427#issuecomment-317293040
+    echo -n "${setJavaClassPath}" > $out/nix-support/propagated-build-inputs
+
+    # Set JAVA_HOME automatically.
+    mkdir -p $out/nix-support
+    cat <<EOF > $out/nix-support/setup-hook
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+    EOF
+  '';
+
+  postFixup = ''
+    # Build the set of output library directories to rpath against
+    LIBDIRS=""
+    for output in $(getAllOutputNames); do
+      if [ "$output" = debug ]; then continue; fi
+      LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
+    done
+    # Add the local library paths to remove dependencies on the bootstrap
+    for output in $(getAllOutputNames); do
+      if [ "$output" = debug ]; then continue; fi
+      OUTPUTDIR=$(eval echo \$$output)
+      BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
+      echo "$BINLIBS" | while read i; do
+        patchelf --set-rpath "$LIBDIRS:$(patchelf --print-rpath "$i")" "$i" || true
+        patchelf --shrink-rpath "$i" || true
+      done
+    done
+  '';
+
+  disallowedReferences = [ openjdk-bootstrap ];
+
+  pos = __curPos;
+  meta = import ./meta.nix lib featureVersion;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/java";
+
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript =
+      let
+        java-json = fetchurl {
+          url = "https://search.maven.org/remotecontent?filepath=org/json/json/20240303/json-20240303.jar";
+          hash = "sha256-PPbNaJLjLitMHDng9S9SSKL1s3ZG/fu3mma0a2GEFO0=";
+        };
+      in
+      writeShellScript "update-java" ''
+        ${finalAttrs.finalPackage}/bin/java \
+          -cp ${java-json} \
+          ${./JavaUpdater.java} \
+          23 pkgs/development/compilers/openjdk/info.json
+      '';
+
+    home = "${finalAttrs.finalPackage}/lib/openjdk";
+
+    inherit gtk3;
+  };
+})

--- a/pkgs/development/compilers/openjdk/info.json
+++ b/pkgs/development/compilers/openjdk/info.json
@@ -1,4 +1,9 @@
 {
+  "23": {
+    "version": "23-ga",
+    "repo":    "jdk23u",
+    "hash":    "sha256-lcLnWAiskWindOqWmOWiIHiYKXGSJZK4d20k19QZfrE="
+  },
   "22": {
     "version": "22.0.2-ga",
     "repo":    "jdk22u",

--- a/pkgs/development/compilers/openjdk/openjfx/23/default.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/23/default.nix
@@ -1,26 +1,27 @@
-{ stdenv
-, lib
-, pkgs
-, fetchFromGitHub
-, fetchpatch2
-, writeText
-, openjdk21_headless
-, gradle
-, pkg-config
-, perl
-, cmake
-, gperf
-, gtk2
-, gtk3
-, libXtst
-, libXxf86vm
-, glib
-, alsa-lib
-, ffmpeg_7
-, python3
-, ruby
-, withMedia ? true
-, withWebKit ? false
+{
+  stdenv,
+  lib,
+  pkgs,
+  fetchFromGitHub,
+  fetchpatch2,
+  writeText,
+  openjdk21_headless,
+  gradle,
+  pkg-config,
+  perl,
+  cmake,
+  gperf,
+  gtk2,
+  gtk3,
+  libXtst,
+  libXxf86vm,
+  glib,
+  alsa-lib,
+  ffmpeg_7,
+  python3,
+  ruby,
+  withMedia ? true,
+  withWebKit ? false,
 }:
 
 let
@@ -31,7 +32,8 @@ let
   repover = "${major}${update}${build}";
   jdk = openjdk21_headless;
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   inherit pname;
   version = "${major}${update}${build}";
 
@@ -51,8 +53,24 @@ in stdenv.mkDerivation {
     })
   ];
 
-  buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_7 ];
-  nativeBuildInputs = [ gradle perl pkg-config cmake gperf python3 ruby ];
+  buildInputs = [
+    gtk2
+    gtk3
+    libXtst
+    libXxf86vm
+    glib
+    alsa-lib
+    ffmpeg_7
+  ];
+  nativeBuildInputs = [
+    gradle
+    perl
+    pkg-config
+    cmake
+    gperf
+    python3
+    ruby
+  ];
 
   dontUseCmakeConfigure = true;
 
@@ -99,7 +117,10 @@ in stdenv.mkDerivation {
     done
   '';
 
-  disallowedReferences = [ jdk gradle.jdk ];
+  disallowedReferences = [
+    jdk
+    gradle.jdk
+  ];
 
   meta = with lib; {
     homepage = "https://openjdk.org/projects/openjfx/";

--- a/pkgs/development/compilers/openjdk/openjfx/23/default.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/23/default.nix
@@ -1,0 +1,111 @@
+{ stdenv
+, lib
+, pkgs
+, fetchFromGitHub
+, fetchpatch2
+, writeText
+, openjdk21_headless
+, gradle
+, pkg-config
+, perl
+, cmake
+, gperf
+, gtk2
+, gtk3
+, libXtst
+, libXxf86vm
+, glib
+, alsa-lib
+, ffmpeg_7
+, python3
+, ruby
+, withMedia ? true
+, withWebKit ? false
+}:
+
+let
+  pname = "openjfx-modular-sdk";
+  major = "23";
+  update = "";
+  build = "-ga";
+  repover = "${major}${update}${build}";
+  jdk = openjdk21_headless;
+
+in stdenv.mkDerivation {
+  inherit pname;
+  version = "${major}${update}${build}";
+
+  src = fetchFromGitHub {
+    owner = "openjdk";
+    repo = "jfx23u";
+    rev = repover;
+    hash = "sha256-a/ev91Rq7D3z9O56ZZQCgvvbfj5GBt5Lonow2NH3s/E=";
+  };
+
+  patches = [
+    # 8338701: Provide media support for libavcodec version 61
+    # <https://github.com/openjdk/jfx/pull/1552>
+    (fetchpatch2 {
+      url = "https://github.com/openjdk/jfx/commit/6115b396bacf62f39dcaa93c7c0adcd60b428b8c.patch?full_index=1";
+      hash = "sha256-6EES4qsumFgXePZSDEetJC1Li65zquz3UjwRbq/6YJM=";
+    })
+  ];
+
+  buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_7 ];
+  nativeBuildInputs = [ gradle perl pkg-config cmake gperf python3 ruby ];
+
+  dontUseCmakeConfigure = true;
+
+  config = writeText "gradle.properties" ''
+    CONF = Release
+    JDK_HOME = ${jdk.home}
+    COMPILE_MEDIA = ${lib.boolToString withMedia}
+    COMPILE_WEBKIT = ${lib.boolToString withWebKit}
+  '';
+
+  postPatch = ''
+    ln -s $config gradle.properties
+  '';
+
+  mitmCache = gradle.fetchDeps {
+    attrPath = "openjfx${major}";
+    pkg = pkgs."openjfx${major}".override { withWebKit = true; };
+    data = ./deps.json;
+  };
+
+  __darwinAllowLocalNetworking = true;
+
+  preBuild = ''
+    export NUMBER_OF_PROCESSORS=$NIX_BUILD_CORES
+    export NIX_CFLAGS_COMPILE="$(pkg-config --cflags glib-2.0) $NIX_CFLAGS_COMPILE"
+  '';
+
+  enableParallelBuilding = false;
+
+  gradleBuildTask = "sdk";
+
+  installPhase = ''
+    cp -r build/modular-sdk $out
+  '';
+
+  stripDebugList = [ "." ];
+
+  postFixup = ''
+    # Remove references to bootstrap.
+    export openjdkOutPath='${jdk.outPath}'
+    find "$out" -name \*.so | while read lib; do
+      new_refs="$(patchelf --print-rpath "$lib" | perl -pe 's,:?\Q$ENV{openjdkOutPath}\E[^:]*,,')"
+      patchelf --set-rpath "$new_refs" "$lib"
+    done
+  '';
+
+  disallowedReferences = [ jdk gradle.jdk ];
+
+  meta = with lib; {
+    homepage = "https://openjdk.org/projects/openjfx/";
+    license = licenses.gpl2Classpath;
+    description = "Next-generation Java client toolkit";
+    maintainers = with maintainers; [ abbradar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/openjdk/openjfx/23/deps.json
+++ b/pkgs/development/compilers/openjdk/openjfx/23/deps.json
@@ -1,0 +1,152 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://download.eclipse.org": {
+  "eclipse/updates/4.30/R-4.30-202312010110/plugins/org.eclipse.swt.gtk.linux.x86_64_3.124.200.v20231113-1355": {
+   "jar": "sha256-Q048o4oWnZ9Y33AxXiSxbxEeayfbWOf1HoxtoLS4SIs="
+  }
+ },
+ "https://github.com": {
+  "unicode-org/icu/releases/download/release-74-2/icu4c-74_2-data-bin-l": {
+   "zip": "sha256-Ks2xuYIigECWPRg7LdnTISUsYT4PTbIT1LvBBBfN5Wk="
+  }
+ },
+ "https://repo.maven.apache.org/maven2": {
+  "com/ibm/icu#icu4j/61.1": {
+   "jar": "sha256-VcmOsYOLKku5oH3Da9N4Uy1k0M3LfO7pFCNoZqfeRGQ=",
+   "pom": "sha256-E7h6QHnOsFUVsZrHoVIDlHB1YB1JQj9xk1ikmACYBWs="
+  },
+  "junit#junit/4.13.2": {
+   "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
+   "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
+  },
+  "net/java#jvnet-parent/3": {
+   "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
+  },
+  "org/abego/treelayout#org.abego.treelayout.core/1.0.3": {
+   "jar": "sha256-+l4xOVw5wufUasoPgfcgYJMWB7L6Qb02A46yy2+5MyY=",
+   "pom": "sha256-o7KyI3lDcDVeeSQzrwEvyZNmfAMxviusrYTbwJrOSgw="
+  },
+  "org/antlr#ST4/4.1": {
+   "jar": "sha256-ixzK7Z7cVc0lXZwZxNjaR1bZtvy0NWcSkrQ0cLFtddg=",
+   "pom": "sha256-cz5r2XyjTMbfk6QkPlEeVnPLm4jHSxiETgQqRdUWmHw="
+  },
+  "org/antlr#antlr-master/3.5.2": {
+   "pom": "sha256-QtkaUx6lEA6wm1QaoALDuQjo8oK9c7bi9S83HvEzG9Y="
+  },
+  "org/antlr#antlr-runtime/3.5.2": {
+   "jar": "sha256-zj/I7LEPOemjzdy7LONQ0nLZzT0LHhjm/nPDuTichzQ=",
+   "pom": "sha256-RqnCIAu4sSvXEkqnpQl/9JCZkIMpyFGgTLIFFCCqfyU="
+  },
+  "org/antlr#antlr4-master/4.7.2": {
+   "pom": "sha256-upnLJdI5DzhoDHUChCoO4JWdHmQD4BPM/2mP1YVu6tE="
+  },
+  "org/antlr#antlr4-runtime/4.7.2": {
+   "jar": "sha256-TFGLh9S9/4tEzYy8GvgW6US2Kj/luAt4FQHPH0dZu8Q=",
+   "pom": "sha256-3AnLqYwl08BuSuxRaIXUw68DBiulX0/mKD/JzxdqYPs="
+  },
+  "org/antlr#antlr4/4.7.2": {
+   "pom": "sha256-z56zaUD6xEiBA4wb4/LFjgbmjRq/v9SmjTS72LrFV3E="
+  },
+  "org/antlr#antlr4/4.7.2/complete": {
+   "jar": "sha256-aFI4bXl17/KRcdrgAswiMlFRDTXyka4neUjzgaezgLQ="
+  },
+  "org/apache#apache/13": {
+   "pom": "sha256-/1E9sDYf1BI3vvR4SWi8FarkeNTsCpSW+BEHLMrzhB0="
+  },
+  "org/apache/lucene#lucene-core/7.7.3": {
+   "jar": "sha256-jrAzNcGjxqixiN9012G6qDVplTWCq0QLU0yIRJ6o4N4=",
+   "pom": "sha256-gvilIoHGyLp5dKy6rESzLXbiYAgvP0u+FlwPbkuJFCo="
+  },
+  "org/apache/lucene#lucene-grouping/7.7.3": {
+   "jar": "sha256-L1vNY7JXQ9MMMTmGIk0Qf3XFKThxSVQlNRDFfT9nvrg=",
+   "pom": "sha256-HwStk+IETUCP2SXu4K6ktKHvjAdXe0Jme7U2BgKCImU="
+  },
+  "org/apache/lucene#lucene-parent/7.7.3": {
+   "pom": "sha256-6PrdU9XwBMQN3SNdQ4ZI5yxyVZn+4VQ+ViTV+1AQcwU="
+  },
+  "org/apache/lucene#lucene-queries/7.7.3": {
+   "jar": "sha256-PLWS2wpulWnGrMvbiKmtex2nQo28p5Ia0cWlhl1bQiY=",
+   "pom": "sha256-rkBsiiuw12SllERCefRiihl2vQlB551CzmTgmHxYnFA="
+  },
+  "org/apache/lucene#lucene-queryparser/7.7.3": {
+   "jar": "sha256-F3XJ/o7dlobTt6ZHd4+kTqqW8cwMSZMVCHEz4amDnoQ=",
+   "pom": "sha256-z2klkhWscjC5+tYKXInKDp9bm6rM7dFGlY/76Q9OsNI="
+  },
+  "org/apache/lucene#lucene-sandbox/7.7.3": {
+   "jar": "sha256-VfG38J2uKwytMhw00Vw8/FmgIRviM/Yp0EbEK/FwErc=",
+   "pom": "sha256-1vbdxsz1xvymRH1HD1BJ4WN6xje/HbWuDV8WaP34EiI="
+  },
+  "org/apache/lucene#lucene-solr-grandparent/7.7.3": {
+   "pom": "sha256-Oig3WAynavNq99/i3B0zT8b/XybRDySJnbd3CtfP2f4="
+  },
+  "org/apiguardian#apiguardian-api/1.1.2": {
+   "jar": "sha256-tQlEisUG1gcxnxglN/CzXXEAdYLsdBgyofER5bW3Czg=",
+   "module": "sha256-4IAoExN1s1fR0oc06aT7QhbahLJAZByz7358fWKCI/w=",
+   "pom": "sha256-MjVQgdEJCVw9XTdNWkO09MG3XVSemD71ByPidy5TAqA="
+  },
+  "org/glassfish#javax.json/1.0.4": {
+   "jar": "sha256-Dh3sQKHt6WWUElHtqWiu7gUsxPUDeLwxbMSOgVm9vrQ=",
+   "pom": "sha256-a6+Dg/+pi2bqls1b/B7H8teUY7uYrJgFKWSxIcIhLVQ="
+  },
+  "org/glassfish#json/1.0.4": {
+   "pom": "sha256-bXxoQjEV+SFxjZRPhZkktMaFIX7AOkn3BFWossqpcuY="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  },
+  "org/junit#junit-bom/5.8.1": {
+   "module": "sha256-a4LLpSoTSxPBmC8M+WIsbUhTcdQLmJJG8xJOOwpbGFQ=",
+   "pom": "sha256-733Ef45KFoZPR3lyjofteFOYGeT7iSdoqdprjvkD+GM="
+  },
+  "org/junit/jupiter#junit-jupiter-api/5.8.1": {
+   "jar": "sha256-zjN0p++6YF4tK2mj/vkBNAMrqz7MPthXmkhxscLEcpw=",
+   "module": "sha256-DWnbwja33Kq0ynNpqlYOmwqbvvf5WIgv+0hTPLunwJ0=",
+   "pom": "sha256-d61+1KYwutH8h0agpuZ1wj+2lAsnq2LMyzTk/Pz+Ob8="
+  },
+  "org/junit/jupiter#junit-jupiter-engine/5.8.1": {
+   "jar": "sha256-Rom8kCJVoZ/pgndoO6MjHAlNEHxUyNNfK2+cl9ImQY4=",
+   "module": "sha256-aHkP7DP5ew7IQM9HrEDuDHLgVvEiyg88ZkZ0M0mTdpk=",
+   "pom": "sha256-qjIKMYpyceMyYsSA/POZZbmobap2Zm63dTQrgOnN1F4="
+  },
+  "org/junit/jupiter#junit-jupiter-params/5.8.1": {
+   "jar": "sha256-OJuNE6jYhy/L1PDrp7LEavxihBn5obKjqfkyQaBqchg=",
+   "module": "sha256-Ek1gPG2AMzZtjKRxY2tEbji5zBvQEPMpVCNYGHr6hl4=",
+   "pom": "sha256-OrrKWfvfJTMg9yRCwQPjnOQDjcEf6MSJ28ScwjoHHws="
+  },
+  "org/junit/jupiter#junit-jupiter/5.8.1": {
+   "jar": "sha256-jxBJ7iSzShC2DNgQBICZ94HCZYzeIYHoMUlqswqYKYU=",
+   "module": "sha256-LjS6TIWMOM0KNlr//syTKnGWzpOF4utUBZQuWBwV/1w=",
+   "pom": "sha256-rssFDSMtOT9Az/EfjMMPUrZslQpB+IOSXIEULt7l9PU="
+  },
+  "org/junit/platform#junit-platform-commons/1.8.1": {
+   "jar": "sha256-+k+mjIvVTdDLScP8vpsuQvTaa+2+fnzPKgXxoeYJtZM=",
+   "module": "sha256-aY/QVBrLfv/GZZhI/Qx91QEKSfFfDBy6Q+U1gH+Q9ms=",
+   "pom": "sha256-4ZcoLlLnANEriJie3FSJh0aTUC5KqJB6zwgpgBq6bUQ="
+  },
+  "org/junit/platform#junit-platform-engine/1.8.1": {
+   "jar": "sha256-cCho7X6GubRnLt4PHhhekFusqa+rV3RqfGUL48e8oEc=",
+   "module": "sha256-2fQgpkU5o+32D4DfDG/XIrdQcldEx5ykD30lrlbKS6Q=",
+   "pom": "sha256-hqrU5ld1TkOgDfIm3VTIrsHsarZTP1ASGQfkZi3i5fI="
+  },
+  "org/junit/vintage#junit-vintage-engine/5.8.1": {
+   "jar": "sha256-F2tTzRvb+SM+lsiwx6nluGQoL7veukO1zq/e2ymkkVY=",
+   "module": "sha256-nOn6Lk7mp0DWEBAlMEYqcc4PqdLxQYUi5LK9tgcvZ5o=",
+   "pom": "sha256-Ndc3M08dvouMVnZ/oVCKwbVEsB1P5cmXl76QA+5YGxI="
+  },
+  "org/opentest4j#opentest4j/1.2.0": {
+   "jar": "sha256-WIEt5giY2Xb7ge87YtoFxmBMGP1KJJ9QRCgkefwoavI=",
+   "pom": "sha256-qW5nGBbB/4gDvex0ySQfAlvfsnfaXStO4CJmQFk2+ZQ="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  }
+ }
+}

--- a/pkgs/development/compilers/zulu/23.nix
+++ b/pkgs/development/compilers/zulu/23.nix
@@ -1,42 +1,54 @@
-{ callPackage
-, enableJavaFX ? false
-, ...
+{
+  callPackage,
+  enableJavaFX ? false,
+  ...
 }@args:
 
-callPackage ./common.nix ({
-  # Details from https://www.azul.com/downloads/?version=java-23&package=jdk
-  # Note that the latest build may differ by platform
-  dists = {
-    x86_64-linux = {
-      zuluVersion = "23.28.85";
-      jdkVersion = "23.0.0";
-      hash =
-        if enableJavaFX then "sha256-TfkuAYcj+D9P3lZKYcQMah8Y/gfNVnB4kaYyQQNdWkc="
-        else "sha256-byvonJmkVVPwPLuqDPV5FX2A+KKoWn/9hYh+xpHckaI=";
-    };
+callPackage ./common.nix (
+  {
+    # Details from https://www.azul.com/downloads/?version=java-23&package=jdk
+    # Note that the latest build may differ by platform
+    dists = {
+      x86_64-linux = {
+        zuluVersion = "23.28.85";
+        jdkVersion = "23.0.0";
+        hash =
+          if enableJavaFX then
+            "sha256-TfkuAYcj+D9P3lZKYcQMah8Y/gfNVnB4kaYyQQNdWkc="
+          else
+            "sha256-byvonJmkVVPwPLuqDPV5FX2A+KKoWn/9hYh+xpHckaI=";
+      };
 
-    aarch64-linux = {
-      zuluVersion = "23.28.85";
-      jdkVersion = "23.0.0";
-      hash =
-        if enableJavaFX then "sha256-4SQmkt8v2cC4qpDP4I1N/0BXHaEru9Tb1NGFYZRF+rc="
-        else "sha256-7Jc1N3rdawWQ13leYEwN5+GvQCFuGtKzWuL7+dEMnDU=";
-    };
+      aarch64-linux = {
+        zuluVersion = "23.28.85";
+        jdkVersion = "23.0.0";
+        hash =
+          if enableJavaFX then
+            "sha256-4SQmkt8v2cC4qpDP4I1N/0BXHaEru9Tb1NGFYZRF+rc="
+          else
+            "sha256-7Jc1N3rdawWQ13leYEwN5+GvQCFuGtKzWuL7+dEMnDU=";
+      };
 
-    x86_64-darwin = {
-      zuluVersion = "23.28.85";
-      jdkVersion = "23.0.0";
-      hash =
-        if enableJavaFX then "sha256-yVAkX2uDZPe1Jf+tPkal9OBEREsC3xhuPEqXZqmKiLk="
-        else "sha256-R5fB74KPaKaJamjL1LpDGSWn4Qb7K1Z3bldYpa513FY=";
-    };
+      x86_64-darwin = {
+        zuluVersion = "23.28.85";
+        jdkVersion = "23.0.0";
+        hash =
+          if enableJavaFX then
+            "sha256-yVAkX2uDZPe1Jf+tPkal9OBEREsC3xhuPEqXZqmKiLk="
+          else
+            "sha256-R5fB74KPaKaJamjL1LpDGSWn4Qb7K1Z3bldYpa513FY=";
+      };
 
-    aarch64-darwin = {
-      zuluVersion = "23.28.85";
-      jdkVersion = "23.0.0";
-      hash =
-        if enableJavaFX then "sha256-opQSE1QmxsilIlZMKaqzU1b8+m8P8/NrLJXNxlcxQTM="
-        else "sha256-C510C53ijwDjgBDyY9eQ2at6BN9I6HqoNd2jxAlSmv8=";
+      aarch64-darwin = {
+        zuluVersion = "23.28.85";
+        jdkVersion = "23.0.0";
+        hash =
+          if enableJavaFX then
+            "sha256-opQSE1QmxsilIlZMKaqzU1b8+m8P8/NrLJXNxlcxQTM="
+          else
+            "sha256-C510C53ijwDjgBDyY9eQ2at6BN9I6HqoNd2jxAlSmv8=";
+      };
     };
-  };
-} // builtins.removeAttrs args [ "callPackage" ])
+  }
+  // builtins.removeAttrs args [ "callPackage" ]
+)

--- a/pkgs/development/compilers/zulu/23.nix
+++ b/pkgs/development/compilers/zulu/23.nix
@@ -1,0 +1,42 @@
+{ callPackage
+, enableJavaFX ? false
+, ...
+}@args:
+
+callPackage ./common.nix ({
+  # Details from https://www.azul.com/downloads/?version=java-23&package=jdk
+  # Note that the latest build may differ by platform
+  dists = {
+    x86_64-linux = {
+      zuluVersion = "23.28.85";
+      jdkVersion = "23.0.0";
+      hash =
+        if enableJavaFX then "sha256-TfkuAYcj+D9P3lZKYcQMah8Y/gfNVnB4kaYyQQNdWkc="
+        else "sha256-byvonJmkVVPwPLuqDPV5FX2A+KKoWn/9hYh+xpHckaI=";
+    };
+
+    aarch64-linux = {
+      zuluVersion = "23.28.85";
+      jdkVersion = "23.0.0";
+      hash =
+        if enableJavaFX then "sha256-4SQmkt8v2cC4qpDP4I1N/0BXHaEru9Tb1NGFYZRF+rc="
+        else "sha256-7Jc1N3rdawWQ13leYEwN5+GvQCFuGtKzWuL7+dEMnDU=";
+    };
+
+    x86_64-darwin = {
+      zuluVersion = "23.28.85";
+      jdkVersion = "23.0.0";
+      hash =
+        if enableJavaFX then "sha256-yVAkX2uDZPe1Jf+tPkal9OBEREsC3xhuPEqXZqmKiLk="
+        else "sha256-R5fB74KPaKaJamjL1LpDGSWn4Qb7K1Z3bldYpa513FY=";
+    };
+
+    aarch64-darwin = {
+      zuluVersion = "23.28.85";
+      jdkVersion = "23.0.0";
+      hash =
+        if enableJavaFX then "sha256-opQSE1QmxsilIlZMKaqzU1b8+m8P8/NrLJXNxlcxQTM="
+        else "sha256-C510C53ijwDjgBDyY9eQ2at6BN9I6HqoNd2jxAlSmv8=";
+    };
+  };
+} // builtins.removeAttrs args [ "callPackage" ])

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15074,7 +15074,7 @@ with pkgs;
 
   hugs = callPackage ../development/interpreters/hugs { };
 
-  inherit (javaPackages) openjfx17 openjfx21 openjfx22;
+  inherit (javaPackages) openjfx17 openjfx21 openjfx22 openjfx23;
   openjfx = openjfx17;
 
   openjdk8-bootstrap = javaPackages.compiler.openjdk8-bootstrap;
@@ -15106,6 +15106,11 @@ with pkgs;
   openjdk22_headless = javaPackages.compiler.openjdk22.headless;
   jdk22 = openjdk22;
   jdk22_headless = openjdk22_headless;
+
+  openjdk23 = javaPackages.compiler.openjdk23;
+  openjdk23_headless = javaPackages.compiler.openjdk23.headless;
+  jdk23 = openjdk23;
+  jdk23_headless = openjdk23_headless;
 
   /* default JDK */
   jdk = jdk21;

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -6,9 +6,10 @@ let
   openjfx17 = callPackage ../development/compilers/openjdk/openjfx/17 { };
   openjfx21 = callPackage ../development/compilers/openjdk/openjfx/21 { };
   openjfx22 = callPackage ../development/compilers/openjdk/openjfx/22 { };
+  openjfx23 = callPackage ../development/compilers/openjdk/openjfx/23 { };
 
 in {
-  inherit openjfx17 openjfx21 openjfx22;
+  inherit openjfx17 openjfx21 openjfx22 openjfx23;
 
   compiler = let
     mkOpenjdk = path-linux: path-darwin: args:
@@ -67,6 +68,14 @@ in {
       {
         openjdk22-bootstrap = temurin-bin.jdk-22;
         openjfx = openjfx22;
+      };
+
+    openjdk23 = mkOpenjdk
+      ../development/compilers/openjdk/23.nix
+      ../development/compilers/zulu/23.nix
+      {
+        openjdk23-bootstrap = temurin-bin.jdk-22;
+        openjfx = openjfx23;
       };
 
     temurin-bin = recurseIntoAttrs (callPackage (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Java 23 was released almost a month ago, so let's add it to nixpkgs.

There are a few relevant adjustments and questions:

- `currency-date-range-jdk10.patch` is not needed anymore (https://github.com/openjdk/jdk23u/commit/5ded8da676d62158d0011086d7f80ff2c9096e13)
- The `remove_removal_of_wformat_during_test_compilation` patch pulled from Fedora does not apply anymore due to surrounding lines that got changed. I probably don't understand the situation there fully, but compiling still works after removing the patch. Is it still needed?
- Java 22 is EOL now. Do we want to deprecate it, or directly remove it? Should that be done separately?
- Previous Java versions currently use temurin binaries of the same version for bootstrapping. Should temurin be updated here too? Or maybe we should use zulu as bootstrap as those binaries are the default jdk for darwin anyway?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
