### PR TITLE
asusd: Support for multiple aura device configs

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -86,6 +86,12 @@
 
 - `ps3-disc-dumper` was updated to 4.2.5, which removed the CLI project and now exclusively offers the GUI
 
+- `asusd` has been upgraded to version 6 which supports multiple aura devices. To account for this, the single `auraConfig` configuration option has been replaced with `auraConfigs` which is an attribute set of config options per each device. The config files may also be now specified as either source files or text strings; to account for this you will need to specify that `text` is used for your existing configs, e.g.:
+  ```diff
+  -services.asusd.asusdConfig = '''file contents'''
+  +services.asusd.asusdConfig.text = '''file contents'''
+  ```
+
 - `timescaledb` requires manual upgrade steps.
     After you run ALTER EXTENSION, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull requests [#6797](https://github.com/timescale/timescaledb/pull/6797).
     PostgreSQL 13 is no longer supported in TimescaleDB v2.16.

--- a/nixos/modules/services/hardware/asusd.nix
+++ b/nixos/modules/services/hardware/asusd.nix
@@ -24,73 +24,95 @@ in
   ];
 
   options = {
-    services.asusd = {
-      enable = lib.mkEnableOption "the asusd service for ASUS ROG laptops";
+    services.asusd =
+      with lib.types;
+      let
+        configType = submodule (
+          { text, source, ... }:
+          {
+            options = {
+              text = lib.mkOption {
+                default = null;
+                type = nullOr lines;
+                description = "Text of the file.";
+              };
 
-      package = lib.mkPackageOption pkgs "asusctl" { };
+              source = lib.mkOption {
+                default = null;
+                type = nullOr path;
+                description = "Path of the source file.";
+              };
+            };
+          }
+        );
+      in
+      {
+        enable = lib.mkEnableOption "the asusd service for ASUS ROG laptops";
 
-      enableUserService = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Activate the asusd-user service.
-        '';
+        package = lib.mkPackageOption pkgs "asusctl" { };
+
+        enableUserService = lib.mkOption {
+          type = bool;
+          default = false;
+          description = ''
+            Activate the asusd-user service.
+          '';
+        };
+
+        animeConfig = lib.mkOption {
+          type = nullOr configType;
+          default = null;
+          description = ''
+            The content of /etc/asusd/anime.ron.
+            See https://asus-linux.org/asusctl/#anime-control.
+          '';
+        };
+
+        asusdConfig = lib.mkOption {
+          type = nullOr configType;
+          default = null;
+          description = ''
+            The content of /etc/asusd/asusd.ron.
+            See https://asus-linux.org/asusctl/.
+          '';
+        };
+
+        auraConfigs = lib.mkOption {
+          type = attrsOf configType;
+          default = { };
+          description = ''
+            The content of /etc/asusd/aura_<name>.ron.
+            See https://asus-linux.org/asusctl/#led-keyboard-control.
+          '';
+        };
+
+        profileConfig = lib.mkOption {
+          type = nullOr configType;
+          default = null;
+          description = ''
+            The content of /etc/asusd/profile.ron.
+            See https://asus-linux.org/asusctl/#profiles.
+          '';
+        };
+
+        fanCurvesConfig = lib.mkOption {
+          type = nullOr configType;
+          default = null;
+          description = ''
+            The content of /etc/asusd/fan_curves.ron.
+            See https://asus-linux.org/asusctl/#fan-curves.
+          '';
+        };
+
+        userLedModesConfig = lib.mkOption {
+          type = nullOr configType;
+          default = null;
+          description = ''
+            The content of /etc/asusd/asusd-user-ledmodes.ron.
+            See https://asus-linux.org/asusctl/#led-keyboard-control.
+          '';
+        };
       };
-
-      animeConfig = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = ''
-          The content of /etc/asusd/anime.ron.
-          See https://asus-linux.org/asusctl/#anime-control.
-        '';
-      };
-
-      asusdConfig = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = ''
-          The content of /etc/asusd/asusd.ron.
-          See https://asus-linux.org/asusctl/.
-        '';
-      };
-
-      auraConfigs = lib.mkOption {
-        type = lib.types.attrsOf lib.types.str;
-        default = { };
-        description = ''
-          The content of /etc/asusd/aura_<name>.ron.
-          See https://asus-linux.org/asusctl/#led-keyboard-control.
-        '';
-      };
-
-      profileConfig = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = ''
-          The content of /etc/asusd/profile.ron.
-          See https://asus-linux.org/asusctl/#profiles.
-        '';
-      };
-
-      fanCurvesConfig = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = ''
-          The content of /etc/asusd/fan_curves.ron.
-          See https://asus-linux.org/asusctl/#fan-curves.
-        '';
-      };
-
-      userLedModesConfig = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = ''
-          The content of /etc/asusd/asusd-user-ledmodes.ron.
-          See https://asus-linux.org/asusctl/#led-keyboard-control.
-        '';
-      };
-    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -100,10 +122,12 @@ in
       let
         maybeConfig =
           name: cfg:
-          lib.mkIf (cfg != null) {
-            source = pkgs.writeText name cfg;
-            mode = "0644";
-          };
+          lib.mkIf (cfg != null) (
+            (if (cfg.source != null) then { source = cfg.source; } else { text = cfg.text; })
+            // {
+              mode = "0644";
+            }
+          );
       in
       {
         "asusd/anime.ron" = maybeConfig "anime.ron" cfg.animeConfig;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since version 6.0.0 asusd supports multiple aura devices (see [the changelog](https://gitlab.com/asus-linux/asusctl/-/blob/8a9564bbfa43e2c5309d3e1c997f964772588664/CHANGELOG.md#breaking)). Since each of them may have a different configuration, the `aura.ron` file, previously used for configuration, is now ignored in favor of device specific `aura_{prod_id}.ron` configuration. This change adds support for specifying multiple aura configs via `auraConfigs` attribute and removes the old `auraConfig` attribute.

Additionally, in a separate commit, it allows specifying config files via paths instead of strings.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
