### PR TITLE
nixedit: init at 1.0.0

### DIFF
--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -1,0 +1,58 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "nixedit";
+  version = "1.0.0";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "fndov";
+    repo = "nixedit";
+    rev = "main";
+    sha256 = "1hmda40xcqdb5akbbafyhhkhnarn677fjvd264ki5pbz71lmlbfl";
+  };
+
+  nativeBuildInputs = [
+    pkgs.makeWrapper
+  ];
+
+  buildInputs = [
+    pkgs.bash
+    pkgs.fzf
+    pkgs.jq
+    pkgs.micro
+    pkgs.git
+    pkgs.nix-tree
+    pkgs.coreutils
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    # Copy the scripts
+    cp src/nixedit.sh $out/bin/nixedit
+
+    # Ensure they are executable
+    chmod +x $out/bin/nixedit
+
+    # Wrap nixedit to include the necessary dependencies in PATH
+    wrapProgram $out/bin/nixedit --prefix PATH : \
+      "${pkgs.bash}/bin:${pkgs.coreutils}/bin:${pkgs.nix-tree}/bin:${pkgs.jq}/bin:${pkgs.micro}/bin:${pkgs.git}/bin"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    if ! uname -a | grep "NixOS" > /dev/null; then
+      echo "This package can only be installed on NixOS."
+      exit 1
+    fi
+
+    $out/bin/nixedit --help 
+  '';
+
+  meta = with pkgs.lib; {
+    homepage = "https://github.com/fndov/nixedit";
+    description = "A NixOS Multipurpose CLI/TUI Utility";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ miyu ];
+  };
+}

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -1,16 +1,16 @@
 {
-  lib
-, stdenv
-, fetchFromGitHub
-, bash
-, fzf
-, jq
-, micro
-, git
-, nix-tree
-, coreutils
-, makeWrapper
-, dialog
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bash,
+  fzf,
+  jq,
+  micro,
+  git,
+  nix-tree,
+  coreutils,
+  makeWrapper,
+  dialog,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -48,7 +48,7 @@ pkgs.stdenv.mkDerivation {
       exit 1
     fi
 
-    $out/bin/nixedit --help 
+    $out/bin/nixedit --help > /dev/null
   '';
 
   meta = with pkgs.lib; {

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> { } }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 pkgs.stdenv.mkDerivation {
   pname = "nixedit";
@@ -11,7 +13,9 @@ pkgs.stdenv.mkDerivation {
     sha256 = "1hmda40xcqdb5akbbafyhhkhnarn677fjvd264ki5pbz71lmlbfl";
   };
 
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [
+    pkgs.makeWrapper
+  ];
 
   buildInputs = [
     pkgs.bash

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -11,9 +11,7 @@ pkgs.stdenv.mkDerivation {
     sha256 = "1hmda40xcqdb5akbbafyhhkhnarn677fjvd264ki5pbz71lmlbfl";
   };
 
-  nativeBuildInputs = [
-    pkgs.makeWrapper
-  ];
+  nativeBuildInputs = [ pkgs.makeWrapper ];
 
   buildInputs = [
     pkgs.bash

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -1,16 +1,16 @@
 {
-  lib,
-  stdenv,
-  fetchFromGitHub,
-  bash,
-  fzf,
-  jq,
-  micro,
-  git,
-  nix-tree,
-  coreutils,
-  makeWrapper,
-  dialog,
+  lib
+, stdenv
+, fetchFromGitHub
+, bash
+, fzf
+, jq
+, micro
+, git
+, nix-tree
+, coreutils
+, makeWrapper
+, dialog
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -20,8 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "fndov";
     repo = "nixedit";
-    rev = "195a07064ff5e8224244605b7944cea3652f8df5";
-    hash = "sha256-XLzaQm8tpAZxvwjRW6eIJkmtv7LNHDAFUK82hj1VUYY=";
+    rev = "72b7ca8933efbf0d4295b7c7704eac2fb66d9b69";
+    hash = "sha256-MUFzvb+pSNWQ1bKd15zaJt+0Z2aUg/7zeOdUH4GJRmk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -1,30 +1,42 @@
 {
-  pkgs ? import <nixpkgs> { },
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bash,
+  fzf,
+  jq,
+  micro,
+  git,
+  nix-tree,
+  coreutils,
+  makeWrapper,
+  dialog,
 }:
 
-pkgs.stdenv.mkDerivation {
+stdenv.mkDerivation {
   pname = "nixedit";
   version = "1.0.0";
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "fndov";
     repo = "nixedit";
-    rev = "main";
-    sha256 = "1hmda40xcqdb5akbbafyhhkhnarn677fjvd264ki5pbz71lmlbfl";
+    rev = "75e7bab546c4946cd65079fdcad8bc2ab1550b8f";
+    hash = "sha256-KpqdyE6TqDHCj2zQZw2F66ZmSI93Oy6LxmPa+DXGB1A=";
   };
 
   nativeBuildInputs = [
-    pkgs.makeWrapper
+    makeWrapper
   ];
 
   buildInputs = [
-    pkgs.bash
-    pkgs.fzf
-    pkgs.jq
-    pkgs.micro
-    pkgs.git
-    pkgs.nix-tree
-    pkgs.coreutils
+    bash
+    fzf
+    jq
+    micro
+    git
+    nix-tree
+    coreutils
+    dialog
   ];
 
   installPhase = ''
@@ -38,7 +50,7 @@ pkgs.stdenv.mkDerivation {
 
     # Wrap nixedit to include the necessary dependencies in PATH
     wrapProgram $out/bin/nixedit --prefix PATH : \
-      "${pkgs.bash}/bin:${pkgs.coreutils}/bin:${pkgs.nix-tree}/bin:${pkgs.jq}/bin:${pkgs.micro}/bin:${pkgs.git}/bin"
+      "${bash}/bin:${coreutils}/bin:${nix-tree}/bin:${jq}/bin:${micro}/bin:${git}/bin:${fzf}/bin:${dialog}/bin"
   '';
 
   doInstallCheck = true;
@@ -51,10 +63,11 @@ pkgs.stdenv.mkDerivation {
     $out/bin/nixedit --help > /dev/null
   '';
 
-  meta = with pkgs.lib; {
+  meta = {
     homepage = "https://github.com/fndov/nixedit";
     description = "A NixOS Multipurpose CLI/TUI Utility";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ miyu ];
+    license = lib.licenses.gpl3;
+    mainProgram = "nixedit";
+    maintainers = with lib.maintainers; [ miyu ];
   };
 }

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -50,7 +50,18 @@ stdenv.mkDerivation {
 
     # Wrap nixedit to include the necessary dependencies in PATH
     wrapProgram $out/bin/nixedit --prefix PATH : \
-      "${bash}/bin:${coreutils}/bin:${nix-tree}/bin:${jq}/bin:${micro}/bin:${git}/bin:${fzf}/bin:${dialog}/bin"
+      "${
+        lib.makeBinPath [
+          bash
+          coreutils
+          nix-tree
+          jq
+          micro
+          git
+          fzf
+          dialog
+        ]
+      }"
   '';
 
   doInstallCheck = true;

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "fndov";
     repo = "nixedit";
-    rev = "stable";
+    rev = "195a07064ff5e8224244605b7944cea3652f8df5";
     hash = "sha256-XLzaQm8tpAZxvwjRW6eIJkmtv7LNHDAFUK82hj1VUYY=";
   };
 

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -13,15 +13,15 @@
   dialog,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "nixedit";
   version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "fndov";
     repo = "nixedit";
-    rev = "75e7bab546c4946cd65079fdcad8bc2ab1550b8f";
-    hash = "sha256-KpqdyE6TqDHCj2zQZw2F66ZmSI93Oy6LxmPa+DXGB1A=";
+    rev = "d5fd24439917b0359529aee7d29da85f20608877";
+    hash = "sha256-Xp7hMDjPuQyBZ535RHq5fI2r9iIeD8uC5LhHB+CB5sA=";
   };
 
   nativeBuildInputs = [
@@ -50,18 +50,7 @@ stdenv.mkDerivation {
 
     # Wrap nixedit to include the necessary dependencies in PATH
     wrapProgram $out/bin/nixedit --prefix PATH : \
-      "${
-        lib.makeBinPath [
-          bash
-          coreutils
-          nix-tree
-          jq
-          micro
-          git
-          fzf
-          dialog
-        ]
-      }"
+      "${lib.makeBinPath buildInputs}"
   '';
 
   doInstallCheck = true;
@@ -74,11 +63,11 @@ stdenv.mkDerivation {
     $out/bin/nixedit --help > /dev/null
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/fndov/nixedit";
     description = "A NixOS Multipurpose CLI/TUI Utility";
-    license = lib.licenses.gpl3;
+    license = licenses.gpl3;
     mainProgram = "nixedit";
-    maintainers = with lib.maintainers; [ miyu ];
+    maintainers = [ maintainers.miyu ];
   };
 }

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "fndov";
     repo = "nixedit";
-    rev = "d5fd24439917b0359529aee7d29da85f20608877";
-    hash = "sha256-Xp7hMDjPuQyBZ535RHq5fI2r9iIeD8uC5LhHB+CB5sA=";
+    rev = "stable";
+    hash = "sha256-XLzaQm8tpAZxvwjRW6eIJkmtv7LNHDAFUK82hj1VUYY=";
   };
 
   nativeBuildInputs = [
@@ -42,10 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     mkdir -p $out/bin
 
-    # Copy the scripts
-    cp src/nixedit.sh $out/bin/nixedit
+    # Move the script
+    mv src/nixedit.sh $out/bin/nixedit
 
-    # Ensure they are executable
+    # Ensure it is executable
     chmod +x $out/bin/nixedit
 
     # Wrap nixedit to include the necessary dependencies in PATH

--- a/pkgs/tools/nix/nixedit/default.nix
+++ b/pkgs/tools/nix/nixedit/default.nix
@@ -13,7 +13,7 @@
   dialog,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nixedit";
   version = "1.0.0";
 
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
     # Wrap nixedit to include the necessary dependencies in PATH
     wrapProgram $out/bin/nixedit --prefix PATH : \
-      "${lib.makeBinPath buildInputs}"
+      "${lib.makeBinPath finalAttrs.buildInputs}"
   '';
 
   doInstallCheck = true;
@@ -70,4 +70,4 @@ stdenv.mkDerivation rec {
     mainProgram = "nixedit";
     maintainers = [ maintainers.miyu ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
A NixOS Multipurpose CLI/TUI Utility. https://github.com/fndov/nixedit
#### Features:
- Full Terminal User Interface & Command line usage.
- Search Configure Build Backup Update Delete Optimise in one step.
- Complete Profile management, Integrated Creation & Removal. 
- Integrates with Github to upload backups of your configuration.

I'm sure there are no problems/bugs with the package, the last step was modifying default.nix. 👍
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
