### PR TITLE
nixos/getty: add option to autologin once per boot, take 2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -660,6 +660,9 @@
 
 - Mikutter was removed because the package was broken and had no maintainers.
 
+- The new option `services.getty.autologinOnce` was added to limit the automatic login to once per boot and on the first tty only.
+  When using full disk encryption, this option allows to unlock the system without retyping the passphrase while keeping the other ttys protected.
+
 - Gollum was upgraded to major version 6. Read their [migration notes](https://github.com/gollum/gollum/wiki/6.0-Release-Notes).
 
 - The hooks `yarnConfigHook` and `yarnBuildHook` were added. These should replace `yarn2nix.mkYarnPackage` and other `yarn2nix` related tools. The motivation to get rid of `yarn2nix` tools is the fact that they are too complex and hard to maintain, and they rely upon too much Nix evaluation which is problematic if import-from-derivation is not allowed (see more details at [#296856](https://github.com/NixOS/nixpkgs/issues/296856). The transition from `mkYarnPackage` to `yarn{Config,Build}Hook` is tracked at [#324246](https://github.com/NixOS/nixpkgs/issues/324246).

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -7,14 +7,26 @@ let
 
   baseArgs = [
     "--login-program" "${cfg.loginProgram}"
-  ] ++ optionals (cfg.autologinUser != null) [
+  ] ++ optionals (cfg.autologinUser != null && !cfg.autologinOnce) [
     "--autologin" cfg.autologinUser
   ] ++ optionals (cfg.loginOptions != null) [
     "--login-options" cfg.loginOptions
   ] ++ cfg.extraArgs;
 
   gettyCmd = args:
-    "@${pkgs.util-linux}/sbin/agetty agetty ${escapeShellArgs baseArgs} ${args}";
+    "${lib.getExe' pkgs.util-linux "agetty"} ${escapeShellArgs baseArgs} ${args}";
+
+  autologinScript = ''
+    otherArgs="--noclear --keep-baud $TTY 115200,38400,9600 $TERM";
+    ${lib.optionalString cfg.autologinOnce ''
+      autologged="/run/agetty.autologged"
+      if test "$TTY" = tty1 && ! test -f "$autologged"; then
+        touch "$autologged"
+        exec ${gettyCmd "$otherArgs --autologin ${cfg.autologinUser}"}
+      fi
+    ''}
+    exec ${gettyCmd "$otherArgs"}
+  '';
 
 in
 
@@ -37,6 +49,16 @@ in
         description = ''
           Username of the account that will be automatically logged in at the console.
           If unspecified, a login prompt is shown as usual.
+        '';
+      };
+
+      autologinOnce = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If enabled the automatic login will only happen in the first tty
+          once per boot. This can be useful to avoid retyping the account
+          password on systems with full disk encrypted.
         '';
       };
 
@@ -106,9 +128,11 @@ in
 
     systemd.services."getty@" =
       { serviceConfig.ExecStart = [
-          "" # override upstream default with an empty ExecStart
-          (gettyCmd "--noclear --keep-baud %I 115200,38400,9600 $TERM")
+          # override upstream default with an empty ExecStart
+          ""
+          (pkgs.writers.writeDash "getty" autologinScript)
         ];
+        environment.TTY = "%I";
         restartIfChanged = false;
       };
 


### PR DESCRIPTION
Another attempt to bring ae48df3e while avoiding the Nix symlink bug[1].
I guess the bug was triggered by the sbin -> bin symlink in util-linux.

[1]: https://github.com/NixOS/nix/issues/9579

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- Tested via 
  - [x] `nixosTests.simple`
  - [x] `nixosTests.gnupg`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
