### PR TITLE
lib/systems/architectures: Correct and supplement x86-64 inferiors

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -386,8 +386,7 @@ rec {
       sapphirerapids = [ "tigerlake" ] ++ inferiors.tigerlake;
       emeraldrapids = [ "sapphirerapids" ] ++ inferiors.sapphirerapids;
 
-      # CX16 does not exist on alderlake, while it does on nearly all other intel CPUs
-      alderlake = [ ];
+      alderlake = [ "skylake" ] ++ inferiors.skylake;
       sierraforest = [ "alderlake" ] ++ inferiors.alderlake;
 
       # x86_64 AMD

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -390,13 +390,13 @@ rec {
       sierraforest = [ "alderlake" ] ++ inferiors.alderlake;
 
       # x86_64 AMD
-      # TODO: fill this (need testing)
-      btver1 = [ ];
-      btver2 = [ ];
-      bdver1 = [ ];
-      bdver2 = [ ];
-      bdver3 = [ ];
-      bdver4 = [ ];
+      # TODO: fill in specific CPU architecture inferiors
+      btver1 = [ "x86-64" ];
+      btver2 = [ "x86-64-v2" ] ++ inferiors.x86-64-v2;
+      bdver1 = [ "x86-64-v2" ] ++ inferiors.x86-64-v2;
+      bdver2 = [ "x86-64-v2" ] ++ inferiors.x86-64-v2;
+      bdver3 = [ "x86-64-v2" ] ++ inferiors.x86-64-v2;
+      bdver4 = [ "x86-64-v3" ] ++ inferiors.x86-64-v3;
       # Regarding `skylake` as inferior of `znver1`, there are reports of
       # successful usage by Gentoo users and Phoronix benchmarking of different
       # `-march` targets.


### PR DESCRIPTION
- Correct inferiors for Alder Lake
- Add generic inferiors for x86-64 AMD

Alder Lake does indeed include CX16 and therefore can be considered a Skylake superset.

I checked both GCC (`gcc -march=… -Q --help=target`) and the CPU flags of my own Alder Lake CPU to confirm:

- [skylake.txt](https://github.com/user-attachments/files/17355301/skylake.txt)
- [alderlake.txt](https://github.com/user-attachments/files/17355302/alderlake.txt)

A diff shows that GCC enables all flags for Alder Lake that it also enables for Skylake, with the exception of the deprecated HLE extension, which has been removed from all recent Intel processors.

For the generic x86-64 AMD inferiors I consulted the GCC documentation and the [x86-64 ABI specification](https://gitlab.com/x86-psABIs/x86-64-ABI/-/blob/master/x86-64-ABI/low-level-sys-info.tex)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
