### PR TITLE
lib/meta: add platform constraints algebra

### DIFF
--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -88,6 +88,10 @@
       name = "derivations";
       description = "miscellaneous derivation-specific functions";
     }
+    {
+      name = "platform";
+      description = "platform constraint algebra";
+    }
   ],
 }:
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1,4 +1,7 @@
 {
+  "sec-functions-library-platform": [
+    "index.html#sec-functions-library-platform"
+  ],
   "chap-build-helpers-finalAttrs": [
     "index.html#chap-build-helpers-finalAttrs"
   ],

--- a/lib/README.md
+++ b/lib/README.md
@@ -136,6 +136,9 @@ path/tests/prop.sh
 
 # Run the lib.fileset tests
 fileset/tests.sh
+
+# Run the platform constraints algebra tests
+nix-instantiate --eval --strict tests/platform-constraints-algebra.nix
 ```
 
 ## Commit conventions

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -99,6 +99,8 @@ let
       # back-compat aliases
       platforms = self.systems.doubles;
 
+      platform = callLibs ./platform.nix;
+
       # linux kernel configuration
       kernel = callLibs ./kernel.nix;
 

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -259,12 +259,17 @@ rec {
   /**
     Check if a package is available on a given platform.
 
-    A package is available on a platform if both
+    A package is available on a platform its platform constraints are met. See
+    the documentation of `lib.meta.platform.constraints` for more information.
+
+    Alternatively, if `meta.platformConstraints` are not used it is available if:
 
     1. One of `meta.platforms` pattern matches the given
         platform, or `meta.platforms` is not present.
 
     2. None of `meta.badPlatforms` pattern matches the given platform.
+
+    Should no constraints be declared, a package is always considered available.
 
     # Inputs
 
@@ -289,8 +294,16 @@ rec {
   */
   availableOn =
     platform: pkg:
-    ((!pkg ? meta.platforms) || any (platformMatch platform) pkg.meta.platforms)
-    && all (elem: !platformMatch platform elem) (pkg.meta.badPlatforms or [ ]);
+    if pkg ? meta.platformConstraints then
+      lib.meta.platform.evalConstraints platform pkg.meta.platformConstraints
+    else if pkg ? meta.platforms then
+      # Legacy platform declarations
+      any (platformMatch platform) pkg.meta.platforms
+      && all (elem: !platformMatch platform elem) (pkg.meta.badPlatforms or [ ])
+    else
+      # If no constraints are declared, we are available on all platforms.
+      # This is necessary for runCommand and friends.
+      true;
 
   /**
     Mapping of SPDX ID to the attributes in lib.licenses.

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -15,6 +15,7 @@ let
     assertMsg
     ;
   inherit (lib.attrsets) mapAttrs' filterAttrs;
+  inherit (lib.meta.platform) evalConstraints;
   inherit (builtins) isString match typeOf;
 
 in
@@ -295,7 +296,7 @@ rec {
   availableOn =
     platform: pkg:
     if pkg ? meta.platformConstraints then
-      lib.meta.platform.evalConstraints platform pkg.meta.platformConstraints
+      evalConstraints platform pkg.meta.platformConstraints
     else if pkg ? meta.platforms then
       # Legacy platform declarations
       any (platformMatch platform) pkg.meta.platforms

--- a/lib/platform.nix
+++ b/lib/platform.nix
@@ -1,0 +1,147 @@
+{ lib }:
+
+# This defines an algebra to express platform constraints using AND, OR and NOT
+# which behave like boolean operators but for platform properties.
+#
+# Examples:
+#
+# with lib.meta.platform.constraints;
+# OR [
+#   isLinux
+#   isDarwin
+# ]
+#
+# with lib.meta.platform.constraints;
+# AND [
+#   (OR [
+#     isLinux
+#     isDarwin
+#   ])
+#   (OR [
+#     isx86
+#     isAarch
+#   ])
+#   (NOT isMusl)
+# ]
+
+{
+  /**
+    A DSL to declare which platform properties constrain a package's function.
+    Many packages only work on some platforms, CPUs or other properties of a platform.
+    This DSL is how you declare those facts.
+    These constraints can be any property of a platform expressed as a platform pattern.
+    See `lib.meta.platformMatch` for more information about platform properties and platform matching.
+
+    Constraints can be combined with arbitrary complexity using the boolean operators `AND`, `OR` and `NOT`.
+
+    For convenience, `lib.systems.inspect.patterns` and `lib.systems.inspect.platformPatterns` are also available in this set.
+
+    `evalConstraints` evaluates a platform constraints expression into a single boolean value for a given platform.
+
+    # Examples
+    :::{.example}
+    ## `lib.meta.platform.constraints` simple usage example
+
+    This will only match Linux platforms:
+
+    ```
+    lib.meta.platform.constraints.isLinux
+    ```
+
+    :::
+
+    :::{.example}
+    ## `lib.meta.platform.constraints` complex usage example
+
+    This is (made up, nonsensical) example of a more complex expression:
+
+    ```nix
+    with lib.meta.platform.constraints;
+    AND [
+      NONE
+      (OR [
+        isLinux
+        isDarwin
+        (AND [
+          isLittleEndian
+          is64bit
+          (OR [ isMusl ])
+        ])
+        NONE
+        {
+          cpu = { family = "myWeirdArch"; };
+        };
+      ])
+    ];
+    ```
+
+    :::
+  */
+  constraints =
+    rec {
+      OR = value: {
+        __operation = "OR";
+        inherit value;
+      };
+      AND = value: {
+        __operation = "AND";
+        inherit value;
+      };
+      NOT = value: {
+        __operation = "NOT";
+        value = [ value ]; # Also make this a list for simplicity
+      };
+
+      ANY = { };
+      NONE = NOT ANY;
+    }
+    # Put patterns in this set for convenient use
+    // lib.systems.inspect.patterns
+    # Platform patterns too. We can just do this because platforms (i.e. `hostPlatform`) have all of these
+    # mashed together too.
+    // lib.systems.inspect.platformPatterns;
+
+  /**
+    Evaluates a platform constraints expression into a boolean value for a given platform similar to how `lib.meta.platformMatch` performs checks for a single constraint.
+    Because this uses `lib.meta.platformMatch` internally, it supports the same set of platform properties.
+    This is intended to be used with `lib.platform.constraints` and supports its boolean operators.
+
+    # Inputs
+
+    `platform`
+    : 1\. The platform to run the constraint checks against
+
+    `constraints`
+    : 2\. A platform constraints expression to check the platform with
+
+    # Examples
+    :::{.example}
+    ## `lib.platform.evaluateConstraints` usage example
+
+    This evaluates to true because `aarch64-linux` matches the `isLinux` constraint `OR`'d with `isDarwin` (which does not match):
+
+    ```
+    lib.platform.evalConstraints "aarch64-linux" (with lib.platform.constraints; OR [ isLinux isDarwin ])
+    ```
+
+    :::
+
+  */
+  evalConstraints =
+    platform: initialValue:
+    let
+      operations = {
+        OR = lib.any lib.id;
+        AND = lib.all lib.id;
+        NOT = x: !(lib.head x); # We have a list with one value
+      };
+      platformMatch' = lib.meta.platformMatch platform;
+      recurse =
+        expression:
+        if expression ? __operation then
+          operations.${expression.__operation} (map recurse expression.value)
+        else
+          platformMatch' expression;
+    in
+    recurse initialValue;
+}

--- a/lib/platform.nix
+++ b/lib/platform.nix
@@ -145,4 +145,44 @@ rec {
       operations.${constraint.__operation} (map (evalConstraints platform) constraint.value)
     else
       platformMatch platform constraint;
+
+  prettyPrinters =
+    let
+      getStandardConstraintNames =
+        v:
+        lib.pipe constraints [
+          (lib.filterAttrs (_: it: it == v))
+          lib.attrNames
+        ];
+    in
+    {
+      operation = {
+        check = v: lib.isAttrs v && v ? __operation;
+        print =
+          {
+            indent,
+            v,
+            go,
+            ...
+          }:
+          "${v.__operation} ${go indent v.value}";
+      };
+      constraint = {
+        check =
+          v:
+          let
+            standardConstraintNames = getStandardConstraintNames v;
+          in
+          lib.length standardConstraintNames >= 1;
+        print =
+          {
+            v,
+            ...
+          }:
+          let
+            standardConstraintNames = getStandardConstraintNames v;
+          in
+          lib.head standardConstraintNames;
+      };
+    };
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2727,6 +2727,50 @@ runTests {
     };
     expected = "«foo»";
   };
+  testToPrettyCustomPrinters = {
+    expr =
+      generators.toPretty
+        {
+          customPrinters.special = {
+            check = v: lib.isAttrs v && v.type or null == "special" && v ? special;
+            print = { v, ... }: "<<special: ${v.special}>>";
+          };
+        }
+        {
+          foo = [
+            {
+              bar = {
+                type = "special";
+                special = "with value";
+              };
+            }
+            {
+              type = "not special";
+              special = "but still with value";
+            }
+            {
+              type = "special";
+              no = "value";
+            }
+          ];
+        };
+    expected = ''
+      {
+        foo = [
+          {
+            bar = <<special: with value>>;
+          }
+          {
+            special = "but still with value";
+            type = "not special";
+          }
+          {
+            no = "value";
+            type = "special";
+          }
+        ];
+      }'';
+  };
 
   testToPlistUnescaped = {
     expr = mapAttrs (const (generators.toPlist { })) {

--- a/lib/tests/platform-constraints-algebra.nix
+++ b/lib/tests/platform-constraints-algebra.nix
@@ -1,0 +1,81 @@
+let
+  lib = import ./..;
+
+  exampleSystem = lib.systems.elaborate "aarch64-darwin";
+in
+lib.runTests (
+  {
+    test_evalPatternMatch_AND = {
+      expr =
+        with lib.platform.constraints;
+        lib.platform.evalConstraints exampleSystem (AND [
+          is64bit
+          is32bit
+        ]);
+      expected = false;
+    };
+    test_evalPatternMatch_AND_is_noop = {
+      expr =
+        with lib.platform.constraints;
+        lib.platform.evalConstraints exampleSystem (AND [ is64bit ]);
+      expected = true;
+    };
+    test_evalPatternMatch_OR = {
+      expr =
+        with lib.platform.constraints;
+        lib.platform.evalConstraints exampleSystem (OR [
+          is64bit
+          is32bit
+        ]);
+      expected = true;
+    };
+    test_evalPatternMatch_OR_is_noop = {
+      expr =
+        with lib.platform.constraints;
+        lib.platform.evalConstraints exampleSystem (OR [ is64bit ]);
+      expected = true;
+    };
+    test_evalPatternMatch_NOT = {
+      expr =
+        with lib.platform.constraints;
+        lib.platform.evalConstraints exampleSystem (NOT is64bit);
+      expected = false;
+    };
+
+    test_evalPatternMatch_ANY = {
+      expr = with lib.platform.constraints; lib.platform.evalConstraints exampleSystem ANY;
+      expected = true;
+    };
+    test_evalPatternMatch_NONE = {
+      expr = with lib.platform.constraints; lib.platform.evalConstraints exampleSystem NONE;
+      expected = false;
+    };
+  }
+  //
+    lib.mapAttrs'
+      (
+        system: expected:
+        lib.nameValuePair "test_evalPatternMatch_nested_combination_${system}" {
+          expr =
+            with lib.platform.constraints;
+            lib.platform.evalConstraints (lib.systems.elaborate system) (AND [
+              (NOT is32bit)
+              (OR [
+                isLinux
+                isFreeBSD
+              ])
+            ]);
+          inherit expected;
+        }
+      )
+      {
+        aarch64-darwin = false;
+        aarch64-linux = true;
+        armv7l-linux = false;
+        armv7l-darwin = false;
+        x86_64-linux = true;
+        x86_64-freebsd = true;
+        aarch64-freebsd = true;
+        i686-freebsd = false;
+      }
+)

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -98,6 +98,9 @@
   "sec-contributing-devmode": [
     "index.html#sec-contributing-devmode"
   ],
+  "sec-functions-library-platform": [
+    "index.html#sec-functions-library-platform"
+  ],
   "sec-mattermost": [
     "index.html#sec-mattermost"
   ],

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -528,6 +528,7 @@ let
         toPretty' = toPretty {
           allowPrettyValues = true;
           indent = "  ";
+          customPrinters = lib.meta.platform.prettyPrinters;
         };
       in
       {
@@ -536,9 +537,18 @@ let
         errormsg = ''
           is not available on the requested hostPlatform:
             hostPlatform.config = "${hostPlatform.config}"
-            package.meta.platforms = ${toPretty' (attrs.meta.platforms or [ ])}
-            package.meta.badPlatforms = ${toPretty' (attrs.meta.badPlatforms or [ ])}
-        '';
+            ${
+              if attrs.meta ? platformConstraints then
+                ''
+                  package.platformConstraints:
+                    ${toPretty' attrs.meta.platformConstraints}
+                ''
+              else
+                ''
+                  package.meta.platforms = ${toPretty' (attrs.meta.platforms or [ ])}
+                  package.meta.badPlatforms = ${toPretty' (attrs.meta.badPlatforms or [ ])}
+                ''
+            }'';
       }
     else if !(hasAllowedInsecure attrs) then
       {


### PR DESCRIPTION
Previously, we were able to express platform constraints in packages using e.g.

    meta.platforms = with lib.platforms; linux ++ darwin;

These platform checks only worked on a coarse level using lists of pre-defined platform strings. It was not possible to express that only e.g. 64bit platforms or that only GNU libcs are supported previously.

This introduces an algebra based on platform patterns which allows you to express arbitrarily complex platform constraints using simple expressions without needing to rely on `stdenv.*Platform.is*` bools.

Once this is in wide-spread use, it can be used for accurate rendering of platform support in manuals and search sites.

It also removes the need for dependency on a package's `stdenv` for expressing which platforms are broken as this can now be expressed using platform constraints instead. This makes progress of potentially evaluating a package's meta information independently of the package or its inputs.

## Things we still need to discuss:

* [ ] The actual integration in platforms/badPlatforms
* [ ] Performance testing (this is on the hot path!)
* [ ] How/when to coordinate this with https://search.nixos.org?
* [ ] Docs and guidelines

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
