### PR TITLE
rapidapi: init at 4.2.8-4002008002

### DIFF
--- a/pkgs/by-name/ra/rapidapi/package.nix
+++ b/pkgs/by-name/ra/rapidapi/package.nix
@@ -3,6 +3,11 @@
   stdenvNoCC,
   fetchurl,
   unzip,
+  writeShellApplication,
+  curl,
+  cacert,
+  gnugrep,
+  common-updater-scripts,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -32,6 +37,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "rapidapi-update-script";
+    runtimeInputs = [
+      curl
+      cacert
+      gnugrep
+      common-updater-scripts
+    ];
+    text = ''
+      url="https://paw.cloud/download"
+      version=$(curl -Ls -o /dev/null -w "%{url_effective}" "$url" | grep -oP '\d+\.\d+\.\d+-\d+')
+      update-source-version rapidapi "$version"
+    '';
+  });
 
   meta = {
     description = "Full-featured HTTP client that lets you test and describe the APIs you build or consume";

--- a/pkgs/by-name/ra/rapidapi/package.nix
+++ b/pkgs/by-name/ra/rapidapi/package.nix
@@ -8,6 +8,10 @@
   cacert,
   gnugrep,
   common-updater-scripts,
+  versionCheckHook,
+  writeShellScript,
+  xcbuild,
+  coreutils,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -52,6 +56,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       update-source-version rapidapi "$version"
     '';
   });
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = writeShellScript "version-check" ''
+    marketing_version=$(${xcbuild}/bin/PlistBuddy -c "Print :CFBundleShortVersionString" "$1" | ${coreutils}/bin/tr -d '"')
+    build_version=$(${xcbuild}/bin/PlistBuddy -c "Print :CFBundleVersion" "$1")
+    echo $marketing_version-$build_version
+  '';
+  versionCheckProgramArg = [ "${placeholder "out"}/Applications/RapidAPI.app/Contents/Info.plist" ];
+  doInstallCheck = true;
 
   meta = {
     description = "Full-featured HTTP client that lets you test and describe the APIs you build or consume";

--- a/pkgs/by-name/ra/rapidapi/package.nix
+++ b/pkgs/by-name/ra/rapidapi/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rapidapi";
+  version = "4.2.8-4002008002";
+
+  src = fetchurl {
+    url = "https://cdn-builds.paw.cloud/paw/RapidAPI-${finalAttrs.version}.zip";
+    hash = "sha256-ApBOYMOjpQJvUe+JsEAnyK7xpIZNt6qkX/2KUIT6S8g=";
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+  dontUnpack = true;
+
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = "RapidAPI.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    unzip -d $out/Applications $src
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Full-featured HTTP client that lets you test and describe the APIs you build or consume";
+    homepage = "https://paw.cloud";
+    changelog = "https://paw.cloud/updates/${lib.head (lib.splitString "-" finalAttrs.version)}";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ DimitarNestorov ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION
[RapidAPI](https://paw.cloud) for Mac is a full-featured HTTP client that lets you test and describe the APIs you build or consume

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/86ac6218-9b15-45fc-b677-f376382a22ff" />

## Things done

### `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
#### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>rapidapi</li>
  </ul>
</details>


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
