### PR TITLE
inkscape: 1.3.2 -> 1.4

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -184,12 +184,14 @@ stdenv.mkDerivation rec {
 
   passthru.tests.ps2pdf-plugin = callPackage ./test-ps2pdf-plugin.nix { };
 
-  meta = with lib; {
+  meta = {
     description = "Vector graphics editor";
     homepage = "https://www.inkscape.org";
-    license = licenses.gpl3Plus;
-    maintainers = [ maintainers.jtojnar ];
-    platforms = platforms.all;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      jtojnar
+    ];
+    platforms = lib.platforms.all;
     mainProgram = "inkscape";
     longDescription = ''
       Inkscape is a feature-rich vector graphics editor that edits

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -7,7 +7,7 @@
 , cmake
 , desktopToDarwinBundle
 , fetchurl
-, fetchpatch
+, fd
 , gettext
 , ghostscript
 , glib
@@ -27,7 +27,6 @@
 , librevenge
 , librsvg
 , libsigcxx
-, libsoup_2_4
 , libvisio
 , libwpg
 , libXft
@@ -40,40 +39,43 @@
 , popt
 , potrace
 , python3
+, runCommand
 , substituteAll
 , wrapGAppsHook3
 , libepoxy
 , zlib
+, yq
 }:
 let
   python3Env = python3.withPackages
     (ps: with ps; [
+      # List taken almost verbatim from the output of nix-build -A inkscape.passthru.pythonDependencies
       appdirs
       beautifulsoup4
       cachecontrol
-    ]
-    # CacheControl requires extra runtime dependencies for FileCache
-    # https://gitlab.com/inkscape/extras/extension-manager/-/commit/9a4acde6c1c028725187ff5972e29e0dbfa99b06
-    ++ cachecontrol.optional-dependencies.filecache
-    ++ [
-      numpy
+      cssselect
+      filelock
+      inkex
       lxml
+      numpy
       packaging
       pillow
-      scour
+      pygobject3
       pyparsing
       pyserial
       requests
-      pygobject3
-    ] ++ inkex.propagatedBuildInputs);
+      scour
+      tinycss2
+      zstandard
+    ]);
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "inkscape";
-  version = "1.3.2";
+  version = "1.4";
 
   src = fetchurl {
-    url = "https://inkscape.org/release/inkscape-${version}/source/archive/xz/dl/inkscape-${version}.tar.xz";
-    sha256 = "sha256-29GETcRD/l4Q0+mohxROX7ciOFL/8ZHPte963qsOCGs=";
+    url = "https://inkscape.org/release/inkscape-${finalAttrs.version}/source/archive/xz/dl/inkscape-${finalAttrs.version}.tar.xz";
+    sha256 = "sha256-xZqFRTtpmt3rzVHB3AdoTdlqEMiuxxaxlVHbUFYuE/U=";
   };
 
   # Inkscape hits the ARGMAX when linking on macOS. It appears to be
@@ -87,28 +89,12 @@ stdenv.mkDerivation rec {
       src = ./fix-python-paths.patch;
       # Python is used at run-time to execute scripts,
       # e.g., those from the "Effects" menu.
-      python3 = "${python3Env}/bin/python";
+      python3 = lib.getExe python3Env;
     })
     (substituteAll {
       # Fix path to ps2pdf binary
       src = ./fix-ps2pdf-path.patch;
       inherit ghostscript;
-    })
-
-    # Fix build with libxml2 2.12
-    # https://gitlab.com/inkscape/inkscape/-/merge_requests/6089
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/694d8ae43d06efff21adebf377ce614d660b24cd.patch";
-      hash = "sha256-9IXJzpZbNU5fnt7XKgqCzUDrwr08qxGwo8TqnL+xc6E=";
-    })
-
-    # Improve distribute along path precision
-    # https://gitlab.com/inkscape/extensions/-/issues/580
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/extensions/-/commit/c576043c195cd044bdfc975e6367afb9b655eb14.patch";
-      extraPrefix = "share/extensions/";
-      stripLen = 1;
-      hash = "sha256-D9HxBx8RNkD7hHuExJqdu3oqlrXX6IOUw9m9Gx6+Dr8=";
     })
   ];
 
@@ -119,7 +105,7 @@ stdenv.mkDerivation rec {
 
     # double-conversion is a dependency of 2geom
     substituteInPlace CMakeScripts/DefineDependsandFlags.cmake \
-      --replace 'find_package(DoubleConversion REQUIRED)' ""
+      --replace-fail 'find_package(DoubleConversion REQUIRED)' ""
   '';
 
   nativeBuildInputs = [
@@ -155,7 +141,6 @@ stdenv.mkDerivation rec {
     librevenge
     librsvg # for loading icons
     libsigcxx
-    libsoup_2_4
     libvisio
     libwpg
     libXft
@@ -182,7 +167,23 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  passthru.tests.ps2pdf-plugin = callPackage ./test-ps2pdf-plugin.nix { };
+  passthru = {
+    tests = {
+      ps2pdf-plugin = callPackage ./test-ps2pdf-plugin.nix { };
+      inherit (python3.pkgs) inkex;
+    };
+
+    pythonDependencies = runCommand "python-dependency-list" {
+      nativeBuildInputs = [
+        fd
+        yq
+      ];
+      inherit (finalAttrs) src;
+    } ''
+      unpackPhase
+      tomlq --slurp 'map(.tool.poetry.dependencies | to_entries | map(.key)) | flatten | map(ascii_downcase) | unique' $(fd pyproject.toml) > "$out"
+    '';
+  };
 
   meta = {
     description = "Vector graphics editor";
@@ -202,4 +203,4 @@ stdenv.mkDerivation rec {
       If you want to import .eps files install ps2edit.
     '';
   };
-}
+})

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -190,6 +190,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       jtojnar
+      x123
     ];
     platforms = lib.platforms.all;
     mainProgram = "inkscape";

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -191,6 +191,7 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       jtojnar
       x123
+      Luflosi
     ];
     platforms = lib.platforms.all;
     mainProgram = "inkscape";

--- a/pkgs/by-name/li/lib2geom/package.nix
+++ b/pkgs/by-name/li/lib2geom/package.nix
@@ -1,6 +1,5 @@
 {
   stdenv,
-  fetchpatch,
   fetchFromGitLab,
   cmake,
   ninja,
@@ -16,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lib2geom";
-  version = "1.3";
+  version = "1.4";
 
   outputs = [
     "out"
@@ -27,32 +26,8 @@ stdenv.mkDerivation rec {
     owner = "inkscape";
     repo = "lib2geom";
     rev = "refs/tags/${version}";
-    hash = "sha256-llUpW8VRBD8RKaGfyedzsMbLRb8DIo0ePt6m2T2w7Po=";
+    hash = "sha256-kbcnefzNhUj/ZKZaB9r19bpI68vxUKOLVAwUXSr/zz0=";
   };
-
-  patches = [
-    # Fix compilation with Clang.
-    # https://gitlab.com/inkscape/lib2geom/-/merge_requests/102
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/lib2geom/-/commit/a5b5ac7d992023f8a80535ede60421e73ecd8e20.patch";
-      hash = "sha256-WJYkk3WRYVyPSvyTbKDUrYvUwFgKA9mmTiEWtYQqM4Q=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/lib2geom/-/commit/23d9393af4bee17aeb66a3c13bdad5dbed982d08.patch";
-      hash = "sha256-LAaGMIXpDI/Wzv5E2LasW1Y2/G4ukhuEzDmFu3AzZOA=";
-    })
-
-    # Fix ellipses rendering near page corners.
-    # https://gitlab.com/inkscape/lib2geom/-/issues/66
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/lib2geom/-/commit/039ce8d4af23a0a2a9d48eb970b321d9795dcc08.patch";
-      hash = "sha256-JfgGrqBcYSYKcdl4Bt7vGZ4aTBPSHM6JjZ95IlzxPwI=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/lib2geom/-/commit/cf523857e48c87f9f6a09217bdf935fff457823d.patch";
-      hash = "sha256-BRg8ANHMSgoi6vt9PNbhwG1fRkzEPXb4gPTPO3sY0XE=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -91,6 +66,17 @@ stdenv.mkDerivation rec {
           # Fails due to rounding differences
           # https://gitlab.com/inkscape/lib2geom/-/issues/70
           "circle-test"
+        ]
+        ++ lib.optionals (stdenv.hostPlatform.system != "x86_64-linux") [
+          # https://gitlab.com/inkscape/lib2geom/-/issues/69
+          "polynomial-test"
+
+          # https://gitlab.com/inkscape/lib2geom/-/issues/75
+          "line-test"
+
+          # Failure observed on aarch64-darwin
+          "bezier-test"
+          "ellipse-test"
         ];
     in
     ''

--- a/pkgs/development/python-modules/inkex/default.nix
+++ b/pkgs/development/python-modules/inkex/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   inkscape,
-  fetchpatch,
   poetry-core,
   cssselect,
   lxml,
@@ -14,6 +13,7 @@
   pyparsing,
   pyserial,
   scour,
+  tinycss2,
   gobject-introspection,
   pytestCheckHook,
   gtk3,
@@ -27,17 +27,6 @@ buildPythonPackage {
 
   inherit (inkscape) src;
 
-  patches = [
-    # Fix “distribute along path” test with Python 3.12.
-    # https://gitlab.com/inkscape/extensions/-/issues/580
-    (fetchpatch {
-      url = "https://gitlab.com/inkscape/extensions/-/commit/c576043c195cd044bdfc975e6367afb9b655eb14.patch";
-      extraPrefix = "share/extensions/";
-      stripLen = 1;
-      hash = "sha256-D9HxBx8RNkD7hHuExJqdu3oqlrXX6IOUw9m9Gx6+Dr8=";
-    })
-  ];
-
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [
@@ -46,6 +35,7 @@ buildPythonPackage {
     numpy
     pygobject3
     pyserial
+    tinycss2
   ];
 
   pythonImportsCheck = [ "inkex" ];
@@ -87,8 +77,7 @@ buildPythonPackage {
     cd share/extensions
 
     substituteInPlace pyproject.toml \
-      --replace-fail 'scour = "^0.37"' 'scour = ">=0.37"' \
-      --replace-fail 'lxml = "^4.5.0"' 'lxml = "^4.5.0 || ^5.0.0"'
+      --replace-fail 'scour = "^0.37"' 'scour = ">=0.37"'
   '';
 
   meta = {

--- a/pkgs/development/python-modules/svg2tikz/default.nix
+++ b/pkgs/development/python-modules/svg2tikz/default.nix
@@ -50,5 +50,6 @@ buildPythonPackage rec {
       dotlambda
       gal_bolle
     ];
+    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9626,10 +9626,6 @@ with pkgs;
 
   lcms = lcms2;
 
-  lib2geom = callPackage ../development/libraries/lib2geom {
-    stdenv = if stdenv.cc.isClang then llvmPackages_13.stdenv else stdenv;
-  };
-
   libacr38u = callPackage ../tools/security/libacr38u {
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };


### PR DESCRIPTION
https://gitlab.com/inkscape/inkscape/-/releases/INKSCAPE_1_4

Also update lib2geom, since Inkscape requires the newer version. For this, I cherry-picked the commit from https://github.com/NixOS/nixpkgs/pull/326652.
Closes #326652.
Cc @jtojnar

<details>
<summary>Marked as a draft, because the new version of lib2geom does not currently compile on macOS</summary>

```
lib2geom> [70/105] Building CXX object tests/CMakeFiles/planar-graph-test.dir/planar-graph-test.cpp.o
lib2geom> FAILED: tests/CMakeFiles/planar-graph-test.dir/planar-graph-test.cpp.o 
lib2geom> /nix/store/z60ayg9svn7msknnlazp2v6qgr3z8vvb-clang-wrapper-13.0.1/bin/clang++ -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -I/tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom -I/nix/store/yhpphcgxcxccivxrjlq901vvah09ijmw-glib-2.80.4-dev/include/glib-2.0 -I/nix/store/mmfyl2jlbaxh7j7h2i568f5kz4j2k6ik-glib-2.80.4/lib/glib-2.0/include -I/tmp/nix-build-lib2geom-1.4.drv-0/source/include -I/tmp/nix-build-lib2geom-1.4.drv-0/source/include/2geom -O3 -DNDEBUG -std=c++20 -MD -MT tests/CMakeFiles/planar-graph-test.dir/planar-graph-test.cpp.o -MF tests/CMakeFiles/planar-graph-test.dir/planar-graph-test.cpp.o.d -o tests/CMakeFiles/planar-graph-test.dir/planar-graph-test.cpp.o -c /tmp/nix-build-lib2geom-1.4.drv-0/source/tests/planar-graph-test.cpp
lib2geom> In file included from /tmp/nix-build-lib2geom-1.4.drv-0/source/tests/planar-graph-test.cpp:42:
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom/planar-graph.h:163:19: error: missing 'typename' prior to dependent type name 'std::list<Incidence>::iterator'
lib2geom>     using IncIt = std::list<Incidence>::iterator;
lib2geom>                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib2geom>                   typename 
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom/planar-graph.h:164:24: error: missing 'typename' prior to dependent type name 'std::list<Incidence>::const_iterator'
lib2geom>     using IncConstIt = std::list<Incidence>::const_iterator;
lib2geom>                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib2geom>                        typename 
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom/planar-graph.h:216:71: error: missing 'typename' prior to dependent type name 'Incidence::Sign'
lib2geom>         Incidence &_addIncidence(unsigned edge_index, double azimuth, Incidence::Sign sign)
lib2geom>                                                                       ^~~~~~~~~~~~~~~
lib2geom>                                                                       typename 
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom/planar-graph.h:235:28: error: missing 'typename' prior to dependent type name 'std::list<Vertex>::iterator'
lib2geom>     using VertexIterator = std::list<Vertex>::iterator;
lib2geom>                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
lib2geom>                            typename 
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom/planar-graph.h:260:26: error: missing 'typename' prior to dependent type name 'std::vector<Edge>::iterator'
lib2geom>     using EdgeIterator = std::vector<Edge>::iterator;
lib2geom>                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
lib2geom>                          typename 
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom/planar-graph.h:261:31: error: missing 'typename' prior to dependent type name 'std::vector<Edge>::const_iterator'
lib2geom>     using EdgeConstIterator = std::vector<Edge>::const_iterator;
lib2geom>                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib2geom>                               typename 
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom/planar-graph.h:321:39: error: missing 'typename' prior to dependent type name 'Incidence::Sign'
lib2geom>     getIncidence(unsigned edge_index, Incidence::Sign sign) const
lib2geom>                                       ^~~~~~~~~~~~~~~
lib2geom>                                       typename 
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom/planar-graph.h:407:58: error: missing 'typename' prior to dependent type name 'Incidence::Sign'
lib2geom>     inline Path _getPathImpl(Incidence const *incidence, Incidence::Sign origin) const
lib2geom>                                                          ^~~~~~~~~~~~~~~
lib2geom>                                                          typename 
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/src/2geom/planar-graph.h:1100:1: error: missing 'typename' prior to dependent type name 'PlanarGraph<EL>::Incidence'
lib2geom> PlanarGraph<EL>::Incidence*
lib2geom> ^~~~~~~~~~~~~~~~~~~~~~~~~~
lib2geom> typename 
lib2geom> 9 errors generated.
lib2geom> [71/105] Linking CXX executable tests/affine-test
lib2geom> [72/105] Linking CXX executable tests/angle-test
lib2geom> [73/105] Building CXX object tests/CMakeFiles/polynomial-test.dir/polynomial-test.cpp.o
lib2geom> [74/105] Linking CXX executable tests/choose-test
lib2geom> [75/105] Linking CXX executable tests/circle-test
lib2geom> [76/105] Linking CXX executable tests/convex-hull-test
lib2geom> [77/105] Building CXX object tests/CMakeFiles/line-test.dir/line-test.cpp.o
lib2geom> [78/105] Building CXX object tests/CMakeFiles/bezier-test.dir/bezier-test.cpp.o
lib2geom> [79/105] Building CXX object tests/CMakeFiles/root-find-test.dir/root-find-test.cpp.o
lib2geom> [80/105] Building CXX object tests/CMakeFiles/sbasis-text-test.dir/sbasis-text-test.cpp.o
lib2geom> [81/105] Building CXX object tests/CMakeFiles/self-intersections-test.dir/self-intersections-test.cpp.o
lib2geom> [82/105] Building CXX object tests/CMakeFiles/sbasis-test.dir/sbasis-test.cpp.o
lib2geom> [83/105] Building CXX object tests/CMakeFiles/rect-test.dir/rect-test.cpp.o
lib2geom> /tmp/nix-build-lib2geom-1.4.drv-0/source/tests/rect-test.cpp:97:1: warning: 'TypedTestCaseIsDeprecated' is deprecated: TYPED_TEST_CASE is deprecated, please use TYPED_TEST_SUITE [-Wdeprecated-declarations]
lib2geom> TYPED_TEST_CASE(GenericRectTest, CoordTypes);
lib2geom> ^
lib2geom> /nix/store/1vrg84lc6n84rk0qbqwh54iyr5y5wqiw-gtest-1.15.2-dev/include/gtest/gtest-typed-test.h:230:38: note: expanded from macro 'TYPED_TEST_CASE'
lib2geom>   static_assert(::testing::internal::TypedTestCaseIsDeprecated(), ""); \
lib2geom>                                      ^
lib2geom> /nix/store/1vrg84lc6n84rk0qbqwh54iyr5y5wqiw-gtest-1.15.2-dev/include/gtest/internal/gtest-internal.h:1254:1: note: 'TypedTestCaseIsDeprecated' has been explicitly marked deprecated here
lib2geom> GTEST_INTERNAL_DEPRECATED(
lib2geom> ^
lib2geom> /nix/store/1vrg84lc6n84rk0qbqwh54iyr5y5wqiw-gtest-1.15.2-dev/include/gtest/internal/gtest-port.h:2383:59: note: expanded from macro 'GTEST_INTERNAL_DEPRECATED'
lib2geom> #define GTEST_INTERNAL_DEPRECATED(message) __attribute__((deprecated(message)))
lib2geom>                                                           ^
lib2geom> 1 warning generated.
lib2geom> [84/105] Building CXX object tests/CMakeFiles/implicitization-test.dir/implicitization-test.cpp.o
lib2geom> [85/105] Building CXX object tests/CMakeFiles/path-test.dir/path-test.cpp.o
lib2geom> ninja: build stopped: subcommand failed.
```
</details>

I haven't spent much time trying to fix this.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
