### PR TITLE
lib/systems/architectures: Define inferiors for ARM64

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -426,11 +426,44 @@ rec {
     );
     znver5 = [ "znver4" ] ++ inferiors.znver4;
 
+    # ARM64 (AArch64)
+    armv8-a = [ ];
+    "armv8.1-a" = [ "armv8-a" ];
+    "armv8.2-a" = [ "armv8.1-a" ] ++ inferiors."armv8.1-a";
+    "armv8.3-a" = [ "armv8.2-a" ] ++ inferiors."armv8.2-a";
+    "armv8.4-a" = [ "armv8.3-a" ] ++ inferiors."armv8.3-a";
+    "armv8.5-a" = [ "armv8.4-a" ] ++ inferiors."armv8.4-a";
+    "armv8.6-a" = [ "armv8.5-a" ] ++ inferiors."armv8.5-a";
+    "armv8.7-a" = [ "armv8.6-a" ] ++ inferiors."armv8.6-a";
+    "armv8.8-a" = [ "armv8.7-a" ] ++ inferiors."armv8.7-a";
+    "armv8.9-a" = [ "armv8.8-a" ] ++ inferiors."armv8.8-a";
+    armv9-a = [ "armv8.5-a" ] ++ inferiors."armv8.5-a";
+    "armv9.1-a" = [
+      "armv9-a"
+      "armv8.6-a"
+    ] ++ inferiors."armv8.6-a";
+    "armv9.2-a" = lib.unique (
+      [
+        "armv9.1-a"
+        "armv8.7-a"
+      ]
+      ++ inferiors."armv9.1-a"
+      ++ inferiors."armv8.7-a"
+    );
+    "armv9.3-a" = lib.unique (
+      [
+        "armv9.2-a"
+        "armv8.8-a"
+      ]
+      ++ inferiors."armv9.2-a"
+      ++ inferiors."armv8.8-a"
+    );
+    "armv9.4-a" = [ "armv9.3-a" ] ++ inferiors."armv9.3-a";
+
     # other
     armv5te = [ ];
     armv6 = [ ];
     armv7-a = [ ];
-    armv8-a = [ ];
     mips32 = [ ];
     loongson2f = [ ];
   };

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -339,134 +339,161 @@ rec {
   };
 
   # a superior CPU has all the features of an inferior and is able to build and test code for it
-  inferiors = {
-    # x86_64 Generic
-    default = [ ];
-    x86-64 = [ ];
-    x86-64-v2 = [ "x86-64" ];
-    x86-64-v3 = [ "x86-64-v2" ] ++ inferiors.x86-64-v2;
-    x86-64-v4 = [ "x86-64-v3" ] ++ inferiors.x86-64-v3;
+  inferiors =
+    let
+      withInferiors = archs: lib.unique (archs ++ lib.flatten (lib.attrVals archs inferiors));
+    in
+    {
+      # x86_64 Generic
+      default = [ ];
+      x86-64 = [ ];
+      x86-64-v2 = [ "x86-64" ];
+      x86-64-v3 = [ "x86-64-v2" ] ++ inferiors.x86-64-v2;
+      x86-64-v4 = [ "x86-64-v3" ] ++ inferiors.x86-64-v3;
 
-    # x86_64 Intel
-    # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
-    nehalem = [ "x86-64-v2" ] ++ inferiors.x86-64-v2;
-    westmere = [ "nehalem" ] ++ inferiors.nehalem;
-    sandybridge = [ "westmere" ] ++ inferiors.westmere;
-    ivybridge = [ "sandybridge" ] ++ inferiors.sandybridge;
+      # x86_64 Intel
+      # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+      nehalem = [ "x86-64-v2" ] ++ inferiors.x86-64-v2;
+      westmere = [ "nehalem" ] ++ inferiors.nehalem;
+      sandybridge = [ "westmere" ] ++ inferiors.westmere;
+      ivybridge = [ "sandybridge" ] ++ inferiors.sandybridge;
 
-    haswell = lib.unique (
-      [
-        "ivybridge"
-        "x86-64-v3"
-      ]
-      ++ inferiors.ivybridge
-      ++ inferiors.x86-64-v3
-    );
-    broadwell = [ "haswell" ] ++ inferiors.haswell;
-    skylake = [ "broadwell" ] ++ inferiors.broadwell;
+      haswell = lib.unique (
+        [
+          "ivybridge"
+          "x86-64-v3"
+        ]
+        ++ inferiors.ivybridge
+        ++ inferiors.x86-64-v3
+      );
+      broadwell = [ "haswell" ] ++ inferiors.haswell;
+      skylake = [ "broadwell" ] ++ inferiors.broadwell;
 
-    skylake-avx512 = lib.unique (
-      [
-        "skylake"
-        "x86-64-v4"
-      ]
-      ++ inferiors.skylake
-      ++ inferiors.x86-64-v4
-    );
-    cannonlake = [ "skylake-avx512" ] ++ inferiors.skylake-avx512;
-    icelake-client = [ "cannonlake" ] ++ inferiors.cannonlake;
-    icelake-server = [ "icelake-client" ] ++ inferiors.icelake-client;
-    cascadelake = [ "cannonlake" ] ++ inferiors.cannonlake;
-    cooperlake = [ "cascadelake" ] ++ inferiors.cascadelake;
-    tigerlake = [ "icelake-server" ] ++ inferiors.icelake-server;
-    sapphirerapids = [ "tigerlake" ] ++ inferiors.tigerlake;
-    emeraldrapids = [ "sapphirerapids" ] ++ inferiors.sapphirerapids;
+      skylake-avx512 = lib.unique (
+        [
+          "skylake"
+          "x86-64-v4"
+        ]
+        ++ inferiors.skylake
+        ++ inferiors.x86-64-v4
+      );
+      cannonlake = [ "skylake-avx512" ] ++ inferiors.skylake-avx512;
+      icelake-client = [ "cannonlake" ] ++ inferiors.cannonlake;
+      icelake-server = [ "icelake-client" ] ++ inferiors.icelake-client;
+      cascadelake = [ "cannonlake" ] ++ inferiors.cannonlake;
+      cooperlake = [ "cascadelake" ] ++ inferiors.cascadelake;
+      tigerlake = [ "icelake-server" ] ++ inferiors.icelake-server;
+      sapphirerapids = [ "tigerlake" ] ++ inferiors.tigerlake;
+      emeraldrapids = [ "sapphirerapids" ] ++ inferiors.sapphirerapids;
 
-    # CX16 does not exist on alderlake, while it does on nearly all other intel CPUs
-    alderlake = [ ];
-    sierraforest = [ "alderlake" ] ++ inferiors.alderlake;
+      # CX16 does not exist on alderlake, while it does on nearly all other intel CPUs
+      alderlake = [ ];
+      sierraforest = [ "alderlake" ] ++ inferiors.alderlake;
 
-    # x86_64 AMD
-    # TODO: fill this (need testing)
-    btver1 = [ ];
-    btver2 = [ ];
-    bdver1 = [ ];
-    bdver2 = [ ];
-    bdver3 = [ ];
-    bdver4 = [ ];
-    # Regarding `skylake` as inferior of `znver1`, there are reports of
-    # successful usage by Gentoo users and Phoronix benchmarking of different
-    # `-march` targets.
-    #
-    # The GCC documentation on extensions used and wikichip documentation
-    # regarding supperted extensions on znver1 and skylake was used to create
-    # this partial order.
-    #
-    # Note:
-    #
-    # - The successors of `skylake` (`cannonlake`, `icelake`, etc) use `avx512`
-    #   which no current AMD Zen michroarch support.
-    # - `znver1` uses `ABM`, `CLZERO`, `CX16`, `MWAITX`, and `SSE4A` which no
-    #   current Intel microarch support.
-    #
-    # https://www.phoronix.com/scan.php?page=article&item=amd-znver3-gcc11&num=1
-    # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
-    # https://en.wikichip.org/wiki/amd/microarchitectures/zen
-    # https://en.wikichip.org/wiki/intel/microarchitectures/skylake
-    znver1 = [ "skylake" ] ++ inferiors.skylake; # Includes haswell and x86-64-v3
-    znver2 = [ "znver1" ] ++ inferiors.znver1;
-    znver3 = [ "znver2" ] ++ inferiors.znver2;
-    znver4 = lib.unique (
-      [
-        "znver3"
-        "x86-64-v4"
-      ]
-      ++ inferiors.znver3
-      ++ inferiors.x86-64-v4
-    );
-    znver5 = [ "znver4" ] ++ inferiors.znver4;
+      # x86_64 AMD
+      # TODO: fill this (need testing)
+      btver1 = [ ];
+      btver2 = [ ];
+      bdver1 = [ ];
+      bdver2 = [ ];
+      bdver3 = [ ];
+      bdver4 = [ ];
+      # Regarding `skylake` as inferior of `znver1`, there are reports of
+      # successful usage by Gentoo users and Phoronix benchmarking of different
+      # `-march` targets.
+      #
+      # The GCC documentation on extensions used and wikichip documentation
+      # regarding supperted extensions on znver1 and skylake was used to create
+      # this partial order.
+      #
+      # Note:
+      #
+      # - The successors of `skylake` (`cannonlake`, `icelake`, etc) use `avx512`
+      #   which no current AMD Zen michroarch support.
+      # - `znver1` uses `ABM`, `CLZERO`, `CX16`, `MWAITX`, and `SSE4A` which no
+      #   current Intel microarch support.
+      #
+      # https://www.phoronix.com/scan.php?page=article&item=amd-znver3-gcc11&num=1
+      # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+      # https://en.wikichip.org/wiki/amd/microarchitectures/zen
+      # https://en.wikichip.org/wiki/intel/microarchitectures/skylake
+      znver1 = [ "skylake" ] ++ inferiors.skylake; # Includes haswell and x86-64-v3
+      znver2 = [ "znver1" ] ++ inferiors.znver1;
+      znver3 = [ "znver2" ] ++ inferiors.znver2;
+      znver4 = lib.unique (
+        [
+          "znver3"
+          "x86-64-v4"
+        ]
+        ++ inferiors.znver3
+        ++ inferiors.x86-64-v4
+      );
+      znver5 = [ "znver4" ] ++ inferiors.znver4;
 
-    # ARM64 (AArch64)
-    armv8-a = [ ];
-    "armv8.1-a" = [ "armv8-a" ];
-    "armv8.2-a" = [ "armv8.1-a" ] ++ inferiors."armv8.1-a";
-    "armv8.3-a" = [ "armv8.2-a" ] ++ inferiors."armv8.2-a";
-    "armv8.4-a" = [ "armv8.3-a" ] ++ inferiors."armv8.3-a";
-    "armv8.5-a" = [ "armv8.4-a" ] ++ inferiors."armv8.4-a";
-    "armv8.6-a" = [ "armv8.5-a" ] ++ inferiors."armv8.5-a";
-    "armv8.7-a" = [ "armv8.6-a" ] ++ inferiors."armv8.6-a";
-    "armv8.8-a" = [ "armv8.7-a" ] ++ inferiors."armv8.7-a";
-    "armv8.9-a" = [ "armv8.8-a" ] ++ inferiors."armv8.8-a";
-    armv9-a = [ "armv8.5-a" ] ++ inferiors."armv8.5-a";
-    "armv9.1-a" = [
-      "armv9-a"
-      "armv8.6-a"
-    ] ++ inferiors."armv8.6-a";
-    "armv9.2-a" = lib.unique (
-      [
-        "armv9.1-a"
-        "armv8.7-a"
-      ]
-      ++ inferiors."armv9.1-a"
-      ++ inferiors."armv8.7-a"
-    );
-    "armv9.3-a" = lib.unique (
-      [
-        "armv9.2-a"
-        "armv8.8-a"
-      ]
-      ++ inferiors."armv9.2-a"
-      ++ inferiors."armv8.8-a"
-    );
-    "armv9.4-a" = [ "armv9.3-a" ] ++ inferiors."armv9.3-a";
+      # ARM64 (AArch64)
+      armv8-a = [ ];
+      "armv8.1-a" = [ "armv8-a" ];
+      "armv8.2-a" = [ "armv8.1-a" ] ++ inferiors."armv8.1-a";
+      "armv8.3-a" = [ "armv8.2-a" ] ++ inferiors."armv8.2-a";
+      "armv8.4-a" = [ "armv8.3-a" ] ++ inferiors."armv8.3-a";
+      "armv8.5-a" = [ "armv8.4-a" ] ++ inferiors."armv8.4-a";
+      "armv8.6-a" = [ "armv8.5-a" ] ++ inferiors."armv8.5-a";
+      "armv8.7-a" = [ "armv8.6-a" ] ++ inferiors."armv8.6-a";
+      "armv8.8-a" = [ "armv8.7-a" ] ++ inferiors."armv8.7-a";
+      "armv8.9-a" = [ "armv8.8-a" ] ++ inferiors."armv8.8-a";
+      armv9-a = [ "armv8.5-a" ] ++ inferiors."armv8.5-a";
+      "armv9.1-a" = [
+        "armv9-a"
+        "armv8.6-a"
+      ] ++ inferiors."armv8.6-a";
+      "armv9.2-a" = lib.unique (
+        [
+          "armv9.1-a"
+          "armv8.7-a"
+        ]
+        ++ inferiors."armv9.1-a"
+        ++ inferiors."armv8.7-a"
+      );
+      "armv9.3-a" = lib.unique (
+        [
+          "armv9.2-a"
+          "armv8.8-a"
+        ]
+        ++ inferiors."armv9.2-a"
+        ++ inferiors."armv8.8-a"
+      );
+      "armv9.4-a" = [ "armv9.3-a" ] ++ inferiors."armv9.3-a";
 
-    # other
-    armv5te = [ ];
-    armv6 = [ ];
-    armv7-a = [ ];
-    mips32 = [ ];
-    loongson2f = [ ];
-  };
+      # ARM
+      cortex-a53 = [ "armv8-a" ];
+      cortex-a72 = [ "armv8-a" ];
+      cortex-a55 = [
+        "armv8.2-a"
+        "cortex-a53"
+        "cortex-a72"
+      ] ++ inferiors."armv8.2-a";
+      cortex-a76 = [
+        "armv8.2-a"
+        "cortex-a53"
+        "cortex-a72"
+      ] ++ inferiors."armv8.2-a";
+
+      # Ampere
+      ampere1 = withInferiors [
+        "armv8.6-a"
+        "cortex-a55"
+        "cortex-a76"
+      ];
+      ampere1a = [ "ampere1" ] ++ inferiors.ampere1;
+      ampere1b = [ "ampere1a" ] ++ inferiors.ampere1a;
+
+      # other
+      armv5te = [ ];
+      armv6 = [ ];
+      armv7-a = [ ];
+      mips32 = [ ];
+      loongson2f = [ ];
+    };
 
   predicates =
     let


### PR DESCRIPTION
Define inferiors for generic ARM64 (AArch64) instruction set variants and some common CPUs.

Information sources:
- https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
- <https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/config/aarch64/aarch64-cores.def;h=cc2260036887721d0727548f96532fa9b5514a89;hb=HEAD>

It should be possible to derive these relations programmatically from extension flags, but that may only be reasonable if we wanted to support a larger set of ARM64 CPUs.

In addition GCC supports specification of individual ISA extensions to the base ISA, but the combinatorial complexity is probably not suitable for the purpose of `lib.systems.architecture.inferiors`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
