### PR TITLE
nixos/godns: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15652,6 +15652,12 @@
     github = "michaelshmitty";
     githubId = 114845;
   };
+  michaelvanstraten = {
+    name = "Michael van Straten";
+    email = "michael@vanstraten.de";
+    github = "michaelvanstraten";
+    githubId = 50352631;
+  };
   michalrus = {
     email = "m@michalrus.com";
     github = "michalrus";

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -214,6 +214,9 @@
 - [ipfs-cluster](https://ipfscluster.io/), Pinset orchestration for IPFS. Available as [services.ipfs-cluster](#opt-services.ipfs-cluster.enable)
 
 - [bitbox-bridge](https://github.com/BitBoxSwiss/bitbox-bridge), a bridge software that connects BitBox hardware wallets to computers & web wallets like [Rabby](https://rabby.io/). Allows one to interact & transact with smart contracts, Web3 websites & financial services without storing private keys anywhere other than the hardware wallet. Available as [services.bitbox-bridge](#opt-services.bitbox-bridge.enable).
+
+- [GoDNS](https://github.com/TimothyYe/godns), a dynamic DNS client written in Go, which supports multiple DNS providers. Available as [services.godns](option.html#opt-services.godns.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1137,6 +1137,7 @@
   ./services/networking/go-shadowsocks2.nix
   ./services/networking/gobgpd.nix
   ./services/networking/gokapi.nix
+  ./services/networking/godns.nix
   ./services/networking/gvpe.nix
   ./services/networking/hans.nix
   ./services/networking/harmonia.nix

--- a/nixos/modules/services/networking/godns.nix
+++ b/nixos/modules/services/networking/godns.nix
@@ -1,0 +1,84 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+
+  cfg = config.services.godns;
+
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  options.services.godns = {
+    enable = mkEnableOption "GoDNS service";
+
+    package = mkPackageOption pkgs "godns" { };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+      };
+
+      description = ''
+        Configuration for GoDNS. Refer to the [configuration section](1) in the
+        GoDNS GitHub repository for details.
+
+        [1]: https://github.com/TimothyYe/godns?tab=readme-ov-file#configuration
+      '';
+
+      example = {
+        provider = "Cloudflare";
+        login_token_file = "$CREDENTIALS_DIRECTORY/login_token";
+        domains = [
+          {
+            domain_name = "example.com";
+            sub_domains = [ "foo" ];
+          }
+        ];
+        ipv6_urls = [
+          "https://api6.ipify.org"
+          "https://ip2location.io/ip"
+          "https://v6.ipinfo.io/ip"
+        ];
+        ip_type = "IPv6";
+        interval = 300;
+      };
+    };
+
+    loadCredential = lib.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "login_token:/path/to/login_token" ];
+      description = ''
+        This can be used to pass secrets to the systemd service without adding
+        them to the nix store.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.godns = {
+      description = "GoDNS service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = "${lib.getExe cfg.package} -c ${settingsFormat.generate "config.yaml" cfg.settings}";
+        LoadCredential = cfg.loadCredential;
+        Restart = "always";
+        RestartSec = "2s";
+      };
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.michaelvanstraten ];
+}


### PR DESCRIPTION
Added a new NixOS module for the GoDNS service, which allows users to enable and configure the GoDNS service on their NixOS system.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
