### PR TITLE
bitmask-vpn: fix calyx build

### DIFF
--- a/pkgs/tools/networking/bitmask-vpn/default.nix
+++ b/pkgs/tools/networking/bitmask-vpn/default.nix
@@ -1,9 +1,11 @@
 { lib
 , stdenv
 , substituteAll
+, git
 , fetchFromGitLab
 , buildGoModule
 , wrapQtAppsHook
+, python3
 , python3Packages
 , pkg-config
 , openvpn
@@ -30,7 +32,8 @@ let
     owner = "leap";
     repo = "bitmask-vpn";
     rev = "8b3ac473f64b6de0262fbf945ff25af8029134f1";
-    sha256 = "sha256-nYMfO091w6H7LyY1+aYubFppg4/3GiZZm4e+0m9Gb3k=";
+    leaveDotGit = true;
+    sha256 = "sha256-XUgCVHnTLZXFU+r0s1yuYryWNBJRgQrFlf3g1iRrLWs=";
   };
 
   # bitmask-root is only used on GNU/Linux
@@ -105,7 +108,9 @@ buildGoModule rec {
 
   nativeBuildInputs = [
     cmake
+    git
     pkg-config
+    python3
     python3Packages.wrapPython
     which
     wrapQtAppsHook
@@ -130,6 +135,8 @@ buildGoModule rec {
   # gui/build.sh will build Go modules into lib/libgoshim.a
   buildPhase = ''
     runHook preBuild
+
+    make vendor
 
     # TODO: this is a hack that copies the qrc file that should by built by qmlcachegen
     # qmlcachegen is in qtdeclarative/libexec, but qmake is in qtbase/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3041,7 +3041,7 @@ with pkgs;
 
   bluetooth_battery = python3Packages.callPackage ../applications/misc/bluetooth_battery { };
 
-  calyx-vpn = libsForQt5.callPackage ../tools/networking/bitmask-vpn {
+  calyx-vpn = qt6Packages.callPackage ../tools/networking/bitmask-vpn {
     provider = "calyx";
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };


### PR DESCRIPTION
This fixes: #347620 

In the last upgrade of bitmask-vpn #344549 the upgrade of callPackage to qt6 for calyx-vpn was missed. This is the immediate cause of the build error reported in #347620.

Beyond this initial build error, there were further errors with calyx-vpn because a new `make vendor` step has been added to the build documentation for bitmask-vpn in the past few months. Riseup-vpn seems to work fine without running this step but calyx-vpn does not. The remaining changes to the default.nix here were required to complete the build when it includes `make vendor`. 

Calyx-vpn now builds and runs, but still cannot actually complete a VPN connection because of certificate errors. It is unclear whether the underlying cause of this bug is from the calyx servers, the bitmask-vpn upstream, or with the nixpkgs build. Building calyx-vpn on a different linux system could determine whether or not it is a nixpkgs build problem. I will leave it to someone else to open an issue about this if necessary. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
