### PR TITLE
usbipd: add usbipd service with autobind

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3756,6 +3756,12 @@
     matrix = "@cedric:cbarrete.com";
     name = "Cédric Barreteau";
   };
+  cbingman = {
+    name = "Christian Bingman";
+    email = "maintainer@christianbingman.com";
+    github = "ChristianBingman";
+    githubId = 42191425;
+  };
   cbleslie = {
     email = "cameronleslie@gmail.com";
     github = "cbleslie";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -643,6 +643,7 @@
   ./services/hardware/udisks2.nix
   ./services/hardware/undervolt.nix
   ./services/hardware/upower.nix
+  ./services/hardware/usbipd.nix
   ./services/hardware/usbmuxd.nix
   ./services/hardware/usbrelayd.nix
   ./services/hardware/vdr.nix

--- a/nixos/modules/services/hardware/usbipd.nix
+++ b/nixos/modules/services/hardware/usbipd.nix
@@ -22,7 +22,7 @@ in
 {
   options.services.usbipd = {
     enable = lib.mkEnableOption "usbip server";
-    kernelPackage = lib.mkPackageOption pkgs.linuxPackages_latest "usbip" {};
+    kernelPackage = lib.mkPackageOption pkgs.linuxPackages_latest "usbip" { };
     devices = lib.mkOption {
       type = lib.types.listOf device;
       default = [ ];

--- a/nixos/modules/services/hardware/usbipd.nix
+++ b/nixos/modules/services/hardware/usbipd.nix
@@ -23,8 +23,9 @@ in
     enable = mkEnableOption "usbip server";
     kernelPackage = mkOption {
       type = types.package;
-      default = config.boot.kernelPackages.usbip;
+      default = pkgs.linuxPackages_latest.usbip;
       description = "The kernel module package to install.";
+      example = config.boot.kernelPackages.usbip;
     };
     devices = mkOption {
       type = types.listOf device;

--- a/nixos/modules/services/hardware/usbipd.nix
+++ b/nixos/modules/services/hardware/usbipd.nix
@@ -11,9 +11,11 @@ let
     options = {
       productid = mkOption {
         type = types.str;
+        description = "The product id of the device";
       };
       vendorid = mkOption {
         type = types.str;
+        description = "The vendor id of the device";
       };
     };
   };
@@ -30,10 +32,10 @@ in
       type = types.listOf device;
       default = [ ];
       description = "List of USB devices to watch and automatically export.";
-      example = {
+      example = [{
         productid = "xxxx";
         vendorid = "xxxx";
-      };
+      }];
     };
     openFirewall = mkOption {
       type = types.bool;

--- a/nixos/modules/services/hardware/usbipd.nix
+++ b/nixos/modules/services/hardware/usbipd.nix
@@ -32,10 +32,12 @@ in
       type = types.listOf device;
       default = [ ];
       description = "List of USB devices to watch and automatically export.";
-      example = [{
-        productid = "xxxx";
-        vendorid = "xxxx";
-      }];
+      example = [
+        {
+          productid = "xxxx";
+          vendorid = "xxxx";
+        }
+      ];
     };
     openFirewall = mkOption {
       type = types.bool;

--- a/nixos/modules/services/hardware/usbipd.nix
+++ b/nixos/modules/services/hardware/usbipd.nix
@@ -25,7 +25,6 @@ in
       type = types.package;
       default = pkgs.linuxPackages_latest.usbip;
       description = "The kernel module package to install.";
-      example = config.boot.kernelPackages.usbip;
     };
     devices = mkOption {
       type = types.listOf device;

--- a/nixos/modules/services/hardware/usbipd.nix
+++ b/nixos/modules/services/hardware/usbipd.nix
@@ -23,9 +23,8 @@ in
     enable = mkEnableOption "usbip server";
     kernelPackage = mkOption {
       type = types.package;
-      default = pkgs.linuxPackages_latest.usbip;
+      default = config.boot.kernelPackages.usbip;
       description = "The kernel module package to install.";
-      example = config.boot.kernelPackages.usbip;
     };
     devices = mkOption {
       type = types.listOf device;
@@ -97,4 +96,5 @@ in
       };
   };
   meta.maintainers = with maintainers; [ cbingman ];
+  meta.buildDocsInSandbox = false
 }

--- a/nixos/modules/services/hardware/usbipd.nix
+++ b/nixos/modules/services/hardware/usbipd.nix
@@ -1,0 +1,75 @@
+{ lib, pkgs, config, ... }:
+with lib;
+let
+  cfg = config.services.usbipd;
+  device = types.submodule {
+    options = {
+      productid = mkOption {
+        type = types.str;
+      };
+      vendorid = mkOption {
+        type = types.str;
+      };
+    };
+  };
+in {
+  options.services.usbipd = {
+    enable = mkEnableOption "usbip server";
+    kernelPackage = mkOption {
+      type = types.package;
+      default = config.boot.kernelPackages.usbip;
+      description = "The kernel module package to install.";
+    };
+    devices = mkOption {
+      type = types.listOf device;
+      default = [];
+      description = "List of USB devices to watch and automatically export.";
+      example = {
+        productid = "xxxx";
+        vendorid = "xxxx";
+      };
+    };
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Open port 3240 for usbipd";
+      example = false;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    boot.extraModulePackages = [ cfg.kernelPackage ];
+    boot.kernelModules = [ "usbip-core" "usbip-host" ];
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ 3240 ];
+    services.udev.extraRules = strings.concatLines 
+      ((map (dev: 
+        "ACTION==\"add\", SUBSYSTEM==\"usb\", ATTRS{idProduct}==\"${dev.productid}\", ATTRS{idVendor}==\"${dev.vendorid}\", RUN+=\"${pkgs.systemd}/bin/systemctl restart usbip-${dev.vendorid}:${dev.productid}.service\"") cfg.devices));
+
+    systemd.services = (builtins.listToAttrs (map (dev: { name = "usbip-${dev.vendorid}:${dev.productid}"; value = {
+          after = [ "usbipd.service" ];
+          script = ''
+            set +e
+            devices=$(${cfg.kernelPackage}/bin/usbip list -l | grep -E "^.*- busid.*(${dev.vendorid}:${dev.productid})" )
+            output=$(${cfg.kernelPackage}/bin/usbip -d bind -b $(echo $devices | ${pkgs.gawk}/bin/awk '{ print $3 }') 2>&1)
+            code=$?
+
+            echo $output
+            if [[ $output =~ "already bound" ]]; then
+              exit 0
+            else
+              exit $code
+            fi
+          '';
+          serviceConfig.Type = "oneshot";
+          serviceConfig.RemainAfterExit = true;
+          restartTriggers = [ "usbipd.service" ];
+        };
+      }) cfg.devices)) // {
+        usbipd = {
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig.ExecStart = "${cfg.kernelPackage}/bin/usbipd -D";
+          serviceConfig.Type = "forking";
+        };
+      };
+  };
+}

--- a/nixos/modules/services/hardware/usbipd.nix
+++ b/nixos/modules/services/hardware/usbipd.nix
@@ -96,5 +96,5 @@ in
       };
   };
   meta.maintainers = with maintainers; [ cbingman ];
-  meta.buildDocsInSandbox = false
+  meta.buildDocsInSandbox = false;
 }

--- a/nixos/modules/services/hardware/usbipd.nix
+++ b/nixos/modules/services/hardware/usbipd.nix
@@ -41,8 +41,8 @@ in {
     boot.extraModulePackages = [ cfg.kernelPackage ];
     boot.kernelModules = [ "usbip-core" "usbip-host" ];
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ 3240 ];
-    services.udev.extraRules = strings.concatLines 
-      ((map (dev: 
+    services.udev.extraRules = strings.concatLines
+      ((map (dev:
         "ACTION==\"add\", SUBSYSTEM==\"usb\", ATTRS{idProduct}==\"${dev.productid}\", ATTRS{idVendor}==\"${dev.vendorid}\", RUN+=\"${pkgs.systemd}/bin/systemctl restart usbip-${dev.vendorid}:${dev.productid}.service\"") cfg.devices));
 
     systemd.services = (builtins.listToAttrs (map (dev: { name = "usbip-${dev.vendorid}:${dev.productid}"; value = {
@@ -72,4 +72,5 @@ in {
         };
       };
   };
+  meta.maintainers = with maintainers; [ cbingman ];
 }


### PR DESCRIPTION
Manage usbip devices with a simple service!

- Automatically installs and starts the usbip daemon
- Automatically binds devices to be shared on the network using udev and systemd
- Opens relevant ports

tested on an x86 vm and a raspberry pi 4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
