### PR TITLE
[Backport release-24.05] discord: format, update discord-canary and discord-ptb, refactor meta

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -1,25 +1,51 @@
-{ pname, version, src, meta, stdenv, binaryName, desktopName, lib, undmg, makeWrapper, writeScript, python3, runCommand
-, branch
-, withOpenASAR ? false, openasar
-, withVencord ? false, vencord }:
+{
+  pname,
+  version,
+  src,
+  meta,
+  stdenv,
+  binaryName,
+  desktopName,
+  lib,
+  undmg,
+  makeWrapper,
+  writeScript,
+  python3,
+  runCommand,
+  branch,
+  withOpenASAR ? false,
+  openasar,
+  withVencord ? false,
+  vencord,
+}:
 
 let
-  disableBreakingUpdates = runCommand "disable-breaking-updates.py"
-    {
-      pythonInterpreter = "${python3.interpreter}";
-      configDirName = lib.toLower binaryName;
-      meta.mainProgram = "disable-breaking-updates.py";
-    } ''
-    mkdir -p $out/bin
-    cp ${./disable-breaking-updates.py} $out/bin/disable-breaking-updates.py
-    substituteAllInPlace $out/bin/disable-breaking-updates.py
-    chmod +x $out/bin/disable-breaking-updates.py
-  '';
+  disableBreakingUpdates =
+    runCommand "disable-breaking-updates.py"
+      {
+        pythonInterpreter = "${python3.interpreter}";
+        configDirName = lib.toLower binaryName;
+        meta.mainProgram = "disable-breaking-updates.py";
+      }
+      ''
+        mkdir -p $out/bin
+        cp ${./disable-breaking-updates.py} $out/bin/disable-breaking-updates.py
+        substituteAllInPlace $out/bin/disable-breaking-updates.py
+        chmod +x $out/bin/disable-breaking-updates.py
+      '';
 in
 stdenv.mkDerivation {
-  inherit pname version src meta;
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
 
-  nativeBuildInputs = [ undmg makeWrapper ];
+  nativeBuildInputs = [
+    undmg
+    makeWrapper
+  ];
 
   sourceRoot = ".";
 
@@ -37,14 +63,16 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  postInstall = lib.strings.optionalString withOpenASAR ''
-    cp -f ${openasar} $out/Applications/${desktopName}.app/Contents/Resources/app.asar
-  '' + lib.strings.optionalString withVencord ''
-    mv $out/Applications/${desktopName}.app/Contents/Resources/app.asar $out/Applications/${desktopName}.app/Contents/Resources/_app.asar
-    mkdir $out/Applications/${desktopName}.app/Contents/Resources/app.asar
-    echo '{"name":"discord","main":"index.js"}' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json
-    echo 'require("${vencord}/patcher.js")' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/index.js
-  '';
+  postInstall =
+    lib.strings.optionalString withOpenASAR ''
+      cp -f ${openasar} $out/Applications/${desktopName}.app/Contents/Resources/app.asar
+    ''
+    + lib.strings.optionalString withVencord ''
+      mv $out/Applications/${desktopName}.app/Contents/Resources/app.asar $out/Applications/${desktopName}.app/Contents/Resources/_app.asar
+      mkdir $out/Applications/${desktopName}.app/Contents/Resources/app.asar
+      echo '{"name":"discord","main":"index.js"}' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json
+      echo 'require("${vencord}/patcher.js")' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/index.js
+    '';
 
   passthru = {
     # make it possible to run disableBreakingUpdates standalone
@@ -56,7 +84,9 @@ stdenv.mkDerivation {
       set -eou pipefail;
       url=$(curl -sI -o /dev/null -w '%header{location}' "https://discord.com/api/download/${branch}?platform=osx&format=dmg")
       version=$(echo $url | grep -oP '/\K(\d+\.){2}\d+')
-      update-source-version ${lib.optionalString (!stdenv.buildPlatform.isDarwin) "pkgsCross.aarch64-darwin."}${pname} "$version" --file=./pkgs/applications/networking/instant-messengers/discord/default.nix --version-key=${branch}
+      update-source-version ${
+        lib.optionalString (!stdenv.buildPlatform.isDarwin) "pkgsCross.aarch64-darwin."
+      }${pname} "$version" --file=./pkgs/applications/networking/instant-messengers/discord/default.nix --version-key=${branch}
     '';
   };
 }

--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -54,11 +54,8 @@ stdenv.mkDerivation {
       #!nix-shell -i bash -p curl gnugrep common-updater-scripts
       set -x
       set -eou pipefail;
-      url=$(curl -sI "https://discordapp.com/api/download/${
-        builtins.replaceStrings [ "discord-" "discord" ] [ "" "stable" ] pname
-      }?platform=osx&format=dmg" | grep -oP 'location: \K\S+')
-      version=''${url##https://dl*.discordapp.net/apps/osx/}
-      version=''${version%%/*.dmg}
+      url=$(curl -sI -o /dev/null -w '%header{location}' "https://discord.com/api/download/${branch}?platform=osx&format=dmg")
+      version=$(echo $url | grep -oP '/\K(\d+\.){2}\d+')
       update-source-version ${lib.optionalString (!stdenv.buildPlatform.isDarwin) "pkgsCross.aarch64-darwin."}${pname} "$version" --file=./pkgs/applications/networking/instant-messengers/discord/default.nix --version-key=${branch}
     '';
   };

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -73,6 +73,7 @@ let
     mainProgram = "discord";
     maintainers = with maintainers; [
       artturin
+      donteatoreo
       infinidoge
       jopejoe1
       Scrumplex

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -11,7 +11,7 @@ let
       {
         stable = "0.0.71";
         ptb = "0.0.111";
-        canary = "0.0.502";
+        canary = "0.0.503";
         development = "0.0.30";
       }
     else
@@ -34,7 +34,7 @@ let
       };
       canary = fetchurl {
         url = "https://canary.dl2.discordapp.net/apps/linux/${version}/discord-canary-${version}.tar.gz";
-        hash = "sha256-2DE7p3eT/mVGC+ejnTcTEhF7sEWyhfUfzj0gYTh+6Dw=";
+        hash = "sha256-Z0dv/jM0RipRI73vO9O5qqE0xf8qJtljZ3Zjr0Tf/KA=";
       };
       development = fetchurl {
         url = "https://development.dl2.discordapp.net/apps/linux/${version}/discord-development-${version}.tar.gz";

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -10,7 +10,7 @@ let
     if stdenv.hostPlatform.isLinux then
       {
         stable = "0.0.71";
-        ptb = "0.0.110";
+        ptb = "0.0.111";
         canary = "0.0.502";
         development = "0.0.30";
       }
@@ -30,7 +30,7 @@ let
       };
       ptb = fetchurl {
         url = "https://ptb.dl2.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz";
-        hash = "sha256-NV/0YKn1rG54Zkc9qAmpeb+4YbKjxhjTCdPOd84Lcc8=";
+        hash = "sha256-mms/qTA3XS+R5CDFWFS2RxiHOWnpU348nYagt9L2k2w=";
       };
       canary = fetchurl {
         url = "https://canary.dl2.discordapp.net/apps/linux/${version}/discord-canary-${version}.tar.gz";

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -17,7 +17,7 @@ let
     else
       {
         stable = "0.0.322";
-        ptb = "0.0.140";
+        ptb = "0.0.141";
         canary = "0.0.612";
         development = "0.0.53";
       };
@@ -48,7 +48,7 @@ let
       };
       ptb = fetchurl {
         url = "https://ptb.dl2.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
-        hash = "sha256-VGhvykujfzI7jwXE+lHTzqT0t08GaON6gCuf13po7wY=";
+        hash = "sha256-EVwosCb/34W4+dx/u/5aq3pl6FqU1QiFT17yPydtGBU=";
       };
       canary = fetchurl {
         url = "https://canary.dl2.discordapp.net/apps/osx/${version}/DiscordCanary.dmg";

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -65,13 +65,13 @@ let
     srcs.${stdenv.hostPlatform.system}.${branch}
       or (throw "${stdenv.hostPlatform.system} not supported on ${branch}");
 
-  meta = with lib; {
+  meta = {
     description = "All-in-one cross-platform voice and text chat for gamers";
     downloadPage = "https://discordapp.com/download";
     homepage = "https://discordapp.com/";
-    license = licenses.unfree;
+    license = lib.licenses.unfree;
     mainProgram = "discord";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       artturin
       donteatoreo
       infinidoge
@@ -83,7 +83,7 @@ let
       "x86_64-darwin"
       "aarch64-darwin"
     ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
   package = if stdenv.hostPlatform.isLinux then ./linux.nix else ./darwin.nix;
 

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -67,10 +67,10 @@ let
 
   meta = with lib; {
     description = "All-in-one cross-platform voice and text chat for gamers";
-    homepage = "https://discordapp.com/";
     downloadPage = "https://discordapp.com/download";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    homepage = "https://discordapp.com/";
     license = licenses.unfree;
+    mainProgram = "discord";
     maintainers = with maintainers; [
       Scrumplex
       artturin
@@ -82,7 +82,7 @@ let
       "x86_64-darwin"
       "aarch64-darwin"
     ];
-    mainProgram = "discord";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
   package = if stdenv.hostPlatform.isLinux then ./linux.nix else ./darwin.nix;
 

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -18,7 +18,7 @@ let
       {
         stable = "0.0.322";
         ptb = "0.0.140";
-        canary = "0.0.611";
+        canary = "0.0.612";
         development = "0.0.53";
       };
   version = versions.${branch};
@@ -52,7 +52,7 @@ let
       };
       canary = fetchurl {
         url = "https://canary.dl2.discordapp.net/apps/osx/${version}/DiscordCanary.dmg";
-        hash = "sha256-QC8RANqoyMAGKjTF0NNhz7wMt65D5LI1xYtd++dHXC4=";
+        hash = "sha256-xvrsohxoCTODG3Au5E773SEX5UXbBJ98J2Eb3Vtybfw=";
       };
       development = fetchurl {
         url = "https://development.dl2.discordapp.net/apps/osx/${version}/DiscordDevelopment.dmg";

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -72,10 +72,10 @@ let
     license = licenses.unfree;
     mainProgram = "discord";
     maintainers = with maintainers; [
-      Scrumplex
       artturin
       infinidoge
       jopejoe1
+      Scrumplex
     ];
     platforms = [
       "x86_64-linux"

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,17 +1,26 @@
-{ branch ? "stable", callPackage, fetchurl, lib, stdenv }:
+{
+  branch ? "stable",
+  callPackage,
+  fetchurl,
+  lib,
+  stdenv,
+}:
 let
   versions =
-    if stdenv.hostPlatform.isLinux then {
-      stable = "0.0.71";
-      ptb = "0.0.110";
-      canary = "0.0.502";
-      development = "0.0.30";
-    } else {
-      stable = "0.0.322";
-      ptb = "0.0.140";
-      canary = "0.0.611";
-      development = "0.0.53";
-    };
+    if stdenv.hostPlatform.isLinux then
+      {
+        stable = "0.0.71";
+        ptb = "0.0.110";
+        canary = "0.0.502";
+        development = "0.0.30";
+      }
+    else
+      {
+        stable = "0.0.322";
+        ptb = "0.0.140";
+        canary = "0.0.611";
+        development = "0.0.53";
+      };
   version = versions.${branch};
   srcs = rec {
     x86_64-linux = {
@@ -52,7 +61,9 @@ let
     };
     aarch64-darwin = x86_64-darwin;
   };
-  src = srcs.${stdenv.hostPlatform.system}.${branch} or (throw "${stdenv.hostPlatform.system} not supported on ${branch}");
+  src =
+    srcs.${stdenv.hostPlatform.system}.${branch}
+      or (throw "${stdenv.hostPlatform.system} not supported on ${branch}");
 
   meta = with lib; {
     description = "All-in-one cross-platform voice and text chat for gamers";
@@ -60,23 +71,35 @@ let
     downloadPage = "https://discordapp.com/download";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ Scrumplex artturin infinidoge jopejoe1 ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    maintainers = with maintainers; [
+      Scrumplex
+      artturin
+      infinidoge
+      jopejoe1
+    ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
     mainProgram = "discord";
   };
-  package =
-    if stdenv.isLinux
-    then ./linux.nix
-    else ./darwin.nix;
+  package = if stdenv.hostPlatform.isLinux then ./linux.nix else ./darwin.nix;
 
   packages = (
     builtins.mapAttrs
-      (_: value:
-        callPackage package (value
+      (
+        _: value:
+        callPackage package (
+          value
           // {
-          inherit src version branch;
-          meta = meta // { mainProgram = value.binaryName; };
-        }))
+            inherit src version branch;
+            meta = meta // {
+              mainProgram = value.binaryName;
+            };
+          }
+        )
+      )
       {
         stable = {
           pname = "discord";

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -151,11 +151,8 @@ stdenv.mkDerivation rec {
       #!/usr/bin/env nix-shell
       #!nix-shell -i bash -p curl gnugrep common-updater-scripts
       set -eou pipefail;
-      url=$(curl -sI "https://discordapp.com/api/download/${
-        builtins.replaceStrings [ "discord-" "discord" ] [ "" "stable" ] pname
-      }?platform=linux&format=tar.gz" | grep -oP 'location: \K\S+')
-      version=''${url##https://dl*.discordapp.net/apps/linux/}
-      version=''${version%%/*.tar.gz}
+      url=$(curl -sI -o /dev/null -w '%header{location}' "https://discord.com/api/download/${branch}?platform=linux&format=tar.gz")
+      version=$(echo $url | grep -oP '/\K(\d+\.){2}\d+')
       update-source-version ${pname} "$version" --file=./pkgs/applications/networking/instant-messengers/discord/default.nix --version-key=${branch}
     '';
   };

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -1,34 +1,92 @@
-{ pname, version, src, meta, binaryName, desktopName, autoPatchelfHook
-, makeDesktopItem, lib, stdenv, wrapGAppsHook3, makeShellWrapper, alsa-lib, at-spi2-atk
-, at-spi2-core, atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk-pixbuf
-, glib, gtk3, libcxx, libdrm, libglvnd, libnotify, libpulseaudio, libuuid, libX11
-, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext, libXfixes
-, libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence, mesa, nspr, nss
-, pango, systemd, libappindicator-gtk3, libdbusmenu, writeScript, python3, runCommand
-, libunity
-, speechd
-, wayland
-, branch
-, withOpenASAR ? false, openasar
-, withVencord ? false, vencord
-, withTTS ? true }:
+{
+  pname,
+  version,
+  src,
+  meta,
+  binaryName,
+  desktopName,
+  autoPatchelfHook,
+  makeDesktopItem,
+  lib,
+  stdenv,
+  wrapGAppsHook3,
+  makeShellWrapper,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libcxx,
+  libdrm,
+  libglvnd,
+  libnotify,
+  libpulseaudio,
+  libuuid,
+  libX11,
+  libXScrnSaver,
+  libXcomposite,
+  libXcursor,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXi,
+  libXrandr,
+  libXrender,
+  libXtst,
+  libxcb,
+  libxshmfence,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  systemd,
+  libappindicator-gtk3,
+  libdbusmenu,
+  writeScript,
+  python3,
+  runCommand,
+  libunity,
+  speechd,
+  wayland,
+  branch,
+  withOpenASAR ? false,
+  openasar,
+  withVencord ? false,
+  vencord,
+  withTTS ? true,
+}:
 
 let
-  disableBreakingUpdates = runCommand "disable-breaking-updates.py"
-    {
-      pythonInterpreter = "${python3.interpreter}";
-      configDirName = lib.toLower binaryName;
-      meta.mainProgram = "disable-breaking-updates.py";
-    } ''
-    mkdir -p $out/bin
-    cp ${./disable-breaking-updates.py} $out/bin/disable-breaking-updates.py
-    substituteAllInPlace $out/bin/disable-breaking-updates.py
-    chmod +x $out/bin/disable-breaking-updates.py
-  '';
+  disableBreakingUpdates =
+    runCommand "disable-breaking-updates.py"
+      {
+        pythonInterpreter = "${python3.interpreter}";
+        configDirName = lib.toLower binaryName;
+        meta.mainProgram = "disable-breaking-updates.py";
+      }
+      ''
+        mkdir -p $out/bin
+        cp ${./disable-breaking-updates.py} $out/bin/disable-breaking-updates.py
+        substituteAllInPlace $out/bin/disable-breaking-updates.py
+        chmod +x $out/bin/disable-breaking-updates.py
+      '';
 in
 
 stdenv.mkDerivation rec {
-  inherit pname version src meta;
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
 
   nativeBuildInputs = [
     alsa-lib
@@ -50,48 +108,51 @@ stdenv.mkDerivation rec {
 
   dontWrapGApps = true;
 
-  libPath = lib.makeLibraryPath ([
-    libcxx
-    systemd
-    libpulseaudio
-    libdrm
-    mesa
-    stdenv.cc.cc
-    alsa-lib
-    atk
-    at-spi2-atk
-    at-spi2-core
-    cairo
-    cups
-    dbus
-    expat
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gtk3
-    libglvnd
-    libnotify
-    libX11
-    libXcomposite
-    libunity
-    libuuid
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXtst
-    nspr
-    libxcb
-    pango
-    libXScrnSaver
-    libappindicator-gtk3
-    libdbusmenu
-    wayland
-  ] ++ lib.optional withTTS speechd);
+  libPath = lib.makeLibraryPath (
+    [
+      libcxx
+      systemd
+      libpulseaudio
+      libdrm
+      mesa
+      stdenv.cc.cc
+      alsa-lib
+      atk
+      at-spi2-atk
+      at-spi2-core
+      cairo
+      cups
+      dbus
+      expat
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib
+      gtk3
+      libglvnd
+      libnotify
+      libX11
+      libXcomposite
+      libunity
+      libuuid
+      libXcursor
+      libXdamage
+      libXext
+      libXfixes
+      libXi
+      libXrandr
+      libXrender
+      libXtst
+      nspr
+      libxcb
+      pango
+      libXScrnSaver
+      libappindicator-gtk3
+      libdbusmenu
+      wayland
+    ]
+    ++ lib.optional withTTS speechd
+  );
 
   installPhase = ''
     runHook preInstall
@@ -113,9 +174,7 @@ stdenv.mkDerivation rec {
 
     ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
     # Without || true the install would fail on case-insensitive filesystems
-    ln -s $out/opt/${binaryName}/${binaryName} $out/bin/${
-      lib.strings.toLower binaryName
-    } || true
+    ln -s $out/opt/${binaryName}/${binaryName} $out/bin/${lib.strings.toLower binaryName} || true
 
     ln -s $out/opt/${binaryName}/discord.png $out/share/pixmaps/${pname}.png
     ln -s $out/opt/${binaryName}/discord.png $out/share/icons/hicolor/256x256/apps/${pname}.png
@@ -125,14 +184,16 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  postInstall = lib.strings.optionalString withOpenASAR ''
-    cp -f ${openasar} $out/opt/${binaryName}/resources/app.asar
-  '' + lib.strings.optionalString withVencord ''
-    mv $out/opt/${binaryName}/resources/app.asar $out/opt/${binaryName}/resources/_app.asar
-    mkdir $out/opt/${binaryName}/resources/app.asar
-    echo '{"name":"discord","main":"index.js"}' > $out/opt/${binaryName}/resources/app.asar/package.json
-    echo 'require("${vencord}/patcher.js")' > $out/opt/${binaryName}/resources/app.asar/index.js
-  '';
+  postInstall =
+    lib.strings.optionalString withOpenASAR ''
+      cp -f ${openasar} $out/opt/${binaryName}/resources/app.asar
+    ''
+    + lib.strings.optionalString withVencord ''
+      mv $out/opt/${binaryName}/resources/app.asar $out/opt/${binaryName}/resources/_app.asar
+      mkdir $out/opt/${binaryName}/resources/app.asar
+      echo '{"name":"discord","main":"index.js"}' > $out/opt/${binaryName}/resources/app.asar/package.json
+      echo 'require("${vencord}/patcher.js")' > $out/opt/${binaryName}/resources/app.asar/index.js
+    '';
 
   desktopItem = makeDesktopItem {
     name = pname;
@@ -140,7 +201,10 @@ stdenv.mkDerivation rec {
     icon = pname;
     inherit desktopName;
     genericName = meta.description;
-    categories = [ "Network" "InstantMessaging" ];
+    categories = [
+      "Network"
+      "InstantMessaging"
+    ];
     mimeTypes = [ "x-scheme-handler/discord" ];
   };
 


### PR DESCRIPTION
Backports:
https://github.com/NixOS/nixpkgs/pull/347313

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc