### PR TITLE
Fix fetchFromSavannah

### DIFF
--- a/pkgs/build-support/fetchsavannah/default.nix
+++ b/pkgs/build-support/fetchsavannah/default.nix
@@ -6,7 +6,8 @@ lib.makeOverridable (
 , ... # For hash agility
 }@args: fetchzip ({
   inherit name;
-  url = "https://git.savannah.gnu.org/cgit/${repo}.git/snapshot/${repo}-${rev}.tar.gz";
+  url = "https://git.savannah.gnu.org/gitweb/?p=${repo}.git;a=snapshot;h=${rev};sf=tgz";
+  extension = "tar.gz";
   meta.homepage = "https://git.savannah.gnu.org/cgit/${repo}.git/";
 } // removeAttrs args [ "repo" "rev" ]) // { inherit rev; }
 )


### PR DESCRIPTION
GNU Savannah broke/changed their snapshot api, this makes fetchFromSavannah work again. Sorry if the PR is bad, this is my first one here, and I definitely don't know what I'm doing.

## Things done

I tested the existing fetch of gnulib from the grub package using nix repl, the hash matches.

```
nix-repl> :l .

nix-repl> gnulib = pkgs.fetchFromSavannah { name = "forceRefetch"; repo = "gnulib"; rev = "9f48fb992a3d7e96610c4ce8be969cff2d61a01b"; hash = "sha256-mzbF66SNqcSlI+xmjpKpNMwzi13yEWoc1Fl7p4snTto="; }           

nix-repl> gnulibwronghash = pkgs.fetchFromSavannah { name = "forceRefetch"; repo = "gnulib"; rev = "9f48fb992a3d7e96610c4ce8be969cff2d61a01b"; hash = "sha256-aaaaaaaaqcSlI+xmjpKpNMwzi13yEWoc1Fl7p4sfTto="; }  

nix-repl> :b gnulib

This derivation produced the following outputs:
  out -> /nix/store/zpfli4mqxhp16zqczzhzhwvdjqzhqyhi-forceRefetch

nix-repl> :b gnulibwronghash
error: hash mismatch in fixed-output derivation '/nix/store/3rc54shr6473kakfnck4gvx4qgvyd4rd-forceRefetch.drv':
        likely URL: https://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=snapshot;h=9f48fb992a3d7e96610c4ce8be969cff2d61a01b;sf=tgz
         specified: sha256-aaaaaaaaqcSlI+xmjpKpNMwzi13yEWoc1Fl7p4sfTto=
            got:    sha256-mzbF66SNqcSlI+xmjpKpNMwzi13yEWoc1Fl7p4snTto=

nix-repl>
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
