### PR TITLE
hdf4: modernize, fix cross

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -1,24 +1,27 @@
-{ lib
-, stdenv
-, fetchpatch
-, fetchurl
-, fixDarwinDylibNames
-, cmake
-, libjpeg
-, uselibtirpc ? stdenv.hostPlatform.isLinux
-, libtirpc
-, zlib
-, szipSupport ? false
-, szip
-, javaSupport ? false
-, jdk
-, fortranSupport ? false
-, gfortran
-, netcdfSupport ? false
+{
+  lib,
+  stdenv,
+  fetchpatch,
+  fetchurl,
+  fixDarwinDylibNames,
+  cmake,
+  libjpeg,
+  uselibtirpc ? stdenv.hostPlatform.isLinux,
+  libtirpc,
+  zlib,
+  szipSupport ? false,
+  szip,
+  javaSupport ? false,
+  jdk,
+  fortranSupport ? false,
+  gfortran,
+  netcdfSupport ? false,
 }:
+
 stdenv.mkDerivation rec {
   pname = "hdf";
   version = "4.2.15";
+
   src = fetchurl {
     url = "https://support.hdfgroup.org/ftp/HDF/releases/HDF${version}/src/hdf-${version}.tar.bz2";
     sha256 = "04nbgfxyj5jg4d6sr28162cxbfwqgv0sa7vz1ayzvm8wbbpkbq5x";
@@ -49,51 +52,63 @@ stdenv.mkDerivation rec {
     ./darwin-aarch64.patch
   ];
 
-  nativeBuildInputs = [
-    cmake
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    fixDarwinDylibNames
-  ] ++ lib.optional fortranSupport gfortran;
+  nativeBuildInputs =
+    [
+      cmake
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      fixDarwinDylibNames
+    ]
+    ++ lib.optional fortranSupport gfortran;
 
-  buildInputs = [
-    libjpeg
-    zlib
-  ]
-  ++ lib.optional javaSupport jdk
-  ++ lib.optional szipSupport szip
-  ++ lib.optional uselibtirpc libtirpc;
+  buildInputs =
+    [
+      libjpeg
+      zlib
+    ]
+    ++ lib.optional javaSupport jdk
+    ++ lib.optional szipSupport szip
+    ++ lib.optional uselibtirpc libtirpc;
 
-  preConfigure = lib.optionalString uselibtirpc ''
-    # Make tirpc discovery work with CMAKE_PREFIX_PATH
-    substituteInPlace config/cmake/FindXDR.cmake \
-      --replace 'find_path(XDR_INCLUDE_DIR NAMES rpc/types.h PATHS "/usr/include" "/usr/include/tirpc")' \
-                'find_path(XDR_INCLUDE_DIR NAMES rpc/types.h PATH_SUFFIXES include/tirpc)'
-  '' + lib.optionalString szipSupport ''
-    export SZIP_INSTALL=${szip}
-  '';
+  preConfigure =
+    lib.optionalString uselibtirpc ''
+      # Make tirpc discovery work with CMAKE_PREFIX_PATH
+      substituteInPlace config/cmake/FindXDR.cmake \
+        --replace 'find_path(XDR_INCLUDE_DIR NAMES rpc/types.h PATHS "/usr/include" "/usr/include/tirpc")' \
+                  'find_path(XDR_INCLUDE_DIR NAMES rpc/types.h PATH_SUFFIXES include/tirpc)'
+    ''
+    + lib.optionalString szipSupport ''
+      export SZIP_INSTALL=${szip}
+    '';
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DHDF4_BUILD_TOOLS=ON"
-    "-DHDF4_BUILD_UTILS=ON"
-    "-DHDF4_BUILD_WITH_INSTALL_NAME=OFF"
-    "-DHDF4_ENABLE_JPEG_LIB_SUPPORT=ON"
-    "-DHDF4_ENABLE_NETCDF=${if netcdfSupport then "ON" else "OFF"}"
-    "-DHDF4_ENABLE_Z_LIB_SUPPORT=ON"
-    "-DJPEG_DIR=${libjpeg}"
-  ] ++ lib.optionals javaSupport [
-    "-DHDF4_BUILD_JAVA=ON"
-    "-DJAVA_HOME=${jdk}"
-  ] ++ lib.optionals szipSupport [
-    "-DHDF4_ENABLE_SZIP_ENCODING=ON"
-    "-DHDF4_ENABLE_SZIP_SUPPORT=ON"
-  ] ++ (if fortranSupport
-  then [
-    "-DHDF4_BUILD_FORTRAN=ON"
-    "-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch"
-  ]
-  else [ "-DHDF4_BUILD_FORTRAN=OFF" ]
-  );
+  cmakeFlags =
+    [
+      "-DBUILD_SHARED_LIBS=ON"
+      "-DHDF4_BUILD_TOOLS=ON"
+      "-DHDF4_BUILD_UTILS=ON"
+      "-DHDF4_BUILD_WITH_INSTALL_NAME=OFF"
+      "-DHDF4_ENABLE_JPEG_LIB_SUPPORT=ON"
+      "-DHDF4_ENABLE_NETCDF=${if netcdfSupport then "ON" else "OFF"}"
+      "-DHDF4_ENABLE_Z_LIB_SUPPORT=ON"
+      "-DJPEG_DIR=${libjpeg}"
+    ]
+    ++ lib.optionals javaSupport [
+      "-DHDF4_BUILD_JAVA=ON"
+      "-DJAVA_HOME=${jdk}"
+    ]
+    ++ lib.optionals szipSupport [
+      "-DHDF4_ENABLE_SZIP_ENCODING=ON"
+      "-DHDF4_ENABLE_SZIP_SUPPORT=ON"
+    ]
+    ++ (
+      if fortranSupport then
+        [
+          "-DHDF4_BUILD_FORTRAN=ON"
+          "-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch"
+        ]
+      else
+        [ "-DHDF4_BUILD_FORTRAN=OFF" ]
+    );
 
   env = lib.optionalAttrs stdenv.cc.isClang {
     NIX_CFLAGS_COMPILE = toString [
@@ -113,7 +128,9 @@ stdenv.mkDerivation rec {
 
   checkPhase =
     let
-      excludedTestsRegex = lib.optionalString (excludedTests != [ ]) "(${lib.concatStringsSep "|" excludedTests})";
+      excludedTestsRegex = lib.optionalString (
+        excludedTests != [ ]
+      ) "(${lib.concatStringsSep "|" excludedTests})";
     in
     ''
       runHook preCheck
@@ -121,7 +138,11 @@ stdenv.mkDerivation rec {
       runHook postCheck
     '';
 
-  outputs = [ "bin" "dev" "out" ];
+  outputs = [
+    "bin"
+    "dev"
+    "out"
+  ];
 
   postInstall = ''
     moveToOutput bin "$bin"


### PR DESCRIPTION
- format
- use `hash`
- use `finalAttrs`
- use `--replace-fail`
- use `lib.cmake*` utility functions
  - the logic was changed a bit: if a toggle is disabled, the cmake flag is set to false instead of being unset.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
