### PR TITLE
craftos-pc: add update script, use regular buildPhase, install headers into $dev

### DIFF
--- a/pkgs/by-name/cr/craftos-pc/package.nix
+++ b/pkgs/by-name/cr/craftos-pc/package.nix
@@ -64,6 +64,8 @@ stdenv.mkDerivation rec {
   ];
   strictDeps = true;
 
+  enableParallelBuilding = true;
+
   outputs = [
     "out"
     "dev"
@@ -73,12 +75,6 @@ stdenv.mkDerivation rec {
     cp -R ${craftos2-lua}/* ./craftos2-lua/
     chmod -R u+w ./craftos2-lua
     make -C craftos2-lua ${if stdenv.hostPlatform.isDarwin then "macosx" else "linux"}
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-    make
-    runHook postBuild
   '';
 
   patches = [

--- a/pkgs/by-name/cr/craftos-pc/package.nix
+++ b/pkgs/by-name/cr/craftos-pc/package.nix
@@ -112,9 +112,12 @@ stdenv.mkDerivation rec {
     ''}
   '';
 
-  passthru.tests = {
-    eval-hello-world = callPackage ./test-eval-hello-world { };
-    eval-periphemu = callPackage ./test-eval-periphemu { };
+  passthru = {
+    updateScript = ./update.sh;
+    tests = {
+      eval-hello-world = callPackage ./test-eval-hello-world { };
+      eval-periphemu = callPackage ./test-eval-periphemu { };
+    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/cr/craftos-pc/package.nix
+++ b/pkgs/by-name/cr/craftos-pc/package.nix
@@ -64,6 +64,11 @@ stdenv.mkDerivation rec {
   ];
   strictDeps = true;
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   preBuild = ''
     cp -R ${craftos2-lua}/* ./craftos2-lua/
     chmod -R u+w ./craftos2-lua
@@ -85,7 +90,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib $out/share/craftos $out/include
+    mkdir -p $out/bin $out/lib $out/share/craftos $dev/include
     DESTDIR=$out/bin make install
     cp ./craftos2-lua/src/liblua${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib
     ${lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -95,7 +100,7 @@ stdenv.mkDerivation rec {
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       patchelf --replace-needed craftos2-lua/src/liblua${stdenv.hostPlatform.extensions.sharedLibrary} liblua${stdenv.hostPlatform.extensions.sharedLibrary} $out/bin/craftos
     ''}
-    cp -R api $out/include/CraftOS-PC
+    cp -R api $dev/include/CraftOS-PC
     cp -R ${craftos2-rom}/* $out/share/craftos
 
     ${lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/pkgs/by-name/cr/craftos-pc/update.sh
+++ b/pkgs/by-name/cr/craftos-pc/update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix-prefetch-github
+set -euo pipefail
+
+package_file="$(dirname "$0")/default.nix"
+
+latest_tag=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+    https://api.github.com/repos/MCJack123/craftos2/releases/latest | jq -e -r ".tag_name")
+
+version="${latest_tag:1}"
+
+function get_old_hash() {
+    local reponame="$1"
+    # HACK: We assume that the hash we want is within four lines of the first occurrence of reponame
+    grep "$reponame = fetchFromGitHub {\$" -A 4 "$package_file" | sed -n 's/.*hash = "\(.*\)".*/\1/p'
+}
+
+function get_new_hash() {
+    local reponame="$1"
+    # We assume that all repositories of interest are owned by MCJack123
+    nix-prefetch-github --json --rev "v$version" MCJack123 "$reponame" | jq -r ".hash"
+}
+
+old_src_hash="$(get_old_hash src)"
+old_lua_hash="$(get_old_hash craftos2-lua)"
+old_rom_hash="$(get_old_hash craftos2-rom)"
+
+new_src_hash="$(get_new_hash craftos2)"
+new_lua_hash="$(get_new_hash craftos2-lua)"
+new_rom_hash="$(get_new_hash craftos2-rom)"
+
+sed -i 's/version = ".*";/version = "'"$version"'";/g' "$package_file"
+sed -i "s|$old_src_hash|$new_src_hash|g" "$package_file"
+sed -i "s|$old_lua_hash|$new_lua_hash|g" "$package_file"
+sed -i "s|$old_rom_hash|$new_rom_hash|g" "$package_file"


### PR DESCRIPTION
Added an update script, use the regular `buildPhase`, and install development headers into `$dev`.

<details><summary>Outdated</summary>
<p>

~~Made package contents consistent with what upstream has, using https://github.com/MCJack123/craftos2-release-resources/blob/524cdf0c47f3f59174f3f180a682f4701ed6a068/ubuntu/debian_craftos-pc/rules as a reference.~~

~~This resolves all of the prerequisites needed for work to begin on #346758.~~

</p>
</details> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
