### PR TITLE
nixos/coturn: set up sandboxing

### DIFF
--- a/nixos/modules/services/networking/coturn.nix
+++ b/nixos/modules/services/networking/coturn.nix
@@ -3,39 +3,39 @@ let
   cfg = config.services.coturn;
   pidfile = "/run/turnserver/turnserver.pid";
   configFile = pkgs.writeText "turnserver.conf" ''
-listening-port=${toString cfg.listening-port}
-tls-listening-port=${toString cfg.tls-listening-port}
-alt-listening-port=${toString cfg.alt-listening-port}
-alt-tls-listening-port=${toString cfg.alt-tls-listening-port}
-${lib.concatStringsSep "\n" (map (x: "listening-ip=${x}") cfg.listening-ips)}
-${lib.concatStringsSep "\n" (map (x: "relay-ip=${x}") cfg.relay-ips)}
-min-port=${toString cfg.min-port}
-max-port=${toString cfg.max-port}
-${lib.optionalString cfg.lt-cred-mech "lt-cred-mech"}
-${lib.optionalString cfg.no-auth "no-auth"}
-${lib.optionalString cfg.use-auth-secret "use-auth-secret"}
-${lib.optionalString (cfg.static-auth-secret != null) ("static-auth-secret=${cfg.static-auth-secret}")}
-${lib.optionalString (cfg.static-auth-secret-file != null) ("static-auth-secret=#static-auth-secret#")}
-realm=${cfg.realm}
-${lib.optionalString cfg.no-udp "no-udp"}
-${lib.optionalString cfg.no-tcp "no-tcp"}
-${lib.optionalString cfg.no-tls "no-tls"}
-${lib.optionalString cfg.no-dtls "no-dtls"}
-${lib.optionalString cfg.no-udp-relay "no-udp-relay"}
-${lib.optionalString cfg.no-tcp-relay "no-tcp-relay"}
-${lib.optionalString (cfg.cert != null) "cert=${cfg.cert}"}
-${lib.optionalString (cfg.pkey != null) "pkey=${cfg.pkey}"}
-${lib.optionalString (cfg.dh-file != null) ("dh-file=${cfg.dh-file}")}
-no-stdout-log
-syslog
-pidfile=${pidfile}
-${lib.optionalString cfg.secure-stun "secure-stun"}
-${lib.optionalString cfg.no-cli "no-cli"}
-cli-ip=${cfg.cli-ip}
-cli-port=${toString cfg.cli-port}
-${lib.optionalString (cfg.cli-password != null) ("cli-password=${cfg.cli-password}")}
-${cfg.extraConfig}
-'';
+    listening-port=${toString cfg.listening-port}
+    tls-listening-port=${toString cfg.tls-listening-port}
+    alt-listening-port=${toString cfg.alt-listening-port}
+    alt-tls-listening-port=${toString cfg.alt-tls-listening-port}
+    ${lib.concatStringsSep "\n" (map (x: "listening-ip=${x}") cfg.listening-ips)}
+    ${lib.concatStringsSep "\n" (map (x: "relay-ip=${x}") cfg.relay-ips)}
+    min-port=${toString cfg.min-port}
+    max-port=${toString cfg.max-port}
+    ${lib.optionalString cfg.lt-cred-mech "lt-cred-mech"}
+    ${lib.optionalString cfg.no-auth "no-auth"}
+    ${lib.optionalString cfg.use-auth-secret "use-auth-secret"}
+    ${lib.optionalString (cfg.static-auth-secret != null) "static-auth-secret=${cfg.static-auth-secret}"}
+    ${lib.optionalString (cfg.static-auth-secret-file != null) "static-auth-secret=#static-auth-secret#"}
+    realm=${cfg.realm}
+    ${lib.optionalString cfg.no-udp "no-udp"}
+    ${lib.optionalString cfg.no-tcp "no-tcp"}
+    ${lib.optionalString cfg.no-tls "no-tls"}
+    ${lib.optionalString cfg.no-dtls "no-dtls"}
+    ${lib.optionalString cfg.no-udp-relay "no-udp-relay"}
+    ${lib.optionalString cfg.no-tcp-relay "no-tcp-relay"}
+    ${lib.optionalString (cfg.cert != null) "cert=${cfg.cert}"}
+    ${lib.optionalString (cfg.pkey != null) "pkey=${cfg.pkey}"}
+    ${lib.optionalString (cfg.dh-file != null) "dh-file=${cfg.dh-file}"}
+    no-stdout-log
+    syslog
+    pidfile=${pidfile}
+    ${lib.optionalString cfg.secure-stun "secure-stun"}
+    ${lib.optionalString cfg.no-cli "no-cli"}
+    cli-ip=${cfg.cli-ip}
+    cli-port=${toString cfg.cli-port}
+    ${lib.optionalString (cfg.cli-password != null) "cli-password=${cfg.cli-password}"}
+    ${cfg.extraConfig}
+  '';
 in {
   options = {
     services.coturn = {
@@ -301,7 +301,7 @@ in {
     };
   };
 
-  config = lib.mkIf cfg.enable (lib.mkMerge ([
+  config = lib.mkIf cfg.enable (lib.mkMerge [
     { assertions = [
       { assertion = cfg.static-auth-secret != null -> cfg.static-auth-secret-file == null ;
         message = "static-auth-secret and static-auth-secret-file cannot be set at the same time";
@@ -402,5 +402,5 @@ in {
           UMask = "0077";
         };
       };
-  }]));
+  }]);
 }

--- a/nixos/tests/coturn.nix
+++ b/nixos/tests/coturn.nix
@@ -30,5 +30,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
           secretsfile.fail("${pkgs.coturn}/bin/turnutils_uclient -W some-very-secret-string 127.0.0.1 -DgX -e 127.0.0.1 -n 1 -c -y")
           # allowed-peer-ip, should succeed:
           secretsfile.succeed("${pkgs.coturn}/bin/turnutils_uclient -W some-very-secret-string 192.168.1.2 -DgX -e 192.168.1.2 -n 1 -c -y")
+
+      default.log(default.execute("systemd-analyze security coturn.service | grep -v '✓'")[1])
     '';
 })

--- a/pkgs/servers/coturn/default.nix
+++ b/pkgs/servers/coturn/default.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./pure-configure.patch
+
+    # Don't call setgroups unconditionally in mainrelay
+    # https://github.com/coturn/coturn/pull/1508
+    ./dont-call-setgroups-unconditionally.patch
   ];
 
   # Workaround build failure on -fno-common toolchains like upstream

--- a/pkgs/servers/coturn/dont-call-setgroups-unconditionally.patch
+++ b/pkgs/servers/coturn/dont-call-setgroups-unconditionally.patch
@@ -1,0 +1,46 @@
+From 1b5da9c7c5423eed7a567a02e66c244705116724 Mon Sep 17 00:00:00 2001
+From: networkException <git@nwex.de>
+Date: Thu, 30 May 2024 02:07:04 +0200
+Subject: [PATCH] Don't call `setgroups` unconditionally in mainrelay
+
+This patch moves the call to `setgroups` from the beginning of the
+`drop_priviliges` function to branch in which `setuid` is actually
+called. This still fulfills the intention of
+acbf7e15c9290e0891a6b6b5ce6e81bbaa77ce5a, initially introducting
+the call to `setgroups`:
+
+> Fix related to POS36-C and rpmlint error
+> "missing-call-to-setgroups-before-setuid".
+
+As per this intention is is not required to call `setgroups`
+otherwise, reducing the more exotic (as in not part of POSIX and
+considered priviliged by systemd) system calls coturn needs to make
+at startup.
+---
+ src/apps/relay/mainrelay.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/apps/relay/mainrelay.c b/src/apps/relay/mainrelay.c
+index cf370ec8a..56eaf82d0 100644
+--- a/src/apps/relay/mainrelay.c
++++ b/src/apps/relay/mainrelay.c
+@@ -2913,7 +2913,6 @@ static void drop_privileges(void) {
+ #if defined(WINDOWS)
+   // TODO: implement it!!!
+ #else
+-  setgroups(0, NULL);
+   if (procgroupid_set) {
+     if (getgid() != procgroupid) {
+       if (setgid(procgroupid) != 0) {
+@@ -2929,6 +2928,11 @@ static void drop_privileges(void) {
+ 
+   if (procuserid_set) {
+     if (procuserid != getuid()) {
++      if (setgroups(0, NULL) != 0) {
++        perror("setgroups: Unable drop supplementary groups");
++        exit(-1);
++      }
++
+       if (setuid(procuserid) != 0) {
+         perror("setuid: Unable to change user privileges");
+         exit(-1);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Coturn is a network-facing implementation of the turn and stun protocols. It is a glorified udp/tcp relay at best and shall be restricted to that surface area.

```
default:   NAME                                                        DESCRIPTION                                                                                         EXPOSURE
✗ SystemCallFilter=~@resources                                System call allow list defined for service, and @resources is included (e.g. ioprio_set is allowed)      0.2
✗ SystemCallFilter=~@privileged                               System call allow list defined for service, and @privileged is included (e.g. setgroups is allowed)      0.2
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                                            0.1
✗ RestrictAddressFamilies=~AF_NETLINK                         Service may allocate netlink sockets                                                                     0.1
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                                                    0.3
✗ PrivateNetwork=                                             Service has access to the host's network                                                                 0.5
✗ DeviceAllow=                                                Service has a device ACL with some special devices: char-rtc:r                                           0.1
✗ IPAddressDeny=                                              Service does not define an IP address allow list                                                         0.2

→ Overall exposure level for coturn.service: 1.3 OK :-)
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
