### PR TITLE
dotultimate: init at 2025.2.4

### DIFF
--- a/pkgs/by-name/do/dotultimate/dotmemory.nix
+++ b/pkgs/by-name/do/dotultimate/dotmemory.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  mkJetBrainsAvaloniaProduct,
+}:
+mkJetBrainsAvaloniaProduct {
+  pname = "dotmemory";
+  version = "2025.2.4";
+  desktopName = "dotMemory";
+  code = "DM";
+
+  sources = {
+    "x86_64-linux" = {
+      url = "https://download.jetbrains.com/resharper/dotUltimate.2025.2.4/JetBrains.dotMemory.linux-x64.2025.2.4.tar.gz";
+      hash = "sha256-gd+UyKqM3rPbn9lwYlJmduaMQI4JfLMdQTILUiaALQs=";
+    };
+    "aarch64-linux" = {
+      url = "https://download.jetbrains.com/resharper/dotUltimate.2025.2.4/JetBrains.dotMemory.linux-arm64.2025.2.4.tar.gz";
+      hash = "sha256-weHWbnW23XfmGlGpXomr/Of7jqr0xtAXD3GHIu1wgYk=";
+    };
+
+    "x86_64-darwin" = {
+      url = "https://download.jetbrains.com/resharper/dotUltimate.2025.2.4/JetBrains.dotMemory.macos-x64.2025.2.4.dmg";
+      hash = "sha256-e9bgZKoWCeipeSUpUxXaOgATUY+X3eT4bxuwGG8XGkA=";
+    };
+    "aarch64-darwin" = {
+      url = "https://download.jetbrains.com/resharper/dotUltimate.2025.2.4/JetBrains.dotMemory.macos-arm64.2025.2.4.dmg";
+      hash = "sha256-gftHaT6tZa6sXTdU4+B1DrRku/A7kD9+ItV103jh3XY=";
+    };
+  };
+
+  iconHolder = "JetBrains.dotMemory.Standalone.Avalonia.exe";
+
+  meta = {
+    homepage = "https://www.jetbrains.com/dotmemory";
+    description = ".NET Memory Profiler";
+    maintainers = with lib.maintainers; [ js6pak ];
+  };
+}

--- a/pkgs/by-name/do/dotultimate/dottrace.nix
+++ b/pkgs/by-name/do/dotultimate/dottrace.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  mkJetBrainsAvaloniaProduct,
+}:
+mkJetBrainsAvaloniaProduct {
+  pname = "dottrace";
+  version = "2025.2.4";
+  desktopName = "dotTrace";
+  code = "DP";
+
+  sources = {
+    "x86_64-linux" = {
+      url = "https://download.jetbrains.com/resharper/dotUltimate.2025.2.4/JetBrains.dotTrace.linux-x64.2025.2.4.tar.gz";
+      hash = "sha256-EOytSRkz6nWUgqa1C2k+FxscPIwF3ukQ90pL6eFPJtw=";
+    };
+    "aarch64-linux" = {
+      url = "https://download.jetbrains.com/resharper/dotUltimate.2025.2.4/JetBrains.dotTrace.linux-arm64.2025.2.4.tar.gz";
+      hash = "sha256-fWP0d+OFsBeFqP10l+HJDs9vKpF0alzzSumlehfTsQQ=";
+    };
+
+    "x86_64-darwin" = {
+      url = "https://download.jetbrains.com/resharper/dotUltimate.2025.2.4/JetBrains.dotTrace.macos-x64.2025.2.4.dmg";
+      hash = "sha256-Xt25nlLu+5ZFl9Lv8bknDxtGZ/+q0GRoS8D2kjus71k=";
+    };
+    "aarch64-darwin" = {
+      url = "https://download.jetbrains.com/resharper/dotUltimate.2025.2.4/JetBrains.dotTrace.macos-arm64.2025.2.4.dmg";
+      hash = "sha256-myiXttfWJ3tkbFfprehbxr10QAdENwq0L68bw+S4DdY=";
+    };
+  };
+
+  iconHolder = "JetBrains.dotTrace.Home.Shell.exe";
+
+  executables = [
+    "dotTrace"
+    "dotTraceViewer"
+  ];
+
+  meta = {
+    homepage = "https://www.jetbrains.com/profiler";
+    description = ".NET Performance Profiler";
+    maintainers = with lib.maintainers; [ js6pak ];
+  };
+}

--- a/pkgs/by-name/do/dotultimate/package.nix
+++ b/pkgs/by-name/do/dotultimate/package.nix
@@ -1,0 +1,271 @@
+{
+  stdenv,
+  lib,
+  symlinkJoin,
+  newScope,
+  fetchurl,
+  undmg,
+  copyDesktopItems,
+  makeDesktopItem,
+
+  writeShellScript,
+  curl,
+  jq,
+  common-updater-scripts,
+
+  autoPatchelfHook,
+  makeWrapper,
+  wrapGAppsHook3,
+  dotnetCorePackages,
+  extract-dotnet-resources,
+  icoutils,
+
+  libX11,
+  libXrandr,
+  libXext,
+  libXi,
+  libXcursor,
+  libSM,
+  libICE,
+  gtk3,
+  libGL,
+  vulkan-loader,
+}:
+let
+  jetBrainsPlatformMap = {
+    "x86_64-linux" = "linux";
+    "aarch64-linux" = "linuxARM64";
+
+    "x86_64-darwin" = "mac";
+    "aarch64-darwin" = "macARM64";
+
+    "i686-windows" = "windows";
+    "x86_64-windows" = "windows64";
+    "aarch64-windows" = "windowsARM64";
+  };
+
+  systemToJetBrainsPlatform =
+    system: jetBrainsPlatformMap.${system} or (throw "Unsupported system: ${system}");
+
+  # These are the same as dotnet rids for everything except macos, for some reason
+  jetBrainsRuntimeIdentifierMap = {
+    "x86_64-linux" = "linux-x64";
+    "aarch64-linux" = "linux-arm64";
+    "x86_64-darwin" = "macos-x64";
+    "aarch64-darwin" = "macos-arm64";
+    "x86_64-windows" = "win-x64";
+    "aarch64-windows" = "win-arm64";
+    "i686-windows" = "win-x86";
+  };
+
+  systemToJetBrainsRid =
+    system: jetBrainsRuntimeIdentifierMap.${system} or (throw "unsupported platform ${system}");
+
+  inherit (stdenv.hostPlatform) system;
+
+  # A lot of these are loaded opportunistically, so provide all of them to be safe
+  avaloniaDependencies = [
+    # https://github.com/AvaloniaUI/Avalonia/blob/11.0.11/src/Avalonia.X11/XLib.cs
+    libX11
+    libXrandr
+    libXext
+    libXi
+    libXcursor
+
+    # https://github.com/AvaloniaUI/Avalonia/blob/11.0.11/src/Avalonia.X11/SMLib.cs
+    libSM
+
+    # https://github.com/AvaloniaUI/Avalonia/blob/11.0.11/src/Avalonia.X11/ICELib.cs
+    libICE
+
+    # https://github.com/AvaloniaUI/Avalonia/blob/11.0.11/src/Avalonia.X11/NativeDialogs/Gtk.cs
+    gtk3
+
+    # https://github.com/AvaloniaUI/Avalonia/blob/11.0.11/src/Avalonia.X11/Glx/Glx.cs#L50
+    libGL
+
+    # https://github.com/AvaloniaUI/Avalonia/blob/11.0.11/src/Avalonia.X11/Vulkan/VulkanSupport.cs#L15
+    vulkan-loader
+  ];
+
+  mkJetBrainsAvaloniaProduct =
+    {
+      pname,
+      version,
+      desktopName,
+      code,
+      sources,
+      dotnet-runtime ? dotnetCorePackages.runtime_8_0,
+      iconHolder,
+      executables ? [ desktopName ],
+      meta,
+    }:
+    stdenv.mkDerivation (finalAttrs: {
+      inherit pname version;
+
+      src = fetchurl (sources.${system} or (throw "Unsupported system: ${system}"));
+
+      nativeBuildInputs =
+        lib.optionals stdenv.hostPlatform.isLinux [
+          autoPatchelfHook
+          makeWrapper
+          wrapGAppsHook3
+          copyDesktopItems
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [ undmg ];
+
+      buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ dotnet-runtime ];
+
+      dontFixup = stdenv.hostPlatform.isDarwin;
+
+      postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+        local dotnet_path="${systemToJetBrainsRid system}/dotnet"
+        local dotnet_version="$(basename "$dotnet_path"/shared/Microsoft.NETCore.App/* | cut -d. -f1-2)"
+        local nix_dotnet_version="${lib.versions.majorMinor (lib.getVersion dotnet-runtime)}"
+        if [[ "$dotnet_version" != "$nix_dotnet_version" ]]; then
+          echo "Provided dotnet runtime version ($nix_dotnet_version) doesn't match the embedded one ($dotnet_version)"
+          exit 1
+        fi
+
+        # Remove the embedded dotnet runtime so we can use our own
+        rm -rf "$dotnet_path"
+      '';
+
+      installPhase = ''
+        runHook preInstall
+      ''
+      + (
+        if stdenv.hostPlatform.isDarwin then
+          ''
+            mkdir -p "$out/Applications/${desktopName}.app"
+            cp -r ./* "$out/Applications/${desktopName}.app"
+
+            mkdir -p "$out/bin"
+            ${lib.concatMapStringsSep "\n" (executable: ''
+              ln -s "$out/Applications/${desktopName}.app/Contents/DotFiles/${systemToJetBrainsRid system}/${executable}" "$out/bin/${executable}"
+            '') executables}
+          ''
+        else
+          ''
+            mkdir -p $out/{bin,lib/$pname}
+            cp -a . $out/lib/$pname
+
+            ${lib.getExe extract-dotnet-resources} "${iconHolder}" "*/ProductIcon"
+            ${lib.getExe' icoutils "icotool"} -x */ProductIcon
+            for f in ProductIcon_*.png; do
+              res=$(basename "$f" | cut -d "_" -f3 | cut -d "x" -f1-2)
+              install -vD "$f" "$out/share/icons/hicolor/$res/apps/$pname.png"
+            done
+          ''
+      )
+      + ''
+        runHook postInstall
+      '';
+
+      dontWrapGApps = true;
+
+      fixupPhase = lib.optionalString stdenv.hostPlatform.isLinux ''
+        runHook preFixup
+
+        wrapDotnetProgram() {
+            makeWrapper "$1" "$2" \
+                --suffix "LD_LIBRARY_PATH" : "${lib.makeLibraryPath avaloniaDependencies}" \
+                --set DOTNET_ROOT "${dotnet-runtime}/share/dotnet" \
+                --prefix PATH : "${dotnet-runtime}/bin" \
+                "''${gappsWrapperArgs[@]}" \
+                "''${makeWrapperArgs[@]}"
+        }
+
+        ${lib.concatMapStringsSep "\n" (executable: ''
+          wrapDotnetProgram "$out/lib/$pname/${systemToJetBrainsRid system}/${executable}" "$out/bin/${executable}"
+        '') executables}
+
+        runHook postFixup
+      '';
+
+      desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
+        (makeDesktopItem {
+          name = finalAttrs.pname;
+          exec = finalAttrs.meta.mainProgram;
+          inherit desktopName;
+          categories = [ "Development" ];
+          icon = finalAttrs.pname;
+          startupWMClass = "JetBrains ${desktopName}";
+        })
+      ];
+
+      meta = {
+        license = lib.licenses.unfree;
+        mainProgram = builtins.head executables;
+        sourceProvenance = with lib.sourceTypes; [
+          binaryNativeCode
+          binaryBytecode
+        ];
+        platforms = builtins.attrNames sources;
+      }
+      // meta;
+
+      passthru.updateScript = writeShellScript "update-${finalAttrs.pname}" ''
+        set -eu -o pipefail
+        PATH="$PATH:${
+          lib.makeBinPath [
+            curl
+            jq
+            common-updater-scripts
+          ]
+        }"
+
+        latest_release=$(curl -s 'https://data.services.jetbrains.com/products/releases?code=${code}&latest=true&type=release' | jq -r '.${code}[0]')
+        version=$(jq -r '.version' <<< "$latest_release")
+
+        function update_system() {
+          local system="$1"
+          local jetbrains_platform="$2"
+
+          local download=$(jq -r ".downloads[\"$jetbrains_platform\"]" <<< "$latest_release")
+          local download_url=$(jq -r '.link' <<< "$download")
+          local download_hash=$(curl -s "$(jq -r ".checksumLink" <<< "$download")" | cut -d ' ' -f1)
+
+          download_hash="$(nix hash convert --to sri --hash-algo sha256 "$download_hash")"
+
+          update-source-version "$UPDATE_NIX_ATTR_PATH" "$version" "$download_hash" "$download_url" \
+            --system="$system" --ignore-same-version
+        }
+
+        ${lib.concatMapStringsSep "\n" (
+          system:
+          "update_system ${
+            lib.escapeShellArgs [
+              system
+              (systemToJetBrainsPlatform system)
+            ]
+          }"
+        ) finalAttrs.meta.platforms}
+      '';
+    });
+
+  callPackage = newScope { inherit mkJetBrainsAvaloniaProduct; };
+in
+symlinkJoin rec {
+  name = "dotultimate";
+
+  dotmemory = callPackage ./dotmemory.nix { };
+  dottrace = callPackage ./dottrace.nix { };
+
+  paths = [
+    dotmemory
+    dottrace
+  ];
+
+  passthru.updateScript = writeShellScript "update-dotultimate" (
+    lib.concatMapStringsSep "\n" (
+      pkg: ''UPDATE_NIX_ATTR_PATH="$UPDATE_NIX_ATTR_PATH.${pkg.pname}" ${pkg.passthru.updateScript}''
+    ) paths
+  );
+
+  meta = {
+    homepage = "https://www.jetbrains.com/dotultimate";
+    description = "All JetBrains .NET tools in one pack";
+    maintainers = with lib.maintainers; [ js6pak ];
+  };
+}

--- a/pkgs/by-name/ex/extract-dotnet-resources/.gitignore
+++ b/pkgs/by-name/ex/extract-dotnet-resources/.gitignore
@@ -1,0 +1,20 @@
+# Build results
+bin/
+obj/
+artifacts/
+
+# User-specific files
+*.user
+.env
+
+# MSBuild Binary and Structured Log
+*.binlog
+
+# JetBrains Rider
+.idea/
+
+# VS Code
+.vscode/
+
+# Visual Studio
+.vs/

--- a/pkgs/by-name/ex/extract-dotnet-resources/Program.cs
+++ b/pkgs/by-name/ex/extract-dotnet-resources/Program.cs
@@ -1,0 +1,178 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Resources;
+using AsmResolver.IO;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+var app = new CommandApp<ExtractCommand>();
+app.Configure(config =>
+{
+    config.SetApplicationName("extract-dotnet-resources");
+
+    config.SetExceptionHandler((exception, _) =>
+    {
+        if (exception is CommandAppException { Pretty: { } pretty })
+        {
+            AnsiConsole.Write(pretty);
+            return;
+        }
+
+        AnsiConsole.WriteException(exception);
+    });
+});
+return app.Run(args);
+
+internal sealed class ExtractCommand : Command<ExtractCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<assemblyPath>")]
+        [Required]
+        public required string AssemblyPath { get; init; }
+
+        [CommandArgument(1, "<patterns>")]
+        public string[] Patterns { get; init; } = [];
+
+        [CommandOption("-o|--output")]
+        public string? OutputDirectoryPath { get; init; }
+    }
+
+    private class Pattern(Regex regex)
+    {
+        public Regex Regex { get; } = regex;
+
+        private static Regex ConvertGlobToRegex(string pattern)
+        {
+            return new Regex(
+                "^" + Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".") + "$",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline
+            );
+        }
+
+        public static Pattern Create(string pattern)
+        {
+            var indexOfSlash = pattern.IndexOf('/');
+            if (indexOfSlash != -1)
+            {
+                var mainPattern = pattern[..indexOfSlash];
+                var subPattern = pattern[(indexOfSlash + 1)..];
+
+                return new SubPattern(ConvertGlobToRegex(mainPattern), ConvertGlobToRegex(subPattern));
+            }
+
+            return new Pattern(ConvertGlobToRegex(pattern));
+        }
+    }
+
+    private class SubPattern(Regex regex, Regex subRegex) : Pattern(regex)
+    {
+        public Regex SubRegex { get; } = subRegex;
+    }
+
+    private static bool IsResourceSet(BinaryStreamReader reader)
+    {
+        if (reader.Length < sizeof(uint)) return false;
+        return reader.ReadUInt32() == ResourceManagerHeader.Magic;
+    }
+
+    private static string Sanitize(string entryPath)
+    {
+        return entryPath.Replace('\0', '_').Replace('/', '_').Replace('\\', '_');
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        var outputDirectoryPath = Path.GetFullPath(settings.OutputDirectoryPath ?? Directory.GetCurrentDirectory());
+        Directory.CreateDirectory(outputDirectoryPath);
+
+        var module = ModuleDefinition.FromFile(settings.AssemblyPath);
+
+        if (!module.Resources.Any())
+        {
+            AnsiConsole.MarkupLine("[red]Provided assembly has no resources[/]");
+            return 1;
+        }
+
+        var patterns = settings.Patterns.Select(Pattern.Create).ToArray();
+
+        foreach (var manifestResource in module.Resources)
+        {
+            if (manifestResource.Name is null) continue;
+
+            var matchingPatterns = patterns.Where(pattern => pattern.Regex.IsMatch(manifestResource.Name)).ToArray();
+            if (matchingPatterns.Length == 0)
+            {
+                continue;
+            }
+
+            if (manifestResource.TryGetReader(out var reader))
+            {
+                if (IsResourceSet(reader))
+                {
+                    if (!matchingPatterns.Any(pattern => pattern is SubPattern))
+                    {
+                        continue;
+                    }
+
+                    var resourceSet = ResourceSet.FromReader(reader);
+
+                    foreach (var entry in resourceSet)
+                    {
+                        if (entry == null) continue;
+
+                        if (matchingPatterns.OfType<SubPattern>().All(subPattern => !subPattern.SubRegex.IsMatch(entry.Name)))
+                        {
+                            continue;
+                        }
+
+                        AnsiConsole.MarkupLineInterpolated($"Extracting [darkcyan]{manifestResource.Name}[/][gray]/[/][cyan]{entry.Name}[/]");
+
+                        var path = Path.GetFullPath(Path.Combine(outputDirectoryPath, Sanitize(manifestResource.Name), Sanitize(entry.Name)));
+                        if (!path.StartsWith(outputDirectoryPath))
+                            throw new IOException("Extracting would have resulted in a file outside the specified destination directory");
+
+                        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+                        switch (entry.Data)
+                        {
+                            case byte[] bytes:
+                            {
+                                File.WriteAllBytes(path, bytes);
+                                break;
+                            }
+
+                            case string text:
+                            {
+                                File.WriteAllText(path, text);
+                                break;
+                            }
+
+                            default:
+                                throw new NotSupportedException($"Can't handle {entry.Data} ({entry.Type.FullName})");
+                        }
+                    }
+                }
+                else
+                {
+                    if (!matchingPatterns.Any(pattern => pattern is not SubPattern))
+                    {
+                        continue;
+                    }
+
+                    AnsiConsole.MarkupLineInterpolated($"Extracting [cyan]{manifestResource.Name}[/]");
+
+                    var path = Path.GetFullPath(Path.Combine(outputDirectoryPath, Sanitize(manifestResource.Name)));
+                    if (!path.StartsWith(outputDirectoryPath))
+                        throw new IOException("Extracting would have resulted in a file outside the specified destination directory");
+
+                    using var fileStream = File.Create(path);
+                    reader.WriteToOutput(new BinaryStreamWriter(fileStream));
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/pkgs/by-name/ex/extract-dotnet-resources/deps.json
+++ b/pkgs/by-name/ex/extract-dotnet-resources/deps.json
@@ -1,0 +1,37 @@
+[
+  {
+    "pname": "AsmResolver",
+    "version": "6.0.0-beta.1",
+    "hash": "sha256-ZW61z6Qmztdy2NaiqxvNcP5RWBIiIO6CWNnqYq0MwoA="
+  },
+  {
+    "pname": "AsmResolver.DotNet",
+    "version": "6.0.0-beta.1",
+    "hash": "sha256-VoTiIr2/r2my6sg2AOEeiqz9vZhWtq5mGaW2Hx90Uo4="
+  },
+  {
+    "pname": "AsmResolver.PE",
+    "version": "6.0.0-beta.1",
+    "hash": "sha256-tTU/flTxRJaC4gkmI/gctqIriGIMntkgTs51TqzcQlg="
+  },
+  {
+    "pname": "AsmResolver.PE.File",
+    "version": "6.0.0-beta.1",
+    "hash": "sha256-hPuFrpcm2VMiYEirsL4kYmAhOzjwjNXUklIfYJEonLo="
+  },
+  {
+    "pname": "Spectre.Console",
+    "version": "0.49.1",
+    "hash": "sha256-tqSVojyuQjuB34lXo759NOcyLgNIw815mKXJPq5JFDo="
+  },
+  {
+    "pname": "Spectre.Console.Analyzer",
+    "version": "1.0.0",
+    "hash": "sha256-Om2PRAfm4LoPImty4zpGo/uoqha6ZnuCU6iNcAvKiUE="
+  },
+  {
+    "pname": "Spectre.Console.Cli",
+    "version": "0.49.1",
+    "hash": "sha256-sar9rhft1ivDMj1kU683+4KxUPUZL+Fb++ewMA6RD4Q="
+  }
+]

--- a/pkgs/by-name/ex/extract-dotnet-resources/extract-dotnet-resources.csproj
+++ b/pkgs/by-name/ex/extract-dotnet-resources/extract-dotnet-resources.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <RootNamespace>ExtractDotNetResources</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.1" />
+        <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
+        <PackageReference Include="Spectre.Console.Analyzer" Version="1.0.0" PrivateAssets="all" />
+    </ItemGroup>
+</Project>

--- a/pkgs/by-name/ex/extract-dotnet-resources/global.json
+++ b/pkgs/by-name/ex/extract-dotnet-resources/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestFeature"
+  }
+}

--- a/pkgs/by-name/ex/extract-dotnet-resources/package.nix
+++ b/pkgs/by-name/ex/extract-dotnet-resources/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  buildDotnetModule,
+  dotnetCorePackages,
+}:
+buildDotnetModule {
+  name = "extract-dotnet-resources";
+
+  src = ./.;
+
+  dotnet-sdk = dotnetCorePackages.sdk_9_0;
+  dotnet-runtime = dotnetCorePackages.runtime_9_0;
+
+  nugetDeps = ./deps.json;
+
+  meta = {
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ js6pak ];
+    mainProgram = "extract-dotnet-resources";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+  };
+}

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -229,13 +229,15 @@ if [[ -n "$newUrl" ]]; then
         die "Couldn't evaluate source url from '$attr.$sourceKey'!"
     fi
 
-    # Escape regex metacharacter that may appear in URLs
-    oldUrlEscaped=$(echo "$oldUrl" | sed -e 's|[*.^$[\|]|\\&|g')
-    newUrlEscaped=$(echo "$newUrl" | sed -e 's|[&\|]|\\&|g')
+    if [[ "$oldUrl" != "$newUrl" ]]; then
+      # Escape regex metacharacter that may appear in URLs
+      oldUrlEscaped=$(echo "$oldUrl" | sed -e 's|[*.^$[\|]|\\&|g')
+      newUrlEscaped=$(echo "$newUrl" | sed -e 's|[&\|]|\\&|g')
 
-    sed -i.cmp "$nixFile" -e "s|\"$oldUrlEscaped\"|\"$newUrlEscaped\"|"
-    if cmp -s "$nixFile" "$nixFile.cmp"; then
-        die "Failed to replace source URL '$oldUrl' to '$newUrl' in '$attr'!"
+      sed -i.cmp "$nixFile" -e "s|\"$oldUrlEscaped\"|\"$newUrlEscaped\"|"
+      if cmp -s "$nixFile" "$nixFile.cmp"; then
+          die "Failed to replace source URL '$oldUrl' to '$newUrl' in '$attr'!"
+      fi
     fi
 fi
 


### PR DESCRIPTION
https://www.jetbrains.com/dotmemory
https://www.jetbrains.com/dottrace

Also adds a [extract-dotnet-resources](https://github.com/NixOS/nixpkgs/commit/ad4dce638364b528646ea0905607d331931917c1) utility to extract the icon from .NET assemblies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
