### PR TITLE
scarab: Apply scaling factor in Wayland

### DIFF
--- a/pkgs/tools/games/scarab/default.nix
+++ b/pkgs/tools/games/scarab/default.nix
@@ -2,12 +2,8 @@
   lib,
   buildDotnetModule,
   fetchFromGitHub,
-  glibc,
-  zlib,
-  gtk3,
   copyDesktopItems,
   icoutils,
-  wrapGAppsHook3,
   makeDesktopItem,
 }:
 
@@ -33,20 +29,9 @@ buildDotnetModule rec {
       -n nuget.org --configfile NuGet.Config
   '';
 
-  runtimeDeps = [
-    glibc
-    zlib
-    gtk3
-  ];
-
-  buildInputs = [
-    gtk3
-  ];
-
   nativeBuildInputs = [
     copyDesktopItems
     icoutils
-    wrapGAppsHook3
   ];
 
   doCheck = true;

--- a/pkgs/tools/games/scarab/default.nix
+++ b/pkgs/tools/games/scarab/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  bc,
   buildDotnetModule,
   fetchFromGitHub,
   copyDesktopItems,
@@ -29,6 +30,10 @@ buildDotnetModule rec {
       -n nuget.org --configfile NuGet.Config
   '';
 
+  runtimeDeps = [
+    bc
+  ];
+
   nativeBuildInputs = [
     copyDesktopItems
     icoutils
@@ -45,6 +50,8 @@ buildDotnetModule rec {
       size=''${sizes[$i]}x''${sizes[$i]}
       install -D omegamaggotprime_''$((i+1))_''${size}x32.png $out/share/icons/hicolor/$size/apps/scarab.png
     done
+
+    wrapProgram "$out/bin/Scarab" --run '. ${./scaling-settings.bash}'
   '';
 
   desktopItems = [

--- a/pkgs/tools/games/scarab/scaling-settings.bash
+++ b/pkgs/tools/games/scarab/scaling-settings.bash
@@ -1,0 +1,24 @@
+# Keep existing value if it is already non-empty
+if [[ -z "${AVALONIA_GLOBAL_SCALE_FACTOR-}" ]] && command -v gsettings >/dev/null; then
+    echo 'Attempting to get GNOME desktop interface scaling factor' >&2
+    AVALONIA_GLOBAL_SCALE_FACTOR="$(gsettings get org.gnome.desktop.interface scaling-factor)"
+    AVALONIA_GLOBAL_SCALE_FACTOR="${AVALONIA_GLOBAL_SCALE_FACTOR##* }"
+fi
+
+if [[ "${AVALONIA_GLOBAL_SCALE_FACTOR-}" == "0" ]]; then
+    echo 'Unset invalid scaling value' >&2
+    unset AVALONIA_GLOBAL_SCALE_FACTOR
+fi
+
+if [[ -z "${AVALONIA_GLOBAL_SCALE_FACTOR-}" ]] && command -v xrdb >/dev/null; then
+    echo 'Attempting to get scaling factor from X FreeType DPI setting' >&2
+    dpi="$(xrdb -get Xft.dpi)"
+    if [[ -n "${dpi}" ]]; then
+        AVALONIA_GLOBAL_SCALE_FACTOR=$(echo "scale=2; ${dpi}/96" | bc)
+    fi
+fi
+
+if [[ -n "${AVALONIA_GLOBAL_SCALE_FACTOR-}" ]]; then
+    echo "Applying scale factor: ${AVALONIA_GLOBAL_SCALE_FACTOR}" >&2
+    export AVALONIA_GLOBAL_SCALE_FACTOR
+fi


### PR DESCRIPTION
Sets `AVALONIA_GLOBAL_SCALE_FACTOR` to the GNOME desktop scaling factor based on
<https://github.com/AvaloniaUI/Avalonia/issues/9390#issuecomment-2382126451>.

Also:

- Removed seemingly unnecessary dependencies
- Formatted using `shfmt --write pkgs/tools/games/scarab/scaling-settings.bash` (necessitated copying the relevant `.editorconfig` settings)
- Linted using `shellcheck --enable=all --severity=style pkgs/tools/games/scarab/scaling-settings.bash`

Thanks to @Artturin for help on Matrix!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] `shellcheck`ed
- [x] `shfmt`ed
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
