### PR TITLE
Revert "nixos/tests/networking: test nameservers via DHCP"

### DIFF
--- a/nixos/tests/networking/networkd-and-scripted.nix
+++ b/nixos/tests/networking/networkd-and-scripted.nix
@@ -132,10 +132,6 @@ let
               client.wait_until_succeeds("ip addr show dev enp2s0 | grep -q '192.168.2'")
               client.wait_until_succeeds("ip addr show dev enp2s0 | grep -q 'fd00:1234:5678:2:'")
 
-          with subtest("Wait until we have received the nameservers"):
-              client.wait_until_succeeds("grep -q 2001:db8::1 /etc/resolv.conf")
-              client.wait_until_succeeds("grep -q 192.168.2.1 /etc/resolv.conf")
-
           with subtest("Test vlan 1"):
               client.wait_until_succeeds("ping -c 1 192.168.1.1")
               client.wait_until_succeeds("ping -c 1 fd00:1234:5678:1::1")

--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -121,7 +121,6 @@ let
         static.wait_for_unit("NetworkManager.service")
 
         dynamic.wait_until_succeeds("cat /etc/resolv.conf | grep -q '192.168.1.1'")
-        dynamic.wait_until_succeeds("cat /etc/resolv.conf | grep -q '2001:db8::1'")
         static.wait_until_succeeds("cat /etc/resolv.conf | grep -q '10.10.10.10'")
         static.wait_until_fails("cat /etc/resolv.conf | grep -q '192.168.1.1'")
       '';

--- a/nixos/tests/networking/router.nix
+++ b/nixos/tests/networking/router.nix
@@ -72,7 +72,6 @@
           AdvSendAdvert on;
           AdvManagedFlag on;
           AdvOtherConfigFlag on;
-          RDNSS 2001:db8::1 {};
 
           prefix fd00:1234:5678:${toString n}::/64 {
             AdvAutonomous off;


### PR DESCRIPTION
This reverts commit bad5251e874bec27438cb8a613ec87e845ed437e.

https://github.com/NixOS/nixpkgs/pull/348305#issuecomment-2410165312 Should've known that commit starting with `bad` will be no good. Fixes nixosTests.networking.networkd.dhcpSimple
https://hydra.nixos.org/build/274843085/nixlog/8/tail

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
