### PR TITLE
aws-sam-cli: ignore warnings when falling back to kqueue on x86_64-darwin to avoid test failures

### DIFF
--- a/pkgs/by-name/aw/aws-sam-cli/package.nix
+++ b/pkgs/by-name/aw/aws-sam-cli/package.nix
@@ -82,6 +82,10 @@ python3.pkgs.buildPythonApplication rec {
       xray
     ]);
 
+  postPatch = ''
+    sed -i '/filterwarnings =/{n;s/\(\s*\)error/\1default/;}' pytest.ini
+  '';
+
   postFixup = ''
     # Disable telemetry: https://github.com/aws/aws-sam-cli/issues/1272
     wrapProgram $out/bin/sam \
@@ -107,9 +111,6 @@ python3.pkgs.buildPythonApplication rec {
 
   pytestFlagsArray = [
     "tests"
-    # Disable warnings
-    "-W"
-    "ignore::DeprecationWarning"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes build failure of `aws-sam-cli` on `x86_64-darwin`.

`aws-sam-cli` uses `watchdog`, and `nixpkgs` applies a patch to `watchdog` to force the use of `kqueue` on `x86_64-darwin` as follows:

https://github.com/NixOS/nixpkgs/blob/6189cfd22be248fca4a9797222bc2b9895328ab4/pkgs/development/python-modules/watchdog/default.nix#L27-L31

[`watchdog` emits a warning when `kqueue` is used as a fallback](https://github.com/gorakhargosh/watchdog/blob/1a1f40024d097ee687b3e5c182f8a5f3c028b820/src/watchdog/observers/__init__.py#L74-L78), which causes test failures in `aws-sam-cli` on `x86_64-darwin` (log: https://hydra.nixos.org/build/274631644).

This PR adds a pytest flag to ignore the warning, allowing the tests to pass successfully.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc