### PR TITLE
audiobookshelf: 2.14.0 -> 2.15.0

### DIFF
--- a/pkgs/by-name/au/audiobookshelf/package.nix
+++ b/pkgs/by-name/au/audiobookshelf/package.nix
@@ -6,6 +6,7 @@
   buildNpmPackage,
   nodejs_18,
   ffmpeg-full,
+  nunicode,
   util-linux,
   python3,
   getopt,
@@ -45,8 +46,7 @@ let
     inherit
       stdenv
       ffmpeg-full
-      pname
-      nodejs
+      nunicode
       getopt
       ;
   };

--- a/pkgs/by-name/au/audiobookshelf/source.json
+++ b/pkgs/by-name/au/audiobookshelf/source.json
@@ -1,9 +1,9 @@
 {
   "owner": "advplyr",
   "repo": "audiobookshelf",
-  "rev": "cf5598aeb9b086a28e853d6a89b82a7467fd6969",
-  "hash": "sha256-tObC7QbdwpAlt97eXB9QzZEaQcquuST+8nC6lYEXTUM=",
-  "version": "2.14.0",
-  "depsHash": "sha256-nVsmV3Vms2S9oM7duFfgt+go1+wM2JniI8B3UFmv/TE=",
-  "clientDepsHash": "sha256-oaoGxcMs8XQVaRx8UO9NSThqbHuZsA4fm8OGlSiaKO0="
+  "rev": "80e0cac4747e61d1fbb5374ec4ac41d3499042e2",
+  "hash": "sha256-gwu9AvxrfW1QSgUy3Q4di1xa964ZMZpRkgdFQlit9+4=",
+  "version": "2.15.0",
+  "depsHash": "sha256-TDZUrzVcmKn4izRn8E+uf6Mh22fRsHeVm5h+wRZAX8o=",
+  "clientDepsHash": "sha256-7R5+Yam9Y4+bj/8wrAE25g4sivg/sw5G0pAZFGPRpMI="
 }

--- a/pkgs/by-name/au/audiobookshelf/wrapper.nix
+++ b/pkgs/by-name/au/audiobookshelf/wrapper.nix
@@ -1,4 +1,9 @@
-{ stdenv, ffmpeg-full, pname, nodejs, getopt }: ''
+{
+  stdenv,
+  ffmpeg-full,
+  nunicode,
+  getopt,
+}: ''
     #!${stdenv.shell}
 
     port=8000
@@ -55,6 +60,7 @@
       SKIP_BINARIES_CHECK=1 \
       FFMPEG_PATH=${ffmpeg-full}/bin/ffmpeg \
       FFPROBE_PATH=${ffmpeg-full}/bin/ffprobe \
+      NUSQLITE3_PATH=${nunicode.sqlite}/lib/libnusqlite3 \
       CONFIG_PATH="$config" \
       METADATA_PATH="$metadata" \
       PORT="$port" \

--- a/pkgs/by-name/nu/nunicode/package.nix
+++ b/pkgs/by-name/nu/nunicode/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromBitbucket,
+  cmake,
+  sqlite,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nunicode";
+  version = "1.11";
+
+  outputs = [
+    "out"
+    "sqlite"
+  ];
+
+  src = fetchFromBitbucket {
+    owner = "alekseyt";
+    repo = "nunicode";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-6255YdX7eYSAj0EAE4RgX1m4XDNIF/Nc4ZCvXzTxpag=";
+  };
+
+  postPatch = ''
+    # load correct SQLite extension on all platforms
+    substituteInPlace sqlite3/testsuite --replace-fail \
+      "NU='./libnusqlite3.so'" \
+      "NU='./libnusqlite3'"
+
+    # fix expressions using like .. escape (https://sqlite.org/lang_expr.html#like)
+    substituteInPlace sqlite3/tests.sql --replace-fail '\\' '\'
+
+    # install SQLite extension in a separate output
+    echo >>sqlite3/CMakeLists.txt \
+      'install(TARGETS nusqlite3 DESTINATION "${placeholder "sqlite"}/lib")'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    sqlite
+  ];
+
+  # avoid name-clash on case-insensitive filesystems
+  cmakeBuildDir = "build-dir";
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    (
+    echo running SQLite testsuite
+
+    cd sqlite3
+    RESULT=$(../../sqlite3/testsuite < ../../sqlite3/tests.sql | sqlite3)
+    grep <<<$RESULT FAILED && echo SQLite testsuite failed && false
+
+    echo SQLite testsuite succeeded
+    )
+
+    runHook postCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast, small and portable Unicode library with SQLite extension";
+    homepage = "https://bitbucket.org/alekseyt/nunicode";
+    changelog = "https://bitbucket.org/alekseyt/nunicode/src/${finalAttrs.version}/CHANGELOG";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.mjoerg ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

enable nusqlite3 extension

https://github.com/advplyr/audiobookshelf/releases/tag/v2.15.0
https://github.com/advplyr/audiobookshelf/compare/refs/tags/v2.14.0...refs/tags/v2.15.0

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>audiobookshelf</li>
    <li>nunicode</li>
    <li>nunicode.sqlite</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>audiobookshelf</li>
    <li>nunicode</li>
    <li>nunicode.sqlite</li>
  </ul>
</details>

---
### `x86_64-darwin`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>nunicode</li>
    <li>nunicode.sqlite</li>
  </ul>
</details>

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>nunicode</li>
    <li>nunicode.sqlite</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc