### PR TITLE
nixos/murmur: support setting custom stateDir, user and group

### DIFF
--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -69,6 +69,24 @@ in
         '';
       };
 
+      user = mkOption {
+        type = types.str;
+        default = "murmur";
+        description = ''
+          The name of an existing user to use to run the service.
+          If not specified, the default user will be created.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "murmur";
+        description = ''
+          The name of an existing group to use to run the service.
+          If not specified, the default group will be created.
+        '';
+      };
+
       stateDir = mkOption {
         type = types.path;
         default = "/var/lib/murmur";
@@ -297,14 +315,14 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.users.murmur = {
+    users.users.murmur = mkIf (cfg.user == "murmur") {
       description     = "Murmur Service user";
       home            = cfg.stateDir;
       createHome      = true;
       uid             = config.ids.uids.murmur;
-      group           = "murmur";
+      group           = cfg.group;
     };
-    users.groups.murmur = {
+    users.groups.murmur = mkIf (cfg.group == "murmur") {
       gid             = config.ids.gids.murmur;
     };
 
@@ -332,8 +350,8 @@ in
         Restart = "always";
         RuntimeDirectory = "murmur";
         RuntimeDirectoryMode = "0700";
-        User = "murmur";
-        Group = "murmur";
+        User = cfg.user;
+        Group = cfg.group;
 
         # service hardening
         AmbientCapabilities = "CAP_NET_BIND_SERVICE";
@@ -369,7 +387,7 @@ in
           "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
           "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
         <busconfig>
-          <policy user="murmur">
+          <policy user="${cfg.user}">
             <allow own="net.sourceforge.mumble.murmur"/>
           </policy>
 

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -6,7 +6,7 @@ let
   cfg = config.services.murmur;
   forking = cfg.logFile != null;
   configFile = pkgs.writeText "murmurd.ini" ''
-    database=/var/lib/murmur/murmur.sqlite
+    database=${cfg.stateDir}/murmur.sqlite
     dbDriver=QSQLITE
 
     autobanAttempts=${toString cfg.autobanAttempts}
@@ -66,6 +66,14 @@ in
         default = false;
         description = ''
           Open ports in the firewall for the Murmur Mumble server.
+        '';
+      };
+
+      stateDir = mkOption {
+        type = types.path;
+        default = "/var/lib/murmur";
+        description = ''
+          Directory to store data for the server.
         '';
       };
 
@@ -257,7 +265,7 @@ in
       environmentFile = mkOption {
         type = types.nullOr types.path;
         default = null;
-        example = "/var/lib/murmur/murmurd.env";
+        example = literalExpression ''"''${config.services.murmur.stateDir}/murmurd.env"'';
         description = ''
           Environment file as defined in {manpage}`systemd.exec(5)`.
 
@@ -291,7 +299,7 @@ in
   config = mkIf cfg.enable {
     users.users.murmur = {
       description     = "Murmur Service user";
-      home            = "/var/lib/murmur";
+      home            = cfg.stateDir;
       createHome      = true;
       uid             = config.ids.uids.murmur;
       group           = "murmur";
@@ -386,9 +394,9 @@ in
 
         r ${config.environment.etc."os-release".source},
         r ${config.environment.etc."lsb-release".source},
-        owner rwk /var/lib/murmur/murmur.sqlite,
-        owner rw /var/lib/murmur/murmur.sqlite-journal,
-        owner r /var/lib/murmur/,
+        owner rwk ${cfg.stateDir}/murmur.sqlite,
+        owner rw ${cfg.stateDir}/murmur.sqlite-journal,
+        owner r ${cfg.stateDir}/,
         r /run/murmur/murmurd.pid,
         r /run/murmur/murmurd.ini,
         r ${configFile},


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR supports setting custom state directory, user and group for the Murmur service:
- The custom state directory is helpful when you want to manage the state in a different place for backup or sync.
- The user and group options allow the service to run as existing users so that permissions can be managed more easily

The `stateDir`, `user`, and `group` options are common in other modules as well. It should be easy for users to use and bring no breaking changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
