### PR TITLE
hifile: 0.9.9.13 -> 0.9.9.15, add update script; maintainers/ymstnt: update name

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23532,7 +23532,7 @@
     githubId = 47071325;
   };
   ymstnt = {
-    name = "YMSTNT";
+    name = "ymstnt";
     github = "ymstnt";
     githubId = 21342713;
   };

--- a/pkgs/by-name/hi/hifile/package.nix
+++ b/pkgs/by-name/hi/hifile/package.nix
@@ -1,19 +1,24 @@
-{ lib, appimageTools, fetchurl }:
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
 
 let
-  version = "0.9.9.13";
+  version = "0.9.9.15";
   pname = "hifile";
 
   src = fetchurl {
     url = "https://www.hifile.app/files/HiFile-${version}.AppImage";
-    hash = "sha256-nZlPdl7D0UWtm8mFz4IDqmvGeBVc7mbeUpzyHrdDQtk=";
+    hash = "sha256-Q0clcmBLWt8qDzHYjRRbwyZBSWW//yBTbRcnRjrSlzM=";
   };
 
   appimageContents = appimageTools.extractType2 {
     inherit pname version src;
   };
 
-in appimageTools.wrapType2 rec {
+in
+appimageTools.wrapType2 rec {
   inherit pname version src;
 
   extraInstallCommands = ''

--- a/pkgs/by-name/hi/hifile/package.nix
+++ b/pkgs/by-name/hi/hifile/package.nix
@@ -28,6 +28,8 @@ appimageTools.wrapType2 rec {
       --replace-fail 'Exec=HiFile' 'Exec=${pname}'
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "Dual-pane graphical file manager for Windows, macOS and Linux";
     longDescription = ''

--- a/pkgs/by-name/hi/hifile/update.sh
+++ b/pkgs/by-name/hi/hifile/update.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl common-updater-scripts
+
+latestVersion=$(curl -s "https://www.hifile.app/otherdownloads" | grep -A 10 '<h1>All downloads</h1>' | grep -m 1 '<li>.*AppImage.*' | sed -n 's/.*HiFile-\([0-9.]*\)\.AppImage.*/\1/p')
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; hifile.version" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+
+
+prefetch=$(nix-prefetch-url "https://www.hifile.app/files/HiFile-$latestVersion.AppImage")
+hash=$(nix-hash --type sha256 --to-sri "$prefetch")
+
+update-source-version hifile 0 "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" --system="x86_64-linux"
+update-source-version hifile "$latestVersion" "$hash" --system="x86_64-linux"
+
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
hifile:
- Update hifile to 0.9.9.15
- Changelog: https://www.hifile.app/changelog
- Added automatic update script

other:
- maintainers/ymstnt: updated name to lowercase, to reflect GitHub name changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
