### PR TITLE
xwayland-satellite: 0.4 -> 0.4-unstable-2024-09-15

### DIFF
--- a/pkgs/by-name/xw/xwayland-satellite/package.nix
+++ b/pkgs/by-name/xw/xwayland-satellite/package.nix
@@ -1,12 +1,13 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, xwayland
-, xcb-util-cursor
-, libxcb
-, nix-update-script
-, makeWrapper
+{
+  lib,
+  fetchFromGitHub,
+  libxcb,
+  makeWrapper,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  xcb-util-cursor,
+  xwayland,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -23,9 +24,9 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-nKPSkHbh73xKWNpN/OpDmLnVmA3uygs3a+ejOhwU3yA=";
 
   nativeBuildInputs = [
+    makeWrapper
     pkg-config
     rustPlatform.bindgenHook
-    makeWrapper
   ];
 
   buildInputs = [
@@ -46,7 +47,7 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     wrapProgram $out/bin/xwayland-satellite \
-      --prefix PATH : "${lib.makeBinPath [xwayland]}"
+      --prefix PATH : "${lib.makeBinPath [ xwayland ]}"
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -55,7 +56,10 @@ rustPlatform.buildRustPackage rec {
     description = "Rootless Xwayland integration to any Wayland compositor implementing xdg_wm_base";
     homepage = "https://github.com/Supreeeme/xwayland-satellite";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ if-loop69420 sodiboo ];
+    maintainers = with maintainers; [
+      if-loop69420
+      sodiboo
+    ];
     mainProgram = "xwayland-satellite";
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/xw/xwayland-satellite/package.nix
+++ b/pkgs/by-name/xw/xwayland-satellite/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   libxcb,
-  makeWrapper,
+  makeBinaryWrapper,
   pkg-config,
   rustPlatform,
   unstableGitUpdater,
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage {
   cargoHash = "sha256-1EtwGMoLfYK0VZj8jdQiweO/RHGBzyEoeMEI4pmqfu8=";
 
   nativeBuildInputs = [
-    makeWrapper
+    makeBinaryWrapper
     pkg-config
     rustPlatform.bindgenHook
   ];

--- a/pkgs/by-name/xw/xwayland-satellite/package.nix
+++ b/pkgs/by-name/xw/xwayland-satellite/package.nix
@@ -67,6 +67,7 @@ rustPlatform.buildRustPackage {
     maintainers = with lib.maintainers; [
       if-loop69420
       sodiboo
+      getchoo
     ];
     mainProgram = "xwayland-satellite";
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/xw/xwayland-satellite/package.nix
+++ b/pkgs/by-name/xw/xwayland-satellite/package.nix
@@ -57,15 +57,18 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
-  meta = with lib; {
-    description = "Rootless Xwayland integration to any Wayland compositor implementing xdg_wm_base";
+  meta = {
+    description = "Xwayland outside your Wayland compositor";
+    longDescription = ''
+      Grants rootless Xwayland integration to any Wayland compositor implementing xdg_wm_base.
+    '';
     homepage = "https://github.com/Supreeeme/xwayland-satellite";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
       if-loop69420
       sodiboo
     ];
     mainProgram = "xwayland-satellite";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Diff: https://github.com/Supreeeme/xwayland-satellite/compare/v0.4...b962a0f33b503aa39c9cf6919f488b664e5b79b4

Along with the regular bug fixes, this adds support for running `xwayland-satellite` as a systemd service. It should go well with #348193

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
