### PR TITLE
treewide: remove qt5.mkDerivation usage (trivial cases)

### DIFF
--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , fetchurl
 , cups
 , libssh
@@ -15,7 +16,7 @@
 , pkg-config
 }:
 
-qt5.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "x2goclient";
   version = "4.1.2.2";
 

--- a/pkgs/applications/networking/synology-drive-client/default.nix
+++ b/pkgs/applications/networking/synology-drive-client/default.nix
@@ -25,7 +25,7 @@ let
     update-source-version synology-drive-client "$version"
   '';
 
-  linux = qt5.mkDerivation {
+  linux = stdenv.mkDerivation {
     inherit pname version meta passthru;
 
     src = fetchurl {
@@ -33,7 +33,7 @@ let
       sha256 = "sha256-VeS5bPcMM4JDCSH5GXkl4OgQjrPKaNDh5PfX28/zqaU=";
     };
 
-    nativeBuildInputs = [ autoPatchelfHook dpkg ];
+    nativeBuildInputs = [ qt5.wrapQtAppsHook autoPatchelfHook dpkg ];
 
     buildInputs = [ glibc gtk3 pango libxcb ];
 

--- a/pkgs/by-name/kg/kgeotag/package.nix
+++ b/pkgs/by-name/kg/kgeotag/package.nix
@@ -1,6 +1,6 @@
-{ cmake, extra-cmake-modules, fetchFromGitLab, lib, libsForQt5 }:
+{ stdenv, cmake, extra-cmake-modules, fetchFromGitLab, lib, libsForQt5 }:
 
-libsForQt5.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "kgeotag";
   version = "1.5.0";
 
@@ -12,7 +12,7 @@ libsForQt5.mkDerivation rec {
     hash = "sha256-G9SyGvoSOL6nsWnMuSIUSFHFUwZUzExBJBkKN46o8GI=";
   };
 
-  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  nativeBuildInputs = [ cmake extra-cmake-modules libsForQt5.wrapQtAppsHook ];
 
   buildInputs = [ libsForQt5.libkexiv2 libsForQt5.marble ];
 

--- a/pkgs/by-name/ne/neovim-qt/package.nix
+++ b/pkgs/by-name/ne/neovim-qt/package.nix
@@ -1,12 +1,12 @@
-{ stdenv, libsForQt5, makeWrapper, neovim, neovim-qt-unwrapped }:
+{ stdenvNoCC, makeWrapper, neovim, neovim-qt-unwrapped }:
 
 let
   unwrapped = neovim-qt-unwrapped;
 in
-libsForQt5.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "neovim-qt";
   version = unwrapped.version;
-  buildCommand = if stdenv.hostPlatform.isDarwin then ''
+  buildCommand = if stdenvNoCC.hostPlatform.isDarwin then ''
     mkdir -p $out/Applications
     cp -r ${unwrapped}/bin/nvim-qt.app $out/Applications
 

--- a/pkgs/by-name/os/oscar/package.nix
+++ b/pkgs/by-name/os/oscar/package.nix
@@ -5,7 +5,7 @@
   fetchFromGitLab,
   libGLU,
 }:
-qt5.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "oscar";
   version = "1.5.1";
 
@@ -22,7 +22,10 @@ qt5.mkDerivation rec {
     qt5.qtserialport
     libGLU
   ];
-  nativeBuildInputs = [ qt5.qmake ];
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+    qt5.qmake
+  ];
   postPatch = ''
     substituteInPlace oscar/oscar.pro --replace "/bin/bash" "${stdenv.shell}"
   '';

--- a/pkgs/by-name/qd/qdirstat/package.nix
+++ b/pkgs/by-name/qd/qdirstat/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  stdenv,
   libsForQt5,
   coreutils,
   xdg-utils,
@@ -9,7 +10,7 @@
   perlPackages,
 }:
 
-libsForQt5.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qdirstat";
   version = "1.9";
 
@@ -20,7 +21,12 @@ libsForQt5.mkDerivation rec {
     hash = "sha256-pwdmltHDNwUMx1FNOoiXl5Pna0zlKqahmicBCN6UVSU=";
   };
 
-  nativeBuildInputs = [ makeWrapper ] ++ (with libsForQt5; [ qmake ]);
+  nativeBuildInputs =
+    [ makeWrapper ]
+    ++ (with libsForQt5; [
+      qmake
+      wrapQtAppsHook
+    ]);
 
   buildInputs = [ perlPackages.perl ];
 

--- a/pkgs/by-name/so/soundwireserver/package.nix
+++ b/pkgs/by-name/so/soundwireserver/package.nix
@@ -1,12 +1,13 @@
 {
   lib,
+  stdenvNoCC,
   qt5,
   autoPatchelfHook,
   fetchzip,
   portaudio,
 }:
 
-qt5.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "soundwire";
   version = "3.0";
 
@@ -17,6 +18,7 @@ qt5.mkDerivation {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    qt5.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/tools/misc/r3ctl/default.nix
+++ b/pkgs/tools/misc/r3ctl/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , qt5
 , qtbase
 , qttools
@@ -7,7 +8,7 @@
 , fetchFromGitHub
 }:
 
-qt5.mkDerivation {
+stdenv.mkDerivation {
   pname = "r3ctl";
   version = "a82cb5b3123224e706835407f21acea9dc7ab0f0";
 


### PR DESCRIPTION
Part of #180841.

Once this is merged, along with ~~#348465 and~~ #348468, ~~we can finally deprecate and then remove `qt5.mkDerivation`.~~ nope

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
