### PR TITLE
python3Packages.libarchive-c: apply patch fixing a test with recent `libarchive` versions

### DIFF
--- a/pkgs/development/python-modules/libarchive-c/default.nix
+++ b/pkgs/development/python-modules/libarchive-c/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   libarchive,
   glibcLocales,
   mock,
@@ -20,6 +21,14 @@ buildPythonPackage rec {
     rev = "refs/tags/${version}";
     sha256 = "sha256-CO9llPIbVTuE74AeohrMAu5ICkuT/MorRlYEEFne6Uk=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-tests-with-recent-libarchive.patch";
+      url = "https://github.com/Changaco/python-libarchive-c/commit/a56e9402c76c2fb9631651de7bae07b5fbb0b624.patch";
+      hash = "sha256-OLwJQurEFAmwZJbQfhkibrR7Rcnc9vpWwBuhKxgmT7g=";
+    })
+  ];
 
   LC_ALL = "en_US.UTF-8";
 


### PR DESCRIPTION
See comments in https://github.com/NixOS/nixpkgs/pull/341705#issuecomment-2411752512

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 348582`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 20 packages built:</summary>
  <ul>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>diffoscopeMinimal</li>
    <li>diffoscopeMinimal.dist</li>
    <li>diffoscopeMinimal.man</li>
    <li>opendrop</li>
    <li>opendrop.dist</li>
    <li>python311Packages.libarchive-c</li>
    <li>python311Packages.libarchive-c.dist</li>
    <li>python311Packages.ratarmount</li>
    <li>python311Packages.ratarmount.dist</li>
    <li>python311Packages.ratarmountcore</li>
    <li>python311Packages.ratarmountcore.dist</li>
    <li>python312Packages.libarchive-c</li>
    <li>python312Packages.libarchive-c.dist</li>
    <li>ratarmount (python312Packages.ratarmount)</li>
    <li>ratarmount.dist (python312Packages.ratarmount.dist)</li>
    <li>python312Packages.ratarmountcore</li>
    <li>python312Packages.ratarmountcore.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
