### PR TITLE
dsp: fix build with ffmpeg7

### DIFF
--- a/pkgs/by-name/ds/dsp/package.nix
+++ b/pkgs/by-name/ds/dsp/package.nix
@@ -13,6 +13,7 @@
 , ladspaH
 , libtool
 , libpulseaudio
+, fetchpatch
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,6 +28,15 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [ pkg-config ];
+
+  patches = [
+    # fix compatibility with ffmpeg7
+    # https://github.com/bmc0/dsp/commit/58a9d0c1f99f2d4c7fc51b6dbe563447ec60120f
+    (fetchpatch {
+      url = "https://github.com/bmc0/dsp/commit/58a9d0c1f99f2d4c7fc51b6dbe563447ec60120f.patch?full_index=1";
+      hash = "sha256-7WgJegDL9sVCRnRwm/f1ZZl2eiuRT5oAQaYoDLjEoqs=";
+    })
+  ];
 
   buildInputs = [
     fftw


### PR DESCRIPTION
- add patch from upstream commit fixing ffmpeg_7 compatibility:
https://github.com/bmc0/dsp/commit/58a9d0c1f99f2d4c7fc51b6dbe563447ec60120f

---

Fixes build of `dsp`:
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.dsp.x86_64-linux
https://hydra.nixos.org/build/274869239
Log:
```text
gcc -c -o obj/dsp/ffmpeg.o -MMD -MP -Os -Wall -std=gnu99 -DENABLE_LADSPA_HOST -DHAVE_SNDFILE -DHAVE_FFMPEG -DHAVE_FFTW3 -DHAVE_ZITA_CONVOLVER -DHAVE_ALSA -DHAVE_AO -DHAVE_MAD -DHAVE_PULSE -D_REENTRANT -I/nix/store/sb6fpy8yryslsqyq8zzjc2wpla2xpkzp-fftw-double-3.3.10-dev/include -I/nix/store/fhwvqwamg9a9ly9wivk3xrh7n5mzn5jf-libsndfile-1.2.2-dev/include -I/nix/store/bakyrc1qx6imk38276zpf4b4hlzpqi62-ffmpeg-7.0.2-dev/include -I/nix/store/i4afj4a5mgj8n4cbr1br7qz0b6pp4djn-alsa-lib-1.2.12-dev/include -I/nix/store/xq61rz0dmyg9r31z4wa4p8jcwjzym6vd-libao-1.2.2-dev/include -I/nix/store/v4yfkc5k6fkz025hgc3kdajk4bzfkhjm-libpulseaudio-17.0-dev/include   ffmpeg.c
ffmpeg.c: In function 'ffmpeg_codec_init':
ffmpeg.c:277:32: error: 'AVCodecContext' has no member named 'channels'
  277 |         c->channels = state->cc->channels;
      |                                ^~
ffmpeg.c:338:17: warning: 'avcodec_close' is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-declarations-Wdeprecated-declarations8;;]
  338 |                 avcodec_close(state->cc);
      |                 ^~~~~~~~~~~~~
In file included from ffmpeg.c:4:
/nix/store/bakyrc1qx6imk38276zpf4b4hlzpqi62-ffmpeg-7.0.2-dev/include/libavcodec/avcodec.h:2387:5: note: declared here
 2387 | int avcodec_close(AVCodecContext *avctx);
      |     ^~~~~~~~~~~~~
make: *** [GNUmakefile:71: obj/dsp/ffmpeg.o] Error 1
```
fails since staging merge with https://github.com/NixOS/nixpkgs/commit/92b0f7cb13eb6d28cc5f929a32d7a294da2896c4 (`ffmpeg: ffmpeg_6 -> ffmpeg_7`)

---

PS there is another upstream commit:
https://github.com/bmc0/dsp/commit/f21c3e41007725254312da42946808abe2846719
That removes `warning: 'avcodec_close' is deprecated`, but it does not seem to affect build for now, so probably not worth pulling another patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
