### PR TITLE
Revert "castxml: fix build on darwin"

### DIFF
--- a/pkgs/by-name/ca/castxml/package.nix
+++ b/pkgs/by-name/ca/castxml/package.nix
@@ -32,11 +32,12 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ] ++ lib.optionals (withManual || withHTML) [ sphinx ];
 
   buildInputs = [
+    libclang
     libffi
     libxml2
     llvm
     zlib
-  ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ libclang ];
+  ];
 
   cmakeFlags =
     [
@@ -46,9 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
 
       (lib.cmakeBool "SPHINX_HTML" withHTML)
       (lib.cmakeBool "SPHINX_MAN" withManual)
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      (lib.cmakeOptionType "path" "Clang_DIR" "${lib.getDev libclang}/lib/cmake/clang")
     ];
 
   doCheck = true;

--- a/pkgs/by-name/ca/castxml/package.nix
+++ b/pkgs/by-name/ca/castxml/package.nix
@@ -39,15 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  cmakeFlags =
-    [
-      (lib.cmakeOptionType "path" "CLANG_RESOURCE_DIR"
-        "${lib.getLib libclang}/lib/clang/${lib.versions.major libclang.version}"
-      )
+  cmakeFlags = [
+    (lib.cmakeOptionType "path" "CLANG_RESOURCE_DIR"
+      "${lib.getLib libclang}/lib/clang/${lib.versions.major libclang.version}"
+    )
 
-      (lib.cmakeBool "SPHINX_HTML" withHTML)
-      (lib.cmakeBool "SPHINX_MAN" withManual)
-    ];
+    (lib.cmakeBool "SPHINX_HTML" withHTML)
+    (lib.cmakeBool "SPHINX_MAN" withManual)
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
Revert "castxml: fix build on darwin"

workaround for clang is no longer needed after change 8c9c8ade2f88a85ccdd4858cc802d7b7d6c48fe0 fixed cmake

This reverts commit 94490fd53141d1be123d2ca0dfe1fdac0487a2da.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
