### PR TITLE
nixos/freshrss: easier nginx vhost configuration

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -359,6 +359,7 @@ in {
   freshrss-pgsql = handleTest ./freshrss-pgsql.nix {};
   freshrss-http-auth = handleTest ./freshrss-http-auth.nix {};
   freshrss-none-auth = handleTest ./freshrss-none-auth.nix {};
+  freshrss-nginx = handleTest ./freshrss-nginx.nix {};
   frigate = handleTest ./frigate.nix {};
   frp = handleTest ./frp.nix {};
   frr = handleTest ./frr.nix {};

--- a/nixos/tests/freshrss-nginx.nix
+++ b/nixos/tests/freshrss-nginx.nix
@@ -1,0 +1,33 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+  {
+    name = "freshrss";
+    meta.maintainers = with lib.maintainers; [ mattchrist ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.freshrss = {
+          enable = true;
+          baseUrl = "http://localhost";
+          passwordFile = pkgs.writeText "password" "secret";
+          dataDir = "/srv/freshrss";
+          nginx.virtualHost = {
+            listen = [
+              {
+                addr = "127.0.0.1";
+                port = 8081;
+              }
+            ];
+          };
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_open_port(8081)
+      response = machine.succeed("curl -vvv -s -H 'Host: freshrss' http://127.0.0.1:8081/i/")
+      assert '<title>Login · FreshRSS</title>' in response, "Login page didn't load successfully"
+    '';
+  }
+)

--- a/pkgs/servers/web-apps/freshrss/default.nix
+++ b/pkgs/servers/web-apps/freshrss/default.nix
@@ -41,7 +41,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   passthru.tests = {
-    inherit (nixosTests) freshrss-sqlite freshrss-pgsql freshrss-http-auth freshrss-none-auth freshrss-extensions;
+    inherit (nixosTests) freshrss-sqlite freshrss-pgsql freshrss-http-auth freshrss-none-auth freshrss-extensions freshrss-nginx;
   };
 
   meta = with lib; {


### PR DESCRIPTION
This patch simplifies configuring the nginx virtualHost used by freshrss, by exposing a new services.freshrss.nginx.virtualHost option.

I renamed the services.freshrss.virtualHost option to services.freshrss.hostname and deprecated virtualHost to avoid confusion with the new nginx.virtualHost option and to make this module more consistent with other modules that provide a nginx.virtualHost option.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
