### PR TITLE
zine: fix build with rust 1.80+

### DIFF
--- a/pkgs/applications/misc/zine/default.nix
+++ b/pkgs/applications/misc/zine/default.nix
@@ -16,7 +16,12 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-pUoMMgZQ+oDs9Yhc1rQuy9cUWiR800DlIe8wxQjnIis=";
   };
 
-  cargoHash = "sha256-dXq8O0jVpr0xxvLTrsLJbiyyOMXXtEz7OMINqDEfG4U=";
+  cargoHash = "sha256-B0yPTyZ+d+s0Mdgeb23IammuABpEYWvAksyP7d+MEig=";
+
+  cargoPatches = [
+    # fix build with rust 1.80+
+    ./update-time-crate.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/misc/zine/update-time-crate.patch
+++ b/pkgs/applications/misc/zine/update-time-crate.patch
@@ -1,0 +1,189 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 30a7f9b1b5..dd3f0104cd 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -103,7 +103,7 @@
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.23",
++ "syn 2.0.32",
+ ]
+ 
+ [[package]]
+@@ -376,7 +376,7 @@
+ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+ dependencies = [
+  "quote",
+- "syn 2.0.23",
++ "syn 2.0.32",
+ ]
+ 
+ [[package]]
+@@ -394,6 +394,16 @@
+ ]
+ 
+ [[package]]
++name = "deranged"
++version = "0.3.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
++dependencies = [
++ "powerfmt",
++ "serde",
++]
++
++[[package]]
+ name = "derive_more"
+ version = "0.99.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -445,7 +455,7 @@
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.23",
++ "syn 2.0.32",
+ ]
+ 
+ [[package]]
+@@ -1383,6 +1393,12 @@
+ ]
+ 
+ [[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
++[[package]]
+ name = "num_cpus"
+ version = "1.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -1441,7 +1457,7 @@
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.23",
++ "syn 2.0.32",
+ ]
+ 
+ [[package]]
+@@ -1623,7 +1639,7 @@
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.23",
++ "syn 2.0.32",
+ ]
+ 
+ [[package]]
+@@ -1659,6 +1675,12 @@
+ ]
+ 
+ [[package]]
++name = "powerfmt"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
++
++[[package]]
+ name = "ppv-lite86"
+ version = "0.2.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -2090,22 +2112,22 @@
+ 
+ [[package]]
+ name = "serde"
+-version = "1.0.166"
++version = "1.0.193"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
++checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+ dependencies = [
+  "serde_derive",
+ ]
+ 
+ [[package]]
+ name = "serde_derive"
+-version = "1.0.166"
++version = "1.0.193"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
++checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.23",
++ "syn 2.0.32",
+ ]
+ 
+ [[package]]
+@@ -2243,9 +2265,9 @@
+ 
+ [[package]]
+ name = "syn"
+-version = "2.0.23"
++version = "2.0.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
++checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -2345,7 +2367,7 @@
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.23",
++ "syn 2.0.32",
+ ]
+ 
+ [[package]]
+@@ -2361,11 +2383,14 @@
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.22"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
++ "deranged",
+  "itoa 1.0.8",
++ "num-conv",
++ "powerfmt",
+  "serde",
+  "time-core",
+  "time-macros",
+@@ -2373,16 +2398,17 @@
+ 
+ [[package]]
+ name = "time-core"
+-version = "0.1.1"
++version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
++checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.9"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+ 
+@@ -2422,7 +2448,7 @@
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.23",
++ "syn 2.0.32",
+ ]
+ 
+ [[package]]


### PR DESCRIPTION
- add patch to Cargo.lock after running "cargo update time", updates `time` crate to `0.3.36` fixing build error on rust 1.80+

---

Fixes build of `zine` (fails since `2024-08-14`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.zine.x86_64-linux
https://hydra.nixos.org/build/274833406
Log:
```text
   Compiling time v0.3.22
error[E0282]: type annotations needed for `Box<_>`
  --> /build/zine-0.16.0-vendor.tar.gz/time/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
   = note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`
```

Tracking rust 1.80 issue:
https://github.com/NixOS/nixpkgs/issues/332957

(no upstream PR as they do not commit `Cargo.lock` to repo, it is only present on crates.io and there have not been any updates since July 2023)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
