### PR TITLE
openssh: Limit capabilities of the sshd service

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -882,6 +882,7 @@ in
                 "~CAP_SYS_ADMIN"
                 "~CAP_SYS_BOOT"
                 "~CAP_SYS_MODULE"
+                "~CAP_SYS_NICE"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -867,6 +867,7 @@ in
                 "~@cpu-emulation"
                 "~@debug"
                 "~@module"
+                "~@obsolete"
               ];
             }
             // (

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -899,6 +899,7 @@ in
                 # don't detach into a daemon process
                 + "-f /etc/ssh/sshd_config";
               KillMode = "process";
+              LockPersonality = true;
               RestrictNamespaces = [
                 "~cgroup"
                 "~ipc"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -854,6 +854,9 @@ in
 
           serviceConfig =
             {
+              CapabilityBoundingSet = [
+                "~CAP_CHOWN"
+              ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")
                 + "${cfg.package}/bin/sshd "

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -856,6 +856,7 @@ in
             {
               CapabilityBoundingSet = [
                 "~CAP_CHOWN"
+                "~CAP_DAC_OVERRIDE"
                 "~CAP_FSETID"
                 "~CAP_SETFCAP"
               ];

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -870,6 +870,7 @@ in
                 "~@obsolete"
                 "~@raw-io"
                 "~@reboot"
+                "~@swap"
               ];
             }
             // (

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -885,6 +885,7 @@ in
                 "~CAP_SYS_NICE"
                 "~CAP_SYS_PACCT"
                 "~CAP_SYS_PTRACE"
+                "~CAP_SYS_RAWIO"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -868,6 +868,7 @@ in
                 "~CAP_IPC_LOCK"
                 "~CAP_IPC_OWNER"
                 "~CAP_KILL"
+                "~CAP_LEASE"
                 "~CAP_SETFCAP"
               ];
               ExecStart =

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -869,6 +869,7 @@ in
                 "~CAP_IPC_OWNER"
                 "~CAP_KILL"
                 "~CAP_LEASE"
+                "~CAP_LINUX_IMMUTABLE"
                 "~CAP_SETFCAP"
               ];
               ExecStart =

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -857,6 +857,7 @@ in
               CapabilityBoundingSet = [
                 "~CAP_AUDIT_CONTROL"
                 "~CAP_AUDIT_READ"
+                "~CAP_AUDIT_WRITE"
                 "~CAP_CHOWN"
                 "~CAP_DAC_OVERRIDE"
                 "~CAP_DAC_READ_SEARCH"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -858,6 +858,7 @@ in
                 "~CAP_AUDIT_CONTROL"
                 "~CAP_AUDIT_READ"
                 "~CAP_AUDIT_WRITE"
+                "~CAP_BLOCK_SUSPEND"
                 "~CAP_CHOWN"
                 "~CAP_DAC_OVERRIDE"
                 "~CAP_DAC_READ_SEARCH"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -873,6 +873,7 @@ in
                 "~CAP_MAC_ADMIN"
                 "~CAP_MAC_OVERRIDE"
                 "~CAP_MKNOD"
+                "~CAP_NET_ADMIN"
                 "~CAP_NET_BROADCAST"
                 "~CAP_NET_RAW"
                 "~CAP_SETFCAP"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -878,6 +878,7 @@ in
                 "~CAP_NET_RAW"
                 "~CAP_SETFCAP"
                 "~CAP_SETPCAP"
+                "~CAP_SYSLOG"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -899,6 +899,15 @@ in
                 # don't detach into a daemon process
                 + "-f /etc/ssh/sshd_config";
               KillMode = "process";
+              RestrictNamespaces = [
+                "~cgroup"
+                "~ipc"
+                "~mnt"
+                "~net"
+                "~pid"
+                "~user"
+                "~uts"
+              ];
               SystemCallFilter = [
                 "~@clock"
                 "~@cpu-emulation"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -880,6 +880,7 @@ in
                 "~CAP_SETPCAP"
                 "~CAP_SYSLOG"
                 "~CAP_SYS_ADMIN"
+                "~CAP_SYS_BOOT"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -887,6 +887,7 @@ in
                 "~CAP_SYS_PTRACE"
                 "~CAP_SYS_RAWIO"
                 "~CAP_SYS_RESOURCE"
+                "~CAP_SYS_TIME"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -865,6 +865,7 @@ in
                 "~CAP_DAC_READ_SEARCH"
                 "~CAP_FOWNER"
                 "~CAP_FSETID"
+                "~CAP_IPC_LOCK"
                 "~CAP_IPC_OWNER"
                 "~CAP_SETFCAP"
               ];

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -857,6 +857,7 @@ in
               CapabilityBoundingSet = [
                 "~CAP_CHOWN"
                 "~CAP_DAC_OVERRIDE"
+                "~CAP_DAC_READ_SEARCH"
                 "~CAP_FSETID"
                 "~CAP_SETFCAP"
               ];

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -871,6 +871,7 @@ in
                 "~CAP_LEASE"
                 "~CAP_LINUX_IMMUTABLE"
                 "~CAP_MAC_ADMIN"
+                "~CAP_MAC_OVERRIDE"
                 "~CAP_SETFCAP"
               ];
               ExecStart =

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -857,6 +857,7 @@ in
               CapabilityBoundingSet = [
                 "~CAP_CHOWN"
                 "~CAP_FSETID"
+                "~CAP_SETFCAP"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -859,6 +859,7 @@ in
                 "~CAP_AUDIT_READ"
                 "~CAP_AUDIT_WRITE"
                 "~CAP_BLOCK_SUSPEND"
+                "~CAP_BPF"
                 "~CAP_CHOWN"
                 "~CAP_DAC_OVERRIDE"
                 "~CAP_DAC_READ_SEARCH"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -869,6 +869,7 @@ in
                 "~@module"
                 "~@obsolete"
                 "~@raw-io"
+                "~@reboot"
               ];
             }
             // (

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -867,6 +867,7 @@ in
                 "~CAP_FSETID"
                 "~CAP_IPC_LOCK"
                 "~CAP_IPC_OWNER"
+                "~CAP_KILL"
                 "~CAP_SETFCAP"
               ];
               ExecStart =

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -862,6 +862,9 @@ in
                 # don't detach into a daemon process
                 + "-f /etc/ssh/sshd_config";
               KillMode = "process";
+              SystemCallFilter = [
+                "~@clock"
+              ];
             }
             // (
               if cfg.startWhenNeeded then

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -855,6 +855,7 @@ in
           serviceConfig =
             {
               CapabilityBoundingSet = [
+                "~CAP_AUDIT_CONTROL"
                 "~CAP_CHOWN"
                 "~CAP_DAC_OVERRIDE"
                 "~CAP_DAC_READ_SEARCH"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -856,6 +856,7 @@ in
             {
               CapabilityBoundingSet = [
                 "~CAP_CHOWN"
+                "~CAP_FSETID"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -864,6 +864,7 @@ in
               KillMode = "process";
               SystemCallFilter = [
                 "~@clock"
+                "~@cpu-emulation"
               ];
             }
             // (

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -879,6 +879,7 @@ in
                 "~CAP_SETFCAP"
                 "~CAP_SETPCAP"
                 "~CAP_SYSLOG"
+                "~CAP_SYS_ADMIN"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -900,6 +900,9 @@ in
                 + "-f /etc/ssh/sshd_config";
               KillMode = "process";
               LockPersonality = true;
+              RestrictAddressFamilies = [
+                "~AF_NETLINK"
+              ];
               RestrictNamespaces = [
                 "~cgroup"
                 "~ipc"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -884,6 +884,7 @@ in
                 "~CAP_SYS_MODULE"
                 "~CAP_SYS_NICE"
                 "~CAP_SYS_PACCT"
+                "~CAP_SYS_PTRACE"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -877,6 +877,7 @@ in
                 "~CAP_NET_BROADCAST"
                 "~CAP_NET_RAW"
                 "~CAP_SETFCAP"
+                "~CAP_SETPCAP"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -868,6 +868,7 @@ in
                 "~@debug"
                 "~@module"
                 "~@obsolete"
+                "~@raw-io"
               ];
             }
             // (

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -883,6 +883,7 @@ in
                 "~CAP_SYS_BOOT"
                 "~CAP_SYS_MODULE"
                 "~CAP_SYS_NICE"
+                "~CAP_SYS_PACCT"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -860,6 +860,7 @@ in
                 "~CAP_DAC_READ_SEARCH"
                 "~CAP_FOWNER"
                 "~CAP_FSETID"
+                "~CAP_IPC_OWNER"
                 "~CAP_SETFCAP"
               ];
               ExecStart =

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -902,6 +902,7 @@ in
               LockPersonality = true;
               RestrictAddressFamilies = [
                 "~AF_NETLINK"
+                "~AF_PACKET"
               ];
               RestrictNamespaces = [
                 "~cgroup"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -888,6 +888,7 @@ in
                 "~CAP_SYS_RAWIO"
                 "~CAP_SYS_RESOURCE"
                 "~CAP_SYS_TIME"
+                "~CAP_SYS_TTY_CONFIG"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -872,6 +872,7 @@ in
                 "~CAP_LINUX_IMMUTABLE"
                 "~CAP_MAC_ADMIN"
                 "~CAP_MAC_OVERRIDE"
+                "~CAP_MKNOD"
                 "~CAP_SETFCAP"
               ];
               ExecStart =

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -870,6 +870,7 @@ in
                 "~CAP_KILL"
                 "~CAP_LEASE"
                 "~CAP_LINUX_IMMUTABLE"
+                "~CAP_MAC_ADMIN"
                 "~CAP_SETFCAP"
               ];
               ExecStart =

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -886,6 +886,7 @@ in
                 "~CAP_SYS_PACCT"
                 "~CAP_SYS_PTRACE"
                 "~CAP_SYS_RAWIO"
+                "~CAP_SYS_RESOURCE"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -881,6 +881,7 @@ in
                 "~CAP_SYSLOG"
                 "~CAP_SYS_ADMIN"
                 "~CAP_SYS_BOOT"
+                "~CAP_SYS_MODULE"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -858,6 +858,7 @@ in
                 "~CAP_CHOWN"
                 "~CAP_DAC_OVERRIDE"
                 "~CAP_DAC_READ_SEARCH"
+                "~CAP_FOWNER"
                 "~CAP_FSETID"
                 "~CAP_SETFCAP"
               ];

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -856,6 +856,7 @@ in
             {
               CapabilityBoundingSet = [
                 "~CAP_AUDIT_CONTROL"
+                "~CAP_AUDIT_READ"
                 "~CAP_CHOWN"
                 "~CAP_DAC_OVERRIDE"
                 "~CAP_DAC_READ_SEARCH"

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -889,6 +889,7 @@ in
                 "~CAP_SYS_RESOURCE"
                 "~CAP_SYS_TIME"
                 "~CAP_SYS_TTY_CONFIG"
+                "~CAP_WAKE_ALARM"
               ];
               ExecStart =
                 (lib.optionalString cfg.startWhenNeeded "-")

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -865,6 +865,7 @@ in
               SystemCallFilter = [
                 "~@clock"
                 "~@cpu-emulation"
+                "~@debug"
               ];
             }
             // (

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -873,6 +873,7 @@ in
                 "~CAP_MAC_ADMIN"
                 "~CAP_MAC_OVERRIDE"
                 "~CAP_MKNOD"
+                "~CAP_NET_BROADCAST"
                 "~CAP_SETFCAP"
               ];
               ExecStart =

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -866,6 +866,7 @@ in
                 "~@clock"
                 "~@cpu-emulation"
                 "~@debug"
+                "~@module"
               ];
             }
             // (

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -874,6 +874,7 @@ in
                 "~CAP_MAC_OVERRIDE"
                 "~CAP_MKNOD"
                 "~CAP_NET_BROADCAST"
+                "~CAP_NET_RAW"
                 "~CAP_SETFCAP"
               ];
               ExecStart =

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -1,24 +1,38 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
 
   # The splicing information needed for nativeBuildInputs isn't available
   # on the derivations likely to be used as `cfg.package`.
   # This middle-ground solution ensures *an* sshd can do their basic validation
   # on the configuration.
-  validationPackage = if pkgs.stdenv.buildPlatform == pkgs.stdenv.hostPlatform
-    then cfg.package
-    else pkgs.buildPackages.openssh;
+  validationPackage =
+    if pkgs.stdenv.buildPlatform == pkgs.stdenv.hostPlatform then
+      cfg.package
+    else
+      pkgs.buildPackages.openssh;
 
   # dont use the "=" operator
   settingsFormat =
     let
       # reports boolean as yes / no
-      mkValueString = with lib; v:
-            if lib.isInt           v then toString v
-            else if lib.isString   v then v
-            else if true  ==   v then "yes"
-            else if false ==   v then "no"
-            else throw "unsupported type ${builtins.typeOf v}: ${(lib.generators.toPretty {}) v}";
+      mkValueString =
+        with lib;
+        v:
+        if lib.isInt v then
+          toString v
+        else if lib.isString v then
+          v
+        else if true == v then
+          "yes"
+        else if false == v then
+          "no"
+        else
+          throw "unsupported type ${builtins.typeOf v}: ${(lib.generators.toPretty { }) v}";
 
       base = pkgs.formats.keyValue {
         mkKeyValue = lib.generators.mkKeyValueDefault { inherit mkValueString; } " ";
@@ -29,33 +43,51 @@ let
       # Consult either sshd_config(5) or, as last resort, the OpehSSH source for parsing
       # the options at servconf.c:process_server_config_line_depth() to determine the right "mode"
       # for each. But fortunaly this fact is documented for most of them in the manpage.
-      commaSeparated = [ "Ciphers" "KexAlgorithms" "Macs" ];
-      spaceSeparated = [ "AuthorizedKeysFile" "AllowGroups" "AllowUsers" "DenyGroups" "DenyUsers" ];
-    in {
+      commaSeparated = [
+        "Ciphers"
+        "KexAlgorithms"
+        "Macs"
+      ];
+      spaceSeparated = [
+        "AuthorizedKeysFile"
+        "AllowGroups"
+        "AllowUsers"
+        "DenyGroups"
+        "DenyUsers"
+      ];
+    in
+    {
       inherit (base) type;
-      generate = name: value:
-        let transformedValue = lib.mapAttrs (key: val:
-          if lib.isList val then
-            if lib.elem key commaSeparated then lib.concatStringsSep "," val
-            else if lib.elem key spaceSeparated then lib.concatStringsSep " " val
-            else throw "list value for unknown key ${key}: ${(lib.generators.toPretty {}) val}"
-          else
-            val
+      generate =
+        name: value:
+        let
+          transformedValue = lib.mapAttrs (
+            key: val:
+            if lib.isList val then
+              if lib.elem key commaSeparated then
+                lib.concatStringsSep "," val
+              else if lib.elem key spaceSeparated then
+                lib.concatStringsSep " " val
+              else
+                throw "list value for unknown key ${key}: ${(lib.generators.toPretty { }) val}"
+            else
+              val
           ) value;
         in
-          base.generate name transformedValue;
+        base.generate name transformedValue;
     };
 
-  configFile = settingsFormat.generate "sshd.conf-settings" (lib.filterAttrs (n: v: v != null) cfg.settings);
+  configFile = settingsFormat.generate "sshd.conf-settings" (
+    lib.filterAttrs (n: v: v != null) cfg.settings
+  );
   sshconf = pkgs.runCommand "sshd.conf-final" { } ''
     cat ${configFile} - >$out <<EOL
     ${cfg.extraConfig}
     EOL
   '';
 
-  cfg  = config.services.openssh;
+  cfg = config.services.openssh;
   cfgc = config.programs.ssh;
-
 
   nssModulesPath = config.system.nssModules.path;
 
@@ -64,7 +96,7 @@ let
     options.openssh.authorizedKeys = {
       keys = lib.mkOption {
         type = lib.types.listOf lib.types.singleLineStr;
-        default = [];
+        default = [ ];
         description = ''
           A list of verbatim OpenSSH public keys that should be added to the
           user's authorized keys. The keys are added to a file that the SSH
@@ -82,7 +114,7 @@ let
 
       keyFiles = lib.mkOption {
         type = lib.types.listOf lib.types.path;
-        default = [];
+        default = [ ];
         description = ''
           A list of files each containing one OpenSSH public key that should be
           added to the user's authorized keys. The contents of the files are
@@ -95,7 +127,7 @@ let
 
     options.openssh.authorizedPrincipals = lib.mkOption {
       type = with lib.types; listOf lib.types.singleLineStr;
-      default = [];
+      default = [ ];
       description = ''
         A list of verbatim principal names that should be added to the user's
         authorized principals.
@@ -108,47 +140,211 @@ let
 
   };
 
-  authKeysFiles = let
-    mkAuthKeyFile = u: lib.nameValuePair "ssh/authorized_keys.d/${u.name}" {
-      mode = "0444";
-      source = pkgs.writeText "${u.name}-authorized_keys" ''
-        ${lib.concatStringsSep "\n" u.openssh.authorizedKeys.keys}
-        ${lib.concatMapStrings (f: lib.readFile f + "\n") u.openssh.authorizedKeys.keyFiles}
-      '';
-    };
-    usersWithKeys = lib.attrValues (lib.flip lib.filterAttrs config.users.users (n: u:
-      lib.length u.openssh.authorizedKeys.keys != 0 || lib.length u.openssh.authorizedKeys.keyFiles != 0
-    ));
-  in lib.listToAttrs (map mkAuthKeyFile usersWithKeys);
+  authKeysFiles =
+    let
+      mkAuthKeyFile =
+        u:
+        lib.nameValuePair "ssh/authorized_keys.d/${u.name}" {
+          mode = "0444";
+          source = pkgs.writeText "${u.name}-authorized_keys" ''
+            ${lib.concatStringsSep "\n" u.openssh.authorizedKeys.keys}
+            ${lib.concatMapStrings (f: lib.readFile f + "\n") u.openssh.authorizedKeys.keyFiles}
+          '';
+        };
+      usersWithKeys = lib.attrValues (
+        lib.flip lib.filterAttrs config.users.users (
+          n: u:
+          lib.length u.openssh.authorizedKeys.keys != 0 || lib.length u.openssh.authorizedKeys.keyFiles != 0
+        )
+      );
+    in
+    lib.listToAttrs (map mkAuthKeyFile usersWithKeys);
 
-  authPrincipalsFiles = let
-    mkAuthPrincipalsFile = u: lib.nameValuePair "ssh/authorized_principals.d/${u.name}" {
-      mode = "0444";
-      text = lib.concatStringsSep "\n" u.openssh.authorizedPrincipals;
-    };
-    usersWithPrincipals = lib.attrValues (lib.flip lib.filterAttrs config.users.users (n: u:
-      lib.length u.openssh.authorizedPrincipals != 0
-    ));
-  in lib.listToAttrs (map mkAuthPrincipalsFile usersWithPrincipals);
+  authPrincipalsFiles =
+    let
+      mkAuthPrincipalsFile =
+        u:
+        lib.nameValuePair "ssh/authorized_principals.d/${u.name}" {
+          mode = "0444";
+          text = lib.concatStringsSep "\n" u.openssh.authorizedPrincipals;
+        };
+      usersWithPrincipals = lib.attrValues (
+        lib.flip lib.filterAttrs config.users.users (n: u: lib.length u.openssh.authorizedPrincipals != 0)
+      );
+    in
+    lib.listToAttrs (map mkAuthPrincipalsFile usersWithPrincipals);
 
 in
 
 {
   imports = [
-    (lib.mkAliasOptionModuleMD [ "services" "sshd" "enable" ] [ "services" "openssh" "enable" ])
-    (lib.mkAliasOptionModuleMD [ "services" "openssh" "knownHosts" ] [ "programs" "ssh" "knownHosts" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "challengeResponseAuthentication" ] [ "services" "openssh" "kbdInteractiveAuthentication" ])
+    (lib.mkAliasOptionModuleMD
+      [
+        "services"
+        "sshd"
+        "enable"
+      ]
+      [
+        "services"
+        "openssh"
+        "enable"
+      ]
+    )
+    (lib.mkAliasOptionModuleMD
+      [
+        "services"
+        "openssh"
+        "knownHosts"
+      ]
+      [
+        "programs"
+        "ssh"
+        "knownHosts"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "challengeResponseAuthentication"
+      ]
+      [
+        "services"
+        "openssh"
+        "kbdInteractiveAuthentication"
+      ]
+    )
 
-    (lib.mkRenamedOptionModule [ "services" "openssh" "kbdInteractiveAuthentication" ] [  "services" "openssh" "settings" "KbdInteractiveAuthentication" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "passwordAuthentication" ] [  "services" "openssh" "settings" "PasswordAuthentication" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "useDns" ] [  "services" "openssh" "settings" "UseDns" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "permitRootLogin" ] [  "services" "openssh" "settings" "PermitRootLogin" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "logLevel" ] [  "services" "openssh" "settings" "LogLevel" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "macs" ] [  "services" "openssh" "settings" "Macs" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "ciphers" ] [  "services" "openssh" "settings" "Ciphers" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "kexAlgorithms" ] [  "services" "openssh" "settings" "KexAlgorithms" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "gatewayPorts" ] [  "services" "openssh" "settings" "GatewayPorts" ])
-    (lib.mkRenamedOptionModule [ "services" "openssh" "forwardX11" ] [  "services" "openssh" "settings" "X11Forwarding" ])
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "kbdInteractiveAuthentication"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "KbdInteractiveAuthentication"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "passwordAuthentication"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "PasswordAuthentication"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "useDns"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "UseDns"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "permitRootLogin"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "PermitRootLogin"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "logLevel"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "LogLevel"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "macs"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "Macs"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "ciphers"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "Ciphers"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "kexAlgorithms"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "KexAlgorithms"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "gatewayPorts"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "GatewayPorts"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "openssh"
+        "forwardX11"
+      ]
+      [
+        "services"
+        "openssh"
+        "settings"
+        "X11Forwarding"
+      ]
+    )
   ];
 
   ###### interface
@@ -204,8 +400,11 @@ in
 
       sftpFlags = lib.mkOption {
         type = with lib.types; listOf str;
-        default = [];
-        example = [ "-f AUTHPRIV" "-l INFO" ];
+        default = [ ];
+        example = [
+          "-f AUTHPRIV"
+          "-l INFO"
+        ];
         description = ''
           Commandline flags to add to sftp-server.
         '';
@@ -213,7 +412,7 @@ in
 
       ports = lib.mkOption {
         type = lib.types.listOf lib.types.port;
-        default = [22];
+        default = [ 22 ];
         description = ''
           Specifies on which ports the SSH daemon listens.
         '';
@@ -228,26 +427,37 @@ in
       };
 
       listenAddresses = lib.mkOption {
-        type = with lib.types; listOf (submodule {
-          options = {
-            addr = lib.mkOption {
-              type = lib.types.nullOr lib.types.str;
-              default = null;
-              description = ''
-                Host, IPv4 or IPv6 address to listen to.
-              '';
+        type =
+          with lib.types;
+          listOf (submodule {
+            options = {
+              addr = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = ''
+                  Host, IPv4 or IPv6 address to listen to.
+                '';
+              };
+              port = lib.mkOption {
+                type = lib.types.nullOr lib.types.int;
+                default = null;
+                description = ''
+                  Port to listen to.
+                '';
+              };
             };
-            port = lib.mkOption {
-              type = lib.types.nullOr lib.types.int;
-              default = null;
-              description = ''
-                Port to listen to.
-              '';
-            };
-          };
-        });
-        default = [];
-        example = [ { addr = "192.168.3.1"; port = 22; } { addr = "0.0.0.0"; port = 64022; } ];
+          });
+        default = [ ];
+        example = [
+          {
+            addr = "192.168.3.1";
+            port = 22;
+          }
+          {
+            addr = "0.0.0.0";
+            port = 64022;
+          }
+        ];
         description = ''
           List of addresses and ports to listen on (ListenAddress directive
           in config). If port is not specified for address sshd will listen
@@ -260,14 +470,32 @@ in
 
       hostKeys = lib.mkOption {
         type = lib.types.listOf lib.types.attrs;
-        default =
-          [ { type = "rsa"; bits = 4096; path = "/etc/ssh/ssh_host_rsa_key"; }
-            { type = "ed25519"; path = "/etc/ssh/ssh_host_ed25519_key"; }
-          ];
-        example =
-          [ { type = "rsa"; bits = 4096; path = "/etc/ssh/ssh_host_rsa_key"; rounds = 100; openSSHFormat = true; }
-            { type = "ed25519"; path = "/etc/ssh/ssh_host_ed25519_key"; rounds = 100; comment = "key comment"; }
-          ];
+        default = [
+          {
+            type = "rsa";
+            bits = 4096;
+            path = "/etc/ssh/ssh_host_rsa_key";
+          }
+          {
+            type = "ed25519";
+            path = "/etc/ssh/ssh_host_ed25519_key";
+          }
+        ];
+        example = [
+          {
+            type = "rsa";
+            bits = 4096;
+            path = "/etc/ssh/ssh_host_rsa_key";
+            rounds = 100;
+            openSSHFormat = true;
+          }
+          {
+            type = "ed25519";
+            path = "/etc/ssh/ssh_host_ed25519_key";
+            rounds = 100;
+            comment = "key comment";
+          }
+        ];
         description = ''
           NixOS can automatically generate SSH host keys.  This option
           specifies the path, type and size of each key.  See
@@ -286,7 +514,7 @@ in
 
       authorizedKeysFiles = lib.mkOption {
         type = lib.types.listOf lib.types.str;
-        default = [];
+        default = [ ];
         description = ''
           Specify the rules for which files to read on the host.
 
@@ -331,8 +559,6 @@ in
         '';
       };
 
-
-
       settings = lib.mkOption {
         description = "Configuration for `sshd_config(5)`.";
         default = { };
@@ -342,177 +568,201 @@ in
             PasswordAuthentication = false;
           }
         '';
-        type = lib.types.submodule ({name, ...}: {
-          freeformType = settingsFormat.type;
-          options = {
-            AuthorizedPrincipalsFile = lib.mkOption {
-              type = lib.types.nullOr lib.types.str;
-              default = "none"; # upstream default
-              description = ''
-                Specifies a file that lists principal names that are accepted for certificate authentication. The default
-                is `"none"`, i.e. not to use	a principals file.
-              '';
-            };
-            LogLevel = lib.mkOption {
-              type = lib.types.nullOr (lib.types.enum [ "QUIET" "FATAL" "ERROR" "INFO" "VERBOSE" "DEBUG" "DEBUG1" "DEBUG2" "DEBUG3" ]);
-              default = "INFO"; # upstream default
-              description = ''
-                Gives the verbosity level that is used when logging messages from sshd(8). Logging with a DEBUG level
-                violates the privacy of users and is not recommended.
-              '';
-            };
-            UsePAM =
-              lib.mkEnableOption "PAM authentication"
-              // { default = true; type = lib.types.nullOr lib.types.bool; };
-            UseDns = lib.mkOption {
-              type = lib.types.nullOr lib.types.bool;
-              # apply if cfg.useDns then "yes" else "no"
-              default = false;
-              description = ''
-                Specifies whether sshd(8) should look up the remote host name, and to check that the resolved host name for
-                the remote IP address maps back to the very same IP address.
-                If this option is set to no (the default) then only addresses and not host names may be used in
-                ~/.ssh/authorized_keys from and sshd_config Match Host directives.
-              '';
-            };
-            X11Forwarding = lib.mkOption {
-              type = lib.types.nullOr lib.types.bool;
-              default = false;
-              description = ''
-                Whether to allow X11 connections to be forwarded.
-              '';
-            };
-            PasswordAuthentication = lib.mkOption {
-              type = lib.types.nullOr lib.types.bool;
-              default = true;
-              description = ''
-                Specifies whether password authentication is allowed.
-              '';
-            };
-            PermitRootLogin = lib.mkOption {
-              default = "prohibit-password";
-              type = lib.types.nullOr (lib.types.enum ["yes" "without-password" "prohibit-password" "forced-commands-only" "no"]);
-              description = ''
-                Whether the root user can login using ssh.
-              '';
-            };
-            KbdInteractiveAuthentication = lib.mkOption {
-              type = lib.types.nullOr lib.types.bool;
-              default = true;
-              description = ''
-                Specifies whether keyboard-interactive authentication is allowed.
-              '';
-            };
-            GatewayPorts = lib.mkOption {
-              type = lib.types.nullOr lib.types.str;
-              default = "no";
-              description = ''
-                Specifies whether remote hosts are allowed to connect to
-                ports forwarded for the client.  See
-                {manpage}`sshd_config(5)`.
-              '';
-            };
-            KexAlgorithms = lib.mkOption {
-              type = lib.types.nullOr (lib.types.listOf lib.types.str);
-              default = [
-                "sntrup761x25519-sha512@openssh.com"
-                "curve25519-sha256"
-                "curve25519-sha256@libssh.org"
-                "diffie-hellman-group-exchange-sha256"
-              ];
-              description = ''
-                Allowed key exchange algorithms
+        type = lib.types.submodule (
+          { name, ... }:
+          {
+            freeformType = settingsFormat.type;
+            options = {
+              AuthorizedPrincipalsFile = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = "none"; # upstream default
+                description = ''
+                  Specifies a file that lists principal names that are accepted for certificate authentication. The default
+                  is `"none"`, i.e. not to use	a principals file.
+                '';
+              };
+              LogLevel = lib.mkOption {
+                type = lib.types.nullOr (
+                  lib.types.enum [
+                    "QUIET"
+                    "FATAL"
+                    "ERROR"
+                    "INFO"
+                    "VERBOSE"
+                    "DEBUG"
+                    "DEBUG1"
+                    "DEBUG2"
+                    "DEBUG3"
+                  ]
+                );
+                default = "INFO"; # upstream default
+                description = ''
+                  Gives the verbosity level that is used when logging messages from sshd(8). Logging with a DEBUG level
+                  violates the privacy of users and is not recommended.
+                '';
+              };
+              UsePAM = lib.mkEnableOption "PAM authentication" // {
+                default = true;
+                type = lib.types.nullOr lib.types.bool;
+              };
+              UseDns = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                # apply if cfg.useDns then "yes" else "no"
+                default = false;
+                description = ''
+                  Specifies whether sshd(8) should look up the remote host name, and to check that the resolved host name for
+                  the remote IP address maps back to the very same IP address.
+                  If this option is set to no (the default) then only addresses and not host names may be used in
+                  ~/.ssh/authorized_keys from and sshd_config Match Host directives.
+                '';
+              };
+              X11Forwarding = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = false;
+                description = ''
+                  Whether to allow X11 connections to be forwarded.
+                '';
+              };
+              PasswordAuthentication = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = true;
+                description = ''
+                  Specifies whether password authentication is allowed.
+                '';
+              };
+              PermitRootLogin = lib.mkOption {
+                default = "prohibit-password";
+                type = lib.types.nullOr (
+                  lib.types.enum [
+                    "yes"
+                    "without-password"
+                    "prohibit-password"
+                    "forced-commands-only"
+                    "no"
+                  ]
+                );
+                description = ''
+                  Whether the root user can login using ssh.
+                '';
+              };
+              KbdInteractiveAuthentication = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = true;
+                description = ''
+                  Specifies whether keyboard-interactive authentication is allowed.
+                '';
+              };
+              GatewayPorts = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = "no";
+                description = ''
+                  Specifies whether remote hosts are allowed to connect to
+                  ports forwarded for the client.  See
+                  {manpage}`sshd_config(5)`.
+                '';
+              };
+              KexAlgorithms = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = [
+                  "sntrup761x25519-sha512@openssh.com"
+                  "curve25519-sha256"
+                  "curve25519-sha256@libssh.org"
+                  "diffie-hellman-group-exchange-sha256"
+                ];
+                description = ''
+                  Allowed key exchange algorithms
 
-                Uses the lower bound recommended in both
-                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                and
-                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-              '';
-            };
-            Macs = lib.mkOption {
-              type = lib.types.nullOr (lib.types.listOf lib.types.str);
-              default = [
-                "hmac-sha2-512-etm@openssh.com"
-                "hmac-sha2-256-etm@openssh.com"
-                "umac-128-etm@openssh.com"
-              ];
-              description = ''
-                Allowed MACs
+                  Uses the lower bound recommended in both
+                  <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+                  and
+                  <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+                '';
+              };
+              Macs = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = [
+                  "hmac-sha2-512-etm@openssh.com"
+                  "hmac-sha2-256-etm@openssh.com"
+                  "umac-128-etm@openssh.com"
+                ];
+                description = ''
+                  Allowed MACs
 
-                Defaults to recommended settings from both
-                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                and
-                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-              '';
-            };
-            StrictModes = lib.mkOption {
-              type = lib.types.nullOr (lib.types.bool);
-              default = true;
-              description = ''
-                Whether sshd should check file modes and ownership of directories
-              '';
-            };
-            Ciphers = lib.mkOption {
-              type = lib.types.nullOr (lib.types.listOf lib.types.str);
-              default = [
-                "chacha20-poly1305@openssh.com"
-                "aes256-gcm@openssh.com"
-                "aes128-gcm@openssh.com"
-                "aes256-ctr"
-                "aes192-ctr"
-                "aes128-ctr"
-              ];
-              description = ''
-                Allowed ciphers
+                  Defaults to recommended settings from both
+                  <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+                  and
+                  <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+                '';
+              };
+              StrictModes = lib.mkOption {
+                type = lib.types.nullOr (lib.types.bool);
+                default = true;
+                description = ''
+                  Whether sshd should check file modes and ownership of directories
+                '';
+              };
+              Ciphers = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = [
+                  "chacha20-poly1305@openssh.com"
+                  "aes256-gcm@openssh.com"
+                  "aes128-gcm@openssh.com"
+                  "aes256-ctr"
+                  "aes192-ctr"
+                  "aes128-ctr"
+                ];
+                description = ''
+                  Allowed ciphers
 
-                Defaults to recommended settings from both
-                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                and
-                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-              '';
+                  Defaults to recommended settings from both
+                  <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+                  and
+                  <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+                '';
+              };
+              AllowUsers = lib.mkOption {
+                type = with lib.types; nullOr (listOf str);
+                default = null;
+                description = ''
+                  If specified, login is allowed only for the listed users.
+                  See {manpage}`sshd_config(5)` for details.
+                '';
+              };
+              DenyUsers = lib.mkOption {
+                type = with lib.types; nullOr (listOf str);
+                default = null;
+                description = ''
+                  If specified, login is denied for all listed users. Takes
+                  precedence over [](#opt-services.openssh.settings.AllowUsers).
+                  See {manpage}`sshd_config(5)` for details.
+                '';
+              };
+              AllowGroups = lib.mkOption {
+                type = with lib.types; nullOr (listOf str);
+                default = null;
+                description = ''
+                  If specified, login is allowed only for users part of the
+                  listed groups.
+                  See {manpage}`sshd_config(5)` for details.
+                '';
+              };
+              DenyGroups = lib.mkOption {
+                type = with lib.types; nullOr (listOf str);
+                default = null;
+                description = ''
+                  If specified, login is denied for all users part of the listed
+                  groups. Takes precedence over
+                  [](#opt-services.openssh.settings.AllowGroups). See
+                  {manpage}`sshd_config(5)` for details.
+                '';
+              };
+              # Disabled by default, since pam_motd handles this.
+              PrintMotd = lib.mkEnableOption "printing /etc/motd when a user logs in interactively" // {
+                type = lib.types.nullOr lib.types.bool;
+              };
             };
-            AllowUsers = lib.mkOption {
-              type = with lib.types; nullOr (listOf str);
-              default = null;
-              description = ''
-                If specified, login is allowed only for the listed users.
-                See {manpage}`sshd_config(5)` for details.
-              '';
-            };
-            DenyUsers = lib.mkOption {
-              type = with lib.types; nullOr (listOf str);
-              default = null;
-              description = ''
-                If specified, login is denied for all listed users. Takes
-                precedence over [](#opt-services.openssh.settings.AllowUsers).
-                See {manpage}`sshd_config(5)` for details.
-              '';
-            };
-            AllowGroups = lib.mkOption {
-              type = with lib.types; nullOr (listOf str);
-              default = null;
-              description = ''
-                If specified, login is allowed only for users part of the
-                listed groups.
-                See {manpage}`sshd_config(5)` for details.
-              '';
-            };
-            DenyGroups = lib.mkOption {
-              type = with lib.types; nullOr (listOf str);
-              default = null;
-              description = ''
-                If specified, login is denied for all users part of the listed
-                groups. Takes precedence over
-                [](#opt-services.openssh.settings.AllowGroups). See
-                {manpage}`sshd_config(5)` for details.
-              '';
-            };
-            # Disabled by default, since pam_motd handles this.
-            PrintMotd =
-              lib.mkEnableOption "printing /etc/motd when a user logs in interactively"
-              // { type = lib.types.nullOr lib.types.bool; };
-          };
-        });
+          }
+        );
       };
 
       extraConfig = lib.mkOption {
@@ -539,204 +789,245 @@ in
 
   };
 
-
   ###### implementation
 
   config = lib.mkIf cfg.enable {
 
-    users.users.sshd =
-      {
-        isSystemUser = true;
-        group = "sshd";
-        description = "SSH privilege separation user";
-      };
-    users.groups.sshd = {};
+    users.users.sshd = {
+      isSystemUser = true;
+      group = "sshd";
+      description = "SSH privilege separation user";
+    };
+    users.groups.sshd = { };
 
     services.openssh.moduliFile = lib.mkDefault "${cfg.package}/etc/ssh/moduli";
     services.openssh.sftpServerExecutable = lib.mkDefault "${cfg.package}/libexec/sftp-server";
 
-    environment.etc = authKeysFiles // authPrincipalsFiles //
-      { "ssh/moduli".source = cfg.moduliFile;
+    environment.etc =
+      authKeysFiles
+      // authPrincipalsFiles
+      // {
+        "ssh/moduli".source = cfg.moduliFile;
         "ssh/sshd_config".source = sshconf;
       };
 
     systemd =
       let
-        service =
-          { description = "SSH Daemon";
-            wantedBy = lib.optional (!cfg.startWhenNeeded) "multi-user.target";
-            after = [ "network.target" ];
-            stopIfChanged = false;
-            path = [ cfg.package pkgs.gawk ];
-            environment.LD_LIBRARY_PATH = nssModulesPath;
+        service = {
+          description = "SSH Daemon";
+          wantedBy = lib.optional (!cfg.startWhenNeeded) "multi-user.target";
+          after = [ "network.target" ];
+          stopIfChanged = false;
+          path = [
+            cfg.package
+            pkgs.gawk
+          ];
+          environment.LD_LIBRARY_PATH = nssModulesPath;
 
-            restartTriggers = lib.optionals (!cfg.startWhenNeeded) [
-              config.environment.etc."ssh/sshd_config".source
-            ];
+          restartTriggers = lib.optionals (!cfg.startWhenNeeded) [
+            config.environment.etc."ssh/sshd_config".source
+          ];
 
-            preStart =
-              ''
-                # Make sure we don't write to stdout, since in case of
-                # socket activation, it goes to the remote side (#19589).
-                exec >&2
+          preStart = ''
+            # Make sure we don't write to stdout, since in case of
+            # socket activation, it goes to the remote side (#19589).
+            exec >&2
 
-                ${lib.flip lib.concatMapStrings cfg.hostKeys (k: ''
-                  if ! [ -s "${k.path}" ]; then
-                      if ! [ -h "${k.path}" ]; then
-                          rm -f "${k.path}"
-                      fi
-                      mkdir -p "$(dirname '${k.path}')"
-                      chmod 0755 "$(dirname '${k.path}')"
-                      ssh-keygen \
-                        -t "${k.type}" \
-                        ${lib.optionalString (k ? bits) "-b ${toString k.bits}"} \
-                        ${lib.optionalString (k ? rounds) "-a ${toString k.rounds}"} \
-                        ${lib.optionalString (k ? comment) "-C '${k.comment}'"} \
-                        ${lib.optionalString (k ? openSSHFormat && k.openSSHFormat) "-o"} \
-                        -f "${k.path}" \
-                        -N ""
+            ${lib.flip lib.concatMapStrings cfg.hostKeys (k: ''
+              if ! [ -s "${k.path}" ]; then
+                  if ! [ -h "${k.path}" ]; then
+                      rm -f "${k.path}"
                   fi
-                '')}
-              '';
+                  mkdir -p "$(dirname '${k.path}')"
+                  chmod 0755 "$(dirname '${k.path}')"
+                  ssh-keygen \
+                    -t "${k.type}" \
+                    ${lib.optionalString (k ? bits) "-b ${toString k.bits}"} \
+                    ${lib.optionalString (k ? rounds) "-a ${toString k.rounds}"} \
+                    ${lib.optionalString (k ? comment) "-C '${k.comment}'"} \
+                    ${lib.optionalString (k ? openSSHFormat && k.openSSHFormat) "-o"} \
+                    -f "${k.path}" \
+                    -N ""
+              fi
+            '')}
+          '';
 
-            serviceConfig =
-              { ExecStart =
-                  (lib.optionalString cfg.startWhenNeeded "-") +
-                  "${cfg.package}/bin/sshd " + (lib.optionalString cfg.startWhenNeeded "-i ") +
-                  "-D " +  # don't detach into a daemon process
-                  "-f /etc/ssh/sshd_config";
-                KillMode = "process";
-              } // (if cfg.startWhenNeeded then {
-                StandardInput = "socket";
-                StandardError = "journal";
-              } else {
-                Restart = "always";
-                Type = "simple";
-              });
+          serviceConfig =
+            {
+              ExecStart =
+                (lib.optionalString cfg.startWhenNeeded "-")
+                + "${cfg.package}/bin/sshd "
+                + (lib.optionalString cfg.startWhenNeeded "-i ")
+                + "-D "
+                # don't detach into a daemon process
+                + "-f /etc/ssh/sshd_config";
+              KillMode = "process";
+            }
+            // (
+              if cfg.startWhenNeeded then
+                {
+                  StandardInput = "socket";
+                  StandardError = "journal";
+                }
+              else
+                {
+                  Restart = "always";
+                  Type = "simple";
+                }
+            );
 
-          };
+        };
       in
 
-      if cfg.startWhenNeeded then {
+      if cfg.startWhenNeeded then
+        {
 
-        sockets.sshd =
-          { description = "SSH Socket";
+          sockets.sshd = {
+            description = "SSH Socket";
             wantedBy = [ "sockets.target" ];
-            socketConfig.ListenStream = if cfg.listenAddresses != [] then
-              lib.concatMap
-                ({ addr, port }:
-                  if port != null then [ "${addr}:${toString port}" ]
-                  else map (p: "${addr}:${toString p}") cfg.ports)
-                cfg.listenAddresses
-            else
-              cfg.ports;
+            socketConfig.ListenStream =
+              if cfg.listenAddresses != [ ] then
+                lib.concatMap (
+                  { addr, port }:
+                  if port != null then [ "${addr}:${toString port}" ] else map (p: "${addr}:${toString p}") cfg.ports
+                ) cfg.listenAddresses
+              else
+                cfg.ports;
             socketConfig.Accept = true;
             # Prevent brute-force attacks from shutting down socket
             socketConfig.TriggerLimitIntervalSec = 0;
           };
 
-        services."sshd@" = service;
+          services."sshd@" = service;
 
-      } else {
+        }
+      else
+        {
 
-        services.sshd = service;
+          services.sshd = service;
 
-      };
+        };
 
     networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall cfg.ports;
 
-    security.pam.services.sshd = lib.mkIf cfg.settings.UsePAM
-      { startSession = true;
-        showMotd = true;
-        unixAuth =
-          if cfg.settings.PasswordAuthentication == true
-          then true
-          else false;
-      };
+    security.pam.services.sshd = lib.mkIf cfg.settings.UsePAM {
+      startSession = true;
+      showMotd = true;
+      unixAuth = if cfg.settings.PasswordAuthentication == true then true else false;
+    };
 
     # These values are merged with the ones defined externally, see:
     # https://github.com/NixOS/nixpkgs/pull/10155
     # https://github.com/NixOS/nixpkgs/pull/41745
     services.openssh.authorizedKeysFiles =
-      lib.optional cfg.authorizedKeysInHomedir "%h/.ssh/authorized_keys" ++ [ "/etc/ssh/authorized_keys.d/%u" ];
+      lib.optional cfg.authorizedKeysInHomedir "%h/.ssh/authorized_keys"
+      ++ [ "/etc/ssh/authorized_keys.d/%u" ];
 
-    services.openssh.settings.AuthorizedPrincipalsFile = lib.mkIf (authPrincipalsFiles != {}) "/etc/ssh/authorized_principals.d/%u";
+    services.openssh.settings.AuthorizedPrincipalsFile = lib.mkIf (
+      authPrincipalsFiles != { }
+    ) "/etc/ssh/authorized_principals.d/%u";
 
-    services.openssh.extraConfig = lib.mkOrder 0
-      ''
-        Banner ${if cfg.banner == null then "none" else pkgs.writeText "ssh_banner" cfg.banner}
+    services.openssh.extraConfig = lib.mkOrder 0 ''
+      Banner ${if cfg.banner == null then "none" else pkgs.writeText "ssh_banner" cfg.banner}
 
-        AddressFamily ${if config.networking.enableIPv6 then "any" else "inet"}
-        ${lib.concatMapStrings (port: ''
-          Port ${toString port}
-        '') cfg.ports}
+      AddressFamily ${if config.networking.enableIPv6 then "any" else "inet"}
+      ${lib.concatMapStrings (port: ''
+        Port ${toString port}
+      '') cfg.ports}
 
-        ${lib.concatMapStrings ({ port, addr, ... }: ''
+      ${lib.concatMapStrings (
+        { port, addr, ... }:
+        ''
           ListenAddress ${addr}${lib.optionalString (port != null) (":" + toString port)}
-        '') cfg.listenAddresses}
+        ''
+      ) cfg.listenAddresses}
 
-        ${lib.optionalString cfgc.setXAuthLocation ''
-            XAuthLocation ${pkgs.xorg.xauth}/bin/xauth
-        ''}
-        ${lib.optionalString cfg.allowSFTP ''
-          Subsystem sftp ${cfg.sftpServerExecutable} ${lib.concatStringsSep " " cfg.sftpFlags}
-        ''}
-        AuthorizedKeysFile ${toString cfg.authorizedKeysFiles}
-        ${lib.optionalString (cfg.authorizedKeysCommand != "none") ''
-          AuthorizedKeysCommand ${cfg.authorizedKeysCommand}
-          AuthorizedKeysCommandUser ${cfg.authorizedKeysCommandUser}
-        ''}
+      ${lib.optionalString cfgc.setXAuthLocation ''
+        XAuthLocation ${pkgs.xorg.xauth}/bin/xauth
+      ''}
+      ${lib.optionalString cfg.allowSFTP ''
+        Subsystem sftp ${cfg.sftpServerExecutable} ${lib.concatStringsSep " " cfg.sftpFlags}
+      ''}
+      AuthorizedKeysFile ${toString cfg.authorizedKeysFiles}
+      ${lib.optionalString (cfg.authorizedKeysCommand != "none") ''
+        AuthorizedKeysCommand ${cfg.authorizedKeysCommand}
+        AuthorizedKeysCommandUser ${cfg.authorizedKeysCommandUser}
+      ''}
 
-        ${lib.flip lib.concatMapStrings cfg.hostKeys (k: ''
-          HostKey ${k.path}
-        '')}
-      '';
+      ${lib.flip lib.concatMapStrings cfg.hostKeys (k: ''
+        HostKey ${k.path}
+      '')}
+    '';
 
     system.checks = [
       (pkgs.runCommand "check-sshd-config"
         {
           nativeBuildInputs = [ validationPackage ];
-        } ''
-        ${lib.concatMapStringsSep "\n"
-          (lport: "sshd -G -T -C lport=${toString lport} -f ${sshconf} > /dev/null")
-          cfg.ports}
-        ${lib.concatMapStringsSep "\n"
-          (la:
-            lib.concatMapStringsSep "\n"
-              (port: "sshd -G -T -C ${lib.escapeShellArg "laddr=${la.addr},lport=${toString port}"} -f ${sshconf} > /dev/null")
-              (if la.port != null then [ la.port ] else cfg.ports)
-          )
-          cfg.listenAddresses}
-        touch $out
-      '')
+        }
+        ''
+          ${lib.concatMapStringsSep "\n" (
+            lport: "sshd -G -T -C lport=${toString lport} -f ${sshconf} > /dev/null"
+          ) cfg.ports}
+          ${lib.concatMapStringsSep "\n" (
+            la:
+            lib.concatMapStringsSep "\n" (
+              port:
+              "sshd -G -T -C ${lib.escapeShellArg "laddr=${la.addr},lport=${toString port}"} -f ${sshconf} > /dev/null"
+            ) (if la.port != null then [ la.port ] else cfg.ports)
+          ) cfg.listenAddresses}
+          touch $out
+        ''
+      )
     ];
 
-    assertions = [{ assertion = if cfg.settings.X11Forwarding then cfgc.setXAuthLocation else true;
-                    message = "cannot enable X11 forwarding without setting xauth location";}
-                  { assertion = (builtins.match "(.*\n)?(\t )*[Kk][Ee][Rr][Bb][Ee][Rr][Oo][Ss][Aa][Uu][Tt][Hh][Ee][Nn][Tt][Ii][Cc][Aa][Tt][Ii][Oo][Nn][ |\t|=|\"]+yes.*" "${configFile}\n${cfg.extraConfig}") != null -> cfgc.package.withKerberos;
-                    message = "cannot enable Kerberos authentication without using a package with Kerberos support";}
-                  { assertion = (builtins.match "(.*\n)?(\t )*[Gg][Ss][Ss][Aa][Pp][Ii][Aa][Uu][Tt][Hh][Ee][Nn][Tt][Ii][Cc][Aa][Tt][Ii][Oo][Nn][ |\t|=|\"]+yes.*" "${configFile}\n${cfg.extraConfig}") != null -> cfgc.package.withKerberos;
-                    message = "cannot enable GSSAPI authentication without using a package with Kerberos support";}
-                  (let
-                    duplicates =
-                      # Filter out the groups with more than 1 element
-                      lib.filter (l: lib.length l > 1) (
-                        # Grab the groups, we don't care about the group identifiers
-                        lib.attrValues (
-                          # Group the settings that are the same in lower case
-                          lib.groupBy lib.strings.toLower (lib.attrNames cfg.settings)
-                        )
-                      );
-                    formattedDuplicates = lib.concatMapStringsSep ", " (dupl: "(${lib.concatStringsSep ", " dupl})") duplicates;
-                  in
-                  {
-                    assertion = lib.length duplicates == 0;
-                    message = ''Duplicate sshd config key; does your capitalization match the option's? Duplicate keys: ${formattedDuplicates}'';
-                  })]
-      ++ lib.forEach cfg.listenAddresses ({ addr, ... }: {
-        assertion = addr != null;
-        message = "addr must be specified in each listenAddresses entry";
-      });
+    assertions =
+      [
+        {
+          assertion = if cfg.settings.X11Forwarding then cfgc.setXAuthLocation else true;
+          message = "cannot enable X11 forwarding without setting xauth location";
+        }
+        {
+          assertion =
+            (builtins.match "(.*\n)?(\t )*[Kk][Ee][Rr][Bb][Ee][Rr][Oo][Ss][Aa][Uu][Tt][Hh][Ee][Nn][Tt][Ii][Cc][Aa][Tt][Ii][Oo][Nn][ |\t|=|\"]+yes.*" "${configFile}\n${cfg.extraConfig}")
+            != null
+            -> cfgc.package.withKerberos;
+          message = "cannot enable Kerberos authentication without using a package with Kerberos support";
+        }
+        {
+          assertion =
+            (builtins.match "(.*\n)?(\t )*[Gg][Ss][Ss][Aa][Pp][Ii][Aa][Uu][Tt][Hh][Ee][Nn][Tt][Ii][Cc][Aa][Tt][Ii][Oo][Nn][ |\t|=|\"]+yes.*" "${configFile}\n${cfg.extraConfig}")
+            != null
+            -> cfgc.package.withKerberos;
+          message = "cannot enable GSSAPI authentication without using a package with Kerberos support";
+        }
+        (
+          let
+            duplicates =
+              # Filter out the groups with more than 1 element
+              lib.filter (l: lib.length l > 1) (
+                # Grab the groups, we don't care about the group identifiers
+                lib.attrValues (
+                  # Group the settings that are the same in lower case
+                  lib.groupBy lib.strings.toLower (lib.attrNames cfg.settings)
+                )
+              );
+            formattedDuplicates = lib.concatMapStringsSep ", " (
+              dupl: "(${lib.concatStringsSep ", " dupl})"
+            ) duplicates;
+          in
+          {
+            assertion = lib.length duplicates == 0;
+            message = ''Duplicate sshd config key; does your capitalization match the option's? Duplicate keys: ${formattedDuplicates}'';
+          }
+        )
+      ]
+      ++ lib.forEach cfg.listenAddresses (
+        { addr, ... }:
+        {
+          assertion = addr != null;
+          message = "addr must be specified in each listenAddresses entry";
+        }
+      );
   };
 
 }

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -1,281 +1,359 @@
-import ./make-test-python.nix ({ pkgs, ... }:
+import ./make-test-python.nix (
+  { pkgs, ... }:
 
-let inherit (import ./ssh-keys.nix pkgs)
-      snakeOilPrivateKey snakeOilPublicKey snakeOilEd25519PrivateKey snakeOilEd25519PublicKey;
-in {
-  name = "openssh";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ aszlig ];
-  };
-
-  nodes = {
-
-    server =
-      { ... }:
-
-      {
-        services.openssh.enable = true;
-        security.pam.services.sshd.limits =
-          [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
-        users.users.root.openssh.authorizedKeys.keys = [
-          snakeOilPublicKey
-        ];
-      };
-
-    server-allowed-users =
-      { ... }:
-
-      {
-        services.openssh = { enable = true; settings.AllowUsers = [ "alice" "bob" ]; };
-        users.groups = { alice = { }; bob = { }; carol = { }; };
-        users.users = {
-          alice = { isNormalUser = true; group = "alice"; openssh.authorizedKeys.keys = [ snakeOilPublicKey ]; };
-          bob = { isNormalUser = true; group = "bob"; openssh.authorizedKeys.keys = [ snakeOilPublicKey ]; };
-          carol = { isNormalUser = true; group = "carol"; openssh.authorizedKeys.keys = [ snakeOilPublicKey ]; };
-        };
-      };
-
-    server-lazy =
-      { ... }:
-
-      {
-        services.openssh = { enable = true; startWhenNeeded = true; };
-        security.pam.services.sshd.limits =
-          [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
-        users.users.root.openssh.authorizedKeys.keys = [
-          snakeOilPublicKey
-        ];
-      };
-
-    server-lazy-socket = {
-      virtualisation.vlans = [ 1 2 ];
-      services.openssh = {
-        enable = true;
-        startWhenNeeded = true;
-        ports = [ 2222 ];
-        listenAddresses = [ { addr = "0.0.0.0"; } ];
-      };
-      users.users.root.openssh.authorizedKeys.keys = [
-        snakeOilPublicKey
-      ];
+  let
+    inherit (import ./ssh-keys.nix pkgs)
+      snakeOilPrivateKey
+      snakeOilPublicKey
+      snakeOilEd25519PrivateKey
+      snakeOilEd25519PublicKey
+      ;
+  in
+  {
+    name = "openssh";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ aszlig ];
     };
 
-    server-localhost-only =
-      { ... }:
+    nodes = {
 
-      {
-        services.openssh = {
-          enable = true; listenAddresses = [ { addr = "127.0.0.1"; port = 22; } ];
-        };
-      };
+      server =
+        { ... }:
 
-    server-localhost-only-lazy =
-      { ... }:
-
-      {
-        services.openssh = {
-          enable = true; startWhenNeeded = true; listenAddresses = [ { addr = "127.0.0.1"; port = 22; } ];
-        };
-      };
-
-    server-match-rule =
-      { ... }:
-
-      {
-        services.openssh = {
-          enable = true; listenAddresses = [ { addr = "127.0.0.1"; port = 22; } { addr = "[::]"; port = 22; } ];
-          extraConfig = ''
-            # Combined test for two (predictable) Match criterias
-            Match LocalAddress 127.0.0.1 LocalPort 22
-              PermitRootLogin yes
-
-            # Separate tests for Match criterias
-            Match User root
-              PermitRootLogin yes
-            Match Group root
-              PermitRootLogin yes
-            Match Host nohost.example
-              PermitRootLogin yes
-            Match LocalAddress 127.0.0.1
-              PermitRootLogin yes
-            Match LocalPort 22
-              PermitRootLogin yes
-            Match RDomain nohost.example
-              PermitRootLogin yes
-            Match Address 127.0.0.1
-              PermitRootLogin yes
-          '';
-        };
-      };
-
-    server-no-openssl =
-      { ... }:
-      {
-        services.openssh = {
-          enable = true;
-          package = pkgs.opensshPackages.openssh.override {
-            linkOpenssl = false;
-          };
-          hostKeys = [
-            { type = "ed25519"; path = "/etc/ssh/ssh_host_ed25519_key"; }
+        {
+          services.openssh.enable = true;
+          security.pam.services.sshd.limits = [
+            {
+              domain = "*";
+              item = "memlock";
+              type = "-";
+              value = 1024;
+            }
           ];
-          settings = {
-            # Since this test is against an OpenSSH-without-OpenSSL,
-            # we have to override NixOS's defaults ciphers (which require OpenSSL)
-            # and instead set these to null, which will mean OpenSSH uses its defaults.
-            # Expectedly, OpenSSH's defaults don't require OpenSSL when it's compiled
-            # without OpenSSL.
-            Ciphers = null;
-            KexAlgorithms = null;
-            Macs = null;
+          users.users.root.openssh.authorizedKeys.keys = [
+            snakeOilPublicKey
+          ];
+        };
+
+      server-allowed-users =
+        { ... }:
+
+        {
+          services.openssh = {
+            enable = true;
+            settings.AllowUsers = [
+              "alice"
+              "bob"
+            ];
+          };
+          users.groups = {
+            alice = { };
+            bob = { };
+            carol = { };
+          };
+          users.users = {
+            alice = {
+              isNormalUser = true;
+              group = "alice";
+              openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+            };
+            bob = {
+              isNormalUser = true;
+              group = "bob";
+              openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+            };
+            carol = {
+              isNormalUser = true;
+              group = "carol";
+              openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+            };
           };
         };
-        users.users.root.openssh.authorizedKeys.keys = [
-          snakeOilEd25519PublicKey
-        ];
-      };
 
-    server-no-pam =
-      { pkgs, ... }:
-      {
+      server-lazy =
+        { ... }:
+
+        {
+          services.openssh = {
+            enable = true;
+            startWhenNeeded = true;
+          };
+          security.pam.services.sshd.limits = [
+            {
+              domain = "*";
+              item = "memlock";
+              type = "-";
+              value = 1024;
+            }
+          ];
+          users.users.root.openssh.authorizedKeys.keys = [
+            snakeOilPublicKey
+          ];
+        };
+
+      server-lazy-socket = {
+        virtualisation.vlans = [
+          1
+          2
+        ];
         services.openssh = {
           enable = true;
-          package = pkgs.opensshPackages.openssh.override {
-            withPAM = false;
-          };
-          settings = {
-            UsePAM = false;
-          };
+          startWhenNeeded = true;
+          ports = [ 2222 ];
+          listenAddresses = [ { addr = "0.0.0.0"; } ];
         };
         users.users.root.openssh.authorizedKeys.keys = [
           snakeOilPublicKey
         ];
       };
 
-    client =
-      { ... }: {
-        virtualisation.vlans = [ 1 2 ];
-      };
+      server-localhost-only =
+        { ... }:
 
-  };
+        {
+          services.openssh = {
+            enable = true;
+            listenAddresses = [
+              {
+                addr = "127.0.0.1";
+                port = 22;
+              }
+            ];
+          };
+        };
 
-  testScript = ''
-    start_all()
+      server-localhost-only-lazy =
+        { ... }:
 
-    server.wait_for_unit("sshd", timeout=30)
-    server_allowed_users.wait_for_unit("sshd", timeout=30)
-    server_localhost_only.wait_for_unit("sshd", timeout=30)
-    server_match_rule.wait_for_unit("sshd", timeout=30)
-    server_no_openssl.wait_for_unit("sshd", timeout=30)
-    server_no_pam.wait_for_unit("sshd", timeout=30)
+        {
+          services.openssh = {
+            enable = true;
+            startWhenNeeded = true;
+            listenAddresses = [
+              {
+                addr = "127.0.0.1";
+                port = 22;
+              }
+            ];
+          };
+        };
 
-    server_lazy.wait_for_unit("sshd.socket", timeout=30)
-    server_localhost_only_lazy.wait_for_unit("sshd.socket", timeout=30)
-    server_lazy_socket.wait_for_unit("sshd.socket", timeout=30)
+      server-match-rule =
+        { ... }:
 
-    with subtest("manual-authkey"):
-        client.succeed("mkdir -m 700 /root/.ssh")
-        client.succeed(
-            '${pkgs.openssh}/bin/ssh-keygen -t ed25519 -f /root/.ssh/id_ed25519 -N ""'
-        )
-        public_key = client.succeed(
-            "${pkgs.openssh}/bin/ssh-keygen -y -f /root/.ssh/id_ed25519"
-        )
-        public_key = public_key.strip()
-        client.succeed("chmod 600 /root/.ssh/id_ed25519")
+        {
+          services.openssh = {
+            enable = true;
+            listenAddresses = [
+              {
+                addr = "127.0.0.1";
+                port = 22;
+              }
+              {
+                addr = "[::]";
+                port = 22;
+              }
+            ];
+            extraConfig = ''
+              # Combined test for two (predictable) Match criterias
+              Match LocalAddress 127.0.0.1 LocalPort 22
+                PermitRootLogin yes
 
-        server.succeed("mkdir -m 700 /root/.ssh")
-        server.succeed("echo '{}' > /root/.ssh/authorized_keys".format(public_key))
-        server_lazy.succeed("mkdir -m 700 /root/.ssh")
-        server_lazy.succeed("echo '{}' > /root/.ssh/authorized_keys".format(public_key))
+              # Separate tests for Match criterias
+              Match User root
+                PermitRootLogin yes
+              Match Group root
+                PermitRootLogin yes
+              Match Host nohost.example
+                PermitRootLogin yes
+              Match LocalAddress 127.0.0.1
+                PermitRootLogin yes
+              Match LocalPort 22
+                PermitRootLogin yes
+              Match RDomain nohost.example
+                PermitRootLogin yes
+              Match Address 127.0.0.1
+                PermitRootLogin yes
+            '';
+          };
+        };
 
-        client.wait_for_unit("network.target")
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server 'echo hello world' >&2",
-            timeout=30
-        )
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server 'ulimit -l' | grep 1024",
-            timeout=30
-        )
+      server-no-openssl =
+        { ... }:
+        {
+          services.openssh = {
+            enable = true;
+            package = pkgs.opensshPackages.openssh.override {
+              linkOpenssl = false;
+            };
+            hostKeys = [
+              {
+                type = "ed25519";
+                path = "/etc/ssh/ssh_host_ed25519_key";
+              }
+            ];
+            settings = {
+              # Since this test is against an OpenSSH-without-OpenSSL,
+              # we have to override NixOS's defaults ciphers (which require OpenSSL)
+              # and instead set these to null, which will mean OpenSSH uses its defaults.
+              # Expectedly, OpenSSH's defaults don't require OpenSSL when it's compiled
+              # without OpenSSL.
+              Ciphers = null;
+              KexAlgorithms = null;
+              Macs = null;
+            };
+          };
+          users.users.root.openssh.authorizedKeys.keys = [
+            snakeOilEd25519PublicKey
+          ];
+        };
 
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server-lazy 'echo hello world' >&2",
-            timeout=30
-        )
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server-lazy 'ulimit -l' | grep 1024",
-            timeout=30
-        )
+      server-no-pam =
+        { pkgs, ... }:
+        {
+          services.openssh = {
+            enable = true;
+            package = pkgs.opensshPackages.openssh.override {
+              withPAM = false;
+            };
+            settings = {
+              UsePAM = false;
+            };
+          };
+          users.users.root.openssh.authorizedKeys.keys = [
+            snakeOilPublicKey
+          ];
+        };
 
-    with subtest("socket activation on a non-standard port"):
-        client.succeed(
-            "cat ${snakeOilPrivateKey} > privkey.snakeoil"
-        )
-        client.succeed("chmod 600 privkey.snakeoil")
-        # The final segment in this IP is allocated according to the alphabetical order of machines in this test.
-        client.succeed(
-            "ssh -p 2222 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil root@192.168.2.5 true",
-            timeout=30
-        )
+      client =
+        { ... }:
+        {
+          virtualisation.vlans = [
+            1
+            2
+          ];
+        };
 
-    with subtest("configured-authkey"):
-        client.succeed(
-            "cat ${snakeOilPrivateKey} > privkey.snakeoil"
-        )
-        client.succeed("chmod 600 privkey.snakeoil")
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server true",
-            timeout=30
-        )
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-lazy true",
-            timeout=30
-        )
+    };
 
-    with subtest("localhost-only"):
-        server_localhost_only.succeed("ss -nlt | grep '127.0.0.1:22'")
-        server_localhost_only_lazy.succeed("ss -nlt | grep '127.0.0.1:22'")
+    testScript = ''
+      start_all()
 
-    with subtest("match-rules"):
-        server_match_rule.succeed("ss -nlt | grep '127.0.0.1:22'")
+      server.wait_for_unit("sshd", timeout=30)
+      server_allowed_users.wait_for_unit("sshd", timeout=30)
+      server_localhost_only.wait_for_unit("sshd", timeout=30)
+      server_match_rule.wait_for_unit("sshd", timeout=30)
+      server_no_openssl.wait_for_unit("sshd", timeout=30)
+      server_no_pam.wait_for_unit("sshd", timeout=30)
 
-    with subtest("allowed-users"):
-        client.succeed(
-            "cat ${snakeOilPrivateKey} > privkey.snakeoil"
-        )
-        client.succeed("chmod 600 privkey.snakeoil")
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil alice@server-allowed-users true",
-            timeout=30
-        )
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil bob@server-allowed-users true",
-            timeout=30
-        )
-        client.fail(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil carol@server-allowed-users true",
-            timeout=30
-        )
+      server_lazy.wait_for_unit("sshd.socket", timeout=30)
+      server_localhost_only_lazy.wait_for_unit("sshd.socket", timeout=30)
+      server_lazy_socket.wait_for_unit("sshd.socket", timeout=30)
 
-    with subtest("no-openssl"):
-        client.succeed(
-            "cat ${snakeOilEd25519PrivateKey} > privkey.snakeoil"
-        )
-        client.succeed("chmod 600 privkey.snakeoil")
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-no-openssl true",
-            timeout=30
-        )
+      with subtest("manual-authkey"):
+          client.succeed("mkdir -m 700 /root/.ssh")
+          client.succeed(
+              '${pkgs.openssh}/bin/ssh-keygen -t ed25519 -f /root/.ssh/id_ed25519 -N ""'
+          )
+          public_key = client.succeed(
+              "${pkgs.openssh}/bin/ssh-keygen -y -f /root/.ssh/id_ed25519"
+          )
+          public_key = public_key.strip()
+          client.succeed("chmod 600 /root/.ssh/id_ed25519")
 
-    with subtest("no-pam"):
-        client.succeed(
-            "cat ${snakeOilPrivateKey} > privkey.snakeoil"
-        )
-        client.succeed("chmod 600 privkey.snakeoil")
-        client.succeed(
-            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-no-pam true",
-            timeout=30
-        )
-  '';
-})
+          server.succeed("mkdir -m 700 /root/.ssh")
+          server.succeed("echo '{}' > /root/.ssh/authorized_keys".format(public_key))
+          server_lazy.succeed("mkdir -m 700 /root/.ssh")
+          server_lazy.succeed("echo '{}' > /root/.ssh/authorized_keys".format(public_key))
+
+          client.wait_for_unit("network.target")
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server 'echo hello world' >&2",
+              timeout=30
+          )
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server 'ulimit -l' | grep 1024",
+              timeout=30
+          )
+
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server-lazy 'echo hello world' >&2",
+              timeout=30
+          )
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server-lazy 'ulimit -l' | grep 1024",
+              timeout=30
+          )
+
+      with subtest("socket activation on a non-standard port"):
+          client.succeed(
+              "cat ${snakeOilPrivateKey} > privkey.snakeoil"
+          )
+          client.succeed("chmod 600 privkey.snakeoil")
+          # The final segment in this IP is allocated according to the alphabetical order of machines in this test.
+          client.succeed(
+              "ssh -p 2222 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil root@192.168.2.5 true",
+              timeout=30
+          )
+
+      with subtest("configured-authkey"):
+          client.succeed(
+              "cat ${snakeOilPrivateKey} > privkey.snakeoil"
+          )
+          client.succeed("chmod 600 privkey.snakeoil")
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server true",
+              timeout=30
+          )
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-lazy true",
+              timeout=30
+          )
+
+      with subtest("localhost-only"):
+          server_localhost_only.succeed("ss -nlt | grep '127.0.0.1:22'")
+          server_localhost_only_lazy.succeed("ss -nlt | grep '127.0.0.1:22'")
+
+      with subtest("match-rules"):
+          server_match_rule.succeed("ss -nlt | grep '127.0.0.1:22'")
+
+      with subtest("allowed-users"):
+          client.succeed(
+              "cat ${snakeOilPrivateKey} > privkey.snakeoil"
+          )
+          client.succeed("chmod 600 privkey.snakeoil")
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil alice@server-allowed-users true",
+              timeout=30
+          )
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil bob@server-allowed-users true",
+              timeout=30
+          )
+          client.fail(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil carol@server-allowed-users true",
+              timeout=30
+          )
+
+      with subtest("no-openssl"):
+          client.succeed(
+              "cat ${snakeOilEd25519PrivateKey} > privkey.snakeoil"
+          )
+          client.succeed("chmod 600 privkey.snakeoil")
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-no-openssl true",
+              timeout=30
+          )
+
+      with subtest("no-pam"):
+          client.succeed(
+              "cat ${snakeOilPrivateKey} > privkey.snakeoil"
+          )
+          client.succeed("chmod 600 privkey.snakeoil")
+          client.succeed(
+              "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-no-pam true",
+              timeout=30
+          )
+    '';
+  }
+)


### PR DESCRIPTION
`systemd-analyze security sshd` with default settings currently summarises as follows:

> Overall exposure level for sshd.service: 9.6 UNSAFE 😨"

This PR moves that up to "5.3 MEDIUM :-|".

---

To do:

- `RootDirectory=/RootImage=` Service runs within the host's root directory 0.1
- `SupplementaryGroups=` Service runs as root, option does not matter
- `RemoveIPC=` Service runs as root, option does not apply
- `User=/DynamicUser=` Service runs as root user 
- `NoNewPrivileges=` Service processes may acquire new privileges 
- `PrivateDevices=` Service potentially has access to hardware devices 
- `ProtectClock=` Service may write to the hardware clock or system clock 
- `ProtectKernelLogs=` Service may read from or write to the kernel log ring buffer 
- `ProtectControlGroups=` Service may modify the control group file system 
- `ProtectKernelModules=` Service may load or read kernel modules 
- `PrivateMounts=` Service may install system mounts 
- `MemoryDenyWriteExecute=` Service may create writable executable memory mappings 
- `RestrictSUIDSGID=` Service may create SUID/SGID files 
- `ProtectHostname=` Service may change system host/domainname 
- `ProtectKernelTunables=` Service may alter kernel tunables 
- `RestrictAddressFamilies=`~AF_UNIX Service may allocate local sockets 
- `RestrictAddressFamilies=`~… Service may allocate exotic sockets 
- `RestrictAddressFamilies=`~AF_(INET|INET6) Service may allocate Internet sockets 
- `RestrictRealtime=` Service may acquire realtime scheduling 
- `DeviceAllow=` Service has no device ACL 
- `ProtectSystem=` Service has full access to the OS file hierarchy 
- `ProtectProc=` Service has full access to process tree (/proc hidepid=) 
- `ProcSubset=` Service has full access to non-process /proc files (/proc subset=) 
- `ProtectHome=` Service has full access to home directories 
- `CapabilityBoundingSet=~CAP_NET_(BIND_SERVICE|BROADCAST|RAW)` Service has elevated networking privileges 
- `PrivateNetwork=` Service has access to the host's network 
- `PrivateUsers=` Service has access to other users 
- `PrivateTmp=` Service has access to other software's temporary files 
- `IPAddressDeny=` Service does not define an IP address allow list 
- `UMask=` Files created by service are world-readable by default 

---

Recommended settings which are *not* part of this PR because they broke `nix-build -A nixosTests.openssh`:

- `CapabilityBoundingSet=~CAP_SETGID` caused sshd-session to fail with "fatal: setgroups: Operation not permitted [preauth]"
- `CapabilityBoundingSet=~CAP_SETUID` caused sshd-session to fail with "fatal: setresuid 997: Operation not permitted [preauth]"
- `CapabilityBoundingSet=~CAP_SYS_CHROOT` caused sshd-session to fail with 'fatal: chroot("/var/empty"): Operation not permitted [preauth]'
- `SystemCallFilter=~@mount` caused sshd-session to dump core:

   ```
   Module libaudit.so.1 without build-id.
   Module libz.so.1 without build-id.
   Module libldns.so.3 without build-id.
   Module libpam.so.0 without build-id.
   Module sshd-session without build-id.
   Stack trace of thread 1138:
   #0  0x00007f5bfbe8a65b chroot (libc.so.6 + 0x10465b)
   #1  0x0000562a749df5b5 main (sshd-session + 0xe5b5)
   #2  0x00007f5bfbdb027e __libc_start_call_main (libc.so.6 + 0x2a27e)
   #3  0x00007f5bfbdb0339 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2a339)
   #4  0x0000562a749dff55 _start (sshd-session + 0xef55)
   ELF object binary architecture: AMD x86-64
   ```
- `SystemCallFilter=~@privileged` caused sshd to dump core:

   ```
   Module libaudit.so.1 without build-id.
   Module libz.so.1 without build-id.
   Module libldns.so.3 without build-id.
   Module libpam.so.0 without build-id.
   Module sshd without build-id.
   Stack trace of thread 1209:
   #0  0x00007f5ee13bbbc8 setgroups (libc.so.6 + 0xf6bc8)
   #1  0x0000561ac714b8dd main (sshd + 0xa8dd)
   #2  0x00007f5ee12ef27e __libc_start_call_main (libc.so.6 + 0x2a27e)
   #3  0x00007f5ee12ef339 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2a339)
   #4  0x0000561ac714eb55 _start (sshd + 0xdb55)
   ELF object binary architecture: AMD x86-64
   ```
- `SystemCallFilter=~@resources` caused sshd-session to dump core:

   ```
   Module pam_warn.so without build-id.
   Module pam_limits.so without build-id.
   Module libcap.so.2 without build-id.
   Module libpam_misc.so.0 without build-id.
   Module pam_loginuid.so without build-id.
   Module pam_env.so without build-id.
   Module pam_deny.so without build-id.
   Module libcrypt.so.2 without build-id.
   Module pam_unix.so without build-id.
   Module libaudit.so.1 without build-id.
   Module libz.so.1 without build-id.
   Module libldns.so.3 without build-id.
   Module libpam.so.0 without build-id.
   Module sshd-session without build-id.
   Stack trace of thread 1148:
   #0  0x00007f4d5fed448b setpriority (libc.so.6 + 0x10448b)
   #1  0x00007f4d5fa8efc4 pam_sm_open_session (pam_limits.so + 0x3fc4)
   #2  0x00007f4d605dce5b _pam_dispatch (libpam.so.0 + 0x3e5b)
   #3  0x0000559f87974f5c do_pam_session (sshd-session + 0x3bf5c)
   #4  0x0000559f87947ee4 main (sshd-session + 0xeee4)
   #5  0x00007f4d5fdfa27e __libc_start_call_main (libc.so.6 + 0x2a27e)
   #6  0x00007f4d5fdfa339 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2a339)
   #7  0x0000559f87947f55 _start (sshd-session + 0xef55)
   ELF object binary architecture: AMD x86-64
   ```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
