### PR TITLE
nixos/tests/networking: test nameservers via DHCP

### DIFF
--- a/nixos/tests/networking/networkd-and-scripted.nix
+++ b/nixos/tests/networking/networkd-and-scripted.nix
@@ -132,6 +132,14 @@ let
               client.wait_until_succeeds("ip addr show dev enp2s0 | grep -q '192.168.2'")
               client.wait_until_succeeds("ip addr show dev enp2s0 | grep -q 'fd00:1234:5678:2:'")
 
+          with subtest("Wait until we have received the nameservers"):
+            if "${builtins.toJSON networkd}" == "true":
+              client.wait_until_succeeds("resolvectl status enp2s0 | grep -q 2001:db8::1")
+              client.wait_until_succeeds("resolvectl status enp2s0 | grep -q 192.168.2.1")
+            else:
+              client.wait_until_succeeds("resolvconf -l | grep -q 2001:db8::1")
+              client.wait_until_succeeds("resolvconf -l | grep -q 192.168.2.1")
+
           with subtest("Test vlan 1"):
               client.wait_until_succeeds("ping -c 1 192.168.1.1")
               client.wait_until_succeeds("ping -c 1 fd00:1234:5678:1::1")

--- a/nixos/tests/networking/router.nix
+++ b/nixos/tests/networking/router.nix
@@ -72,6 +72,7 @@
           AdvSendAdvert on;
           AdvManagedFlag on;
           AdvOtherConfigFlag on;
+          RDNSS 2001:db8::1 {};
 
           prefix fd00:1234:5678:${toString n}::/64 {
             AdvAutonomous off;


### PR DESCRIPTION
Re-add bad5251e874bec27438cb8a613ec87e845ed437e, this time it should work for both backends.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- Tested with
  - [x] `nixosTests.networking.networkd.dhcpSimple`
  - [x] `nixosTests.networking.scripted.dhcpSimple`
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
