### PR TITLE
copilot-node-server: init at 1.41.0

### DIFF
--- a/pkgs/by-name/co/copilot-node-server/package-lock.json
+++ b/pkgs/by-name/co/copilot-node-server/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "copilot-node-server",
+  "version": "1.41.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "copilot-node-server",
+      "version": "1.41.0",
+      "license": "GitHub Terms of Service",
+      "bin": {
+        "copilot-node-server": "copilot/dist/language-server.js"
+      }
+    }
+  }
+}

--- a/pkgs/by-name/co/copilot-node-server/package.nix
+++ b/pkgs/by-name/co/copilot-node-server/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "copilot-node-server";
+  version = "1.41.0";
+
+  src = fetchFromGitHub {
+    owner = "jfcherng";
+    repo = "copilot-node-server";
+    rev = "v${version}";
+    hash = "sha256-yOqA2Xo4c7u0g6RQYt9joQk8mI9KE0xTAnLjln9atmg=";
+  };
+
+  npmDepsHash = "sha256-tbcNRQBbJjN1N5ENxCvPQbfteyxTbPpi35dYmeUc4A4=";
+
+  postPatch = ''
+    # Upstream doesn't provide any lock file so we provide our own:
+    cp ${./package-lock.json} package-lock.json
+  '';
+
+  preInstall = ''
+    # `npmInstallHook` requires a `node_modules/` folder but `npm
+    # install` doesn't generate one because the project has no
+    # dependencies:
+    mkdir node_modules/
+  '';
+
+  forceEmptyCache = true;
+  dontNpmBuild = true;
+
+  meta = with lib; {
+    description = "Copilot Node.js server";
+    homepage = src.meta.homepage;
+    license = licenses.unfree; # I don't know: https://github.com/jfcherng/copilot-node-server/blob/main/LICENSE.md
+    maintainers = with maintainers; [ DamienCassou ];
+    mainProgram = "copilot-node-server";
+  };
+}


### PR DESCRIPTION
-------

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc