### PR TITLE
easyroam-connect-desktop: init at 1.3.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12980,6 +12980,12 @@
     githubId = 34819524;
     name = "Marcel";
   };
+  MarchCraft = {
+    email = "felix@dienilles.de";
+    github = "MarchCraft";
+    githubId = 30194994;
+    name = "Felix Nilles";
+  };
   marcovergueira = {
     email = "vergueira.marco@gmail.com";
     github = "marcovergueira";
@@ -19432,6 +19438,12 @@
     github = "ShadowRZ";
     githubId = 23130178;
     name = "夜坂雅";
+  };
+  shadows_withal = {
+    email = "shadows@with.al";
+    github = "shadows-withal";
+    githubId = 6445316;
+    name = "liv";
   };
   shahrukh330 = {
     email = "shahrukh330@gmail.com";

--- a/pkgs/by-name/ea/easyroam-connect-desktop/package.nix
+++ b/pkgs/by-name/ea/easyroam-connect-desktop/package.nix
@@ -1,0 +1,78 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  autoPatchelfHook,
+  glib,
+  gtk3,
+  pango,
+  cairo,
+  harfbuzz,
+  networkmanager,
+  libsecret,
+  libsoup_3,
+  webkitgtk_4_1,
+  glib-networking,
+  wrapGAppsHook3,
+}:
+stdenv.mkDerivation rec {
+  pname = "easyroam-connect-desktop";
+  version = "1.3.5";
+
+  src = fetchurl {
+    url = "http://packages.easyroam.de/repos/easyroam-desktop/pool/main/e/easyroam-desktop/easyroam_connect_desktop-${version}+${version}-linux.deb";
+    hash = "sha256-TRzEPPjsD1+eSuElvbTV4HJFfwfS+EH+r/OhdMP8KG0=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    pango
+    cairo
+    harfbuzz
+    libsecret
+    networkmanager
+    webkitgtk_4_1
+    libsoup_3
+    glib-networking
+  ];
+
+  unpackPhase = ''
+    ar p $src data.tar.xz | tar xJ
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r usr/share $out/share
+
+    mkdir -p $out/bin
+    ln -s $out/share/easyroam_connect_desktop/easyroam_connect_desktop $out/bin/easyroam_connect_desktop
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Manage and install your easyroam WiFi profiles";
+    mainProgram = "easyroam_connect_desktop";
+    longDescription = ''
+      Using this software you can easily connect your device to eduroam® by simply logging in with your DFN-AAI account.
+    '';
+    homepage = "https://easyroam.de";
+    license = licenses.unfree;
+    maintainers = with maintainers; [
+      shadows_withal
+      MarchCraft
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Creates a package for the [easyroam](https://easyroam.de) desktop application, which helps users to connect to German academic WiFi networks. Closes #228158.

This is my first time packaging for NixOS, so any feedback is appreciated!
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (the application is only released for x86_64, and I don't have a Darwin host to test those versions)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
