### PR TITLE
ffmpeg: add new external libs added in 7.1

### DIFF
--- a/pkgs/by-name/lc/lcevcdec/package.nix
+++ b/pkgs/by-name/lc/lcevcdec/package.nix
@@ -1,0 +1,104 @@
+{
+  cmake,
+  copyPkgconfigItems,
+  fetchFromGitHub,
+  fmt,
+  git,
+  gitUpdater,
+  gtest,
+  lib,
+  makePkgconfigItem,
+  pkg-config,
+  python3,
+  range-v3,
+  rapidjson,
+  stdenv,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lcevcdec";
+  version = "3.2.1";
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "v-novaltd";
+    repo = "LCEVCdec";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-Nf0YntB1A3AH0MTXlfUHhxYbzZqeB0EH9Fe9Xrqdsts=";
+  };
+
+  postPatch = ''
+    substituteInPlace cmake/tools/version_files.py \
+      --replace-fail "args.git_version" '"${finalAttrs.version}"' \
+      --replace-fail "args.git_hash" '"${finalAttrs.src.rev}"' \
+      --replace-fail "args.git_date" '"1970-01-01"'
+  '';
+
+  env = {
+    includedir = "${placeholder "dev"}/include";
+    libdir = "${placeholder "out"}/lib";
+  };
+
+  pkgconfigItems = [
+    (makePkgconfigItem rec {
+      name = "lcevc_dec";
+      inherit (finalAttrs) version;
+      libs = [
+        "-L${variables.libdir}"
+        "-llcevc_dec_api"
+      ];
+      libsPrivate = [
+        "-lpthread"
+        "-llcevc_dec_core"
+      ];
+      cflags = [
+        "-I${variables.includedir}"
+      ];
+      variables = {
+        prefix = "@dev@";
+        includedir = "@includedir@";
+        libdir = "@libdir@";
+      };
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    python3
+    git
+    pkg-config
+    copyPkgconfigItems
+  ];
+
+  buildInputs = [
+    rapidjson
+    fmt
+    range-v3
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "VN_SDK_FFMPEG_LIBS_PACKAGE" "")
+    (lib.cmakeBool "VN_SDK_UNIT_TESTS" false)
+    (lib.cmakeBool "VN_SDK_SAMPLE_SOURCE" false)
+  ];
+
+  passthru = {
+    updateScript = gitUpdater { };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    homepage = "https://github.com/v-novaltd/LCEVCdec";
+    description = "MPEG-5 LCEVC Decoder";
+    license = lib.licenses.bsd3Clear;
+    pkgConfigModules = [ "lcevc_dec" ];
+    maintainers = with lib.maintainers; [ jopejoe1 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/vv/vvenc/package.nix
+++ b/pkgs/by-name/vv/vvenc/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  gitUpdater,
+  testers,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vvenc";
+  version = "1.12.0";
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "fraunhoferhhi";
+    repo = "vvenc";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-C7ApayhubunkXBqJ/EqntaFPn6zk8rZ9fUqg7kbhvAk=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "VVENC_INSTALL_FULLFEATURE_APP" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    homepage = "https://github.com/fraunhoferhhi/vvenc";
+    description = "Fraunhofer Versatile Video Encoder";
+    license = lib.licenses.bsd3Clear;
+    mainProgram = "vvencapp";
+    pkgConfigModules = [ "libvvenc" ];
+    maintainers = with lib.maintainers; [ jopejoe1 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -127,6 +127,7 @@
 , withVpl ? false # Hardware acceleration via intel libvpl
 , withVpx ? withHeadlessDeps && stdenv.buildPlatform == stdenv.hostPlatform # VP8 & VP9 de/encoding
 , withVulkan ? withSmallDeps && !stdenv.hostPlatform.isDarwin
+, withVvenc ? withFullDeps && lib.versionAtLeast version "7.1" # H.266/VVC encoding
 , withWebp ? withHeadlessDeps # WebP encoder
 , withX264 ? withHeadlessDeps && withGPL # H.264/AVC encoder
 , withX265 ? withHeadlessDeps && withGPL # H.265/HEVC encoder
@@ -315,6 +316,7 @@
 , vo-amrwbenc
 , vulkan-headers
 , vulkan-loader
+, vvenc
 , x264
 , x265
 , xavs
@@ -665,6 +667,9 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withVorbis "libvorbis")
     (enableFeature withVpx "libvpx")
     (enableFeature withVulkan "vulkan")
+  ] ++ optionals (versionAtLeast version "7.1")  [
+    (enableFeature withVvenc "libvvenc")
+  ] ++ [
     (enableFeature withWebp "libwebp")
     (enableFeature withX264 "libx264")
     (enableFeature withX265 "libx265")
@@ -808,6 +813,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withVpl [ libvpl ]
   ++ optionals withVpx [ libvpx ]
   ++ optionals withVulkan [ vulkan-headers vulkan-loader ]
+  ++ optionals withVvenc [ vvenc ]
   ++ optionals withWebp [ libwebp ]
   ++ optionals withX264 [ x264 ]
   ++ optionals withX265 [ x265 ]

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -76,6 +76,7 @@
 , withJxl ? withFullDeps && lib.versionAtLeast version "5" # JPEG XL de/encoding
 , withLadspa ? withFullDeps # LADSPA audio filtering
 , withLc3 ? withFullDeps && lib.versionAtLeast version "7.1" # LC3 de/encoding
+, withLcevcdec ? withFullDeps && lib.versionAtLeast version "7.1" # LCEVC decoding
 , withLcms2 ? withFullDeps # ICC profile support via lcms2
 , withLzma ? withHeadlessDeps # xz-utils
 , withMetal ? false # Unfree and requires manual downloading of files
@@ -247,6 +248,7 @@
 , intel-media-sdk
 , ladspaH
 , lame
+, lcevcdec
 , lcms2
 , libaom
 , libaribcaption
@@ -607,6 +609,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withLadspa "ladspa")
   ] ++ optionals (versionAtLeast version "7.1") [
     (enableFeature withLc3 "liblc3")
+    (enableFeature withLcevcdec "liblcevc-dec")
   ] ++ optionals (versionAtLeast version "5.1") [
     (enableFeature withLcms2 "lcms2")
   ] ++ [
@@ -771,6 +774,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withJxl [ libjxl ]
   ++ optionals withLadspa [ ladspaH ]
   ++ optionals withLc3 [ liblc3 ]
+  ++ optionals withLcevcdec [ lcevcdec ]
   ++ optionals withLcms2 [ lcms2 ]
   ++ optionals withLzma [ xz ]
   ++ optionals withMfx [ intel-media-sdk ]

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -75,6 +75,7 @@
 , withJack ? withFullDeps && !stdenv.hostPlatform.isDarwin # Jack audio
 , withJxl ? withFullDeps && lib.versionAtLeast version "5" # JPEG XL de/encoding
 , withLadspa ? withFullDeps # LADSPA audio filtering
+, withLc3 ? withFullDeps && lib.versionAtLeast version "7.1" # LC3 de/encoding
 , withLcms2 ? withFullDeps # ICC profile support via lcms2
 , withLzma ? withHeadlessDeps # xz-utils
 , withMetal ? false # Unfree and requires manual downloading of files
@@ -263,6 +264,7 @@
 , libilbc
 , libjack2
 , libjxl
+, liblc3
 , libmodplug
 , libmysofa
 , libopenmpt
@@ -603,6 +605,8 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withJxl "libjxl")
   ] ++ [
     (enableFeature withLadspa "ladspa")
+  ] ++ optionals (versionAtLeast version "7.1") [
+    (enableFeature withLc3 "liblc3")
   ] ++ optionals (versionAtLeast version "5.1") [
     (enableFeature withLcms2 "lcms2")
   ] ++ [
@@ -766,6 +770,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withJack [ libjack2 ]
   ++ optionals withJxl [ libjxl ]
   ++ optionals withLadspa [ ladspaH ]
+  ++ optionals withLc3 [ liblc3 ]
   ++ optionals withLcms2 [ lcms2 ]
   ++ optionals withLzma [ xz ]
   ++ optionals withMfx [ intel-media-sdk ]


### PR DESCRIPTION
Adds the new external libs added in FFmpeg 7.1, I have tested `lc3` and `vvenc`, ~but I could not test `lcevcdec` as I did not find a video file with that encoding or an encoder to encode into it.~ Edit also tested lcevcdec now.

lc3 and vvenc can be tested with the following:

```bash
# Testing vvc
## Encoding
ffmpeg -f lavfi -i testsrc -t 10 -c:v vvc /tmp/test.vvc
## Decoding
ffmpeg -i /tmp/test.vvc -c:v hevc /tmp/decoded-vvc.mkv

# Testing lc3
## Downloading Sample file
curl "http://fate-suite.ffmpeg.org/aac/al_sbr_cm_48_2.mp4" -o /tmp/sample.mp4
## Encoding
ffmpeg -i /tmp/sample.mp4 -ac 2 -c:a lc3 /tmp/test.lc3
## Decoding
ffmpeg -i /tmp/test.lc3 -c:a aac /tmp/decoded-lc3.aac

# Testing lcevc-dec
## Downloading Sample file
curl "https://d3mfda3gpj3dw1.cloudfront.net/vn9s0p86SVbJorX6/lcevc_vn9s0p86SVbJorX6_2.mp4" -o /tmp/lcevc-sample.mp4
## Decoding
ffmpeg -i /tmp/lcevc-sample.mp4 -filter lcevc /tmp/decoded-lcevc.mp4
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
