### PR TITLE
fuse-t: init at 1.0.42

### DIFF
--- a/pkgs/by-name/fu/fuse-t/fuse-t.pc.in
+++ b/pkgs/by-name/fu/fuse-t/fuse-t.pc.in
@@ -1,0 +1,10 @@
+prefix=@out@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include/fuse
+
+Name: fuse-t
+Description: Userspace FUSE implementation for macOS
+Version: @version@
+Libs:  -L${libdir} -Wl,-rpath,${libdir} -lfuse-t
+Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64

--- a/pkgs/by-name/fu/fuse-t/no-universal-binaries.patch
+++ b/pkgs/by-name/fu/fuse-t/no-universal-binaries.patch
@@ -1,0 +1,20 @@
+diff --git a/example/CMakeLists.txt b/example/CMakeLists.txt
+index e1184cb..9989d0b 100644
+--- a/example/CMakeLists.txt
++++ b/example/CMakeLists.txt
+@@ -1,5 +1,3 @@
+-set(CMAKE_OSX_ARCHITECTURES arm64;x86_64)
+-
+ add_executable (hello hello.c)
+ add_executable (hello_ll hello_ll.c)
+ add_executable (cusexmp cusexmp.c)
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index db6f2ac..70592cd 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -1,5 +1,3 @@
+-set(CMAKE_OSX_ARCHITECTURES arm64;x86_64)
+-
+ set(SRC
+     buffer.c
+     fuse_darwin.c

--- a/pkgs/by-name/fu/fuse-t/package.nix
+++ b/pkgs/by-name/fu/fuse-t/package.nix
@@ -1,0 +1,185 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  libarchive,
+  p7zip,
+  libtapi,
+  fetchFromGitHub,
+  cmake,
+  libiconv,
+  DiskArbitration,
+}:
+
+let
+  version = "1.0.42";
+
+  # This can be used instead of fuse-t however downstream programs
+  # will need to be run with the environment variable `FUSE_NFSSRV_PATH`
+  # set to `<fuse-t.binaryDistribution>/bin/go-nfsv4`
+  binaryDistribution = stdenv.mkDerivation {
+    pname = "fuse-t-binary-dist";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://github.com/macos-fuse-t/fuse-t/releases/download/${version}/fuse-t-macos-installer-${version}.pkg";
+      hash = "sha256-pYrQT05hGDcTPYXebTftvd3xGS8ozGTCa47FvWVZQ68=";
+    };
+
+    nativeBuildInputs = [
+      libarchive
+      p7zip
+      libtapi
+    ];
+    propagatedBuildInputs = [ DiskArbitration ];
+
+    unpackPhase = ''
+      7z x $src
+      bsdtar -xf Payload~
+    '';
+
+    buildPhase = ''
+      fuseDir="Library/Application Support/fuse-t"
+      sed -i "s|^prefix=.*|prefix=$out|" "$fuseDir/pkgconfig/fuse-t.pc"
+      sed -i "s|^\(Cflags: .*\)|\1 -D_FILE_OFFSET_BITS=64|" "$fuseDir/pkgconfig/fuse-t.pc"
+      ln -s libfuse-t-${version}.a "$fuseDir/lib/libfuse-t.a"
+      ln -s libfuse-t-${version}.dylib "$fuseDir/lib/libfuse-t.dylib"
+      rm "$fuseDir/uninstall.sh"
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/lib
+      mv "$fuseDir/bin" $out
+      mv "$fuseDir/include" $out
+      mv "$fuseDir/lib" $out
+      mv "$fuseDir/pkgconfig" $out/lib
+      mv Library $out/Library
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "FUSE-T is a kext-less implementation of FUSE for macOS that uses NFS v4 local server instead of a kernel extension.";
+      homepage = "https://www.fuse-t.org/";
+      # free for non-commercial use, see: https://github.com/macos-fuse-t/fuse-t/blob/main/License.txt
+      license = [ lib.licenses.unfreeRedistributable ];
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+      platforms = lib.platforms.darwin;
+    };
+  };
+
+  stubs = stdenv.mkDerivation {
+    pname = "fuse-t-stubs";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "macos-fuse-t";
+      repo = "libfuse";
+      rev = "da72c8b60eb929d86c4594fc1792ae49865cd659";
+      hash = "sha256-++edBetY+Xfvp5X4i+mL+FJgJXeV43toDRRKhLHlMhw=";
+    };
+
+    patches = [
+      ./no-universal-binaries.patch
+      ./use-correct-path.patch
+    ];
+
+    postPatch = ''
+      substituteAllInPlace lib/fuse_darwin_private.h
+    '';
+
+    nativeBuildInputs = [
+      cmake
+      libtapi
+    ];
+
+    # TODO: remove `.out` after https://github.com/NixOS/nixpkgs/pull/346043 is merged to `master`
+    buildInputs = [
+      libiconv.out
+      DiskArbitration
+    ];
+
+    propagatedBuildInputs = [ DiskArbitration ];
+
+    # Removes a lot of warning spam
+    # `warning: 'pthread_setugid_np' is deprecated: Use of per-thread security contexts is error-prone and discouraged.`
+    env.NIX_CFLAGS_COMPILE = "-Wno-deprecated-declarations";
+
+    postBuild = ''
+      mkdir -p lib/pkgconfig
+      tapi stubify --filetype=tbd-v2 lib/libfuse-t.dylib -o lib/libfuse-t.tbd
+      substituteAll ${./fuse-t.pc.in} lib/pkgconfig/fuse-t.pc
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      frameworkDir=$out/Library/Frameworks/fuse_t.framework
+      frameworkADir=$frameworkDir/Versions/A
+      mkdir -p $out/lib/pkgconfig $out/include/fuse $frameworkADir/Headers $frameworkADir/PrivateHeaders
+      cp lib/libfuse-t.a lib/libfuse-t.dylib lib/libfuse-t.tbd $out/lib
+      cp lib/pkgconfig/fuse-t.pc $out/lib/pkgconfig
+      cd ..
+      cp include/fuse* $out/include/fuse
+      cp include/fuse* $frameworkADir/Headers
+      cp include/fuse* $frameworkADir/PrivateHeaders
+      ln -s A $out/Library/Frameworks/fuse_t.framework/Versions/Current
+      ln -s Versions/Current/Headers $frameworkDir
+      ln -s Versions/Current/PrivateHeaders $frameworkDir
+      cp include/config.h include/cuse_*.h lib/fuse_*.h $frameworkADir/PrivateHeaders
+      cp include/cuse_*.h $frameworkADir/PrivateHeaders
+      cp lib/fuse_*.h $frameworkADir/PrivateHeaders
+      runHook postInstall
+    '';
+
+    doCheck = false;
+
+    meta = with lib; {
+      description = "Library that allows filesystems to be implemented in user space";
+      longDescription = ''
+        FUSE (Filesystem in Userspace) is an interface for userspace programs to
+        export a filesystem to the Linux kernel. The FUSE project consists of two
+        components: The fuse kernel module (maintained in the regular kernel
+        repositories) and the libfuse userspace library (this package). libfuse
+        provides the reference implementation for communicating with the FUSE
+        kernel module.
+      '';
+      homepage = "https://github.com/macos-fuse-t/libfuse";
+      platforms = platforms.darwin;
+      license = licenses.lgpl21Only;
+    };
+  };
+in
+stubs.overrideAttrs {
+  pname = "fuse-t";
+
+  postInstall = ''
+    cp -RHnv ${binaryDistribution}/. $out
+    rm $out/lib/libfuse-t-${version}.a $out/lib/libfuse-t-${version}.dylib
+  '';
+
+  passthru = {
+    inherit binaryDistribution stubs;
+  };
+
+  meta = {
+    description = "FUSE-T is a kext-less implementation of FUSE for macOS that uses NFS v4 local server instead of a kernel extension.";
+    homepage = "https://www.fuse-t.org/";
+    license = [
+      # libfuse/stubs
+      lib.licenses.lgpl21Only
+
+      # NFS server
+      # free for non-commercial use, see: https://github.com/macos-fuse-t/fuse-t/blob/main/License.txt
+      lib.licenses.unfreeRedistributable
+    ];
+    sourceProvenance = [
+      # libfuse/stubs
+      lib.sourceTypes.fromSource
+
+      # NFS server
+      lib.sourceTypes.binaryNativeCode
+    ];
+    maintainers = [ lib.maintainers.Enzime ];
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/by-name/fu/fuse-t/use-correct-path.patch
+++ b/pkgs/by-name/fu/fuse-t/use-correct-path.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/fuse_darwin_private.h b/lib/fuse_darwin_private.h
+index 4d4cc68..840b06f 100644
+--- a/lib/fuse_darwin_private.h
++++ b/lib/fuse_darwin_private.h
+@@ -38,7 +38,7 @@ extern "C" {
+ #endif
+ 
+ #ifndef FUSE_NFSSRV_PROG
+-#  define FUSE_NFSSRV_PROG "/usr/local/bin/go-nfsv4"
++#  define FUSE_NFSSRV_PROG "@out@/bin/go-nfsv4"
+ #endif
+ 
+ #ifndef OSXFUSE_VOLUME_ICON

--- a/pkgs/tools/filesystems/sshfs-fuse/common.nix
+++ b/pkgs/tools/filesystems/sshfs-fuse/common.nix
@@ -1,15 +1,12 @@
-{ version, sha256, platforms, patches ? [ ] }:
+{ version, sha256, platforms, patches ? [ ], fuse }:
 
 { lib, stdenv, fetchFromGitHub
 , meson, pkg-config, ninja, docutils, makeWrapper
-, fuse3, macfuse-stubs, glib
-, which, python3Packages
+, glib, which, python3Packages
 , openssh
 }:
 
-let
-  fuse = if stdenv.hostPlatform.isDarwin then macfuse-stubs else fuse3;
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "sshfs-fuse";
   inherit version;
 
@@ -53,7 +50,6 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     inherit platforms;
     description = "FUSE-based filesystem that allows remote filesystems to be mounted over SSH";
-    longDescription = macfuse-stubs.warning;
     homepage = "https://github.com/libfuse/sshfs";
     license = licenses.gpl2Plus;
     mainProgram = "sshfs";

--- a/pkgs/tools/filesystems/sshfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/sshfs-fuse/default.nix
@@ -1,12 +1,13 @@
-{ lib, stdenv, callPackage, fetchpatch }:
+{ lib, stdenv, callPackage, fuse-t, fetchpatch, fuse3 }:
 
 let mkSSHFS = args: callPackage (import ./common.nix args) { };
 in if stdenv.hostPlatform.isDarwin then
   mkSSHFS {
-    version = "2.10"; # macFUSE isn't yet compatible with libfuse 3.x
+    version = "2.10"; # FUSE-T isn't yet compatible with libfuse 3.x
     sha256 = "1dmw4kx6vyawcywiv8drrajnam0m29mxfswcp4209qafzx3mjlp1";
+    fuse = fuse-t;
     patches = [
-      # remove reference to fuse_darwin.h which doens't exist on recent macFUSE
+      # remove reference to fuse_darwin.h which doesn't exist on newer macFUSE or FUSE-T
       ./fix-fuse-darwin-h.patch
 
       # From https://github.com/libfuse/sshfs/pull/185:
@@ -17,6 +18,8 @@ in if stdenv.hostPlatform.isDarwin then
         url = "https://github.com/libfuse/sshfs/commit/667cf34622e2e873db776791df275c7a582d6295.patch";
         sha256 = "0d65lawd2g2aisk1rw2vl65dgxywf4vqgv765n9zj9zysyya8a54";
       })
+
+      ./support-fuse-t.patch
     ];
     platforms = lib.platforms.darwin;
   }
@@ -24,5 +27,6 @@ else
   mkSSHFS {
     version = "3.7.3";
     sha256 = "0s2hilqixjmv4y8n67zaq374sgnbscp95lgz5ignp69g3p1vmhwz";
+    fuse = fuse3;
     platforms = lib.platforms.linux;
   }

--- a/pkgs/tools/filesystems/sshfs-fuse/support-fuse-t.patch
+++ b/pkgs/tools/filesystems/sshfs-fuse/support-fuse-t.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 5bbba54..736e3e2 100644
+--- a/meson.build
++++ b/meson.build
+@@ -45,7 +45,7 @@ configure_file(input: 'sshfs.1.in',
+ configure_file(output: 'config.h',
+                configuration : cfg)
+ 
+-sshfs_deps = [ dependency('fuse', version: '>= 2.3'),
++sshfs_deps = [ dependency('fuse-t'),
+                dependency('glib-2.0'),
+                dependency('gthread-2.0') ]
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25661,6 +25661,10 @@ with pkgs;
   fuse3 = fusePackages.fuse_3;
   fuse-common = hiPrio fusePackages.fuse_3.common;
 
+  fuse-t = callPackage ../by-name/fu/fuse-t/package.nix {
+    inherit (darwin.apple_sdk.frameworks) DiskArbitration;
+  };
+
   fxload = callPackage ../os-specific/linux/fxload { };
 
   gfxtablet = callPackage ../os-specific/linux/gfxtablet { };


### PR DESCRIPTION
- Added `fuse-t`, `fuse-t.binaryDistribution` and `fuse-t.stubs`
- Use `fuse-t` instead of `macFUSE` for `sshfs-fuse`

You can test this PR with:

```
nix run github:numtide/nixpkgs-unfree#fuse-t --override-input nixpkgs github:Enzime/nixpkgs/fuse-t -- user@host:/path /mount/point 
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
