### PR TITLE
nixos/monado: add forceDefaultRuntime option

### DIFF
--- a/nixos/modules/services/hardware/monado.nix
+++ b/nixos/modules/services/hardware/monado.nix
@@ -16,6 +16,7 @@ let
 
   cfg = config.services.monado;
 
+  runtimeManifest = "${cfg.package}/share/openxr/1/openxr_monado.json";
 in
 {
   options.services.monado = {
@@ -30,6 +31,19 @@ in
 
         Note that applications can bypass this option by setting an active
         runtime in a writable XDG_CONFIG_DIRS location like `~/.config`.
+      '';
+      default = false;
+      example = true;
+    };
+
+    forceDefaultRuntime = mkOption {
+      type = types.bool;
+      description = ''
+        Whether to ensure that Monado is the active runtime set for the current
+        user.
+
+        This replaces the file `XDG_CONFIG_HOME/openxr/1/active_runtime.json`
+        when starting the service.
       '';
       default = false;
       example = true;
@@ -67,6 +81,16 @@ in
           XRT_PRINT_OPTIONS = mkDefault "on";
           IPC_EXIT_ON_DISCONNECT = mkDefault "off";
         };
+
+        preStart = mkIf cfg.forceDefaultRuntime ''
+          XDG_CONFIG_HOME="''${XDG_CONFIG_HOME:-$HOME/.config}"
+          targetDir="$XDG_CONFIG_HOME/openxr/1"
+          activeRuntimePath="$targetDir/active_runtime.json"
+
+          echo "Note: Replacing active runtime at '$activeRuntimePath'"
+          mkdir --parents "$targetDir"
+          ln --symbolic --force ${runtimeManifest} "$activeRuntimePath"
+        '';
 
         serviceConfig = {
           ExecStart =
@@ -106,7 +130,7 @@ in
     hardware.graphics.extraPackages = [ pkgs.monado-vulkan-layers ];
 
     environment.etc."xdg/openxr/1/active_runtime.json" = mkIf cfg.defaultRuntime {
-      source = "${cfg.package}/share/openxr/1/openxr_monado.json";
+      source = runtimeManifest;
     };
   };
 

--- a/nixos/tests/monado.nix
+++ b/nixos/tests/monado.nix
@@ -1,39 +1,43 @@
-import ./make-test-python.nix ({ pkgs, ... }: {
-  name = "monado";
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  {
+    name = "monado";
 
-  nodes.machine =
-    { pkgs, ... }:
+    nodes.machine =
+      { pkgs, ... }:
 
-    {
-      hardware.graphics.enable = true;
-      users.users.alice = {
-        isNormalUser = true;
-        uid = 1000;
+      {
+        hardware.graphics.enable = true;
+        users.users.alice = {
+          isNormalUser = true;
+          uid = 1000;
+        };
+
+        services.monado = {
+          enable = true;
+          defaultRuntime = true;
+        };
+        # Stop Monado from probing for any hardware
+        systemd.user.services.monado.environment.SIMULATED_ENABLE = "1";
+
+        environment.systemPackages = with pkgs; [ openxr-loader ];
       };
 
-      services.monado = {
-        enable = true;
-        defaultRuntime = true;
-      };
-      # Stop Monado from probing for any hardware
-      systemd.user.services.monado.environment.SIMULATED_ENABLE = "1";
+    testScript =
+      { nodes, ... }:
+      let
+        userId = toString nodes.machine.users.users.alice.uid;
+        runtimePath = "/run/user/${userId}";
+      in
+      ''
+        machine.succeed("loginctl enable-linger alice")
+        machine.wait_for_unit("user@${userId}.service")
 
-      environment.systemPackages = with pkgs; [ openxr-loader ];
-    };
+        machine.wait_for_unit("monado.socket", "alice")
+        machine.systemctl("start monado.service", "alice")
+        machine.wait_for_unit("monado.service", "alice")
 
-  testScript = { nodes, ... }:
-    let
-      userId = toString nodes.machine.users.users.alice.uid;
-      runtimePath = "/run/user/${userId}";
-    in
-    ''
-      machine.succeed("loginctl enable-linger alice")
-      machine.wait_for_unit("user@${userId}.service")
-
-      machine.wait_for_unit("monado.socket", "alice")
-      machine.systemctl("start monado.service", "alice")
-      machine.wait_for_unit("monado.service", "alice")
-
-      machine.succeed("su -- alice -c env XDG_RUNTIME_DIR=${runtimePath} openxr_runtime_list")
-    '';
-})
+        machine.succeed("su -- alice -c env XDG_RUNTIME_DIR=${runtimePath} openxr_runtime_list")
+      '';
+  }
+)


### PR DESCRIPTION
This option replaces the active runtime manifest in the user directory.
Games running through Steam's Pressure Vessel cannot read /etc so forcefully overriding the file every time the service starts, will allow those games to use Monado.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
