### PR TITLE
msedgedriver: init at 130.0.2849.1

### DIFF
--- a/pkgs/by-name/ms/msedgedriver/package.nix
+++ b/pkgs/by-name/ms/msedgedriver/package.nix
@@ -1,0 +1,84 @@
+{
+  autoPatchelfHook,
+  fetchzip,
+  glib,
+  lib,
+  libxcb,
+  nspr,
+  nss,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "msedgedriver";
+  # finding a version that has all 4 builds is a pain
+  # https://msedgewebdriverstorage.z22.web.core.windows.net/?form=MA13LH
+  version = "130.0.2849.1";
+
+  src =
+    let
+      inherit (stdenvNoCC.hostPlatform) system;
+      selectSystem = attrs: attrs.${system} or (throw "Unsupported system: ${system}");
+      suffix = selectSystem {
+        x86_64-linux = "linux64";
+        aarch64-linux = "arm64";
+        x86_64-darwin = "mac64";
+        aarch64-darwin = "mac64_m1";
+      };
+
+      hash = selectSystem {
+        x86_64-linux = "sha256-U6YGD2PAhVUa7f+R5pmKLazGLOBbf3bRqzlwIJewA+w=";
+        aarch64-linux = "sha256-QJ1jRw8kkWbT8US5qI8DMZI/7Q8yJWpFXrfzGdxDWKE=";
+        x86_64-darwin = "sha256-Ejcv1DtuEiLJvTsv48AwoCQlFO3xM9PkM3HvZG65AC4=";
+        aarch64-darwin = "sha256-ykn4bYREE6xmJY02WiCRGsGnyWjnmnZM8FemK4XZqhc=";
+      };
+    in
+    fetchzip {
+      url = "https://msedgedriver.azureedge.net/${finalAttrs.version}/edgedriver_${suffix}.zip";
+      inherit hash;
+      stripRoot = false;
+    };
+
+  buildInputs = [
+    glib
+    libxcb
+    nspr
+    nss
+  ];
+
+  nativeBuildInputs = lib.optionals (!stdenvNoCC.hostPlatform.isDarwin) [ autoPatchelfHook ];
+
+  installPhase =
+    if stdenvNoCC.hostPlatform.isDarwin then
+      ''
+        runHook preInstall
+
+        mkdir -p $out/{Applications/msedgedriver,bin}
+        cp -R . $out/Applications/msedgedriver
+
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+
+        install -m777 -D "msedgedriver" $out/bin/msedgedriver
+
+        runHook postInstall
+      '';
+
+  meta = {
+    homepage = "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver";
+    description = "WebDriver implementation that controls an Edge browser running on the local machine";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ cholli ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "msedgedriver";
+  };
+})


### PR DESCRIPTION
This initializes a package from 

[https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver?form=MA13LH](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver?form=MA13LH)

for now this is only the stable channel, and would need to be updated together with the `microsoft-edge` package I would love to include the edgedrivers for the other channels aswell but I don't know how yet

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
