### PR TITLE
razer-cli: init at 2.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11009,6 +11009,12 @@
     githubId = 1730718;
     name = "Hideaki Kawai";
   };
+  kaylorben = {
+    email = "blkaylor22@gmail.com";
+    github = "kaylorben";
+    githubId = 41012641;
+    name = "Benjamin Kaylor";
+  };
   kazcw = {
     email = "kaz@lambdaverse.org";
     github = "kazcw";

--- a/pkgs/by-name/ra/razer-cli/package.nix
+++ b/pkgs/by-name/ra/razer-cli/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  xrdb,
+}:
+
+# requires openrazer-daemon to be running on the system
+# on NixOS hardware.openrazer.enable or pkgs.openrazer-daemon
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "razer-cli";
+  version = "2.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lolei";
+    repo = "razer-cli";
+    rev = "v${version}";
+    hash = "sha256-p/RcBpkvtqYQ3Ekt0pLvKyi1Vv93oHDd7hqSTu/5CSw=";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+  ];
+
+  dependencies = [
+    python3.pkgs.openrazer
+  ];
+
+  buildInputs = [
+    xrdb
+  ];
+
+  meta = {
+    homepage = "https://github.com/LoLei/razer-cli";
+    description = "Command line interface for controlling Razer devices on Linux";
+    mainProgram = "razer-cli";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.kaylorben ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Python CLI utility to control various razer devices via openrazer. Useful for changing mouse dpi, rgb, etc with command line and user scripts/services.
https://github.com/LoLei/razer-cli
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
