### PR TITLE
dclib: fix build after libxml2 update

### DIFF
--- a/pkgs/development/libraries/dclib/default.nix
+++ b/pkgs/development/libraries/dclib/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, libxml2, openssl, bzip2}:
+{lib, stdenv, fetchurl, libxml2, openssl, bzip2, zlib}:
 
 stdenv.mkDerivation rec {
   pname = "dclib";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "02jdzm5hqzs1dv2rd596vgpcjaapm55pqqapz5m94l30v4q72rfc";
   };
 
-  buildInputs = [libxml2 openssl bzip2];
+  buildInputs = [libxml2 openssl bzip2 zlib];
 
   meta = with lib; {
     description = "Peer-to-Peer file sharing client";


### PR DESCRIPTION
- add zlib to buildInputs as libxml2 no longer propagates it

---

Fixes build of `dclib` (fails since `2024-07-29`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.dclib.x86_64-linux
https://hydra.nixos.org/build/274764482

Error log:
```text
/nix/store/717iy55ncqs0wmhdkwc5fg2vci5wbmq8-bash-5.2p32/bin/bash ../../libtool --silent --mode=compile --tag=CXX g++ -DHAVE_CONFIG_H -I. -I. -I../.. -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE    -Wnon-virtual-dtor -Wno-long-long -Wundef -Wall -W -Wpointer-arith -Wwrite-strings -O2 -fno-exceptions -fno-check-new -fno-common -D_REENTRANT -Wall -I/nix/store/x6y7max0zx622sp0p12wi4xzmg82jw08-libxml2-2.13.4-dev/include/libxml2  -Wnon-virtual-dtor -Wno-long-long -Wundef -Wall -W -Wpointer-arith -Wwrite-strings -O2 -fno-exceptions -fno-check-new -fno-common  -c -o czlib.lo `test -f 'czlib.cpp' || echo './'`czlib.cpp
In file included from czlib.cpp:24:
czlib.h:28:10: fatal error: zlib.h: No such file or directory
   28 | #include <zlib.h>
      |          ^~~~~~~~
compilation terminated.
```
Could not find exactly which change to `libxml2` led to this.
Information about propagation is from other similar commits around the time `dclib` started failing to build:
https://github.com/NixOS/nixpkgs/commit/adb4258ce2f647c39a859893234fae336b9ac4c1
https://github.com/NixOS/nixpkgs/commit/2fe2c2824571b47e3c51072761576465007c1e21
https://github.com/NixOS/nixpkgs/commit/2c36ff7a18ac3325273eafc5ba71155a1b1764d6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
