### PR TITLE
bitwarden-desktop: fix build

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -2,7 +2,6 @@
 , buildNpmPackage
 , cargo
 , copyDesktopItems
-, dbus
 , electron_32
 , fetchFromGitHub
 , glib
@@ -135,7 +134,6 @@ in buildNpmPackage rec {
   doCheck = true;
 
   nativeCheckInputs = [
-    dbus
     (gnome-keyring.override { useWrappedDaemon = false; })
   ];
 
@@ -148,14 +146,9 @@ in buildNpmPackage rec {
 
     (
       cd ${cargoRoot}
-      export HOME=$(mktemp -d)
-      export cargoCheckType=release
-      for function in $(declare -F | awk '{print $3}'); do
-        export -f "$function"
-      done
-      dbus-run-session \
-        --config-file=${dbus}/share/dbus-1/session.conf \
-        -- bash -e -c cargoCheckHook
+      HOME=$(mktemp -d)
+      cargoCheckType=release
+      cargoCheckHook
     )
 
     runHook postCheck

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -146,14 +146,17 @@ in buildNpmPackage rec {
   checkPhase = ''
     runHook preCheck
 
-    pushd ${cargoRoot}
-    export HOME=$(mktemp -d)
-    export -f cargoCheckHook runHook _eval _callImplicitHook _logHook
-    export cargoCheckType=release
-    dbus-run-session \
-      --config-file=${dbus}/share/dbus-1/session.conf \
-      -- bash -e -c cargoCheckHook
-    popd
+    (
+      cd ${cargoRoot}
+      export HOME=$(mktemp -d)
+      export cargoCheckType=release
+      for function in $(declare -F | awk '{print $3}'); do
+        export -f "$function"
+      done
+      dbus-run-session \
+        --config-file=${dbus}/share/dbus-1/session.conf \
+        -- bash -e -c cargoCheckHook
+    )
 
     runHook postCheck
   '';


### PR DESCRIPTION
See commit messages. While the first commit is mostly pointless given the second, I still think it’s valuable as it’s more likely we’d want to go back to that state if we end up needing `dbus-run-session` in the future, rather than the current master.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
