### PR TITLE
dmenu: fix build on `staging-next`

### DIFF
--- a/pkgs/applications/misc/dmenu/default.nix
+++ b/pkgs/applications/misc/dmenu/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libX11, libXinerama, libXft, zlib, writeText
+{ lib, stdenv, fetchurl, fontconfig, libX11, libXinerama, libXft, pkg-config, zlib, writeText
 , conf ? null, patches ? null
   # update script dependencies
 , gitUpdater }:
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Go9T5v0tdJg57IcMXiez4U2lw+6sv8uUXRWeHVQzeV8=";
   };
 
-  buildInputs = [ libX11 libXinerama zlib libXft ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ fontconfig libX11 libXinerama zlib libXft ];
 
   inherit patches;
 
@@ -28,10 +29,14 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    sed -i "s@PREFIX = /usr/local@PREFIX = $out@g" config.mk
+    makeFlagsArray+=(
+      PREFIX="$out"
+      CC="$CC"
+      # default config.mk hardcodes dependent libraries and include paths
+      INCS="`$PKG_CONFIG --cflags fontconfig x11 xft xinerama`"
+      LIBS="`$PKG_CONFIG --libs   fontconfig x11 xft xinerama`"
+    )
   '';
-
-  makeFlags = [ "CC:=$(CC)" ];
 
   passthru.updateScript = gitUpdater { url = "git://git.suckless.org/dmenu"; };
 


### PR DESCRIPTION
Without the change `dmenu` fails to build on `staging-next` as:

    $ nix build --no-link -f. dmenu -L
    ...
    dmenu> build flags: SHELL=/nix/store/mm0pa3z7kk6jh1i9rkxqxjqmd8h1qpxf-bash-5.2p37/bin/bash CC:=\$\(CC\)
    dmenu> cp config.def.h config.h
    dmenu> gcc -c -std=c99 -pedantic -Wall -Os -I/usr/X11R6/include -I/usr/include/freetype2 -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE=700 -D_POSIX_C_SOURCE=200809L -DVERSION=\"5.3\" -DXINERAMA dmenu.c
    dmenu> In file included from dmenu.c:17:
    dmenu> /nix/store/2rxphcg0qabc3a8c4lvy610sm03bh72y-libXft-2.3.8-dev/include/X11/Xft/Xft.h:40:10: fatal error: ft2build.h: No such file or directory
    dmenu>    40 | #include <ft2build.h>
    dmenu>       |          ^~~~~~~~~~~~
    dmenu> compilation terminated.
    dmenu> make: *** [Makefile:12: dmenu.o] Error 1

The change uses `pkg-config` to discover library dependencies and lib paths.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
