### PR TITLE
alsa-firmware: fix riscv64-linux build

### DIFF
--- a/pkgs/by-name/al/alsa-firmware/package.nix
+++ b/pkgs/by-name/al/alsa-firmware/package.nix
@@ -29,7 +29,9 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-hotplug-dir=$(out)/lib/firmware" ];
 
   depsBuildBuild = lib.optional (
-    stdenv.buildPlatform != stdenv.hostPlatform || stdenv.hostPlatform.isAarch64
+    stdenv.buildPlatform != stdenv.hostPlatform
+    || stdenv.hostPlatform.isAarch64
+    || stdenv.hostPlatform.isRiscV64
   ) buildPackages.stdenv.cc;
 
   dontStrip = true;


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/332147 the compilation of `alsa-firmware` on native `riscv64-linux` fails with

```
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
fixing libtool script ./ltmain.sh
patching script interpreter paths in ./configure
./configure: interpreter directive changed from "#! /bin/sh" to "/nix/store/l6qw1d4q6lak02qppc9gdz2sfdpcf3cg-bash-5.2p32/bin/sh"
configure flags: --disable-dependency-tracking --prefix=/nix/store/14jc4d5fcsma7yjj5f326d247spa3rqz-alsa-firmware-1.2.4 --with-hotplug-dir=\$\(out\)/lib/firmware
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking whether gcc understands -c and -o together... yes
checking how to run the C preprocessor... gcc -E
checking build system type... riscv64-unknown-linux-gnu
checking for riscv64-unknown-linux-gnu-gcc... riscv64-unknown-linux-gnu-gcc
checking whether we are using the GNU C compiler... yes
checking whether riscv64-unknown-linux-gnu-gcc accepts -g... yes
checking for riscv64-unknown-linux-gnu-gcc option to enable C11 features... (cached) none needed
checking whether riscv64-unknown-linux-gnu-gcc understands -c and -o together... yes
checking whether the C compiler works... no
configure: error: in '/build/alsa-firmware-1.2.4':
configure: error: C compiler cannot create executables
See 'config.log' for more details
```

The PR https://github.com/NixOS/nixpkgs/pull/332147  put `buildPackages.stdenv.cc` behind a check. This PR simply adds the test for the riscv64 hostplatform to get the old behaviour.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] riscv64-linux 
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
