### PR TITLE
gale: init at 0.8.11

### DIFF
--- a/pkgs/by-name/ga/gale/package.nix
+++ b/pkgs/by-name/ga/gale/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  fetchNpmDeps,
+  npmHooks,
+  nodejs,
+  cargo-tauri,
+  pkg-config,
+  wrapGAppsHook3,
+
+  openssl,
+  libsoup_3,
+  webkitgtk_4_1,
+}:
+
+let
+  cargo-tauri_2 =
+    let
+      pname = "cargo-tauri";
+      version = "2.0.0-rc.3";
+      src = fetchFromGitHub {
+        owner = "tauri-apps";
+        repo = "tauri";
+        rev = "tauri-v${version}";
+        hash = "sha256-PV8m/MzYgbY4Hv71dZrqVbrxmxrwFfOAraLJIaQk6FQ=";
+      };
+    in
+    cargo-tauri.overrideAttrs {
+      inherit src version;
+      cargoDeps = rustPlatform.fetchCargoTarball {
+        inherit pname version src;
+        sourceRoot = "${src.name}/tooling/cli";
+        hash = "sha256-JPlMaoPw6a7D20KQH7iuhHKfGT5oUKf55tMaMYEM/Z4=";
+      };
+    };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gale";
+  version = "0.8.11";
+
+  src = fetchFromGitHub {
+    owner = "Kesomannen";
+    repo = "gale";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-PXK64WD3vb3uVxBFNU+LiGOipUjIAKW9RLWr1o4RigU=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-W0ryt3WH/3SireaOHa9i1vKpuokzIsDlD8R9Fnd0s4k=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) pname version src;
+    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
+    hash = "sha256-zXZkjSYN6/qNwBh+xUgJPWQvduIUSMVSt/XGbocKTwg=";
+  };
+
+  cargoRoot = "src-tauri";
+
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    nodejs
+    rustPlatform.cargoSetupHook
+    (cargo-tauri.hook.override { cargo-tauri = cargo-tauri_2; })
+    rustPlatform.cargoCheckHook
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    libsoup_3
+    webkitgtk_4_1
+    openssl
+  ];
+
+  meta = {
+    description = "Lightweight Thunderstore client";
+    homepage = "https://github.com/Kesomannen/gale";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "gale";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/348522

TIL that `buildRustPackage` doesn't seem to consider `cargoRoot` when trying to compute `cargoHash`. I switched over to just using the hooks. This wasn't an issue before, because every other tauri app has its `Cargo.lock` vendored (because of git-deps), so it wasn't using `cargoHash`.

The `cargo-tauri_2` usage is based on the `surrealist` package. Not pretty, but will be able to be cleaned up later treewide.

Please note that I don't know how to use this package, I just know how to package Tauri apps :)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
