### PR TITLE
libtomcrypt: improve packaging

### DIFF
--- a/pkgs/development/libraries/libtomcrypt/default.nix
+++ b/pkgs/development/libraries/libtomcrypt/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ libtool libtommath ];
+  nativeBuildInputs = [ libtool ];
+  buildInputs = [ libtommath ];
 
   postPatch = ''
     substituteInPlace makefile.shared --replace "LIBTOOL:=glibtool" "LIBTOOL:=libtool"

--- a/pkgs/development/libraries/libtomcrypt/default.nix
+++ b/pkgs/development/libraries/libtomcrypt/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ libtool ];
   buildInputs = [ libtommath ];
 
+  outputs = [ "out" "dev" ];
+
   postPatch = ''
     substituteInPlace makefile.shared --replace "LIBTOOL:=glibtool" "LIBTOOL:=libtool"
   '';

--- a/pkgs/development/libraries/libtomcrypt/default.nix
+++ b/pkgs/development/libraries/libtomcrypt/default.nix
@@ -27,12 +27,21 @@ stdenv.mkDerivation rec {
     substituteInPlace makefile.shared --replace "LIBTOOL:=glibtool" "LIBTOOL:=libtool"
   '';
 
+  # Flags needed only when building libtomcrypt
+  env.BUILD_CFLAGS = "-DUSE_LTM";
+  # Flags needed by libtomcrypt and dependent packages
+  env.USER_CFLAGS = "-DLTM_DESC -DLTC_PTHREAD";
+
   preBuild = ''
     makeFlagsArray+=(PREFIX=$out \
-      CFLAGS="-DUSE_LTM -DLTM_DESC -DLTC_PTHREAD" \
+      CFLAGS="$BUILD_CFLAGS $USER_CFLAGS" \
       EXTRALIBS=\"-ltommath\" \
       INSTALL_GROUP=$(id -g) \
       INSTALL_USER=$(id -u))
+  '';
+
+  preFixup = ''
+    sed -i "/^Cflags:/s|\$| $USER_CFLAGS|" $out/lib/pkgconfig/libtomcrypt.pc
   '';
 
   makefile = "makefile.shared";


### PR DESCRIPTION
Fixes #346707

As described in that bug, the CFLAGS used to compile libtomcrypt also need to be used when compiling dependent code. Without them, the `ltm_desc` symbol isn't declared for dependent code, and any use of libtomcrypt's PRNG code crashes the dependent progam. Remarkably, none of the dependent packages currently in nixpkgs appear to be affected by either symptom of the issue, but a program that I'd like to package is.

(I filed a bug with upstream, but don't think it makes sense to wait for a fix and new release from them.)

While I was looking at it, I made two other minor changes:
- Added a "dev" output for headers, etc.
- Moved libtommath to `buildInputs` since it's a runtime dependency (cross-compiling appears to be broken either way, but in theory this is a step in the right direction)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
