### PR TITLE
refurb: Disable another failing test

### DIFF
--- a/pkgs/development/tools/refurb/default.nix
+++ b/pkgs/development/tools/refurb/default.nix
@@ -44,6 +44,7 @@ python3Packages.buildPythonApplication rec {
 
   disabledTests = [
     "test_checks" # broken because new mypy release added new checks
+    "test_mypy_consistence" # broken by new mypy release
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
https://hydra.nixos.org/build/273774875/nixlog/8

```
=================================== FAILURES ===================================
____________________________ test_mypy_consistence _____________________________

    def test_mypy_consistence() -> None:
        """
        Ensure the visitor method name to node type mappings used in refurb are
        in sync with the ones of mypy.
    
        This is meant as a failsafe, especially when the mypy dependency is
        upgraded.
    
        If this fails, review the mappings in refurb.visitor.METHOD_NODE_MAPPINGS.
        """
    
        mypy_visitor_mapping = get_mypy_visitor_mapping()
>       assert mypy_visitor_mapping == METHOD_NODE_MAPPINGS
E       AssertionError: assert {'visit__prom...peExpr'>, ...} == {'visit__prom...peExpr'>, ...}
E         
E         Omitting 83 identical items, use -vv to show
E         Left contains 1 more item:
E         {'visit_type_alias_stmt': <class 'mypy.nodes.TypeAliasStmt'>}
E         Use -v to get more diff

test/test_visitor.py:82: AssertionError
=========================== short test summary info ============================
FAILED test/test_visitor.py::test_mypy_consistence - AssertionError: assert {'visit__prom...peExpr'>, ...} == {'visit__prom...pe...
=========== 1 failed, 112 passed, 1 skipped, 23 deselected in 26.98s ===========
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
