### PR TITLE
pappl: update; modernize; format; move to by-name

### DIFF
--- a/pkgs/applications/printing/pappl/default.nix
+++ b/pkgs/applications/printing/pappl/default.nix
@@ -16,9 +16,9 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "michaelrsweet";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-Npry3H+QbAH19hoqAZuOwjpZwCPhOLewD8uKZlo4gdQ=";
+    repo = "pappl";
+    rev = "refs/tagsv${version}";
+    hash = "sha256-Npry3H+QbAH19hoqAZuOwjpZwCPhOLewD8uKZlo4gdQ=";
   };
 
   outputs = [ "out" "dev" ];
@@ -52,12 +52,13 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "C-based framework/library for developing CUPS Printer Applications";
+    changelog = "https://github.com/michaelrsweet/pappl/blob/v${version}/CHANGES.md";
     mainProgram = "pappl-makeresheader";
     homepage = "https://github.com/michaelrsweet/pappl";
-    license = licenses.asl20;
-    platforms = platforms.linux; # should also work for darwin, but requires additional work
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux; # should also work for darwin, but requires additional work
+    maintainers = [lib.maintainers.NotAShelf];
   };
 }

--- a/pkgs/applications/printing/pappl/default.nix
+++ b/pkgs/applications/printing/pappl/default.nix
@@ -1,13 +1,17 @@
-{ lib, stdenv, fetchFromGitHub
-, avahi
-, cups
-, gnutls
-, libjpeg
-, libpng
-, libusb1
-, pkg-config
-, withPAMSupport ? true, pam
-, zlib
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  avahi,
+  cups,
+  gnutls,
+  libjpeg,
+  libpng,
+  libusb1,
+  pkg-config,
+  withPAMSupport ? true,
+  pam,
+  zlib,
 }:
 
 stdenv.mkDerivation rec {
@@ -21,26 +25,32 @@ stdenv.mkDerivation rec {
     hash = "sha256-Npry3H+QbAH19hoqAZuOwjpZwCPhOLewD8uKZlo4gdQ=";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   nativeBuildInputs = [
     pkg-config
   ];
 
-  buildInputs = [
-    cups
-    libjpeg
-    libpng
-    libusb1
-    zlib
-  ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    # upstream mentions these are not needed for Mac
-    # see: https://github.com/michaelrsweet/pappl#requirements
-    avahi
-    gnutls
-  ] ++ lib.optionals withPAMSupport [
-    pam
-  ];
+  buildInputs =
+    [
+      cups
+      libjpeg
+      libpng
+      libusb1
+      zlib
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      # upstream mentions these are not needed for Mac
+      # see: https://github.com/michaelrsweet/pappl#requirements
+      avahi
+      gnutls
+    ]
+    ++ lib.optionals withPAMSupport [
+      pam
+    ];
 
   # testing requires some networking
   # doCheck = true;
@@ -59,6 +69,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/michaelrsweet/pappl";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux; # should also work for darwin, but requires additional work
-    maintainers = [lib.maintainers.NotAShelf];
+    maintainers = [ lib.maintainers.NotAShelf ];
   };
 }

--- a/pkgs/applications/printing/pappl/default.nix
+++ b/pkgs/applications/printing/pappl/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pappl";
-  version = "1.4.6";
+  version = "1.4.7";
 
   src = fetchFromGitHub {
     owner = "michaelrsweet";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-d7QD6Kz4tBVHGFPBYcvRSzW+EtsNgpfweFvCx3ovfWE=";
+    sha256 = "sha256-Npry3H+QbAH19hoqAZuOwjpZwCPhOLewD8uKZlo4gdQ=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/by-name/pa/pappl/package.nix
+++ b/pkgs/by-name/pa/pappl/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "michaelrsweet";
     repo = "pappl";
-    rev = "refs/tagsv${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-Npry3H+QbAH19hoqAZuOwjpZwCPhOLewD8uKZlo4gdQ=";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10962,8 +10962,6 @@ with pkgs;
 
   papertrail = callPackage ../tools/text/papertrail { };
 
-  pappl = callPackage ../applications/printing/pappl { };
-
   par2cmdline = callPackage ../tools/networking/par2cmdline { };
 
   parallel = callPackage ../tools/misc/parallel { };


### PR DESCRIPTION
- **pappl: 1.4.6 -> 1.4.7**
- **pappl: modernize derivation; add changelog**
- **pappl: format via nixfmt**
- **pappl: migrate to by-name**

Adds myself to maintainers, and performs maintenance on the pappl package
that was missing a maintainer following jonringer's... departure. Updated
the package to the 14 minute old update, formatted and moved to by-name.

If anyone can test Darwin support, I can try adding Darwin to the supported
platforms!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
