### PR TITLE
darling: fix build with ffmpeg_7

### DIFF
--- a/pkgs/applications/emulators/darling/default.nix
+++ b/pkgs/applications/emulators/darling/default.nix
@@ -134,6 +134,14 @@ in stdenv.mkDerivation {
       url = "https://github.com/darlinghq/darling/commit/f46eb721c11d32addd807f092f4b3a6ea515bb6d.patch?full_index=1";
       hash = "sha256-FnLcHnK4cNto+E3OQSxE3iK+FHSU8y459FcpMvrzd6o=";
     })
+
+    # Fix compatibility with ffmpeg_7
+    # https://github.com/darlinghq/darling/pull/1537
+    # https://github.com/darlinghq/darling/commit/9655d5598c87dcb22c54a83cc7741b77cb47a1b0
+    (fetchpatch {
+      url = "https://github.com/darlinghq/darling/commit/9655d5598c87dcb22c54a83cc7741b77cb47a1b0.patch?full_index=1";
+      hash = "sha256-ogMo4SRRwiOhaVJ+OS8BVolGDa7vGKyR9bdGiOiCuRc=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
- add patch from upstream commit:
https://www.github.com/darlinghq/darling/pull/1537
https://www.github.com/darlinghq/darling/commit/9655d5598c87dcb22c54a83cc7741b77cb47a1b0

---

Fixes build of `darling` (fails since `2024-10-13`):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.darling.x86_64-linux
https://hydra.nixos.org/build/274829843

Error log:
```text
[11721/25908] Building CXX object src/CoreAudio/AudioToolbox/CMakeFiles/AudioToolbox.dir/AudioConverterImpl.cpp.o
FAILED: src/CoreAudio/AudioToolbox/CMakeFiles/AudioToolbox.dir/AudioConverterImpl.cpp.o 
/nix/store/3h5kbycdgc66c6p5927233wavdfirdbg-cc-wrapper-bypass/bin/clang++ -DAudioToolbox_EXPORTS -DDARLING -DDARWIN -DENABLE_PULSEAUDIO -DHAVE_AV_FRAME_ALLOC=1 -DPLATFORM_MacOSX -DTARGET_OS_MAC=1 -D_DARWIN_C_SOURCE -D_LIBC_NO_FEATURE_VERIFICATION -D_POSIX_C_SOURCE -D__APPLE__ -D__DYNAMIC__ -D__MACH__ -I/build/source/build/src/CoreAudio/AudioToolbox -I/build/source/src/external/libcxx/include -I/build/source/build/src/include -I/build/source/src/include -I/build/source/basic-headers -I/build/source/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -I/build/source/build/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -I/build/source/framework-include -I/build/source/framework-private-include -I/build/source/src/external/lkm/include -I/build/source/src/libDiagnosticMessagesClient/include -I/build/source/src/libMobileGestalt/include -I/build/source/src/lib/include -I/build/source/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libxml2 -I/build/source/build/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libxml2 -I/nix/store/bakyrc1qx6imk38276zpf4b4hlzpqi62-ffmpeg-7.0.2-dev/include -I/nix/store/apr4nzqrfv9bidsswxgmzhghsj4fn9i0-pulseaudio-17.0-dev/include -I/build/source/src/startup/mldr/elfcalls -I/build/source/src/CoreAudio/AudioToolbox/../include -I/build/source/src/CoreAudio/AudioToolbox/../include/AudioToolbox -isystem /nix/store/qb1x0mipbcvnkr40xwiwp24gg8lffrc0-clang-wrapper-18.1.8/resource-root/include -Wno-nullability-completeness -Wno-deprecated-declarations -Wno-availability -Wno-expansion-to-defined -Wno-elaborated-enum-base -Wno-undef-prefix -mmacosx-version-min=11.0 -std=c++17 -fPIC   -target x86_64-apple-darwin20  -B /build/source/build/src/external/cctools-port/cctools/misc/ -arch x86_64 -B /build/source/build/src/external/cctools-port/cctools/misc/ -arch x86_64 -MD -MT src/CoreAudio/AudioToolbox/CMakeFiles/AudioToolbox.dir/AudioConverterImpl.cpp.o -MF src/CoreAudio/AudioToolbox/CMakeFiles/AudioToolbox.dir/AudioConverterImpl.cpp.o.d -o src/CoreAudio/AudioToolbox/CMakeFiles/AudioToolbox.dir/AudioConverterImpl.cpp.o -c /build/source/src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp
/build/source/src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp:103:8: error: no member named 'channels' in 'AVCodecContext'
  103 |                 cIn->channels = inSourceFormat->mChannelsPerFrame;
      |                 ~~~  ^
/build/source/src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp:106:52: error: no member named 'channels' in 'AVCodecContext'
  106 |                 std::cout << "Converting from PCM with " << cIn->channels << " channels at " << cIn->sample_rate << " Hz\n";
      |                                                             ~~~  ^
/build/source/src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp:134:13: error: no member named 'channels' in 'AVCodecContext'
  134 |         m_encoder->channels = m_destinationFormat.mChannelsPerFrame;
      |         ~~~~~~~~~  ^
/build/source/src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp:136:13: error: no member named 'channel_layout' in 'AVCodecContext'
  136 |         m_encoder->channel_layout = CAChannelCountToLayout(m_destinationFormat.mChannelsPerFrame);
      |         ~~~~~~~~~  ^
/build/source/src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp:164:16: error: no member named 'channel_layout' in 'AVFrame'
  164 |         m_audioFrame->channel_layout = m_encoder->channel_layout;
      |         ~~~~~~~~~~~~  ^
/build/source/src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp:164:44: error: no member named 'channel_layout' in 'AVCodecContext'
  164 |         m_audioFrame->channel_layout = m_encoder->channel_layout;
      |                                        ~~~~~~~~~  ^
/build/source/src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp:167:78: error: no member named 'channels' in 'AVCodecContext'
  167 |         int audioSampleBuffer_size = av_samples_get_buffer_size(nullptr, m_encoder->channels, m_audioFrame->nb_samples, m_encoder->sample_fmt, 0);
      |                                                                          ~~~~~~~~~  ^
/build/source/src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp:177:66: error: no member named 'channels' in 'AVCodecContext'
  177 |         if (int err = avcodec_fill_audio_frame(m_audioFrame, m_encoder->channels, m_encoder->sample_fmt,
      |                                                              ~~~~~~~~~  ^
```
build fails since default `ffmpeg` got updated to `ffmpeg_7` in https://github.com/NixOS/nixpkgs/pull/337855

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
