### PR TITLE
[Backport release-24.05] edl: mark as unfree

### DIFF
--- a/pkgs/development/embedded/edl/default.nix
+++ b/pkgs/development/embedded/edl/default.nix
@@ -36,7 +36,8 @@ python3Packages.buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/bkerler/edl";
     description = "Qualcomm EDL tool (Sahara / Firehose / Diag)";
-    license = licenses.mit;
+    # See https://github.com/NixOS/nixpkgs/issues/348931
+    license = licenses.unfree;
     maintainers = with maintainers; [ lorenz ];
     # Case-sensitive files in 'Loader' submodule
     broken = stdenv.isDarwin;


### PR DESCRIPTION
Backport of #348934 to 24.05.