### PR TITLE
nixos/docker: keep live-restore disabled by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -629,6 +629,8 @@
 
 - `lib.misc.mapAttrsFlatten` is now formally deprecated and will be removed in future releases; use the identical [`lib.attrsets.mapAttrsToList`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.attrsets.mapAttrsToList) instead.
 
+- `virtualisation.docker.liveRestore` has been renamed to `virtualisation.docker.daemon.settings."live-restore"` and turned off by default for state versions of at least 24.11.
+
 - Tailscale's `authKeyFile` can now have its corresponding parameters set through `config.services.tailscale.authKeyParameters`, allowing for non-ephemeral unsupervised deployment and more.
   See [Registering new nodes using OAuth credentials](https://tailscale.com/kb/1215/oauth-clients#registering-new-nodes-using-oauth-credentials) for the supported options.
 

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -60,7 +60,7 @@ in
               # Prior to NixOS 24.11, this was set to true by default, while upstream defaulted to false.
               # Keep the option unset to follow upstream defaults
               default = versionOlder config.system.stateVersion "24.11";
-              defaultText = literalExpression "versionOlder config.system.stateVersion \"24.11\"";
+              defaultText = literalExpression "lib.versionOlder config.system.stateVersion \"24.11\"";
               description = ''
                 Allow dockerd to be restarted without affecting running container.
                 This option is incompatible with docker swarm.

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -173,6 +173,11 @@ in
     };
   };
 
+  imports = [
+    (mkRemovedOptionModule ["virtualisation" "docker" "socketActivation"] "This option was removed and socket activation is now always active")
+    (mkAliasOptionModule ["virtualisation" "docker" "liveRestore"] ["virtualisation" "docker" "daemon" "settings" "live-restore"])
+  ];
+
   ###### implementation
 
   config = mkIf cfg.enable (mkMerge [{
@@ -271,10 +276,4 @@ in
       };
     }
   ]);
-
-  imports = [
-    (mkRemovedOptionModule ["virtualisation" "docker" "socketActivation"] "This option was removed and socket activation is now always active")
-    (mkAliasOptionModule ["virtualisation" "docker" "liveRestore"] ["virtualisation" "docker" "daemon" "settings" "live-restore"])
-  ];
-
 }

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -52,7 +52,19 @@ in
 
     daemon.settings =
       mkOption {
-        type = settingsFormat.type;
+        type = types.submodule {
+          freeformType = settingsFormat.type;
+          options = {
+            live-restore = mkOption {
+              type = types.bool;
+              default = true;
+              description = ''
+                Allow dockerd to be restarted without affecting running container.
+                This option is incompatible with docker swarm.
+              '';
+            };
+          };
+        };
         default = { };
         example = {
           ipv6 = true;
@@ -73,16 +85,6 @@ in
 
           Enable nvidia-docker wrapper, supporting NVIDIA GPUs inside docker containers.
         '';
-      };
-
-    liveRestore =
-      mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-            Allow dockerd to be restarted without affecting running container.
-            This option is incompatible with docker swarm.
-          '';
       };
 
     storageDriver =
@@ -253,7 +255,6 @@ in
         hosts = [ "fd://" ];
         log-driver = mkDefault cfg.logDriver;
         storage-driver = mkIf (cfg.storageDriver != null) (mkDefault cfg.storageDriver);
-        live-restore = mkDefault cfg.liveRestore;
         runtimes = mkIf cfg.enableNvidia {
           nvidia = {
             # Use the legacy nvidia-container-runtime wrapper to allow
@@ -269,6 +270,7 @@ in
 
   imports = [
     (mkRemovedOptionModule ["virtualisation" "docker" "socketActivation"] "This option was removed and socket activation is now always active")
+    (mkAliasOptionModule ["virtualisation" "docker" "liveRestore"] ["virtualisation" "docker" "daemon" "settings" "live-restore"])
   ];
 
 }

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -57,7 +57,10 @@ in
           options = {
             live-restore = mkOption {
               type = types.bool;
-              default = true;
+              # Prior to NixOS 24.11, this was set to true by default, while upstream defaulted to false.
+              # Keep the option unset to follow upstream defaults
+              default = versionOlder config.system.stateVersion "24.11";
+              defaultText = literalExpression "versionOlder config.system.stateVersion \"24.11\"";
               description = ''
                 Allow dockerd to be restarted without affecting running container.
                 This option is incompatible with docker swarm.
@@ -68,6 +71,7 @@ in
         default = { };
         example = {
           ipv6 = true;
+          "live-restore" = true;
           "fixed-cidr-v6" = "fd00::/80";
         };
         description = ''


### PR DESCRIPTION
See https://docs.docker.com/engine/daemon/live-restore/
See https://discourse.nixos.org/t/docker-hanging-on-reboot/18270/5
Closes https://github.com/NixOS/nixpkgs/issues/182916

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
