### PR TITLE
kpcli: KDBX 4 support

### DIFF
--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -30,19 +30,6 @@ let
     };
   };
 
-  IteratorSimple = perlPackages.buildPerlPackage {
-    pname = "Iterator-Simple";
-    version = "0.07";
-    src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MICHAEL/Iterator-Simple-0.07.tar.gz";
-      hash = "sha256-y1dNBju0gcj7nLV4GkZFiWqg4e5xW6lHz3ZvH/Tp60Q=";
-    };
-    meta = {
-      description = "Simple iterator and utilities";
-      license = with lib.licenses; [ artistic1 gpl2Only ];
-    };
-  };
-
   IteratorSimpleLookahead = perlPackages.buildPerlPackage {
     pname = "Iterator-Simple-Lookahead";
     version = "0.09";
@@ -50,9 +37,9 @@ let
       url = "mirror://cpan/authors/id/P/PS/PSCUST/Iterator-Simple-Lookahead-0.09.tar.gz";
       hash = "sha256-FmPE1xdU8LAXS21+H4DJaQ87qDi4Q4UkLawsUAqseZw=";
     };
-    propagatedBuildInputs = [ IteratorSimple ] ++ (with perlPackages; [
-      ClassAccessor
-    ]);
+    propagatedBuildInputs = with perlPackages; [
+      ClassAccessor IteratorSimple
+    ];
     meta = {
       description = "Simple iterator with lookahead and unget";
       license = with lib.licenses; [ artistic1 gpl2Only ];
@@ -67,9 +54,9 @@ let
       hash = "sha256-pVTpIqGxZpBxZlAbXuGDapuOxsp3uM/AM5dKUxlej1M=";
     };
     propagatedBuildInputs = [
-        IteratorSimple
         IteratorSimpleLookahead
       ] ++ (with perlPackages; [
+        IteratorSimple
         TextTemplate
         DataDump
         FileSlurp

--- a/pkgs/tools/security/kpcli/default.nix
+++ b/pkgs/tools/security/kpcli/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/kpcli/${pname}-${version}.pl";
-    sha256 = "sha256-hvyCC8eUXNm1d1g+/kEnVllRJokChgJWzuoQB5Xd8j8=";
+    hash = "sha256-hvyCC8eUXNm1d1g+/kEnVllRJokChgJWzuoQB5Xd8j8=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
 
     makeWrapper $out/share/kpcli.pl $out/bin/kpcli --set PERL5LIB \
       "${with perlPackages; makePerlPath ([
-         CaptureTiny Clipboard Clone CryptRijndael SortNaturally TermReadKey TermShellUI FileKeePass TermReadLineGnu XMLParser
+         BHooksEndOfScope CaptureTiny Clipboard Clone CryptRijndael CryptX DevelGlobalDestruction ModuleImplementation
+         ModuleRuntime SortNaturally SubExporterProgressive TermReadKey TermShellUI TryTiny FileKDBX FileKeePass
+         PackageStash RefUtil TermReadLineGnu XMLParser boolean namespaceclean
       ] ++ lib.optional stdenv.hostPlatform.isDarwin MacPasteboard)}"
   '';
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13317,6 +13317,19 @@ with self; {
     };
   };
 
+  IteratorSimple = buildPerlPackage {
+    pname = "Iterator-Simple";
+    version = "0.07";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MI/MICHAEL/Iterator-Simple-0.07.tar.gz";
+      hash = "sha256-y1dNBju0gcj7nLV4GkZFiWqg4e5xW6lHz3ZvH/Tp60Q=";
+    };
+    meta = {
+      description = "Simple iterator and utilities";
+      license = with lib.licenses; [ artistic1 gpl2Only ];
+    };
+  };
+
   IPCSignal = buildPerlPackage {
     pname = "IPC-Signal";
     version = "1.00";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9938,6 +9938,21 @@ with self; {
     };
   };
 
+  FileKDBX = buildPerlPackage {
+    pname = "File-KDBX";
+    version = "0.906";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/C/CC/CCM/File-KDBX-0.906.tar.gz";
+      hash = "sha256-tHt/kzOrtJHqrsY0WhTn+TlW0UOUTBS4Fkp/0bIkvW8=";
+    };
+    propagatedBuildInputs = [ CryptArgon2 CryptX DevelGlobalDestruction FileKeePass IteratorSimple RefUtil XMLLibXML boolean namespaceclean ];
+    buildInputs = [ ScopeGuard TestDeep TestFatal TestWarnings ];
+    meta = {
+      description = "Interface to KeePass V3 and V4 database files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   FileKeePass = buildPerlPackage {
     pname = "File-KeePass";
     version = "2.03";


### PR DESCRIPTION
Fixes #330177

cc @Schweber

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc