### PR TITLE
cemu-ti: Fix build failure

### DIFF
--- a/pkgs/applications/science/math/cemu-ti/default.nix
+++ b/pkgs/applications/science/math/cemu-ti/default.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/gui/qt/";
 
+  patches = [
+    # This is resolved upstream, but I can't apply the patch because the
+    # sourceRoot isn't set to the base of the Git repo.
+    ./resolve-ambiguous-constexpr.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/science/math/cemu-ti/resolve-ambiguous-constexpr.patch
+++ b/pkgs/applications/science/math/cemu-ti/resolve-ambiguous-constexpr.patch
@@ -1,0 +1,13 @@
+diff --git a/mainwindow.cpp b/mainwindow.cpp
+index f03a743e..70c29a45 100644
+--- a/mainwindow.cpp
++++ b/mainwindow.cpp
+@@ -970,7 +970,7 @@ void MainWindow::showEvent(QShowEvent *e) {
+ DockWidget *MainWindow::redistributeFindDock(const QPoint &pos) {
+     QWidget *child = childAt(pos);
+     if (QTabBar *tabBar = findSelfOrParent<QTabBar *>(child)) {
+-        child = childAt({pos.x(), tabBar->mapTo(this, QPoint{}).y() - 1});
++        child = childAt(QPoint({pos.x(), tabBar->mapTo(this, QPoint{}).y() - 1}));
+     }
+     return findSelfOrParent<DockWidget *>(child);
+ }


### PR DESCRIPTION
The update of Qt 6.8.0 caused an error in `gui/qt/mainwindow.cpp`, so I [got it fixed](https://github.com/CE-Programming/CEmu/pull/497) upstream. The `sourceRoot` is not the base of the Git repository, so I had to use Git to use a relative path. The patch also has different line numbers because I wanted that patch to be against v2.0, and not master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
