### PR TITLE
[Backport release-24.05] warp-terminal: 0.2024.07.16.08.02.stable_03 -> 0.2024.10.08.08.02.stable_02

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -23,12 +23,17 @@ pname = "warp-terminal";
 versions = lib.importJSON ./versions.json;
 passthru.updateScript = ./update.sh;
 
+linux_arch =
+  if stdenv.hostPlatform.system == "x86_64-linux"
+    then "x86_64"
+    else "aarch64";
+
 linux = stdenv.mkDerivation (finalAttrs:  {
   inherit pname meta passthru;
-  inherit (versions.linux) version;
+  inherit (versions."linux_${linux_arch}") version;
   src = fetchurl {
-    inherit (versions.linux) hash;
-    url = "https://releases.warp.dev/stable/v${finalAttrs.version}/warp-terminal-v${finalAttrs.version}-1-x86_64.pkg.tar.zst";
+    inherit (versions."linux_${linux_arch}") hash;
+    url = "https://releases.warp.dev/stable/v${finalAttrs.version}/warp-terminal-v${finalAttrs.version}-1-${linux_arch}.pkg.tar.zst";
   };
 
   sourceRoot = ".";
@@ -99,8 +104,8 @@ meta = with lib; {
   homepage = "https://www.warp.dev";
   license = licenses.unfree;
   sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-  maintainers = with maintainers; [ emilytrau Enzime imadnyc donteatoreo ];
-  platforms = platforms.darwin ++ [ "x86_64-linux" ];
+  maintainers = with maintainers; [ emilytrau imadnyc donteatoreo johnrtitor ];
+  platforms = platforms.darwin ++ [ "x86_64-linux" "aarch64-linux" ];
 };
 
 in

--- a/pkgs/by-name/wa/warp-terminal/update.sh
+++ b/pkgs/by-name/wa/warp-terminal/update.sh
@@ -27,8 +27,12 @@ resolve_url() {
             pkg=macos
             sfx=dmg
             ;;
-        linux)
+        linux_x86_64)
             pkg=pacman
+            sfx=pkg.tar.zst
+            ;;
+        linux_aarch64)
+            pkg=pacman_arm64
             sfx=pkg.tar.zst
             ;;
         *)
@@ -64,7 +68,8 @@ sri_get() {
 }
 
 
-for sys in darwin linux; do
+for sys in darwin linux_x86_64 linux_aarch64; do
+    echo ${sys}
     url=$(resolve_url ${sys})
     version=$(get_version "${url}")
     if [[ ${version} != "$(json_get ".${sys}.version")" ]]; then

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "darwin": {
-    "hash": "sha256-+v4yqJ6L1wKKkKE3wVnt0MQswZR3Dla5XnjHQgLMeoo=",
-    "version": "0.2024.08.06.08.01.stable_00"
+    "hash": "sha256-imHJKbE+M4jFzeymhBaFkzUqG1jiY6Bi17Ll+JSsj7w=",
+    "version": "0.2024.08.13.08.02.stable_03"
   },
   "linux": {
-    "hash": "sha256-PwpoUDvy3uXzvRgx7xTVS3vf5qar+fgp6pY+OP2HYhY=",
-    "version": "0.2024.08.06.08.01.stable_00"
+    "hash": "sha256-MkNt6LzZdn/FjLcISm49ELPjIa8KAs/fd3k0/EhAyZQ=",
+    "version": "0.2024.08.13.08.02.stable_04"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-qaJP+du/jaI8zZPRZnM7K1DnC2GOzdZzs5JmKWj6OLQ=",
-    "version": "0.2024.09.17.08.02.stable_01"
+    "hash": "sha256-zbnOkld+6UnSeMfvc6P6qZ474KaHcx1Qzyr4HCWsv98=",
+    "version": "0.2024.09.24.08.02.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-l51KJoEOXGokgnDb9pz5LVhgBN7B1eipsFA9J+QpQzM=",
-    "version": "0.2024.09.17.08.02.stable_01"
+    "hash": "sha256-SeTzKFsY+p0oJFTmBEmj64tOPS7BlBLtYdoIJ9jmTD0=",
+    "version": "0.2024.09.24.08.02.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-zyiDYhxYG+JmiSdB7JBJ+H7yaIIvXaDlpslfa3TTsfI=",
-    "version": "0.2024.09.17.08.02.stable_01"
+    "hash": "sha256-lAiu20udBEJhu29vqiS8vYauuu0fcX1LlvqEqYN5WXU=",
+    "version": "0.2024.09.24.08.02.stable_01"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "darwin": {
-    "hash": "sha256-imHJKbE+M4jFzeymhBaFkzUqG1jiY6Bi17Ll+JSsj7w=",
-    "version": "0.2024.08.13.08.02.stable_03"
+    "hash": "sha256-EDhj4Gb0ykFX8W2G8osusjggemcuHO7hkUKb151cQ6g=",
+    "version": "0.2024.08.20.08.02.stable_00"
   },
   "linux": {
-    "hash": "sha256-MkNt6LzZdn/FjLcISm49ELPjIa8KAs/fd3k0/EhAyZQ=",
-    "version": "0.2024.08.13.08.02.stable_04"
+    "hash": "sha256-Uk5pSoAvEppjLnskLc5/ftcCaiJnXATJfCPDP2QpBo8=",
+    "version": "0.2024.08.20.08.02.stable_00"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-Awr2NvXsWaEeJpdCA94q7kxQ04IDpwNxnm7GxB4J09w=",
-    "version": "0.2024.10.08.08.02.stable_01"
+    "hash": "sha256-LPH9JbOXOBjT4vMWNGMvQYDVnTE6p2tFTlOe8HOFsk0=",
+    "version": "0.2024.10.08.08.02.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-fNY+wXqlqUSdRVptDNuk1ouddSlIKQrBFPIij9Qa0jM=",
-    "version": "0.2024.10.08.08.02.stable_01"
+    "hash": "sha256-jwbwRgQ7WR04zCki7PQuuMZD7v2tFl3Gm1olZ28FAp8=",
+    "version": "0.2024.10.08.08.02.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-EdQjc8uXG4cpkgnIYRaBXLeuYqhbN7rs4bU+L/Cc7XA=",
-    "version": "0.2024.10.08.08.02.stable_01"
+    "hash": "sha256-Ticn8OMYHWQT88WQSpgcT/kBVnHyoDHNhTk0m4T45bQ=",
+    "version": "0.2024.10.08.08.02.stable_02"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-nED8SIfrxlKKT4J88L1Vnpq4Iq6TA4QMFK9TQfX4uRk=",
-    "version": "0.2024.09.10.08.02.stable_01"
+    "hash": "sha256-qaJP+du/jaI8zZPRZnM7K1DnC2GOzdZzs5JmKWj6OLQ=",
+    "version": "0.2024.09.17.08.02.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-fNy0cNNgpq3JoeZhN20/7pRwCf53DwGkHl92/974FLQ=",
-    "version": "0.2024.09.10.08.02.stable_01"
+    "hash": "sha256-l51KJoEOXGokgnDb9pz5LVhgBN7B1eipsFA9J+QpQzM=",
+    "version": "0.2024.09.17.08.02.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-HlPR3Q94KEdVlBsy2L+GQcyQ1qxw+As6qhWF5N3n3i4=",
-    "version": "0.2024.09.10.08.02.stable_01"
+    "hash": "sha256-zyiDYhxYG+JmiSdB7JBJ+H7yaIIvXaDlpslfa3TTsfI=",
+    "version": "0.2024.09.17.08.02.stable_01"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "darwin": {
-    "hash": "sha256-xTvLT6bYWBxF2mkICBGEKorGW/gFQ+9GNwnhfvqm8NE=",
-    "version": "0.2024.07.30.08.02.stable_01"
+    "hash": "sha256-+v4yqJ6L1wKKkKE3wVnt0MQswZR3Dla5XnjHQgLMeoo=",
+    "version": "0.2024.08.06.08.01.stable_00"
   },
   "linux": {
-    "hash": "sha256-z/EpRHn+P2QOn0dFzoa4EfhIGceX9VJXWdqLAZ45aK4=",
-    "version": "0.2024.07.30.08.02.stable_01"
+    "hash": "sha256-PwpoUDvy3uXzvRgx7xTVS3vf5qar+fgp6pY+OP2HYhY=",
+    "version": "0.2024.08.06.08.01.stable_00"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "darwin": {
-    "hash": "sha256-SNSWXDOmZAjPv33ioDOHSEflC6BKTmVAcAvc/Bn4VwE=",
-    "version": "0.2024.07.16.08.02.stable_03"
+    "hash": "sha256-xTvLT6bYWBxF2mkICBGEKorGW/gFQ+9GNwnhfvqm8NE=",
+    "version": "0.2024.07.30.08.02.stable_01"
   },
   "linux": {
-    "hash": "sha256-rn97dcZ1XsQllzmQ9HbvLyvq5EsN42A5WHe1fVUjilY=",
-    "version": "0.2024.07.16.08.02.stable_03"
+    "hash": "sha256-z/EpRHn+P2QOn0dFzoa4EfhIGceX9VJXWdqLAZ45aK4=",
+    "version": "0.2024.07.30.08.02.stable_01"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -3,8 +3,12 @@
     "hash": "sha256-EDhj4Gb0ykFX8W2G8osusjggemcuHO7hkUKb151cQ6g=",
     "version": "0.2024.08.20.08.02.stable_00"
   },
-  "linux": {
+  "linux_x86_64": {
     "hash": "sha256-Uk5pSoAvEppjLnskLc5/ftcCaiJnXATJfCPDP2QpBo8=",
+    "version": "0.2024.08.20.08.02.stable_00"
+  },
+  "linux_aarch64": {
+    "hash": "sha256-B0mUAwydIgi7Nhm/iUhEjkV3LL+qLfXZcOz6+7eDZGc=",
     "version": "0.2024.08.20.08.02.stable_00"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-EDhj4Gb0ykFX8W2G8osusjggemcuHO7hkUKb151cQ6g=",
-    "version": "0.2024.08.20.08.02.stable_00"
+    "hash": "sha256-EDu3BwNvCsy11pycqwDasSdV1g50fFQCa2eaax3mGTg=",
+    "version": "0.2024.09.03.08.02.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-Uk5pSoAvEppjLnskLc5/ftcCaiJnXATJfCPDP2QpBo8=",
-    "version": "0.2024.08.20.08.02.stable_00"
+    "hash": "sha256-yG7Gr2B5VqDuZfB4RJZYZNt7SNOJ2HSwSCM+1iKhshc=",
+    "version": "0.2024.09.03.08.02.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-B0mUAwydIgi7Nhm/iUhEjkV3LL+qLfXZcOz6+7eDZGc=",
-    "version": "0.2024.08.20.08.02.stable_00"
+    "hash": "sha256-gg5ACoABFesDUhdVBOlv+bQtliQ3N/RZlmzDMuONef8=",
+    "version": "0.2024.09.03.08.02.stable_03"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-EDu3BwNvCsy11pycqwDasSdV1g50fFQCa2eaax3mGTg=",
-    "version": "0.2024.09.03.08.02.stable_03"
+    "hash": "sha256-nED8SIfrxlKKT4J88L1Vnpq4Iq6TA4QMFK9TQfX4uRk=",
+    "version": "0.2024.09.10.08.02.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-yG7Gr2B5VqDuZfB4RJZYZNt7SNOJ2HSwSCM+1iKhshc=",
-    "version": "0.2024.09.03.08.02.stable_03"
+    "hash": "sha256-fNy0cNNgpq3JoeZhN20/7pRwCf53DwGkHl92/974FLQ=",
+    "version": "0.2024.09.10.08.02.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-gg5ACoABFesDUhdVBOlv+bQtliQ3N/RZlmzDMuONef8=",
-    "version": "0.2024.09.03.08.02.stable_03"
+    "hash": "sha256-HlPR3Q94KEdVlBsy2L+GQcyQ1qxw+As6qhWF5N3n3i4=",
+    "version": "0.2024.09.10.08.02.stable_01"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-zbnOkld+6UnSeMfvc6P6qZ474KaHcx1Qzyr4HCWsv98=",
-    "version": "0.2024.09.24.08.02.stable_01"
+    "hash": "sha256-Awr2NvXsWaEeJpdCA94q7kxQ04IDpwNxnm7GxB4J09w=",
+    "version": "0.2024.10.08.08.02.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-SeTzKFsY+p0oJFTmBEmj64tOPS7BlBLtYdoIJ9jmTD0=",
-    "version": "0.2024.09.24.08.02.stable_01"
+    "hash": "sha256-fNY+wXqlqUSdRVptDNuk1ouddSlIKQrBFPIij9Qa0jM=",
+    "version": "0.2024.10.08.08.02.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-lAiu20udBEJhu29vqiS8vYauuu0fcX1LlvqEqYN5WXU=",
-    "version": "0.2024.09.24.08.02.stable_01"
+    "hash": "sha256-EdQjc8uXG4cpkgnIYRaBXLeuYqhbN7rs4bU+L/Cc7XA=",
+    "version": "0.2024.10.08.08.02.stable_01"
   }
 }


### PR DESCRIPTION
Backports:
#329627
#332584
#334350
#336292
#337690
#337811
#340319
#342293
#343244
#345520
#347779
#348065

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
