### PR TITLE
jam: fix OS determination on linux 

### DIFF
--- a/pkgs/by-name/ja/jam/package.nix
+++ b/pkgs/by-name/ja/jam/package.nix
@@ -49,21 +49,26 @@ stdenv.mkDerivation (finalAttrs: {
     export AR="$AR rc"
   '';
 
-  # When cross-compiling, we need to set the preprocessor macros
-  # OSMAJOR/OSMINOR/OSPLAT to the values from the target platform, not the host
-  # platform. This looks a little ridiculous because the vast majority of build
-  # tools don't embed target-specific information into their binary, but in this
-  # case we behave more like a compiler than a make(1)-alike.
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
-     cat >>jam.h <<EOF
-     #undef OSMAJOR
-     #undef OSMINOR
-     #undef OSPLAT
-     $(
-       ${pkgsBuildTarget.targetPackages.stdenv.cc}/bin/${pkgsBuildTarget.targetPackages.stdenv.cc.targetPrefix}cc -E -dM jam.h | grep -E '^#define (OSMAJOR|OSMINOR|OSPLAT) '
-      )
-    EOF
-  '';
+  postPatch =
+    ''
+      substituteInPlace jam.h --replace-fail 'ifdef linux' 'ifdef __linux__'
+    ''
+    +
+      # When cross-compiling, we need to set the preprocessor macros
+      # OSMAJOR/OSMINOR/OSPLAT to the values from the target platform, not the host
+      # platform. This looks a little ridiculous because the vast majority of build
+      # tools don't embed target-specific information into their binary, but in this
+      # case we behave more like a compiler than a make(1)-alike.
+      lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+         cat >>jam.h <<EOF
+         #undef OSMAJOR
+         #undef OSMINOR
+         #undef OSPLAT
+         $(
+           ${pkgsBuildTarget.targetPackages.stdenv.cc}/bin/${pkgsBuildTarget.targetPackages.stdenv.cc.targetPrefix}cc -E -dM jam.h | grep -E '^#define (OSMAJOR|OSMINOR|OSPLAT) '
+          )
+        EOF
+      '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ja/jam/package.nix
+++ b/pkgs/by-name/ja/jam/package.nix
@@ -87,6 +87,15 @@ stdenv.mkDerivation (finalAttrs: {
       package = finalAttrs.finalPackage;
       command = "jam -v";
     };
+    tests.os = testers.runCommand {
+      name = "${finalAttrs.finalPackage.name}-os";
+      nativeBuildInputs = [ finalAttrs.finalPackage ];
+      script = ''
+        echo 'echo $(OS) ;' > Jamfile
+        os=$(jam -d0)
+        [[ $os != UNKNOWN* ]] && touch $out
+      '';
+    };
   };
 
   meta = {


### PR DESCRIPTION
With std=c89, `linux` is no longer defined, and that's how jam currently determines it's being compiled on linux.

This causes breakage in downstream packages (e.g. `p4`).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
