### PR TITLE
nixos/activation, switch-to-configuration-ng, doc: improve NIXOS_LUSTRATE installation experience

### DIFF
--- a/nixos/doc/manual/installation/installing-from-other-distro.section.md
+++ b/nixos/doc/manual/installation/installing-from-other-distro.section.md
@@ -160,6 +160,18 @@ The first steps to all these are the same:
     Refer to the `nixos-generate-config` step in
     [](#sec-installation) for more information.
 
+    ::: {.note}
+    On [UEFI](https://en.wikipedia.org/wiki/UEFI) systems, check that your `/etc/nixos/hardware-configuration.nix` did the right thing with the [EFI System Partition](https://en.wikipedia.org/wiki/EFI_system_partition).
+    In NixOS, by default, both [systemd-boot](https://systemd.io/BOOT/) and [grub](https://www.gnu.org/software/grub/index.html) expect it to be mounted on `/boot`.
+    However, the configuration generator bases its [](#opt-fileSystems) configuration on the current mount points at the time it is run.
+    If the current system and NixOS's bootloader configuration don't agree on where the [EFI System Partition](https://en.wikipedia.org/wiki/EFI_system_partition) is to be mounted, you'll need to manually alter the mount point in `hardware-configuration.nix` before building the system closure.
+    :::
+
+    ::: {.note}
+    The lustrate process will not work if the [](#opt-boot.initrd.systemd.enable) option is set to `true`.
+    If you want to use this option, wait until after the first boot into the NixOS system to enable it and rebuild.
+    :::
+
     You'll likely want to set a root password for your first boot using
     the configuration files because you won't have a chance to enter a
     password until after you reboot. You can initialize the root password
@@ -231,25 +243,45 @@ The first steps to all these are the same:
     $ echo etc/nixos | sudo tee -a /etc/NIXOS_LUSTRATE
     ```
 
-1.  Finally, move the `/boot` directory of your current distribution out
-    of the way (the lustrate process will take care of the rest once you
-    reboot, but this one must be moved out now because NixOS needs to
-    install its own boot files:
+1.  Finally, install NixOS's boot system, backing up the current boot system's files in the process.
+
+    The details of this step can vary depending on the bootloader configuration in NixOS and the bootloader in use by the current system.
+
+    The commands below should work for:
+
+    - [BIOS](https://en.wikipedia.org/wiki/BIOS) systems.
+
+    - [UEFI](https://en.wikipedia.org/wiki/UEFI) systems where both the current system and NixOS mount the [EFI System Partition](https://en.wikipedia.org/wiki/EFI_system_partition) on `/boot`.
+      Both [systemd-boot](https://systemd.io/BOOT/) and [grub](https://www.gnu.org/software/grub/index.html) expect this by default in NixOS, but other distributions vary.
 
     ::: {.warning}
-    Once you complete this step, your current distribution will no
-    longer be bootable! If you didn't get all the NixOS configuration
-    right, especially those settings pertaining to boot loading and root
-    partition, NixOS may not be bootable either. Have a USB rescue
-    device ready in case this happens.
+    Once you complete this step, your current distribution will no longer be bootable!
+    If you didn't get all the NixOS configuration right, especially those settings pertaining to boot loading and root partition, NixOS may not be bootable either.
+    Have a USB rescue device ready in case this happens.
+    :::
+
+    ::: {.warning}
+    On [UEFI](https://en.wikipedia.org/wiki/UEFI) systems, anything on the [EFI System Partition](https://en.wikipedia.org/wiki/EFI_system_partition) will be removed by these commands, such as other coexisting OS's bootloaders.
     :::
 
     ```ShellSession
-    $ sudo mv -v /boot /boot.bak &&
-    sudo /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+    $ sudo mkdir /boot.bak && sudo mv /boot/* /boot.bak &&
+    sudo NIXOS_INSTALL_BOOTLOADER=1 /nix/var/nix/profiles/system/bin/switch-to-configuration boot
     ```
 
     Cross your fingers, reboot, hopefully you should get a NixOS prompt!
+
+    In other cases, most commonly where the [EFI System Partition](https://en.wikipedia.org/wiki/EFI_system_partition) of the current system is instead mounted on `/boot/efi`, the goal is to:
+
+    - Make sure `/boot` (and the [EFI System Partition](https://en.wikipedia.org/wiki/EFI_system_partition), if mounted elsewhere) are mounted how the NixOS configuration would mount them.
+
+    - Clear them of files related to the current system, backing them up outside of `/boot`.
+      NixOS will move the backups into `/old-root` along with everything else when it first boots.
+
+    - Instruct the NixOS closure built earlier to install its bootloader with:
+      ```ShellSession
+      sudo NIXOS_INSTALL_BOOTLOADER=1 /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+      ```
 
 1.  If for some reason you want to revert to the old distribution,
     you'll need to boot on a USB rescue disk and do something along

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -41,10 +41,6 @@ use Fcntl ':flock';
 my $out = "@out@";
 # System closure path to switch to
 my $toplevel = "@toplevel@";
-# Path to the directory containing systemd tools of the old system
-my $cur_systemd = abs_path("/run/current-system/sw/bin");
-# Path to the systemd store path of the new system
-my $new_systemd = "@systemd@";
 
 # To be robust against interruption, record what units need to be started etc.
 # We read these files again every time this script starts to make sure we continue
@@ -117,6 +113,12 @@ if (($ENV{"NIXOS_NO_SYNC"} // "") ne "1") {
 if ($action eq "boot") {
     exit(0);
 }
+
+# Path to the directory containing systemd tools of the old system
+# Needs to be after the "boot" action exits, as this directory will not exist when doing a NIXOS_LUSTRATE install
+my $cur_systemd = abs_path("/run/current-system/sw/bin");
+# Path to the systemd store path of the new system
+my $new_systemd = "@systemd@";
 
 # Check if we can activate the new configuration.
 my $cur_init_interface_version = read_file("/run/current-system/init-interface-version", err_mode => "quiet") // "";

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -970,10 +970,6 @@ fn do_system_switch(action: Action) -> anyhow::Result<()> {
         std::env::set_var("LOCALE_ARCHIVE", locale_archive);
     }
 
-    let current_system_bin = std::path::PathBuf::from("/run/current-system/sw/bin")
-        .canonicalize()
-        .context("/run/current-system/sw/bin is missing")?;
-
     let os_release = parse_os_release().context("Failed to parse os-release")?;
 
     let distro_id_re = Regex::new(format!("^\"?{}\"?$", distro_id).as_str())
@@ -1032,6 +1028,11 @@ fn do_system_switch(action: Action) -> anyhow::Result<()> {
     if *action == Action::Boot {
         std::process::exit(0);
     }
+
+    // Needs to be after the "boot" action exits, as this directory will not exist when doing a NIXOS_LUSTRATE install
+    let current_system_bin = std::path::PathBuf::from("/run/current-system/sw/bin")
+        .canonicalize()
+        .context("/run/current-system/sw/bin is missing")?;
 
     let current_init_interface_version =
         std::fs::read_to_string("/run/current-system/init-interface-version").unwrap_or_default();


### PR DESCRIPTION
I recently helped a user trying to install nixos via the NIXOS_LUSTRATE method described in the manual, who ran into some rather glaring issues, which have apparently existed for an embarassingly long time without being addressed (#49520), so I took it upon myself to improve the situation.

- Altered `switch-to-configuration.pl` (and `switch-to-configuration-ng`) so that when the action is `boot`, it does not complain when `/run/current-system/sw/bin` does not exist.
- Rewrote the main install step of the relevant section of the manual to:
  - Include the necessary `NIXOS_INSTALL_BOOTLOADER` variable
  - Alter the backup mechanism used in the code block to correctly handle cases where `/boot` is a mount point
  - Explain enough to hopefully handle cases where the given commands won't work verbatim
- Added a note about lustration not working with the systemd initrd.

Closes #49520.

~~Note that I have not actually tested these instructions, and that should definitely happen before merge, but from second-hand reports, it should be correct... hopefully.~~ (now tested)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
