### PR TITLE
nixos/test-driver: fix resource cleanup of vlan/qmp objects

### DIFF
--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -99,7 +99,16 @@ class Driver:
         with self.logger.nested("cleanup"):
             self.race_timer.cancel()
             for machine in self.machines:
-                machine.release()
+                try:
+                    machine.release()
+                except Exception as e:
+                    self.logger.error(f"Error during cleanup of {machine.name}: {e}")
+
+            for vlan in self.vlans:
+                try:
+                    vlan.stop()
+                except Exception as e:
+                    self.logger.error(f"Error during cleanup of vlan{vlan.nr}: {e}")
 
     def subtest(self, name: str) -> Iterator[None]:
         """Group logs under a given test name"""

--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -1234,6 +1234,9 @@ class Machine:
         self.monitor.close()
         self.serial_thread.join()
 
+        if self.qmp_client:
+            self.qmp_client.close()
+
     def run_callbacks(self) -> None:
         for callback in self.callbacks:
             callback()

--- a/nixos/lib/test-driver/test_driver/qmp.py
+++ b/nixos/lib/test-driver/test_driver/qmp.py
@@ -49,7 +49,7 @@ class QMPSession:
         sock.connect(str(path))
         return cls(sock)
 
-    def __del__(self) -> None:
+    def close(self) -> None:
         self.sock.close()
 
     def _wait_for_new_result(self) -> dict[str, str]:

--- a/nixos/lib/test-driver/test_driver/vlan.py
+++ b/nixos/lib/test-driver/test_driver/vlan.py
@@ -59,7 +59,7 @@ class VLan:
 
         self.logger.info(f"running vlan (pid {self.pid}; ctl {self.socket_dir})")
 
-    def __del__(self) -> None:
+    def stop(self) -> None:
         self.logger.info(f"kill vlan (pid {self.pid})")
         self.fd.close()
         self.process.terminate()


### PR DESCRIPTION
Using `__del__` is somewhat unsound to do resource cleanup. In our case the logger already closed its logfile and therefore fails with exception before the rest of the resources can be cleaned up.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
