### PR TITLE
stylelint-lsp: fix script launch issue on macOS

### DIFF
--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -1,5 +1,4 @@
 {
-  bash,
   fetchFromGitHub,
   lib,
   nodejs,
@@ -18,8 +17,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-mzhY6MKkXb1jFYZvs/VkGipBjBfUY3GukICb9qVQI80=";
   };
 
-  nativeBuildInputs = [
+  buildInputs = [
     nodejs
+  ];
+
+  nativeBuildInputs = [
     pnpm_9.configHook
   ];
 
@@ -41,11 +43,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     mkdir -p $out/{bin,lib/${finalAttrs.pname}}
     mv {dist,node_modules} $out/lib/${finalAttrs.pname}
-    echo "
-      #!${lib.getExe bash}
-      ${lib.getExe nodejs} $out/lib/${finalAttrs.pname}/dist/index.js \$@
-    " > $out/bin/stylelint-lsp
-    chmod +x $out/bin/stylelint-lsp
+    chmod a+x $out/lib/${finalAttrs.pname}/dist/index.js
+    ln -s $out/lib/${finalAttrs.pname}/dist/index.js $out/bin/stylelint-lsp
 
     runHook postInstall
   '';


### PR DESCRIPTION
A leading space before the shebang doesn't affect script execution when run from the shell or via exec on Linux. However, on macOS, it results in an ENOEXEC (File format error) when using exec. This fix removes the space to ensure stylelint-lsp can be launched from nixvim on macOS without errors.

Thanks to @gepbird for suggesting the proper fix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
