### PR TITLE
dashy-ui: init at 3.1.1-unstable-2024-07-14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21751,6 +21751,12 @@
     githubId = 57180880;
     name = "Ansh Tyagi";
   };
+  therealgramdalf = {
+    email = "gramdalftech@gmail.com";
+    github = "TheRealGramdalf";
+    githubId = 79593869;
+    name = "Gramdalf";
+  };
   therealr5 = {
     email = "rouven@rfive.de";
     github = "therealr5";

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -109,6 +109,8 @@
 
 - [Firefly-iii Data Importer](https://github.com/firefly-iii/data-importer), a data importer for Firefly-III. Available as [services.firefly-iii-data-importer](options.html#opt-services.firefly-iii-data-importer.enable).
 
+- [Dashy](https://dashy.to), an open source, highly customizable, easy to use, privacy-respecting dashboard app. Available as [services.dashy](options.html#opt-services.dashy).
+
 - [QGroundControl], a ground station support and configuration manager for the PX4 and APM Flight Stacks. Available as [programs.qgroundcontrol](options.html#opt-programs.qgroundcontrol.enable).
 
 - [Eintopf](https://eintopf.info), a community event and calendar web application. Available as [services.eintopf](options.html#opt-services.eintopf.enable).

--- a/nixos/modules/services/web-apps/dashy.nix
+++ b/nixos/modules/services/web-apps/dashy.nix
@@ -1,0 +1,173 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib.types) package str;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    ;
+  cfg = config.services.dashy;
+in
+{
+  options.services.dashy = {
+    enable = mkEnableOption ''
+      Dashy, a highly customizable, easy to use, privacy-respecting dashboard app.
+
+      Note that this builds a static web app as opposed to running a full node server, unlike the default docker image.
+
+      Writing config changes to disk through the UI, triggering a rebuild through the UI and application status checks are
+      unavailable without the node server; Everything else will work fine.
+
+      See the deployment docs for [building from source](https://dashy.to/docs/deployment#build-from-source), [hosting with a CDN](https://dashy.to/docs/deployment#hosting-with-cdn) and [CDN cloud deploy](https://dashy.to/docs/deployment#cdn--cloud-deploy) for more information.
+    '';
+
+    virtualHost = {
+      enableNginx = mkEnableOption "a virtualhost to serve dashy through nginx";
+
+      domain = mkOption {
+        description = ''
+          Domain to use for the virtual host.
+
+          This can be used to change nginx options like
+          ```nix
+          services.nginx.virtualHosts."$\{config.services.dashy.virtualHost.domain}".listen = [ ... ]
+          ```
+          or
+          ```nix
+          services.nginx.virtualHosts."example.com".listen = [ ... ]
+          ```
+        '';
+        type = str;
+      };
+    };
+
+    package = mkPackageOption pkgs "dashy-ui" { };
+
+    finalDrv = mkOption {
+      readOnly = true;
+      default =
+        if cfg.settings != { } then cfg.package.override { inherit (cfg) settings; } else cfg.package;
+      defaultText = ''
+        if cfg.settings != {}
+        then cfg.package.override {inherit (cfg) settings;}
+        else cfg.package;
+      '';
+      type = package;
+      description = ''
+        Final derivation containing the fully built static files
+      '';
+    };
+
+    settings = mkOption {
+      default = { };
+      description = ''
+        Settings serialized into `user-data/conf.yml` before build.
+        If left empty, the default configuration shipped with the package will be used instead.
+
+        Note that the full configuration will be written to the nix store as world readable, which may include secrets such as [password hashes](https://dashy.to/docs/configuring#appconfigauthusers-optional).
+
+        To add files such as icons or backgrounds, you can reference them in line such as
+        ```nix
+        icon = "$\{./icon.png}";
+        ```
+        This will add the file to the nix store upon build, referencing it by file path as expected by Dashy.
+      '';
+      example = ''
+        {
+          appConfig = {
+            cssThemes = [
+              "example-theme-1"
+              "example-theme-2"
+            ];
+            enableFontAwesome = true;
+            fontAwesomeKey = "e9076c7025";
+            theme = "thebe";
+          };
+          pageInfo = {
+            description = "My Awesome Dashboard";
+            navLinks = [
+              {
+                path = "/";
+                title = "Home";
+              }
+              {
+                path = "https://example.com";
+                title = "Example 1";
+              }
+              {
+                path = "https://example.com";
+                title = "Example 2";
+              }
+            ];
+            title = "Dashy";
+          };
+          sections = [
+            {
+              displayData = {
+                collapsed = true;
+                cols = 2;
+                customStyles = "border: 2px dashed red;";
+                itemSize = "large";
+              };
+              items = [
+                {
+                  backgroundColor = "#0079ff";
+                  color = "#00ffc9";
+                  description = "Source code and documentation on GitHub";
+                  icon = "fab fa-github";
+                  target = "sametab";
+                  title = "Source";
+                  url = "https://github.com/Lissy93/dashy";
+                }
+                {
+                  description = "View currently open issues, or raise a new one";
+                  icon = "fas fa-bug";
+                  title = "Issues";
+                  url = "https://github.com/Lissy93/dashy/issues";
+                }
+                {
+                  description = "Live Demo #1";
+                  icon = "fas fa-rocket";
+                  target = "iframe";
+                  title = "Demo 1";
+                  url = "https://dashy-demo-1.as93.net";
+                }
+                {
+                  description = "Live Demo #2";
+                  icon = "favicon";
+                  target = "newtab";
+                  title = "Demo 2";
+                  url = "https://dashy-demo-2.as93.net";
+                }
+              ];
+              name = "Getting Started";
+            }
+          ];
+        }
+      '';
+      inherit (pkgs.formats.json { }) type;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.nginx = mkIf cfg.virtualHost.enableNginx {
+      enable = true;
+      virtualHosts."${cfg.virtualHost.domain}" = {
+        locations."/" = {
+          root = cfg.finalDrv;
+          tryFiles = "$uri /index.html ";
+        };
+      };
+    };
+  };
+
+  meta.maintainers = [
+    lib.maintainers.therealgramdalf
+  ];
+}

--- a/pkgs/by-name/da/dashy-ui/package.nix
+++ b/pkgs/by-name/da/dashy-ui/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  yarnConfigHook,
+  yarnBuildHook,
+  nodejs,
+  yq-go,
+  settings ? { },
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dashy-ui";
+  # This is like 3.1.1 but the latest working yarn.lock.
+  # All other changes are for docs with the exception of 768d746cbfcf365c58ad1194c5ccc74c14f3ed3a, which simply adds no-referrer meta tag
+  version = "3.1.1-unstable-2024-07-14";
+  src = fetchFromGitHub {
+    owner = "lissy93";
+    repo = "dashy";
+    rev = "0b1af9db483f80323e782e7834da2a337393e111";
+    hash = "sha256-lRJ3lI9UUIaw9GWPEy81Dbf4cu6rClA4VjdWejVQN+g=";
+  };
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-KVAZIBM47yp1NWYc2esvTwfoAev4q7Wgi0c73PUZRNw=";
+  };
+  # - If no settings are passed, use the default config provided by upstream
+  # - Despite JSON being valid YAML (and the JSON passing the config validator),
+  # there seem to be some issues with JSON in the final build - potentially due to
+  # the way the client parses things
+  # - Instead, we use `yq-go` to convert it to yaml
+  # Config validation needs to happen after yarnConfigHook, since it's what sets the yarn offline cache
+  postYarnConfigHook = lib.optional (settings != { }) ''
+    echo "Writing settings override..."
+    yq --output-format yml '${builtins.toFile "conf.json" ''${builtins.toJSON settings}''}' > user-data/conf.yml
+    yarn validate-config --offline
+  '';
+  installPhase = ''
+    mkdir $out
+    cp -R dist/* $out
+  '';
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+    # For yaml parsing
+    yq-go
+  ];
+  doDist = false;
+  meta = {
+    description = "dashy";
+    homepage = "https://dashy.to";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.therealgramdalf ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added a new package, `dashy-ui`. This builds [Dashy](https://dashy.to/), an "...open source, highly customizable, easy to use, privacy-respecting dashboard app." as a static web app (using the new yarnHooks system) as described in the documentation ([1](https://dashy.to/docs/deployment#build-from-source), [2](https://dashy.to/docs/deployment#hosting-with-cdn), [3](https://dashy.to/docs/deployment#cdn--cloud-deploy)). 

The NixOS module overrides the package with settings (written in nix) which are serialized to YAML upon build, and subsequently checked using the config validator provided by upstream. Due to the yarn offline cache, the full build dependencies must be downloaded prior to config validation.
Due to an issue which has been fixed upstream (but not yet included in a release), the `dashy-ui` package was initialized at [0b1af9d](https://github.com/Lissy93/dashy/tree/0b1af9db483f80323e782e7834da2a337393e111); the closest commit to a full release which contained the necessary fix.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux [^1]
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
[^1]: Against nixpkgs `4f807e8940284ad7925ebd0a0993d2a1791acb2f`