### PR TITLE
ncspot: 1.1.2 -> 1.2.0

### DIFF
--- a/pkgs/applications/audio/ncspot/default.nix
+++ b/pkgs/applications/audio/ncspot/default.nix
@@ -1,21 +1,30 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, rustPlatform
-, pkg-config
-, ncurses
-, openssl
-, Cocoa
-, withALSA ? false, alsa-lib
-, withClipboard ? true, libxcb, python3
-, withCover ? false, ueberzug
-, withPulseAudio ? true, libpulseaudio
-, withPortAudio ? false, portaudio
-, withMPRIS ? true, withNotify ? true, dbus
-, withCrossterm ? true
-, nix-update-script
-, testers
-, ncspot
+{
+  lib,
+  stdenv,
+  Cocoa,
+  alsa-lib,
+  dbus,
+  fetchFromGitHub,
+  libpulseaudio,
+  libxcb,
+  ncspot,
+  ncurses,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  portaudio,
+  python3,
+  rustPlatform,
+  testers,
+  ueberzug,
+  withALSA ? false,
+  withClipboard ? true,
+  withCover ? false,
+  withCrossterm ? true,
+  withMPRIS ? true,
+  withNotify ? true,
+  withPortAudio ? false,
+  withPulseAudio ? true,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -31,10 +40,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-JJTnaq0JLWHQxAbDpzDRPi5B+ePlQNlDOAsugPah7j4=";
 
-  nativeBuildInputs = [ pkg-config ]
-    ++ lib.optional withClipboard python3;
+  nativeBuildInputs = [ pkg-config ] ++ lib.optional withClipboard python3;
 
-  buildInputs = [ ncurses ]
+  buildInputs =
+    [ ncurses ]
     ++ lib.optional stdenv.hostPlatform.isLinux openssl
     ++ lib.optional withALSA alsa-lib
     ++ lib.optional withClipboard libxcb
@@ -48,15 +57,16 @@ rustPlatform.buildRustPackage rec {
 
   buildNoDefaultFeatures = true;
 
-  buildFeatures = [ "cursive/pancurses-backend" ]
+  buildFeatures =
+    [ "cursive/pancurses-backend" ]
     ++ lib.optional withALSA "alsa_backend"
     ++ lib.optional withClipboard "share_clipboard"
     ++ lib.optional withCover "cover"
-    ++ lib.optional withPulseAudio "pulseaudio_backend"
-    ++ lib.optional withPortAudio "portaudio_backend"
-    ++ lib.optional withMPRIS "mpris"
     ++ lib.optional withCrossterm "crossterm_backend"
-    ++ lib.optional withNotify "notify";
+    ++ lib.optional withMPRIS "mpris"
+    ++ lib.optional withNotify "notify"
+    ++ lib.optional withPortAudio "portaudio_backend"
+    ++ lib.optional withPulseAudio "pulseaudio_backend";
 
   postInstall = ''
     install -D --mode=444 $src/misc/ncspot.desktop $out/share/applications/${pname}.desktop
@@ -64,8 +74,8 @@ rustPlatform.buildRustPackage rec {
   '';
 
   passthru = {
-    updateScript = nix-update-script { };
     tests.version = testers.testVersion { package = ncspot; };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/nc/ncspot/package.nix
+++ b/pkgs/by-name/nc/ncspot/package.nix
@@ -23,9 +23,14 @@
   withCover ? false,
   withCrossterm ? true,
   withMPRIS ? stdenv.hostPlatform.isLinux,
+  withNcurses ? false,
   withNotify ? true,
+  withPancurses ? false,
   withPortAudio ? stdenv.hostPlatform.isDarwin,
   withPulseAudio ? config.pulseaudio or stdenv.hostPlatform.isLinux,
+  withRodio ? false,
+  withShareSelection ? false,
+  withTermion ? false,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -46,28 +51,33 @@ rustPlatform.buildRustPackage rec {
   buildInputs =
     [ ncurses ]
     ++ lib.optional stdenv.hostPlatform.isLinux openssl
-    ++ lib.optional withALSA alsa-lib
+    ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Cocoa
+    ++ lib.optional (withALSA || withRodio) alsa-lib
     ++ lib.optional withClipboard libxcb
     ++ lib.optional withCover ueberzug
-    ++ lib.optional withPulseAudio libpulseaudio
-    ++ lib.optional withPortAudio portaudio
     ++ lib.optional (withMPRIS || withNotify) dbus
-    ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Cocoa;
+    ++ lib.optional withNcurses ncurses
+    ++ lib.optional withPortAudio portaudio
+    ++ lib.optional withPulseAudio libpulseaudio;
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-DNCURSES_UNCTRL_H_incl";
 
   buildNoDefaultFeatures = true;
 
   buildFeatures =
-    [ "cursive/pancurses-backend" ]
-    ++ lib.optional withALSA "alsa_backend"
+    lib.optional withALSA "alsa_backend"
     ++ lib.optional withClipboard "share_clipboard"
     ++ lib.optional withCover "cover"
     ++ lib.optional withCrossterm "crossterm_backend"
     ++ lib.optional withMPRIS "mpris"
+    ++ lib.optional withNcurses "ncurses_backend"
     ++ lib.optional withNotify "notify"
+    ++ lib.optional withPancurses "pancurses_backend"
     ++ lib.optional withPortAudio "portaudio_backend"
-    ++ lib.optional withPulseAudio "pulseaudio_backend";
+    ++ lib.optional withPulseAudio "pulseaudio_backend"
+    ++ lib.optional withRodio "rodio_backend"
+    ++ lib.optional withShareSelection "share_selection"
+    ++ lib.optional withTermion "termion_backend";
 
   postInstall = ''
     install -D --mode=444 $src/misc/ncspot.desktop $out/share/applications/nscpot.desktop

--- a/pkgs/by-name/nc/ncspot/package.nix
+++ b/pkgs/by-name/nc/ncspot/package.nix
@@ -30,16 +30,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ncspot";
-  version = "1.1.2";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "hrkfdn";
     repo = "ncspot";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Lt2IuoiXYgSVPi4u8y16u9m5ya4HdpQme6snvNJrwso=";
+    hash = "sha256-FI/MZRxTyYWh+CWq3roO6d48xlPsyL58+euGmCZ8p4Y=";
   };
 
-  cargoHash = "sha256-JJTnaq0JLWHQxAbDpzDRPi5B+ePlQNlDOAsugPah7j4=";
+  cargoHash = "sha256-Jg/P6aaMlgpunYd30eoBt1leL0vgEBn2wNRGZsP4abc=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optional withClipboard python3;
 

--- a/pkgs/by-name/nc/ncspot/package.nix
+++ b/pkgs/by-name/nc/ncspot/package.nix
@@ -94,7 +94,10 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/hrkfdn/ncspot";
     changelog = "https://github.com/hrkfdn/ncspot/releases/tag/v${version}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ liff ];
+    maintainers = with lib.maintainers; [
+      liff
+      getchoo
+    ];
     mainProgram = "ncspot";
   };
 }

--- a/pkgs/by-name/nc/ncspot/package.nix
+++ b/pkgs/by-name/nc/ncspot/package.nix
@@ -1,8 +1,9 @@
 {
   lib,
   stdenv,
-  Cocoa,
   alsa-lib,
+  config,
+  darwin,
   dbus,
   fetchFromGitHub,
   libpulseaudio,
@@ -17,14 +18,14 @@
   rustPlatform,
   testers,
   ueberzug,
-  withALSA ? false,
+  withALSA ? stdenv.hostPlatform.isLinux,
   withClipboard ? true,
   withCover ? false,
   withCrossterm ? true,
-  withMPRIS ? true,
+  withMPRIS ? stdenv.hostPlatform.isLinux,
   withNotify ? true,
-  withPortAudio ? false,
-  withPulseAudio ? true,
+  withPortAudio ? stdenv.hostPlatform.isDarwin,
+  withPulseAudio ? config.pulseaudio or stdenv.hostPlatform.isLinux,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -51,7 +52,7 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional withPulseAudio libpulseaudio
     ++ lib.optional withPortAudio portaudio
     ++ lib.optional (withMPRIS || withNotify) dbus
-    ++ lib.optional stdenv.hostPlatform.isDarwin Cocoa;
+    ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Cocoa;
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-DNCURSES_UNCTRL_H_incl";
 

--- a/pkgs/by-name/nc/ncspot/package.nix
+++ b/pkgs/by-name/nc/ncspot/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "hrkfdn";
     repo = "ncspot";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-Lt2IuoiXYgSVPi4u8y16u9m5ya4HdpQme6snvNJrwso=";
   };
 
@@ -70,8 +70,8 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional withPulseAudio "pulseaudio_backend";
 
   postInstall = ''
-    install -D --mode=444 $src/misc/ncspot.desktop $out/share/applications/${pname}.desktop
-    install -D --mode=444 $src/images/logo.svg $out/share/icons/hicolor/scalable/apps/${pname}.png
+    install -D --mode=444 $src/misc/ncspot.desktop $out/share/applications/nscpot.desktop
+    install -D --mode=444 $src/images/logo.svg $out/share/icons/hicolor/scalable/apps/nscpot.png
   '';
 
   passthru = {
@@ -79,12 +79,12 @@ rustPlatform.buildRustPackage rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cross-platform ncurses Spotify client written in Rust, inspired by ncmpc and the likes";
     homepage = "https://github.com/hrkfdn/ncspot";
     changelog = "https://github.com/hrkfdn/ncspot/releases/tag/v${version}";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ liff ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ liff ];
     mainProgram = "ncspot";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31483,15 +31483,6 @@ with pkgs;
 
   ncdu_1 = callPackage ../tools/misc/ncdu/1.nix { };
 
-  ncspot = callPackage ../applications/audio/ncspot {
-    inherit (darwin.apple_sdk.frameworks) Cocoa;
-
-    withALSA = stdenv.hostPlatform.isLinux;
-    withPulseAudio = config.pulseaudio or stdenv.hostPlatform.isLinux;
-    withPortAudio = stdenv.hostPlatform.isDarwin;
-    withMPRIS = stdenv.hostPlatform.isLinux;
-  };
-
   ncview = callPackage ../tools/X11/ncview { } ;
 
   ne = callPackage ../applications/editors/ne { };


### PR DESCRIPTION
Most notably this fixes the "Bad credentials" login [issue](https://www.github.com/hrkfdn/ncspot/issues/1500)

Diff: https://github.com/hrkfdn/ncspot/compare/refs/tags/v1.1.2...v1.2.0

Changelog: https://github.com/hrkfdn/ncspot/releases/tag/v1.2.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
