### PR TITLE
nixedit: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ni/nixedit/package.nix
+++ b/pkgs/by-name/ni/nixedit/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     homepage = "https://github.com/fndov/nixedit";
-    description = "A NixOS Multipurpose CLI/TUI Utility";
+    description = "NixOS Multipurpose CLI/TUI Utility";
     license = licenses.gpl3;
     mainProgram = "nixedit";
     maintainers = [ maintainers.miyu ];

--- a/pkgs/by-name/ni/nixedit/package.nix
+++ b/pkgs/by-name/ni/nixedit/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installPhase = ''
+    runHook reInstall
+
     mkdir -p $out/bin
 
     # Move the script
@@ -48,12 +50,14 @@ stdenv.mkDerivation (finalAttrs: {
     # Ensure it is executable
     chmod +x $out/bin/nixedit
 
-    # Wrap nixedit to include the necessary dependencies in PATH
-    wrapProgram $out/bin/nixedit --prefix PATH : \
-      "${lib.makeBinPath finalAttrs.buildInputs}"
+    runHook postInstall
   '';
 
-  doInstallCheck = true;
+  postFixup = ''
+    wrapProgram $out/bin/nixedit \
+      --prefix PATH : "${lib.makeBinPath finalAttrs.buildInputs}"
+  '';
+
   installCheckPhase = ''
     if ! uname -a | grep "NixOS" > /dev/null; then
       echo "This package can only be installed on NixOS."
@@ -69,5 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3;
     mainProgram = "nixedit";
     maintainers = [ maintainers.miyu ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ni/nixedit/package.nix
+++ b/pkgs/by-name/ni/nixedit/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "NixOS Multipurpose CLI/TUI Utility";
     license = licenses.gpl3;
     mainProgram = "nixedit";
-    maintainers = [ maintainers.miyu ];
+    maintainers = with maintainers; [ miyu ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ni/nixedit/package.nix
+++ b/pkgs/by-name/ni/nixedit/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bash,
+  fzf,
+  jq,
+  micro,
+  git,
+  nix-tree,
+  coreutils,
+  makeWrapper,
+  dialog,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nixedit";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "fndov";
+    repo = "nixedit";
+    rev = "72b7ca8933efbf0d4295b7c7704eac2fb66d9b69";
+    hash = "sha256-MUFzvb+pSNWQ1bKd15zaJt+0Z2aUg/7zeOdUH4GJRmk=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    bash
+    fzf
+    jq
+    micro
+    git
+    nix-tree
+    coreutils
+    dialog
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    # Move the script
+    mv src/nixedit.sh $out/bin/nixedit
+
+    # Ensure it is executable
+    chmod +x $out/bin/nixedit
+
+    # Wrap nixedit to include the necessary dependencies in PATH
+    wrapProgram $out/bin/nixedit --prefix PATH : \
+      "${lib.makeBinPath finalAttrs.buildInputs}"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    if ! uname -a | grep "NixOS" > /dev/null; then
+      echo "This package can only be installed on NixOS."
+      exit 1
+    fi
+
+    $out/bin/nixedit --help > /dev/null
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/fndov/nixedit";
+    description = "A NixOS Multipurpose CLI/TUI Utility";
+    license = licenses.gpl3;
+    mainProgram = "nixedit";
+    maintainers = [ maintainers.miyu ];
+  };
+})

--- a/pkgs/by-name/ni/nixedit/package.nix
+++ b/pkgs/by-name/ni/nixedit/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installCheckPhase = ''
-
     $out/bin/nixedit --help > /dev/null
   '';
 

--- a/pkgs/by-name/ni/nixedit/package.nix
+++ b/pkgs/by-name/ni/nixedit/package.nix
@@ -59,10 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installCheckPhase = ''
-    if ! uname -a | grep "NixOS" > /dev/null; then
-      echo "This package can only be installed on NixOS."
-      exit 1
-    fi
 
     $out/bin/nixedit --help > /dev/null
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
A NixOS Multipurpose CLI/TUI Utility. https://github.com/fndov/nixedit

I have created a new PR that only contains one commit, as requested.

Merge ready.

@drupol 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
