### PR TITLE
Mark pkgs.av-98 and python3Packages.ansiwrap as broken

### DIFF
--- a/pkgs/applications/networking/browsers/av-98/default.nix
+++ b/pkgs/applications/networking/browsers/av-98/default.nix
@@ -1,6 +1,9 @@
-{ lib, python3Packages, fetchgit }:
-
-python3Packages.buildPythonApplication rec {
+{
+  lib,
+  python3Packages,
+  fetchgit,
+}:
+python3Packages.buildPythonApplication {
   pname = "av-98";
   version = "1.0.2dev";
 
@@ -10,7 +13,10 @@ python3Packages.buildPythonApplication rec {
     sha256 = "09iskh33hl5aaif763j1fmbz7yvf0yqsxycfd41scj7vbwdsbxl0";
   };
 
-  propagatedBuildInputs = with python3Packages; [ ansiwrap cryptography ];
+  propagatedBuildInputs = with python3Packages; [
+    ansiwrap
+    cryptography
+  ];
 
   # No tests are available
   doCheck = false;
@@ -22,5 +28,7 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "av98";
     license = licenses.bsd2;
     maintainers = with maintainers; [ ehmry ];
+
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/ansiwrap/default.nix
+++ b/pkgs/development/python-modules/ansiwrap/default.nix
@@ -9,7 +9,6 @@
   setuptools,
   textwrap3,
 }:
-
 buildPythonPackage rec {
   pname = "ansiwrap";
   version = "0.8.4";
@@ -47,5 +46,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/jonathaneunice/ansiwrap/blob/master/CHANGES.yml";
     license = licenses.asl20;
     maintainers = [ ];
+
+    broken = true;
   };
 }


### PR DESCRIPTION
`av-98` fails to evaluate because `ansiwrap` isn't able to work for python 3.12. This was confirmed by removing the version check within the derivation itself. Furthermore, upstream for this module seems completely unmaintained, with the last commit being 6 years ago.

There were no other references to `ansiwrap` or `av-98` across the nix codebase, and since it doesn't build anyways, I think it's a good idea to mark as broken.

cc @ehmry as the maintainer of av-98 for input.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
