### PR TITLE
python3Packages.taskw: fix failing build

### DIFF
--- a/pkgs/development/python-modules/bugzilla/default.nix
+++ b/pkgs/development/python-modules/bugzilla/default.nix
@@ -3,19 +3,20 @@
   buildPythonPackage,
   fetchPypi,
   requests,
+  responses,
   pytestCheckHook,
   glibcLocalesUtf8,
 }:
 
 buildPythonPackage rec {
   pname = "bugzilla";
-  version = "3.2.0";
+  version = "3.3.0";
   format = "setuptools";
 
   src = fetchPypi {
-    pname = "python-${pname}";
+    pname = "python_${pname}";
     inherit version;
-    sha256 = "TvyM+il4N8nk6rIg4ZcXZxW9Ye4zzsLBsPJ5DweGA4c=";
+    sha256 = "sha256-4YIgFx4DPrO6YAxNE5NZ0BqhrOwdrrxDCJEORQdj3kc=";
   };
 
   propagatedBuildInputs = [ requests ];
@@ -23,6 +24,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     glibcLocalesUtf8
+    responses
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/taskw/default.nix
+++ b/pkgs/development/python-modules/taskw/default.nix
@@ -2,13 +2,13 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonAtLeast,
 
   # build-system
   setuptools,
 
   # native dependencies
   taskwarrior2,
+  distutils,
 
   # dependencies
   kitchen,
@@ -23,9 +23,6 @@ buildPythonPackage rec {
   pname = "taskw";
   version = "2.0.0";
   pyproject = true;
-
-  # ModuleNotFoundError: No module named 'distutils'
-  disabled = pythonAtLeast "3.12";
 
   src = fetchPypi {
     inherit pname version;
@@ -44,7 +41,10 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  buildInputs = [ taskwarrior2 ];
+  buildInputs = [
+    taskwarrior2
+    distutils
+  ];
 
   dependencies = [
     kitchen


### PR DESCRIPTION
This is part of fixing `pkgs.calcure`, which was failing due to `taskw` not having distutils available (because Python 3.12 shenanigans).

`python3Packages.bugzilla` was bumped due to an error in the test case, which was reported back in 2019 as being an issue. I assume it was just a regression.

cc @nbp as maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
