### PR TITLE
clouddrive2: init at 0.7.21

### DIFF
--- a/pkgs/by-name/cl/clouddrive2/package.nix
+++ b/pkgs/by-name/cl/clouddrive2/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  versionCheckHook,
+}:
+let
+  os = if stdenv.hostPlatform.isDarwin then "macos" else "linux";
+  arch = if stdenv.hostPlatform.isAarch64 then "aarch64" else "x86_64";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "clouddrive2";
+  version = "0.7.21";
+
+  src = fetchurl {
+    url = "https://github.com/cloud-fs/cloud-fs.github.io/releases/download/v${finalAttrs.version}/clouddrive-2-${os}-${arch}-${finalAttrs.version}.tgz";
+    hash =
+      {
+        x86_64-linux = "sha256-U8th7cEAFDBg+CV6DEX0YnqaM2+NJNKmyA/IRtnWESo=";
+        aarch64-linux = "sha256-LaAVO4p0sSfsGmFPSzly1Hzo+t4oY6mgaTdnHrhu0vI=";
+        x86_64-darwin = "sha256-/cyLcX7A+WpuS6yciqAz3jvDIJvXEoyQyX+xe6+eRmE=";
+        aarch64-darwin = "sha256-Y5cKIHVzX0TjMNZGW3YvU8MNpuGsIjp4qNlB+b2BRJM=";
+      }
+      .${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/opt/clouddrive2
+    cp -r wwwroot "$out/opt/clouddrive2/wwwroot"
+    cp -r clouddrive "$out/opt/clouddrive2/clouddrive"
+    makeWrapper $out/opt/clouddrive2/clouddrive $out/bin/clouddrive
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckPhaseInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    homepage = "https://www.clouddrive2.com";
+    changelog = "https://github.com/cloud-fs/cloud-fs.github.io/releases/tag/v${finalAttrs.version}";
+    description = "Multi-cloud drives management tool supporting mounting cloud drives locally";
+    longDescription = ''
+      CloudDrive is a powerful multi-cloud drive management tool that provides a multi-cloud
+      drive solution that includes local mounting of cloud drives. It supports lots of cloud
+      drives in China.
+    '';
+    mainProgram = "clouddrive";
+    license = lib.licenses.unfree;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ ltrump ];
+  };
+})

--- a/pkgs/by-name/cl/clouddrive2/update.sh
+++ b/pkgs/by-name/cl/clouddrive2/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl coreutils jq common-updater-scripts
+
+latestTag=$(curl -sSfL ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/cloud-fs/cloud-fs.github.io/releases/latest | jq -r ".tag_name")
+latestVersion="$(expr "$latestTag" : 'v\(.*\)')"
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; clouddrive2.version" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+for i in \
+    "x86_64-linux linux-x86_64" \
+    "aarch64-linux linux-aarch64" \
+    "x86_64-darwin macos-x86_64" \
+    "aarch64-darwin macos-aarch64"; do
+    set -- $i
+    prefetch=$(nix-prefetch-url "https://github.com/cloud-fs/cloud-fs.github.io/releases/download/v$latestVersion/clouddrive-2-$2-$latestVersion.tgz")
+    hash=$(nix-hash --type sha256 --to-sri $prefetch)
+
+    update-source-version clouddrive2 $latestVersion $hash --system=$1 --ignore-same-version
+done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Clouddrive2 is a multi-cloud drives management tool supporting mounting cloud drives locally. It supports lots of cloud drives in China.

Homepage: https://www.clouddrive2.com

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
