### PR TITLE
rambox: fix hash

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -6,7 +6,7 @@ let
 
   src = fetchurl {
     url = "https://github.com/ramboxapp/download/releases/download/v${version}/Rambox-${version}-linux-x64.AppImage";
-    hash = "sha256-pm4Ji1gv5vNMgB9ZWNKMLZSUE9wBklQ/MnFOKHP+Rcc=";
+    hash = "sha256-x9GDiSkkO0zYx/veB6xSr6/9/SW6JRTGAASlvWd/P0c=";
   };
 
   desktopItem = (makeDesktopItem {


### PR DESCRIPTION
I updated the hash with the one mentioned for rambox 2.4.0. I didn't checked, what has changed on rambox though (and why there's a hash mismatch for this version).

```
home-manager switch --flake .
warning: Git tree '/home/blaschke/nixos-config' is dirty
warning: Git tree '/home/blaschke/nixos-config' is dirty
warning: Git tree '/home/blaschke/nixos-config' is dirty
warning: Git tree '/home/blaschke/nixos-config' is dirty
error: hash mismatch in fixed-output derivation '/nix/store/8a2rrqh5sqwkgih9i68rfhkihwfaal3b-Rambox-2.4.0-linux-x64.AppImage.drv':
         specified: sha256-pm4Ji1gv5vNMgB9ZWNKMLZSUE9wBklQ/MnFOKHP+Rcc=
            got:    sha256-x9GDiSkkO0zYx/veB6xSr6/9/SW6JRTGAASlvWd/P0c=
error: 1 dependencies of derivation '/nix/store/ixxv83v52d7y49rcwy17a7vm8nm6rvf3-rambox-2.4.0-extracted.drv' failed to build
error: 1 dependencies of derivation '/nix/store/m56xypr32lri9hgr77ismcm8jyj1q7jy-rambox-2.4.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/10ivjyygh78pnyx8xski1h2dsigff8f0-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/fhd7rv7mgnwjdgbgs92fgk1nxj7j5rjx-man-paths.drv' failed to build
error: 1 dependencies of derivation '/nix/store/c4h05ipafpgm0xj048fy55fhh69hwp6l-rambox-2.4.0-fish-completions.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8nqyya3w5l3dlkpbpxpxhhlb32c4lp2k-home-manager-generation.drv' failed to build
```