### PR TITLE
halide: 16.0.0 -> 18.0.0

### DIFF
--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -1,17 +1,18 @@
-{ stdenv
-, llvmPackages
-, lib
-, fetchFromGitHub
-, cmake
-, libffi
-, libpng
-, libjpeg
-, mesa
-, libGL
-, eigen
-, openblas
-, blas
-, lapack
+{
+  stdenv,
+  llvmPackages,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  libffi,
+  libpng,
+  libjpeg,
+  mesa,
+  libGL,
+  eigen,
+  openblas,
+  blas,
+  lapack,
 }:
 
 assert blas.implementation == "openblas" && lapack.implementation == "openblas";
@@ -27,29 +28,30 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-lJQrXkJgBmGb/QMSxwuPkkHOSgEDowLWzIolp1km2Y8=";
   };
 
-  postPatch = ''
-    # See https://github.com/halide/Halide/issues/7785
-    substituteInPlace 'src/runtime/HalideRuntime.h' \
-      --replace '#if defined(__x86_64__) || defined(__i386__) || defined(__arm__) || defined(__aarch64__)
-    #define HALIDE_CPP_COMPILER_HAS_FLOAT16' \
-                '#if defined(__x86_64__) || defined(__i386__)
-    #define HALIDE_CPP_COMPILER_HAS_FLOAT16'
-  ''
-  # Note: on x86_64-darwin, clang fails to find AvailabilityVersions.h, so we remove it.
-  # Halide uses AvailabilityVersions.h and TargetConditionals.h to determine whether
-  # ::aligned_alloc is available. For us, it isn't.
-  + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
-    substituteInPlace 'src/runtime/HalideBuffer.h' \
-      --replace '#ifdef __APPLE__
-    #include <AvailabilityVersions.h>
-    #include <TargetConditionals.h>
-    #endif' \
-                ' ' \
-      --replace 'TARGET_OS_OSX && (__MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_15)' \
-                '1' \
-      --replace 'TARGET_OS_IPHONE && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_14_0)' \
-                '0'
-  '';
+  postPatch =
+    ''
+      # See https://github.com/halide/Halide/issues/7785
+      substituteInPlace 'src/runtime/HalideRuntime.h' \
+        --replace '#if defined(__x86_64__) || defined(__i386__) || defined(__arm__) || defined(__aarch64__)
+      #define HALIDE_CPP_COMPILER_HAS_FLOAT16' \
+                  '#if defined(__x86_64__) || defined(__i386__)
+      #define HALIDE_CPP_COMPILER_HAS_FLOAT16'
+    ''
+    # Note: on x86_64-darwin, clang fails to find AvailabilityVersions.h, so we remove it.
+    # Halide uses AvailabilityVersions.h and TargetConditionals.h to determine whether
+    # ::aligned_alloc is available. For us, it isn't.
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
+      substituteInPlace 'src/runtime/HalideBuffer.h' \
+        --replace '#ifdef __APPLE__
+      #include <AvailabilityVersions.h>
+      #include <TargetConditionals.h>
+      #endif' \
+                  ' ' \
+        --replace 'TARGET_OS_OSX && (__MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_15)' \
+                  '1' \
+        --replace 'TARGET_OS_IPHONE && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_14_0)' \
+                  '0'
+    '';
 
   cmakeFlags = [
     "-DWARNINGS_AS_ERRORS=OFF"
@@ -74,20 +76,22 @@ stdenv.mkDerivation rec {
   # Note: only openblas and not atlas part of this Nix expression
   # see pkgs/development/libraries/science/math/liblapack/3.5.0.nix
   # to get a hint howto setup atlas instead of openblas
-  buildInputs = [
-    llvmPackages.llvm
-    llvmPackages.lld
-    llvmPackages.openmp
-    llvmPackages.libclang
-    libffi
-    libpng
-    libjpeg
-    eigen
-    openblas
-  ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    mesa
-    libGL
-  ];
+  buildInputs =
+    [
+      llvmPackages.llvm
+      llvmPackages.lld
+      llvmPackages.openmp
+      llvmPackages.libclang
+      libffi
+      libpng
+      libjpeg
+      eigen
+      openblas
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      mesa
+      libGL
+    ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -96,6 +100,10 @@ stdenv.mkDerivation rec {
     homepage = "https://halide-lang.org";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ck3d atila twesterhout ];
+    maintainers = with maintainers; [
+      ck3d
+      atila
+      twesterhout
+    ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8387,7 +8387,7 @@ with pkgs;
   halibut = callPackage ../tools/typesetting/halibut { };
 
   halide = callPackage ../development/compilers/halide {
-    llvmPackages = llvmPackages_16;
+    llvmPackages = llvmPackages_18;
   };
 
   hareThirdParty = recurseIntoAttrs (callPackage ./hare-third-party.nix { });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5562,6 +5562,8 @@ self: super: with self; {
 
   hakuin = callPackage ../development/python-modules/hakuin { };
 
+  halide = toPythonModule (pkgs.halide.override { pythonSupport = true; python3Packages = self; });
+
   halo = callPackage ../development/python-modules/halo { };
 
   halohome = callPackage ../development/python-modules/halohome { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Updates Halide C++ library from version 16 to version 18.
- Adds support for using Halide from Python.

Supercedes #291572 and #340106.

- The reason that #291572 wasn't merged at the time was that halide didn't compile on darwin. This is fixed in the current PR.
- #340106 messed up the branches a bit and generated some conflicts with master. This is also addressed in the current PR.

----

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
