### PR TITLE
libcpr: 1.10.5 -> 1.11.0

### DIFF
--- a/pkgs/by-name/in/influxdb-cxx/package.nix
+++ b/pkgs/by-name/in/influxdb-cxx/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, boost, catch2_3, libcpr, trompeloeil }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, boost, catch2_3, libcpr_1_10_5, trompeloeil }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "influxdb-cxx";
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ boost libcpr ]
+  buildInputs = [ boost libcpr_1_10_5 ]
     ++ lib.optionals finalAttrs.finalPackage.doCheck [ catch2_3 trompeloeil ];
 
   cmakeFlags = [

--- a/pkgs/by-name/li/libcpr/package.nix
+++ b/pkgs/by-name/li/libcpr/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  curl,
+  staticOnly ? stdenv.hostPlatform.isStatic,
+}:
+
+let
+  version = "1.11.0";
+in
+stdenv.mkDerivation {
+  pname = "libcpr";
+  inherit version;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "libcpr";
+    repo = "cpr";
+    rev = version;
+    hash = "sha256-jWyss0krj8MVFqU1LAig+4UbXO5pdcWIT+hCs9DxemM=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  propagatedBuildInputs = [ curl ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if staticOnly then "OFF" else "ON"}"
+    "-DCPR_USE_SYSTEM_CURL=ON"
+  ];
+
+  postPatch = ''
+    # Linking with stdc++fs is no longer necessary.
+    sed -i '/stdc++fs/d' include/CMakeLists.txt
+  '';
+
+  postInstall = ''
+    substituteInPlace "$out/lib/cmake/cpr/cprTargets.cmake" \
+      --replace "_IMPORT_PREFIX \"$out\"" \
+                "_IMPORT_PREFIX \"$dev\""
+  '';
+
+  meta = with lib; {
+    description = "C++ wrapper around libcurl";
+    homepage = "https://docs.libcpr.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rycee ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/li/libcpr_1_10_5/package.nix
+++ b/pkgs/by-name/li/libcpr_1_10_5/package.nix
@@ -1,11 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, cmake, curl }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  curl,
+}:
 
-let version = "1.10.5"; in
+let
+  version = "1.10.5";
+in
 stdenv.mkDerivation {
   pname = "libcpr";
   inherit version;
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   src = fetchFromGitHub {
     owner = "libcpr";
@@ -18,9 +29,7 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [ curl ];
 
-  cmakeFlags = [
-    "-DCPR_USE_SYSTEM_CURL=ON"
-  ];
+  cmakeFlags = [ "-DCPR_USE_SYSTEM_CURL=ON" ];
 
   postPatch = ''
     # Linking with stdc++fs is no longer necessary.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20667,8 +20667,6 @@ with pkgs;
 
   libcomps = callPackage ../tools/package-management/libcomps { python = python3; };
 
-  libcpr = callPackage ../development/libraries/libcpr { };
-
   libcredis = callPackage ../development/libraries/libcredis { };
 
   libctb = callPackage ../development/libraries/libctb { };


### PR DESCRIPTION
## Things done

Also introduce `libcpr_1_10_5` for use by influxdb-cxx, which is incompatible with the new version. The 1.10.5 is to be removed when influxdb-cxx is updated.

This PR replaces #348271.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
