### PR TITLE
nixos/restic: refactor for rfc42

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -176,6 +176,23 @@
 
 - The systemd target `kbrequest.target` is now unset by default, instead of being forcibly symlinked to `rescue.target`. In case you were relying on this behavior (Alt + ArrowUp on the tty causing the current target to be changed to `rescue.target`), you can restore it by setting `systemd.targets.rescue.aliases = [ "kbrequest.target" ];` in your configuration.
 
+- The NixOS `services.restic` module has received an overhaul to fit [RFC42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md). Most of Restic is configurable with environment variables, so now you can specify those environment variables verbatim in `settings` option.
+
+Most Restic-related options can be configured via `settings`, but no all of them. In particular, things like backup `paths` and `exclude` patterns can't be specified in `settings` due to a limitation in Restic. Also, extended options that can be specified with `extraOptions` don't have corresponding environment variables; for that reason, they are untouched.
+
+Due to a technical limitation in Nixpkgs, automatic migration is not possible. You will have to migrate manually. The migration path looks like this:
+
+- `services.restic.backups.foo.passwordFile -> services.restic.backups.foo.settings.RESTIC_PASSWORD_FILE`
+- `services.restic.backups.foo.repository -> services.restic.backups.foo.settings.RESTIC_REPOSITORY`
+- `services.restic.backups.foo.repositoryFile -> services.restic.backups.foo.settings.RESTIC_REPOSITORY_FILE`
+- `services.restic.backups.foo.progressFps -> services.restic.backups.foo.settings.RESTIC_PROGRESS_FPS`
+
+Rclone subsystem is also now configured via `settings`. Here's the migration path:
+
+- `services.restic.backups.foo.rcloneOptions -> services.restic.backups.foo.settings`. `rcloneOptions` can be converted to `settings` by replacing `-` with `_`, making all letters uppercase and prefixing them with `RCLONE_`. For example, `rcloneOptions.drive-use-trash = "true"` becomes `settings.RCLONE_DRIVE_USE_TRASH = "true"`.
+- `services.restic.backups.foo.rcloneConfig -> services.restic.backups.foo.settings`. `rcloneConfig` can be converted to `settings` by making all letters uppercase and prefixing them with `RCLONE_`. For example, `rcloneOptions.hard_delete = true` becomes `settings.RCLONE_HARD_DELETE = "true"`.
+- `services.restic.backups.foo.rcloneConfigFile -> services.restic.backups.foo.settings.RCLONE_CONFIG`
+
 ## Other Notable Changes {#sec-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->


### PR DESCRIPTION
RFC42-ifies `restic` module, as much as Restic currently allows. See #144575.

Due to a limitation of Nixpkgs submodule system, this is a breaking change. `mkRenamedOptionModule` can't be used with `attrsOf` submodules, so assertions are used instead, which throws. See #96006.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
