### PR TITLE
python3Packages: remove all usage of pytest-cov in builds

### DIFF
--- a/pkgs/development/python-modules/clickclick/default.nix
+++ b/pkgs/development/python-modules/clickclick/default.nix
@@ -7,7 +7,7 @@
   pyyaml,
   six,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
   propagatedBuildInputs = [
     flake8

--- a/pkgs/development/python-modules/dbus-next/default.nix
+++ b/pkgs/development/python-modules/dbus-next/default.nix
@@ -6,7 +6,7 @@
   setuptools,
   dbus,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-asyncio,
   pytest-timeout,
 }:
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     dbus
     pytest
-    pytest-cov
+    pytest-cov-stub
     pytest-asyncio
     pytest-timeout
   ];

--- a/pkgs/development/python-modules/echo/default.nix
+++ b/pkgs/development/python-modules/echo/default.nix
@@ -11,7 +11,7 @@
   qtpy,
   pyqt6,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "echo" ];

--- a/pkgs/development/python-modules/fairscale/default.nix
+++ b/pkgs/development/python-modules/fairscale/default.nix
@@ -11,7 +11,7 @@
   # check inputs
   pytestCheckHook,
   parameterized,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-timeout,
   remote-pdb,
 }:
@@ -51,7 +51,7 @@ buildPythonPackage {
   nativeCheckInputs = [
     pytestCheckHook
     parameterized
-    pytest-cov
+    pytest-cov-stub
     pytest-timeout
     remote-pdb
   ];

--- a/pkgs/development/python-modules/fast-histogram/default.nix
+++ b/pkgs/development/python-modules/fast-histogram/default.nix
@@ -10,7 +10,7 @@
   numpy,
   wheel,
   hypothesis,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     hypothesis
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pytestFlagsArray = [ "${builtins.placeholder "out"}/${python.sitePackages}" ];

--- a/pkgs/development/python-modules/flufl/lock.nix
+++ b/pkgs/development/python-modules/flufl/lock.nix
@@ -5,7 +5,7 @@
   fetchPypi,
   hatchling,
   psutil,
-  pytest-cov,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   sybil,
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     sybil
   ];
 

--- a/pkgs/development/python-modules/googlemaps/default.nix
+++ b/pkgs/development/python-modules/googlemaps/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pytest-cov,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   requests,
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ requests ];
 
   nativeCheckInputs = [
-    pytest-cov
+    pytest-cov-stub
     pytestCheckHook
     responses
   ];

--- a/pkgs/development/python-modules/gunicorn/default.nix
+++ b/pkgs/development/python-modules/gunicorn/default.nix
@@ -17,7 +17,7 @@
   setproctitle,
 
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -50,7 +50,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   meta = {

--- a/pkgs/development/python-modules/haystack-ai/default.nix
+++ b/pkgs/development/python-modules/haystack-ai/default.nix
@@ -42,7 +42,7 @@
   pylint,
   pytest,
   pytest-asyncio,
-  pytest-cov,
+  pytest-cov-stub,
   # , pytest-custom-exit-code
   python-multipart,
   reno,
@@ -167,7 +167,7 @@ buildPythonPackage rec {
       pylint
       pytest
       pytest-asyncio
-      pytest-cov
+      pytest-cov-stub
       # pytest-custom-exit-code
       python-multipart
       reno

--- a/pkgs/development/python-modules/injector/default.nix
+++ b/pkgs/development/python-modules/injector/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   typing-extensions,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "injector" ];

--- a/pkgs/development/python-modules/iocapture/default.nix
+++ b/pkgs/development/python-modules/iocapture/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   flexmock,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   six,
 }:
 
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     flexmock
     pytest
-    pytest-cov
+    pytest-cov-stub
     six
   ];
 

--- a/pkgs/development/python-modules/ipfshttpclient/default.nix
+++ b/pkgs/development/python-modules/ipfshttpclient/default.nix
@@ -8,7 +8,7 @@
   py-multiaddr,
   requests,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-dependency,
   pytest-localserver,
   pytest-mock,
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     pytest-dependency
     pytest-localserver
     pytest-mock

--- a/pkgs/development/python-modules/isbnlib/default.nix
+++ b/pkgs/development/python-modules/isbnlib/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   setuptools,
 }:
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pytestFlagsArray = [ "isbnlib/test/" ];

--- a/pkgs/development/python-modules/jwt/default.nix
+++ b/pkgs/development/python-modules/jwt/default.nix
@@ -6,7 +6,7 @@
   cryptography,
   freezegun,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     freezegun
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "jwt" ];

--- a/pkgs/development/python-modules/monero/default.nix
+++ b/pkgs/development/python-modules/monero/default.nix
@@ -9,7 +9,7 @@
   six,
   varint,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   responses,
 }:
 
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     responses
   ];
 

--- a/pkgs/development/python-modules/pettingzoo/default.nix
+++ b/pkgs/development/python-modules/pettingzoo/default.nix
@@ -17,7 +17,7 @@
   pre-commit,
   pynput,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-markdown-docs,
   pytest-xdist,
   pytestCheckHook,
@@ -87,7 +87,7 @@ buildPythonPackage rec {
       pre-commit
       pynput
       pytest
-      pytest-cov
+      pytest-cov-stub
       pytest-markdown-docs
       pytest-xdist
     ];

--- a/pkgs/development/python-modules/pgmpy/default.nix
+++ b/pkgs/development/python-modules/pgmpy/default.nix
@@ -20,7 +20,7 @@
 
   # tests
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   coverage,
   mock,
   black,
@@ -69,7 +69,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     # xdoctest
-    pytest-cov
+    pytest-cov-stub
     coverage
     mock
     black

--- a/pkgs/development/python-modules/plaster/default.nix
+++ b/pkgs/development/python-modules/plaster/default.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   fetchPypi,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -21,6 +21,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest
-    pytest-cov
+    pytest-cov-stub
   ];
 }

--- a/pkgs/development/python-modules/property-manager/default.nix
+++ b/pkgs/development/python-modules/property-manager/default.nix
@@ -6,7 +6,7 @@
   verboselogs,
   coloredlogs,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   ];
   nativeCheckInputs = [
     pytest
-    pytest-cov
+    pytest-cov-stub
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -8,7 +8,7 @@
   fs, # for fonttools extras
   setuptools-scm,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   runAllTests ? false,
   psautohint, # for passthru.tests
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     pytest-xdist
   ];
   disabledTests = lib.optionals (!runAllTests) [

--- a/pkgs/development/python-modules/pyevtk/default.nix
+++ b/pkgs/development/python-modules/pyevtk/default.nix
@@ -5,7 +5,7 @@
   setuptools,
   numpy,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "pyevtk" ];

--- a/pkgs/development/python-modules/pyexcel-xls/default.nix
+++ b/pkgs/development/python-modules/pyexcel-xls/default.nix
@@ -8,7 +8,7 @@
   xlwt,
   pyexcel,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   setuptools,
 }:
 
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pyexcel
-    pytest-cov
+    pytest-cov-stub
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/pymaven-patch/default.nix
+++ b/pkgs/development/python-modules/pymaven-patch/default.nix
@@ -7,7 +7,7 @@
   six,
   lxml,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   mock,
 }:
 buildPythonPackage rec {
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     mock
   ];
 

--- a/pkgs/development/python-modules/pyscaffold/default.nix
+++ b/pkgs/development/python-modules/pyscaffold/default.nix
@@ -23,7 +23,7 @@
   certifi,
   flake8,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-randomly,
   pytest-xdist,
   sphinx,
@@ -80,7 +80,7 @@ buildPythonPackage rec {
       flake8
       pre-commit
       pytest
-      pytest-cov
+      pytest-cov-stub
       pytest-randomly
       pytest-xdist
       setuptools

--- a/pkgs/development/python-modules/pyscaffoldext-cookiecutter/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-cookiecutter/default.nix
@@ -11,7 +11,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   tox,
   virtualenv,
@@ -44,7 +44,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov
+      pytest-cov-stub
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-custom-extension/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-custom-extension/default.nix
@@ -11,7 +11,7 @@
   pyscaffold,
   pre-commit,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   tox,
   virtualenv,
@@ -45,7 +45,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov
+      pytest-cov-stub
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-django/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-django/default.nix
@@ -10,7 +10,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   tox,
   virtualenv,
@@ -42,7 +42,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov
+      pytest-cov-stub
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-dsproject/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-dsproject/default.nix
@@ -11,7 +11,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   tox,
   virtualenv,
@@ -44,7 +44,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov
+      pytest-cov-stub
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-markdown/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-markdown/default.nix
@@ -11,7 +11,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   tox,
   twine,
@@ -46,7 +46,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov
+      pytest-cov-stub
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-travis/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-travis/default.nix
@@ -10,7 +10,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   tox,
   virtualenv,
@@ -42,7 +42,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov
+      pytest-cov-stub
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pystac/default.nix
+++ b/pkgs/development/python-modules/pystac/default.nix
@@ -7,7 +7,7 @@
 
   html5lib,
   jsonschema,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-mock,
   pytest-recording,
   python-dateutil,
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     html5lib
     jsonschema
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     pytest-mock
     pytest-recording
     requests-mock

--- a/pkgs/development/python-modules/pytest-cid/default.nix
+++ b/pkgs/development/python-modules/pytest-cid/default.nix
@@ -6,7 +6,7 @@
   flit-core,
   py-cid,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "pytest_cid" ];

--- a/pkgs/development/python-modules/pytest-filter-subpackage/default.nix
+++ b/pkgs/development/python-modules/pytest-filter-subpackage/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-doctestplus,
   pytestCheckHook,
   pythonOlder,
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     pytest-doctestplus
-    pytest-cov
+    pytest-cov-stub
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/pytest-notebook/default.nix
+++ b/pkgs/development/python-modules/pytest-notebook/default.nix
@@ -12,7 +12,7 @@
   black,
   coverage,
   ipykernel,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-regressions,
   pytestCheckHook,
 }:
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     black
     coverage
     ipykernel
-    pytest-cov
+    pytest-cov-stub
     pytest-regressions
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/rdflib/default.nix
+++ b/pkgs/development/python-modules/rdflib/default.nix
@@ -23,7 +23,7 @@
 
   # tests
   pip,
-  pytest-cov,
+  pytest-cov-stub,
   pytest7CheckHook,
   setuptools,
 }:
@@ -59,7 +59,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pip
-    pytest-cov
+    pytest-cov-stub
     # Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
     pytest7CheckHook
     setuptools

--- a/pkgs/development/python-modules/reikna/default.nix
+++ b/pkgs/development/python-modules/reikna/default.nix
@@ -3,7 +3,7 @@
   fetchPypi,
   buildPythonPackage,
   sphinx,
-  pytest-cov,
+  pytest-cov-stub,
   pytest,
   mako,
   numpy,
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     sphinx
-    pytest-cov
+    pytest-cov-stub
     pytest
   ];
 

--- a/pkgs/development/python-modules/schwifty/default.nix
+++ b/pkgs/development/python-modules/schwifty/default.nix
@@ -18,7 +18,7 @@
 
   # tests
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   pythonOlder,
 }:
 
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
-    pytest-cov
+    pytest-cov-stub
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 

--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -23,7 +23,7 @@
   accelerate,
   datasets,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     accelerate
     datasets
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "sentence_transformers" ];

--- a/pkgs/development/python-modules/snapshottest/default.nix
+++ b/pkgs/development/python-modules/snapshottest/default.nix
@@ -6,7 +6,7 @@
   six,
   termcolor,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   django,
 }:
 
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     django
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "snapshottest" ];

--- a/pkgs/development/python-modules/sortedcollections/default.nix
+++ b/pkgs/development/python-modules/sortedcollections/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pytest-cov,
+  pytest-cov-stub,
   pytestCheckHook,
   sortedcontainers,
 }:
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ sortedcontainers ];
 
   nativeCheckInputs = [
-    pytest-cov
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/stups-fullstop/default.nix
+++ b/pkgs/development/python-modules/stups-fullstop/default.nix
@@ -7,7 +7,7 @@
   stups-cli-support,
   stups-zign,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   isPy3k,
 }:
 
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest
-    pytest-cov
+    pytest-cov-stub
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/subliminal/default.nix
+++ b/pkgs/development/python-modules/subliminal/default.nix
@@ -21,7 +21,7 @@
   tomli,
 
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   mypy,
   sympy,
@@ -62,7 +62,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     pytest-xdist
     mypy
     sympy

--- a/pkgs/development/python-modules/tf2onnx/default.nix
+++ b/pkgs/development/python-modules/tf2onnx/default.nix
@@ -14,7 +14,7 @@
   pytestCheckHook,
   graphviz,
   parameterized,
-  pytest-cov,
+  pytest-cov-stub,
   pyyaml,
   timeout-decorator,
   onnxruntime,
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytestCheckHook
     graphviz
     parameterized
-    pytest-cov
+    pytest-cov-stub
     pyyaml
     timeout-decorator
     keras

--- a/pkgs/development/python-modules/torch-geometric/default.nix
+++ b/pkgs/development/python-modules/torch-geometric/default.nix
@@ -52,7 +52,7 @@
   onnx,
   onnxruntime,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
 
   # tests
   pytestCheckHook,
@@ -137,7 +137,7 @@ buildPythonPackage rec {
       onnx
       onnxruntime
       pytest
-      pytest-cov
+      pytest-cov-stub
     ];
   };
 

--- a/pkgs/development/python-modules/uarray/default.nix
+++ b/pkgs/development/python-modules/uarray/default.nix
@@ -9,7 +9,7 @@
   astunparse,
   typing-extensions,
   pytest7CheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest7CheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   # Tests must be run from outside the source directory

--- a/pkgs/development/python-modules/unstructured-api-tools/default.nix
+++ b/pkgs/development/python-modules/unstructured-api-tools/default.nix
@@ -22,7 +22,7 @@
   flake8,
   httpx,
   ipython,
-  pytest-cov,
+  pytest-cov-stub,
   requests,
   requests-toolbelt,
   nbdev,
@@ -77,7 +77,7 @@ buildPythonPackage {
     flake8
     httpx
     ipython
-    pytest-cov
+    pytest-cov-stub
     requests
     requests-toolbelt
     nbdev

--- a/pkgs/development/python-modules/unstructured-inference/default.nix
+++ b/pkgs/development/python-modules/unstructured-inference/default.nix
@@ -17,7 +17,7 @@
   click,
   httpx,
   mypy,
-  pytest-cov,
+  pytest-cov-stub,
   pdf2image,
 }:
 
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     click
     httpx
     mypy
-    pytest-cov
+    pytest-cov-stub
     pdf2image
     huggingface-hub
   ];

--- a/pkgs/development/python-modules/unstructured/default.nix
+++ b/pkgs/development/python-modules/unstructured/default.nix
@@ -51,7 +51,7 @@
   freezegun,
   # , label-studio-sdk
   mypy,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-mock,
   vcrpy,
   grpcio,
@@ -137,7 +137,7 @@ buildPythonPackage {
     click
     freezegun
     mypy
-    pytest-cov
+    pytest-cov-stub
     pytest-mock
     vcrpy
     grpcio

--- a/pkgs/development/python-modules/validator-collection/default.nix
+++ b/pkgs/development/python-modules/validator-collection/default.nix
@@ -35,7 +35,7 @@
   pyparsing,
   pytest,
   pytest-benchmark,
-  pytest-cov,
+  pytest-cov-stub,
   pytz,
   readme-renderer,
   requests,
@@ -108,7 +108,7 @@ buildPythonPackage rec {
     pyparsing
     pytest
     pytest-benchmark
-    pytest-cov
+    pytest-cov-stub
     pytz
     readme-renderer
     requests

--- a/pkgs/development/python-modules/venusian/default.nix
+++ b/pkgs/development/python-modules/venusian/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   isPy27,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   setuptools,
 }:
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/xformers/default.nix
+++ b/pkgs/development/python-modules/xformers/default.nix
@@ -10,7 +10,7 @@
   torch,
   # check dependencies
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   # , pytest-mpi
   pytest-timeout,
   # , pytorch-image-models
@@ -99,7 +99,7 @@ buildPythonPackage {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     pytest-timeout
     hydra-core
     fairscale


### PR DESCRIPTION
Updates all packages using pytest-cov to use pytest-cov-stub. Several are broken on Python3.11/12, but all remaining cases have been fixed where possible. I've confirmed that every non-broken package does build properly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
