### PR TITLE
coqPackages.Perennial: init at unstable-2024-10-17

### DIFF
--- a/pkgs/development/coq-modules/Perennial/default.nix
+++ b/pkgs/development/coq-modules/Perennial/default.nix
@@ -1,0 +1,75 @@
+{
+  coq,
+  coq-record-update,
+  coq-tactical,
+  coqutil,
+  iris,
+  iris-named-props,
+  lib,
+  mkCoqDerivation,
+  stdpp,
+  version ? null,
+}:
+
+mkCoqDerivation {
+  pname = "Perennial";
+  owner = "mit-pdos";
+
+  inherit version;
+  displayVersion.Perennial = v: "unstable-${v}";
+  defaultVersion =
+    with lib.versions;
+    lib.switch coq.version [
+      {
+        case = range "8.16" "8.20";
+        out = "2024-12-16";
+      }
+    ] null;
+
+  release."2024-12-16" = {
+    rev = "e28f1b537cd138210190d3ec5c384acb5d67db78";
+    sha256 = "sha256-fQul9Do/iOK+tBCtb4umcwbC2AxteAGbwDzhXsXoSMQ=";
+  };
+
+  preConfigure =
+    let
+      mkCoqLibReplaceStr = drv: name: "-Q ${drv}/lib/coq/${coq.coq-version}/user-contrib/${name} ";
+    in
+    ''
+      substituteInPlace _CoqProject \
+        --replace-fail '-Q external/stdpp/stdpp ' "${mkCoqLibReplaceStr stdpp stdpp.pname}" \
+        --replace-fail '-Q external/stdpp/stdpp_unstable ' "${mkCoqLibReplaceStr stdpp stdpp.pname}" \
+        --replace-fail '-Q external/stdpp/stdpp_bitvector ' "${mkCoqLibReplaceStr stdpp stdpp.pname}" \
+        --replace-fail '-Q external/iris/iris ' "${mkCoqLibReplaceStr iris iris.pname}" \
+        --replace-fail '-Q external/iris/iris_deprecated ' "${mkCoqLibReplaceStr iris iris.pname}" \
+        --replace-fail '-Q external/iris/iris_unstable ' "${mkCoqLibReplaceStr iris iris.pname}" \
+        --replace-fail '-Q external/iris/iris_heap_lang ' "${mkCoqLibReplaceStr iris iris.pname}" \
+        --replace-fail '-Q external/coqutil/src/coqutil ' "${mkCoqLibReplaceStr coqutil coqutil.pname}" \
+        --replace-fail '-Q external/record-update/src ' "${mkCoqLibReplaceStr coq-record-update "RecordUpdate"}" \
+        --replace-fail '-Q external/coq-tactical/src ' "${mkCoqLibReplaceStr coq-tactical "Tactical"}" \
+        --replace-fail '-Q external/iris-named-props/src ' "${mkCoqLibReplaceStr iris-named-props "iris_named_props"}"
+    '';
+
+  makeFlags = [ "TIMED=false" ];
+
+  propagatedBuildInputs = [
+    coq-record-update
+    coq-tactical
+    coqutil
+    iris
+    iris-named-props
+    stdpp
+  ];
+
+  installPhase = ''
+    COQLIB=$out/lib/coq/${coq.coq-version}
+    mkdir -p $COQLIB/user-contrib/Perennial
+    cp -pR src/* $COQLIB/user-contrib/Perennial
+  '';
+
+  meta = {
+    description = "Verifying concurrent crash-safe systems";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stepbrobd ];
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -137,6 +137,7 @@ let
       paco = callPackage ../development/coq-modules/paco {};
       paramcoq = callPackage ../development/coq-modules/paramcoq {};
       parsec = callPackage ../development/coq-modules/parsec {};
+      Perennial = callPackage ../development/coq-modules/Perennial {};
       pocklington = callPackage ../development/coq-modules/pocklington {};
       QuickChick = callPackage ../development/coq-modules/QuickChick {};
       reglang = callPackage ../development/coq-modules/reglang {};


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
