### PR TITLE
glycin-loaders: 1.0.1 -> 1.1.1

### DIFF
--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -3,29 +3,31 @@
 , fetchurl
 , substituteAll
 , bubblewrap
+, cairo
 , cargo
 , git
+, gnome
+, gtk4
+, lcms2
+, libheif
+, libjxl
+, librsvg
+, libseccomp
+, libxml2
 , meson
 , ninja
 , pkg-config
 , rustc
 , rustPlatform
-, gtk4
-, cairo
-, libheif
-, libxml2
-, libseccomp
-, libjxl
-, gnome
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glycin-loaders";
-  version = "1.0.1";
+  version = "1.1.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/glycin-loaders/${lib.versions.majorMinor finalAttrs.version}/glycin-loaders-${finalAttrs.version}.tar.xz";
-    hash = "sha256-0PAiRi/1VYVuheqUBHRHC7NrN8n/y8umOgP+XpVDcM8=";
+    url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Vg7kIWfB7SKCZhjmHYPkkUDbW/R6Zam6js4s1z0qSqg=";
   };
 
   patches = [
@@ -49,15 +51,24 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gtk4 # for GdkTexture
     cairo
+    lcms2
     libheif
     libxml2 # for librsvg crate
+    librsvg
     libseccomp
     libjxl
   ];
 
+  mesonFlags = [
+    "-Dglycin-loaders=true"
+    "-Dlibglycin=false"
+    "-Dvapi=false"
+  ];
+
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = "glycin-loaders";
+      attrPath = "glycin-loaders";
+      packageName = "glycin";
     };
 
     glycinPathsPatch = substituteAll {


### PR DESCRIPTION
glycin-loader is now published on the same artifact as glycin with a meson flag

some new deps are required

https://gitlab.gnome.org/sophie-h/glycin/-/compare/1.0.1...1.1.1?page=4#ca9bb7eff80503c97c83505e8acea4002fd87ac6

https://gitlab.gnome.org/sophie-h/glycin/-/blob/main/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
