### PR TITLE
chromium,chromedriver: 129.0.6668.100 -> 130.0.6723.58

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -70,9 +70,9 @@ let
   # source tree.
   extraAttrs = buildFun base;
 
-  githubPatch = { commit, hash, revert ? false }: fetchpatch {
+  githubPatch = { commit, hash, revert ? false, excludes ? [] }: fetchpatch {
     url = "https://github.com/chromium/chromium/commit/${commit}.patch";
-    inherit hash revert;
+    inherit hash revert excludes;
   };
 
   mkGnFlags =
@@ -314,6 +314,22 @@ let
     ] ++ lib.optionals (chromiumVersionAtLeast "129") [
       # Rebased variant of patch right above to build M129+ with our rust and our clang.
       ./patches/chromium-129-rust.patch
+    ] ++ lib.optionals (chromiumVersionAtLeast "130") [
+      # Our rustc.llvmPackages is too old for std::hardware_destructive_interference_size
+      # and std::hardware_constructive_interference_size.
+      # So let's revert the change for now and hope that our rustc.llvmPackages and
+      # nixpkgs-stable catch up sooner than later.
+      # https://groups.google.com/a/chromium.org/g/cxx/c/cwktrFxxUY4
+      # https://chromium-review.googlesource.com/c/chromium/src/+/5767325
+      # Note: We exclude the changes made to the partition_allocator (PA), as the revert
+      # would otherwise not apply because upstream reverted those changes to PA already
+      # in https://chromium-review.googlesource.com/c/chromium/src/+/5841144
+      (githubPatch {
+        commit = "fc838e8cc887adbe95110045d146b9d5885bf2a9";
+        hash = "sha256-NNKzIp6NYdeZaqBLWDW/qNxiDB1VFRz7msjMXuMOrZ8=";
+        excludes = [ "base/allocator/partition_allocator/src/partition_alloc/*" ];
+        revert = true;
+      })
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -58,6 +58,12 @@ let
         # Relax hardening as otherwise gn unstable 2024-06-06 and later fail with:
         # cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
         hardeningDisable = [ "format" ];
+      } // lib.optionalAttrs (chromiumVersionAtLeast "130") {
+        # At the time of writing, gn is at v2024-05-13 and has a backported patch.
+        # This patch appears to be already present in v2024-09-09 (from M130), which
+        # results in the patch not applying and thus failing the build.
+        # As a work around until gn is updated again, we filter specifically that patch out.
+        patches = lib.filter (e: lib.getName e != "LFS64.patch") oldAttrs.patches;
       });
       recompressTarball = callPackage ./recompress-tarball.nix { inherit chromiumVersionAtLeast; };
     });

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -1,22 +1,22 @@
 {
   stable = {
     chromedriver = {
-      hash_darwin = "sha256-/0mBZCSNULvZSQ/irsQSgNPsuOSWiRRnJA/6ogHYeGk=";
+      hash_darwin = "sha256-YndBzhUNmn5tJdCqLmpUrs2WBXXpTxiKCNczWEz6DU4=";
       hash_darwin_aarch64 =
-        "sha256-JWcYFYaaXM2KN6oSu7wwxztYPbhql2XYZlvL2ymKgwI=";
-      hash_linux = "sha256-odFoTWjDa9ilyOrQ0T+0xxedRD7YOe/s7xdAyyku74w=";
-      version = "129.0.6668.91";
+        "sha256-taG58kMgQUD40aGqnyx9O9e9m4qGsTWX57cjD3NeHm4=";
+      hash_linux = "sha256-raWGzhjqWdm5bRK+Z7Qga8QM9kQYSXxdL5N+wk1hlXI=";
+      version = "130.0.6723.58";
     };
     deps = {
       gn = {
-        hash = "sha256-8o3rDdojqVHMQCxI2T3MdJOXKlW3XX7lqpy3zWhJiaA=";
-        rev = "d010e218ca7077928ad7c9e9cc02fe43b5a8a0ad";
+        hash = "sha256-iNXRq3Mr8+wmY1SR4sV7yd2fDiIZ94eReelwFI0UhGU=";
+        rev = "20806f79c6b4ba295274e3a589d85db41a02fdaa";
         url = "https://gn.googlesource.com/gn";
-        version = "2024-08-19";
+        version = "2024-09-09";
       };
     };
-    hash = "sha256-LOZ9EPw7VgBNEV7Wxb8H5WfSYTTWOL8EDP91uCrZAsA=";
-    version = "129.0.6668.100";
+    hash = "sha256-w1xQr+B7ROeCqBRN+M9vmh45YTRqVfjDYSsN5saDuDo=";
+    version = "130.0.6723.58";
   };
   ungoogled-chromium = {
     deps = {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2024/10/stable-channel-update-for-desktop_15.html

This update includes 17 security fixes.

CVEs:
CVE-2024-9954 CVE-2024-9955 CVE-2024-9956 CVE-2024-9957 CVE-2024-9958 CVE-2024-9959 CVE-2024-9960 CVE-2024-9961 CVE-2024-9962 CVE-2024-9963 CVE-2024-9964 CVE-2024-9965 CVE-2024-9966

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).