### PR TITLE
erlang: 25.3.2.13 -> 25.3.2.15, erlang_26: 26.2.5.1 -> 26.2.5.4, erlang_27: 27.0.1 -> 27.1.2

### DIFF
--- a/pkgs/development/interpreters/erlang/25.nix
+++ b/pkgs/development/interpreters/erlang/25.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "25.3.2.13";
-  sha256 = "sha256-ZBk6oOT0vFY66ttyn4G2zy7Ur5bDKkxPzlTsZPaiosc=";
+  version = "25.3.2.15";
+  sha256 = "sha256-y1QZZ+W5jkAygTRtXVu6FyG4I98SGXXourDfPPlEfg8=";
 }

--- a/pkgs/development/interpreters/erlang/26.nix
+++ b/pkgs/development/interpreters/erlang/26.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "26.2.5.1";
-  sha256 = "sha256-oxOynBFW++igiJtIv1ZjoMgtmumgnsWgwyVx4buhxCo=";
+  version = "26.2.5.4";
+  sha256 = "sha256-fvpSvsr7wWgFKa8vODVz4RUn8JKe8NuT9sjvau38B+Y=";
 }

--- a/pkgs/development/interpreters/erlang/27.nix
+++ b/pkgs/development/interpreters/erlang/27.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "27.0.1";
-  sha256 = "sha256-Lp6J9eq6RXDi0RRjeVO/CIa4h/m7/fwOp/y0u0sTdFQ=";
+  version = "27.1.2";
+  sha256 = "sha256-urHJMPo9XG+sIBuCaWvEhAcykGxlVSdKKem7vCiMjcg=";
 }

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -98,6 +98,8 @@ stdenv.mkDerivation ({
 
   inherit src version;
 
+  LANG = "C.UTF-8";
+
   nativeBuildInputs = [ autoconf makeWrapper perl gnum4 libxslt libxml2 ];
 
   buildInputs = [ ncurses opensslPackage ]

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   beamPackages,
   fetchFromGitHub,
   fetchFromGitLab,
@@ -11,6 +12,7 @@
   vips,
   pkg-config,
   glib,
+  darwin,
   ...
 }:
 
@@ -91,10 +93,16 @@ beamPackages.mixRelease rec {
 
       vix = prev.vix.override {
         nativeBuildInputs = [ pkg-config ];
-        buildInputs = [
-          vips
-          glib.dev
-        ];
+        buildInputs =
+          [
+            vips
+            glib.dev
+          ]
+          ++ lib.optionals stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.Foundation
+            darwin.apple_sdk.frameworks.AppKit
+            darwin.apple_sdk.frameworks.Kerberos
+          ];
         VIX_COMPILATION_MODE = "PLATFORM_PROVIDED_LIBVIPS";
       };
 


### PR DESCRIPTION
Contains updates to OTP for 25, 26, 27

- https://github.com/erlang/otp/releases/tag/OTP-25.3.2.15
- https://github.com/erlang/otp/releases/tag/OTP-26.2.5.4
- https://github.com/erlang/otp/releases/tag/OTP-27.1.2

Note: when running `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` on my OSX (aarch64-darwin) machine I wasn't able to build https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/servers/pleroma/default.nix due to a dependency called [`vix`](https://hexdocs.pm/vix/readme.html) which is a NIF wrapper around [`libvips`](https://www.libvips.org/). However, I can't build any of these packages on `master` on the same machine so AFAICT they are broken on OSX.

Running this same command on my Linux machine (x86_64-linux): `mercury` fails to compile with GCC bug. I don't think that is something I will try to fix. `mercury` is also a dependency of `notmuch-bower` so I wasn't able to build that either.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
