### PR TITLE
apkeditor: init at 1.4.1

### DIFF
--- a/pkgs/by-name/ap/apkeditor/arsclib/default.nix
+++ b/pkgs/by-name/ap/apkeditor/arsclib/default.nix
@@ -1,0 +1,33 @@
+{
+  fetchFromGitHub,
+  gradle,
+  lib,
+  REAndroidLibrary,
+}:
+
+let
+  self = REAndroidLibrary {
+    pname = "arsclib";
+    # 1.3.5 is not new enough for APKEditor because of API changes
+    version = "1.3.5-unstable-2024-10-21";
+    projectName = "ARSCLib";
+
+    src = fetchFromGitHub {
+      owner = "REAndroid";
+      repo = "ARSCLib";
+      # This is the latest commit at the time of packaging.
+      # It can be changed to a stable release ("V${version}")
+      # if it is compatible with APKEditor.
+      rev = "ed6ccf00e56d7cce13e8648ad46a2678a6093248";
+      hash = "sha256-jzd7xkc4O+P9hlGsFGGl2P3pqVvV5+mDyKTRUuGfFSA=";
+    };
+
+    mitmCache = gradle.fetchDeps {
+      pkg = self;
+      data = ./deps.json;
+    };
+
+    meta.license = lib.licenses.asl20;
+  };
+in
+self

--- a/pkgs/by-name/ap/apkeditor/arsclib/deps.json
+++ b/pkgs/by-name/ap/apkeditor/arsclib/deps.json
@@ -1,0 +1,17 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://repo.maven.apache.org/maven2": {
+  "junit#junit/4.12": {
+   "jar": "sha256-WXIfCAXiI9hLkGd4h9n/Vn3FNNfFAsqQPAwrF/BcEWo=",
+   "pom": "sha256-kPFj944/+28cetl96efrpO6iWAcUG4XW0SvmfKJUScQ="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  }
+ }
+}

--- a/pkgs/by-name/ap/apkeditor/fix-gradle.patch
+++ b/pkgs/by-name/ap/apkeditor/fix-gradle.patch
@@ -1,0 +1,41 @@
+diff --git a/build.gradle b/build.gradle
+index 97fd54f..128a269 100755
+--- a/build.gradle
++++ b/build.gradle
+@@ -5,8 +5,8 @@ group 'com.reandroid.apkeditor'
+ version '1.4.1'
+ 
+ java {
+-    sourceCompatibility JavaVersion.VERSION_1_8
+-    targetCompatibility JavaVersion.VERSION_1_8
++    sourceCompatibility JavaVersion.VERSION_17
++    targetCompatibility JavaVersion.VERSION_17
+ }
+ 
+ if (JavaVersion.current().isJava8Compatible()) {
+@@ -22,13 +22,13 @@ repositories {
+ 
+ dependencies {
+     //implementation("io.github.reandroid:ARSCLib:+")
+-    compile(files("$rootProject.projectDir/libs/ARSCLib.jar"))
++    implementation(files("$rootProject.projectDir/libs/ARSCLib.jar"))
+ 
+     // built from: https://github.com/REAndroid/smali-lib
+-    compile(files("$rootProject.projectDir/libs/smali.jar"))
++    implementation(files("$rootProject.projectDir/libs/smali.jar"))
+ 
+     // built from: https://github.com/REAndroid/JCommand
+-    compile(files("$rootProject.projectDir/libs/JCommand.jar"))
++    implementation(files("$rootProject.projectDir/libs/JCommand.jar"))
+ }
+ 
+ processResources {
+@@ -52,7 +52,7 @@ task fatJar(type: Jar) {
+                 'Main-Class': 'com.reandroid.apkeditor.Main'
+         )
+     }
+-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
++    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+     with jar
+ }
+ 

--- a/pkgs/by-name/ap/apkeditor/jcommand/default.nix
+++ b/pkgs/by-name/ap/apkeditor/jcommand/default.nix
@@ -1,0 +1,33 @@
+{
+  fetchFromGitHub,
+  gradle,
+  lib,
+  REAndroidLibrary,
+}:
+
+let
+  self = REAndroidLibrary {
+    pname = "jcommand";
+    version = "0-unstable-2024-09-20";
+    projectName = "JCommand";
+
+    src = fetchFromGitHub {
+      owner = "REAndroid";
+      repo = "JCommand";
+      # No tagged releases, and
+      # it is hard to determine the actual commit that APKEditor is intended to use,
+      # so I think we should use the latest commit that doesn't break compilation or basic functionality.
+      # Currently this is the latest commit at the time of packaging.
+      rev = "714b6263c28dabb34adc858951cf4bc60d6c3fed";
+      hash = "sha256-6Em+1ddUkZBCYWs88qtfeGnxISZchFrHgDL8fsgZoQg=";
+    };
+
+    mitmCache = gradle.fetchDeps {
+      pkg = self;
+      data = ./deps.json;
+    };
+
+    meta.license = lib.licenses.asl20;
+  };
+in
+self

--- a/pkgs/by-name/ap/apkeditor/jcommand/deps.json
+++ b/pkgs/by-name/ap/apkeditor/jcommand/deps.json
@@ -1,0 +1,17 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://repo.maven.apache.org/maven2": {
+  "junit#junit/4.12": {
+   "jar": "sha256-WXIfCAXiI9hLkGd4h9n/Vn3FNNfFAsqQPAwrF/BcEWo=",
+   "pom": "sha256-kPFj944/+28cetl96efrpO6iWAcUG4XW0SvmfKJUScQ="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  }
+ }
+}

--- a/pkgs/by-name/ap/apkeditor/package.nix
+++ b/pkgs/by-name/ap/apkeditor/package.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  callPackage,
+
+  jre,
+  gradle,
+  makeWrapper,
+}:
+
+let
+  REAndroidLibrary =
+    args:
+    let
+      inherit (args) pname version projectName;
+      outJar = "share/${projectName}/${projectName}.jar";
+      self = stdenv.mkDerivation (
+        {
+          __darwinAllowLocalNetworking = true;
+
+          buildInputs = [ jre ];
+          nativeBuildInputs = [ gradle ];
+
+          gradleFlags = [ "-Dfile.encoding=utf-8" ];
+          gradleBuildTask = "jar";
+          doCheck = true;
+
+          inherit outJar;
+          installPhase = ''
+            runHook preInstall
+            install -Dm644 build/libs/*.jar $out/${outJar}
+            runHook postInstall
+          '';
+        }
+        // args
+        // {
+          meta = {
+            sourceProvenance = with lib.sourceTypes; [
+              fromSource
+              binaryBytecode # mitm cache
+            ];
+          } // args.meta;
+        }
+      );
+    in
+    self;
+
+  arsclib = callPackage ./arsclib { inherit REAndroidLibrary; };
+  smali = callPackage ./smali { inherit REAndroidLibrary; };
+  jcommand = callPackage ./jcommand { inherit REAndroidLibrary; };
+
+  apkeditor =
+    let
+      pname = "apkeditor";
+      version = "1.4.1";
+      projectName = "APKEditor";
+    in
+    REAndroidLibrary {
+      inherit pname version projectName;
+
+      # When you need to update **/deps.json for the dependencies (e.g. for smali),
+      # run `nix build apkeditor.passthru.deps.smali.mitmCache.updateScript`.
+      passthru.deps = {
+        inherit arsclib smali jcommand;
+      };
+
+      src = fetchFromGitHub {
+        owner = "REAndroid";
+        repo = "APKEditor";
+        rev = "V${version}";
+        hash = "sha256-a72j9qGjJXnTFeqLez2rhBSArFVYCX+Xs7NQd8CY5Yk=";
+      };
+
+      patches = [
+        # Remove this patch after REAndroid/APKEditor#144 is merged
+        ./fix-gradle.patch
+      ];
+
+      nativeBuildInputs = [
+        gradle
+        makeWrapper
+      ];
+
+      gradleBuildTask = "fatJar";
+
+      # The paths libs/*.jar are hardcoded in build.gradle of APKEditor:
+      # https://github.com/REAndroid/APKEditor/blob/V1.4.1/build.gradle#L24-L31
+      preConfigure = ''
+        ln -sf ${arsclib}/${arsclib.outJar} libs/ARSCLib.jar
+        ln -sf ${smali}/${smali.outJar} libs/smali.jar
+        ln -sf ${jcommand}/${jcommand.outJar} libs/JCommand.jar
+      '';
+
+      postInstall = ''
+        mkdir -p $out/bin
+        makeWrapper ${lib.getExe jre} $out/bin/APKEditor \
+          --add-flags "-jar $out/${apkeditor.outJar}"
+      '';
+
+      meta = {
+        description = "Powerful android apk resources editor";
+        maintainers = with lib.maintainers; [ ulysseszhan ];
+        license = lib.licenses.asl20;
+        platforms = lib.platforms.all;
+        mainProgram = "APKEditor";
+      };
+    };
+in
+apkeditor

--- a/pkgs/by-name/ap/apkeditor/smali/default.nix
+++ b/pkgs/by-name/ap/apkeditor/smali/default.nix
@@ -1,0 +1,57 @@
+{
+  fetchFromGitHub,
+  gradle,
+  lib,
+  REAndroidLibrary,
+}:
+
+let
+  self = REAndroidLibrary {
+    pname = "smali";
+    version = "0-unstable-2024-10-15";
+    projectName = "smali";
+
+    src = fetchFromGitHub {
+      owner = "REAndroid";
+      repo = "smali-lib";
+      # No tagged releases, and
+      # it is hard to determine the actual commit that APKEditor is intended to use,
+      # so I think we should use the latest commit that doesn't break compilation or basic functionality.
+      # Currently this is the latest commit at the time of packaging.
+      rev = "c781eafb31f526abce9fdf406ce2c925fec20d28";
+      hash = "sha256-6tkvikgWMUcKwzsgbfpxlB6NZBAlZtTE34M3qPQw7Y4=";
+    };
+
+    patches = [
+      # Remove this patch after REAndroid/smali-lib#1 is merged
+      ./fix-gradle.patch
+    ];
+
+    mitmCache = gradle.fetchDeps {
+      pkg = self;
+      data = ./deps.json;
+    };
+    gradleBuildTask = "build";
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm644 smali/build/libs/*-fat.jar $out/${self.outJar}
+      runHook postInstall
+    '';
+
+    # This fork deleted the NOTICE file from the original repo:
+    # https://github.com/REAndroid/smali-lib/commit/40c075a1ff5fa8e29f339f4e71f45c028789c86c#diff-dfb14fbb9e7d095209ec4cfd621069437bf9c442ff9de9d4ce889781bd0fefcf
+    # Here is the gist of the original NOTICE file:
+    # Various portions of the code are from AOSP and is licensed under Apache 2.0.
+    # Other parts are copyrighted by JesusFreke and Google,
+    # permitting redistribution (with or without modification) of source and binary
+    # as long as the copyright notice is present.
+    # For full details, see:
+    # https://github.com/JesusFreke/smali/blob/master/NOTICE
+    meta.license = with lib.licenses; [
+      asl20
+      free
+    ];
+  };
+in
+self

--- a/pkgs/by-name/ap/apkeditor/smali/deps.json
+++ b/pkgs/by-name/ap/apkeditor/smali/deps.json
@@ -1,0 +1,86 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://repo.maven.apache.org/maven2": {
+  "antlr#antlr/2.7.7": {
+   "jar": "sha256-iPvaS5Ellrn1bo4S5YDMlUus+1F3bs/d0+GPwc9W3Ew=",
+   "pom": "sha256-EA95O6J/i05CBO20YXHr825U4PlM/AJSf+oHoLsfzrc="
+  },
+  "com/beust#jcommander/1.48": {
+   "jar": "sha256-pzE/z94HCTDkDsee3zxZSM805PDSXLOgn5lj2L3YQRM=",
+   "pom": "sha256-EH4aAn6KszS4H7KJYGDba68y430uME5glCNtPn6ymQM="
+  },
+  "de/jflex#jflex-parent/1.6.1": {
+   "pom": "sha256-zgOPd5P3f7eO+hFMMyjlx37OF9MzRfB7TsCm4U4WB1k="
+  },
+  "de/jflex#jflex/1.6.1": {
+   "jar": "sha256-EsuEWC3TPm3O2yTaSwwf6AdfxjkWx8xt8UCHDPHpKbY=",
+   "pom": "sha256-MXynvUMHgykKCEHUwxEvcbyY1aR+6cyIaZXEFChcnes="
+  },
+  "junit#junit/4.12": {
+   "jar": "sha256-WXIfCAXiI9hLkGd4h9n/Vn3FNNfFAsqQPAwrF/BcEWo=",
+   "pom": "sha256-kPFj944/+28cetl96efrpO6iWAcUG4XW0SvmfKJUScQ="
+  },
+  "org/antlr#ST4/4.0.8": {
+   "jar": "sha256-WMqrxAyfdLC1mT/YaOD2SlDAdZCU5qJRqq+tmO38ejs=",
+   "pom": "sha256-PAiQ3scRdOs7o9QEyp40GQH/awQhgIsAcTsNuxMGwXw="
+  },
+  "org/antlr#antlr-master/3.5.2": {
+   "pom": "sha256-QtkaUx6lEA6wm1QaoALDuQjo8oK9c7bi9S83HvEzG9Y="
+  },
+  "org/antlr#antlr-runtime/3.5.2": {
+   "jar": "sha256-zj/I7LEPOemjzdy7LONQ0nLZzT0LHhjm/nPDuTichzQ=",
+   "pom": "sha256-RqnCIAu4sSvXEkqnpQl/9JCZkIMpyFGgTLIFFCCqfyU="
+  },
+  "org/antlr#antlr/3.5.2": {
+   "jar": "sha256-WsNsKs+woPPTfa/iC1tXDyZD4tAAxkjURQPCc4vmQ98=",
+   "pom": "sha256-Bl5egGYv64WHldPAH3cUJHvdMZRZcF7hOxpLGWj6IuQ="
+  },
+  "org/antlr#stringtemplate/3.2.1": {
+   "jar": "sha256-9mznLpZeUwHLDwIOVNK6atdv65Gzy/ww278AwGpt9tc=",
+   "pom": "sha256-tF6CZVqlpI8z0TpD5DRUJrFWM1s14kta6hLbWCPBahY="
+  },
+  "org/apache/ant#ant-launcher/1.7.0": {
+   "jar": "sha256-crPQPg19hqVlE+w43UzWq+PaZiAYm+IiqyVTUstuuko=",
+   "pom": "sha256-0p0myykG6cOYOBvUhz7KuwTWMO9hNDXssUmoWirvyvQ="
+  },
+  "org/apache/ant#ant-parent/1.7.0": {
+   "pom": "sha256-GlLYNxpsvG4F7b8CZGcXEX3SNERZvulnAU8EH9zzCJM="
+  },
+  "org/apache/ant#ant/1.7.0": {
+   "jar": "sha256-kvcjB+dEDx41LJFvJDjSu6s//Sz3MMcTFhF60Eq63qg=",
+   "pom": "sha256-fAIXQD9XogDLgNSJiSzgTqdi8qEzq+PdOEcGUUNM+vI="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  },
+  "org/mockito#mockito-core/1.10.19": {
+   "jar": "sha256-1YMe5PcQVYAIIaNKMFHPHtWzcC8pX/69UPZftdgacbg=",
+   "pom": "sha256-cVJo2AC6zQcjbuHm9EB2UOYc+XlzO8Ji5N4V+9E7kg0="
+  },
+  "org/objenesis#objenesis-parent/2.1": {
+   "pom": "sha256-NDsaMJNBDj+ybGaZhCOrOJw6dEHNGohZvTJ90VtHmqQ="
+  },
+  "org/objenesis#objenesis/2.1": {
+   "jar": "sha256-x0MwzGuAbIBP0350SHtP5dfCdQxeFfvG76E73uG974A=",
+   "pom": "sha256-QFTxhhN+O4SafCPJ6EbNV9ii/jLBfUxivUIFEtdMPT8="
+  },
+  "org/sonatype/oss#oss-parent/3": {
+   "pom": "sha256-DCeIkmfAlGJEYRaZcJPGcVzMAMKzqVTmZDRDDY9Nrt4="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/xbib/gradle/plugin#gradle-plugin-jflex/1.1.0": {
+   "jar": "sha256-nfON5Bsazk30I3o2pAw8k0qzVWBomj9b6DiwfQ3jn3g=",
+   "pom": "sha256-Ikxjj1TL8LCYxDw6GylqmsF/dfYC9m65szjnkqr6C5g="
+  }
+ }
+}

--- a/pkgs/by-name/ap/apkeditor/smali/fix-gradle.patch
+++ b/pkgs/by-name/ap/apkeditor/smali/fix-gradle.patch
@@ -1,0 +1,87 @@
+diff --git a/baksmali/build.gradle b/baksmali/build.gradle
+index d346970e..eaddfa27 100644
+--- a/baksmali/build.gradle
++++ b/baksmali/build.gradle
+@@ -25,7 +25,7 @@ task fatJar(type: Jar) {
+     from sourceSets.main.output
+     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+ 
+-    classifier = 'fat'
++    archiveClassifier = 'fat'
+ 
+     manifest {
+         attributes('Main-Class': 'org.jf.baksmali.Main')
+@@ -36,6 +36,10 @@ task fatJar(type: Jar) {
+             ant.symlink(link: file("${destinationDirectory.get()}/baksmali.jar"), resource: archivePath, overwrite: true)
+         }
+     }
++
++    // Necessary on Gradle 7 to eplicitly set dependency
++    dependsOn project(':util').jar
++    dependsOn project(':dexlib2').jar
+ }
+ tasks.getByPath('build').dependsOn(fatJar)
+ 
+diff --git a/build.gradle b/build.gradle
+index 5656b634..e519c53e 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -30,8 +30,8 @@ subprojects {
+     version = parent.version
+ 
+     java {
+-        sourceCompatibility JavaVersion.VERSION_1_8
+-        targetCompatibility JavaVersion.VERSION_1_8
++        sourceCompatibility JavaVersion.VERSION_17
++        targetCompatibility JavaVersion.VERSION_17
+     }
+ 
+     ext {
+diff --git a/dexlib2/build.gradle b/dexlib2/build.gradle
+index e1c39897..fc45707c 100644
+--- a/dexlib2/build.gradle
++++ b/dexlib2/build.gradle
+@@ -18,4 +18,7 @@ task ragel(type:Exec) {
+             'SyntheticAccessorFSM.rl'
+ }
+ 
+-
++test {
++    // Since Java 9, this is needed. See https://stackoverflow.com/a/41265267
++    jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
++}
+diff --git a/smali/build.gradle b/smali/build.gradle
+index 6ec5f483..2b3bb771 100644
+--- a/smali/build.gradle
++++ b/smali/build.gradle
+@@ -57,13 +57,17 @@ dependencies {
+ 
+ processResources.inputs.property('version', version)
+ processResources.expand('version': version)
++processResources.configure {
++    // Necessary on Gradle 7 to eplicitly set dependency
++    dependsOn generateGrammarSource
++}
+ 
+ // Build a separate jar that contains all dependencies
+ task fatJar(type: Jar, dependsOn: jar) {
+     from sourceSets.main.output
+     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+ 
+-    classifier = 'fat'
++    archiveClassifier = 'fat'
+ 
+     manifest {
+         attributes('Main-Class': 'org.jf.smali.Main')
+@@ -74,6 +78,11 @@ task fatJar(type: Jar, dependsOn: jar) {
+             ant.symlink(link: file("${destinationDirectory.get()}/smali.jar"), resource: archivePath, overwrite: true)
+         }
+     }
++
++    // Necessary on Gradle 7 to eplicitly set dependency
++    dependsOn project(':util').jar
++    dependsOn project(':dexlib2').jar
++    dependsOn project(':baksmali').jar
+ }
+ tasks.getByPath('build').dependsOn(fatJar)
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[APKEditor](https://github.com/REAndroid/APKEditor): Powerful android apk resources editor.

This package installs a command `APKEditor`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
