### PR TITLE
rpPPPoE: 3.12 -> 4.0 and build kernel mode plugin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5495,6 +5495,12 @@
     githubId = 15774340;
     name = "Thomas Depierre";
   };
+  DictXiong = {
+    email = "me@beardic.cn";
+    github = "DictXiong";
+    githubId = 41772157;
+    name = "Dict Xiong";
+  };
   diegolelis = {
     email = "diego.o.lelis@gmail.com";
     github = "DiegoLelis";

--- a/pkgs/by-name/rp/rpPPPoE/package.nix
+++ b/pkgs/by-name/rp/rpPPPoE/package.nix
@@ -1,13 +1,15 @@
-{ lib, stdenv, fetchurl, ppp } :
+{ lib, stdenv, fetchFromGitHub, ppp } :
 let
 in
 stdenv.mkDerivation rec {
   pname = "rp-pppoe";
-  version = "3.12";
+  version = "4.0";
 
-  src = fetchurl {
-    url = "https://www.roaringpenguin.com/files/download/rp-pppoe-${version}.tar.gz";
-    sha256 = "1hl6rjvplapgsyrap8xj46kc9kqwdlm6ya6gp3lv0ihm0c24wy80";
+  src = fetchFromGitHub {
+    owner = "dfskoll";
+    repo = "rp-pppoe";
+    rev = version;
+    hash = "sha256-2y26FVxVn8sU9/E2yJeJmbhAeOB0Go7EUPMU9H58H6U=";
   };
 
   buildInputs = [ ppp ];
@@ -17,11 +19,13 @@ stdenv.mkDerivation rec {
     export PPPD=${ppp}/sbin/pppd
   '';
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "rpppoe_cv_pack_bitfields=rev" ];
+  configureFlags = [ "--enable-plugin=${ppp}/include" ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "rpppoe_cv_pack_bitfields=rev" ];
 
   postConfigure = ''
     sed -i Makefile -e 's@DESTDIR)/etc/ppp@out)/etc/ppp@'
+    sed -i Makefile -e 's@/etc/ppp/plugins@$(out)/lib@'
     sed -i Makefile -e 's@PPPOESERVER_PPPD_OPTIONS=@&$(out)@'
+    sed -i Makefile -e '/# Directory created by rp-pppoe for kernel-mode plugin/d'
   '';
 
   makeFlags = [ "AR:=$(AR)" ];
@@ -29,7 +33,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Roaring Penguin Point-to-Point over Ethernet tool";
     platforms = platforms.linux;
-    homepage = "https://www.roaringpenguin.com/products/pppoe";
+    homepage = "https://github.com/dfskoll/rp-pppoe";
     license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ DictXiong ];
   };
 }


### PR DESCRIPTION
The old rpPPPoE package from Roaring Penguin is no longer maintained and the download link is also inaccessible. So I switch the upstream to https://github.com/dfskoll/rp-pppoe. Release note: https://github.com/dfskoll/rp-pppoe/blob/master/doc/CHANGES.

Also, according to the discussions in https://github.com/dfskoll/rp-pppoe/issues/32, it is strongly recommended to use rpPPPoE in the kernel mode, as it is more stable and performant than in the user mode. So I enable the compilation of the kernel mode plugin `rp-pppoe.so`. It will be available at `/run/current-system/sw/lib/rp-pppoe.so`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

### Working example

It functions as expected with the following configuration:

```nix
  sops.secrets."pppoe" = {
    # check https://github.com/Distrotech/rp-pppoe/blob/master/configs/pap-secrets for the format
    path = "/etc/ppp/pap-secrets";
    owner = "root";
    mode = "0600";
  };
  services.pppd = {
    enable = true;
    peers = {
      <a custom name> = {
        name = "<a custom name>";
        config = ''
          plugin /run/current-system/sw/lib/rp-pppoe.so
          nic-<physical interface name>
          user "<user name from the isp>"
          debug
          maxfail 0
          holdoff 5
          noipdefault
          defaultroute
          hide-password
          lcp-echo-interval 20
          lcp-echo-failure 3
          noauth
          persist
          noaccomp
          default-asyncmap
          nodetach
          nodeflate
          nopcomp
          novj
          novjccomp
        '';
      };
    };
  };

```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
