### PR TITLE
sogo: 5.11.0 -> 5.11.2

### DIFF
--- a/pkgs/by-name/so/sogo/package.nix
+++ b/pkgs/by-name/so/sogo/package.nix
@@ -5,14 +5,14 @@
 , libwbxml }:
 gnustep.stdenv.mkDerivation rec {
   pname = "sogo";
-  version = "5.11.0";
+  version = "5.11.2";
 
   # always update the sope package as well, when updating sogo
   src = fetchFromGitHub {
     owner = "Alinto";
     repo = pname;
     rev = "SOGo-${version}";
-    hash = "sha256-2/0OaCAQkdnDPGOVERZs2Oz+bCpQN3MTLzp2pz0WB08=";
+    hash = "sha256-c+547x7ugYoLMgGVLcMmmb9rzquRJOv8n+Js2CuE7I0=";
   };
 
   nativeBuildInputs = [ gnustep.make makeWrapper python3 pkg-config ];

--- a/pkgs/by-name/so/sope/package.nix
+++ b/pkgs/by-name/so/sope/package.nix
@@ -59,6 +59,6 @@ gnustep.stdenv.mkDerivation rec {
     license = licenses.publicDomain;
     homepage = "https://github.com/inverse-inc/sope";
     platforms = platforms.linux;
-    maintainers = [ ];
+    maintainers = with maintainers; [ jceb ];
   };
 }

--- a/pkgs/by-name/so/sope/package.nix
+++ b/pkgs/by-name/so/sope/package.nix
@@ -3,22 +3,14 @@
 
 gnustep.stdenv.mkDerivation rec {
   pname = "sope";
-  version = "5.9.0";
+  version = "5.11.2";
 
   src = fetchFromGitHub {
-    owner = "inverse-inc";
+    owner = "Alinto";
     repo = pname;
     rev = "SOPE-${version}";
-    hash = "sha256-JZh8sC/w2MRy3UyWYGMvU47XtWKGnLuUlCsVyyxd7zg=";
+    hash = "sha256-6vec2ZgpK5jcKr3c2SLn6fLAun56MDjupWtR6dMdjag=";
   };
-
-  patches = [
-    (fetchpatch {  # https://github.com/Alinto/sope/pull/66
-      name = "sope-fix-gnustep-1.29.0+.patch";
-      url = "https://github.com/Alinto/sope/pull/66/commits/9ec2744cc851b11886c3ebb723138e4d672bd5c7.patch";
-      hash = "sha256-JgYRwjmjlitgzYz9Jfei5XJRThP1TunPjI0g5M2wZPA=";
-    })
-  ];
 
   nativeBuildInputs = [ gnustep.make ];
   buildInputs = [ gnustep.base libxml2 openssl ]
@@ -45,7 +37,7 @@ gnustep.stdenv.mkDerivation rec {
 
   env = {
     GNUSTEP_CONFIG_FILE = "/build/GNUstep.conf";
-    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=int-conversion";
   };
 
   # Move over the makefiles (see comment over preConfigure)
@@ -54,11 +46,11 @@ gnustep.stdenv.mkDerivation rec {
     find /build/Makefiles -mindepth 1 -maxdepth 1 -not -type l -exec cp -r '{}' $out/share/GNUstep/Makefiles \;
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Extensive set of frameworks which form a complete Web application server environment";
-    license = licenses.publicDomain;
+    license = lib.licenses.publicDomain;
     homepage = "https://github.com/inverse-inc/sope";
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ jceb ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ jceb ];
   };
 }


### PR DESCRIPTION
Since sogo and the sope library need to be updated together, I combined the changes in on PR. Replaces #347289

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
