### PR TITLE
stellarium: make qtwebengine an optional dependency

### DIFF
--- a/pkgs/by-name/st/stellarium/package.nix
+++ b/pkgs/by-name/st/stellarium/package.nix
@@ -17,6 +17,7 @@
   xvfb-run,
   gitUpdater,
   md4c,
+  withQtWebEngine ? lib.meta.availableOn stdenv.hostPlatform qt6.qtwebengine,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -59,7 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtpositioning
     qt6.qtmultimedia
     qt6.qtserialport
-    qt6.qtwebengine
     calcmysky
     qt6Packages.qxlsx
     indilib
@@ -70,6 +70,9 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     qt6.qtwayland
+  ]
+  ++ lib.optionals withQtWebEngine [
+    qt6.qtwebengine
   ];
 
   preConfigure = ''


### PR DESCRIPTION
This pull request makes `qtwebengine` an optional dependency for stellarium. Since `qtwebengine` currently fails to build on Darwin, it is now disabled by default for that platform.

Since I do not have access to a Darwin machine, it would be helpful if someone could verify that stellarium now builds and runs on Darwin before this PR is merged.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
