### PR TITLE
angular-language-server: init at 18.2.0

### DIFF
--- a/pkgs/by-name/an/angular-language-server/package.nix
+++ b/pkgs/by-name/an/angular-language-server/package.nix
@@ -1,68 +1,118 @@
-{
-  lib,
-  stdenvNoCC,
-  fetchYarnDeps,
-  fetchFromGitHub,
-  nodejs,
-  typescript,
-  yarnConfigHook,
-  yarnBuildHook,
-  makeBinaryWrapper,
-  runCommand,
-  angular-language-server,
-  writeShellApplication,
-  curl,
-  common-updater-scripts,
-  jq,
-  gnused,
-  pcre,
-  gawk,
+{ lib
+, fetchYarnDeps
+, fetchFromGitHub
+, nodejs
+, typescript
+, yarnConfigHook
+, makeBinaryWrapper
+, runCommand
+, angular-language-server
+, writeShellApplication
+, curl
+, common-updater-scripts
+, jq
+, gnused
+, pcre
+, gawk
+, bazel_5
+, buildBazelPackage
+, pnpm_8
+,
 }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+buildBazelPackage rec {
   pname = "angular-language-server";
   version = "18.2.0";
   src = fetchFromGitHub {
     owner = "angular";
     repo = "vscode-ng-language-service";
-    rev = "refs/tags/v${finalAttrs.version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-9+WWKvy/Vu4k0BzJwPEme+9+eDPI1QP0+Ds1CbErCN8=";
   };
+
   offlineCache = fetchYarnDeps {
-    yarnLock = "${finalAttrs.src}/yarn.lock";
+    yarnLock = "${src}/yarn.lock";
     hash = "sha256-N0N0XbNQRN7SHkilzo/xNlmn9U/T/WL5x8ttTqUmXl0=";
+  };
+
+  pnpmDeps = pnpm_8.fetchDeps {
+    inherit pname version src;
+    hash = "sha256-NOKElUu5LBzachxmdiOU2gbJBy65aEqyBAWFaqg8AXk=";
   };
 
   nativeBuildInputs = [
     yarnConfigHook
-    yarnBuildHook
     nodejs
     makeBinaryWrapper
+    #pnpm_8.configHook
   ];
 
   buildInputs = [ typescript ];
 
-  yarnBuildScript = "compile";
+  bazel = bazel_5;
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 bazel-bin/vsix_sandbox/server/bin/ngserver $out/bin/ngserver
-    install -Dm755 bazel-bin/vsix_sandbox/server/index.js $out/index.js
-    cp -r bazel-bin/vsix_sandbox/node_modules $out/node_modules
-    runHook postInstall
+  fetchAttrs = {
+    hash = "sha256-NOKElUu5LBzachxmdiOU2gbJBy65aEqyBAWFaqg8AXk=";
+  };
+
+  bazelTargets = [ ":npm" ];
+
+  postPatch = ''
+    bazel --version | cut -c 7-11 > .bazelversion
+    cat >> BUILD.bazel << EOF
+    load("@rules_nodejs//nodejs:toolchain.bzl", "nodejs_toolchain")
+    nodejs_toolchain(
+      name = "nix-node-toolchain",
+      node_path = "${nodejs}/bin/node",
+    )
+    toolchain(
+      name = "nix_nodejs",
+      exec_compatible_with = [
+        "@platforms//os:linux",
+      ],
+      toolchain = ":nix-node-toolchain",
+      toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
+    )
+    EOF
+
+    substituteInPlace WORKSPACE \
+      --replace-fail 'nodejs_register_toolchains(
+        name = "nodejs",
+        node_version = "18.13.0",
+    )' 'register_toolchains("//:nix_nodejs")' \
+      --replace-fail 'load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")' ""
+
+    cat WORKSPACE | grep "nodejs"
   '';
 
-  postFixup = ''
-    patchShebangs $out/bin/ngserver
-    patchShebangs $out/index.js
-    patchShebangs $out/node_modules
-    wrapProgram $out/bin/ngserver \
-      --add-flags "--tsProbeLocations $out/node_modules --ngProbeLocations $out/node_modules"
-  '';
+  buildAttrs = {
+
+    preBuild = ''
+      echo "running preBuild"
+      tsc -b
+      ls -la
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 bazel-bin/vsix_sandbox/server/bin/ngserver $out/bin/ngserver
+      install -Dm755 bazel-bin/vsix_sandbox/server/index.js $out/index.js
+      cp -r bazel-bin/vsix_sandbox/node_modules $out/node_modules
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      patchShebangs $out/bin/ngserver
+      patchShebangs $out/index.js
+      patchShebangs $out/node_modules
+      wrapProgram $out/bin/ngserver \
+        --add-flags "--tsProbeLocations $out/node_modules --ngProbeLocations $out/node_modules"
+    '';
+  };
 
   passthru = {
     tests = {
-      start-ok = runCommand "${finalAttrs.pname}-test" { } ''
+      start-ok = runCommand "${pname}-test" { } ''
         ${angular-language-server}/bin/ngserver --stdio --help &> $out
         cat $out | grep "Angular Language Service that implements the Language Server Protocol (LSP)"
       '';
@@ -73,7 +123,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         pkgFile = builtins.toString ./package.nix;
       in
       lib.getExe (writeShellApplication {
-        name = "update-${finalAttrs.pname}";
+        name = "update-${pname}";
         runtimeInputs = [
           curl
           pcre
@@ -84,16 +134,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         ];
         text = ''
           LATEST_VERSION=$(curl -H "Accept: application/vnd.github+json" \
-            -Ls https://api.github.com/repos/${finalAttrs.src.owner}/${finalAttrs.src.repo}/releases/latest | \
+            -Ls https://api.github.com/repos/${src.owner}/${src.repo}/releases/latest | \
             jq -r .tag_name | cut -c 2-)
-            update-source-version ${finalAttrs.pname} "$LATEST_VERSION"
+            update-source-version ${pname} "$LATEST_VERSION"
             # match from line 32 on (index starts at 0) to avoid replacing the src hash
             sed -i '31,/hash *= *"[^"]*"/{s/hash = "[^"]*"/hash = ""/}' ${pkgFile}
 
             echo -e "\nFetching yarn dependencies This may take a while ..."
-            nix-build -A ${finalAttrs.pname} 2> ${finalAttrs.pname}-stderr.log || true
-            NEW_YARN_HASH=$(grep "got:" ${finalAttrs.pname}-stderr.log | awk '{print ''$2}')
-            rm ${finalAttrs.pname}-stderr.log
+            nix-build -A ${pname} 2> ${pname}-stderr.log || true
+            NEW_YARN_HASH=$(grep "got:" ${pname}-stderr.log | awk '{print ''$2}')
+            rm ${pname}-stderr.log
             # escaping double quotes looks ugly but is needed for variable substitution
             # use # instead of / as separator because the sha256 might contain the / character
             sed -i "31,/hash *= *\"[^\"]*\"/{s#hash = \"[^\"]*\"#hash = \"$NEW_YARN_HASH\"#}" ${pkgFile}
@@ -104,9 +154,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "LSP for angular completions, AOT diagnostic, quick info and go to definitions";
     homepage = "https://github.com/angular/vscode-ng-language-service";
-    changelog = "https://github.com/angular/vscode-ng-language-service/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/angular/vscode-ng-language-service/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "ngserver";
     maintainers = with lib.maintainers; [ tricktron ];
   };
-})
+}

--- a/pkgs/by-name/an/angular-language-server/package.nix
+++ b/pkgs/by-name/an/angular-language-server/package.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchYarnDeps,
+  fetchFromGitHub,
+  nodejs,
+  typescript,
+  yarnConfigHook,
+  yarnBuildHook,
+  makeBinaryWrapper,
+  runCommand,
+  angular-language-server,
+  writeShellApplication,
+  curl,
+  common-updater-scripts,
+  jq,
+  gnused,
+  pcre,
+  gawk,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "angular-language-server";
+  version = "18.2.0";
+  src = fetchFromGitHub {
+    owner = "angular";
+    repo = "vscode-ng-language-service";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-9+WWKvy/Vu4k0BzJwPEme+9+eDPI1QP0+Ds1CbErCN8=";
+  };
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-N0N0XbNQRN7SHkilzo/xNlmn9U/T/WL5x8ttTqUmXl0=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [ typescript ];
+
+  yarnBuildScript = "compile";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bazel-bin/vsix_sandbox/server/bin/ngserver $out/bin/ngserver
+    install -Dm755 bazel-bin/vsix_sandbox/server/index.js $out/index.js
+    cp -r bazel-bin/vsix_sandbox/node_modules $out/node_modules
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    patchShebangs $out/bin/ngserver
+    patchShebangs $out/index.js
+    patchShebangs $out/node_modules
+    wrapProgram $out/bin/ngserver \
+      --add-flags "--tsProbeLocations $out/node_modules --ngProbeLocations $out/node_modules"
+  '';
+
+  passthru = {
+    tests = {
+      start-ok = runCommand "${finalAttrs.pname}-test" { } ''
+        ${angular-language-server}/bin/ngserver --stdio --help &> $out
+        cat $out | grep "Angular Language Service that implements the Language Server Protocol (LSP)"
+      '';
+    };
+
+    updateScript =
+      let
+        pkgFile = builtins.toString ./package.nix;
+      in
+      lib.getExe (writeShellApplication {
+        name = "update-${finalAttrs.pname}";
+        runtimeInputs = [
+          curl
+          pcre
+          common-updater-scripts
+          jq
+          gnused
+          gawk
+        ];
+        text = ''
+          LATEST_VERSION=$(curl -H "Accept: application/vnd.github+json" \
+            -Ls https://api.github.com/repos/${finalAttrs.src.owner}/${finalAttrs.src.repo}/releases/latest | \
+            jq -r .tag_name | cut -c 2-)
+            update-source-version ${finalAttrs.pname} "$LATEST_VERSION"
+            # match from line 32 on (index starts at 0) to avoid replacing the src hash
+            sed -i '31,/hash *= *"[^"]*"/{s/hash = "[^"]*"/hash = ""/}' ${pkgFile}
+
+            echo -e "\nFetching yarn dependencies This may take a while ..."
+            nix-build -A ${finalAttrs.pname} 2> ${finalAttrs.pname}-stderr.log || true
+            NEW_YARN_HASH=$(grep "got:" ${finalAttrs.pname}-stderr.log | awk '{print ''$2}')
+            rm ${finalAttrs.pname}-stderr.log
+            # escaping double quotes looks ugly but is needed for variable substitution
+            # use # instead of / as separator because the sha256 might contain the / character
+            sed -i "31,/hash *= *\"[^\"]*\"/{s#hash = \"[^\"]*\"#hash = \"$NEW_YARN_HASH\"#}" ${pkgFile}
+        '';
+      });
+  };
+
+  meta = {
+    description = "LSP for angular completions, AOT diagnostic, quick info and go to definitions";
+    homepage = "https://github.com/angular/vscode-ng-language-service";
+    changelog = "https://github.com/angular/vscode-ng-language-service/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "ngserver";
+    maintainers = with lib.maintainers; [ tricktron ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
EDIT:

Packaging the angular language server from source turns out to be tricky because it uses a combination of nodejs and bazel (and bazel is known to not play well together with nixpkgs https://github.com/NixOS/nixpkgs/issues/224446). The main problem is that bazel downloads a separate nodejs binary and then uses the pnpm lock file to transform all dependencies. Unfortunately, we cannot use that separate nodejs binary because it escapes the sandbox and probably will not even execute on nixos (e.g. nix-ld problem).

 I tried the following three approaches before I gave up and packged is as binary in https://github.com/NixOS/nixpkgs/pull/350257:

- https://github.com/NixOS/nixpkgs/pull/349521/commits/904f6667eb32381113bc007952659dc60f2dacce) was the start but I only realized afterwards that this only works without the sandbox on darwin.  On linux and darwin with the sandbox this fails because Bazel downloads its own nodejs binary which is not allowed in the buildPhase (no network access allowed).
- As a next step I tried to combine the yarn hooks with the buildBazelPackage function in https://github.com/NixOS/nixpkgs/pull/349521/commits/2e418c7d752e7e0938cc507599622e5b114c626f but that still failed because the downloaded nodejs binary still escapes the sandbox somehow. I then tried to manipulate the bazel files to inject the nix nodejs but then I got a bazel cycle dependency problem and since I am no bazel expert I stopped there.
- Finally, in https://github.com/NixOS/nixpkgs/pull/349521/commits/b1a395d84f0e1e6f99e3d2521ec9cdadbd8472ec I tried to replicate the esbuild bazel rules manually with the esbuild cli command but it still failed with some errors. I then gave up because this approach basically builds its own build script which will diverge in the future from upstream and does not seem maintainable to me. Besides you still need to be a bazel expert to continue transforming the upstream bazel build files to esbuild commands.

Continues on https://github.com/NixOS/nixpkgs/pull/343326.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
