### PR TITLE
wine: Improvements to cross and maybe static compilation

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -57,6 +57,8 @@ lib.optionalAttrs (buildScript != null) { builder = buildScript; }
 
   pname = prevName + lib.optionalString (wineRelease != "stable" && wineRelease != "unstable") "-${wineRelease}";
 
+  outputs = [ "out" "tools" ];
+
   # Fixes "Compiler cannot create executables" building wineWow with mingwSupport
   strictDeps = true;
 
@@ -142,7 +144,10 @@ lib.optionalAttrs (buildScript != null) { builder = buildScript; }
 
   postInstall = let
     links = prefix: pkg: "ln -s ${pkg} $out/${prefix}/${pkg.name}";
-  in lib.optionalString supportFlags.embedInstallers ''
+  in ''
+    mkdir -p "$tools"
+    cp -avT tools "$tools/tools" # not a typo; grep `/configure` for `$wine_cv_toolsdir`
+  '' + lib.optionalString supportFlags.embedInstallers ''
     mkdir -p $out/share/wine/gecko $out/share/wine/mono/
     ${lib.strings.concatStringsSep "\n"
           ((map (links "share/wine/gecko") geckos)

--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, pkgArches, makeSetupHook,
+{ stdenv, pkgsBuildHost, lib, pkgArches, makeSetupHook,
   pname, version, src, mingwGccs, monos, geckos, platforms,
   bison, flex, fontforge, makeWrapper, pkg-config,
   nixosTests,
@@ -115,6 +115,7 @@ lib.optionalAttrs (buildScript != null) { builder = buildScript; }
   inherit patches;
 
   configureFlags = prevConfigFlags
+    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--with-wine-tools=${lib.getOutput "tools" pkgsBuildHost.wine64Packages.minimal}"
     ++ lib.optionals supportFlags.waylandSupport [ "--with-wayland" ]
     ++ lib.optionals supportFlags.vulkanSupport [ "--with-vulkan" ]
     ++ lib.optionals ((stdenv.hostPlatform.isDarwin && !supportFlags.xineramaSupport) || !supportFlags.x11Support) [ "--without-x" ];

--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -116,6 +116,7 @@ lib.optionalAttrs (buildScript != null) { builder = buildScript; }
 
   configureFlags = prevConfigFlags
     ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--with-wine-tools=${lib.getOutput "tools" pkgsBuildHost.wine64Packages.minimal}"
+    ++ lib.optional stdenv.hostPlatform.isStatic "--without-freetype" # no idea why, but it was failing with "checking for -lfreetype... <...>-musl-1.2.3-bin/bin/ldd: conftest: Not a valid dynamic program"
     ++ lib.optionals supportFlags.waylandSupport [ "--with-wayland" ]
     ++ lib.optionals supportFlags.vulkanSupport [ "--with-vulkan" ]
     ++ lib.optionals ((stdenv.hostPlatform.isDarwin && !supportFlags.xineramaSupport) || !supportFlags.x11Support) [ "--without-x" ];


### PR DESCRIPTION
Back in March, I decided to try building `pkgsStatic.wine64Packages.minimal` and seeing how far I could get, but I soon shelved the project because I was relying on a fix for #295608 from an open PR. It's now merged and I'm still interested in a static WINE for use with [libTAS](https://github.com/clementgallet/libTAS), and also just out of curiosity. There's [this existing project](https://github.com/MIvanchev/static-wine32) but it uses Docker :(

After rebasing, I'm not seeing the "build success but ldd says it's dynamic" that my earlier commit messages would imply, so I'm not sure what happened there. The build fails with:
```
/nix/store/vnq97ff4729byby4jxc5hqfyxzixnv3i-wine64-9.0-tools/tools/winegcc/winegcc -o dlls/activeds/tests/activeds_test.exe.so \
  --wine-objdir . --winebuild \
  /nix/store/vnq97ff4729byby4jxc5hqfyxzixnv3i-wine64-9.0-tools/tools/winebuild/winebuild -b \
  x86_64-unknown-linux-musl -m64 -mno-cygwin -fPIC -fasynchronous-unwind-tables \
  dlls/activeds/tests/activeds.o dlls/activeds/tests/testlist.o dlls/ole32/libole32.a \
  dlls/oleaut32/liboleaut32.a dlls/activeds/libactiveds.a dlls/winecrt0/libwinecrt0.a \
  dlls/msvcrt/libmsvcrt.a dlls/kernel32/libkernel32.a dlls/ntdll/libntdll.a 
/nix/store/s2cjhni3s6shh0n35ay1hpj8d85k44qk-x86_64-unknown-linux-musl-binutils-2.43.1/bin/x86_64-unknown-linux-musl-ld: /nix/store/zdcraj3sk2sdd8giarhrydn3q96xw7k1-x86_64-unknown-linux-musl-gcc-13.3.0/lib/gcc/x86_64-unknown-linux-musl/13.3.0/crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
/nix/store/s2cjhni3s6shh0n35ay1hpj8d85k44qk-x86_64-unknown-linux-musl-binutils-2.43.1/bin/x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
winegcc: /nix/store/g5a11kdv41frlkl36qd0dn7mcrivy9af-x86_64-unknown-linux-musl-gcc-wrapper-13.3.0/bin/x86_64-unknown-linux-musl-gcc failed
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
