### PR TITLE
auto-cpufreq: copy icon to correct location

### DIFF
--- a/pkgs/by-name/au/auto-cpufreq/package.nix
+++ b/pkgs/by-name/au/auto-cpufreq/package.nix
@@ -82,7 +82,7 @@ python3Packages.buildPythonPackage rec {
     mkdir -p $out/share/applications
     mkdir $out/share/pixmaps
     cp scripts/auto-cpufreq-gtk.desktop $out/share/applications
-    cp images/icon.png $out/share/pixmaps/auto-cpufreq.python3Packages
+    cp images/icon.png $out/share/pixmaps/auto-cpufreq.png
 
     # polkit policy
     mkdir -p $out/share/polkit-1/actions


### PR DESCRIPTION
Fixes #337494

auto-cpufreq-gtk successfully starts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).