### PR TITLE
python3Packages.pytorch-ocl: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/pytorch-ocl/default.nix
+++ b/pkgs/development/python-modules/pytorch-ocl/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cmake,
+  torch,
+  ocl-icd,
+  opencl-clhpp,
+  sqlite,
+  python,
+}:
+buildPythonPackage rec {
+  pname = "pytorch-ocl";
+  version = "0.2.0";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "artyom-beilis";
+    repo = "pytorch_dlprim";
+    rev = "${version}";
+    hash = "sha256-N0NjpRWFAYeh2GQu8PPTtf4ZG2Jp9fgttjCbWOYQOmg=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  dependencies = [
+    torch
+    ocl-icd
+    opencl-clhpp
+    sqlite
+  ];
+
+  dontUseSetuptoolsBuild = true;
+  dontUsePipInstall = true;
+  dontUseSetuptoolsCheck = true;
+
+  postInstall = ''
+    mkdir -p $out/${python.sitePackages}
+    mv $out/python/* $out/${python.sitePackages}
+    rmdir $out/python
+  '';
+
+  pythonImportsCheck = [
+    "pytorch_ocl"
+  ];
+
+  meta = with lib; {
+    description = "DLPrimitives/OpenCL out of tree backend for pytorch";
+    maintainers = with maintainers; [ gm6k ];
+    license = licenses.mit;
+    homepage = "https://github.com/artyom-beilis/pytorch_dlprim";
+    changelog = "https://github.com/artyom-beilis/pytorch_dlprim/releases/tag/${src.rev}";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12993,6 +12993,8 @@ self: super: with self; {
 
   pytorch-msssim = callPackage ../development/python-modules/pytorch-msssim { };
 
+  pytorch-ocl = callPackage ../development/python-modules/pytorch-ocl { };
+
   pytorch-pfn-extras = callPackage ../development/python-modules/pytorch-pfn-extras { };
 
   pytraccar = callPackage ../development/python-modules/pytraccar { };


### PR DESCRIPTION
Adding an out-of-tree backend to use pytorch accelerated by OpenCL devices.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
