### PR TITLE
nixos/eval-config: Deprecate NIXOS_EXTRA_MODULE_PATH

### DIFF
--- a/nixos/doc/manual/development/importing-modules.section.md
+++ b/nixos/doc/manual/development/importing-modules.section.md
@@ -16,31 +16,3 @@ outside of Nixpkgs. These modules can be imported:
   services.exampleModule.enable = true;
 }
 ```
-
-The environment variable `NIXOS_EXTRA_MODULE_PATH` is an absolute path
-to a NixOS module that is included alongside the Nixpkgs NixOS modules.
-Like any NixOS module, this module can import additional modules:
-
-```nix
-# ./module-list/default.nix
-[
-  ./example-module1
-  ./example-module2
-]
-```
-
-```nix
-# ./extra-module/default.nix
-{ imports = import ./module-list.nix; }
-```
-
-```nix
-# NIXOS_EXTRA_MODULE_PATH=/absolute/path/to/extra-module
-{ config, lib, pkgs, ... }:
-
-{
-  # No `imports` needed
-
-  services.exampleModule1.enable = true;
-}
-```

--- a/nixos/doc/manual/development/meta-attributes.section.md
+++ b/nixos/doc/manual/development/meta-attributes.section.md
@@ -45,7 +45,7 @@ file.
 -  `buildDocsInSandbox` indicates whether the option documentation for the
    module can be built in a derivation sandbox. This option is currently only
    honored for modules shipped by nixpkgs. User modules and modules taken from
-   `NIXOS_EXTRA_MODULE_PATH` are always built outside of the sandbox, as has
+   `extraModules` are always built outside of the sandbox, as has
    been the case in previous releases.
 
    Building NixOS option documentation in a sandbox allows caching of the built

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -30,8 +30,29 @@ evalConfigArgs@
   check ? true
 , prefix ? []
 , lib ? import ../../lib
-, extraModules ? let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
-                 in lib.optional (e != "") (import e)
+, extraModules ?
+    let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
+    in lib.optional (e != "") (
+      lib.warn
+        ''
+          The NIXOS_EXTRA_MODULE_PATH environment variable is deprecated and will be
+          removed in NixOS 25.05.
+          We recommend a workflow where you update the expression files instead, but
+          if you wish to continue to use this variable, you may do so with a module like:
+
+          {
+            imports = [
+              (builtins.getEnv "NIXOS_EXTRA_MODULE_PATH")
+            ];
+          }
+
+          This has the benefit that your configuration hints at the
+          non-standard workflow.
+        ''
+        # NOTE: this import call is unnecessary and it even removes the file name
+        #       from error messages.
+        import e
+    )
 }:
 
 let


### PR DESCRIPTION
# Motivation

- Simplify important code.
- Make frown-worthy workflows explicit in user code.
- `getEnv` is just no good for Nix-style configuration management, even if you're not using pure mode or flakes.
- Closes https://github.com/NixOS/nixpkgs/issues/62116

# Description

This gets rid of a potentially confusing behavior that doesn't need to be in NixOS, and nobody ever bothered to write a test for it. Let's keep things simple!
The suggested snippet is better than this feature ever was, and will be in the user's face, where it belongs, kindly.

Tested with

    nix-instantiate nixos/lib/eval-config.nix --arg modules '[{fileSystems."/".device="x";boot.loader.grub.enable=false;}]' -A config.system.build.toplevel
    NIXOS_EXTRA_MODULE_PATH=$HOME/whatever.nix nix-instantiate nixos/lib/eval-config.nix --arg modules '[{fileSystems."/".device="x";boot.loader.grub.enable=false;}]' -A config.system.build.toplevel

I'm not adding a release note, because whoever needs to read about this will do so when they evaluate their upgrade.
No need to bother other users with it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
