### PR TITLE
nixos/zfs: fix shellcheck findings with enableStrictShellChecks enabled

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -57,6 +57,7 @@ let
   # latter case it makes one last attempt at importing, allowing the system to
   # (eventually) boot even with a degraded pool.
   importLib = {zpoolCmd, awkCmd, cfgZfs}: ''
+    # shellcheck disable=SC2013
     for o in $(cat /proc/cmdline); do
       case $o in
         zfs_force|zfs_force=1|zfs_force=y)
@@ -80,6 +81,7 @@ let
     }
     poolImport() {
       pool="$1"
+      # shellcheck disable=SC2086
       "${zpoolCmd}" import -d "${cfgZfs.devNodes}" -N $ZFS_FORCE "$pool"
     }
   '';
@@ -146,7 +148,7 @@ let
         if ! poolImported "${pool}"; then
           echo -n "importing ZFS pool \"${pool}\"..."
           # Loop across the import until it succeeds, because the devices needed may not be discovered yet.
-          for trial in `seq 1 60`; do
+          for _ in $(seq 1 60); do
             poolReady "${pool}" && poolImport "${pool}" && break
             sleep 1
           done
@@ -157,7 +159,7 @@ let
 
 
           ${lib.optionalString keyLocations.hasKeys ''
-            ${keyLocations.command} | while IFS=$'\t' read ds kl ks; do
+            ${keyLocations.command} | while IFS=$'\t' read -r ds kl ks; do
               {
               if [[ "$ks" != unavailable ]]; then
                 continue
@@ -613,7 +615,7 @@ in
             echo -n "importing root ZFS pool \"${pool}\"..."
             # Loop across the import until it succeeds, because the devices needed may not be discovered yet.
             if ! poolImported "${pool}"; then
-              for trial in `seq 1 60`; do
+              for _ in $(seq 1 60); do
                 poolReady "${pool}" > /dev/null && msg="$(poolImport "${pool}" 2>&1)" && break
                 sleep 1
                 echo -n .
@@ -865,6 +867,7 @@ in
           Type = "simple";
         };
         script = ''
+          # shellcheck disable=SC2046
           ${cfgZfs.package}/bin/zpool scrub -w ${
             if cfgScrub.pools != [] then
               (lib.concatStringsSep " " cfgScrub.pools)


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
