### PR TITLE
nagiosPlugins.check_interfaces: init at 1.4.4

### DIFF
--- a/pkgs/servers/monitoring/nagios-plugins/check_interfaces/default.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/check_interfaces/default.nix
@@ -1,0 +1,46 @@
+{
+  check_interfaces,
+  fetchurl,
+  lib,
+  net-snmp,
+  nix-update-script,
+  stdenv,
+  testers,
+}:
+stdenv.mkDerivation rec {
+  pname = "check_interfaces";
+  version = "1.4.4";
+
+  src = fetchurl {
+    url = "https://github.com/NETWAYS/check_interfaces/releases/download/v${version}/check_interfaces-${version}.tar.gz";
+    hash = "sha256-sQ2lee2gxyrl455tumMJ4EbKc8mYEDXl18Wik6daf5Q=";
+  };
+
+  buildInputs = [ net-snmp ];
+
+  configureFlags = [ "--libexecdir=${placeholder "out"}/bin" ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    # Remove unnecessary header files
+    rm --recursive $out/include
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = check_interfaces;
+    };
+  };
+
+  meta = with lib; {
+    changelog = "https://github.com/NETWAYS/check_interfaces/releases/tag/v${version}";
+    description = "Icinga check plugin for network hardware interfaces";
+    homepage = "https://github.com/NETWAYS/check_interfaces/";
+    license = with licenses; [ gpl2Only ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jwillikers ];
+    mainProgram = "check_interfaces";
+  };
+}

--- a/pkgs/servers/monitoring/nagios-plugins/plugins.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/plugins.nix
@@ -2,6 +2,7 @@
 
 {
   check_esxi_hardware = callPackage ./check_esxi_hardware { };
+  check_interfaces = callPackage ./check_interfaces { };
   check_openvpn = callPackage ./check_openvpn { };
   check_smartmon = callPackage ./check_smartmon { };
   check_ssl_cert = callPackage ./check_ssl_cert { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[check_interfaces](https://github.com/NETWAYS/check_interfaces) is an Icinga / Nagios check plugin for network hardware interfaces.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
