### PR TITLE
nagiosPlugins.manubulon-snmp-plugins: init at 2.1.0-unstable-2024-03-13

### DIFF
--- a/pkgs/servers/monitoring/nagios-plugins/manubulon-snmp-plugins/default.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/manubulon-snmp-plugins/default.nix
@@ -1,0 +1,67 @@
+{
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  manubulon-snmp-plugins,
+  nix-update-script,
+  perlPackages,
+  stdenv,
+  testers,
+}:
+stdenv.mkDerivation rec {
+  pname = "manubulon-snmp-plugins";
+  version = "2.1.0-unstable-2024-03-13";
+
+  src = fetchFromGitHub {
+    owner = "SteScho";
+    repo = "manubulon-snmp";
+    rev = "1a5afb2486802034146277010d956eba9c2ad54b";
+    hash = "sha256-B5CCGMkNv1wGnLQIl0yiGTH2j5MOlj5+MrRqbLNIwhE=";
+  };
+
+  buildInputs = with perlPackages; [
+    CryptDES
+    CryptRijndael
+    DigestHMAC
+    DigestSHA1
+    GetoptLongDescriptive
+    NetSNMP
+    perl
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir --parents $out/bin
+    install --mode=0755 plugins/*.pl $out/bin
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    for f in $out/bin/* ; do
+      wrapProgram $f --set PERL5LIB $PERL5LIB --set LC_ALL C
+    done
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    tests.version = testers.testVersion {
+      package = manubulon-snmp-plugins;
+      # Program returns status code 3
+      command = "check_snmp_int.pl --version || true";
+      version = builtins.head (lib.splitString "-" version);
+    };
+  };
+
+  meta = with lib; {
+    changelog = "https://github.com/SteScho/manubulon-snmp/releases/tag/v${version}";
+    description = "Set of Icinga/Nagios plugins to check hosts and hardware with the SNMP protocol";
+    homepage = "https://github.com/SteScho/manubulon-snmp";
+    license = with licenses; [ gpl2Only ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jwillikers ];
+  };
+}

--- a/pkgs/servers/monitoring/nagios-plugins/plugins.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/plugins.nix
@@ -11,4 +11,5 @@
   check_zfs = callPackage ./check_zfs { };
 
   inherit (callPackage ./labs_consol_de { }) check_mssql_health check_nwc_health check_ups_health;
+  manubulon-snmp-plugins = callPackage ./manubulon-snmp-plugins { };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The [Manubulon SNMP Plugins]( https://github.com/SteScho/manubulon-snmp) are a set of Icinga/Nagios plugins to check hosts and hardware with the SNMP protocol.

Fixes #349569.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
