### PR TITLE
hickory-util: init at 0.24.1

### DIFF
--- a/pkgs/by-name/hi/hickory-util/package.nix
+++ b/pkgs/by-name/hi/hickory-util/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "hickory-util";
+  version = "0.24.1";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-cDFKsD/6LmMrMZ5B2eC7ACmmh0Sxfnd3Y2KRbZ4e0yY=";
+  };
+
+  cargoHash = "sha256-8XDl+05cFcN+oZZMGUHS53QawKm+DiKPTIkU/HmP9dY=";
+
+  meta = {
+    description = "CLI utilities for Hickory DNS client";
+    homepage = "https://github.com/hickory-dns/hickory-dns/";
+    maintainers = with lib.maintainers; [ nartsiss ];
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+  };
+}


### PR DESCRIPTION
New package: [hickory-util](https://github.com/hickory-dns/hickory-dns/tree/main/util) - CLI utilities for [Hickory DNS](https://github.com/hickory-dns/hickory-dns) client (resolver, recursor, dns)
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
