### PR TITLE
tests.cc-wrapper: Run with an empty path

### DIFF
--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -11,6 +11,9 @@ let
   emulator = stdenv.hostPlatform.emulator buildPackages;
   isCxx = stdenv.cc.libcxx != null;
   libcxxStdenvSuffix = lib.optionalString isCxx "-libcxx";
+  CC = "PATH= ${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}cc"}";
+  CXX = "PATH= ${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}c++"}";
+  READELF = "PATH= ${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}readelf"}";
 in stdenv.mkDerivation {
   pname = "cc-wrapper-test-${stdenv.cc.cc.pname}${libcxxStdenvSuffix}";
   version = stdenv.cc.version;
@@ -20,38 +23,38 @@ in stdenv.mkDerivation {
     echo "With libc: ${stdenv.cc.libc.name}" >&2
     set -o pipefail
 
-    NIX_DEBUG=1 $CC -v
-    NIX_DEBUG=1 $CXX -v
+    NIX_DEBUG=1 ${CC} -v
+    NIX_DEBUG=1 ${CXX} -v
 
     echo "checking whether compiler builds valid C binaries... " >&2
-    $CC -o cc-check ${./cc-main.c}
+    ${CC} -o cc-check ${./cc-main.c}
     ${emulator} ./cc-check
 
     echo "checking whether compiler builds valid C++ binaries... " >&2
-    $CXX -o cxx-check ${./cxx-main.cc}
+    ${CXX} -o cxx-check ${./cxx-main.cc}
     ${emulator} ./cxx-check
 
     # test for https://github.com/NixOS/nixpkgs/issues/214524#issuecomment-1431745905
     # .../include/cxxabi.h:20:10: fatal error: '__cxxabi_config.h' file not found
     # in libcxxStdenv
     echo "checking whether cxxabi.h can be included... " >&2
-    $CXX -o include-cxxabi ${./include-cxxabi.cc}
+    ${CXX} -o include-cxxabi ${./include-cxxabi.cc}
     ${emulator} ./include-cxxabi
 
     # cxx doesn't have libatomic.so
     ${lib.optionalString (!isCxx) ''
       # https://github.com/NixOS/nixpkgs/issues/91285
       echo "checking whether libatomic.so can be linked... " >&2
-      $CXX -shared -o atomics.so ${./atomics.cc} -latomic ${lib.optionalString (stdenv.cc.isClang && lib.versionOlder stdenv.cc.version "6.0.0" ) "-std=c++17"}
-      $READELF -d ./atomics.so | grep libatomic.so && echo "ok" >&2 || echo "failed" >&2
+      ${CXX} -shared -o atomics.so ${./atomics.cc} -latomic ${lib.optionalString (stdenv.cc.isClang && lib.versionOlder stdenv.cc.version "6.0.0" ) "-std=c++17"}
+      ${READELF} -d ./atomics.so | grep libatomic.so && echo "ok" >&2 || echo "failed" >&2
     ''}
 
     # Test that linking libc++ works, and statically.
     ${lib.optionalString isCxx ''
       echo "checking whether can link with libc++... " >&2
-      NIX_DEBUG=1 $CXX ${./cxx-main.cc} -c -o cxx-main.o
-      NIX_DEBUG=1 $CC cxx-main.o -lc++ -o cxx-main
-      NIX_DEBUG=1 $CC cxx-main.o ${lib.getLib stdenv.cc.libcxx}/lib/libc++.a -o cxx-main-static
+      NIX_DEBUG=1 ${CXX} ${./cxx-main.cc} -c -o cxx-main.o
+      NIX_DEBUG=1 ${CC} cxx-main.o -lc++ -o cxx-main
+      NIX_DEBUG=1 ${CC} cxx-main.o ${lib.getLib stdenv.cc.libcxx}/lib/libc++.a -o cxx-main-static
       ${emulator} ./cxx-main
       ${emulator} ./cxx-main-static
       rm cxx-main{,-static,.o}
@@ -60,18 +63,18 @@ in stdenv.mkDerivation {
     ${lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.cc.isClang) ''
       echo "checking whether compiler can build with CoreFoundation.framework... " >&2
       mkdir -p foo/lib
-      $CC -framework CoreFoundation -o core-foundation-check ${./core-foundation-main.c}
+      ${CC} -framework CoreFoundation -o core-foundation-check ${./core-foundation-main.c}
       ${emulator} ./core-foundation-check
     ''}
 
 
     ${lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
       echo "checking whether compiler builds valid static C binaries... " >&2
-      $CC ${staticLibc} -static -o cc-static ${./cc-main.c}
+      ${CC} ${staticLibc} -static -o cc-static ${./cc-main.c}
       ${emulator} ./cc-static
       ${lib.optionalString (stdenv.cc.isGNU && lib.versionAtLeast (lib.getVersion stdenv.cc.name) "8.0.0") ''
         echo "checking whether compiler builds valid static pie C binaries... " >&2
-        $CC ${staticLibc} -static-pie -o cc-static-pie ${./cc-main.c}
+        ${CC} ${staticLibc} -static-pie -o cc-static-pie ${./cc-main.c}
         ${emulator} ./cc-static-pie
       ''}
     ''}
@@ -84,47 +87,47 @@ in stdenv.mkDerivation {
 
         # Make sure `--` is not parsed as a "non flag arg"; we should get an
         # input file error here and *not* a linker error.
-        { ! $CC --; } |& grep -q "no input files"
+        { ! ${CC} --; } |& grep -q "no input files"
 
         # And that positional file args _must_ be files (this is just testing
         # that we remembered to put the `--` back in the args to the compiler):
-        { ! $CC -c -- -o foo ${./foo.c}; } \
+        { ! ${CC} -c -- -o foo ${./foo.c}; } \
           |& grep -q "no such file or directory: '-o'"
 
         # Now check that we accept single and multiple positional file args:
-        $CC -c -DVALUE=42 -o positional/foo.o -- ${./foo.c}
-        $CC -o positional/main -- positional/foo.o ${./ldflags-main.c}
+        ${CC} -c -DVALUE=42 -o positional/foo.o -- ${./foo.c}
+        ${CC} -o positional/main -- positional/foo.o ${./ldflags-main.c}
         ${emulator} ./positional/main
     ''}
 
     echo "checking whether compiler uses NIX_CFLAGS_COMPILE... " >&2
     mkdir -p foo/include
     cp ${./foo.c} foo/include/foo.h
-    NIX_CFLAGS_COMPILE="-Ifoo/include -DVALUE=42" $CC -o cflags-check ${./cflags-main.c}
+    NIX_CFLAGS_COMPILE="-Ifoo/include -DVALUE=42" ${CC} -o cflags-check ${./cflags-main.c}
     ${emulator} ./cflags-check
 
     echo "checking whether compiler uses NIX_LDFLAGS... " >&2
     mkdir -p foo/lib
-    $CC -shared \
+    ${CC} -shared \
       ${lib.optionalString stdenv.hostPlatform.isDarwin "-Wl,-install_name,@rpath/libfoo.dylib"} \
       -DVALUE=42 \
       -o foo/lib/libfoo${stdenv.hostPlatform.extensions.sharedLibrary} \
       ${./foo.c}
 
-    NIX_LDFLAGS="-L$NIX_BUILD_TOP/foo/lib -rpath $NIX_BUILD_TOP/foo/lib" $CC -lfoo -o ldflags-check ${./ldflags-main.c}
+    NIX_LDFLAGS="-L$NIX_BUILD_TOP/foo/lib -rpath $NIX_BUILD_TOP/foo/lib" ${CC} -lfoo -o ldflags-check ${./ldflags-main.c}
     ${emulator} ./ldflags-check
 
     echo "Check whether -nostdinc and -nostdinc++ is handled correctly" >&2
     mkdir -p std-include
     cp ${./stdio.h} std-include/stdio.h
-    NIX_DEBUG=1 $CC -I std-include -nostdinc -o nostdinc-main ${./nostdinc-main.c}
+    NIX_DEBUG=1 ${CC} -I std-include -nostdinc -o nostdinc-main ${./nostdinc-main.c}
     ${emulator} ./nostdinc-main
-    $CXX -I std-include -nostdinc++ -o nostdinc-main++ ${./nostdinc-main.c}
+    ${CXX} -I std-include -nostdinc++ -o nostdinc-main++ ${./nostdinc-main.c}
     ${emulator} ./nostdinc-main++
 
     ${lib.optionalString sanitizersWorking ''
       echo "checking whether sanitizers are fully functional... ">&2
-      $CC -o sanitizers -fsanitize=address,undefined ${./sanitizers.c}
+      ${CC} -o sanitizers -fsanitize=address,undefined ${./sanitizers.c}
       ASAN_OPTIONS=use_sigaltstack=0 ${emulator} ./sanitizers
     ''}
 

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -30,6 +30,8 @@ with pkgs;
         (filter (lib.hasPrefix "gcc"))
         (filter (lib.hasSuffix "Stdenv"))
         (filter (n: n != "gccCrossLibcStdenv"))
+        (filter (n: n != "gcc49Stdenv"))
+        (filter (n: n != "gcc6Stdenv"))
       ] ++ lib.optionals (!(
         (stdenv.buildPlatform.isLinux && stdenv.buildPlatform.isx86_64) &&
         (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64)


### PR DESCRIPTION
Ensure our wrappers hardcode all the necessary tools


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
