### PR TITLE
foxmarks: init at 2.1.0

### DIFF
--- a/pkgs/by-name/fo/foxmarks/package.nix
+++ b/pkgs/by-name/fo/foxmarks/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  sqlite,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "foxmarks";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "zer0-x";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-tkmmu6A7vqK4yO9zHjVEeACaOHP3+hJQLBK7p/Svn7Q=";
+  };
+
+  cargoHash = "sha256-m3JtibgNHsZScxziNEu1ycslJocBXRbtloMWE0G5ZyM=";
+
+  buildInputs = [ sqlite ];
+
+  meta = {
+    description = "CLI read-only interface for Mozilla Firefox's bookmarks";
+    homepage = "https://github.com/zer0-x/foxmarks";
+    changelog = "https://github.com/zer0-x/foxmarks/blobl/v${version}/CHANGELOG.md";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ loicreynier ];
+  };
+}

--- a/pkgs/by-name/fo/foxmarks/package.nix
+++ b/pkgs/by-name/fo/foxmarks/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "zer0-x";
-    repo = pname;
+    repo = "foxmarks";
     rev = "v${version}";
     hash = "sha256-tkmmu6A7vqK4yO9zHjVEeACaOHP3+hJQLBK7p/Svn7Q=";
   };


### PR DESCRIPTION
Add `foxmarks`, a CLI read-only interface for Firefox bookmarks and history.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
