### PR TITLE
nagiosPlugins.openbsd_snmp3_check: init at 0.55

### DIFF
--- a/pkgs/servers/monitoring/nagios-plugins/openbsd_snmp3_check/default.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/openbsd_snmp3_check/default.nix
@@ -1,0 +1,41 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  openbsd_snmp3_check,
+  python3Packages,
+  testers,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "openbsd_snmp3_check";
+  version = "0.55";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "alexander-naumov";
+    repo = "openbsd_snmp3_check";
+    rev = "v${version}";
+    hash = "sha256-qDYANMvQU72f9wz8os7S1PfBH08AAqhtWLHVuSmkub4=";
+  };
+
+  postInstall = ''
+    install -Dm755 openbsd_snmp3.py $out/bin/openbsd_snmp3.py
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = openbsd_snmp3_check;
+    };
+  };
+
+  meta = with lib; {
+    changelog = "https://github.com/alexander-naumov/openbsd_snmp3_check/releases/tag/v${version}";
+    description = "SNMP v3 check for OpenBSD systems state monitoring";
+    homepage = "https://github.com/alexander-naumov/openbsd_snmp3_check";
+    license = with licenses; [ bsd3 ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jwillikers ];
+    mainProgram = "openbsd_snmp3.py";
+  };
+}

--- a/pkgs/servers/monitoring/nagios-plugins/plugins.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/plugins.nix
@@ -13,4 +13,5 @@
 
   inherit (callPackage ./labs_consol_de { }) check_mssql_health check_nwc_health check_ups_health;
   manubulon-snmp-plugins = callPackage ./manubulon-snmp-plugins { };
+  openbsd_snmp3_check = callPackage ./openbsd_snmp3_check { };
 }


### PR DESCRIPTION
[openbsd_snmp3_check](https://github.com/alexander-naumov/openbsd_snmp3_check) is an Icinga / Nagios SNMP v3 check plugin for OpenBSD systems state monitoring.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
