### PR TITLE
mbedtls: 3.6.1 -> 3.6.2

### DIFF
--- a/pkgs/development/libraries/mbedtls/3.nix
+++ b/pkgs/development/libraries/mbedtls/3.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "3.6.1";
-  hash = "sha256-SVWz2uOvGIplnBr4g6nwfxKMWVpzdZjusseAhw6GOJ8=";
+  version = "3.6.2";
+  hash = "sha256-tSWhF8i0Tx9QSFmyDEHdd2xveZvpyd+HXR+8xYj2Syo=";
 }


### PR DESCRIPTION
Release notes: https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.2

Fixes CVE-2024-49195


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:x: 6 packages failed to build:</summary>
  <ul>
    <li>obs-studio-plugins.advanced-scene-switcher</li>
    <li>obs-studio-plugins.obs-hyperion</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-ndi</li>
    <li>obs-studio-plugins.obs-transition-table</li>
    <li>obs-studio-plugins.obs-vertical-canvas</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 47 packages built:</summary>
  <ul>
    <li>gauche</li>
    <li>gaucheBootstrap</li>
    <li>hiawatha</li>
    <li>hyperhdr</li>
    <li>hyperion-ng</li>
    <li>imhex</li>
    <li>librist</li>
    <li>mbedtls</li>
    <li>nanomq</li>
    <li>nng</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.droidcam-obs</li>
    <li>obs-studio-plugins.input-overlay</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-3d-effect</li>
    <li>obs-studio-plugins.obs-backgroundremoval</li>
    <li>obs-studio-plugins.obs-command-source</li>
    <li>obs-studio-plugins.obs-composite-blur</li>
    <li>obs-studio-plugins.obs-freeze-filter</li>
    <li>obs-studio-plugins.obs-gradient-source</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-livesplit-one</li>
    <li>obs-studio-plugins.obs-move-transition</li>
    <li>obs-studio-plugins.obs-mute-filter</li>
    <li>obs-studio-plugins.obs-nvfbc</li>
    <li>obs-studio-plugins.obs-pipewire-audio-capture</li>
    <li>obs-studio-plugins.obs-replay-source</li>
    <li>obs-studio-plugins.obs-rgb-levels-filter</li>
    <li>obs-studio-plugins.obs-scale-to-sound</li>
    <li>obs-studio-plugins.obs-shaderfilter</li>
    <li>obs-studio-plugins.obs-source-clone</li>
    <li>obs-studio-plugins.obs-source-record</li>
    <li>obs-studio-plugins.obs-source-switcher</li>
    <li>obs-studio-plugins.obs-teleport</li>
    <li>obs-studio-plugins.obs-text-pthread</li>
    <li>obs-studio-plugins.obs-tuna</li>
    <li>obs-studio-plugins.obs-vaapi</li>
    <li>obs-studio-plugins.obs-vintage-filter</li>
    <li>obs-studio-plugins.obs-vkcapture</li>
    <li>obs-studio-plugins.obs-webkitgtk</li>
    <li>obs-studio-plugins.obs-websocket</li>
    <li>obs-studio-plugins.waveform</li>
    <li>obs-studio-plugins.wlrobs</li>
    <li>ps3netsrv</li>
    <li>shaka-packager</li>
    <li>sratoolkit</li>
    <li>srsran</li>
  </ul>
</details>

No new failures, the OBS plugins are currently failing to build on nixos-unstable: https://hydra.nixos.org/build/275148726 https://hydra.nixos.org/build/275147640 https://hydra.nixos.org/build/275152507 https://hydra.nixos.org/build/275153775 https://hydra.nixos.org/build/275155664

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
