### PR TITLE
dnslookup: init at 1.11.1

### DIFF
--- a/pkgs/by-name/dn/dnslookup/package.nix
+++ b/pkgs/by-name/dn/dnslookup/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "dnslookup";
+  version = "1.11.1";
+
+  src = fetchFromGitHub {
+    owner = "ameshkov";
+    repo = "dnslookup";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-zgEW4ANIlwF0f6YqTQicGhGgLc9RaL7Xy0wg/ICzOK4=";
+  };
+
+  vendorHash = "sha256-pdnKYsXBw/IjakUyQym4thnO3gXgvwNm80Ha8AUVt54=";
+
+  meta = {
+    changelog = "https://github.com/ameshkov/dnslookup/releases/tag/v${version}";
+    description = "Simple command line utility to make DNS lookups to the specified server";
+    homepage = "https://github.com/ameshkov/dnslookup";
+    license = lib.licenses.mit;
+    mainProgram = "dnslookup";
+    maintainers = [ lib.maintainers.philiptaron ];
+  };
+}


### PR DESCRIPTION
[`dnslookup`](https://github.com/ameshkov/dnslookup) is a simple command line utility to make DNS lookups to the specified server.

It supports:

1. plain UDP DNS
2. plain TCP DNS `tcp://`
3. DNS over TLS `tls://`
4. DNS over HTTPS `https://`
5. [DNSCrypt](https://www.dnscrypt.org/) `sdns://`
6. DNS over QUIC `quic://`

As far as I (@philiptaron) am aware, this is the most comprehensive DNS query tool in terms of number of formats supported that exists.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).