### PR TITLE
nixos/ntpd: cleanup; add tests

### DIFF
--- a/nixos/modules/services/networking/ntp/ntpd.nix
+++ b/nixos/modules/services/networking/ntp/ntpd.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
@@ -25,7 +30,12 @@ let
     ${cfg.extraConfig}
   '';
 
-  ntpFlags = [ "-c" "${configFile}" "-u" "ntp:ntp" ] ++ cfg.extraFlags;
+  ntpFlags = [
+    "-c"
+    "${configFile}"
+    "-u"
+    "ntp:ntp"
+  ] ++ cfg.extraFlags;
 
 in
 
@@ -58,7 +68,14 @@ in
           recommended in section 6.5.1.1.3, answer "No" of
           https://support.ntp.org/Support/AccessRestrictions
         '';
-        default = [ "limited" "kod" "nomodify" "notrap" "noquery" "nopeer" ];
+        default = [
+          "limited"
+          "kod"
+          "nomodify"
+          "notrap"
+          "noquery"
+          "nopeer"
+        ];
       };
 
       restrictSource = mkOption {
@@ -69,7 +86,13 @@ in
           The default flags allow peers to be added by ntpd from configured
           pool(s), but not by other means.
         '';
-        default = [ "limited" "kod" "nomodify" "notrap" "noquery" ];
+        default = [
+          "limited"
+          "kod"
+          "nomodify"
+          "notrap"
+          "noquery"
+        ];
       };
 
       servers = mkOption {
@@ -96,13 +119,12 @@ in
         type = types.listOf types.str;
         description = "Extra flags passed to the ntpd command.";
         example = literalExpression ''[ "--interface=eth0" ]'';
-        default = [];
+        default = [ ];
       };
 
     };
 
   };
-
 
   ###### implementation
 
@@ -113,34 +135,35 @@ in
     environment.systemPackages = [ pkgs.ntp ];
     services.timesyncd.enable = mkForce false;
 
-    systemd.services.systemd-timedated.environment = { SYSTEMD_TIMEDATED_NTP_SERVICES = "ntpd.service"; };
+    systemd.services.systemd-timedated.environment = {
+      SYSTEMD_TIMEDATED_NTP_SERVICES = "ntpd.service";
+    };
 
-    users.users.ntp =
-      { isSystemUser = true;
-        group = "ntp";
-        description = "NTP daemon user";
-        home = stateDir;
+    users.users.ntp = {
+      isSystemUser = true;
+      group = "ntp";
+      description = "NTP daemon user";
+      home = stateDir;
+    };
+    users.groups.ntp = { };
+
+    systemd.services.ntpd = {
+      description = "NTP Daemon";
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "time-sync.target" ];
+      before = [ "time-sync.target" ];
+
+      preStart = ''
+        mkdir -m 0755 -p ${stateDir}
+        chown ntp ${stateDir}
+      '';
+
+      serviceConfig = {
+        ExecStart = "@${ntp}/bin/ntpd ntpd -g ${builtins.toString ntpFlags}";
+        Type = "forking";
       };
-    users.groups.ntp = {};
-
-    systemd.services.ntpd =
-      { description = "NTP Daemon";
-
-        wantedBy = [ "multi-user.target" ];
-        wants = [ "time-sync.target" ];
-        before = [ "time-sync.target" ];
-
-        preStart =
-          ''
-            mkdir -m 0755 -p ${stateDir}
-            chown ntp ${stateDir}
-          '';
-
-        serviceConfig = {
-          ExecStart = "@${ntp}/bin/ntpd ntpd -g ${builtins.toString ntpFlags}";
-          Type = "forking";
-        };
-      };
+    };
 
   };
 

--- a/nixos/modules/services/networking/ntp/ntpd.nix
+++ b/nixos/modules/services/networking/ntp/ntpd.nix
@@ -13,10 +13,8 @@ let
 
   cfg = config.services.ntp;
 
-  stateDir = "/var/lib/ntp";
-
   configFile = pkgs.writeText "ntp.conf" ''
-    driftfile ${stateDir}/ntp.drift
+    driftfile /var/lib/ntp/ntp.drift
 
     restrict default ${toString cfg.restrictDefault}
     restrict -6 default ${toString cfg.restrictDefault}
@@ -143,7 +141,7 @@ in
       isSystemUser = true;
       group = "ntp";
       description = "NTP daemon user";
-      home = stateDir;
+      home = "/var/lib/ntp";
     };
     users.groups.ntp = { };
 
@@ -154,14 +152,10 @@ in
       wants = [ "time-sync.target" ];
       before = [ "time-sync.target" ];
 
-      preStart = ''
-        mkdir -m 0755 -p ${stateDir}
-        chown ntp ${stateDir}
-      '';
-
       serviceConfig = {
         ExecStart = "@${ntp}/bin/ntpd ntpd -g ${builtins.toString ntpFlags}";
         Type = "forking";
+        StateDirectory = "ntp";
       };
     };
 

--- a/nixos/modules/services/networking/ntp/ntpd.nix
+++ b/nixos/modules/services/networking/ntp/ntpd.nix
@@ -156,6 +156,32 @@ in
         ExecStart = "@${ntp}/bin/ntpd ntpd -g ${builtins.toString ntpFlags}";
         Type = "forking";
         StateDirectory = "ntp";
+
+        # Hardening options
+        PrivateDevices = true;
+        PrivateIPC = true;
+        PrivateTmp = true;
+        ProtectClock = false;
+        ProtectHome = true;
+
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = true;
+
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        AmbientCapabilities = [
+          "CAP_SYS_TIME"
+        ];
+
+        ProtectControlGroups = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        RestrictSUIDSGID = true;
       };
     };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -714,6 +714,7 @@ in {
   nsd = handleTest ./nsd.nix {};
   ntfy-sh = handleTest ./ntfy-sh.nix {};
   ntfy-sh-migration = handleTest ./ntfy-sh-migration.nix {};
+  ntpd = handleTest ./ntpd.nix {};
   ntpd-rs = handleTest ./ntpd-rs.nix {};
   nvidia-container-toolkit = runTest ./nvidia-container-toolkit.nix;
   nvmetcfg = handleTest ./nvmetcfg.nix {};

--- a/nixos/tests/ntpd.nix
+++ b/nixos/tests/ntpd.nix
@@ -1,0 +1,25 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+  {
+    name = "ntpd";
+
+    meta = {
+      maintainers = with lib.maintainers; [ pyrox0 ];
+    };
+
+    nodes.machine = {
+      services.ntp = {
+        enable = true;
+      };
+    };
+
+    testScript = ''
+      start_all()
+
+      machine.wait_for_unit('ntpd.service')
+      machine.wait_for_console_text('Listen normally on 10 eth*')
+      machine.succeed('systemctl is-active ntpd.service')
+      machine.succeed('ntpq -p')
+    '';
+  }
+)


### PR DESCRIPTION
Brings the NTPd service more in line with modern services, reducing its security impact on a system, and also adds tests to ensure it works properly. Currently the tests are very basic, but they ensure that the unit starts properly and that userland tools are able to communicate with ntpd.

Part of #349572

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
