### PR TITLE
ghidra: add wasm extension

### DIFF
--- a/pkgs/tools/security/ghidra/extensions.nix
+++ b/pkgs/tools/security/ghidra/extensions.nix
@@ -31,4 +31,5 @@ lib.makeScope newScope (self: {
 
   sleighdevtools = self.callPackage ./extensions/sleighdevtools { inherit ghidra; };
 
+  wasm = self.callPackage ./extensions/wasm { inherit ghidra; };
 })

--- a/pkgs/tools/security/ghidra/extensions/wasm/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/wasm/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGhidraExtension,
+  ghidra,
+  ant,
+}:
+let
+  version = "2.3.1";
+in
+buildGhidraExtension {
+  pname = "wasm";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "nneonneo";
+    repo = "ghidra-wasm-plugin";
+    rev = "v${version}";
+    hash = "sha256-aoSMNzv+TgydiXM4CbvAyu/YsxmdZPvpkZkYEE3C+V4=";
+  };
+
+  nativeBuildInputs = [ ant ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    # this doesn't really compile, it compresses sinc into sla
+    pushd data
+    ant -f build.xml -Dghidra.install.dir=${ghidra}/lib/ghidra sleighCompile
+    popd
+
+    runHook postConfigure
+  '';
+
+  meta = {
+    description = "Ghidra Wasm plugin with disassembly and decompilation support";
+    homepage = "https://github.com/nneonneo/ghidra-wasm-plugin";
+    downloadPage = "https://github.com/nneonneo/ghidra-wasm-plugin/releases/tag/v${version}";
+    changelog = "https://github.com/nneonneo/ghidra-wasm-plugin/releases/tag/v${version}";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.BonusPlay ];
+  };
+}


### PR DESCRIPTION
ghidra-wasm-plugin is an extension that adds WASM support to ghidra. I haven't tested it extensively, but it does seem to be working. This also shows how to implement sleigh language compilation for ghidra extensions using nix.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
