### PR TITLE
copywrite: init at 0.19.0

### DIFF
--- a/pkgs/by-name/co/copywrite/package.nix
+++ b/pkgs/by-name/co/copywrite/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  testers,
+  copywrite,
+}:
+
+let
+  commitHash = "6ed520a710166c6094098b786c63f212604654a4"; # matches tag release
+  shortCommitHash = builtins.substring 0 7 commitHash;
+in
+buildGoModule rec {
+  pname = "copywrite";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = "copywrite";
+    rev = "v${version}";
+    hash = "sha256-DmlPioaw/wMk8GoBYNG24P4J1C6h0bjVjjOuMYW6Tgo=";
+  };
+
+  vendorHash = "sha256-ZIu0/fue3xi+YVE9GFsVjCNs8t3c3TWH8O0xUzJdim8=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/hashicorp/copywrite/cmd.version=${version}"
+    "-X github.com/hashicorp/copywrite/cmd.commit=${shortCommitHash}"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    $out/bin/copywrite completion bash > copywrite.bash
+    $out/bin/copywrite completion zsh > copywrite.zsh
+    $out/bin/copywrite completion fish > copywrite.fish
+    installShellCompletion copywrite.{bash,zsh,fish}
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = copywrite;
+    command = "copywrite --version";
+    version = "${version}-${shortCommitHash}";
+  };
+
+  meta = {
+    description = "Automate copyright headers and license files at scale";
+    mainProgram = "copywrite";
+    homepage = "https://github.com/hashicorp/copywrite";
+    changelog = "https://github.com/hashicorp/copywrite/releases/tag/v${version}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ dvcorreia ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Copywrite provides utilities for managing copyright headers and license files.
You can use it to report on what licenses repos are using, add LICENSE files, and add or validate the presence of copyright headers on source code files.

I've been using this tool for quite some time and it is fairly nice. Previously I would install it with Go, but migrating some CIs to Nix made it useful to have it upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
