### PR TITLE
python312Packages.llama-cpp-python: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/llama-cpp-python/default.nix
+++ b/pkgs/development/python-modules/llama-cpp-python/default.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  buildPythonPackage,
+  cmake,
+  fetchFromGitHub,
+  gitUpdater,
+  ninja,
+  pathspec,
+  pyproject-metadata,
+  pytestCheckHook,
+  pythonOlder,
+  scikit-build-core,
+
+  config,
+  cudaSupport ? config.cudaSupport,
+  cudaPackages ? { },
+
+  diskcache,
+  jinja2,
+  numpy,
+  typing-extensions,
+  scipy,
+  huggingface-hub,
+}:
+
+buildPythonPackage rec {
+  pname = "llama-cpp-python";
+  version = "0.3.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "abetlen";
+    repo = "llama-cpp-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-eO1zvNJZBE5BCnbgbh00tFIRWBCWor1lIsrLXs/HFds=";
+    fetchSubmodules = true;
+  };
+
+  dontUseCmakeConfigure = true;
+  SKBUILD_CMAKE_ARGS = lib.strings.concatStringsSep ";" (
+    lib.optionals cudaSupport [
+      "-DGGML_CUDA=on"
+      "-DCUDAToolkit_ROOT=${lib.getDev cudaPackages.cuda_nvcc}"
+      "-DCMAKE_CUDA_COMPILER=${lib.getExe cudaPackages.cuda_nvcc}"
+    ]
+  );
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pathspec
+    pyproject-metadata
+    scikit-build-core
+  ];
+
+  buildInputs = lib.optionals cudaSupport (
+    with cudaPackages;
+    [
+      cuda_cudart # cuda_runtime.h
+      cuda_cccl # <thrust/*>
+      libcublas # cublas_v2.h
+    ]
+  );
+
+  propagatedBuildInputs = [
+    diskcache
+    jinja2
+    numpy
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    scipy
+    huggingface-hub
+  ];
+
+  disabledTests = [
+    # tries to download model from huggingface-hub
+    "test_real_model"
+    "test_real_llama"
+  ];
+
+  pythonImportsCheck = [ "llama_cpp" ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "Python bindings for llama.cpp";
+    homepage = "https://github.com/abetlen/llama-cpp-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kirillrdy ];
+  };
+}

--- a/pkgs/development/python-modules/llama-cpp-python/default.nix
+++ b/pkgs/development/python-modules/llama-cpp-python/default.nix
@@ -10,6 +10,7 @@
   pytestCheckHook,
   pythonOlder,
   scikit-build-core,
+  llama-cpp-python,
 
   config,
   cudaSupport ? config.cudaSupport,
@@ -86,6 +87,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "llama_cpp" ];
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+  passthru.tests.llama-cpp-python = llama-cpp-python.override { cudaSupport = true; };
 
   meta = {
     description = "Python bindings for llama.cpp";

--- a/pkgs/development/python-modules/llama-cpp-python/default.nix
+++ b/pkgs/development/python-modules/llama-cpp-python/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   cmake,
   fetchFromGitHub,
@@ -23,13 +24,17 @@
   scipy,
   huggingface-hub,
 }:
-
-buildPythonPackage rec {
-  pname = "llama-cpp-python";
+let
   version = "0.3.1";
+in
+buildPythonPackage {
+  pname = "llama-cpp-python";
+  inherit version;
   pyproject = true;
 
   disabled = pythonOlder "3.7";
+
+  stdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
 
   src = fetchFromGitHub {
     owner = "abetlen";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7366,6 +7366,8 @@ self: super: with self; {
 
   lizard = callPackage ../development/python-modules/lizard { };
 
+  llama-cpp-python = callPackage ../development/python-modules/llama-cpp-python { };
+
   llama-cloud = callPackage ../development/python-modules/llama-cloud { };
 
   llama-index = callPackage ../development/python-modules/llama-index { };


### PR DESCRIPTION
unlike previous attempt https://github.com/NixOS/nixpkgs/pull/268712

this uses bundled version of llama-cpp, also tested CUDA support


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
