### PR TITLE
lesspipe: use resholve.mkDerivation for overriding

### DIFF
--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -18,7 +18,7 @@
 , ncurses
 }:
 
-stdenv.mkDerivation rec {
+resholve.mkDerivation rec {
   pname = "lesspipe";
   version = "2.11";
 
@@ -36,6 +36,9 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs --build configure
     substituteInPlace configure --replace '/etc/bash_completion.d' '/share/bash-completion/completions'
+
+    # resholve doesn't see strings in an array definition
+    substituteInPlace lesspipe.sh --replace 'nodash strings' "nodash ${binutils-unwrapped}/bin/strings"
   '';
 
   configureFlags = [ "--shell=${bash}/bin/bash" "--prefix=/" ];
@@ -45,11 +48,8 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "DESTDIR=$(out)" ];
 
-  postInstall = ''
-    # resholve doesn't see strings in an array definition
-    substituteInPlace $out/bin/lesspipe.sh --replace 'nodash strings' "nodash ${binutils-unwrapped}/bin/strings"
-
-    ${resholve.phraseSolution "lesspipe.sh" {
+  solutions = {
+    lesspipe = {
       scripts = [ "bin/lesspipe.sh" ];
       interpreter = "${bash}/bin/bash";
       inputs = [
@@ -84,8 +84,8 @@ stdenv.mkDerivation rec {
       execer = [
         "cannot:${iconv}/bin/iconv"
       ];
-    }}
-    ${resholve.phraseSolution "lesscomplete" {
+    };
+    lesscomplete = {
       scripts = [ "bin/lesscomplete" ];
       interpreter = "${bash}/bin/bash";
       inputs = [
@@ -104,8 +104,8 @@ stdenv.mkDerivation rec {
         ];
         builtin = [ "setopt" ];
       };
-    }}
-  '';
+    };
+  };
 
   meta = with lib; {
     description = "Preprocessor for less";


### PR DESCRIPTION
Existing derivation is using resholve's phraseSolution API from its postInstall. Since that's all just a string, it isn't as easy for end users to be able to override as it is if everything is defined in a solutions attrset.

cc @sliedes (who pointed out the problem on Matrix)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
