### PR TITLE
lixVersions.lix_2_91: 2.91.0 -> 2.91.1

### DIFF
--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -63,26 +63,9 @@ lib.makeExtensible (self: {
 
   lix_2_91 = (
     common {
-      version = "2.91.0";
-      hash = "sha256-Rosl9iA9MybF5Bud4BTAQ9adbY81aGmPfV8dDBGl34s=";
-      docCargoHash = "sha256-KOn1fXF7k7c/0e5ZCNZwt3YZmjL1oi5A2mhwxQWKaUo=";
-
-      patches = [
-        # Fix meson to not use target_machine, fixing cross. This commit is in release-2.91: remove when updating to 2.91.1 (if any).
-        # https://gerrit.lix.systems/c/lix/+/1781
-        # https://git.lix.systems/lix-project/lix/commit/ca2b514e20de12b75088b06b8e0e316482516401
-        (fetchpatch {
-          url = "https://git.lix.systems/lix-project/lix/commit/ca2b514e20de12b75088b06b8e0e316482516401.patch";
-          hash = "sha256-TZauU4RIsn07xv9vZ33amrDvCLMbrtcHs1ozOTLgu98=";
-        })
-        # Fix musl builds. This commit is in release-2.91: remove when updating to 2.91.1 (if any).
-        # https://gerrit.lix.systems/c/lix/+/1823
-        # https://git.lix.systems/lix-project/lix/commit/ed51a172c69996fc6f3b7dfaa86015bff50c8ba8
-        (fetchpatch {
-          url = "https://git.lix.systems/lix-project/lix/commit/ed51a172c69996fc6f3b7dfaa86015bff50c8ba8.patch";
-          hash = "sha256-X59N+tOQ2GN17p9sXvo9OiuEexzB23ieuOvtq2sre5c=";
-        })
-      ];
+      version = "2.91.1";
+      hash = "sha256-hiGtfzxFkDc9TSYsb96Whg0vnqBVV7CUxyscZNhed0U=";
+      docCargoHash = "sha256-F6Ld0HfRvW9r5zn8eMTP6djnV/jvwjYQet4Ghp2T90k=";
     }
   );
 


### PR DESCRIPTION
This release comprises really only a couple of commits: Fix build bugs found immediately following release:
- cross fix: https://gerrit.lix.systems/c/lix/+/1781
- musl fix: https://gerrit.lix.systems/c/lix/+/1823

Check TLS certificates in builtins:fetchurl: https://gerrit.lix.systems/c/lix/+/1966

Yes, the latter is a bit delayed to get into a release, sorry.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
