### PR TITLE
rdkafka: switch to cmake, split outputs, remove static library from non-static targets, fix static build

### DIFF
--- a/pkgs/by-name/mo/modern-cpp-kafka/package.nix
+++ b/pkgs/by-name/mo/modern-cpp-kafka/package.nix
@@ -53,13 +53,18 @@ stdenv.mkDerivation rec {
   buildInputs = [ boost ];
   propagatedBuildInputs = [ rdkafka ];
 
-  cmakeFlags = [
-    "-DLIBRDKAFKA_INCLUDE_DIR=${rdkafka.out}/include"
-    "-DGTEST_LIBRARY_DIR=${gtest.out}/lib"
-    "-DGTEST_INCLUDE_DIR=${gtest.dev}/include"
-    "-DRAPIDJSON_INCLUDE_DIRS=${rapidjson.out}/include"
-    "-DCMAKE_CXX_FLAGS=-Wno-uninitialized"
-  ];
+  cmakeFlags =
+    let
+      inherit (lib) cmakeFeature getLib getInclude;
+    in
+    [
+      (cmakeFeature "LIBRDKAFKA_LIBRARY_DIR" "${getLib rdkafka}/lib")
+      (cmakeFeature "LIBRDKAFKA_INCLUDE_DIR" "${getInclude rdkafka}/include")
+      (cmakeFeature "GTEST_LIBRARY_DIR" "${getLib gtest}/lib")
+      (cmakeFeature "GTEST_INCLUDE_DIR" "${getInclude gtest}/include")
+      (cmakeFeature "RAPIDJSON_INCLUDE_DIRS" "${getInclude rapidjson}/include")
+      (cmakeFeature "CMAKE_CXX_FLAGS" "-Wno-uninitialized")
+    ];
 
   checkInputs = [
     gtest

--- a/pkgs/by-name/mo/modern-cpp-kafka/package.nix
+++ b/pkgs/by-name/mo/modern-cpp-kafka/package.nix
@@ -41,6 +41,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/morganstanley/modern-cpp-kafka/commit/236f8f91f5c3ad6e1055a6f55cd3aebd218e1226.patch";
       hash = "sha256-cy568TQUu08sadq79hDz9jMvDqiDjfr+1cLMxFWGm1Q=";
     })
+    (fetchpatch {
+      name = "macos-find-dylib.patch";
+      url = "https://github.com/morganstanley/modern-cpp-kafka/commit/dc2753cd95b607a7202b40bad3aad472558bf350.patch";
+      hash = "sha256-Te3GwAVRDyb6GFWlvkq1mIcNeXCtMyLr+/w1LilUYbE=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/by-name/rd/rdkafka/package.nix
+++ b/pkgs/by-name/rd/rdkafka/package.nix
@@ -4,11 +4,10 @@
   fetchFromGitHub,
   zlib,
   zstd,
-  pkg-config,
-  python3,
   openssl,
-  which,
   curl,
+  cmake,
+  ninja,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -22,10 +21,14 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-OCCsxgEO8UvCcC0XwzqpqmaT8dV0Klrspp+2o1FbH2Y=";
   };
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   nativeBuildInputs = [
-    pkg-config
-    python3
-    which
+    cmake
+    ninja
   ];
 
   buildInputs = [
@@ -35,7 +38,12 @@ stdenv.mkDerivation (finalAttrs: {
     curl
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=strict-overflow";
+  # some tests don't build on darwin
+  cmakeFlags = [
+    (lib.cmakeBool "RDKAFKA_BUILD_TESTS" (!stdenv.hostPlatform.isDarwin))
+    (lib.cmakeBool "RDKAFKA_BUILD_EXAMPLES" (!stdenv.hostPlatform.isDarwin))
+    (lib.cmakeFeature "CMAKE_C_FLAGS" "-Wno-error=strict-overflow")
+  ];
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/by-name/rd/rdkafka/package.nix
+++ b/pkgs/by-name/rd/rdkafka/package.nix
@@ -38,15 +38,28 @@ stdenv.mkDerivation (finalAttrs: {
     curl
   ];
 
-  # some tests don't build on darwin
+  # examples and tests don't build on darwin statically
   cmakeFlags = [
-    (lib.cmakeBool "RDKAFKA_BUILD_TESTS" (!stdenv.hostPlatform.isDarwin))
-    (lib.cmakeBool "RDKAFKA_BUILD_EXAMPLES" (!stdenv.hostPlatform.isDarwin))
+    (lib.cmakeBool "RDKAFKA_BUILD_STATIC" stdenv.hostPlatform.isStatic)
+    (lib.cmakeBool "RDKAFKA_BUILD_TESTS" (
+      !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isStatic
+    ))
+    (lib.cmakeBool "RDKAFKA_BUILD_EXAMPLES" (
+      !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isStatic
+    ))
     (lib.cmakeFeature "CMAKE_C_FLAGS" "-Wno-error=strict-overflow")
   ];
 
   postPatch = ''
     patchShebangs .
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isStatic ''
+    # rdkafka changes the library names for static libraries but users in pkgsStatic aren't likely to be aware of this
+    # make sure the libraries are findable with both names
+    for pc in rdkafka{,++}; do
+      ln -s $dev/lib/pkgconfig/$pc{-static,}.pc
+    done
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/php-packages/rdkafka/default.nix
+++ b/pkgs/development/php-packages/rdkafka/default.nix
@@ -18,7 +18,7 @@ buildPecl {
 
   postPhpize = ''
     substituteInPlace configure \
-      --replace 'SEARCH_PATH="/usr/local /usr"' 'SEARCH_PATH=${rdkafka}'
+      --replace-fail 'SEARCH_PATH="/usr/local /usr"' 'SEARCH_PATH=${lib.getInclude rdkafka}'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
(refer to PR title)

As a nice side-effect, this reduces the size of .out from 12MB to 3MB.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>12 packages failed to build:</summary>
  <ul>
    <li>authentik</li>
    <li>dvc-with-remotes</li>
    <li>dvc-with-remotes.dist</li>
    <li>kafka-delta-ingest</li>
    <li>python311Packages.django-health-check</li>
    <li>python311Packages.django-health-check.dist</li>
    <li>python312Packages.django-health-check</li>
    <li>python312Packages.django-health-check.dist</li>
    <li>quickgui</li>
    <li>quickgui.debug</li>
    <li>quickgui.pubcache</li>
    <li>vector</li>
  </ul>
</details>
<details>
  <summary>153 packages built:</summary>
  <ul>
    <li>ceph</li>
    <li>ceph-client</li>
    <li>ceph-csi</li>
    <li>ceph.dev</li>
    <li>ceph.doc</li>
    <li>libceph (ceph.lib ,libceph.dev ,libceph.doc ,libceph.lib ,libceph.man)</li>
    <li>ceph.man</li>
    <li>collectd</li>
    <li>dvc (python312Packages.dvc)</li>
    <li>dvc.dist (python312Packages.dvc.dist)</li>
    <li>kcat</li>
    <li>libserdes</li>
    <li>libserdes.dev</li>
    <li>materialize</li>
    <li>modern-cpp-kafka</li>
    <li>ntopng</li>
    <li>ocamlPackages.kafka</li>
    <li>paperless-ngx</li>
    <li>php81Extensions.rdkafka</li>
    <li>php82Extensions.rdkafka</li>
    <li>php83Extensions.rdkafka</li>
    <li>php84Extensions.rdkafka</li>
    <li>pretalx</li>
    <li>pretalx.dist</li>
    <li>pretalx.static</li>
    <li>pretix</li>
    <li>pretix.dist</li>
    <li>python311Packages.bytewax</li>
    <li>python311Packages.bytewax.dist</li>
    <li>python311Packages.celery</li>
    <li>python311Packages.celery-redbeat</li>
    <li>python311Packages.celery-redbeat.dist</li>
    <li>python311Packages.celery-singleton</li>
    <li>python311Packages.celery-singleton.dist</li>
    <li>python311Packages.celery.dist</li>
    <li>python311Packages.confluent-kafka</li>
    <li>python311Packages.confluent-kafka.dist</li>
    <li>python311Packages.django-celery-beat</li>
    <li>python311Packages.django-celery-beat.dist</li>
    <li>python311Packages.django-celery-email</li>
    <li>python311Packages.django-celery-email.dist</li>
    <li>python311Packages.django-celery-results</li>
    <li>python311Packages.django-celery-results.dist</li>
    <li>python311Packages.django-google-analytics-app</li>
    <li>python311Packages.django-google-analytics-app.dist</li>
    <li>python311Packages.django-raster</li>
    <li>python311Packages.django-raster.dist</li>
    <li>python311Packages.djmail</li>
    <li>python311Packages.djmail.dist</li>
    <li>python311Packages.dvc</li>
    <li>python311Packages.dvc-gdrive</li>
    <li>python311Packages.dvc-gdrive.dist</li>
    <li>python311Packages.dvc-hdfs</li>
    <li>python311Packages.dvc-hdfs.dist</li>
    <li>python311Packages.dvc-task</li>
    <li>python311Packages.dvc-task.dist</li>
    <li>python311Packages.dvc.dist</li>
    <li>python311Packages.dvclive</li>
    <li>python311Packages.dvclive.dist</li>
    <li>python311Packages.flower</li>
    <li>python311Packages.flower.dist</li>
    <li>python311Packages.kombu</li>
    <li>python311Packages.kombu.dist</li>
    <li>python311Packages.mmcv</li>
    <li>python311Packages.mmcv.dist</li>
    <li>python311Packages.mmengine</li>
    <li>python311Packages.mmengine.dist</li>
    <li>python311Packages.nameko</li>
    <li>python311Packages.nameko.dist</li>
    <li>python311Packages.opentelemetry-instrumentation-celery</li>
    <li>python311Packages.opentelemetry-instrumentation-celery.dist</li>
    <li>python311Packages.streamz</li>
    <li>python311Packages.streamz.dist</li>
    <li>python312Packages.bytewax</li>
    <li>python312Packages.bytewax.dist</li>
    <li>python312Packages.celery</li>
    <li>python312Packages.celery-redbeat</li>
    <li>python312Packages.celery-redbeat.dist</li>
    <li>python312Packages.celery-singleton</li>
    <li>python312Packages.celery-singleton.dist</li>
    <li>python312Packages.celery.dist</li>
    <li>python312Packages.confluent-kafka</li>
    <li>python312Packages.confluent-kafka.dist</li>
    <li>python312Packages.django-celery-beat</li>
    <li>python312Packages.django-celery-beat.dist</li>
    <li>python312Packages.django-celery-email</li>
    <li>python312Packages.django-celery-email.dist</li>
    <li>python312Packages.django-celery-results</li>
    <li>python312Packages.django-celery-results.dist</li>
    <li>python312Packages.django-google-analytics-app</li>
    <li>python312Packages.django-google-analytics-app.dist</li>
    <li>python312Packages.django-raster</li>
    <li>python312Packages.django-raster.dist</li>
    <li>python312Packages.djmail</li>
    <li>python312Packages.djmail.dist</li>
    <li>python312Packages.dvc-gdrive</li>
    <li>python312Packages.dvc-gdrive.dist</li>
    <li>python312Packages.dvc-hdfs</li>
    <li>python312Packages.dvc-hdfs.dist</li>
    <li>python312Packages.dvc-task</li>
    <li>python312Packages.dvc-task.dist</li>
    <li>python312Packages.dvclive</li>
    <li>python312Packages.dvclive.dist</li>
    <li>python312Packages.flower</li>
    <li>python312Packages.flower.dist</li>
    <li>python312Packages.kombu</li>
    <li>python312Packages.kombu.dist</li>
    <li>python312Packages.mmcv</li>
    <li>python312Packages.mmcv.dist</li>
    <li>python312Packages.mmengine</li>
    <li>python312Packages.mmengine.dist</li>
    <li>python312Packages.nameko</li>
    <li>python312Packages.nameko.dist</li>
    <li>python312Packages.opentelemetry-instrumentation-celery</li>
    <li>python312Packages.opentelemetry-instrumentation-celery.dist</li>
    <li>python312Packages.streamz</li>
    <li>python312Packages.streamz.dist</li>
    <li>qemu_full</li>
    <li>qemu_full.debug</li>
    <li>qemu_full.ga</li>
    <li>quickemu</li>
    <li>rdkafka</li>
    <li>rdkafka.dev</li>
    <li>rsyslog</li>
    <li>samba4Full</li>
    <li>samba4Full.dev</li>
    <li>samba4Full.man</li>
    <li>sbclPackages.cl-rdkafka</li>
    <li>sourcehut.buildsrht</li>
    <li>sourcehut.buildsrht.dist</li>
    <li>sourcehut.coresrht</li>
    <li>sourcehut.coresrht.dist</li>
    <li>sourcehut.gitsrht</li>
    <li>sourcehut.gitsrht.dist</li>
    <li>sourcehut.hgsrht</li>
    <li>sourcehut.hgsrht.dist</li>
    <li>sourcehut.hubsrht</li>
    <li>sourcehut.hubsrht.dist</li>
    <li>sourcehut.listssrht</li>
    <li>sourcehut.listssrht.dist</li>
    <li>sourcehut.mansrht</li>
    <li>sourcehut.mansrht.dist</li>
    <li>sourcehut.metasrht</li>
    <li>sourcehut.metasrht.dist</li>
    <li>sourcehut.pastesrht</li>
    <li>sourcehut.pastesrht.dist</li>
    <li>sourcehut.todosrht</li>
    <li>sourcehut.todosrht.dist</li>
    <li>syslogng</li>
    <li>syslogng.man</li>
    <li>weblate</li>
    <li>weblate.dist</li>
    <li>weblate.static</li>
  </ul>
</details>

I've checked that authentik, dvc-with-remotes, kafka-delta-ingest, django-health-check, quickgui, and vector all also fail on the merge base, so I consider the failures to be benign.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
