### PR TITLE
electrum: fix build, update to 4.5.6

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -33,10 +33,10 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-LO2ZUvbDJaIxrdgA+cM3sGgqJ+N+UlA9ObNINQcrorA=";
   };
 
-  nativeBuildInputs = [ protobuf ] ++ lib.optionals enableQt [ wrapQtAppsHook ];
+  build-system = [ protobuf ] ++ lib.optionals enableQt [ wrapQtAppsHook ];
   buildInputs = lib.optional (stdenv.hostPlatform.isLinux && enableQt) qtwayland;
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     aiohttp
     aiohttp-socks
     aiorpcx

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -9,26 +9,9 @@
 , enableQt ? true
 , callPackage
 , qtwayland
-, fetchPypi
 }:
 
 let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: {
-      # Pin ledger-bitcoin to 0.2.1
-      ledger-bitcoin = super.ledger-bitcoin.overridePythonAttrs (oldAttrs: rec {
-        version = "0.2.1";
-        format = "pyproject";
-        src = fetchPypi {
-          pname = "ledger_bitcoin";
-          inherit version;
-          hash = "sha256-AWl/q2MzzspNIo6yf30S92PgM/Ygsb+1lJsg7Asztso=";
-        };
-      });
-    };
-  };
-
   libsecp256k1_name =
     if stdenv.hostPlatform.isLinux then "libsecp256k1.so.{v}"
     else if stdenv.hostPlatform.isDarwin then "libsecp256k1.{v}.dylib"
@@ -41,7 +24,7 @@ let
 
 in
 
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "electrum";
   version = "4.5.6";
 
@@ -53,7 +36,7 @@ python.pkgs.buildPythonApplication rec {
   nativeBuildInputs = [ protobuf ] ++ lib.optionals enableQt [ wrapQtAppsHook ];
   buildInputs = lib.optional (stdenv.hostPlatform.isLinux && enableQt) qtwayland;
 
-  propagatedBuildInputs = with python.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     aiohttp
     aiohttp-socks
     aiorpcx
@@ -84,7 +67,7 @@ python.pkgs.buildPythonApplication rec {
     qdarkstyle
   ];
 
-  checkInputs = with python.pkgs; lib.optionals enableQt [
+  checkInputs = with python3.pkgs; lib.optionals enableQt [
     pyqt6
   ];
 
@@ -116,7 +99,7 @@ python.pkgs.buildPythonApplication rec {
     wrapQtApp $out/bin/electrum
   '';
 
-  nativeCheckInputs = with python.pkgs; [ pytestCheckHook pyaes pycryptodomex ];
+  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook pyaes pycryptodomex ];
 
   pytestFlagsArray = [ "tests" ];
 

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchurl
-, fetchFromGitHub
 , protobuf
 , wrapQtAppsHook
 , python3
@@ -14,8 +13,6 @@
 }:
 
 let
-  version = "4.5.5";
-
   python = python3.override {
     self = python;
     packageOverrides = self: super: {
@@ -42,34 +39,16 @@ let
     else if stdenv.hostPlatform.isDarwin then "libzbar.0.dylib"
     else "libzbar${stdenv.hostPlatform.extensions.sharedLibrary}";
 
-  # Not provided in official source releases, which are what upstream signs.
-  tests = fetchFromGitHub {
-    owner = "spesmilo";
-    repo = "electrum";
-    rev = version;
-    sha256 = "sha256-CbhI/q+zjk9odxuvdzpogi046FqkedJooiQwS+WAkJ8=";
-
-    postFetch = ''
-      mv $out ./all
-      mv ./all/tests $out
-    '';
-  };
-
 in
 
-python.pkgs.buildPythonApplication {
+python.pkgs.buildPythonApplication rec {
   pname = "electrum";
-  inherit version;
+  version = "4.5.6";
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "1jiagz9avkbd158pcip7p4wz0pdsxi94ndvg5p8afvshb32aqwav";
+    hash = "sha256-LO2ZUvbDJaIxrdgA+cM3sGgqJ+N+UlA9ObNINQcrorA=";
   };
-
-  postUnpack = ''
-    # can't symlink, tests get confused
-    cp -ar ${tests} $sourceRoot/tests
-  '';
 
   nativeBuildInputs = [ protobuf ] ++ lib.optionals enableQt [ wrapQtAppsHook ];
   buildInputs = lib.optional (stdenv.hostPlatform.isLinux && enableQt) qtwayland;

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchurl
 , fetchFromGitHub
+, protobuf
 , wrapQtAppsHook
 , python3
 , zbar
@@ -70,7 +71,7 @@ python.pkgs.buildPythonApplication {
     cp -ar ${tests} $sourceRoot/tests
   '';
 
-  nativeBuildInputs = lib.optionals enableQt [ wrapQtAppsHook ];
+  nativeBuildInputs = [ protobuf ] ++ lib.optionals enableQt [ wrapQtAppsHook ];
   buildInputs = lib.optional (stdenv.hostPlatform.isLinux && enableQt) qtwayland;
 
   propagatedBuildInputs = with python.pkgs; [


### PR DESCRIPTION
*   Since the [update to version 5](https://github.com/NixOS/nixpkgs/pull/338885), the `python3Packages.protobuf` package no longer provides the `protoc` program, causing the [`electrum` build to fail](https://hydra.nixos.org/build/275626673/nixlog/1).  Instead, one has to add `pkgs.protobuf` (not the python package) directly.
*   Update `electrum` to newest version 4.5.6.  Notable changes (documented in the [release notes](https://github.com/spesmilo/electrum/blob/4.5.6/RELEASE-NOTES)) include:
    *   [Tests are now packaged in the release tarball](https://github.com/spesmilo/electrum/blob/4.5.6/RELEASE-NOTES#L31).  Due to this we can drop our mechanism to inject the tests during the build process.  This is even necessary as the build would now fail with this mechanism still active (therefore the update commit also drops the test injection mechanism).
    *   The version requirement for `ledger-bitcoin` [got bumped to "<0.4"](https://github.com/spesmilo/electrum/blob/4.5.6/RELEASE-NOTES#L24).  This allows us to unpin the version.
*   Switch to new [build-system/dependencies](https://github.com/NixOS/nixpkgs/pull/271597)

This should fix https://github.com/NixOS/nixpkgs/issues/349746

Notifying maintainers: @joachifm @np @prusnak @chewblacka

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>electrum</li>
    <li>electrum.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc