### PR TITLE
bitmagnet: pin Go 1.22, module fixes

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1359,6 +1359,7 @@
   ./services/system/uptimed.nix
   ./services/system/userborn.nix
   ./services/system/zram-generator.nix
+  ./services/torrent/bitmagnet.nix
   ./services/torrent/deluge.nix
   ./services/torrent/flexget.nix
   ./services/torrent/flood.nix

--- a/nixos/modules/services/torrent/bitmagnet.nix
+++ b/nixos/modules/services/torrent/bitmagnet.nix
@@ -40,48 +40,57 @@ in
         options = {
           http_server = mkOption {
             default = { };
+            description = "HTTP server settings";
             type = submodule {
               inherit freeformType;
               options = {
                 port = mkOption {
                   type = str;
                   default = ":3333";
+                  description = "HTTP server listen port";
                 };
               };
             };
           };
           dht_server = mkOption {
             default = { };
+            description = "DHT server settings";
             type = submodule {
               inherit freeformType;
               options = {
                 port = mkOption {
                   type = port;
                   default = 3334;
+                  description = "DHT listen port";
                 };
               };
             };
           };
           postgres = mkOption {
             default = { };
+            description = "PostgreSQL database configuration";
             type = submodule {
               inherit freeformType;
               options = {
                 host = mkOption {
                   type = str;
                   default = "";
+                  description = "Address, hostname or Unix socket path of the database server";
                 };
                 name = mkOption {
                   type = str;
                   default = "bitmagnet";
+                  description = "Database name to connect to";
                 };
                 user = mkOption {
                   type = str;
                   default = "";
+                  description = "User to connect as";
                 };
                 password = mkOption {
                   type = str;
                   default = "";
+                  description = "Password for database user";
                 };
               };
             };
@@ -163,8 +172,8 @@ in
     };
     users.groups = mkIf (cfg.group == "bitmagnet") { bitmagnet = { }; };
     networking.firewall = mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.dht_server.port ];
-      allowedUDPPorts = [ cfg.dht_server.port ];
+      allowedTCPPorts = [ cfg.settings.dht_server.port ];
+      allowedUDPPorts = [ cfg.settings.dht_server.port ];
     };
     services.postgresql = mkIf cfg.useLocalPostgresDB {
       enable = true;

--- a/pkgs/by-name/bi/bitmagnet/package.nix
+++ b/pkgs/by-name/bi/bitmagnet/package.nix
@@ -1,10 +1,10 @@
 { lib
-, buildGoModule
+, buildGo122Module  # builds, but does not start on 1.23
 , fetchFromGitHub
 , nix-update-script
 }:
 
-buildGoModule rec {
+buildGo122Module rec {
   pname = "bitmagnet";
   version = "0.9.5";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fails to start on 1.23, same thing as grafana-agent and others.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
