### PR TITLE
visidata: 3.0.2 -> 3.1.1

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -2,7 +2,6 @@
 , lib
 , buildPythonApplication
 , fetchFromGitHub
-, fetchpatch
   # python requirements
 , beautifulsoup4
 , boto3
@@ -23,6 +22,8 @@
 , pyarrow
 , pyshp
 , pypng
+, msgpack
+, brotli
 , python-dateutil
 , pyyaml
 , requests
@@ -46,28 +47,14 @@
 }:
 buildPythonApplication rec {
   pname = "visidata";
-  version = "3.0.2";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "saulpw";
     repo = "visidata";
     rev = "v${version}";
-    hash = "sha256-gplrkrFTIP6TLvk1YazD5roDzsPvDtOXLlTOmTio52s=";
+    hash = "sha256-ICEYC9QjYrB+oTzakfjgyg4DigzDOtYnqHRTaqF7Gw0=";
   };
-
-  patches = [
-    # Drop when next release is out
-    (fetchpatch {
-      name = "drop-support-for-python-37.patch";
-      url = "https://github.com/saulpw/visidata/commit/738bb8b43814c14b1b8a1f1f60397c1520c5ef4a.patch";
-      hash = "sha256-5jDAzKMuW3s7BCGpWyLcS4Lw8GUbjNxVhF5mUKbR1YY=";
-    })
-    (fetchpatch {
-      name = "update-tests-for-python-312.patch";
-      url = "https://github.com/saulpw/visidata/commit/627f6f126cdd49bcdda0bbc16fab42eb5bd42103.patch";
-      hash = "sha256-3FHgjLrzMHObEheJoRY8VlnDUtDZ68FqCqAyhP7333E=";
-    })
-  ];
 
   propagatedBuildInputs = [
     # from visidata/requirements.txt
@@ -86,6 +73,9 @@ buildPythonApplication rec {
     #mapbox-vector-tile
     pypng
     #pyconll
+    msgpack
+    brotli
+    #fecfile
     fonttools
     #sas7bdat
     #xport
@@ -139,6 +129,7 @@ buildPythonApplication rec {
     # tests to disable because we don't have a package to load such files
     rm -f tests/load-conllu.vdj         # no 'pyconll'
     rm -f tests/load-sav.vd             # no 'savReaderWriter'
+    rm -f tests/load-fec.vdj            # no 'fecfile'
 
     # tests use git to compare outputs to references
     git init -b "test-reference"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13339,8 +13339,7 @@ with pkgs;
 
   vimwiki-markdown = python3Packages.callPackage ../tools/misc/vimwiki-markdown { };
 
-  visidata = (newScope python3Packages) ../applications/misc/visidata {
-  };
+  visidata = python3Packages.callPackage ../applications/misc/visidata { };
 
   vit = callPackage ../applications/misc/vit { };
 


### PR DESCRIPTION
## Things done

See commit messages for details.

- **visidata: 3.0.2 -> 3.1.1**
- **visidata: newScope -> python3Packages.callPackage**


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
