### PR TITLE
packetry: init at 0.2.2

### DIFF
--- a/pkgs/by-name/pa/packetry/package.nix
+++ b/pkgs/by-name/pa/packetry/package.nix
@@ -1,0 +1,51 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  rustPlatform,
+  gtk4,
+  pkg-config,
+  pango,
+  wrapGAppsHook4,
+  darwin,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "packetry";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "greatscottgadgets";
+    repo = "packetry";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-FlimHJS3hwB2Tkulb8uToKFe165uv/gFxJ4uezVNka4=";
+  };
+
+  cargoHash = "sha256-n1hPoSUEFUGpEUOiuirSbeAnU+qiENDg4XyN5Jkjo/Y=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs =
+    [
+      gtk4
+      pango
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.AppKit
+    ];
+
+  # Tests need a display to run
+  doCheck = false;
+
+  meta = with lib; {
+    description = "USB 2.0 protocol analysis application for use with Cynthion";
+    homepage = "https://github.com/greatscottgadgets/packetry";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ carlossless ];
+    mainProgram = "packetry";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}


### PR DESCRIPTION
A fast, intuitive USB 2.0 protocol analysis application for use with Cynthion. https://github.com/greatscottgadgets/packetry

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


Related to https://github.com/NixOS/nixpkgs/issues/81418