### PR TITLE
pdfarranger: Add macOS support

### DIFF
--- a/pkgs/by-name/pd/pdfarranger/package.nix
+++ b/pkgs/by-name/pd/pdfarranger/package.nix
@@ -6,6 +6,7 @@
   gtk3,
   poppler_gi,
   libhandy,
+  pkgs,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -20,7 +21,15 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-94qziqJaKW8/L/6+U1yojxdG8BmeAStn+qbfGemTrVA=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook3 ];
+  nativeBuildInputs = [ wrapGAppsHook3 ]
+  ++ lib.optionals pkgs.stdenv.isDarwin [
+    pkgs.gettext
+  ];
+
+  patchPhase = '' '' + lib.optionals pkgs.stdenv.isDarwin  ''
+    LINTL="${lib.getLib pkgs.gettext}/lib/libintl.8.dylib"
+    sed -i "s@return 'libintl.8.dylib'@return '$LINTL'@" pdfarranger/pdfarranger.py
+  '';
 
   build-system = with python3Packages; [ setuptools ];
 
@@ -49,7 +58,6 @@ python3Packages.buildPythonApplication rec {
     inherit (src.meta) homepage;
     description = "Merge or split pdf documents and rotate, crop and rearrange their pages using a graphical interface";
     mainProgram = "pdfarranger";
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ symphorien ];
     license = lib.licenses.gpl3Plus;
     changelog = "https://github.com/pdfarranger/pdfarranger/releases/tag/${version}";

--- a/pkgs/by-name/pd/pdfarranger/package.nix
+++ b/pkgs/by-name/pd/pdfarranger/package.nix
@@ -21,15 +21,18 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-94qziqJaKW8/L/6+U1yojxdG8BmeAStn+qbfGemTrVA=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook3 ]
-  ++ lib.optionals pkgs.stdenv.isDarwin [
-    pkgs.gettext
-  ];
+  nativeBuildInputs =
+    [ wrapGAppsHook3 ]
+    ++ lib.optionals pkgs.stdenv.isDarwin [
+      pkgs.gettext
+    ];
 
-  patchPhase = '' '' + lib.optionals pkgs.stdenv.isDarwin  ''
-    LINTL="${lib.getLib pkgs.gettext}/lib/libintl.8.dylib"
-    sed -i "s@return 'libintl.8.dylib'@return '$LINTL'@" pdfarranger/pdfarranger.py
-  '';
+  patchPhase =
+    ''''
+    + lib.optionals pkgs.stdenv.isDarwin ''
+      LINTL="${lib.getLib pkgs.gettext}/lib/libintl.8.dylib"
+      sed -i "s@return 'libintl.8.dylib'@return '$LINTL'@" pdfarranger/pdfarranger.py
+    '';
 
   build-system = with python3Packages; [ setuptools ];
 

--- a/pkgs/by-name/pd/pdfarranger/package.nix
+++ b/pkgs/by-name/pd/pdfarranger/package.nix
@@ -22,20 +22,15 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-94qziqJaKW8/L/6+U1yojxdG8BmeAStn+qbfGemTrVA=";
   };
 
-  nativeBuildInputs =
-    [ wrapGAppsHook3 ]
-    ++ lib.optionals stdenv.isDarwin [
-      gettext
-    ];
+  nativeBuildInputs = [ wrapGAppsHook3 ] ++ lib.optionals stdenv.isDarwin [ gettext ];
 
-  postPatch =
-    lib.optionalString stdenv.isDarwin ''
-      LINTL="${lib.getLib gettext}/lib/libintl.8.dylib"
-      substituteInPlace pdfarranger/pdfarranger.py --replace-fail \
-        "return 'libintl.8.dylib'" \
-        "return '$LINTL'"
-      unset LINTL
-    '';
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    LINTL="${lib.getLib gettext}/lib/libintl.8.dylib"
+    substituteInPlace pdfarranger/pdfarranger.py --replace-fail \
+      "return 'libintl.8.dylib'" \
+      "return '$LINTL'"
+    unset LINTL
+  '';
 
   build-system = with python3Packages; [ setuptools ];
 
@@ -64,7 +59,10 @@ python3Packages.buildPythonApplication rec {
     inherit (src.meta) homepage;
     description = "Merge or split pdf documents and rotate, crop and rearrange their pages using a graphical interface";
     mainProgram = "pdfarranger";
-    maintainers = with lib.maintainers; [ symphorien endle ];
+    maintainers = with lib.maintainers; [
+      symphorien
+      endle
+    ];
     license = lib.licenses.gpl3Plus;
     changelog = "https://github.com/pdfarranger/pdfarranger/releases/tag/${version}";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
pdfarranger has macOS support in 1.11.1:  https://github.com/pdfarranger/pdfarranger/commit/5e4db7cddccecdfe034841512cb9860892473921

At nixpkgs side, we just need to set up the lib path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
