### PR TITLE
switch-to-configuration-ng: improve user experience

### DIFF
--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -937,33 +937,27 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn usage(argv0: &str) -> ! {
+    eprintln!(
+        r#"Usage: {} [switch|boot|test|dry-activate]
+switch:       make the configuration the boot default and activate now
+boot:         make the configuration the boot default
+test:         activate the configuration, but don't make it the boot default
+dry-activate: show what would be done if this configuration were activated
+"#,
+        argv0
+    );
+    std::process::exit(1);
+}
+
 /// Performs switch-to-configuration functionality for the entire system
-fn do_system_switch() -> anyhow::Result<()> {
+fn do_system_switch(action: Action) -> anyhow::Result<()> {
     let out = PathBuf::from(required_env("OUT")?);
     let toplevel = PathBuf::from(required_env("TOPLEVEL")?);
     let distro_id = required_env("DISTRO_ID")?;
     let install_bootloader = required_env("INSTALL_BOOTLOADER")?;
     let locale_archive = required_env("LOCALE_ARCHIVE")?;
     let new_systemd = PathBuf::from(required_env("SYSTEMD")?);
-
-    let mut args = std::env::args();
-    let argv0 = args.next().ok_or(anyhow!("no argv[0]"))?;
-
-    let Some(Ok(action)) = args.next().map(|a| Action::from_str(&a)) else {
-        eprintln!(
-            r#"Usage: {} [switch|boot|test|dry-activate]
-switch:       make the configuration the boot default and activate now
-boot:         make the configuration the boot default
-test:         activate the configuration, but don't make it the boot default
-dry-activate: show what would be done if this configuration were activated
-"#,
-            argv0
-                .split(std::path::MAIN_SEPARATOR_STR)
-                .last()
-                .unwrap_or("switch-to-configuration")
-        );
-        std::process::exit(1);
-    };
 
     let action = ACTION.get_or_init(|| action);
 
@@ -1939,13 +1933,26 @@ won't take effect until you reboot the system.
 }
 
 fn main() -> anyhow::Result<()> {
-    match (
-        unsafe { nix::libc::geteuid() },
-        std::env::var("__NIXOS_SWITCH_TO_CONFIGURATION_PARENT_EXE").ok(),
-    ) {
-        (0, None) => do_system_switch(),
-        (1..=u32::MAX, None) => bail!("This program does not support being ran outside of the switch-to-configuration environment"),
-        (_, Some(parent_exe)) => do_user_switch(parent_exe),
+    match std::env::var("__NIXOS_SWITCH_TO_CONFIGURATION_PARENT_EXE").ok() {
+        Some(parent_exe) => do_user_switch(parent_exe),
+        None => {
+            let mut args = std::env::args();
+            let argv0 = args.next().ok_or(anyhow!("no argv[0]"))?;
+            let argv0 = argv0
+                .split(std::path::MAIN_SEPARATOR_STR)
+                .last()
+                .unwrap_or("switch-to-configuration");
+
+            let Some(Ok(action)) = args.next().map(|a| Action::from_str(&a)) else {
+                usage(&argv0);
+            };
+
+            if unsafe { nix::libc::geteuid() } == 0 {
+                do_system_switch(action)
+            } else {
+                bail!("{} must be run as the root user", argv0);
+            }
+        }
     }
 }
 


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

When calling switch-to-configuration (ng) as a non-root user, the user calling the program should be guided to calling the program in the correct way, not given a confusing error message.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
