### PR TITLE
detect-it-easy: init at 3.09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9466,6 +9466,12 @@
     githubId = 1318743;
     name = "Ivar";
   };
+  ivyfanchiang = {
+    email = "dev@ivyfanchiang.ca";
+    github = "hexadecimalDinosaur";
+    githubId = 36890802;
+    name = "Ivy Fan-Chiang";
+  };
   iwanb = {
     email = "tracnar@gmail.com";
     github = "iwanb";

--- a/pkgs/by-name/de/detect-it-easy/0001-remove-hard-coded-paths-in-xoptions.patch
+++ b/pkgs/by-name/de/detect-it-easy/0001-remove-hard-coded-paths-in-xoptions.patch
@@ -1,0 +1,44 @@
+diff --git a/XOptions/xoptions.cpp b/XOptions/xoptions.cpp
+index ca5723e..30574a5 100755
+--- a/XOptions/xoptions.cpp
++++ b/XOptions/xoptions.cpp
+@@ -1531,14 +1531,7 @@ bool XOptions::checkNative(const QString &sIniFileName)
+ #if defined(Q_OS_MAC)
+     bResult = true;
+ #elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+-    QString sApplicationDirPath = qApp->applicationDirPath();
+-
+-    if ((sApplicationDirPath == "/bin") || (sApplicationDirPath == "/usr/bin") || (sApplicationDirPath == "/usr/local/bin") ||
+-        (sApplicationDirPath.contains("/usr/local/bin$")) || isAppImage()) {
+-        bResult = true;
+-    } else {
+-        bResult = false;
+-    }
++    bResult = true;
+ #elif defined(Q_OS_WIN)
+     QString sApplicationDirPath = qApp->applicationDirPath();
+ 
+@@ -1565,22 +1558,7 @@ QString XOptions::getApplicationDataPath()
+ #ifdef Q_OS_MAC
+     sResult = sApplicationDirPath + "/../Resources";
+ #elif defined(Q_OS_LINUX)
+-    if (isNative()) {
+-        if (sApplicationDirPath.contains("/usr/local/bin$")) {
+-            QString sPrefix = sApplicationDirPath.section("/usr/local/bin", 0, 0);
+-
+-            sResult += sPrefix + QString("/usr/local/lib/%1").arg(qApp->applicationName());
+-        } else {
+-            if (sApplicationDirPath.contains("/tmp/.mount_"))  // AppImage
+-            {
+-                sResult = sApplicationDirPath.section("/", 0, 2);
+-            }
+-
+-            sResult += QString("/usr/lib/%1").arg(qApp->applicationName());
+-        }
+-    } else {
+-        sResult = sApplicationDirPath;
+-    }
++    sResult = sApplicationDirPath + "/../lib/die";
+ #elif defined(Q_OS_FREEBSD)
+     sResult = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation).at(1) + QDir::separator() + qApp->applicationName();
+ #else

--- a/pkgs/by-name/de/detect-it-easy/package.nix
+++ b/pkgs/by-name/de/detect-it-easy/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libsForQt5,
+  freetype,
+  graphite2,
+  icu,
+  krb5,
+  systemdLibs,
+  imagemagick,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "detect-it-easy";
+  version = "3.09";
+
+  src = fetchFromGitHub {
+    owner = "horsicq";
+    repo = "DIE-engine";
+    rev = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-A9YZBlGf3j+uSefPiDhrS1Qtu6vaLm4Yodt7BioGD2Q=";
+  };
+
+  patches = [ ./0001-remove-hard-coded-paths-in-xoptions.patch ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libsForQt5.qtscript
+    libsForQt5.qtsvg
+    graphite2
+    freetype
+    icu
+    krb5
+    systemdLibs
+  ];
+  nativeBuildInputs = [
+    libsForQt5.wrapQtAppsHook
+    libsForQt5.qmake
+    imagemagick
+  ];
+
+  enableParallelBuilding = true;
+
+  # work around wrongly created dirs in `install.sh`
+  # https://github.com/horsicq/DIE-engine/issues/110
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons
+  '';
+
+  # clean up wrongly created dirs in `install.sh` and broken .desktop file
+  postInstall = ''
+    rm -r $out/lib/{bin,share}
+    grep -v "Version=#VERSION#" $src/LINUX/die.desktop > $out/share/applications/die.desktop
+  '';
+
+  meta = {
+    description = "Program for determining types of files for Windows, Linux and MacOS.";
+    mainProgram = "die";
+    homepage = "https://github.com/horsicq/Detect-It-Easy";
+    maintainers = with lib.maintainers; [ ivyfanchiang ];
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
Program for determining types of files for Windows, Linux and MacOS.  https://github.com/horsicq/Detect-It-Easy/

Used for reverse engineering and binary analysis work to identify compiler versions and other file information.

Note that there is support for aarch64-linux and aarch64-darwin was recently added to the DIE-engine repository but no support exists in the latest stable 3.09 version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
