### PR TITLE
Implement custom binutils for pwntools

### DIFF
--- a/pkgs/development/python-modules/pwntools/binutils.nix
+++ b/pkgs/development/python-modules/pwntools/binutils.nix
@@ -1,0 +1,85 @@
+{
+  stdenv,
+  binutils-unwrapped,
+  bison,
+  buildPackages,
+  fetchFromGitHub,
+  fetchurl,
+  gettext,
+  lib,
+  perl,
+  zlib,
+  texinfo,
+  targetArch,
+}:
+
+let
+  version = "2.43.1";
+  target = targetArch + "-unknown-linux-gnu";
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "binutils-cross-" + targetArch;
+  inherit version;
+
+  src = binutils-unwrapped.src;
+
+  strictDeps = true;
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [
+    texinfo
+    bison
+    perl
+  ];
+
+  buildInputs = [
+    zlib
+    gettext
+  ];
+
+  configureFlags = [
+    "--enable-64-bit-bfd"
+    "--with-system-zlib"
+
+    "--disable-werror"
+
+    # force target prefix. Some versions of binutils will make it empty if
+    # `--host` and `--target` are too close, even if Nixpkgs thinks the
+    # platforms are different (e.g. because not all the info makes the
+    # `config`). Other versions of binutils will always prefix if `--target` is
+    # passed, even if `--host` and `--target` are the same. The easiest thing
+    # for us to do is not leave it to chance, and force the program prefix to be
+    # what we want it to be.
+    "--program-prefix=${target}-"
+
+    # Unconditionally disable:
+    # - musl target needs porting: https://sourceware.org/PR29477
+    "--disable-gprofng"
+
+    "--target=${target}"
+
+    "--disable-static"
+    "--disable-multilib"
+    "--disable-werror"
+    "--disable-nls"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Tools for manipulating binaries (linker, assembler, etc.)";
+    longDescription = ''
+      The GNU Binutils are a collection of binary tools.  The main
+      ones are `ld' (the GNU linker) and `as' (the GNU assembler).
+      They also include the BFD (Binary File Descriptor) library,
+      `gprof', `nm', `strip', etc.
+    '';
+    homepage = "https://www.gnu.org/software/binutils/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [
+      kristoff3r
+      TethysSvensson
+    ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
-  stdenv,
+  callPackage,
+  symlinkJoin,
   buildPythonPackage,
-  debugger,
   fetchPypi,
   capstone,
   colored-traceback,
@@ -26,11 +26,48 @@
   unix-ar,
   zstandard,
   installShellFiles,
+  pwndbg,
+  gdb,
+  runCommandNoCC,
 }:
 
 let
-  debuggerName = lib.strings.getName debugger;
+  binutilsArchs = [
+    "aarch64"
+    "alpha"
+    "arm"
+    "avr"
+    "cris"
+    "hppa"
+    "ia64"
+    "m68k"
+    "mips"
+    "mips64"
+    "msp430"
+    "powerpc"
+    "powerpc64"
+    "s390"
+    "sparc"
+    "vax"
+    "xscale"
+    "i386"
+    "x86_64"
+  ];
+  binutilsPackages = lib.attrsets.genAttrs binutilsArchs (
+    targetArch: callPackage ./binutils.nix { inherit targetArch; }
+  );
+  binutilsAll = symlinkJoin {
+    name = "binutils-cross-all";
+    paths = builtins.attrValues binutilsPackages;
+  };
+  wrap-debugger =
+    pkg: path:
+    runCommandNoCC (lib.strings.getName pkg + "-wrapped") { } ''
+      mkdir -p $out/bin
+      ln -s ${pkg}/bin/${path} $out/bin/pwntools-gdb
+    '';
 in
+
 buildPythonPackage rec {
   pname = "pwntools";
   version = "4.13.1";
@@ -43,8 +80,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     # Upstream hardcoded the check for the command `gdb-multiarch`;
-    # Forcefully use the provided debugger, as `gdb` (hence `pwndbg`) is built with multiarch in `nixpkgs`.
-    sed -i 's/gdb-multiarch/${debuggerName}/' pwnlib/gdb.py
+    # However `gdb` and `pwndbg` is already built with multiarch support.
+    # Here we change name it looks for to `pwntools-gdb` and which matches
+    # the name set by the `wrap-debugger` function.
+    sed -i 's/gdb-multiarch/pwntools-gdb/' pwnlib/gdb.py
   '';
 
   nativeBuildInputs = [ installShellFiles ];
@@ -82,12 +121,16 @@ buildPythonPackage rec {
     installShellCompletion --bash extra/bash_completion.d/shellcraft
   '';
 
-  postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    mkdir -p "$out/bin"
-    makeWrapper "${debugger}/bin/${debuggerName}" "$out/bin/pwntools-gdb"
-  '';
-
   pythonImportsCheck = [ "pwn" ];
+
+  passthru.binutils = binutilsPackages // {
+    "all" = binutilsAll;
+  };
+  passthru.debugger = {
+    inherit wrap-debugger;
+    gdb = wrap-debugger gdb "gdb";
+    pwndbg = wrap-debugger pwndbg "pwndbg";
+  };
 
   meta = with lib; {
     description = "CTF framework and exploit development library";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10863,9 +10863,7 @@ self: super: with self; {
 
   pwndbg = callPackage ../development/python-modules/pwndbg { };
 
-  pwntools = callPackage ../development/python-modules/pwntools {
-    debugger = pkgs.gdb;
-  };
+  pwntools = callPackage ../development/python-modules/pwntools { };
 
   py-air-control = callPackage ../development/python-modules/py-air-control { };
 


### PR DESCRIPTION
This is an alternative to #339556.

This implements a custom binutils package with the purpose of providing the assemblers and disassemblers needed for pwntools.

The binutils derivation is based on the derivation in `development/tools/misc/binutils`, but removes a lot of unneeded features and adds support for directly specifying the desired target.

I do not have a way to test this on anything except `x86_64-linux`, so I might have removed a few too many things for it to still build on other platforms. Any feedback on this would be appreciated.

While implementing this feature, I also cleanup up the handling of how you specify the debugger in pwntools. Currently the python package is parameterized on the debugger you want, but this instead implements binding using `$PATH`.

CC @alyssais @adisbladis @Ericson2314 @kristoff3r 

## Things done

* Add a custom binutils derivation
* Add a passthru in pwntools for these binutils
* Remove the customization for debuggers and replace it with a passthru as well

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
