### PR TITLE
tigervnc: fix `VncAuth` security type

### DIFF
--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , xorg
 , xkeyboard_config
 , zlib
@@ -32,6 +33,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-TgVV/4MRsQHYKpDf9L5eHMLVpdwvNy1KPDIe7xMlQ9o=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "vncauth-security-type.patch";
+      url = "https://github.com/TigerVNC/tigervnc/commit/4f6a3521874da5a67fd746389cfa9b6199eb3582.diff";
+      hash = "sha256-lSkR8e+jsBwkQUJZmA0tb8nM5iSbYtO8uVXtgk5wdF8=";
+    })
+  ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -xkbdir ${xkeyboard_config}/etc/X11/xkb";' unix/vncserver/vncserver.in


### PR DESCRIPTION
tigervnc v1.14.0 introduced a regression in its list of supported security types: Due to a missing comma in the code, the `VncAuth` security type (i.e. simple password check) isn't tried unless it is explicitely requested on the command line.  The pull request at hand adds a patch from upstream to fix this oversight.

Upstream bug report: https://github.com/TigerVNC/tigervnc/issues/1789

There are no maintainers, notifying recent contributors @expenses @trofi @apfelkuchen6

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>crowbar</li>
    <li>crowbar.dist</li>
  </ul>
</details>
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>nemu</li>
    <li>tigervnc</li>
  </ul>
</details>

Note: `crowbar` [is already broken](https://hydra.nixos.org/build/274781481)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
