### PR TITLE
os-prober: 1.81 -> 1.83

### DIFF
--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -84,6 +84,10 @@ in {
           docbook5
           docbook_xsl_ns
           grub2
+          nixos-artwork.wallpapers.simple-dark-gray-bootloader
+          perlPackages.FileCopyRecursive
+          perlPackages.XMLSAX
+          perlPackages.XMLSAXBase
           kbd
           kbd.dev
           kmod.dev
@@ -92,16 +96,20 @@ in {
           libxml2.bin
           libxslt.bin
           nixos-artwork.wallpapers.simple-dark-gray-bottom
-          ntp
+          perlPackages.ConfigIniFiles
+          perlPackages.FileSlurp
+          perlPackages.JSON
           perlPackages.ListCompare
           perlPackages.XMLLibXML
-          python3
+          # make-options-doc/default.nix
+          (python3.withPackages (p: [ p.mistune ]))
           shared-mime-info
-          stdenv
           sudo
+          switch-to-configuration-ng
           texinfo
           unionfs-fuse
           xorg.lndir
+          os-prober
 
           # add curl so that rather than seeing the test attempt to download
           # curl's tarball, we see what it's trying to download

--- a/pkgs/tools/misc/os-prober/default.nix
+++ b/pkgs/tools/misc/os-prober/default.nix
@@ -11,14 +11,14 @@ lvm2        # lvs
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.81";
+  version = "1.83";
   pname = "os-prober";
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
     owner = "installer-team";
     repo = pname;
     rev = version;
-    sha256 = "sha256-3FXfGadIcmKp4qn6ZDcOSQHYsUNP2ObL1cJesNle+8A=";
+    sha256 = "sha256-cTufM82YE1L7d3kIOtncICInBPEw4o4NzQXB4uDrMKI=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
r-ryantm opened this PR but the nixos-test was broken so I fixed it. https://github.com/NixOS/nixpkgs/pull/349423

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
