### PR TITLE
{equicord, equibop}: init

### DIFF
--- a/pkgs/by-name/eq/equibop/disable_update_checking.patch
+++ b/pkgs/by-name/eq/equibop/disable_update_checking.patch
@@ -1,0 +1,16 @@
+diff --git i/src/main/index.ts w/src/main/index.ts
+index 23ea0d6..1ef465f 100644
+--- i/src/main/index.ts
++++ w/src/main/index.ts
+@@ -32,7 +32,9 @@ if (process.platform === "linux") {
+ if (IS_DEV) {
+     require("source-map-support").install();
+ } else {
+-    autoUpdater.checkForUpdatesAndNotify();
++    console.log("Update checking is disabled. Skipping...");
++    // autoUpdater.checkForUpdatesAndNotify();
++
+ }
+ 
+ // Make the Vencord files use our DATA_DIR
+

--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -1,0 +1,153 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  substituteAll,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  equicord,
+  electron,
+  libicns,
+  pipewire,
+  libpulseaudio,
+  autoPatchelfHook,
+  pnpm_9,
+  nodejs,
+  nix-update-script,
+  withTTS ? true,
+  withMiddleClickScroll ? false,
+  # Enables the use of Equicord from nixpkgs instead of
+  # letting Equibop manage it's own version
+  withSystemEquicord ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "equibop";
+  version = "2.0.9";
+
+  src = fetchFromGitHub {
+    owner = "Equicord";
+    repo = "Equibop";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-mK/zoW8Km6xlppxJnVbuas4yE1rpAOd9QnjETlxxnsE=";
+  };
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      patches
+      ;
+    hash = "sha256-TSdkHSZTbFf3Nq0QHDNTeUHmd6N+L1N1kSiKt0uNF6s=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_9.configHook
+    # XXX: Equibop *does not* ship venmic as a prebuilt node module. The package
+    # seems to build with or without this hook, but I (NotAShelf) don't have the
+    # time to test the consequences of removing this hook. Please open a pull
+    # request if this bothers you in some way.
+    autoPatchelfHook
+    copyDesktopItems
+    # we use a script wrapper here for environment variable expansion at runtime
+    # https://github.com/NixOS/nixpkgs/issues/172583
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libpulseaudio
+    pipewire
+    stdenv.cc.cc.lib
+  ];
+
+  patches =
+    [ ./disable_update_checking.patch ]
+    ++ lib.optional withSystemEquicord (substituteAll {
+      inherit equicord;
+      src = ./use_system_equicord.patch;
+    });
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+    pnpm exec electron-builder \
+      --dir \
+      -c.asarUnpack="**/*.node" \
+      -c.electronDist=${electron.dist} \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  postBuild = ''
+    pushd build
+    ${libicns}/bin/icns2png -x icon.icns
+    popd
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/opt/Equibop
+    cp -r dist/*unpacked/resources $out/opt/Equibop/
+
+    for file in build/icon_*x32.png; do
+      file_suffix=''${file//build\/icon_}
+      install -Dm0644 $file $out/share/icons/hicolor/''${file_suffix//x32.png}/apps/equibop.png
+    done
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${electron}/bin/electron $out/bin/equibop \
+      --add-flags $out/opt/Equibop/resources/app.asar \
+      ${lib.optionalString withTTS "--add-flags \"--enable-speech-dispatcher\""} \
+      ${lib.optionalString withMiddleClickScroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""} \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime}}"
+  '';
+
+  desktopItems = makeDesktopItem {
+    name = "equibop";
+    desktopName = "Equibop";
+    exec = "equibop %U";
+    icon = "equibop";
+    startupWMClass = "Equibop";
+    genericName = "Internet Messenger";
+    keywords = [
+      "discord"
+      "equibop"
+      "electron"
+      "chat"
+    ];
+    categories = [
+      "Network"
+      "InstantMessaging"
+      "Chat"
+    ];
+  };
+
+  passthru = {
+    inherit (finalAttrs) pnpmDeps;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Custom Discord App aiming to give you better performance and improve linux support";
+    homepage = "https://github.com/Equicord/Equibop";
+    changelog = "https://github.com/Equicord/Equibop/releases/tag/${finalAttrs.src.rev}";
+    license = lib.licenses.gpl3Only;
+    maintainers = [
+      lib.maintainers.NotAShelf
+    ];
+    mainProgram = "equibop";
+    # I am not confident in my ability to support Darwin, please PR if this is important to you
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/eq/equibop/use_system_equicord.patch
+++ b/pkgs/by-name/eq/equibop/use_system_equicord.patch
@@ -1,0 +1,17 @@
+diff --git i/src/main/constants.ts w/src/main/constants.ts
+index afb171f..c6a014e 100644
+--- i/src/main/constants.ts
++++ w/src/main/constants.ts
+@@ -47,10 +47,7 @@ export const VENCORD_THEMES_DIR = join(DATA_DIR, "themes");
+ 
+ // needs to be inline require because of circular dependency
+ // as otherwise "DATA_DIR" (which is used by ./settings) will be uninitialised
+-export const VENCORD_DIR = (() => {
+-    const { State } = require("./settings") as typeof import("./settings");
+-    return State.store.vencordDir ? join(State.store.vencordDir, "equibop") : join(SESSION_DATA_DIR, "equicord.asar");
+-})();
++export const VENCORD_DIR = "@equicord@";
+ 
+ export const USER_AGENT = `Equibop/${app.getVersion()} (https://github.com/Equicord/Equibop)`;
+ 
+

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -1,0 +1,63 @@
+{
+  fetchFromGitHub,
+  git,
+  lib,
+  nodejs,
+  pnpm_9,
+  stdenv,
+  buildWebExtension ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "equicord";
+  version = "1.10.4"; # from package.json
+
+  src = fetchFromGitHub {
+    owner = "Equicord";
+    repo = "Equicord";
+    rev = "440b68ea82b6fd44bf5ec70b759a0207ee9f4ca7";
+    hash = "sha256-9GIw8g2HZ6/5Lb4gtDyuBqZWi5YK5Uz0lo+u+LrIZwI=";
+  };
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-kGLF6uIr0xxlB5LaSqKiBKESbmWN7PzDErrCmiT6vXA=";
+  };
+
+  nativeBuildInputs = [
+    git
+    nodejs
+    pnpm_9.configHook
+  ];
+
+  env = {
+    EQUICORD_REMOTE = "${finalAttrs.src.owner}/${finalAttrs.src.repo}";
+    EQUICORD_HASH = "${finalAttrs.src.rev}";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run ${if buildWebExtension then "buildWeb" else "build"} \
+      -- --standalone --disable-updater
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist/${lib.optionalString buildWebExtension "chromium-unpacked/"} $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "The other cutest Discord client mod";
+    homepage = "https://github.com/Equicord/Equicord";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = [
+      lib.maintainers.NotAShelf
+    ];
+  };
+})


### PR DESCRIPTION
- **equicord: init at 1.10.4**
- **equibop: init at 2.0.9**

Adds Equicord and Equibop derivations based mostly on existing work done on
Vencord and Vesktop respectively. The build process is almost exactly the same
(minus some changes in variable names), so I expect everything to work as
intended.

**Equicord** needs testing, as I currently lack the bandwidth to test it.
Equibop is tested, and seems to work as intended. Though I'll CC @TanvirOnGH for
further testing and possibly @Scrumplex for their review as we base on Vencord
and Vesktop.

Fixes #333175

P.S. Darwin support is omitted as I **do not** have a Darwin machine, and
therefore will not make an effort to support it. Please open a pull request and
add yourself as a maintaier if Darwin support is important to you.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package)
    to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  (or backporting
  [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md)
  and
  [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md)
  Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
- [x] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
