### PR TITLE
nushellPlugins.dbus: init at 0.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -662,6 +662,13 @@
     githubId = 4296804;
     name = "Alex Franchuk";
   };
+  aftix = {
+    name = "Wyatt Campbell";
+    email = "aftix@aftix.xyz";
+    matrix = "@aftix:matrix.org";
+    github = "aftix";
+    githubId = 4008299;
+  };
   agbrooks = {
     email = "andrewgrantbrooks@gmail.com";
     github = "agbrooks";

--- a/pkgs/shells/nushell/plugins/dbus.nix
+++ b/pkgs/shells/nushell/plugins/dbus.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  runCommand,
+  lib,
+  rustPlatform,
+  pkg-config,
+  nix-update-script,
+  fetchFromGitHub,
+  dbus,
+  nushell,
+  nushell_plugin_dbus,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nu_plugin_dbus";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "devyn";
+    repo = pname;
+    rev = version;
+    hash = "sha256-I6FB2Hu/uyA6lBGRlC6Vwxad7jrl2OtlngpmiyhblKs=";
+  };
+
+  cargoHash = "sha256-WwdeDiFVyk8ixxKS1v3P274E1wp+v70qCk+rNEpoce4=";
+
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+  buildInputs = [ dbus ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.check =
+      let
+        nu = lib.getExe nushell;
+        plugin = lib.getExe nushell_plugin_dbus;
+      in
+      runCommand "${pname}-test" { } ''
+        touch $out
+        ${nu} -n -c "plugin add --plugin-config $out ${plugin}"
+        ${nu} -n -c "plugin use --plugin-config $out dbus"
+      '';
+  };
+
+  meta = with lib; {
+    description = "Nushell plugin for communicating with D-Bus";
+    mainProgram = "nu_plugin_dbus";
+    homepage = "https://github.com/devyn/nu_plugin_dbus";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aftix ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -1,4 +1,4 @@
-{ lib, newScope, IOKit, CoreFoundation, Foundation, Security }:
+{ lib, newScope, dbus, IOKit, CoreFoundation, Foundation, Security }:
 
 lib.makeScope newScope (self: with self; {
   gstat = callPackage ./gstat.nix { inherit Security; };
@@ -9,4 +9,5 @@ lib.makeScope newScope (self: with self; {
   net = callPackage ./net.nix { inherit IOKit CoreFoundation; };
   units = callPackage ./units.nix { };
   highlight = callPackage ./highlight.nix { };
+  dbus = callPackage ./dbus.nix { inherit dbus; nushell_plugin_dbus = self.dbus; };
 })


### PR DESCRIPTION
Added [nu_plugin_dbus](https://github.com/devyn/nu_plugin_dbus), a nushell plugin for interacting with dbus on linux, to the `nushellPlugins` package set. I've added myself as a maintainer for the package.

I am unsure about the naming of `dbus`: Naming it that matches the convention of what's already in the package set, but it conflicts with `pkgs.dbus` which is a dependency of the nushell plugin, which means there has to be the workaround in `pkgs/shells/nushell/plugins/default.nix` for the new scope overriding the `dbus` attribute.

The package contains a simple passthru test that just checks that the plugin is able to be loaded by the passed in `nushell` derivation. This test also shares the concern with the package name (I worked around it by passing the package itself as `nu_plugin_dbus`). It would also be possible to put the `runCommand` into a separate file so all nushell plugins can have the test.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
