### PR TITLE
obfs4: 0.1.0 -> 0.4.0

### DIFF
--- a/pkgs/tools/networking/obfs4/default.nix
+++ b/pkgs/tools/networking/obfs4/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "obfs4";
-  version = "0.1.0";
+  version = "0.4.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
@@ -12,18 +12,20 @@ buildGoModule rec {
     # will collide with lyrebird Gtk3 program.
     repo = "lyrebird";
     rev = "lyrebird-${version}";
-    hash = "sha256-2qBSmAsaR3hfxuoR5U5UAFQAepUOEUnIGoxc/GZ5LmY=";
+    hash = "sha256-aPALWvngC/BVQO73yUAykHvEb6T0DZcGMowXINDqhpQ=";
   };
 
-  vendorHash = "sha256-O8CsvpwL9cfipl4M0BquSnG9tBrt/+i+i80OYk2mNiI=";
+  vendorHash = "sha256-iR3+ZMEF0SB3EoLTf2gtqTe3CQcjtDRhfwwbwGj3pXo=";
 
   ldflags = [ "-s" "-w" ];
+
+  subPackages = [ "cmd/lyrebird" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
-    installManPage doc/obfs4proxy.1
-    ln -s $out/share/man/man1/{obfs4proxy,lyrebird}.1
+    installManPage doc/lyrebird.1
+    ln -s $out/share/man/man1/{lyrebird,obfs4proxy}.1
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Bump lyrebird tor pluggable transport (fka obfs4proxy) from 0.1.0 to 0.4.0. 

Minor fixups to make the package build:

- The build fails with `no non-test Go files in...` without `subPackages = [ "cmd/lyrebird" ];`
- The man page got renamed to lyrebird.1 necessitating the swap of arguments to `ln -s`

I think keeping the old package name (obfs4 vs lyrebird) is getting more confusing, as the package now also implements newer obfuscation protocols like meek and webtunnel. But this is out-of-scope of this pull request. I just want the newer version packaged, so folks can host webtunnel bridges without Docker.
 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
