### PR TITLE
wivrn: 0.19 -> 0.20

### DIFF
--- a/nixos/modules/services/video/wivrn.nix
+++ b/nixos/modules/services/video/wivrn.nix
@@ -101,7 +101,7 @@ in
             Note that the application option must be either a package or a
             list with package as the first element.
 
-            See https://github.com/Meumeu/WiVRn/blob/master/docs/configuration.md
+            See https://github.com/WiVRn/WiVRn/blob/master/docs/configuration.md
           '';
           default = { };
           example = literalExpression ''

--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -17,6 +17,7 @@
   freetype,
   git,
   glm,
+  glib,
   glslang,
   harfbuzz,
   libdrm,
@@ -43,13 +44,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wivrn";
-  version = "0.19";
+  version = "0.20";
 
   src = fetchFromGitHub {
     owner = "wivrn";
     repo = "wivrn";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-DYV+JUWjjhLZLq+4Hv7jxOyxDqQut/mU1X0ZFMoNkDI=";
+    hash = "sha256-mxvfwp/9CUoc6tU3KW257qlpXEZu7tK33jxn1TjAZYc=";
   };
 
   monado = applyPatches {
@@ -57,18 +58,20 @@ stdenv.mkDerivation (finalAttrs: {
       domain = "gitlab.freedesktop.org";
       owner = "monado";
       repo = "monado";
-      rev = "bcbe19ddd795f182df42051e5495e9727db36c1c";
-      hash = "sha256-sh5slHROcuC3Dgenu1+hm8U5lUOW48JUbiluYvc3NiQ=";
+      rev = "d7089f182b0514e13554e99512d63e69c30523c5";
+      hash = "sha256-5+8cFDQ2ptaBIJMdZ6gyb0GSL8vBaZktbuBnRlTWOmg=";
     };
 
-    patches = [
-      "${finalAttrs.src}/patches/monado/0001-c-multi-disable-dropping-of-old-frames.patch"
-      "${finalAttrs.src}/patches/monado/0002-ipc-server-Always-listen-to-stdin.patch"
-      "${finalAttrs.src}/patches/monado/0003-c-multi-Don-t-log-frame-time-diff.patch"
-      "${finalAttrs.src}/patches/monado/0005-distortion-images.patch"
-      "${finalAttrs.src}/patches/monado/0008-Use-mipmaps-for-distortion-shader.patch"
-      "${finalAttrs.src}/patches/monado/0009-convert-to-YCbCr-in-monado.patch"
-    ];
+    patches = (
+      map (f: "${finalAttrs.src}/patches/monado/${f}") [
+        "0002-ipc-server-Always-listen-to-stdin.patch"
+        "0003-Use-extern-socket-fd.patch"
+        "0005-distortion-images.patch"
+        "0008-Use-mipmaps-for-distortion-shader.patch"
+        "0009-convert-to-YCbCr-in-monado.patch"
+        "0010-d-solarxr-Add-SolarXR-WebSockets-driver.patch"
+      ]
+    );
   };
 
   strictDeps = true;
@@ -91,6 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     glslang
     pkg-config
     python3
+    glib # provide gdbus-codegen
   ] ++ lib.optionals cudaSupport [ autoAddDriverRunpath ];
 
   buildInputs = [
@@ -101,6 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
     freetype
     glm
+    glib
     harfbuzz
     libdrm
     libGL

--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -41,6 +41,8 @@
   vulkan-loader,
   vulkan-tools,
   x264,
+  wrapQtAppsHook,
+  makeDesktopItem,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wivrn";
@@ -95,6 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
     glib # provide gdbus-codegen
+    wrapQtAppsHook
   ] ++ lib.optionals cudaSupport [ autoAddDriverRunpath ];
 
   buildInputs = [
@@ -131,13 +134,26 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WIVRN_USE_VAAPI" true)
     (lib.cmakeBool "WIVRN_USE_X264" true)
     (lib.cmakeBool "WIVRN_USE_NVENC" cudaSupport)
-    (lib.cmakeBool "WIVRN_USE_SYSTEMD" true)
     (lib.cmakeBool "WIVRN_USE_PIPEWIRE" true)
     (lib.cmakeBool "WIVRN_USE_PULSEAUDIO" true)
     (lib.cmakeBool "WIVRN_BUILD_CLIENT" false)
     (lib.cmakeBool "WIVRN_OPENXR_INSTALL_ABSOLUTE_RUNTIME_PATH" true)
     (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MONADO" "${finalAttrs.monado}")
+    (lib.cmakeFeature "WIVRN_BUILD_DASHBOARD" true)
+  ];
+
+    desktopItems = [
+    (makeDesktopItem {
+      name = "WiVRn Server";
+      desktopName = "WiVRn Server";
+      genericName = "WiVRn Server";
+      comment = "Play your PC VR games on a standalone headset";
+      icon = "io.github.wivrn.wivrn";
+      exec = "wivrn-dashboard";
+      type = "Application";
+      categories = [ "Network" "Game" ];
+    })
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
https://github.com/WiVRn/WiVRn/releases/tag/v0.20

## Things done

Ported to: https://github.com/WiVRn/WiVRn/releases/tag/v0.20

added glib as a dependency

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@PassiveLemon 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
