### PR TITLE
cargo-tauri.hook: use finalPackage as cargo-tauri

### DIFF
--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -12,63 +12,70 @@
   webkitgtk_4_0,
 }:
 
-rustPlatform.buildRustPackage rec {
-  pname = "tauri";
-  version = "1.7.1-unstable-2024-08-16";
+let
+  cargo-tauri = rustPlatform.buildRustPackage rec {
+    pname = "tauri";
+    version = "1.7.1-unstable-2024-08-16";
 
-  src = fetchFromGitHub {
-    owner = "tauri-apps";
-    repo = "tauri";
-    rev = "2b61447dfc167ec11724f99671bf9e2de0bf6768";
-    hash = "sha256-gKG7olZuTCkW+SKI3FVZqgS6Pp5hFemRJshdma8rpyg=";
-  };
+    src = fetchFromGitHub {
+      owner = "tauri-apps";
+      repo = "tauri";
+      rev = "2b61447dfc167ec11724f99671bf9e2de0bf6768";
+      hash = "sha256-gKG7olZuTCkW+SKI3FVZqgS6Pp5hFemRJshdma8rpyg=";
+    };
 
-  # Manually specify the sourceRoot since this crate depends on other crates in the workspace. Relevant info at
-  # https://discourse.nixos.org/t/difficulty-using-buildrustpackage-with-a-src-containing-multiple-cargo-workspaces/10202
-  sourceRoot = "${src.name}/tooling/cli";
+    # Manually specify the sourceRoot since this crate depends on other crates in the workspace. Relevant info at
+    # https://discourse.nixos.org/t/difficulty-using-buildrustpackage-with-a-src-containing-multiple-cargo-workspaces/10202
+    sourceRoot = "${src.name}/tooling/cli";
 
-  cargoHash = "sha256-VXg/dAhwPTSrLwJm8HNzAi/sVF9RqgpHIF3PZe1LjSA=";
+    cargoHash = "sha256-VXg/dAhwPTSrLwJm8HNzAi/sVF9RqgpHIF3PZe1LjSA=";
 
-  nativeBuildInputs = [ pkg-config ];
+    nativeBuildInputs = [ pkg-config ];
 
-  buildInputs =
-    [ openssl ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      gtk3
-      libsoup
-      webkitgtk_4_0
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (
-      with darwin.apple_sdk.frameworks;
-      [
-        CoreServices
-        Security
-        SystemConfiguration
+    buildInputs =
+      [ openssl ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        gtk3
+        libsoup
+        webkitgtk_4_0
       ]
-    );
+      ++ lib.optionals stdenv.hostPlatform.isDarwin (
+        with darwin.apple_sdk.frameworks;
+        [
+          CoreServices
+          Security
+          SystemConfiguration
+        ]
+      );
 
-  passthru = {
-    # See ./doc/hooks/tauri.section.md
-    hook = callPackage ./hook.nix { };
-
-    tests = {
-      setupHooks = callPackage ./test-app.nix { };
+    meta = {
+      description = "Build smaller, faster, and more secure desktop applications with a web frontend";
+      homepage = "https://tauri.app/";
+      changelog = "https://github.com/tauri-apps/tauri/releases/tag/tauri-v${version}";
+      license = with lib.licenses; [
+        asl20 # or
+        mit
+      ];
+      maintainers = with lib.maintainers; [
+        dit7ya
+        getchoo
+        happysalada
+      ];
+      mainProgram = "cargo-tauri";
     };
   };
+in
 
-  meta = {
-    description = "Build smaller, faster, and more secure desktop applications with a web frontend";
-    homepage = "https://tauri.app/";
-    changelog = "https://github.com/tauri-apps/tauri/releases/tag/tauri-v${version}";
-    license = with lib.licenses; [
-      asl20 # or
-      mit
-    ];
-    maintainers = with lib.maintainers; [
-      dit7ya
-      getchoo
-      happysalada
-    ];
-    mainProgram = "cargo-tauri";
-  };
-}
+# We use overrideAttrs, since we can't directly use the finalAttrs pattern with buildRustPackage
+cargo-tauri.overrideAttrs (
+  finalAttrs: prevAttrs: {
+    passthru = {
+      # See ./doc/hooks/tauri.section.md
+      hook = callPackage ./hook.nix { cargo-tauri = finalAttrs.finalPackage; };
+
+      tests = {
+        setupHooks = callPackage ./test-app.nix { cargo-tauri = finalAttrs.finalPackage; };
+      };
+    };
+  }
+)

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -48,21 +48,6 @@ let
         ]
       );
 
-    meta = {
-      description = "Build smaller, faster, and more secure desktop applications with a web frontend";
-      homepage = "https://tauri.app/";
-      changelog = "https://github.com/tauri-apps/tauri/releases/tag/tauri-v${version}";
-      license = with lib.licenses; [
-        asl20 # or
-        mit
-      ];
-      maintainers = with lib.maintainers; [
-        dit7ya
-        getchoo
-        happysalada
-      ];
-      mainProgram = "cargo-tauri";
-    };
   };
 in
 
@@ -76,6 +61,22 @@ cargo-tauri.overrideAttrs (
       tests = {
         setupHooks = callPackage ./test-app.nix { cargo-tauri = finalAttrs.finalPackage; };
       };
+    };
+
+    meta = {
+      description = "Build smaller, faster, and more secure desktop applications with a web frontend";
+      homepage = "https://tauri.app/";
+      changelog = "https://github.com/tauri-apps/tauri/releases/tag/tauri-v${finalAttrs.version}";
+      license = with lib.licenses; [
+        asl20 # or
+        mit
+      ];
+      maintainers = with lib.maintainers; [
+        dit7ya
+        getchoo
+        happysalada
+      ];
+      mainProgram = "cargo-tauri";
     };
   }
 )

--- a/pkgs/by-name/ga/gale/package.nix
+++ b/pkgs/by-name/ga/gale/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     npmHooks.npmConfigHook
     nodejs
     rustPlatform.cargoSetupHook
-    (cargo-tauri.hook.override { cargo-tauri = cargo-tauri_2; })
+    cargo-tauri_2.hook
     rustPlatform.cargoCheckHook
     pkg-config
     wrapGAppsHook3

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -90,7 +90,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cargo
-    (cargo-tauri.hook.override { cargo-tauri = cargo-tauri_2; })
+    cargo-tauri_2.hook
     gobject-introspection
     makeBinaryWrapper
     nodejs


### PR DESCRIPTION
This PR simplifies usage of cargo-tauri.hook when cargo-tauri is overridden

This PR should not cause any rebuilds.

---

The related question that still remains is how to package `cargo_tauri_2` and how a `cargo-tauri_2` vs `cargo-tauri_1` split will work inside `pkgs/by-name`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
