### PR TITLE
synfigstudio: 1.5.1 -> 1.5.3

### DIFF
--- a/pkgs/applications/graphics/synfigstudio/default.nix
+++ b/pkgs/applications/graphics/synfigstudio/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , pkg-config
 , autoreconfHook
 , wrapGAppsHook3
@@ -29,12 +28,12 @@
 }:
 
 let
-  version = "1.5.1";
+  version = "1.5.3";
   src = fetchFromGitHub {
     owner = "synfig";
     repo = "synfig";
     rev = "v${version}";
-    hash = "sha256-9vBYESaSgW/1FWH2uFBvPiYvxLlX0LLNnd4S7ACJcwI=";
+    hash = "sha256-D+FUEyzJ74l0USq3V9HIRAfgyJfRP372aEKDqF8+hsQ=";
   };
 
   ETL = stdenv.mkDerivation {
@@ -55,17 +54,6 @@ let
   synfig = stdenv.mkDerivation {
     pname = "synfig";
     inherit version src;
-
-    patches = [
-      # Pull upstream fix for autoconf-2.72 support:
-      #   https://github.com/synfig/synfig/pull/2930
-      (fetchpatch {
-        name = "autoconf-2.72.patch";
-        url = "https://github.com/synfig/synfig/commit/80a3386c701049f597cf3642bb924d2ff832ae05.patch";
-        stripLen = 1;
-        hash = "sha256-7gX8tJCR81gw8ZDyNYa8UaeZFNOx4o1Lnq0cAcaKb2I=";
-      })
-    ];
 
     sourceRoot = "${src.name}/synfig-core";
 
@@ -161,7 +149,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "2D animation program";
     homepage = "http://www.synfig.org";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl3Plus;
     maintainers = [ ];
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/applications/graphics/synfigstudio/default.nix
+++ b/pkgs/applications/graphics/synfigstudio/default.nix
@@ -78,6 +78,8 @@ let
       "CXXFLAGS=-std=c++14"
     ];
 
+    enableParallelBuilding = true;
+
     nativeBuildInputs = [
       pkg-config
       autoreconfHook


### PR DESCRIPTION
[ChangeLog](https://github.com/synfig/synfig/blob/v1.5.3/ChangeLog-development.md)

This PR also enables parallel build for the synfig core library. It was only enabled (by mistake?) for the GUI.

Close #349890.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
