### PR TITLE
trunk-recorder: init at 5.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16303,6 +16303,11 @@
     githubId = 33182938;
     name = "Pankaj";
   };
+  PapayaJackal = {
+    github = "PapayaJackal";
+    githubId = 145766029;
+    name = "PapayaJackal";
+  };
   paperdigits = {
     email = "mica@silentumbrella.com";
     github = "paperdigits";

--- a/pkgs/by-name/tr/trunk-recorder/package.nix
+++ b/pkgs/by-name/tr/trunk-recorder/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  git,
+  makeWrapper,
+  pkg-config,
+  boost,
+  curl,
+  gmp,
+  gnuradio,
+  gnuradioPackages,
+  hackrf,
+  mpir,
+  openssl,
+  spdlog,
+  uhd,
+  volk,
+  fdk-aac-encoder,
+  sox,
+  hackrfSupport ? true,
+}:
+stdenv.mkDerivation rec {
+  pname = "trunk-recorder";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "robotastic";
+    repo = "trunk-recorder";
+    rev = "v${version}";
+    hash = "sha256-d2iBCSLR3kr6rnLXO3MeGVdi6+8pqXZqW/yhxAvA1cY=";
+  };
+
+  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=ON" ];
+
+  nativeBuildInputs = [
+    cmake
+    git
+    pkg-config
+    makeWrapper
+  ];
+  buildInputs = [
+    boost
+    curl
+    gmp
+    gnuradio
+    gnuradioPackages.osmosdr
+    openssl
+    spdlog
+    uhd
+    volk
+  ] ++ lib.optionals hackrfSupport [ hackrf ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ mpir ];
+
+  postFixup = ''
+    wrapProgram $out/bin/trunk-recorder --prefix PATH : ${
+      lib.makeBinPath [
+        sox
+        fdk-aac-encoder
+      ]
+    }
+  '';
+
+  meta = {
+    description = "Record calls from trunked radio systems";
+    homepage = "https://trunkrecorder.com/";
+    changelog = "https://github.com/robotastic/trunk-recorder/releases/tag/v${version}";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ PapayaJackal ];
+    mainProgram = "trunk-recorder";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package [robotastic/trunk-recorder](https://github.com/robotastic/trunk-recorder), a program for recording calls from trunk radio systems with software-defined radios.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
