### PR TITLE
nixos/nginx: re-enable ssl_session_tickets

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -209,8 +209,6 @@ let
 
               ssl_session_timeout 1d;
               ssl_session_cache shared:SSL:10m;
-              # Breaks forward secrecy: https://github.com/mozilla/server-side-tls/issues/135
-              ssl_session_tickets off;
               # We don't enable insecure ciphers by default, so this allows
               # clients to pick the most performant, per https://github.com/mozilla/server-side-tls/issues/260
               ssl_prefer_server_ciphers off;


### PR DESCRIPTION
Mozilla's [recommendations][1] no longer include this item. Per [mozilla/server-side-tls#135][2] and
[mozilla/ssl-config-generator#252][3], it sounds like versions of nginx prior to 1.23.2 (released 2022-10-19) didn't make it easy to properly rotate the ticket encryption keys, but since that version it's now done automatically. Since nixos-24.05 is already on nginx-1.26.2, it seems safe to remove this option.

[1]: https://ssl-config.mozilla.org/#server=nginx&config=intermediate
[2]: https://github.com/mozilla/server-side-tls/issues/135
[3]: https://github.com/mozilla/ssl-config-generator/pull/252

I came across this while looking to see what was included in `recommendedTlsSettings` and noticing that it had fallen out of sync with its own source. I don't personally feel strongly that `ssl_session_tickets` is important to set one way or the other, this just seems like housekeeping to me. I believe it has performance implications (reducing the amount of memory nginx needs?) but the [docs](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets) are not very helpful.

One other notable difference between the Mozilla settings and ours is Mozilla enables HSTS. I don't know if this is not included because it's new or if it's omitted intentionally, but I decided not to include it here because it seems like it could be a more significant / impactful / client-facing change. Let me know if we want it and I might do a followup PR, perhaps adding it as an option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux -- well, actually I cherry-picked onto `nixos-24.05` and then built that, but I imagine that's sufficient?
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true` (because it's the default on Linux and I haven't overridden it)
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
