### PR TITLE
idris2Packages: add methods parseIpkg and importIpkg

### DIFF
--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -5,4 +5,6 @@
   idris2Lsp = callPackage ./idris2-lsp.nix { };
 
   buildIdris = callPackage ./build-idris.nix { };
+
+  inherit (callPackage ./ipkg-parse.nix { }) parseIpkg importIpkg;
 }

--- a/pkgs/development/compilers/idris2/ipkg-parse.nix
+++ b/pkgs/development/compilers/idris2/ipkg-parse.nix
@@ -1,0 +1,466 @@
+{lib}: let
+  # Test 1
+  test1_text = ''
+    package micropack
+
+    version = 0.0.1
+
+    authors = "Stefan Höck"
+
+    brief   = "Minimalistic installer for pack"
+
+    langversion >= 0.6.0
+
+    depends = base >= 0.6.0
+            , elab-util
+
+            , idris2
+            , parser-toml
+
+    main       = MicroPack
+    executable = micropack
+    modules = Pack.CmdLn
+        , Pack.CmdLn.Completion
+        , Pack.CmdLn.Types
+
+        , Pack.Config
+
+    sourcedir  = "src"
+  '';
+
+  # Test 1
+  test2_text = ''
+    package pack
+
+    version = 0.0.1
+
+    authors = "Stefan Höck"
+
+    brief   = "A package manager for Idris2 with curated package collections"
+
+    langversion >= 0.6.0
+
+    -- script to run before building
+    prebuild = "bash version.sh"
+
+    postbuild = "bash restore.sh"
+
+    depends = base >= 0.6.0
+            , elab-util
+
+            , idris2
+            , parser-toml
+
+    modules = Pack.CmdLn
+            , Pack.CmdLn.Completion
+            , Pack.CmdLn.Opts
+            , Pack.CmdLn.Types
+
+            , Pack.Config
+
+    main       = Main
+
+    executable = pack
+
+    sourcedir  = "src"
+  '';
+
+  startsWith = prefix: str: let
+    prefixLength = builtins.stringLength prefix;
+  in
+    builtins.substring 0 prefixLength str == prefix;
+
+  parseToLines = text: let
+    splitLines = lib.splitString "\n" text;
+    trimmedLines = map lib.trim splitLines;
+    nonEmptyLines = builtins.filter (line: line != "") trimmedLines;
+    nonEmptyLinesWithoutComments = builtins.filter (line: !(startsWith "--" line)) nonEmptyLines;
+
+    foldLines =
+      builtins.foldl'
+      (
+        acc: line: let
+          isCommaLine = builtins.substring 0 1 line == ",";
+          init = lib.sublist 0 lastIndex acc;
+          lastIndex = builtins.length acc - 1;
+          last =
+            if lastIndex >= 0
+            then builtins.elemAt acc lastIndex
+            else "";
+          newLastLine = last + line;
+        in
+          if isCommaLine
+          then (init ++ [newLastLine])
+          else acc ++ [line]
+      )
+      []
+      nonEmptyLinesWithoutComments;
+  in
+    foldLines;
+
+  # ">= 0.6.0" -> {"lowerInclusive": true,"lowerBound": "0.6.0","upperInclusive": true,"upperBound": "*"}
+  # "<= 0.6.0" -> {"lowerInclusive": true,"lowerBound": "*","upperInclusive": true,"upperBound": "0.6.0"}
+  # "0.6.0" -> throw error
+  # "> 0.6.0 && < 0.5.0" -> {"lowerInclusive": false,"lowerBound": "0.6.0","upperInclusive": false,"upperBound": "0.5.0"}
+  # "> 0.6.0" -> {"lowerInclusive": false,"lowerBound": "0.6.0","upperInclusive": true,"upperBound": "*"}
+  # "> 0.6.0 && < 0.7.0" -> {"lowerInclusive": false,"lowerBound": "0.6.0","upperInclusive": false,"upperBound": "0.7.0"}
+  parseVersion = value: let
+    # split &&
+    split = lib.splitString " && " value;
+    # parse left part (required)
+    # parse right part (optional)
+
+    parseVersionPart = value: let
+      split = lib.splitString " " value;
+      operatorAndInclusive = builtins.elemAt split 0;
+
+      operatorAndInclusiveAttrset =
+        {
+          ">=" = {
+            operator = ">";
+            inclusive = true;
+          };
+          "<=" = {
+            operator = "<";
+            inclusive = true;
+          };
+          "<" = {
+            operator = "<";
+            inclusive = false;
+          };
+          ">" = {
+            operator = ">";
+            inclusive = false;
+          };
+        }
+        .${operatorAndInclusive}
+        or (throw "Invalid version operator ${operatorAndInclusive} in version part ${value}");
+    in
+      {
+        version = builtins.elemAt split 1;
+      }
+      // operatorAndInclusiveAttrset;
+
+    left = parseVersionPart (builtins.elemAt split 0);
+    right = parseVersionPart (builtins.elemAt split 1);
+  in
+    if value == null
+    then throw "Version cannot be null"
+    else if value == ""
+    then throw "Version cannot be empty"
+    else if builtins.length split == 1
+    then
+      {
+        "<" = {
+          lowerInclusive = true;
+          lowerBound = "*";
+          upperInclusive = left.inclusive;
+          upperBound = left.version;
+        };
+        ">" = {
+          lowerInclusive = left.inclusive;
+          lowerBound = left.version;
+          upperInclusive = true;
+          upperBound = "*";
+        };
+      }
+      .${left.operator}
+      or (throw "Invalid version string ${value}")
+    else if builtins.length split == 2
+    then
+      {
+        "><" = {
+          lowerInclusive = left.inclusive;
+          lowerBound = left.version;
+          upperInclusive = right.inclusive;
+          upperBound = right.version;
+        };
+      }
+      .${"${left.operator}${right.operator}"}
+      or (throw "Invalid version string ${value}")
+    else throw "Invalid version string ${value}";
+
+  parseVersion_emptyIsInfinity = value:
+    if value == ""
+    then {
+      lowerInclusive = true;
+      lowerBound = "*";
+      upperInclusive = true;
+      upperBound = "*";
+    }
+    else parseVersion value;
+
+  parseIpkg = text: let
+    lines = parseToLines text;
+    # split by first whitespace using regex, first element is the key
+    dict =
+      builtins.foldl'
+      (acc: line: let
+        splitByFirstWhitespaceIgnoreEqualSign = builtins.match "([[:alnum:]_]+)[[:space:]]+=?[[:space:]]*(.*)" line;
+        key = builtins.elemAt splitByFirstWhitespaceIgnoreEqualSign 0;
+        value = builtins.elemAt splitByFirstWhitespaceIgnoreEqualSign 1;
+
+        keyParsed =
+          if key == "package"
+          then "name"
+          else key;
+
+        valueParsed =
+          if key == "depends"
+          then parseDependencies value
+          else if key == "modules"
+          then commaSeparatedToArray value
+          else if key == "langversion"
+          then parseVersion value
+          else removeQuotes value;
+      in
+        acc // {${keyParsed} = valueParsed;})
+      {}
+      lines;
+
+    removeQuotes = value:
+      if builtins.substring 0 1 value == "\"" && builtins.substring (builtins.stringLength value - 1) 1 value == "\""
+      then builtins.substring 1 (builtins.stringLength value - 2) value
+      else value;
+
+    # "foo, bar, baz" -> ["foo", "bar", "baz"]
+    commaSeparatedToArray = value:
+      builtins.map lib.trim (lib.splitString "," value);
+
+    # "foo >= 0.6.0" -> { name = "foo"; value = ">= 0.6.0"; }
+    dependecyToHashNameValue = stringValue: let
+      split = lib.splitString " " stringValue;
+      value = lib.concatStringsSep " " (lib.tail split);
+      name = lib.head split;
+    in
+      lib.nameValuePair name value;
+
+    # "foo >= 0.6.0, bar >= 0.7.0" => { foo = { lowerInclusive = true; lowerBound = "0.6.0"; ... }; bar = { lowerInclusive = true; lowerBound = "0.7.0"; ... } }
+    parseDependencies = string: let
+      nameValuesArray = builtins.map dependecyToHashNameValue (commaSeparatedToArray string);
+    in
+      builtins.mapAttrs (_name: value: parseVersion_emptyIsInfinity value) (builtins.listToAttrs nameValuesArray);
+  in
+    dict;
+
+  importIpkg = path: parseIpkg (builtins.readFile path);
+
+  #################################################################
+
+  tests = {
+    testMoreEq0_6_0 = {
+      expr = parseVersion ">= 0.6.0";
+      expected = {
+        lowerInclusive = true;
+        lowerBound = "0.6.0";
+        upperInclusive = true;
+        upperBound = "*";
+      };
+    };
+    testLessEq0_6_0 = {
+      expr = parseVersion "<= 0.6.0";
+      expected = {
+        lowerInclusive = true;
+        lowerBound = "*";
+        upperInclusive = true;
+        upperBound = "0.6.0";
+      };
+    };
+    testMore0_6_0_less0_5_0 = {
+      expr = parseVersion "> 0.6.0 && < 0.5.0";
+      expected = {
+        lowerInclusive = false;
+        lowerBound = "0.6.0";
+        upperInclusive = false;
+        upperBound = "0.5.0";
+      };
+    };
+    testMore0_6_0 = {
+      expr = parseVersion "> 0.6.0";
+      expected = {
+        lowerInclusive = false;
+        lowerBound = "0.6.0";
+        upperInclusive = true;
+        upperBound = "*";
+      };
+    };
+    testMore0_6_0_less0_7_0 = {
+      expr = parseVersion "> 0.6.0 && < 0.7.0";
+      expected = {
+        lowerInclusive = false;
+        lowerBound = "0.6.0";
+        upperInclusive = false;
+        upperBound = "0.7.0";
+      };
+    };
+    testThrowsIfJustNumber = {
+      expr = builtins.tryEval (parseVersion "0.6.0");
+      expected = {
+        "success" = false;
+        "value" = false;
+      };
+    };
+    testThrowsIfWrongOrder = {
+      expr = builtins.tryEval (parseVersion "< 0.6.0 && > 0.7.0");
+      expected = {
+        "success" = false;
+        "value" = false;
+      };
+    };
+    testToLines = {
+      expr = parseToLines test1_text;
+      expected = [
+        "package micropack"
+        "version = 0.0.1"
+        "authors = \"Stefan Höck\""
+        "brief   = \"Minimalistic installer for pack\""
+        "langversion >= 0.6.0"
+        "depends = base >= 0.6.0, elab-util, idris2, parser-toml"
+        "main       = MicroPack"
+        "executable = micropack"
+        "modules = Pack.CmdLn, Pack.CmdLn.Completion, Pack.CmdLn.Types, Pack.Config"
+        "sourcedir  = \"src\""
+      ];
+    };
+    # taken from idris2 --dump-ipkg-json ./micropack.ipkg
+    testParsed = {
+      expr = parseIpkg test1_text;
+      expected = {
+        name = "micropack";
+        version = "0.0.1";
+        authors = "Stefan Höck";
+        brief = "Minimalistic installer for pack";
+        langversion = {
+          lowerInclusive = true;
+          lowerBound = "0.6.0";
+          upperInclusive = true;
+          upperBound = "*";
+        };
+        depends = {
+          base = {
+            lowerInclusive = true;
+            lowerBound = "0.6.0";
+            upperInclusive = true;
+            upperBound = "*";
+          };
+          elab-util = {
+            lowerInclusive = true;
+            lowerBound = "*";
+            upperInclusive = true;
+            upperBound = "*";
+          };
+          idris2 = {
+            lowerInclusive = true;
+            lowerBound = "*";
+            upperInclusive = true;
+            upperBound = "*";
+          };
+          parser-toml = {
+            lowerInclusive = true;
+            lowerBound = "*";
+            upperInclusive = true;
+            upperBound = "*";
+          };
+        };
+        main = "MicroPack";
+        executable = "micropack";
+        modules = [
+          "Pack.CmdLn"
+          "Pack.CmdLn.Completion"
+          "Pack.CmdLn.Types"
+          "Pack.Config"
+        ];
+        sourcedir = "src";
+      };
+    };
+    test2ToLines = {
+      expr = parseToLines test2_text;
+      expected = [
+        "package pack"
+        "version = 0.0.1"
+        "authors = \"Stefan Höck\""
+        "brief   = \"A package manager for Idris2 with curated package collections\""
+        "langversion >= 0.6.0"
+        "prebuild = \"bash version.sh\""
+        "postbuild = \"bash restore.sh\""
+        "depends = base >= 0.6.0, elab-util, idris2, parser-toml"
+        "modules = Pack.CmdLn, Pack.CmdLn.Completion, Pack.CmdLn.Opts, Pack.CmdLn.Types, Pack.Config"
+        "main       = Main"
+        "executable = pack"
+        "sourcedir  = \"src\""
+      ];
+    };
+    test2Parsed = {
+      expr = parseIpkg test2_text;
+      expected = {
+        name = "pack";
+        depends = {
+          base = {
+            lowerInclusive = true;
+            lowerBound = "0.6.0";
+            upperInclusive = true;
+            upperBound = "*";
+          };
+          elab-util = {
+            lowerInclusive = true;
+            lowerBound = "*";
+            upperInclusive = true;
+            upperBound = "*";
+          };
+          idris2 = {
+            lowerInclusive = true;
+            lowerBound = "*";
+            upperInclusive = true;
+            upperBound = "*";
+          };
+          parser-toml = {
+            lowerInclusive = true;
+            lowerBound = "*";
+            upperInclusive = true;
+            upperBound = "*";
+          };
+        };
+        modules = [
+          "Pack.CmdLn"
+          "Pack.CmdLn.Completion"
+          "Pack.CmdLn.Opts"
+          "Pack.CmdLn.Types"
+          "Pack.Config"
+        ];
+        version = "0.0.1";
+        langversion = {
+          lowerInclusive = true;
+          lowerBound = "0.6.0";
+          upperInclusive = true;
+          upperBound = "*";
+        };
+        authors = "Stefan Höck";
+        brief = "A package manager for Idris2 with curated package collections";
+        main = "Main";
+        executable = "pack";
+        sourcedir = "src";
+        prebuild = "bash version.sh";
+        postbuild = "bash restore.sh";
+      };
+    };
+  };
+
+  #################################################################
+
+  runTestsAll = tests: let
+    testResults = lib.reverseList (lib.debug.runTests tests);
+  in
+    if testResults == []
+    then true
+    else let
+      errorMessage = lib.concatStringsSep "\n\n" (map (
+          test:
+            "Test: " + test.name + "\nExpected: " + builtins.toJSON test.expected + "\nActual  : " + builtins.toJSON test.result
+        )
+        testResults);
+    in
+      builtins.throw "\nTests failed.\n${errorMessage}\n";
+in
+  assert (runTestsAll tests); {
+    inherit parseIpkg importIpkg;
+  }


### PR DESCRIPTION
add methods parseIpkg and importIpkg, which give identical output to `idris2 --dump-ipkg-json ./mypackage.ipkg`, but implemented in pure nix

tests run on each import of these methods

@mattpolzin

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
