### PR TITLE
bcache-tools: fix udev patch to use bash from explicit path

### DIFF
--- a/pkgs/tools/filesystems/bcache-tools/bcache-udev-modern.patch
+++ b/pkgs/tools/filesystems/bcache-tools/bcache-udev-modern.patch
@@ -24,7 +24,7 @@ index 9cc7f0d..6a52893 100644
  LABEL="bcache_backing_found"
  RUN{builtin}+="kmod load bcache"
 -RUN+="bcache-register $tempnode"
-+RUN+="/bin/sh -c 'echo $tempnode > /sys/fs/bcache/register_quiet'"
++RUN+="@shell@ -c 'echo $tempnode > /sys/fs/bcache/register_quiet'"
  LABEL="bcache_backing_end"
  
  # Cached devices: symlink

--- a/pkgs/tools/filesystems/bcache-tools/default.nix
+++ b/pkgs/tools/filesystems/bcache-tools/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, util-linux, bash }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, util-linux, bash, substituteAll }:
 
 stdenv.mkDerivation rec {
   pname = "bcache-tools";
@@ -26,7 +26,10 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
-    ./bcache-udev-modern.patch
+    (substituteAll {
+      src = ./bcache-udev-modern.patch;
+      shell = "${bash}/bin/sh";
+    })
     ./fix-static.patch
   ];
 


### PR DESCRIPTION
## Things done

This fixes the issue in:

https://github.com/NixOS/nixpkgs/issues/349975

The bcache udev rule was patched to run `/bin/sh`, but at some point there was a check introduced which checked if all the binaries called in the udev rules actually exist. This one failed the check, and resulted a broken build. What is now fixed here is we explicitly set the path to the system bash, and the udev check is now successful.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
