### PR TITLE
python312Packages.fabric: add pynacl as dependency

### DIFF
--- a/pkgs/development/python-modules/fabric/default.nix
+++ b/pkgs/development/python-modules/fabric/default.nix
@@ -8,14 +8,16 @@
   mock,
   paramiko,
   pynacl,
-  pytestCheckHook,
+  pypaInstallHook,
   pytest-relaxed,
+  pytestCheckHook,
+  setuptoolsBuildHook,
 }:
 
 buildPythonPackage rec {
   pname = "fabric";
   version = "3.2.2";
-  format = "setuptools";
+  pyproject = false;
 
   src = fetchPypi {
     inherit pname version;
@@ -28,18 +30,23 @@ buildPythonPackage rec {
         --replace ', "pathlib2"' ' '
   '';
 
-  propagatedBuildInputs = [
-    invoke
-    paramiko
+  nativeBuildInputs = [
+    pypaInstallHook
+    setuptoolsBuildHook
+  ];
+
+  dependencies = [
     cryptography
     decorator
+    invoke
+    paramiko
     pynacl
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-    pytest-relaxed
     mock
+    pytest-relaxed
+    pytestCheckHook
   ];
 
   # ==================================== ERRORS ====================================
@@ -50,11 +57,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "fabric" ];
 
-  meta = with lib; {
+  meta = {
     description = "Pythonic remote execution";
-    mainProgram = "fab";
-    homepage = "https://www.fabfile.org/";
-    license = licenses.bsd2;
+    homepage = "http://fabfile.org/";
+    changelog = "https://www.fabfile.org/changelog.html";
+    license = lib.licenses.bsd2;
     maintainers = [ ];
+    mainProgram = "fab";
   };
 }

--- a/pkgs/development/python-modules/fabric/default.nix
+++ b/pkgs/development/python-modules/fabric/default.nix
@@ -7,6 +7,7 @@
   invoke,
   mock,
   paramiko,
+  pynacl,
   pytestCheckHook,
   pytest-relaxed,
 }:
@@ -32,6 +33,7 @@ buildPythonPackage rec {
     paramiko
     cryptography
     decorator
+    pynacl
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/fabric/default.nix
+++ b/pkgs/development/python-modules/fabric/default.nix
@@ -24,12 +24,6 @@ buildPythonPackage rec {
     hash = "sha256-h4PKQuOwB28IsmkBqsa52bHxnEEAdOesz6uQLBhP9KM=";
   };
 
-  # only relevant to python < 3.4
-  postPatch = ''
-    substituteInPlace setup.py \
-        --replace ', "pathlib2"' ' '
-  '';
-
   nativeBuildInputs = [
     pypaInstallHook
     setuptoolsBuildHook

--- a/pkgs/development/python-modules/fabric/default.nix
+++ b/pkgs/development/python-modules/fabric/default.nix
@@ -2,13 +2,15 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  cryptography,
   decorator,
+  deprecated,
+  icecream,
+  invocations,
   invoke,
-  mock,
   paramiko,
   pynacl,
   pypaInstallHook,
+  pytest-cov,
   pytest-relaxed,
   pytestCheckHook,
   setuptoolsBuildHook,
@@ -30,23 +32,22 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    cryptography
     decorator
+    deprecated
     invoke
     paramiko
     pynacl
   ];
 
   nativeCheckInputs = [
-    mock
+    icecream
+    invocations
+    pytest-cov
     pytest-relaxed
     pytestCheckHook
   ];
 
-  # ==================================== ERRORS ====================================
-  # ________________________ ERROR collecting test session _________________________
-  # Direct construction of SpecModule has been deprecated, please use SpecModule.from_parent
-  # See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent for more details.
+  # distutils.errors.DistutilsArgError: no commands supplied
   doCheck = false;
 
   pythonImportsCheck = [ "fabric" ];

--- a/pkgs/development/python-modules/fabric/default.nix
+++ b/pkgs/development/python-modules/fabric/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     homepage = "http://fabfile.org/";
     changelog = "https://www.fabfile.org/changelog.html";
     license = lib.licenses.bsd2;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "fab";
   };
 }


### PR DESCRIPTION
Fixes the build failure that appeared in https://hydra.nixos.org/build/274289142

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
