### PR TITLE
pnpm.fetchDeps: ensure consistent hashes by setting file permissions after fetching

### DIFF
--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -97,6 +97,18 @@
               jq --sort-keys "del(.. | .checkedAt?)" $f | sponge $f
             done
 
+            # NOTE: For reasons not yet known, pnpm might create files with
+            # inconsistent permissions, for example inside the ubuntu-24.04
+            # github actions runner.
+            # To ensure stable derivations, we need to set permissions
+            # consistently, namely:
+            # * All files with `-exec` suffix have 555.
+            # * All other files have 444.
+            # * All folders have 555.
+            find $out -type f -name "*-exec" -print0 | xargs -0 chmod 555
+            find $out -type f -not -name "*-exec" -print0 | xargs -0 chmod 444
+            find $out -type d -print0 | xargs -0 chmod 555
+
             runHook postFixup
           '';
 


### PR DESCRIPTION
For reasons not yet completely understood, `pnpm` might create dependency files with inconsistent file permissions. Since file permissions influence the resulting hash, this PR attempts a workaround by ensuring consistency after the fact.

**NOTE: I am unsure that this should be merged prior to understanding what causes `pnpm` to generate inconsistent file permissions in the first place.**
Maybe this PR already helps others facing the same issue.

More details:
We tried to build a small pnpm-based application locally versus within Github actions.
Here we observed build failures due to differing hashes for `pnpmDeps`. After investigation of the actual derivation contents we discovered that on a local, Ubuntu 24.04.1 LTS-based laptops with multi-user nix installs, all files in the derivation either had `444` or `555`, the same derivation within the `ubuntu-24.04`-based runner (with _single user install_ via [nix-quick-install](https://github.com/nixbuild/nix-quick-install-action)) had `644`/`755` as permissions _and_ in different quantities.
To make things even more confusing: The `ubuntu-22.04` agent runner showed the same behavior as our local environment.

<details><summary>Detailed statistics.</summary>

| environment                                                        | permission | count |
| ------------------------------------------------------------------ | ---------- | ----- |
| Ubuntu 24.04 LTS-based laptop/`ubuntu-22.04` Github actions runner | 444        | 27511 |
| Ubuntu 24.04 LTS-based laptop/`ubuntu-22.04` Github actions runner | 555        | 108   |
| `ubuntu-24.04` Github actions runner                               | 444        | 27497 |
| `ubuntu-24.04` Github actions runner                               | 555        | 122   |

</details>

Since file permissions are stored in the NAR-archives used to derive the hash of a fixed output derivation, this leads to inconsistencies depending on where a derivation is built.

Hence, we ensure a consistent file permission schema:
* All files with `-exec` suffix have 555.
* All other files have 444.
* All folders have 555.

This schema was chosen because it as already upheld in most environments we tested (i.e. local multi user installs on Ubuntu 24.04.1 LTS and _single user install_ via [nix-quick-install](https://github.com/nixbuild/nix-quick-install-action) in `ubuntu-22.04`-based Github action runners).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

