### PR TITLE
Revert "nixos/ssh: disable `authorizedKeysInHomedir` by default"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -397,9 +397,6 @@
     * from `/var/log/private/gns3` to `/var/log/gns3`
   and to change the ownership of these directories and their contents to `gns3` (including `/etc/gns3`).
 
-- The `sshd` module now doesn't include `%h/.ssh/authorized_keys` as `AuthorizedKeysFile` unless
-  `services.openssh.authorizedKeysInHomedir` is set to `true` (the default is `false` for `stateVersion` 24.11 onwards).
-
 - Legacy package `stalwart-mail_0_6` was dropped, please note the
   [manual upgrade process](https://github.com/stalwartlabs/mail-server/blob/main/UPGRADING.md)
   before changing the package to `pkgs.stalwart-mail` in

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -14,10 +14,7 @@ in {
       { ... }:
 
       {
-        services.openssh = {
-          enable = true;
-          authorizedKeysInHomedir = true;
-        };
+        services.openssh.enable = true;
         security.pam.services.sshd.limits =
           [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
         users.users.root.openssh.authorizedKeys.keys = [
@@ -42,11 +39,7 @@ in {
       { ... }:
 
       {
-        services.openssh = {
-          enable = true;
-          startWhenNeeded = true;
-          authorizedKeysInHomedir = true;
-        };
+        services.openssh = { enable = true; startWhenNeeded = true; };
         security.pam.services.sshd.limits =
           [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
         users.users.root.openssh.authorizedKeys.keys = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#309025

Breaks eval, let's just revert for now.