### PR TITLE
nixos/bat: init bat module

### DIFF
--- a/doc/manpage-urls.json
+++ b/doc/manpage-urls.json
@@ -322,5 +322,6 @@
   "nix-shell(1)": "https://nixos.org/manual/nix/stable/command-ref/nix-shell.html",
   "mksquashfs(1)": "https://man.archlinux.org/man/extra/squashfs-tools/mksquashfs.1.en",
   "curl(1)": "https://curl.se/docs/manpage.html",
-  "netrc(5)": "https://man.cx/netrc"
+  "netrc(5)": "https://man.cx/netrc",
+  "cat(1)": "https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html"
 }

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -22,6 +22,8 @@
 
 - [Amazon CloudWatch Agent](https://github.com/aws/amazon-cloudwatch-agent), the official telemetry collector for AWS CloudWatch and AWS X-Ray. Available as [services.amazon-cloudwatch-agent](options.html#opt-services.amazon-cloudwatch-agent.enable).
 
+- [Bat](https://github.com/sharkdp/bat), a {manpage}`cat(1)` clone with wings. Available as [programs.bat](options.html#opt-programs.bat).
+
 - [agorakit](https://github.com/agorakit/agorakit), an organization tool for citizens' collectives. Available with [services.agorakit](options.html#opt-services.agorakit.enable).
 
 - [mqtt-exporter](https://github.com/kpetremann/mqtt-exporter/), a Prometheus exporter for exposing messages from MQTT. Available as [services.prometheus.exporters.mqtt](#opt-services.prometheus.exporters.mqtt.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -161,6 +161,7 @@
   ./programs/bash/ls-colors.nix
   ./programs/bash/undistract-me.nix
   ./programs/bazecor.nix
+  ./programs/bat.nix
   ./programs/bcc.nix
   ./programs/benchexec.nix
   ./programs/browserpass.nix

--- a/nixos/modules/programs/bat.nix
+++ b/nixos/modules/programs/bat.nix
@@ -1,0 +1,122 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (builtins) isList elem;
+  inherit (lib)
+    getExe
+    literalExpression
+    maintainers
+    mapAttrs'
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    nameValuePair
+    optionalString
+    types
+    ;
+  inherit (types) listOf package;
+
+  cfg = config.programs.bat;
+
+  settingsFormat = pkgs.formats.keyValue { listsAsDuplicateKeys = true; };
+  inherit (settingsFormat) generate type;
+
+  initScript =
+    {
+      program,
+      shell,
+      flags ? [ ],
+    }:
+    if (shell != "fish") then
+      ''
+        eval "$(${getExe program} ${toString flags})"
+      ''
+    else
+      ''
+        ${getExe program} ${toString flags} | source
+      '';
+
+  shellInit =
+    shell:
+    optionalString (elem pkgs.bat-extras.batpipe cfg.extraPackages) (initScript {
+      program = pkgs.bat-extras.batpipe;
+      inherit shell;
+    })
+    + optionalString (elem pkgs.bat-extras.batman cfg.extraPackages) (initScript {
+      program = pkgs.bat-extras.batman;
+      inherit shell;
+      flags = [ "--export-env" ];
+    });
+in
+{
+  options.programs.bat = {
+    enable = mkEnableOption "`bat`, a {manpage}`cat(1)` clone with wings";
+
+    package = mkPackageOption pkgs "bat" { };
+
+    extraPackages = mkOption {
+      default = [ ];
+      example = literalExpression ''
+        with pkgs.bat-extras; [
+          batdiff
+          batman
+          prettybat
+        ];
+      '';
+      description = ''
+        Extra `bat` scripts to be added to the system configuration.
+      '';
+      type = listOf package;
+    };
+
+    settings = mkOption {
+      default = { };
+      example = {
+        theme = "TwoDark";
+        italic-text = "always";
+        paging = "never";
+        pager = "less --RAW-CONTROL-CHARS --quit-if-one-screen --mouse";
+        map-syntax = [
+          "*.ino:C++"
+          ".ignore:Git Ignore"
+        ];
+      };
+      description = ''
+        Parameters to be written to the system-wide `bat` configuration file.
+      '';
+      inherit type;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment = {
+      systemPackages = [ cfg.package ] ++ cfg.extraPackages;
+      etc."bat/config".source = generate "bat-config" (
+        mapAttrs' (
+          name: value:
+          nameValuePair ("--" + name) (
+            if (isList value) then map (str: "\"${str}\"") value else "\"${value}\""
+          )
+        ) cfg.settings
+      );
+    };
+
+    programs = {
+      bash = mkIf (!config.programs.fish.enable) {
+        interactiveShellInit = shellInit "bash";
+      };
+      fish = mkIf config.programs.fish.enable {
+        interactiveShellInit = shellInit "fish";
+      };
+      zsh = mkIf (!config.programs.fish.enable && config.programs.zsh.enable) {
+        interactiveShellInit = shellInit "zsh";
+      };
+    };
+  };
+  meta.maintainers = with maintainers; [ sigmasquadron ];
+}


### PR DESCRIPTION
Adds a module for `bat`. Bat's configuration format is pretty difficult to translate into a structured Nix submodule, so I'd appreciate some help in converting this `extraConfig` to the RFC 0042 standard.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
