### PR TITLE
nixos/transmission: improvements

### DIFF
--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -1,10 +1,28 @@
-{ config, lib, pkgs, options, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
 
 let
-  inherit (lib) mkRenamedOptionModule mkAliasOptionModuleMD mkEnableOption
-                mkOption types literalExpression mkPackageOption mkIf
-                optionalString optional mkDefault escapeShellArgs optionalAttrs
-                mkMerge;
+  inherit (lib)
+    mkRenamedOptionModule
+    mkAliasOptionModuleMD
+    mkEnableOption
+    mkOption
+    types
+    literalExpression
+    mkPackageOption
+    mkIf
+    optionalString
+    optional
+    mkDefault
+    escapeShellArgs
+    optionalAttrs
+    mkMerge
+    ;
 
   cfg = config.services.transmission;
   opt = options.services.transmission;
@@ -15,15 +33,36 @@ let
   downloadsDir = "Downloads";
   incompleteDir = ".incomplete";
   watchDir = "watchdir";
-  settingsFormat = pkgs.formats.json {};
+  settingsFormat = pkgs.formats.json { };
   settingsFile = settingsFormat.generate "settings.json" cfg.settings;
 in
 {
   imports = [
-    (mkRenamedOptionModule ["services" "transmission" "port"]
-                           ["services" "transmission" "settings" "rpc-port"])
-    (mkAliasOptionModuleMD ["services" "transmission" "openFirewall"]
-                           ["services" "transmission" "openPeerPorts"])
+    (mkRenamedOptionModule
+      [
+        "services"
+        "transmission"
+        "port"
+      ]
+      [
+        "services"
+        "transmission"
+        "settings"
+        "rpc-port"
+      ]
+    )
+    (mkAliasOptionModuleMD
+      [
+        "services"
+        "transmission"
+        "openFirewall"
+      ]
+      [
+        "services"
+        "transmission"
+        "openPeerPorts"
+      ]
+    )
   ];
   options = {
     services.transmission = {
@@ -49,7 +88,7 @@ in
           See [Transmission's Wiki](https://github.com/transmission/transmission/wiki/Editing-Configuration-Files)
           for documentation of settings not explicitly covered by this module.
         '';
-        default = {};
+        default = { };
         type = types.submodule {
           freeformType = settingsFormat.type;
           options = {
@@ -162,15 +201,17 @@ in
             watch-dir-enabled = mkOption {
               type = types.bool;
               default = false;
-              description = ''Whether to enable the
-                [](#opt-services.transmission.settings.watch-dir).
+              description = ''
+                Whether to enable the
+                                [](#opt-services.transmission.settings.watch-dir).
               '';
             };
             trash-original-torrent-files = mkOption {
               type = types.bool;
               default = false;
-              description = ''Whether to delete torrents added from the
-                [](#opt-services.transmission.settings.watch-dir).
+              description = ''
+                Whether to delete torrents added from the
+                                [](#opt-services.transmission.settings.watch-dir).
               '';
             };
           };
@@ -245,7 +286,7 @@ in
 
       extraFlags = mkOption {
         type = types.listOf types.str;
-        default = [];
+        default = [ ];
         example = [ "--log-debug" ];
         description = ''
           Extra flags passed to the transmission command in the service definition.
@@ -321,18 +362,23 @@ in
 
       serviceConfig = {
         # Use "+" because credentialsFile may not be accessible to User= or Group=.
-        ExecStartPre = [("+" + pkgs.writeShellScript "transmission-prestart" ''
-          set -eu${lib.optionalString (cfg.settings.message-level >= 3) "x"}
-          ${pkgs.jq}/bin/jq --slurp add ${settingsFile} '${cfg.credentialsFile}' |
-          install -D -m 600 -o '${cfg.user}' -g '${cfg.group}' /dev/stdin \
-           '${cfg.home}/${settingsDir}/settings.json'
-        '')];
-        ExecStart="${cfg.package}/bin/transmission-daemon -f -g ${cfg.home}/${settingsDir} ${escapeShellArgs cfg.extraFlags}";
+        ExecStartPre = [
+          (
+            "+"
+            + pkgs.writeShellScript "transmission-prestart" ''
+              set -eu${lib.optionalString (cfg.settings.message-level >= 3) "x"}
+              ${pkgs.jq}/bin/jq --slurp add ${settingsFile} '${cfg.credentialsFile}' |
+              install -D -m 600 -o '${cfg.user}' -g '${cfg.group}' /dev/stdin \
+               '${cfg.home}/${settingsDir}/settings.json'
+            ''
+          )
+        ];
+        ExecStart = "${cfg.package}/bin/transmission-daemon -f -g ${cfg.home}/${settingsDir} ${escapeShellArgs cfg.extraFlags}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         User = cfg.user;
         Group = cfg.group;
         # Create rootDir in the host's mount namespace.
-        RuntimeDirectory = [(baseNameOf rootDir)];
+        RuntimeDirectory = [ (baseNameOf rootDir) ];
         RuntimeDirectoryMode = "755";
         # This is for BindPaths= and BindReadOnlyPaths=
         # to allow traversal of directories they create in RootDirectory=.
@@ -350,27 +396,30 @@ in
         RootDirectoryStartOnly = true;
         MountAPIVFS = true;
         BindPaths =
-          [ "${cfg.home}/${settingsDir}"
+          [
+            "${cfg.home}/${settingsDir}"
             cfg.settings.download-dir
             # Transmission may need to read in the host's /run (eg. /run/systemd/resolve)
             # or write in its private /run (eg. /run/host).
             "/run"
-          ] ++
-          optional cfg.settings.incomplete-dir-enabled
-            cfg.settings.incomplete-dir ++
-          optional (cfg.settings.watch-dir-enabled && cfg.settings.trash-original-torrent-files)
-            cfg.settings.watch-dir;
-        BindReadOnlyPaths = [
-          # No confinement done of /nix/store here like in systemd-confinement.nix,
-          # an AppArmor profile is provided to get a confinement based upon paths and rights.
-          builtins.storeDir
-          "/etc"
-          ] ++
-          optional (cfg.settings.script-torrent-done-enabled &&
-                    cfg.settings.script-torrent-done-filename != null)
-            cfg.settings.script-torrent-done-filename ++
-          optional (cfg.settings.watch-dir-enabled && !cfg.settings.trash-original-torrent-files)
-            cfg.settings.watch-dir;
+          ]
+          ++ optional cfg.settings.incomplete-dir-enabled cfg.settings.incomplete-dir
+          ++ optional (
+            cfg.settings.watch-dir-enabled && cfg.settings.trash-original-torrent-files
+          ) cfg.settings.watch-dir;
+        BindReadOnlyPaths =
+          [
+            # No confinement done of /nix/store here like in systemd-confinement.nix,
+            # an AppArmor profile is provided to get a confinement based upon paths and rights.
+            builtins.storeDir
+            "/etc"
+          ]
+          ++ optional (
+            cfg.settings.script-torrent-done-enabled && cfg.settings.script-torrent-done-filename != null
+          ) cfg.settings.script-torrent-done-filename
+          ++ optional (
+            cfg.settings.watch-dir-enabled && !cfg.settings.trash-original-torrent-files
+          ) cfg.settings.watch-dir;
         StateDirectory = [
           "transmission"
           "transmission/${settingsDir}"
@@ -409,7 +458,11 @@ in
         RemoveIPC = true;
         # AF_UNIX may become usable one day:
         # https://github.com/transmission/transmission/issues/441
-        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
@@ -418,7 +471,13 @@ in
           # Groups in @system-service which do not contain a syscall
           # listed by perf stat -e 'syscalls:sys_enter_*' transmission-daemon -f
           # in tests, and seem likely not necessary for transmission-daemon.
-          "~@aio" "~@chown" "~@keyring" "~@memlock" "~@resources" "~@setuid" "~@timer"
+          "~@aio"
+          "~@chown"
+          "~@keyring"
+          "~@memlock"
+          "~@resources"
+          "~@setuid"
+          "~@timer"
           # In the @privileged group, but reached when querying infos through RPC (eg. with stig).
           "quotactl"
         ];
@@ -446,21 +505,24 @@ in
 
     networking.firewall = mkMerge [
       (mkIf cfg.openPeerPorts (
-        if cfg.settings.peer-port-random-on-start
-        then
-          { allowedTCPPortRanges =
-              [ { from = cfg.settings.peer-port-random-low;
-                  to   = cfg.settings.peer-port-random-high;
-                }
-              ];
-            allowedUDPPortRanges =
-              [ { from = cfg.settings.peer-port-random-low;
-                  to   = cfg.settings.peer-port-random-high;
-                }
-              ];
+        if cfg.settings.peer-port-random-on-start then
+          {
+            allowedTCPPortRanges = [
+              {
+                from = cfg.settings.peer-port-random-low;
+                to = cfg.settings.peer-port-random-high;
+              }
+            ];
+            allowedUDPPortRanges = [
+              {
+                from = cfg.settings.peer-port-random-low;
+                to = cfg.settings.peer-port-random-high;
+              }
+            ];
           }
         else
-          { allowedTCPPorts = [ cfg.settings.peer-port ];
+          {
+            allowedTCPPorts = [ cfg.settings.peer-port ];
             allowedUDPPorts = [ cfg.settings.peer-port ];
           }
       ))
@@ -522,14 +584,16 @@ in
         ''}
       }
 
-      ${optionalString (cfg.settings.script-torrent-done-enabled &&
-                        cfg.settings.script-torrent-done-filename != null) ''
-        # Stack transmission_directories profile on top of
-        # any existing profile for script-torrent-done-filename
-        # FIXME: to be tested as I'm not sure it works well with NoNewPrivileges=
-        # https://gitlab.com/apparmor/apparmor/-/wikis/AppArmorStacking#seccomp-and-no_new_privs
-        px ${cfg.settings.script-torrent-done-filename} -> &@{dirs},
-      ''}
+      ${optionalString
+        (cfg.settings.script-torrent-done-enabled && cfg.settings.script-torrent-done-filename != null)
+        ''
+          # Stack transmission_directories profile on top of
+          # any existing profile for script-torrent-done-filename
+          # FIXME: to be tested as I'm not sure it works well with NoNewPrivileges=
+          # https://gitlab.com/apparmor/apparmor/-/wikis/AppArmorStacking#seccomp-and-no_new_privs
+          px ${cfg.settings.script-torrent-done-filename} -> &@{dirs},
+        ''
+      }
 
       ${optionalString (cfg.webHome != null) ''
         r ${cfg.webHome}/**,

--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -176,13 +176,18 @@ in
               description = "Executable to be run at torrent completion.";
             };
             umask = mkOption {
-              type = types.str;
-              default = "022";
+              type = types.either types.int types.str;
+              default = if cfg.package == pkgs.transmission_3 then 18 else "022";
+              defaultText = literalExpression "if cfg.package == pkgs.transmission_3 then 18 else \"022\"";
               description = ''
                 Sets transmission's file mode creation mask.
                 See the umask(2) manpage for more information.
                 Users who want their saved torrents to be world-writable
-                may want to set this value to `000`.
+                may want to set this value to 0/`"000"`.
+
+                Keep in mind, that if you are using Transmission 3, this has to
+                be passed as a base 10 integer, whereas Transmission 4 takes
+                an octal number in a string instead.
               '';
             };
             utp-enabled = mkOption {

--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -1,8 +1,11 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkRenamedOptionModule mkAliasOptionModuleMD mkEnableOption
+                mkOption types literalExpression mkPackageOption mkIf
+                optionalString optional mkDefault escapeShellArgs optionalAttrs
+                mkMerge;
+
   cfg = config.services.transmission;
   opt = options.services.transmission;
   inherit (config.environment) etc;
@@ -49,127 +52,127 @@ in
         default = {};
         type = types.submodule {
           freeformType = settingsFormat.type;
-          options.download-dir = mkOption {
-            type = types.path;
-            default = "${cfg.home}/${downloadsDir}";
-            defaultText = literalExpression ''"''${config.${opt.home}}/${downloadsDir}"'';
-            description = "Directory where to download torrents.";
-          };
-          options.incomplete-dir = mkOption {
-            type = types.path;
-            default = "${cfg.home}/${incompleteDir}";
-            defaultText = literalExpression ''"''${config.${opt.home}}/${incompleteDir}"'';
-            description = ''
-              When enabled with
-              services.transmission.home
-              [](#opt-services.transmission.settings.incomplete-dir-enabled),
-              new torrents will download the files to this directory.
-              When complete, the files will be moved to download-dir
-              [](#opt-services.transmission.settings.download-dir).
-            '';
-          };
-          options.incomplete-dir-enabled = mkOption {
-            type = types.bool;
-            default = true;
-            description = "";
-          };
-          options.message-level = mkOption {
-            type = types.ints.between 0 6;
-            default = 2;
-            description = "Set verbosity of transmission messages.";
-          };
-          options.peer-port = mkOption {
-            type = types.port;
-            default = 51413;
-            description = "The peer port to listen for incoming connections.";
-          };
-          options.peer-port-random-high = mkOption {
-            type = types.port;
-            default = 65535;
-            description = ''
-              The maximum peer port to listen to for incoming connections
-              when [](#opt-services.transmission.settings.peer-port-random-on-start) is enabled.
-            '';
-          };
-          options.peer-port-random-low = mkOption {
-            type = types.port;
-            default = 65535;
-            description = ''
-              The minimal peer port to listen to for incoming connections
-              when [](#opt-services.transmission.settings.peer-port-random-on-start) is enabled.
-            '';
-          };
-          options.peer-port-random-on-start = mkOption {
-            type = types.bool;
-            default = false;
-            description = "Randomize the peer port.";
-          };
-          options.rpc-bind-address = mkOption {
-            type = types.str;
-            default = "127.0.0.1";
-            example = "0.0.0.0";
-            description = ''
-              Where to listen for RPC connections.
-              Use `0.0.0.0` to listen on all interfaces.
-            '';
-          };
-          options.rpc-port = mkOption {
-            type = types.port;
-            default = 9091;
-            description = "The RPC port to listen to.";
-          };
-          options.script-torrent-done-enabled = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''
-              Whether to run
-              [](#opt-services.transmission.settings.script-torrent-done-filename)
-              at torrent completion.
-            '';
-          };
-          options.script-torrent-done-filename = mkOption {
-            type = types.nullOr types.path;
-            default = null;
-            description = "Executable to be run at torrent completion.";
-          };
-          options.umask = mkOption {
-            type = types.int;
-            default = 2;
-            description = ''
-              Sets transmission's file mode creation mask.
-              See the umask(2) manpage for more information.
-              Users who want their saved torrents to be world-writable
-              may want to set this value to 0.
-              Bear in mind that the json markup language only accepts numbers in base 10,
-              so the standard umask(2) octal notation "022" is written in settings.json as 18.
-            '';
-          };
-          options.utp-enabled = mkOption {
-            type = types.bool;
-            default = true;
-            description = ''
-              Whether to enable [Micro Transport Protocol (µTP)](https://en.wikipedia.org/wiki/Micro_Transport_Protocol).
-            '';
-          };
-          options.watch-dir = mkOption {
-            type = types.path;
-            default = "${cfg.home}/${watchDir}";
-            defaultText = literalExpression ''"''${config.${opt.home}}/${watchDir}"'';
-            description = "Watch a directory for torrent files and add them to transmission.";
-          };
-          options.watch-dir-enabled = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''Whether to enable the
-              [](#opt-services.transmission.settings.watch-dir).
-            '';
-          };
-          options.trash-original-torrent-files = mkOption {
-            type = types.bool;
-            default = false;
-            description = ''Whether to delete torrents added from the
-              [](#opt-services.transmission.settings.watch-dir).
-            '';
+          options = {
+            download-dir = mkOption {
+              type = types.path;
+              default = "${cfg.home}/${downloadsDir}";
+              defaultText = literalExpression ''"''${config.${opt.home}}/${downloadsDir}"'';
+              description = "Directory where to download torrents.";
+            };
+            incomplete-dir = mkOption {
+              type = types.path;
+              default = "${cfg.home}/${incompleteDir}";
+              defaultText = literalExpression ''"''${config.${opt.home}}/${incompleteDir}"'';
+              description = ''
+                When enabled with
+                services.transmission.home
+                [](#opt-services.transmission.settings.incomplete-dir-enabled),
+                new torrents will download the files to this directory.
+                When complete, the files will be moved to download-dir
+                [](#opt-services.transmission.settings.download-dir).
+              '';
+            };
+            incomplete-dir-enabled = mkOption {
+              type = types.bool;
+              default = true;
+              description = "";
+            };
+            message-level = mkOption {
+              type = types.ints.between 0 6;
+              default = 2;
+              description = "Set verbosity of transmission messages.";
+            };
+            peer-port = mkOption {
+              type = types.port;
+              default = 51413;
+              description = "The peer port to listen for incoming connections.";
+            };
+            peer-port-random-high = mkOption {
+              type = types.port;
+              default = 65535;
+              description = ''
+                The maximum peer port to listen to for incoming connections
+                when [](#opt-services.transmission.settings.peer-port-random-on-start) is enabled.
+              '';
+            };
+            peer-port-random-low = mkOption {
+              type = types.port;
+              default = 65535;
+              description = ''
+                The minimal peer port to listen to for incoming connections
+                when [](#opt-services.transmission.settings.peer-port-random-on-start) is enabled.
+              '';
+            };
+            peer-port-random-on-start = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Randomize the peer port.";
+            };
+            rpc-bind-address = mkOption {
+              type = types.str;
+              default = "127.0.0.1";
+              example = "0.0.0.0";
+              description = ''
+                Where to listen for RPC connections.
+                Use `0.0.0.0` to listen on all interfaces.
+              '';
+            };
+            rpc-port = mkOption {
+              type = types.port;
+              default = 9091;
+              description = "The RPC port to listen to.";
+            };
+            script-torrent-done-enabled = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Whether to run
+                [](#opt-services.transmission.settings.script-torrent-done-filename)
+                at torrent completion.
+              '';
+            };
+            script-torrent-done-filename = mkOption {
+              type = types.nullOr types.path;
+              default = null;
+              description = "Executable to be run at torrent completion.";
+            };
+            umask = mkOption {
+              type = types.str;
+              default = "022";
+              description = ''
+                Sets transmission's file mode creation mask.
+                See the umask(2) manpage for more information.
+                Users who want their saved torrents to be world-writable
+                may want to set this value to `000`.
+              '';
+            };
+            utp-enabled = mkOption {
+              type = types.bool;
+              default = true;
+              description = ''
+                Whether to enable [Micro Transport Protocol (µTP)](https://en.wikipedia.org/wiki/Micro_Transport_Protocol).
+              '';
+            };
+            watch-dir = mkOption {
+              type = types.path;
+              default = "${cfg.home}/${watchDir}";
+              defaultText = literalExpression ''"''${config.${opt.home}}/${watchDir}"'';
+              description = "Watch a directory for torrent files and add them to transmission.";
+            };
+            watch-dir-enabled = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''Whether to enable the
+                [](#opt-services.transmission.settings.watch-dir).
+              '';
+            };
+            trash-original-torrent-files = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''Whether to delete torrents added from the
+                [](#opt-services.transmission.settings.watch-dir).
+              '';
+            };
           };
         };
       };
@@ -310,8 +313,11 @@ in
       after = [ "network.target" ] ++ optional apparmor.enable "apparmor.service";
       requires = optional apparmor.enable "apparmor.service";
       wantedBy = [ "multi-user.target" ];
-      environment.CURL_CA_BUNDLE = etc."ssl/certs/ca-certificates.crt".source;
-      environment.TRANSMISSION_WEB_HOME = lib.mkIf (cfg.webHome != null) cfg.webHome;
+
+      environment = {
+        CURL_CA_BUNDLE = etc."ssl/certs/ca-certificates.crt".source;
+        TRANSMISSION_WEB_HOME = lib.mkIf (cfg.webHome != null) cfg.webHome;
+      };
 
       serviceConfig = {
         # Use "+" because credentialsFile may not be accessible to User= or Group=.


### PR DESCRIPTION
As per [Transmission's documentation](https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md), the umask option should be a string.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
