### PR TITLE
python31{1,2}Packages.hvplot: enable (most) tests

### DIFF
--- a/pkgs/development/python-modules/bokeh-sampledata/default.nix
+++ b/pkgs/development/python-modules/bokeh-sampledata/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  setuptools-git-versioning,
+
+  # dependencies
+  icalendar,
+  pandas,
+}:
+
+buildPythonPackage rec {
+  pname = "bokeh-sampledata";
+  version = "2024.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "bokeh_sampledata";
+    inherit version;
+    hash = "sha256-5j2qluedVj7IuE8gZy/+lPkFshRV+rjYPuM05G2jNiQ=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-git-versioning
+  ];
+
+  dependencies = [
+    icalendar
+    pandas
+  ];
+
+  pythonImportsCheck = [
+    "bokeh_sampledata"
+  ];
+
+  meta = {
+    description = "Sample datasets for Bokeh examples";
+    homepage = "https://pypi.org/project/bokeh-sampledata";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/holoviews/default.nix
+++ b/pkgs/development/python-modules/holoviews/default.nix
@@ -1,15 +1,19 @@
 {
   lib,
   buildPythonPackage,
-  colorcet,
   fetchPypi,
+  pythonOlder,
+
+  # build-system
   hatch-vcs,
   hatchling,
+
+  # dependencies
+  colorcet,
   numpy,
   pandas,
   panel,
   param,
-  pythonOlder,
   pyviz-comms,
 }:
 
@@ -44,11 +48,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "holoviews" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python data analysis and visualization seamless and simple";
     mainProgram = "holoviews";
     homepage = "https://www.holoviews.org/";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/holoviews/default.nix
+++ b/pkgs/development/python-modules/holoviews/default.nix
@@ -15,6 +15,11 @@
   panel,
   param,
   pyviz-comms,
+
+  # tests
+  pytestCheckHook,
+  pytest-cov,
+  flaky,
 }:
 
 buildPythonPackage rec {
@@ -43,8 +48,24 @@ buildPythonPackage rec {
     pyviz-comms
   ];
 
-  # tests not fully included with pypi release
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov
+    flaky
+  ];
+
+  disabledTests = [
+    # All the below fail due to some change in flaky API
+    "test_periodic_param_fn_non_blocking"
+    "test_callback_cleanup"
+    "test_poly_edit_callback"
+    "test_launch_server_with_complex_plot"
+    "test_launch_server_with_stream"
+    "test_launch_simple_server"
+    "test_server_dynamicmap_with_dims"
+    "test_server_dynamicmap_with_stream"
+    "test_server_dynamicmap_with_stream_dims"
+  ];
 
   pythonImportsCheck = [ "holoviews" ];
 

--- a/pkgs/development/python-modules/hvplot/default.nix
+++ b/pkgs/development/python-modules/hvplot/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "hvplot";
-  version = "0.10.0";
+  version = "0.11.1";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-6HSGqVv+FRq1LvFjpek9nL0EOZLPC3Vcyt0r82/t03Y=";
+    hash = "sha256-mJ7QOJGJrcR+3NJgHS6rGL82bnSwf14oc+AhMjxKFLs=";
   };
 
   build-system = [ setuptools-scm ];

--- a/pkgs/development/python-modules/hvplot/default.nix
+++ b/pkgs/development/python-modules/hvplot/default.nix
@@ -1,13 +1,17 @@
 {
   lib,
-  bokeh,
   buildPythonPackage,
-  colorcet,
   fetchPypi,
+  pythonOlder,
+
+  # build-system
+  setuptools-scm,
+
+  # dependencies
+  bokeh,
+  colorcet,
   holoviews,
   pandas,
-  pythonOlder,
-  setuptools-scm,
 }:
 
 buildPythonPackage rec {
@@ -22,7 +26,9 @@ buildPythonPackage rec {
     hash = "sha256-mJ7QOJGJrcR+3NJgHS6rGL82bnSwf14oc+AhMjxKFLs=";
   };
 
-  build-system = [ setuptools-scm ];
+  build-system = [
+    setuptools-scm
+  ];
 
   dependencies = [
     bokeh
@@ -36,11 +42,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hvplot.pandas" ];
 
-  meta = with lib; {
+  meta = {
     description = "High-level plotting API for the PyData ecosystem built on HoloViews";
     homepage = "https://hvplot.pyviz.org";
     changelog = "https://github.com/holoviz/hvplot/releases/tag/v${version}";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/hvplot/default.nix
+++ b/pkgs/development/python-modules/hvplot/default.nix
@@ -12,6 +12,17 @@
   colorcet,
   holoviews,
   pandas,
+
+  # tests
+  pytestCheckHook,
+  dask,
+  xarray,
+  bokeh-sampledata,
+  parameterized,
+  selenium,
+  matplotlib,
+  scipy,
+  plotly,
 }:
 
 buildPythonPackage rec {
@@ -37,8 +48,26 @@ buildPythonPackage rec {
     pandas
   ];
 
-  # Many tests require a network connection
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+    dask
+    xarray
+    bokeh-sampledata
+    parameterized
+    selenium
+    matplotlib
+    scipy
+    plotly
+  ];
+
+  disabledTestPaths = [
+    # All of the following below require xarray.tutorial files that require
+    # downloading files from the internet (not possible in the sandbox).
+    "hvplot/tests/testgeo.py"
+    "hvplot/tests/testinteractive.py"
+    "hvplot/tests/testui.py"
+    "hvplot/tests/testutil.py"
+  ];
 
   pythonImportsCheck = [ "hvplot.pandas" ];
 

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -19,6 +19,7 @@
   pytestCheckHook,
   python-snappy,
   pythonOlder,
+  pythonAtLeast,
   pyyaml,
   networkx,
   requests,
@@ -126,12 +127,18 @@ buildPythonPackage rec {
       # Timing-based, flaky on darwin and possibly others
       "test_idle_timer"
     ]
-    ++ lib.optionals
-      (stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13")
-      [
-        # Flaky with older low-res mtime on darwin < 10.13 (#143987)
-        "test_second_load_timestamp"
-      ];
+    ++ lib.optionals (pythonAtLeast "3.12") [
+      # Require deprecated distutils
+      "test_which"
+      "test_load"
+    ]
+    ++
+      lib.optionals
+        (stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13")
+        [
+          # Flaky with older low-res mtime on darwin < 10.13 (#143987)
+          "test_second_load_timestamp"
+        ];
 
   pythonImportsCheck = [ "intake" ];
 

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  appdirs,
+  platformdirs,
   bokeh,
   buildPythonPackage,
   dask,
@@ -20,6 +20,7 @@
   python-snappy,
   pythonOlder,
   pyyaml,
+  networkx,
   requests,
   setuptools,
   setuptools-scm,
@@ -28,7 +29,7 @@
 
 buildPythonPackage rec {
   pname = "intake";
-  version = "2.0.3";
+  version = "2.0.7";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -37,7 +38,7 @@ buildPythonPackage rec {
     owner = "intake";
     repo = "intake";
     rev = "refs/tags/${version}";
-    hash = "sha256-Fyv85HkoE9OPOoSHR1sgCG0iAFuSiQMT7cyZcQyLvv0=";
+    hash = "sha256-F13jbAQP3G3cKeAegM1w/t32xyC0BgL9/67aIlzA4SE=";
   };
 
   nativeBuildInputs = [
@@ -46,7 +47,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    appdirs
+    platformdirs
     dask
     entrypoints
     fsspec
@@ -54,6 +55,7 @@ buildPythonPackage rec {
     jinja2
     pandas
     pyyaml
+    networkx
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyct/default.nix
+++ b/pkgs/development/python-modules/pyct/default.nix
@@ -2,17 +2,24 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  param,
-  pytestCheckHook,
   pythonAtLeast,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  param,
   pyyaml,
   requests,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pyct";
   version = "0.5.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonAtLeast "3.12";
 
@@ -21,22 +28,28 @@ buildPythonPackage rec {
     hash = "sha256-3Z9KxcvY43w1LAQDYGLTxfZ+/sdtQEdh7xawy/JqpqA=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     param
     pyyaml
     requests
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "pyct" ];
 
-  meta = with lib; {
+  meta = {
     description = "ClI for Python common tasks for users";
     mainProgram = "pyct";
     homepage = "https://github.com/pyviz/pyct";
     changelog = "https://github.com/pyviz-dev/pyct/releases/tag/v${version}";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyct/default.nix
+++ b/pkgs/development/python-modules/pyct/default.nix
@@ -21,8 +21,6 @@ buildPythonPackage rec {
   version = "0.5.0";
   pyproject = true;
 
-  disabled = pythonAtLeast "3.12";
-
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-3Z9KxcvY43w1LAQDYGLTxfZ+/sdtQEdh7xawy/JqpqA=";
@@ -40,6 +38,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+  ];
+  # Only the command line doesn't work on with Python 3.12, due to usage of
+  # deprecated distutils module. Not disabling it totally.
+  disabledTestPaths = lib.optionals (pythonAtLeast "3.12") [
+    "pyct/tests/test_cmd.py"
   ];
 
   pythonImportsCheck = [ "pyct" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1753,6 +1753,8 @@ self: super: with self; {
 
   bokeh = callPackage ../development/python-modules/bokeh { };
 
+  bokeh-sampledata = callPackage ../development/python-modules/bokeh-sampledata { };
+
   boltons = callPackage ../development/python-modules/boltons { };
 
   boltztrap2 = callPackage ../development/python-modules/boltztrap2 { };


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
