### PR TITLE
nixos/ssh: disable `authorizedKeysInHomedir` by default (v2)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -34,6 +34,9 @@
 - `strawberry` has been updated to 1.2, which drops support for the VLC backend and Qt 5. The `strawberry-qt5` package
   and `withGstreamer`/`withVlc` override options have been removed due to this.
 
+- The `sshd` module now doesn't include `%h/.ssh/authorized_keys` as `AuthorizedKeysFile` unless
+  `services.openssh.authorizedKeysInHomedir` is set to `true` (the default is `false` for `stateVersion` 24.11 onwards).
+
 - `timescaledb` requires manual upgrade steps.
     After you run ALTER EXTENSION, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull requests [#6797](https://github.com/timescale/timescaledb/pull/6797).
     PostgreSQL 13 is no longer supported in TimescaleDB v2.16.

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -75,6 +75,7 @@ with lib;
     # mounting the storage in a different system.
     services.openssh = {
       enable = mkDefault true;
+      authorizedKeysInHomedir = mkDefault true;
       settings.PermitRootLogin = mkDefault "yes";
     };
 

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -108,6 +108,10 @@ let
 
   };
 
+  usersWithKeys = lib.attrValues (lib.flip lib.filterAttrs config.users.users (n: u:
+    lib.length u.openssh.authorizedKeys.keys != 0 || lib.length u.openssh.authorizedKeys.keyFiles != 0
+  ));
+
   authKeysFiles = let
     mkAuthKeyFile = u: lib.nameValuePair "ssh/authorized_keys.d/${u.name}" {
       mode = "0444";
@@ -116,9 +120,6 @@ let
         ${lib.concatMapStrings (f: lib.readFile f + "\n") u.openssh.authorizedKeys.keyFiles}
       '';
     };
-    usersWithKeys = lib.attrValues (lib.flip lib.filterAttrs config.users.users (n: u:
-      lib.length u.openssh.authorizedKeys.keys != 0 || lib.length u.openssh.authorizedKeys.keyFiles != 0
-    ));
   in lib.listToAttrs (map mkAuthKeyFile usersWithKeys);
 
   authPrincipalsFiles = let
@@ -544,6 +545,19 @@ in
   ###### implementation
 
   config = lib.mkIf cfg.enable {
+
+    warnings = lib.optional (with cfg; lib.all lib.id [
+      # ~/.ssh/authorized_keys is ignored and no custom file locations were set
+      (authorizedKeysFiles == [ "/etc/ssh/authorized_keys.d/%u" ])
+      # no command provides authorized keys
+      (authorizedKeysCommand == "none")
+      # no users have keys in declarative configuration
+      (usersWithKeys == [])
+      # no authentication methods other than public keys are configured
+      (!settings.PasswordAuthentication or true)
+      (package.withKerberos -> !settings.GSSAPIAuthentication or false)
+      (settings ? "AuthenticationMethods" -> settings.AuthenticationMethods == [ "publickey" ])
+    ]) "services.openssh: no keys were set in `users.users.*.openssh.authorizedKeys` and `~/.ssh/authorized_keys` will be ignored";
 
     users.users.sshd =
       {

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -302,7 +302,8 @@ in
 
       authorizedKeysInHomedir = lib.mkOption {
         type = lib.types.bool;
-        default = true;
+        default = lib.versionOlder config.system.stateVersion "25.05";
+        defaultText = lib.literalMD "`false` unless [](#opt-system.stateVersion) is (strictly) less than 25.05";
         description = ''
           Enables the use of the `~/.ssh/authorized_keys` file.
 

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -14,7 +14,10 @@ in {
       { ... }:
 
       {
-        services.openssh.enable = true;
+        services.openssh = {
+          enable = true;
+          authorizedKeysInHomedir = true;
+        };
         security.pam.services.sshd.limits =
           [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
         users.users.root.openssh.authorizedKeys.keys = [
@@ -39,7 +42,11 @@ in {
       { ... }:
 
       {
-        services.openssh = { enable = true; startWhenNeeded = true; };
+        services.openssh = {
+          enable = true;
+          startWhenNeeded = true;
+          authorizedKeysInHomedir = true;
+        };
         security.pam.services.sshd.limits =
           [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
         users.users.root.openssh.authorizedKeys.keys = [


### PR DESCRIPTION
Fixed version of #309025, which was rolled back due to a bug (not caught by ofborg somehow?)

See that PR for prior discussion.


## Description of changes

- [x] Default `services.openssh.authorizedKeysInHomedir` to `false` **on `stateVersion` 24.11 and later**
  By request of maintainer, and would prevent future issues similar to #31611
- [x] Warn when only pubkey authentication is configured, keys are only taken from declarative configuration, and no user has an SSH key configured.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [x] `nixosTests.openssh`
  - [x] Manually tested the warning
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
