### PR TITLE
mutmut: 2.2.0 -> 3.2.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -236,6 +236,8 @@
 
 - `knot-dns` has been updated to version 3.4.x. Check the [migration guide](https://www.knot-dns.cz/docs/latest/html/migration.html#upgrade-3-3-x-to-3-4-x) for breaking changes.
 
+- `mutmut` has been updated to version 3.0.5.
+
 - `services.kubernetes.kubelet.clusterDns` now accepts a list of DNS resolvers rather than a single string, bringing the module more in line with the upstream Kubelet configuration schema.
 
 - `bluemap` has changed the format used to store map tiles, and the database layout has been heavily modified. Upstream recommends a clean reinstallation: <https://github.com/BlueMap-Minecraft/BlueMap/releases/tag/v5.2>. Unless you are using an SQL storage backend, this should only entail deleting the contents of `config.services.bluemap.coreSettings.data` (defaults to `/var/lib/bluemap`) and `config.services.bluemap.webRoot` (defaults to `/var/lib/bluemap/web`).

--- a/pkgs/by-name/mu/mutmut/package.nix
+++ b/pkgs/by-name/mu/mutmut/package.nix
@@ -1,39 +1,50 @@
-{ lib
-, fetchFromGitHub
-, python3
-, testers
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  testers,
 }:
 
-let self = with python3.pkgs; buildPythonApplication rec {
-  pname = "mutmut";
-  version = "2.2.0";
+let
+  self =
+    with python3.pkgs;
+    buildPythonApplication rec {
+      pname = "mutmut";
+      version = "2.2.0";
 
-  src = fetchFromGitHub {
-    repo = pname;
-    owner = "boxed";
-    rev = version;
-    hash = "sha256-G+OL/9km2iUeZ1QCpU73CIWVWMexcs3r9RdCnAsESnY=";
-  };
+      src = fetchFromGitHub {
+        repo = pname;
+        owner = "boxed";
+        rev = version;
+        hash = "sha256-G+OL/9km2iUeZ1QCpU73CIWVWMexcs3r9RdCnAsESnY=";
+      };
 
-  postPatch = ''
-    substituteInPlace requirements.txt --replace 'junit-xml==1.8' 'junit-xml==1.9'
-  '';
+      postPatch = ''
+        substituteInPlace requirements.txt --replace 'junit-xml==1.8' 'junit-xml==1.9'
+      '';
 
-  disabled = pythonOlder "3.7";
+      disabled = pythonOlder "3.7";
 
-  doCheck = false;
+      doCheck = false;
 
-  propagatedBuildInputs = [ click glob2 parso pony junit-xml ];
+      propagatedBuildInputs = [
+        click
+        glob2
+        parso
+        pony
+        junit-xml
+      ];
 
-  passthru.tests.version = testers.testVersion { package = self; };
+      passthru.tests.version = testers.testVersion { package = self; };
 
-  meta = with lib; {
-    description = "mutation testing system for Python, with a strong focus on ease of use";
-    mainProgram = "mutmut";
-    homepage = "https://github.com/boxed/mutmut";
-    changelog = "https://github.com/boxed/mutmut/blob/${version}/HISTORY.rst";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ synthetica ];
-  };
-};
-in self
+      meta = with lib; {
+        description = "mutation testing system for Python, with a strong focus on ease of use";
+        mainProgram = "mutmut";
+        homepage = "https://github.com/boxed/mutmut";
+        changelog = "https://github.com/boxed/mutmut/blob/${version}/HISTORY.rst";
+        license = licenses.bsd3;
+        maintainers = with maintainers; [ synthetica ];
+      };
+    };
+in
+self

--- a/pkgs/by-name/mu/mutmut/package.nix
+++ b/pkgs/by-name/mu/mutmut/package.nix
@@ -1,50 +1,45 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  mutmut,
+  python3Packages,
   testers,
 }:
+python3Packages.buildPythonApplication rec {
+  pname = "mutmut";
+  version = "2.2.0";
 
-let
-  self =
-    with python3.pkgs;
-    buildPythonApplication rec {
-      pname = "mutmut";
-      version = "2.2.0";
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "boxed";
+    rev = "refs/tags/${version}";
+    hash = "sha256-G+OL/9km2iUeZ1QCpU73CIWVWMexcs3r9RdCnAsESnY=";
+  };
 
-      src = fetchFromGitHub {
-        repo = pname;
-        owner = "boxed";
-        rev = "refs/tags/${version}";
-        hash = "sha256-G+OL/9km2iUeZ1QCpU73CIWVWMexcs3r9RdCnAsESnY=";
-      };
+  postPatch = ''
+    substituteInPlace requirements.txt --replace 'junit-xml==1.8' 'junit-xml==1.9'
+  '';
 
-      postPatch = ''
-        substituteInPlace requirements.txt --replace 'junit-xml==1.8' 'junit-xml==1.9'
-      '';
+  disabled = python3Packages.pythonOlder "3.7";
 
-      disabled = pythonOlder "3.7";
+  doCheck = false;
 
-      doCheck = false;
+  propagatedBuildInputs = with python3Packages; [
+    click
+    glob2
+    parso
+    pony
+    junit-xml
+  ];
 
-      propagatedBuildInputs = [
-        click
-        glob2
-        parso
-        pony
-        junit-xml
-      ];
+  passthru.tests.version = testers.testVersion { package = mutmut; };
 
-      passthru.tests.version = testers.testVersion { package = self; };
-
-      meta = with lib; {
-        description = "mutation testing system for Python, with a strong focus on ease of use";
-        mainProgram = "mutmut";
-        homepage = "https://github.com/boxed/mutmut";
-        changelog = "https://github.com/boxed/mutmut/blob/${version}/HISTORY.rst";
-        license = licenses.bsd3;
-        maintainers = with maintainers; [ synthetica ];
-      };
-    };
-in
-self
+  meta = with lib; {
+    description = "mutation testing system for Python, with a strong focus on ease of use";
+    mainProgram = "mutmut";
+    homepage = "https://github.com/boxed/mutmut";
+    changelog = "https://github.com/boxed/mutmut/blob/${version}/HISTORY.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ synthetica ];
+  };
+}

--- a/pkgs/by-name/mu/mutmut/package.nix
+++ b/pkgs/by-name/mu/mutmut/package.nix
@@ -15,7 +15,7 @@ let
       src = fetchFromGitHub {
         repo = pname;
         owner = "boxed";
-        rev = version;
+        rev = "refs/tags/${version}";
         hash = "sha256-G+OL/9km2iUeZ1QCpU73CIWVWMexcs3r9RdCnAsESnY=";
       };
 

--- a/pkgs/by-name/mu/mutmut/package.nix
+++ b/pkgs/by-name/mu/mutmut/package.nix
@@ -1,23 +1,22 @@
 {
   lib,
   fetchFromGitHub,
-  mutmut,
   python3Packages,
-  testers,
 }:
+
 python3Packages.buildPythonApplication rec {
   pname = "mutmut";
-  version = "2.2.0";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "boxed";
     rev = "refs/tags/${version}";
-    hash = "sha256-G+OL/9km2iUeZ1QCpU73CIWVWMexcs3r9RdCnAsESnY=";
+    hash = "sha256-+e2FmfpGtK401IW8LNqeHk0v8Hh5rF3LbZJkSOJ3yPY=";
   };
 
   postPatch = ''
-    substituteInPlace requirements.txt --replace 'junit-xml==1.8' 'junit-xml==1.9'
+    substituteInPlace requirements.txt --replace-fail 'junit-xml==1.8' 'junit-xml==1.9'
   '';
 
   disabled = python3Packages.pythonOlder "3.7";
@@ -26,13 +25,11 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     click
-    glob2
     parso
-    pony
     junit-xml
+    setproctitle
+    textual
   ];
-
-  passthru.tests.version = testers.testVersion { package = mutmut; };
 
   meta = with lib; {
     description = "mutation testing system for Python, with a strong focus on ease of use";

--- a/pkgs/by-name/mu/mutmut/package.nix
+++ b/pkgs/by-name/mu/mutmut/package.nix
@@ -37,6 +37,9 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/boxed/mutmut";
     changelog = "https://github.com/boxed/mutmut/blob/${version}/HISTORY.rst";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ synthetica ];
+    maintainers = with maintainers; [
+      l0b0
+      synthetica
+    ];
   };
 }


### PR DESCRIPTION
Hopefully closes the following issues:

- https://github.com/boxed/mutmut/issues/221
- https://github.com/boxed/mutmut/issues/251
- https://github.com/boxed/mutmut/issues/298

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
