### PR TITLE
python3Packages: Fix and document the removal of the local `.overrideAttrs` attribute

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -196,8 +196,9 @@
 
 - The nvidia driver no longer defaults to the proprietary driver starting with version 560. You will need to manually set `hardware.nvidia.open` to select the proprietary or open driver.
 
-- The `(buildPythonPackage { ... }).override` attribute is now deprecated and removed in favour of `overridePythonAttrs`.
+- The `(buildPythonPackage { ... }).override` and `(buildPythonPackage { ... }).overrideDerivation` attributes is now deprecated and removed in favour of `overridePythonAttrs` and `lib.overrideDerivation`.
   This change does not affect the override interface of most Python packages, as [`<pkg>.override`](https://nixos.org/manual/nixpkgs/unstable/#sec-pkg-override) provided by `callPackage` shadows such a locally-defined `override` attribute.
+  The `<pkg>.overrideDerivation` attribute of Python packages called with `callPackage` will also remain available after this change.
 
 - All Cinnamon and XApp packages have been moved to top-level (i.e., `cinnamon.nemo` is now `nemo`).
 

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -122,6 +122,7 @@ in {
       };
       passthru.tests = import ./python-catch-conflicts-hook-tests.nix {
         inherit pythonOnBuildForHost runCommand;
+        inherit lib;
         inherit (pkgs) coreutils gnugrep writeShellScript;
       };
     } ./python-catch-conflicts-hook.sh) {};

--- a/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
+++ b/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
@@ -1,4 +1,4 @@
-{ pythonOnBuildForHost, runCommand, writeShellScript, coreutils, gnugrep }: let
+{ lib, pythonOnBuildForHost, runCommand, writeShellScript, coreutils, gnugrep }: let
 
   pythonPkgs = pythonOnBuildForHost.pkgs;
 
@@ -38,7 +38,7 @@
   );
 
   # in order to test for a failing build, wrap it in a shell script
-  expectFailure = build: errorMsg: build.overrideDerivation (old: {
+  expectFailure = build: errorMsg: lib.overrideDerivation build (old: {
     builder = writeShellScript "test-for-failure" ''
       export PATH=${coreutils}/bin:${gnugrep}/bin:$PATH
       ${old.builder} "$@" > ./log 2>&1

--- a/pkgs/development/python-modules/scikit-image/default.nix
+++ b/pkgs/development/python-modules/scikit-image/default.nix
@@ -157,7 +157,7 @@ let
     ];
 
     passthru.tests = {
-      all-tests = self.override { doCheck = true; };
+      all-tests = self.overridePythonAttrs { doCheck = true; };
     };
 
     meta = {


### PR DESCRIPTION
This PR cleans up the leftover of #333670.

After #333670, `buildPythonPackage` and `buildPythonApplication` no longer apply `lib.makeOverridable` themselves and no longer provide `.override` and `.overrideDerivation` of the returning package.

For Python packages provided by Nixpkgs, the local `.override` attribute is almost always shadowed by the one provided by `callPackage`, and so does the `.overrideDerivation` attribute.  I didn't find any use of the local `override` in Nixpkgs, but @trofi reported the evaluation failure of `python3Packages.pythonCatchConflictsHook.tests.catches-conflict-multiple-chains` due to the loss of the local `overrideDerivation`.

This PR uses `lib.overrideDerivation` instead of the `overrideDerivation` attribute to fix the evaluation of `python3Packages.pythonCatchConflictsHook.tests.catches-conflict-multiple-chains` and document the removal of the `buildPython*`-generated local `overrideDerivation` attribute in the release note.

Update: As the Nixpkgs 24.11 branch-off is made, this PR should be backported onto the `release-24.11` branch once it is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
