### PR TITLE
python312Packages.pymumble: 1.6.1 -> unstable-2024-10-2

### DIFF
--- a/pkgs/development/python-modules/pymumble/default.nix
+++ b/pkgs/development/python-modules/pymumble/default.nix
@@ -9,25 +9,19 @@
   pythonOlder,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pymumble";
-  version = "1.6.1"; # Don't upgrade to 1.7, version was yanked
+  version = "unstable-2024-10-20";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = "azlux";
+    owner = "tjni";
     repo = "pymumble";
-    rev = "refs/tags/${version}";
-    hash = "sha256-+sT5pqdm4A2rrUcUUmvsH+iazg80+/go0zM1vr9oeuE=";
+    rev = "3241e84e5ce162a20597e4df6a9c443122357fec";
+    hash = "sha256-9lfWvfrS+vUFTf9jo4T+VHkm9u/hVjsDszLBQIEZVcQ=";
   };
-
-  postPatch = ''
-    # Changes all `library==x.y.z` statements to just `library`
-    # So that we aren't constrained to a specific version
-    sed -i 's/\(.*\)==.*/\1/' requirements.txt
-  '';
 
   propagatedBuildInputs = [
     opuslib
@@ -46,8 +40,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Library to create mumble bots";
-    homepage = "https://github.com/azlux/pymumble";
-    changelog = "https://github.com/azlux/pymumble/releases/tag/${version}";
+    homepage = "https://github.com/tjni/pymumble";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ thelegy ];
   };

--- a/pkgs/development/python-modules/pymumble/default.nix
+++ b/pkgs/development/python-modules/pymumble/default.nix
@@ -42,6 +42,9 @@ buildPythonPackage {
     description = "Library to create mumble bots";
     homepage = "https://github.com/tjni/pymumble";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ thelegy ];
+    maintainers = with maintainers; [
+      thelegy
+      tjni
+    ];
   };
 }

--- a/pkgs/development/python-modules/pymumble/default.nix
+++ b/pkgs/development/python-modules/pymumble/default.nix
@@ -7,12 +7,13 @@
   pytestCheckHook,
   pycrypto,
   pythonOlder,
+  setuptools,
 }:
 
 buildPythonPackage {
   pname = "pymumble";
   version = "unstable-2024-10-20";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -23,7 +24,11 @@ buildPythonPackage {
     hash = "sha256-9lfWvfrS+vUFTf9jo4T+VHkm9u/hVjsDszLBQIEZVcQ=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     opuslib
     protobuf
   ];


### PR DESCRIPTION
Move to using my fork of pymumble with a commit that regenerates proto files using protoc 3.20 and relaxes version constraints.

Original upstream has declared in their README that they are no longer maintaining the project, so I created a fork instead of submitting a PR.

I'm not an active user of this package but invested in keeping packages building if they take minimal effort. In this case, it currently just requires regenerating the `mumble_pb2.py` file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
