### PR TITLE
nushellPlugins.skim: init at 0.7.0

### DIFF
--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -10,4 +10,5 @@ lib.makeScope newScope (self: with self; {
   units = callPackage ./units.nix { };
   highlight = callPackage ./highlight.nix { };
   dbus = callPackage ./dbus.nix { inherit dbus; nushell_plugin_dbus = self.dbus; };
+  skim = callPackage ./skim.nix { inherit IOKit CoreFoundation; };
 })

--- a/pkgs/shells/nushell/plugins/skim.nix
+++ b/pkgs/shells/nushell/plugins/skim.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  runCommand,
+  lib,
+  rustPlatform,
+  nix-update-script,
+  fetchFromGitHub,
+  IOKit,
+  CoreFoundation,
+  nushell,
+  skim,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nu_plugin_skim";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "idanarye";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-3q2qt35lZ07N8E3p4/BoYX1H4B8qcKXJWnZhdJhgpJE=";
+  };
+
+  cargoHash = "sha256-+RYrQsB8LVjxZsQ7dVDK6GT6nXSM4b+qpILOe0Q2SjA=";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ rustPlatform.bindgenHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    IOKit
+    CoreFoundation
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.check =
+      let
+        nu = lib.getExe nushell;
+        plugin = lib.getExe skim;
+      in
+      runCommand "${pname}-test" { } ''
+        touch $out
+        ${nu} -n -c "plugin add --plugin-config $out ${plugin}"
+        ${nu} -n -c "plugin use --plugin-config $out skim"
+      '';
+  };
+
+  meta = with lib; {
+    description = "A nushell plugin that adds integrates the skim fuzzy finder";
+    mainProgram = "nu_plugin_skim";
+    homepage = "https://github.com/idanarye/nu_plugin_skim";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aftix ];
+    platforms = with platforms; all;
+  };
+}


### PR DESCRIPTION
Added package for [nu_plugin_skim](https://github.com/idanarye/nu_plugin_skim). It includes a simple test that the passed in `nushell` can load the plugin.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
