### PR TITLE
python312Packages.xdis: support new python minor versions

### DIFF
--- a/pkgs/development/python-modules/xdis/default.nix
+++ b/pkgs/development/python-modules/xdis/default.nix
@@ -6,13 +6,14 @@
   fetchpatch,
   pytestCheckHook,
   pythonOlder,
+  setuptools,
   six,
 }:
 
 buildPythonPackage rec {
   pname = "xdis";
   version = "6.1.1";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
@@ -47,7 +48,11 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     click
     six
   ];

--- a/pkgs/development/python-modules/xdis/default.nix
+++ b/pkgs/development/python-modules/xdis/default.nix
@@ -24,7 +24,6 @@ buildPythonPackage rec {
   };
 
   # Backport magics for newer newer python versions
-  # 6.1.1 only supports up to 3.12.4 while nixpkgs is already on 3.12.5+
   patches = [
     (fetchpatch {
       url = "https://github.com/rocky/python-xdis/commit/fcba74a7f64c5e2879ca0779ff10f38f9229e7da.patch";
@@ -33,6 +32,18 @@ buildPythonPackage rec {
     (fetchpatch {
       url = "https://github.com/rocky/python-xdis/commit/b66976ff53a2c6e17a73fb7652ddd6c8054df8db.patch";
       hash = "sha256-KO1y0nDTPmEZ+0/3Pjh+CvTdpr/p4AYZ8XdH5J+XzXo=";
+    })
+    (fetchpatch {
+      url = "https://github.com/rocky/python-xdis/commit/a9f50c0ba77cdbf4693388404c13a02796a4221a.patch";
+      hash = "sha256-gwMagKBY7d/+ohESTSl6M2IEjzABxfrddpdr58VJAk8=";
+    })
+    (fetchpatch {
+      url = "https://github.com/rocky/python-xdis/commit/d9e15acae76a413667912a10fbf8259711ed9c65.patch";
+      hash = "sha256-hpmKg+K1RiLSnmUIS8KtZRVBfvTO9bWbpsNhBFUM38o=";
+    })
+    (fetchpatch {
+      url = "https://github.com/rocky/python-xdis/commit/b412c878d0bc1b516bd01612d46d8830c36a14ad.patch";
+      hash = "sha256-W1JuIXYLO6iyjWiSnzCoXzFsedZjesq31gEPgrtjxas=";
     })
   ];
 


### PR DESCRIPTION
Observed that this package was failing in staging-next, due to Python being updated to 3.12.7. Followed current practice of cherry-picking patches that add support for new Python versions:

- https://github.com/rocky/python-xdis/commit/a9f50c0ba77cdbf4693388404c13a02796a4221a.patch
- https://github.com/rocky/python-xdis/commit/d9e15acae76a413667912a10fbf8259711ed9c65.patch
- https://github.com/rocky/python-xdis/commit/b412c878d0bc1b516bd01612d46d8830c36a14ad.patch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
