### PR TITLE
git-prole: 0.1.1 -> 0.5.1

### DIFF
--- a/pkgs/by-name/gi/git-prole/package.nix
+++ b/pkgs/by-name/gi/git-prole/package.nix
@@ -7,7 +7,7 @@
   nix-update-script,
 }:
 let
-  version = "0.1.1";
+  version = "0.5.1";
 in
 rustPlatform.buildRustPackage {
   pname = "git-prole";
@@ -17,10 +17,10 @@ rustPlatform.buildRustPackage {
     owner = "9999years";
     repo = "git-prole";
     rev = "refs/tags/v${version}";
-    hash = "sha256-IJsNZt5eID1ghz5Rj53OfidgPoMS2qq+7qgqYEu4zPc=";
+    hash = "sha256-jJEskahZRCpM2WEH4myTLfowQxEJ4WCNXbTwGkwBHnY=";
   };
 
-  cargoHash = "sha256-2z7UEHVomm2zuImdcQq0G9fEhKrHLrPNUhVrFugG3w4=";
+  cargoHash = "sha256-u4UJH+dIDI+I6fEQTRe3RRufYZwxBENxnwULSSCOZF8=";
 
   nativeCheckInputs = [
     git


### PR DESCRIPTION
Changes:
- Convert multiple worktrees
- Improve path display
- Fix copying broken symlinks in `git prole add`
- Print a message if there's nothing to do when converting a repository
- Log working directory and env variables when running commands
- Fix `git prole add` in the container directory
- Run commands when adding worktrees
- `git prole add` now knows how to create `--detached` worktrees
- Add `branch_replacements` option
- Rework config option names

Diff: https://github.com/9999years/git-prole/compare/refs/tags/v0.1.1...v0.5.1

Changelogs:
- https://github.com/9999years/git-prole/releases/tag/v0.2.0
- https://github.com/9999years/git-prole/releases/tag/v0.3.0
- https://github.com/9999years/git-prole/releases/tag/v0.4.0
- https://github.com/9999years/git-prole/releases/tag/v0.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
