### PR TITLE
New NixOS hardware acceleration drivers API implementation draft

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -510,6 +510,27 @@ rec {
           else res;
     };
 
+    driverPackage = package // rec {
+      check = (x:
+        isDerivation x
+        # Must have an APIs attribute
+        && x.passthru.APIs or [ ] != [ ]
+        # If it has a lower bitness package, check it aswell
+        && (
+          if x.stdenv.is64bit && x.passthru ? lowerBitnessPackage
+          then check x.passthru.lowerBitnessPackage
+          else true
+        )
+      );
+    };
+
+    packageSelector = mkOptionType {
+      name = "packageSelector";
+      descriptionClass = "noun";
+      check = x: isFunction x; # TODO check whether the package selects a drv
+      merge = mergeEqualOption;
+    };
+
     shellPackage = package // {
       check = x: isDerivation x && hasAttr "shellPath" x;
     };

--- a/nixos/modules/hardware/acceleration/default.nix
+++ b/nixos/modules/hardware/acceleration/default.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkOption
+    mkIf
+    mkRemovedOptionModule
+    mkEnableOption
+    optional
+    types
+    ;
+
+  this = config.hardware.acceleration;
+
+  envFor =
+    p:
+    p.buildEnv {
+      name = "drivers";
+      paths = map (selector: selector p) this.packages;
+    };
+in
+
+{
+  options.hardware.acceleration = {
+    packages = mkOption {
+      type = with types; listOf packageSelector;
+      description = ''
+        Driver packages to be added to the global driver library path.
+
+        If there is an option for your driver in {option}`hardware.drivers`, you should use that instead.
+      '';
+    };
+
+    support32Bit =
+      mkEnableOption "32 bit drivers usable by 32 bit applications"
+      // mkOption { default = false; };
+    setLdLibraryPath = mkOption {
+      type = types.bool;
+      internal = true;
+      default = false;
+      description = ''
+        Whether the `LD_LIBRARY_PATH` environment variable
+        should be set to the locations of driver libraries. Drivers which
+        rely on overriding libraries should set this to true. Drivers which
+        support `libglvnd` and other dispatch libraries
+        instead of overriding libraries should not set this.
+      '';
+    };
+  };
+  imports = [
+    # (mkRemovedOptionModule
+    #   [
+    #     "hardware"
+    #     "opengl"
+    #   ]
+    #   "The hardware acceleration drivers have been refactored. Please use `hardware.acceleration` and `hardware.drivers` instead."
+    # )
+  ];
+
+  config = mkIf (this.packages != [ ]) {
+    assertions = [
+      {
+        assertion = this.support32Bit -> pkgs.stdenv.is64bit;
+        message = "Option support32Bit only makes sense on a 64-bit system.";
+      }
+      {
+        assertion =
+          this.support32Bit -> (config.boot.kernelPackages.kernel.features.ia32Emulation or false);
+        message = "Option support32Bit requires a kernel that supports 32bit emulation";
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "L+ /run/opengl-driver - - - - ${envFor pkgs}"
+      (
+        if pkgs.stdenv.is32bit then
+          "L+ /run/opengl-driver-32 - - - - opengl-driver"
+        else if this.support32Bit then
+          "L+ /run/opengl-driver-32 - - - - ${envFor pkgs.pkgsi686Linux}"
+        else
+          "r /run/opengl-driver-32"
+      )
+    ];
+
+    environment.sessionVariables.LD_LIBRARY_PATH = mkIf this.setLdLibraryPath (
+      [ "/run/opengl-driver/lib" ] ++ optional this.support32Bit "/run/opengl-driver-32/lib"
+    );
+  };
+}

--- a/nixos/modules/hardware/acceleration/default.nix
+++ b/nixos/modules/hardware/acceleration/default.nix
@@ -34,11 +34,13 @@ in
 
         If there is an option for your driver in {option}`hardware.drivers`, you should use that instead.
       '';
+      default = [ ];
     };
 
     support32Bit =
       mkEnableOption "32 bit drivers usable by 32 bit applications"
       // mkOption { default = false; };
+
     setLdLibraryPath = mkOption {
       type = types.bool;
       internal = true;

--- a/nixos/modules/hardware/acceleration/opengl.nix
+++ b/nixos/modules/hardware/acceleration/opengl.nix
@@ -1,12 +1,14 @@
-{ lib, ... }:
+{ lib, config, ... }:
 
 let
-  inherit (lib) mkEnableOption mkOption;
-  inherit (lib.types) attrsOf functionTo package;
+  inherit (lib) mkEnableOption mkOption mkIf attrValues filterAttrs;
+  inherit (lib.types) attrsOf nullOr packageSelector;
+
+  this = config.hardware.acceleration.api.opengl;
 in
 
 {
-  options.hardware.acceleration.opengl = {
+  options.hardware.acceleration.api.opengl = {
     enable = mkEnableOption ''
       the Open Graphics Layer acceleration API.
 
@@ -14,12 +16,12 @@ in
     '';
 
     drivers = mkOption {
-      # type = attrsOf (submodule {
-      #   options = {
-      #     "64" =
-      #   };
-      # });
-      # type = attrsOf (functionTo package);
+      default = { };
+      type = attrsOf (nullOr (packageSelector));
     };
+  };
+
+  config = mkIf this.enable {
+    hardware.acceleration.packages = attrValues (filterAttrs (n: v: v != null) this.drivers);
   };
 }

--- a/nixos/modules/hardware/acceleration/opengl.nix
+++ b/nixos/modules/hardware/acceleration/opengl.nix
@@ -22,6 +22,6 @@ in
   };
 
   config = mkIf this.enable {
-    hardware.acceleration.packages = attrValues (filterAttrs (n: v: v != null) this.drivers);
+    hardware.drivers.packages = attrValues (filterAttrs (n: v: v != null) this.drivers);
   };
 }

--- a/nixos/modules/hardware/acceleration/opengl.nix
+++ b/nixos/modules/hardware/acceleration/opengl.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkEnableOption mkOption;
+  inherit (lib.types) attrsOf functionTo package;
+in
+
+{
+  options.hardware.acceleration.opengl = {
+    enable = mkEnableOption ''
+      the Open Graphics Layer acceleration API.
+
+      This is commonly used by graphical applications, desktop environments and games.
+    '';
+
+    drivers = mkOption {
+      # type = attrsOf (submodule {
+      #   options = {
+      #     "64" =
+      #   };
+      # });
+      # type = attrsOf (functionTo package);
+    };
+  };
+}

--- a/nixos/modules/hardware/acceleration/opengl.nix
+++ b/nixos/modules/hardware/acceleration/opengl.nix
@@ -1,7 +1,13 @@
 { lib, config, ... }:
 
 let
-  inherit (lib) mkEnableOption mkOption mkIf attrValues filterAttrs;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    attrValues
+    filterAttrs
+    ;
   inherit (lib.types) attrsOf nullOr packageSelector;
 
   this = config.hardware.acceleration.api.opengl;
@@ -17,7 +23,7 @@ in
 
     drivers = mkOption {
       default = { };
-      type = attrsOf (nullOr (packageSelector));
+      type = attrsOf (nullOr packageSelector);
     };
   };
 

--- a/nixos/modules/hardware/drivers/default.nix
+++ b/nixos/modules/hardware/drivers/default.nix
@@ -15,7 +15,7 @@ let
     types
     ;
 
-  this = config.hardware.acceleration;
+  this = config.hardware.drivers;
 
   envFor =
     p:
@@ -26,7 +26,7 @@ let
 in
 
 {
-  options.hardware.acceleration = {
+  options.hardware.drivers = {
     packages = mkOption {
       type = with types; listOf packageSelector;
       description = ''
@@ -35,6 +35,7 @@ in
         If there is an option for your driver in {option}`hardware.drivers`, you should use that instead.
       '';
       default = [ ];
+      internal = true;
     };
 
     support32Bit =

--- a/nixos/modules/hardware/drivers/default.nix
+++ b/nixos/modules/hardware/drivers/default.nix
@@ -67,16 +67,15 @@ in
       }
     ];
 
-    systemd.tmpfiles.rules = [
-      "L+ /run/opengl-driver - - - - ${envFor pkgs}"
-      (
-        if pkgs.stdenv.is32bit then
-          "L+ /run/opengl-driver-32 - - - - opengl-driver"
+    systemd.tmpfiles.settings.graphics-driver = {
+      "/run/opengl-driver"."L+".argument = toString (envFor pkgs);
+      "/run/opengl-driver-32" =
+        if pkgs.stdenv.hostPlatform.isi686 then
+          { "L+".argument = "opengl-driver"; }
         else if this.support32Bit then
-          "L+ /run/opengl-driver-32 - - - - ${envFor pkgs.pkgsi686Linux}"
+          { "L+".argument = toString (envFor pkgs.pkgsi686Linux); }
         else
-          "r /run/opengl-driver-32"
-      )
-    ];
+          { "r" = { }; };
+    };
   };
 }

--- a/nixos/modules/hardware/drivers/default.nix
+++ b/nixos/modules/hardware/drivers/default.nix
@@ -42,6 +42,7 @@ in
       // mkOption { default = false; };
   };
   imports = [
+    (lib.mkRenamedOptionModule [ "hardware" "graphics" "enable32Bit"] [ "hardware" "drivers" "support32Bit" ])
     # (mkRemovedOptionModule
     #   [
     #     "hardware"

--- a/nixos/modules/hardware/drivers/default.nix
+++ b/nixos/modules/hardware/drivers/default.nix
@@ -38,7 +38,9 @@ in
     };
 
     support32Bit =
-      mkEnableOption "32 bit drivers usable by 32 bit applications"
+      mkEnableOption ''
+        On 64-bit systems, whether to also enable 32-bit drivers for use in 32-bit applications such as WINE.
+      ''
       // mkOption { default = false; };
   };
   imports = [

--- a/nixos/modules/hardware/drivers/default.nix
+++ b/nixos/modules/hardware/drivers/default.nix
@@ -11,7 +11,6 @@ let
     mkIf
     mkRemovedOptionModule
     mkEnableOption
-    optional
     types
     ;
 
@@ -41,19 +40,6 @@ in
     support32Bit =
       mkEnableOption "32 bit drivers usable by 32 bit applications"
       // mkOption { default = false; };
-
-    setLdLibraryPath = mkOption {
-      type = types.bool;
-      internal = true;
-      default = false;
-      description = ''
-        Whether the `LD_LIBRARY_PATH` environment variable
-        should be set to the locations of driver libraries. Drivers which
-        rely on overriding libraries should set this to true. Drivers which
-        support `libglvnd` and other dispatch libraries
-        instead of overriding libraries should not set this.
-      '';
-    };
   };
   imports = [
     # (mkRemovedOptionModule
@@ -89,9 +75,5 @@ in
           "r /run/opengl-driver-32"
       )
     ];
-
-    environment.sessionVariables.LD_LIBRARY_PATH = mkIf this.setLdLibraryPath (
-      [ "/run/opengl-driver/lib" ] ++ optional this.support32Bit "/run/opengl-driver-32/lib"
-    );
   };
 }

--- a/nixos/modules/hardware/drivers/mesa.nix
+++ b/nixos/modules/hardware/drivers/mesa.nix
@@ -22,7 +22,7 @@ in
   };
 
   config = mkIf this.enable {
-    hardware.acceleration = genAttrs (this.package pkgs).passthru.apis (name: if true then { } else {
+    hardware.acceleration.api = genAttrs (this.package pkgs).passthru.apis (name: {
       drivers.mesa = this.package;
     });
   };

--- a/nixos/modules/hardware/drivers/mesa.nix
+++ b/nixos/modules/hardware/drivers/mesa.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+let
+  this = config.hardware.drivers.mesa;
+  inherit (lib) mkIf genAttrs;
+  inherit (lib.options) mkPackageOption' mkEnableOption mkOption;
+  inherit (lib.types) attrsOf submodule;
+in
+
+{
+  options.hardware.drivers.mesa = {
+    enable = mkEnableOption ''
+      the Mesa 3D Graphics Library.
+
+      This provides many open graphics APIs for common hardware accelerators such as GPUs and TPUs.
+    '';
+
+    package = mkPackageOption' "mesa" {
+      # defaultPackage = "mesa";
+      # defaultText = "pkgs: pkgs.mesa";
+    };
+  };
+
+  config = mkIf this.enable {
+    hardware.acceleration = genAttrs (this.package pkgs).passthru.apis (name: if true then { } else {
+      drivers.mesa = this.package;
+    });
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -46,6 +46,8 @@
   ./config/xdg/sounds.nix
   ./config/xdg/terminal-exec.nix
   ./config/zram.nix
+  ./hardware/acceleration/default.nix
+  ./hardware/acceleration/opengl.nix
   ./hardware/acpilight.nix
   ./hardware/all-firmware.nix
   ./hardware/bladeRF.nix
@@ -61,6 +63,7 @@
   ./hardware/decklink.nix
   ./hardware/device-tree.nix
   ./hardware/digitalbitbox.nix
+  ./hardware/drivers/mesa.nix
   ./hardware/flipperzero.nix
   ./hardware/flirc.nix
   ./hardware/gkraken.nix
@@ -1730,8 +1733,6 @@
   ./virtualisation/waydroid.nix
   ./virtualisation/xe-guest-utilities.nix
   ./virtualisation/xen-dom0.nix
-  ./hardware/drivers/mesa.nix
-  ./hardware/acceleration/opengl.nix
   {
     documentation.nixos.extraModules = [
       ./virtualisation/qemu-vm.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1730,6 +1730,8 @@
   ./virtualisation/waydroid.nix
   ./virtualisation/xe-guest-utilities.nix
   ./virtualisation/xen-dom0.nix
+  ./hardware/drivers/mesa.nix
+  ./hardware/acceleration/opengl.nix
   {
     documentation.nixos.extraModules = [
       ./virtualisation/qemu-vm.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -46,7 +46,6 @@
   ./config/xdg/sounds.nix
   ./config/xdg/terminal-exec.nix
   ./config/zram.nix
-  ./hardware/acceleration/default.nix
   ./hardware/acceleration/opengl.nix
   ./hardware/acpilight.nix
   ./hardware/all-firmware.nix
@@ -63,6 +62,7 @@
   ./hardware/decklink.nix
   ./hardware/device-tree.nix
   ./hardware/digitalbitbox.nix
+  ./hardware/drivers/default.nix
   ./hardware/drivers/mesa.nix
   ./hardware/flipperzero.nix
   ./hardware/flirc.nix

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -178,7 +178,9 @@ in {
       # Steam games require OGL and VK
       api.opengl.enable = lib.mkDefault true;
       # api.vulkan.enable = mkDefault true; # TODO
+    };
 
+    hardware.drivers = {
       # Some games are 32bit-only
       support32Bit = lib.mkDefault true;
     };

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -385,6 +385,8 @@ in stdenv.mkDerivation {
     inherit (libglvnd) driverLink;
     inherit llvmPackages;
 
+    apis = [ "opengl" ];
+
     tests.devDoesNotDependOnLLVM = stdenv.mkDerivation {
       name = "mesa-dev-does-not-depend-on-llvm";
       buildCommand = ''


### PR DESCRIPTION
WIP implementation draft for https://github.com/NixOS/nixpkgs/issues/350162

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
