### PR TITLE
isa-l: 2.31.0 -> 2.31.0-unstable-2024-04-25 to fix compilation on aarch64-darwin

### DIFF
--- a/pkgs/development/libraries/isa-l/default.nix
+++ b/pkgs/development/libraries/isa-l/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, nasm }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "isa-l";
   version = "2.31.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "isa-l";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-xBBtpjtWyba0DogdLobtuWmiiAHTXMK4oRnjYuTUCNk=";
   };
 
@@ -17,13 +17,13 @@ stdenv.mkDerivation rec {
     export AS=nasm
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Collection of optimised low-level functions targeting storage applications";
     mainProgram = "igzip";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     homepage = "https://github.com/intel/isa-l";
-    maintainers = with maintainers; [ jbedo ];
-    platforms = platforms.all;
+    maintainers = with lib.maintainers; [ jbedo ];
+    platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64; # does not build on M1 mac (asm/hwcap.h file not found) maybe needs gcc not clang?
   };
-}
+})

--- a/pkgs/development/libraries/isa-l/default.nix
+++ b/pkgs/development/libraries/isa-l/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "isa-l";
-  version = "2.31.0";
+  version = "2.31.0-unstable-2024-04-25";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "isa-l";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-xBBtpjtWyba0DogdLobtuWmiiAHTXMK4oRnjYuTUCNk=";
+    rev = "dbaf284e112bea1b90983772a3164e794b923aaf";
+    sha256 = "sha256-eM1K3uObb4eZq0nSfafltp5DuZIDwknUYj9CdLn14lY=";
   };
 
   nativeBuildInputs = [ nasm autoreconfHook ];
@@ -24,6 +24,5 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/intel/isa-l";
     maintainers = with lib.maintainers; [ jbedo ];
     platforms = lib.platforms.all;
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64; # does not build on M1 mac (asm/hwcap.h file not found) maybe needs gcc not clang?
   };
 })


### PR DESCRIPTION
Bump onto an unstable revision from the upstream `master` branch to fix isa-l on aarch64-darwin.

Add igzip functionality tests in `isa-l.tests` to guard the functionality of this library and the igzip binary.

This change caused 900 rebuilds on x86_64-linux, most of which are named `homeassistant-test-*`, which seems to be the package tests of the same package. This should justify merging into `master` instead of `staging`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
