### PR TITLE
daggerfall-unity: init at 1.1.1

### DIFF
--- a/pkgs/by-name/da/daggerfall-unity/package.nix
+++ b/pkgs/by-name/da/daggerfall-unity/package.nix
@@ -1,0 +1,123 @@
+{
+  alsa-lib,
+  autoPatchelfHook,
+  copyDesktopItems,
+  fetchurl,
+  fetchzip,
+  lib,
+  libGL,
+  libXScrnSaver,
+  libXcursor,
+  libXi,
+  libXinerama,
+  libXrandr,
+  libXxf86vm,
+  libpulseaudio,
+  libudev0-shim,
+  makeDesktopItem,
+  nix-update-script,
+  stdenv,
+  vulkan-loader,
+  pname ? "daggerfall-unity",
+  includeUnfree ? false,
+}:
+let
+  docFiles =
+    [
+      (fetchurl {
+        url = "https://www.dfworkshop.net/static_files/daggerfallunity/Daggerfall%20Unity%20Manual.pdf";
+        hash = "sha256-FywlD0K5b4vUWzyzANlF9575XTDLivbsym7F+qe0Dm8=";
+        name = "Daggerfall Unity Manual.pdf";
+        meta.license = lib.licenses.mit;
+      })
+    ]
+    ++ lib.optionals includeUnfree [
+      (fetchurl {
+        url = "https://cdn.bethsoft.com/bethsoft.com/manuals/Daggerfall/daggerfall-en.pdf";
+        hash = "sha256-24KSP/E7+KvSRTMDq63NVlVWTFZnQj1yya8wc36yrC0=";
+        meta.license = lib.licenses.unfree;
+      })
+    ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname;
+  version = "1.1.1";
+
+  src = fetchzip {
+    url = "https://github.com/Interkarma/daggerfall-unity/releases/download/v${finalAttrs.version}/dfu_linux_64bit-v${finalAttrs.version}.zip";
+    hash = "sha256-JuhhVLpREM9e9UtlDttvFUhHWpH7Sh79OEo1OM4ggKA=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libGL
+    libXScrnSaver
+    libXcursor
+    libXi
+    libXinerama
+    libXrandr
+    libXxf86vm
+    libpulseaudio
+    libudev0-shim
+    vulkan-loader
+  ];
+
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir --parents "$out/share/doc/"
+    cp --recursive * "$out"
+
+    ${lib.strings.concatMapStringsSep "\n" (file: ''
+      cp "${file}" "$out/share/doc/${file.name}"
+    '') docFiles}
+
+    runHook postInstall
+  '';
+
+  appendRunpaths = [ (lib.makeLibraryPath finalAttrs.buildInputs) ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "daggerfall-unity";
+      desktopName = "Daggerfall Unity";
+      comment = finalAttrs.meta.description;
+      icon = "UnityPlayer";
+      exec = "DaggerfallUnity.x86_64";
+      categories = [ "Game" ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^v(\\d+(\\.\\d+)*)$" ];
+  };
+
+  meta = {
+    homepage = "https://www.dfworkshop.net/";
+    description = "Open source recreation of Daggerfall in the Unity engine";
+    longDescription = ''
+      Daggerfall Unity is an open source recreation of Daggerfall in the Unity engine created by Daggerfall Workshop.
+
+      Experience the adventure and intrigue of Daggerfall with all of its original charm along with hundreds of fixes, quality of life enhancements, and extensive mod support.
+
+      Includes Daggerfall Unity manual.
+
+      ${lib.optionalString includeUnfree ''
+        This "unfree" variant also includes the manual for Daggerfall (the game, not the open source engine).
+      ''}
+    '';
+    changelog = "https://github.com/Interkarma/daggerfall-unity/releases/tag/v${finalAttrs.version}";
+    mainProgram = "DaggerfallUnity.x86_64";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ l0b0 ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7889,6 +7889,11 @@ with pkgs;
     inherit (llvmPackages) llvm libclang;
   };
 
+  daggerfall-unity-unfree = daggerfall-unity.override {
+    pname = "daggerfall-unity-unfree";
+    includeUnfree = true;
+  };
+
   dbt = with python3Packages; toPythonApplication dbt-core;
 
   devbox = callPackage ../development/tools/devbox { buildGoModule = buildGo123Module; };


### PR DESCRIPTION
>  Open source recreation of Daggerfall in the Unity engine

Closes #109385.

Notes:

- I could not figure out [how to build this from source](https://forums.dfworkshop.net/viewtopic.php?t=6820). The [upstream build docs](https://github.com/Interkarma/daggerfall-unity/wiki/Building-DFU-for-distribution) only explain how to do it from the Unity GUI, and there is no `.csproj` or `.sln` file in the project to use with `buildDotnetModule` or the like.
- `./result/DaggerfallUnity.x86_64` starts the GUI and asks for the Daggerfall game files.
- The [official game page](https://elderscrolls.bethesda.net/en/daggerfall) links to Steam to download the game files, so I don't think I can package them as part of this.
- `strings ./result/UnityPlayer.so | grep '\.so'` listed two libraries I could not find, but which did not seem to be necessary, at least for basic functionality: `libGLES_CM.so.1`, and `libmono.so`. Please add a comment if you know where to find them, or why they would not be necessary.
- Thanks to emilazy on Matrix for helping me understand how platform support works.

## Things done

- Played for tens of hours already 😅
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
