### PR TITLE
treewide: use stdenv.buildPlatform.canExecute

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -126,7 +126,7 @@ buildPythonApplication rec {
   ];
 
   # check phase uses the output bin, which is not possible when cross-compiling
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/applications/networking/cluster/kaniko/default.nix
+++ b/pkgs/applications/networking/cluster/kaniko/default.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
 
   doCheck = false; # requires docker, container-diff (unpackaged yet)
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for shell in bash fish zsh; do
       $out/bin/executor completion $shell > executor.$shell
       installShellCompletion executor.$shell

--- a/pkgs/applications/networking/cluster/kubeshark/default.nix
+++ b/pkgs/applications/networking/cluster/kubeshark/default.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
   '';
   doCheck = true;
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kubeshark \
       --bash <($out/bin/kubeshark completion bash) \
       --fish <($out/bin/kubeshark completion fish) \

--- a/pkgs/applications/networking/cluster/kubevela/default.nix
+++ b/pkgs/applications/networking/cluster/kubevela/default.nix
@@ -40,7 +40,7 @@ buildGoModule rec {
   '';
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd vela \
       --bash <($out/bin/vela completion bash) \
       --zsh <($out/bin/vela completion zsh)

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -117,7 +117,7 @@ let
         --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
     '';
 
-    doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+    doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
     # In particular, this detects missing python imports in some of the tools.
     postFixup = let
       # TODO: python is a script, so it doesn't work as interpreter on darwin

--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_TESTS=${if doCheck then "ON" else "OFF"}"
   ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   nativeCheckInputs = [ check ];
 
   meta = with lib; {

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
       "kmymoney/plugins/woob/interface/kmymoneywoob.py"
   '';
 
-  doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   nativeInstallCheckInputs = [ xvfb-run ];
   installCheckPhase =
     lib.optionalString doInstallCheck ''

--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   configureFlags =
     lib.optional (!withInternalSqlite) "--disable-internal-sqlite"

--- a/pkgs/by-name/ei/eiwd/package.nix
+++ b/pkgs/by-name/ei/eiwd/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   # override this to false if you don't want to build python3
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   # prevent the `install-data-local` Makefile rule from running;
   # all it does is attempt to `mkdir` the `localstatedir`.

--- a/pkgs/by-name/gl/glab/package.nix
+++ b/pkgs/by-name/gl/glab/package.nix
@@ -28,7 +28,7 @@ buildGo123Module rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     make manpage
     installManPage share/man/man1/*
     installShellCompletion --cmd glab \

--- a/pkgs/by-name/ma/mangal/package.nix
+++ b/pkgs/by-name/ma/mangal/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     # Mangal creates a config file in the folder ~/.config/mangal and fails if not possible
     export HOME=$(mktemp -d)
     installShellCompletion --cmd mangal \

--- a/pkgs/by-name/mt/mtdutils/package.nix
+++ b/pkgs/by-name/mt/mtdutils/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "AR:=$(AR)" ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   outputs = [
     "out"

--- a/pkgs/by-name/ve/velero/package.nix
+++ b/pkgs/by-name/ve/velero/package.nix
@@ -31,7 +31,7 @@ buildGoModule rec {
   '';
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $out/bin/velero completion bash > velero.bash
     $out/bin/velero completion zsh > velero.zsh
     installShellCompletion velero.{bash,zsh}

--- a/pkgs/by-name/ze/zerotierone/package.nix
+++ b/pkgs/by-name/ze/zerotierone/package.nix
@@ -115,7 +115,7 @@ in stdenv.mkDerivation {
 
   buildFlags = [ "all" "selftest" ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   checkPhase = ''
     runHook preCheck
     ./zerotier-selftest

--- a/pkgs/development/libraries/bencodetools/default.nix
+++ b/pkgs/development/libraries/bencodetools/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   ];
 
   # installCheck instead of check due to -install_name'd library on Darwin
-  doInstallCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   installCheckTarget = "check";
 
   meta = with lib; {

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -840,7 +840,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
   };
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   # Fails with SIGABRT otherwise FIXME: Why?
   checkPhase = let

--- a/pkgs/development/libraries/flatbuffers/23.nix
+++ b/pkgs/development/libraries/flatbuffers/23.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     "-DFLATBUFFERS_OSX_BUILD_UNIVERSAL=OFF"
   ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   checkTarget = "test";
 
   meta = with lib; {

--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     "-DFLATBUFFERS_OSX_BUILD_UNIVERSAL=OFF"
   ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   checkTarget = "test";
 
   meta = with lib; {

--- a/pkgs/development/libraries/minizip-ng/default.nix
+++ b/pkgs/development/libraries/minizip-ng/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     fi
   '';
 
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   nativeCheckInputs = [ gtest ];
   enableParallelChecking = false;
 

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation (finalAttrs: {
     "-DJSON_MultipleHeaders=ON"
   ] ++ lib.optional finalAttrs.finalPackage.doCheck "-DJSON_TestDataDirectory=${testData}";
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   # skip tests that require git or modify “installed files”
   preCheck = ''

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = false;
-  doInstallCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   # Since we rewrote the load path in the dynamic loader for the TCTI
   # The various tcti implementation should be placed in their target directory
   # before we could run tests, so we make turn checkPhase into installCheckPhase

--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional (!doCheck) "-DURIPARSER_BUILD_TESTS=OFF";
 
   nativeCheckInputs = [ gtest ];
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   meta = with lib; {
     changelog = "https://github.com/uriparser/uriparser/blob/uriparser-${version}/ChangeLog";

--- a/pkgs/development/tools/k6/default.nix
+++ b/pkgs/development/tools/k6/default.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     $out/bin/k6 version | grep ${version} > /dev/null
   '';
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd k6 \
       --bash <($out/bin/k6 completion bash) \
       --fish <($out/bin/k6 completion fish) \


### PR DESCRIPTION
candidate for https://github.com/NixOS/nixpkgs/issues/346453

candidates were made using

```shell
old='postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform)'
new='postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)'
rg -F -l -- "$old" pkgs/ | xe sd -F -- "$old" "$new"

old='postInstall = lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform)'
new='postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)'
rg -F -l -- "$old" pkgs/ | xe sd -F -- "$old" "$new"


old='doCheck = stdenv.hostPlatform == stdenv.buildPlatform;'
new='doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;'
rg -F -l -- "$old" pkgs/ | xe sd -F -- "$old" "$new"

old='doCheck = stdenv.buildPlatform == stdenv.hostPlatform;'
new='doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;'
rg -F -l -- "$old" pkgs/ | xe sd -F -- "$old" "$new"


old='doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;'
new='doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;'
rg -F -l -- "$old" pkgs/ | xe sd -F -- "$old" "$new"

old='doInstallCheck = stdenv.buildPlatform == stdenv.hostPlatform;'
new='doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;'
rg -F -l -- "$old" pkgs/ | xe sd -F -- "$old" "$new"
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
