### PR TITLE
networkmanager: use PATH to search for binaries instead of hard-coding store paths

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -117,6 +117,7 @@ let
   packages = [
     pkgs.modemmanager
     pkgs.networkmanager
+    pkgs.openconnect
   ]
   ++ cfg.plugins
   ++ lib.optionals (!delegateWireless && !enableIwd) [
@@ -578,6 +579,10 @@ in
       wantedBy = [ "network.target" ];
       restartTriggers = [ configFile ];
 
+      # NetworkManager has been patched to search for needed binaries in its PATH.
+      # nftables, dnsmasq, dhcpcd and iputils are required for standard functionality.
+      path = [ pkgs.openconnect pkgs.nftables pkgs.dnsmasq pkgs.dhcpcd pkgs.iputils ];
+
       aliases = [ "dbus-org.freedesktop.NetworkManager.service" ];
 
       serviceConfig = {
@@ -609,6 +614,9 @@ in
       wantedBy = [ "multi-user.target" ];
       before = [ "network-online.target" ];
       after = [ "NetworkManager.service" ];
+      # This might be needed if some ensured profile needs to enable an
+      # openconnect VPN connection.
+      path = [ pkgs.openconnect ];
       script = let
         path = id: "/run/NetworkManager/system-connections/${id}.nmconnection";
       in ''

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -10,13 +10,9 @@
 , polkit
 , gnutls
 , ppp
-, dhcpcd
-, iptables
-, nftables
 , python3
 , vala
 , libgcrypt
-, dnsmasq
 , bluez5
 , readline
 , libselinux
@@ -30,7 +26,6 @@
 , libsoup
 , ethtool
 , gnused
-, iputils
 , kmod
 , jansson
 , elfutils
@@ -40,7 +35,6 @@
 , docbook_xml_dtd_412
 , docbook_xml_dtd_42
 , docbook_xml_dtd_43
-, openconnect
 , curl
 , meson
 , mesonEmulatorHook
@@ -53,6 +47,7 @@
 , systemd
 , udev
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
+, withModemManager ? true
 }:
 
 let
@@ -93,12 +88,8 @@ stdenv.mkDerivation rec {
     # Features
     # Allow using iwd when configured to do so
     "-Diwd=true"
-    "-Dpppd=${ppp}/bin/pppd"
-    "-Diptables=${iptables}/bin/iptables"
-    "-Dnft=${nftables}/bin/nft"
-    "-Dmodem_manager=true"
+    (lib.mesonBool "modem_manager" withModemManager)
     "-Dnmtui=true"
-    "-Ddnsmasq=${dnsmasq}/bin/dnsmasq"
     "-Dqt=false"
 
     # Handlers
@@ -107,7 +98,6 @@ stdenv.mkDerivation rec {
     # DHCP clients
     # ISC DHCP client has reached it's end of life, so stop using it
     "-Ddhclient=no"
-    "-Ddhcpcd=${dhcpcd}/bin/dhcpcd"
     "-Ddhcpcanon=no"
 
     # Miscellaneous
@@ -124,9 +114,13 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit iputils openconnect ethtool gnused systemd;
+      inherit ethtool gnused;
       inherit runtimeShell;
     })
+
+    # Enables searching for needed binaries in PATH instead of hard-coding
+    # binary locations at runtime.
+    ./env-paths.patch
 
     # Meson does not support using different directories during build and
     # for installation like Autotools did with flags passed to make install.
@@ -146,15 +140,15 @@ stdenv.mkDerivation rec {
     ppp
     libndp
     curl
-    mobile-broadband-provider-info
-    bluez5
-    dnsmasq
-    modemmanager
     readline
     newt
     libsoup
     jansson
     dbus # used to get directory paths with pkg-config during configuration
+  ] ++ lib.optionals withModemManager [
+    mobile-broadband-provider-info
+    bluez5
+    modemmanager
   ];
 
   propagatedBuildInputs = [ gnutls libgcrypt ];

--- a/pkgs/tools/networking/networkmanager/env-paths.patch
+++ b/pkgs/tools/networking/networkmanager/env-paths.patch
@@ -1,0 +1,171 @@
+diff --git a/src/core/nm-firewall-utils.c b/src/core/nm-firewall-utils.c
+index b6b2b0d721..bc1ad8996e 100644
+--- a/src/core/nm-firewall-utils.c
++++ b/src/core/nm-firewall-utils.c
+@@ -13,12 +13,14 @@
+ #include "libnm-platform/nm-platform.h"
+ 
+ #include "nm-config.h"
++#include "nm-utils.h"
+ #include "NetworkManagerUtils.h"
+ 
+ /*****************************************************************************/
+ 
+-static const struct {
++static struct {
+     const char *name;
++    const char *binary;
+     const char *path;
+ } FirewallBackends[] = {
+     [NM_FIREWALL_BACKEND_NONE - 1] =
+@@ -28,11 +30,13 @@ static const struct {
+     [NM_FIREWALL_BACKEND_NFTABLES - 1] =
+         {
+             .name = "nftables",
++            .binary = "nft",
+             .path = NFT_PATH,
+         },
+     [NM_FIREWALL_BACKEND_IPTABLES - 1] =
+         {
+             .name = "iptables",
++            .binary = "iptables",
+             .path = IPTABLES_PATH,
+         },
+ };
+@@ -213,7 +217,7 @@ _share_iptables_call_v(const char *const *argv)
+ }
+ 
+ #define _share_iptables_call(...) \
+-    _share_iptables_call_v(NM_MAKE_STRV("" IPTABLES_PATH "", "--wait", "2", __VA_ARGS__))
++    _share_iptables_call_v(NM_MAKE_STRV(FirewallBackends[NM_FIREWALL_BACKEND_IPTABLES-1].path, "--wait", "2", __VA_ARGS__))
+ 
+ static gboolean
+ _share_iptables_chain_op(const char *table, const char *chain, const char *op)
+@@ -598,7 +602,7 @@ nm_firewall_nft_call(GBytes             *stdin_buf,
+     g_subprocess_launcher_set_environ(subprocess_launcher, NM_STRV_EMPTY());
+ 
+     call_data->subprocess = g_subprocess_launcher_spawnv(subprocess_launcher,
+-                                                         NM_MAKE_STRV(NFT_PATH, "-f", "-"),
++                                                         NM_MAKE_STRV(FirewallBackends[NM_FIREWALL_BACKEND_NFTABLES-1].path, "-f", "-"),
+                                                          &error);
+ 
+     if (!call_data->subprocess) {
+@@ -1013,9 +1017,9 @@ nm_firewall_config_apply_sync(NMFirewallConfig *self, gboolean up)
+ static NMFirewallBackend
+ _firewall_backend_detect(void)
+ {
+-    if (g_file_test(NFT_PATH, G_FILE_TEST_IS_EXECUTABLE))
++    if (nm_utils_find_helper(FirewallBackends[NM_FIREWALL_BACKEND_NFTABLES - 1].binary, NULL, NULL) != NULL)
+         return NM_FIREWALL_BACKEND_NFTABLES;
+-    if (g_file_test(IPTABLES_PATH, G_FILE_TEST_IS_EXECUTABLE))
++    if (nm_utils_find_helper(FirewallBackends[NM_FIREWALL_BACKEND_IPTABLES - 1].binary, NULL, NULL) != NULL)
+         return NM_FIREWALL_BACKEND_IPTABLES;
+ 
+     return NM_FIREWALL_BACKEND_NFTABLES;
+@@ -1030,9 +1034,10 @@ nm_firewall_utils_get_backend(void)
+ again:
+     b = g_atomic_int_get(&backend);
+     if (b == NM_FIREWALL_BACKEND_UNKNOWN) {
+-        gs_free char *conf_value = NULL;
+-        gboolean      detect;
+-        int           i;
++        gs_free char    *conf_value = NULL;
++        gboolean        detect;
++        const char      *path_value = NULL;
++        int             i;
+ 
+         conf_value =
+             nm_config_data_get_value(NM_CONFIG_GET_DATA_ORIG,
+@@ -1053,6 +1058,19 @@ again:
+         if (detect)
+             b = _firewall_backend_detect();
+ 
++        nm_log_dbg(LOGD_SHARING, "firewall: trying to find %s (%s) backend.",
++                   FirewallBackends[b - 1].name, FirewallBackends[b - 1].binary);
++
++        path_value = nm_utils_find_helper(FirewallBackends[b - 1].binary,
++                                         NULL,
++                                         NULL);
++
++        if (path_value == NULL) {
++            g_atomic_int_set(&backend, NM_FIREWALL_BACKEND_NONE);
++        } else {
++            FirewallBackends[b - 1].path = path_value;
++        }
++
+         nm_assert(NM_IN_SET(b,
+                             NM_FIREWALL_BACKEND_NONE,
+                             NM_FIREWALL_BACKEND_IPTABLES,
+@@ -1062,18 +1080,12 @@ again:
+             goto again;
+ 
+         nm_log_dbg(LOGD_SHARING,
+-                   "firewall: use %s backend%s%s%s%s%s%s%s",
++                   "firewall: use %s backend%s%s%s",
+                    FirewallBackends[b - 1].name,
+                    NM_PRINT_FMT_QUOTED(FirewallBackends[b - 1].path,
+                                        " (",
+                                        FirewallBackends[b - 1].path,
+                                        ")",
+-                                       ""),
+-                   detect ? " (detected)" : "",
+-                   NM_PRINT_FMT_QUOTED(detect && conf_value,
+-                                       " (invalid setting \"",
+-                                       conf_value,
+-                                       "\")",
+                                        ""));
+     }
+ 
+diff --git a/src/libnm-core-impl/nm-utils.c b/src/libnm-core-impl/nm-utils.c
+index 06a96318ab..cda89ba96a 100644
+--- a/src/libnm-core-impl/nm-utils.c
++++ b/src/libnm-core-impl/nm-utils.c
+@@ -3647,10 +3647,31 @@ nm_utils_file_search_in_paths(const char                       *progname,
+                               gpointer                          user_data,
+                               GError                          **error)
+ {
++    const char          *path_env  = NULL;
++    gs_free const char **env_paths = NULL;
++    gs_free const char **all_paths = NULL;
++    size_t               paths_len;
++    size_t               env_paths_len;
++    guint                i;
++
+     g_return_val_if_fail(!error || !*error, NULL);
+     g_return_val_if_fail(progname && progname[0] && !strchr(progname, '/'), NULL);
+     g_return_val_if_fail(file_test_flags || predicate, NULL);
+ 
++    path_env  = g_getenv("PATH");
++    env_paths = nm_strsplit_set_full(path_env, ":", NM_STRSPLIT_SET_FLAGS_STRSTRIP);
++
++    paths_len     = g_strv_length((char **) paths);
++    env_paths_len = g_strv_length((char **) env_paths);
++
++    all_paths = g_new(const char *, (env_paths_len + paths_len + 1));
++
++    for (i = 0; i < env_paths_len; i++)
++        all_paths[i] = env_paths[i];
++    for (i = 0; i < paths_len; i++)
++        all_paths[env_paths_len + i] = paths[i];
++    all_paths[env_paths_len + i] = NULL;
++
+     /* Only consider @try_first if it is a valid, absolute path. This makes
+      * it simpler to pass in a path from configure checks. */
+     if (try_first && try_first[0] == '/'
+@@ -3658,12 +3679,13 @@ nm_utils_file_search_in_paths(const char                       *progname,
+         && (!predicate || predicate(try_first, user_data)))
+         return g_intern_string(try_first);
+ 
+-    if (paths && paths[0]) {
++    if (all_paths && all_paths[0]) {
+         nm_auto_str_buf NMStrBuf strbuf =
+             NM_STR_BUF_INIT(NM_UTILS_GET_NEXT_REALLOC_SIZE_104, FALSE);
++        const char **ptr = all_paths;
+ 
+-        for (; *paths; paths++) {
+-            const char *path = *paths;
++        for (; *ptr; ptr++) {
++            const char *path = *ptr;
+             const char *s;
+ 
+             if (!path[0])

--- a/pkgs/tools/networking/networkmanager/fix-paths.patch
+++ b/pkgs/tools/networking/networkmanager/fix-paths.patch
@@ -10,27 +10,6 @@ index 148acade5c..6395fbfbe5 100644
 +PROGRAM="@runtimeShell@ -c '@ethtool@/bin/ethtool -i $$1 |@gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", ENV{ID_NET_DRIVER}="%c"
  
  LABEL="nm_drivers_end"
-diff --git a/src/core/devices/nm-device.c b/src/core/devices/nm-device.c
-index f3441508ab..7cde8d7d39 100644
---- a/src/core/devices/nm-device.c
-+++ b/src/core/devices/nm-device.c
-@@ -14839,14 +14839,14 @@ nm_device_start_ip_check(NMDevice *self)
-             gw = nm_l3_config_data_get_best_default_route(l3cd, AF_INET);
-             if (gw) {
-                 nm_inet4_ntop(NMP_OBJECT_CAST_IP4_ROUTE(gw)->gateway, buf);
--                ping_binary = nm_utils_find_helper("ping", "/usr/bin/ping", NULL);
-+                ping_binary = "@iputils@/bin/ping";
-                 log_domain  = LOGD_IP4;
-             }
-         } else if (priv->ip_data_6.state == NM_DEVICE_IP_STATE_READY) {
-             gw = nm_l3_config_data_get_best_default_route(l3cd, AF_INET6);
-             if (gw) {
-                 nm_inet6_ntop(&NMP_OBJECT_CAST_IP6_ROUTE(gw)->gateway, buf);
--                ping_binary = nm_utils_find_helper("ping6", "/usr/bin/ping6", NULL);
-+                ping_binary = "@iputils@/bin/ping";
-                 log_domain  = LOGD_IP6;
-             }
-         }
 diff --git a/src/libnm-client-impl/meson.build b/src/libnm-client-impl/meson.build
 index 3dd2338a82..de75cc040b 100644
 --- a/src/libnm-client-impl/meson.build
@@ -51,43 +30,6 @@ index 3dd2338a82..de75cc040b 100644
          gen_gir_cmd,
          '--lib-path', meson.current_build_dir(),
          '--gir', libnm_gir[0],
-diff --git a/src/libnmc-base/nm-vpn-helpers.c b/src/libnmc-base/nm-vpn-helpers.c
-index cbe76f5f1c..8515f94994 100644
---- a/src/libnmc-base/nm-vpn-helpers.c
-+++ b/src/libnmc-base/nm-vpn-helpers.c
-@@ -284,15 +284,6 @@ nm_vpn_openconnect_authenticate_helper(NMSettingVpn *s_vpn, GPtrArray *secrets,
-     const char *const   *iter;
-     const char          *path;
-     const char          *opt;
--    const char *const    DEFAULT_PATHS[] = {
--        "/sbin/",
--        "/usr/sbin/",
--        "/usr/local/sbin/",
--        "/bin/",
--        "/usr/bin/",
--        "/usr/local/bin/",
--        NULL,
--    };
-     const char *oc_argv[(12 + 2 * G_N_ELEMENTS(oc_property_args))];
-     const char *gw;
-     int         port;
-@@ -311,15 +302,7 @@ nm_vpn_openconnect_authenticate_helper(NMSettingVpn *s_vpn, GPtrArray *secrets,
- 
-     port = extract_url_port(gw);
- 
--    path = nm_utils_file_search_in_paths("openconnect",
--                                         "/usr/sbin/openconnect",
--                                         DEFAULT_PATHS,
--                                         G_FILE_TEST_IS_EXECUTABLE,
--                                         NULL,
--                                         NULL,
--                                         error);
--    if (!path)
--        return FALSE;
-+    path = "@openconnect@/bin/openconnect";
- 
-     oc_argv[oc_argc++] = path;
-     oc_argv[oc_argc++] = "--authenticate";
 diff --git a/src/libnmc-setting/meson.build b/src/libnmc-setting/meson.build
 index 4d5079dfb3..5a15447fde 100644
 --- a/src/libnmc-setting/meson.build


### PR DESCRIPTION
Hi,

this PR is a set of changes to NetworkManager with the general goal of reducing closure size. The default size of NetworkManager's closure is currently 500 MB, half of that closure being openconnect which pulls in all of GTK3, including X and wayland libs.

The main reason for the closure size is the general behavior of NetworkManager and its libs to search for needed binaries in standard FHS paths.

[This was already remarked upon when the package was originally built many years ago.](https://github.com/NixOS/nixpkgs/blob/f6bdbd1605b17cfbd8af51ba68db779e130d54b3/pkgs/tools/networking/networkmanager/default.nix#L72)

These needed binaries include:

* `openconnect`
* `iptables`
* `nftables`
* `dnsmasq`
* `dhcpcd`
* ...

The approach of this PR is to patch NetworkManager so needed binaries are searched for in the `$PATH` of the running binary instead of some pre-defined and hard-coded dependency paths. It adds a `nm_utils_find_in_path_env` function to `nm_utils.h` which searches for binaries in the path. Additionally, the firewall-helper functions in `nm-firewall-utils.c` were modified to allow runtime-detection of `nftables` or `iptables` binaries.

To make this work, the NetworkManager NixOS module also needed to be touched to add missing paths to the systemd service's `$PATH` variable and to the general environment's system packages. The reason for the global addition is that the
`nmcli` or `nmtui` tools pull in the NetworkManager library and use those functions to search for binaries. If you then, for example, add an openconnect VPN and try to connect, they will search for the `openconnect` binary in their PATH as well.

Alternatively, we could consider using a [wrapper](https://nixos.org/manual/nixpkgs/stable/#fun-makeWrapper) instead and add those paths directly.

With the given changes, the closure size is halved to about 250 MB. By disabling modemmanager, another 25MB can be saved. One additional, smaller change, is the ability to build the `NetworkManager` package without `modemmanager`. This would fit nicely with https://github.com/NixOS/nixpkgs/pull/316824.

I've also extended existing tests for NetworkManager to test that the given changes work correctly (meaning the needed binaries are found).

Some additional work is still required on this PR but I'm very interested in feedback towards this approach before continuing to work on this. Some of the required work is: 

* Modifying plugins and services (such as the `NetworkManager-ensure-profiles` service) to improve compatibility with this approach.
* Adding a few additional tests to make sure that `openconnect` and other plugins continue to work properly. 
* Check that dependencies that might start or interact with NM or its libs are still functioning properly.
* Document extensively ;)

Our main use-case for this change is that we use NetworkManager in a constrained environment without a graphical user interface. Currently, we rebuild NM to be more minimal but with this approach we could start using the upstream NM again.

In a future PR, I'd would also be interested in modularizing the nm-module further to allow us to disable more features generally, such as openconnect.

Thanks!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
