### PR TITLE
nixos/apple-touchbar: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -190,6 +190,8 @@
 
 - [Zapret](https://github.com/bol-van/zapret), a DPI bypass tool. Available as [services.zapret](option.html#opt-services.zapret).
 
+- [tiny-dfr](https://github.com/WhatAmISupposedToPutHere/tiny-dfr), a dynamic function row daemon for the Touch Bar found on some Apple laptops. Available as [hardware.apple.touchBar.enable](options.html#opt-hardware.apple.touchBar.enable).
+
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}
 
 - The `sound` options have been removed or renamed, as they had a lot of unintended side effects. See [below](#sec-release-24.11-migration-sound) for details.

--- a/nixos/modules/hardware/apple-touchbar.nix
+++ b/nixos/modules/hardware/apple-touchbar.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 let

--- a/nixos/modules/hardware/apple-touchbar.nix
+++ b/nixos/modules/hardware/apple-touchbar.nix
@@ -13,13 +13,15 @@ in
 {
   options.hardware.apple.touchBar = {
     enable = lib.mkEnableOption "support for the Touch Bar on some Apple laptops using tiny-dfr";
+    package = lib.mkPackageOption pkgs "tiny-dfr" { };
 
     settings = lib.mkOption {
       type = format.type;
       default = { };
       description = ''
-        Configuration for tiny-dfr. See
-        <https://github.com/WhatAmISupposedToPutHere/tiny-dfr/blob/master/share/tiny-dfr/config.toml>
+        Configuration for tiny-dfr. See [example configuration][1] for available options.
+
+        [1]: https://github.com/WhatAmISupposedToPutHere/tiny-dfr/blob/master/share/tiny-dfr/config.toml
       '';
       example = lib.literalExpression ''
         {
@@ -32,18 +34,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = cfg.enable -> config.services.udev.enable;
-        message = "Touch Bar support via tiny-dfr requires udev.";
-      }
-    ];
+    systemd.packages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
 
     environment.etc."tiny-dfr/config.toml".source = cfgFile;
-
-    systemd.packages = with pkgs; [ tiny-dfr ];
-    services.udev.packages = with pkgs; [ tiny-dfr ];
-
     systemd.services.tiny-dfr.restartTriggers = [ cfgFile ];
   };
 }

--- a/nixos/modules/hardware/apple-touchbar.nix
+++ b/nixos/modules/hardware/apple-touchbar.nix
@@ -30,31 +30,7 @@ in
 
     environment.etc."tiny-dfr/config.toml".source = cfgFile;
 
-    systemd.services."systemd-backlight@backlight:228200000.display-pipe.0" = {};
-    systemd.services."systemd-backlight@backlight:appletb_backlight" = {};
-
-    systemd.services.tiny-dfr = {
-      enable = true;
-      description = "Tiny Apple silicon touch bar daemon";
-      after = [
-        "systemd-user-sessions.service"
-        "getty@tty1.service"
-        "systemd-logind.service"
-        "dev-tiny_dfr_display.device"
-        "dev-tiny_dfr_backlight.device"
-        "dev-tiny_dfr_display_backlight.device"
-      ] ++ optional config.boot.plymouth.enable "plymouth-quit.service";
-      bindsTo = [
-        "dev-tiny_dfr_display.device"
-        "dev-tiny_dfr_backlight.device"
-        "dev-tiny_dfr_display_backlight.device"
-      ];
-      serviceConfig = {
-        ExecStart = "${pkgs.tiny-dfr}/bin/tiny-dfr";
-        Restart = "always";
-      };
-    };
-
+    systemd.packages = with pkgs; [ tiny-dfr ];
     services.udev.packages = with pkgs; [ tiny-dfr ];
   };
 }

--- a/nixos/modules/hardware/apple-touchbar.nix
+++ b/nixos/modules/hardware/apple-touchbar.nix
@@ -55,28 +55,6 @@ in
       };
     };
 
-    services.udev.extraRules = ''
-      SUBSYSTEM=="drm", KERNEL=="card*", DRIVERS=="adp|appletbdrm", TAG-="master-of-seat", ENV{ID_SEAT}="seat-touchbar"
-
-      SUBSYSTEM=="input", ATTR{name}=="Apple Inc. Touch Bar Display Touchpad", ENV{ID_SEAT}="seat-touchbar"
-      SUBSYSTEM=="input", ATTR{name}=="MacBookPro17,1 Touch Bar", ENV{ID_SEAT}="seat-touchbar"
-      SUBSYSTEM=="input", ATTR{name}=="Mac14,7 Touch Bar", ENV{ID_SEAT}="seat-touchbar"
-
-      ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="8302", ATTR{bConfigurationValue}=="1", ATTR{bConfigurationValue}="0", ATTR{bConfigurationValue}="2"
-
-      SUBSYSTEM=="input", ATTR{name}=="Apple Inc. Touch Bar Display Touchpad", TAG+="systemd", ENV{SYSTEMD_WANTS}="tiny-dfr.service"
-      SUBSYSTEM=="input", ATTR{name}=="MacBookPro17,1 Touch Bar", TAG+="systemd", ENV{SYSTEMD_WANTS}="tiny-dfr.service"
-      SUBSYSTEM=="input", ATTR{name}=="Mac14,7 Touch Bar", TAG+="systemd", ENV{SYSTEMD_WANTS}="tiny-dfr.service"
-
-      SUBSYSTEM=="drm", KERNEL=="card[0-9]*", DRIVERS=="adp|appletbdrm", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display"
-
-      SUBSYSTEM=="backlight", KERNEL=="appletb_backlight", DRIVERS=="hid-appletb-bl", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_backlight"
-      SUBSYSTEM=="backlight", KERNEL=="228200000.display-pipe.0", DRIVERS=="panel-summit", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_backlight"
-
-      SUBSYSTEM=="backlight", KERNEL=="apple-panel-bl", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
-      SUBSYSTEM=="backlight", KERNEL=="gmux_backlight", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
-      SUBSYSTEM=="backlight", KERNEL=="intel_backlight", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
-      SUBSYSTEM=="backlight", KERNEL=="acpi_video0", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
-    '';
+    services.udev.packages = with pkgs; [ tiny-dfr ];
   };
 }

--- a/nixos/modules/hardware/apple-touchbar.nix
+++ b/nixos/modules/hardware/apple-touchbar.nix
@@ -43,5 +43,7 @@ in
 
     systemd.packages = with pkgs; [ tiny-dfr ];
     services.udev.packages = with pkgs; [ tiny-dfr ];
+
+    systemd.services.tiny-dfr.restartTriggers = [ cfgFile ];
   };
 }

--- a/nixos/modules/hardware/apple-touchbar.nix
+++ b/nixos/modules/hardware/apple-touchbar.nix
@@ -17,6 +17,13 @@ in
         Configuration for tiny-dfr. See
         <https://github.com/WhatAmISupposedToPutHere/tiny-dfr/blob/master/share/tiny-dfr/config.toml>
       '';
+      example = literalExpression ''
+        {
+          MediaLayerDefault = true;
+          ShowButtonOutlines = false;
+          EnablePixelShift = true;
+        }
+      '';
     };
   };
 

--- a/nixos/modules/hardware/apple-touchbar.nix
+++ b/nixos/modules/hardware/apple-touchbar.nix
@@ -1,0 +1,82 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.hardware.apple.touchBar;
+  format = pkgs.formats.toml { };
+  cfgFile = format.generate "config.toml" cfg.settings;
+in
+{
+  options.hardware.apple.touchBar = {
+    enable = mkEnableOption "support for the Touch Bar on some Apple laptops using tiny-dfr";
+
+    settings = mkOption {
+      type = format.type;
+      default = { };
+      description = ''
+        Configuration for tiny-dfr. See
+        <https://github.com/WhatAmISupposedToPutHere/tiny-dfr/blob/master/share/tiny-dfr/config.toml>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.enable -> config.services.udev.enable;
+        message = "Touch Bar support via tiny-dfr requires udev.";
+      }
+    ];
+
+    environment.etc."tiny-dfr/config.toml".source = cfgFile;
+
+    systemd.services."systemd-backlight@backlight:228200000.display-pipe.0" = {};
+    systemd.services."systemd-backlight@backlight:appletb_backlight" = {};
+
+    systemd.services.tiny-dfr = {
+      enable = true;
+      description = "Tiny Apple silicon touch bar daemon";
+      after = [
+        "systemd-user-sessions.service"
+        "getty@tty1.service"
+        "systemd-logind.service"
+        "dev-tiny_dfr_display.device"
+        "dev-tiny_dfr_backlight.device"
+        "dev-tiny_dfr_display_backlight.device"
+      ] ++ optional config.boot.plymouth.enable "plymouth-quit.service";
+      bindsTo = [
+        "dev-tiny_dfr_display.device"
+        "dev-tiny_dfr_backlight.device"
+        "dev-tiny_dfr_display_backlight.device"
+      ];
+      serviceConfig = {
+        ExecStart = "${pkgs.tiny-dfr}/bin/tiny-dfr";
+        Restart = "always";
+      };
+    };
+
+    services.udev.extraRules = ''
+      SUBSYSTEM=="drm", KERNEL=="card*", DRIVERS=="adp|appletbdrm", TAG-="master-of-seat", ENV{ID_SEAT}="seat-touchbar"
+
+      SUBSYSTEM=="input", ATTR{name}=="Apple Inc. Touch Bar Display Touchpad", ENV{ID_SEAT}="seat-touchbar"
+      SUBSYSTEM=="input", ATTR{name}=="MacBookPro17,1 Touch Bar", ENV{ID_SEAT}="seat-touchbar"
+      SUBSYSTEM=="input", ATTR{name}=="Mac14,7 Touch Bar", ENV{ID_SEAT}="seat-touchbar"
+
+      ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="8302", ATTR{bConfigurationValue}=="1", ATTR{bConfigurationValue}="0", ATTR{bConfigurationValue}="2"
+
+      SUBSYSTEM=="input", ATTR{name}=="Apple Inc. Touch Bar Display Touchpad", TAG+="systemd", ENV{SYSTEMD_WANTS}="tiny-dfr.service"
+      SUBSYSTEM=="input", ATTR{name}=="MacBookPro17,1 Touch Bar", TAG+="systemd", ENV{SYSTEMD_WANTS}="tiny-dfr.service"
+      SUBSYSTEM=="input", ATTR{name}=="Mac14,7 Touch Bar", TAG+="systemd", ENV{SYSTEMD_WANTS}="tiny-dfr.service"
+
+      SUBSYSTEM=="drm", KERNEL=="card[0-9]*", DRIVERS=="adp|appletbdrm", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display"
+
+      SUBSYSTEM=="backlight", KERNEL=="appletb_backlight", DRIVERS=="hid-appletb-bl", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_backlight"
+      SUBSYSTEM=="backlight", KERNEL=="228200000.display-pipe.0", DRIVERS=="panel-summit", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_backlight"
+
+      SUBSYSTEM=="backlight", KERNEL=="apple-panel-bl", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
+      SUBSYSTEM=="backlight", KERNEL=="gmux_backlight", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
+      SUBSYSTEM=="backlight", KERNEL=="intel_backlight", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
+      SUBSYSTEM=="backlight", KERNEL=="acpi_video0", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
+    '';
+  };
+}

--- a/nixos/modules/hardware/apple-touchbar.nix
+++ b/nixos/modules/hardware/apple-touchbar.nix
@@ -5,7 +5,6 @@
   ...
 }:
 
-with lib;
 let
   cfg = config.hardware.apple.touchBar;
   format = pkgs.formats.toml { };
@@ -13,16 +12,16 @@ let
 in
 {
   options.hardware.apple.touchBar = {
-    enable = mkEnableOption "support for the Touch Bar on some Apple laptops using tiny-dfr";
+    enable = lib.mkEnableOption "support for the Touch Bar on some Apple laptops using tiny-dfr";
 
-    settings = mkOption {
+    settings = lib.mkOption {
       type = format.type;
       default = { };
       description = ''
         Configuration for tiny-dfr. See
         <https://github.com/WhatAmISupposedToPutHere/tiny-dfr/blob/master/share/tiny-dfr/config.toml>
       '';
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           MediaLayerDefault = true;
           ShowButtonOutlines = false;
@@ -32,7 +31,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.enable -> config.services.udev.enable;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -48,6 +48,7 @@
   ./config/zram.nix
   ./hardware/acpilight.nix
   ./hardware/all-firmware.nix
+  ./hardware/apple-touchbar.nix
   ./hardware/bladeRF.nix
   ./hardware/brillo.nix
   ./hardware/ckb-next.nix


### PR DESCRIPTION
This PR adds `hardware.apple.touchBar`, a module for setting up the Touch Bar on some Apple laptops. It uses [tiny-dfr](https://github.com/WhatAmISupposedToPutHere/tiny-dfr), a small daemon originating out of the Asahi Linux project (but works also on T2 Macs, already in nixpkgs).

With this change, enabling support for the Touch Bar becomes one line of configuration:

```
hardware.apple.touchBar.enable = true;
```

followed by a rebuild and reboot. Tiny DFR can also be configured through this module, like so:

```
hardware.apple.touchBar.settings = {
  MediaLayerDefault = true;
  ShowButtonOutlines = false;
  EnablePixelShift = true;
};
```

##### Reviewed points

- [x] module path fits the guidelines
  - see comments
- [ ] module tests, if any, succeed on ARCHITECTURE
- [ ] module tests, if any, are added to package `passthru.tests`
- [x] options have appropriate types
- [x] options have default
- [x] options have example
- [x] options have descriptions
- [x] No unneeded package is added to `environment.systemPackages`
- [ ] `meta.maintainers` is set
- [ ] module documentation is declared in `meta.doc`

##### Possible improvements

- ~~Service can be restarted after config changes~~ done

##### Comments

- I put it as `hardware.apple.touchBar` instead of e.g. `services.tiny-dfr` because of the following:
  - Since it's hardware dependent and related to setting up hardware, I think it should go in `hardware`.
  - Touch Bar only exists on Apple devices, hence `hardware.apple`. This is more descriptive than just simply `hardware.touchBar` and as a bonus, creates a space for any future Apple hardware modules to go into.
  - From my understanding, `tiny-dfr` is the main implementation of support for Touch Bars. The only other implementation I'm aware of is `touchbard` and it's deprecated, with `tiny-dfr` being the recommended replacement.
  - I put `touchBar` instead of `touchbar` as in official branding, documentation etc. it's "Touch Bar", two words, so translating to camelCase it becomes `touchBar`.
- I'm not sure if I should put myself as maintainer, as it's really quite a simple module and I didn't write any of the code for it, I just wrote this very simple integration. Previously I did it a more complicated way by manually doing the udev rules and systemd units, but now I've simplified it to just use the rules and units provided by the package.
- All of the above is just my opinion, I'm more than happy to change anything, I'm new to contributing to NixOS and am just trying to upstream some stuff I've had privately for a while.

---

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
