### PR TITLE
fetchNpmDeps: always enable TLS verification

### DIFF
--- a/pkgs/build-support/node/fetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-npm-deps/default.nix
@@ -198,9 +198,11 @@
       # `{ "registry.example.com": "example-registry-bearer-token", ... }`
       impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [ "NIX_NPM_TOKENS" ];
 
-      SSL_CERT_FILE = if (hash_.outputHash == "" || hash_.outputHash == lib.fakeSha256 || hash_.outputHash == lib.fakeSha512 || hash_.outputHash == lib.fakeHash)
-        then "${cacert}/etc/ssl/certs/ca-bundle.crt"
-        else "/no-cert-file.crt";
+      SSL_CERT_FILE = let
+        nixSSLCertFile = builtins.getEnv "NIX_SSL_CERT_FILE";
+      in if nixSSLCertFile != ""
+      then nixSSLCertFile
+      else "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
       outputHashMode = "recursive";
     } // hash_ // forceGitDeps_ // forceEmptyCache_);

--- a/pkgs/build-support/node/fetch-npm-deps/src/util.rs
+++ b/pkgs/build-support/node/fetch-npm-deps/src/util.rs
@@ -2,7 +2,7 @@ use backoff::{retry, ExponentialBackoff};
 use data_encoding::BASE64;
 use digest::Digest;
 use isahc::{
-    config::{CaCertificate, Configurable, RedirectPolicy, SslOption},
+    config::{CaCertificate, Configurable, RedirectPolicy},
     Body, Request, RequestExt,
 };
 use nix_nar::{Encoder, NarError};
@@ -23,11 +23,6 @@ pub fn get_url(url: &Url) -> Result<Body, isahc::Error> {
         if Path::new(&ssl_cert_file).exists() {
             // When file exists, use it. NIX_SSL_CERT_FILE will still override.
             request = request.ssl_ca_certificate(CaCertificate::file(ssl_cert_file));
-        } else if env::var("outputHash").is_ok() {
-            // When file does not exist, assume we are downloading in a FOD and
-            // therefore do not need to check certificates, since the output is
-            // already hashed.
-            request = request.ssl_options(SslOption::DANGER_ACCEPT_INVALID_CERTS);
         }
     }
 


### PR DESCRIPTION
Credentials might still be present even if we are downloading in a FOD so we should not disable the TLS verification.
Even without credentials being involved, attackers might still be able to gather information that they would otherwise be unable to obtain.

See also #350222 and #344000


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
