### PR TITLE
old: versatiles: init at 0.12.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23072,6 +23072,12 @@
     githubId = 1215623;
     keys = [ { fingerprint = "DA03 D6C6 3F58 E796 AD26  E99B 366A 2940 479A 06FC"; } ];
   };
+  wilhelmines = {
+    email = "mail@aesz.org";
+    name = "Ronja Schwarz";
+    github = "wilhelmines";
+    githubId = 71409721;
+  };
   willbush = {
     email = "git@willbush.dev";
     matrix = "@willbush:matrix.org";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -383,6 +383,7 @@ with lib.maintainers;
       nh2
       nialov
       sikmir
+      wilhelmines
       willcohen
     ];
     githubTeams = [ "geospatial" ];

--- a/pkgs/by-name/ve/versatiles/package.nix
+++ b/pkgs/by-name/ve/versatiles/package.nix
@@ -1,0 +1,41 @@
+{ lib, fetchFromGitHub, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "versatiles";
+  version = "0.12.9"; # When updating: Replace with current version
+
+  src = fetchFromGitHub {
+    owner = "versatiles-org";
+    repo = "versatiles-rs";
+    rev = "a1896bc1e639ec46bd00f89bffaba9181614515a"; # When updating: Replace with long commit hash of new version
+    hash = "sha256-oyTsL+oqpYxIlG7C7yS94TY8c8v15NbQ/U3fJdEEVDQ=" ; # When updating: Use `lib.fakeHash` for recomputing the hash once. Run: 'nix-build -A versatiles'. Swap with new hash and proceed.
+  };
+
+  cargoHash = "sha256-SeTDfxoIVTWXI1miolHthIhgBWDtFtPEMWGjmFl/f4o=" ; # When updating: Same as above
+
+  checkFlags = [
+    # Skip tests that require network access
+    "--skip tools::convert::tests::test_remote1"
+    "--skip tools::convert::tests::test_remote2"
+    "--skip tools::probe::tests::test_remote"
+    "--skip tools::serve::tests::test_remote"
+    "--skip utils::io::data_reader_http"
+    "--skip utils::io::data_reader_http::tests::read_range_git"
+    "--skip utils::io::data_reader_http::tests::read_range_googleapis"
+   ];
+
+  meta = with lib; {
+      description = "VersaTiles - A toolbox for converting, checking and serving map tiles in various formats.";
+      longDescription = ''
+        VersaTiles is a Rust-based project designed for processing and serving tile data efficiently.
+        It supports multiple tile formats and offers various functionalities for handling tile data.
+      '';
+      homepage = "https://versatiles.org/";
+      downloadPage = "https://github.com/versatiles-org/versatiles-rs";
+      license = licenses.mit;
+      maintainers = with maintainers;[ wilhelmines ];
+      mainProgram = "versatiles";
+      platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" "x86_64-windows" ];
+    };
+}

--- a/pkgs/by-name/ve/versatiles/package.nix
+++ b/pkgs/by-name/ve/versatiles/package.nix
@@ -17,8 +17,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-SeTDfxoIVTWXI1miolHthIhgBWDtFtPEMWGjmFl/f4o="; # When updating: Same as above
 
+  # Testing only necessary for the `bins` and `lib` features
+  cargoTestFlags = [
+    "--bins"
+    "--lib"
+  ];
+
+  # Skip tests that require network access
   checkFlags = [
-    # Skip tests that require network access
     "--skip tools::convert::tests::test_remote1"
     "--skip tools::convert::tests::test_remote2"
     "--skip tools::probe::tests::test_remote"

--- a/pkgs/by-name/ve/versatiles/package.nix
+++ b/pkgs/by-name/ve/versatiles/package.nix
@@ -1,4 +1,7 @@
-{ lib, fetchFromGitHub, rustPlatform
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -9,10 +12,10 @@ rustPlatform.buildRustPackage rec {
     owner = "versatiles-org";
     repo = "versatiles-rs";
     rev = "a1896bc1e639ec46bd00f89bffaba9181614515a"; # When updating: Replace with long commit hash of new version
-    hash = "sha256-oyTsL+oqpYxIlG7C7yS94TY8c8v15NbQ/U3fJdEEVDQ=" ; # When updating: Use `lib.fakeHash` for recomputing the hash once. Run: 'nix-build -A versatiles'. Swap with new hash and proceed.
+    hash = "sha256-oyTsL+oqpYxIlG7C7yS94TY8c8v15NbQ/U3fJdEEVDQ="; # When updating: Use `lib.fakeHash` for recomputing the hash once. Run: 'nix-build -A versatiles'. Swap with new hash and proceed.
   };
 
-  cargoHash = "sha256-SeTDfxoIVTWXI1miolHthIhgBWDtFtPEMWGjmFl/f4o=" ; # When updating: Same as above
+  cargoHash = "sha256-SeTDfxoIVTWXI1miolHthIhgBWDtFtPEMWGjmFl/f4o="; # When updating: Same as above
 
   checkFlags = [
     # Skip tests that require network access
@@ -23,19 +26,25 @@ rustPlatform.buildRustPackage rec {
     "--skip utils::io::data_reader_http"
     "--skip utils::io::data_reader_http::tests::read_range_git"
     "--skip utils::io::data_reader_http::tests::read_range_googleapis"
-   ];
+  ];
 
   meta = with lib; {
-      description = "VersaTiles - A toolbox for converting, checking and serving map tiles in various formats.";
-      longDescription = ''
-        VersaTiles is a Rust-based project designed for processing and serving tile data efficiently.
-        It supports multiple tile formats and offers various functionalities for handling tile data.
-      '';
-      homepage = "https://versatiles.org/";
-      downloadPage = "https://github.com/versatiles-org/versatiles-rs";
-      license = licenses.mit;
-      maintainers = with maintainers;[ wilhelmines ];
-      mainProgram = "versatiles";
-      platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" "x86_64-windows" ];
-    };
+    description = "VersaTiles - A toolbox for converting, checking and serving map tiles in various formats.";
+    longDescription = ''
+      VersaTiles is a Rust-based project designed for processing and serving tile data efficiently.
+      It supports multiple tile formats and offers various functionalities for handling tile data.
+    '';
+    homepage = "https://versatiles.org/";
+    downloadPage = "https://github.com/versatiles-org/versatiles-rs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wilhelmines ];
+    mainProgram = "versatiles";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+      "x86_64-windows"
+    ];
+  };
 }


### PR DESCRIPTION
## VersaTiles

This is a pull request to add VersaTiles to nixpkgs.

VersaTiles is a Rust-based project designed for processing and serving tile data efficiently. It supports multiple tile formats and offers various functionalities for handling tile data.
More information can be found on the project's website https://versatiles.org as well as on the GitHub repo: https://github.com/versatiles-org/versatiles-rs

Currently, I'm not included in the development of VersaTiles, but have decided to create the package based on a wish on their contributing page. I plan to be the package maintainer. The lead developer knows about my effort and helped me with fixing related bugs.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

