### PR TITLE
angular-language-server: init at 18.2.0

### DIFF
--- a/pkgs/by-name/an/angular-language-server/package.nix
+++ b/pkgs/by-name/an/angular-language-server/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nodejs,
+  makeBinaryWrapper,
+  runCommand,
+  angular-language-server,
+  writeShellApplication,
+  curl,
+  common-updater-scripts,
+  unzip,
+}:
+
+let
+  owner = "angular";
+  repo = "vscode-ng-language-service";
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "angular-language-server";
+  version = "18.2.0";
+  src = fetchurl {
+    name = "${finalAttrs.pname}-${finalAttrs.version}.zip";
+    url = "https://github.com/${owner}/${repo}/releases/download/v${finalAttrs.version}/ng-template.vsix";
+    hash = "sha256-rl04nqSSBMjZfPW8Y+UtFLFLDFd5FSxJs3S937mhDWE=";
+  };
+
+  nativeBuildInputs = [
+    unzip
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [ nodejs ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 server/bin/ngserver $out/lib/bin/ngserver
+    install -Dm755 server/index.js $out/lib/index.js
+    cp -r node_modules $out/lib/node_modules
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    patchShebangs $out/lib/bin/ngserver $out/lib/index.js $out/lib/node_modules
+    makeWrapper $out/lib/bin/ngserver $out/bin/ngserver \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+      --add-flags "--tsProbeLocations $out/lib/node_modules --ngProbeLocations $out/lib/node_modules"
+  '';
+
+  passthru = {
+    tests = {
+      start-ok = runCommand "${finalAttrs.pname}-test" { } ''
+        ${lib.getExe angular-language-server} --stdio --help &> $out
+        cat $out | grep "Angular Language Service that implements the Language Server Protocol (LSP)"
+      '';
+    };
+
+    updateScript = lib.getExe (writeShellApplication {
+      name = "update-${finalAttrs.pname}";
+      runtimeInputs = [
+        curl
+        common-updater-scripts
+      ];
+      text = ''
+        if [ -z "''${GITHUB_TOKEN:-}" ]; then
+            echo "no GITHUB_TOKEN provided - you could meet API request limiting" >&2
+        fi
+
+        LATEST_VERSION=$(curl -H "Accept: application/vnd.github+json" \
+            ''${GITHUB_TOKEN:+-H "Authorization: bearer $GITHUB_TOKEN"} \
+          -Lsf https://api.github.com/repos/${owner}/${repo}/releases/latest | \
+          jq -r .tag_name | cut -c 2-)
+        update-source-version ${finalAttrs.pname} "$LATEST_VERSION"
+      '';
+    });
+  };
+
+  meta = {
+    description = "LSP for angular completions, AOT diagnostic, quick info and go to definitions";
+    homepage = "https://github.com/angular/vscode-ng-language-service";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    changelog = "https://github.com/angular/vscode-ng-language-service/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    mainProgram = "ngserver";
+    maintainers = with lib.maintainers; [ tricktron ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packages the angular language server as binary because packaging from source is especially difficult (see https://github.com/NixOS/nixpkgs/pull/349521 for more details).

Closes https://github.com/NixOS/nixpkgs/issues/244019 and closes https://github.com/NixOS/nixpkgs/pull/349521.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
