### PR TITLE
python312Packages.tensordict: 0.6.2 -> 0.7.0; python312Packages.torchrl: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/tensordict/default.nix
+++ b/pkgs/development/python-modules/tensordict/default.nix
@@ -1,18 +1,17 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
 
   # build-system
   setuptools,
   torch,
-  which,
 
   # dependencies
   cloudpickle,
   numpy,
   orjson,
+  packaging,
 
   # checks
   h5py,
@@ -23,28 +22,26 @@
 
 buildPythonPackage rec {
   pname = "tensordict";
-  version = "0.6.2";
+  version = "0.7.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "tensordict";
     tag = "v${version}";
-    hash = "sha256-dsbpk0O5Gs5WUfi3ENqHdpy4rWoBjm1i44+ycp0jDJ0=";
+    hash = "sha256-KbCNBFewMx4kaWMoV+zREj6XTZiwmR4/I3zpf55wuOQ=";
   };
 
   build-system = [
     setuptools
     torch
-    which
   ];
 
   dependencies = [
     cloudpickle
     numpy
     orjson
+    packaging
     torch
   ];
 
@@ -62,6 +59,10 @@ buildPythonPackage rec {
 
   disabledTests =
     [
+      # FileNotFoundError: [Errno 2] No such file or directory: '/build/source/tensordict/tensorclass.pyi
+      "test_tensorclass_instance_methods"
+      "test_tensorclass_stub_methods"
+
       # Hangs forever
       "test_copy_onto"
 
@@ -86,14 +87,15 @@ buildPythonPackage rec {
       "test_isend"
     ];
 
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    # torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
-    # OpenMP support not found.
-    "test/test_compile.py"
-
-    # ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-    "test/test_distributed.py"
-  ];
+  disabledTestPaths =
+    [
+      # torch._dynamo.exc.Unsupported: Graph break due to unsupported builtin None.ReferenceType.__new__.
+      "test/test_compile.py"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
+      "test/test_distributed.py"
+    ];
 
   meta = {
     description = "Pytorch dedicated tensor container";

--- a/pkgs/development/python-modules/torchrl/default.nix
+++ b/pkgs/development/python-modules/torchrl/default.nix
@@ -48,14 +48,14 @@
 
 buildPythonPackage rec {
   pname = "torchrl";
-  version = "0.6.0";
+  version = "0.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "rl";
     tag = "v${version}";
-    hash = "sha256-2jxvxhhKZQVy1aU0G9PE8nPlg8yp+/+EUACkLNLRpMQ=";
+    hash = "sha256-SMVm1XfHHqSkWTDVSqqO3kIxMBgV9A+XrEpJ56AyaBE=";
   };
 
   build-system = [
@@ -186,5 +186,8 @@ buildPythonPackage rec {
     changelog = "https://github.com/pytorch/rl/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
+    # torhcrl is not compatible with our current version of gymnasium (>=1.0)
+    # https://github.com/pytorch/rl/pull/2473
+    broken = true;
   };
 }


### PR DESCRIPTION
## Things done

Currently `torchrl` is not compatible with `gymnasium>=1.0`.
Hence, I'll hold this back until compatibility has been achieved upstream.

- **python312Packages.tensordict: 0.6.2 -> 0.7.0**
  Changelog: https://github.com/pytorch/tensordict/releases/tag/v0.7.0
- **python312Packages.torchrl: 0.6.0 -> 0.7.0**
  Changelog: https://github.com/pytorch/rl/releases/tag/v0.7.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
