### PR TITLE
protonmail-bridge-gui: patch source to support Qt 6.8

### DIFF
--- a/pkgs/by-name/pr/protonmail-bridge-gui/0001-Fix-ColorImage-Qt-crash.patch
+++ b/pkgs/by-name/pr/protonmail-bridge-gui/0001-Fix-ColorImage-Qt-crash.patch
@@ -1,0 +1,104 @@
+From 5615176ca9eb172f223bec9f85f8ca1d090c2686 Mon Sep 17 00:00:00 2001
+From: Cimbali <me@cimba.li>
+Date: Wed, 23 Oct 2024 12:46:43 +0100
+Subject: [PATCH 1/2] Fix ColorImage Qt crash
+
+---
+ bridge-gui/qml/BugReport/QuestionItem.qml              | 1 +
+ bridge-gui/qml/Proton/InfoTooltip.qml                  | 1 +
+ bridge-gui/qml/Proton/LinkLabel.qml                    | 1 +
+ bridge-gui/qml/SetupWizard/ClientConfigCertInstall.qml | 1 +
+ bridge-gui/qml/SetupWizard/ClientConfigParameters.qml  | 1 +
+ bridge-gui/qml/SetupWizard/ClientListItem.qml          | 1 +
+ bridge-gui/qml/SetupWizard/Login.qml                   | 1 +
+ 7 files changed, 7 insertions(+)
+
+diff --git a/bridge-gui/qml/BugReport/QuestionItem.qml b/bridge-gui/qml/BugReport/QuestionItem.qml
+index 9cf37cc1972d80fbd47ca353ea5d2420b2e05cdf..2e0ca39c63874fe8ede3b9c1eea9ab1ef2800d95 100644
+--- a/bridge-gui/qml/BugReport/QuestionItem.qml
++++ b/bridge-gui/qml/BugReport/QuestionItem.qml
+@@ -13,6 +13,7 @@
+ import QtQuick
+ import QtQuick.Layouts
+ import QtQuick.Controls
++import QtQuick.Controls.impl
+ import Proton
+ 
+ Item {
+diff --git a/bridge-gui/qml/Proton/InfoTooltip.qml b/bridge-gui/qml/Proton/InfoTooltip.qml
+index 281e93e8fb21f179179211d6d750e4c12b685de1..0ec6bf2629f56f26aa92bba209b6eb679bf25d58 100644
+--- a/bridge-gui/qml/Proton/InfoTooltip.qml
++++ b/bridge-gui/qml/Proton/InfoTooltip.qml
+@@ -16,6 +16,7 @@
+ // along with Proton Mail Bridge. If not, see <https://www.gnu.org/licenses/>.
+ import QtQuick
+ import QtQuick.Controls
++import QtQuick.Controls.impl
+ import QtQuick.Layouts
+ 
+ ColorImage {
+diff --git a/bridge-gui/qml/Proton/LinkLabel.qml b/bridge-gui/qml/Proton/LinkLabel.qml
+index 30871f21fa7932c062a0a9d37f9413beaf2277d6..af9b40d2e1afa1d5bc564f3dc96ad811221121bd 100644
+--- a/bridge-gui/qml/Proton/LinkLabel.qml
++++ b/bridge-gui/qml/Proton/LinkLabel.qml
+@@ -12,6 +12,7 @@
+ // along with Proton Mail Bridge. If not, see <https://www.gnu.org/licenses/>.
+ import QtQuick
+ import QtQuick.Controls
++import QtQuick.Controls.impl
+ import QtQuick.Layouts
+ 
+ RowLayout {
+diff --git a/bridge-gui/qml/SetupWizard/ClientConfigCertInstall.qml b/bridge-gui/qml/SetupWizard/ClientConfigCertInstall.qml
+index 1ac498b0ad9af5b8a75986f122e3cd6ef25318c3..9790afe9c5a9a15b64cf1655edc90b850c78fdf5 100644
+--- a/bridge-gui/qml/SetupWizard/ClientConfigCertInstall.qml
++++ b/bridge-gui/qml/SetupWizard/ClientConfigCertInstall.qml
+@@ -15,6 +15,7 @@ import QtQml
+ import QtQuick
+ import QtQuick.Layouts
+ import QtQuick.Controls
++import QtQuick.Controls.impl
+ 
+ Item {
+     id: root
+diff --git a/bridge-gui/qml/SetupWizard/ClientConfigParameters.qml b/bridge-gui/qml/SetupWizard/ClientConfigParameters.qml
+index 52e3fec2e97c68fe2931d2c3d78c27082bbba0b5..2a4c7d39a5b8fb33c847a786a9fcd044483ad7a1 100644
+--- a/bridge-gui/qml/SetupWizard/ClientConfigParameters.qml
++++ b/bridge-gui/qml/SetupWizard/ClientConfigParameters.qml
+@@ -14,6 +14,7 @@ import QtQml
+ import QtQuick
+ import QtQuick.Layouts
+ import QtQuick.Controls
++import QtQuick.Controls.impl
+ import ".."
+ 
+ Rectangle {
+diff --git a/bridge-gui/qml/SetupWizard/ClientListItem.qml b/bridge-gui/qml/SetupWizard/ClientListItem.qml
+index 3e781d1654880ab56f0b9e5104456c1ea385291e..30e9307e28b2c3c996d2cd44a51dbc82166a4f78 100644
+--- a/bridge-gui/qml/SetupWizard/ClientListItem.qml
++++ b/bridge-gui/qml/SetupWizard/ClientListItem.qml
+@@ -14,6 +14,7 @@ import QtQml
+ import QtQuick
+ import QtQuick.Layouts
+ import QtQuick.Controls
++import QtQuick.Controls.impl
+ 
+ Rectangle {
+     id: root
+diff --git a/bridge-gui/qml/SetupWizard/Login.qml b/bridge-gui/qml/SetupWizard/Login.qml
+index 20eba75312a335f4f61d1cf8455a53a0d352cc1e..2f1a86a92b4216b4c6b9c9551552048432330ef4 100644
+--- a/bridge-gui/qml/SetupWizard/Login.qml
++++ b/bridge-gui/qml/SetupWizard/Login.qml
+@@ -14,6 +14,7 @@ import QtQml
+ import QtQuick
+ import QtQuick.Layouts
+ import QtQuick.Controls
++import QtQuick.Controls.impl
+ 
+ FocusScope {
+     id: root
+
+base-commit: df78e292341043b196c2aba812fc48d2c2e8501b
+-- 
+2.46.1
+

--- a/pkgs/by-name/pr/protonmail-bridge-gui/0002-Avoid-name-clash-with-6.8-introduced-popupType.patch
+++ b/pkgs/by-name/pr/protonmail-bridge-gui/0002-Avoid-name-clash-with-6.8-introduced-popupType.patch
@@ -1,0 +1,80 @@
+From 834a2f910a30086132d53004fd8f7d770925bdad Mon Sep 17 00:00:00 2001
+From: Cimbali <me@cimba.li>
+Date: Wed, 23 Oct 2024 13:26:43 +0100
+Subject: [PATCH 2/2] Avoid name clash with 6.8-introduced popupType
+
+---
+ bridge-gui/qml/Banner.qml                   | 2 +-
+ bridge-gui/qml/Proton/ApplicationWindow.qml | 6 +++---
+ bridge-gui/qml/Proton/Dialog.qml            | 2 +-
+ bridge-gui/qml/Proton/Popup.qml             | 2 +-
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/bridge-gui/qml/Banner.qml b/bridge-gui/qml/Banner.qml
+index f3affdc90f5f7e068cbda3a5445551255ee0f24f..88d3a48abe857b7812ee80be28b241e7c4a3924c 100644
+--- a/bridge-gui/qml/Banner.qml
++++ b/bridge-gui/qml/Banner.qml
+@@ -28,7 +28,7 @@ Popup {
+     implicitWidth: 600 // contentLayout.implicitWidth + contentLayout.anchors.leftMargin + contentLayout.anchors.rightMargin
+     leftMargin: (mainWindow.width - root.implicitWidth) / 2
+     modal: false
+-    popupType: ApplicationWindow.PopupType.Banner
++    popupPrio: ApplicationWindow.PopupPriority.Banner
+     shouldShow: notification ? (notification.active && !notification.dismissed) : false
+     topMargin: 37
+ 
+diff --git a/bridge-gui/qml/Proton/ApplicationWindow.qml b/bridge-gui/qml/Proton/ApplicationWindow.qml
+index ef23ede58bf2db67799714e2f2c0c47e74ce10a9..7220789670776a8749d79a219993237585d52208 100644
+--- a/bridge-gui/qml/Proton/ApplicationWindow.qml
++++ b/bridge-gui/qml/Proton/ApplicationWindow.qml
+@@ -21,7 +21,7 @@ T.ApplicationWindow {
+     id: root
+ 
+     // popup priority based on types
+-    enum PopupType {
++    enum PopupPriority {
+         Banner,
+         Dialog
+     }
+@@ -78,10 +78,10 @@ T.ApplicationWindow {
+                 topmost = obj;
+                 break;
+             }
+-            if (topmost && (topmost.popupType > obj.popupType)) {
++            if (topmost && (topmost.popupPrio > obj.popupPrio)) {
+                 continue;
+             }
+-            if (topmost && (topmost.popupType === obj.popupType) && (topmost.occurred > obj.occurred)) {
++            if (topmost && (topmost.popupPrio === obj.popupPrio) && (topmost.occurred > obj.occurred)) {
+                 continue;
+             }
+             topmost = obj;
+diff --git a/bridge-gui/qml/Proton/Dialog.qml b/bridge-gui/qml/Proton/Dialog.qml
+index f1ab61a0374e916ce6ab3819de33828af063bbee..30e7a99d854d952178ffed731062789f6ac98150 100644
+--- a/bridge-gui/qml/Proton/Dialog.qml
++++ b/bridge-gui/qml/Proton/Dialog.qml
+@@ -21,7 +21,7 @@ T.Dialog {
+ 
+     property ColorScheme colorScheme
+     readonly property var occurred: shouldShow ? new Date() : undefined
+-    readonly property int popupType: ApplicationWindow.PopupType.Dialog
++    readonly property int popupPrio: ApplicationWindow.PopupPriority.Dialog
+     property bool shouldShow: false
+ 
+     function close() {
+diff --git a/bridge-gui/qml/Proton/Popup.qml b/bridge-gui/qml/Proton/Popup.qml
+index 68c3af7c52eb6a9864b24d58155844bc219504e0..78fa29c1eb259b708f8301fcde8e21a40e3c0563 100644
+--- a/bridge-gui/qml/Proton/Popup.qml
++++ b/bridge-gui/qml/Proton/Popup.qml
+@@ -21,7 +21,7 @@ T.Popup {
+ 
+     property ColorScheme colorScheme
+     readonly property var occurred: shouldShow ? new Date() : undefined
+-    property int popupType: ApplicationWindow.PopupType.Banner
++    property int popupPrio: ApplicationWindow.PopupPriority.Banner
+     property bool shouldShow: false
+ 
+     function close() {
+-- 
+2.46.1
+

--- a/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
+++ b/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
@@ -21,6 +21,9 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Use `gtest` from Nixpkgs to allow an offline build
     ./use-nix-googletest.patch
+    # From https://github.com/ProtonMail/proton-bridge/pull/502 hopefully superceded by next upstream release
+    ./0001-Fix-ColorImage-Qt-crash.patch
+    ./0002-Avoid-name-clash-with-6.8-introduced-popupType.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
+++ b/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
@@ -65,6 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i "/add_subdirectory(bridge-gui-tester)/d" CMakeLists.txt
   '';
 
+  __structuredAttrs = true; # to allow spaces in `cmakeFlags`
+
   cmakeFlags = [
     "-DBRIDGE_APP_FULL_NAME=Proton Mail Bridge"
     "-DBRIDGE_VENDOR=Proton AG"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/350165 (runtime errors encountered when using a version of the GUI built with Qt 6.8). Patches upstream's Qt Modeling Language (QML) files to support Qt 6.8. [Proton AG seem unlikely to update upstream to support Qt 6.8 anytime soon.](https://github.com/ProtonMail/proton-bridge/issues/500)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
