### PR TITLE
splice.nix: improve performance with early cut-off 

### DIFF
--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -129,6 +129,15 @@ let
     "packages"
   ];
 
+  packagesWithXorg = pkgs // builtins.removeAttrs pkgs.xorg [
+    "callPackage"
+    "newScope"
+    "overrideScope"
+    "packages"
+  ];
+
+  pkgsForCall = if actuallySplice then splicedPackagesWithXorg else packagesWithXorg;
+
 in
 
 {
@@ -139,9 +148,9 @@ in
   # `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).
   callPackage = pkgs.newScope { };
 
-  callPackages = lib.callPackagesWith splicedPackagesWithXorg;
+  callPackages = lib.callPackagesWith pkgsForCall;
 
-  newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // extra);
+  newScope = extra: lib.callPackageWith (pkgsForCall // extra);
 
   # prefill 2 fields of the function for convenience
   makeScopeWithSplicing = lib.makeScopeWithSplicing splicePackages pkgs.newScope;
@@ -170,5 +179,5 @@ in
 
   # Haskell package sets need this because they reimplement their own
   # `newScope`.
-  __splicedPackages = splicedPackages // { recurseForDerivations = false; };
+  __splicedPackages = if actuallySplice then splicedPackages // { recurseForDerivations = false; } else pkgs;
 }


### PR DESCRIPTION
All these https://www.github.com/NixOS/nixpkgs/blob/062c4f59744fcffa2e5aa3ef443dc8b4d1674ed6/pkgs/top-level/splice.nix#L116-L121
are already in pkgs, so they don't have to be added on top again when there's no splicing

|stat                  | before         | after          | Δ              | Δ%    |
|----------------------|----------------|----------------|----------------|-------|
|cpuTime               | 767.33         | 757.25         | ↘ 10.08        | -1.31%|
|envs-bytes            | 23,767,294,088 | 23,767,243,520 | ↘ 50,568       | -0.00%|
|envs-elements         | 1,260,156,605  | 1,260,151,924  | ↘ 4,681        | -0.00%|
|envs-number           | 855,377,578    | 855,376,758    | ↘ 820          | -0.00%|
|gc-heapSize           | 66,525,835,264 | 64,428,679,168 | ↘ 2,097,156,096| -3.15%|
|gc-totalBytes         | 146,231,201,712| 145,437,495,488| ↘ 793,706,224  | -0.54%|
|list-bytes            | 3,319,349,160  | 3,319,349,160  | 0              |       |
|list-concats          | 88,567,304     | 88,567,304     | 0              |       |
|list-elements         | 414,918,645    | 414,918,645    | 0              |       |
|nrAvoided             | 989,429,178    | 989,427,108    | ↘ 2,070        | -0.00%|
|nrFunctionCalls       | 784,049,358    | 784,048,538    | ↘ 820          | -0.00%|
|nrLookups             | 412,401,378    | 412,399,016    | ↘ 2,362        | -0.00%|
|nrOpUpdateValuesCopied| 2,132,453,124  | 2,082,900,933  | ↘ 49,552,191   | -2.32%|
|nrOpUpdates           | 99,050,775     | 99,048,489     | ↘ 2,286        | -0.00%|
|nrPrimOpCalls         | 411,581,753    | 411,581,753    | 0              |       |
|nrThunks              | 1,248,612,305  | 1,248,600,848  | ↘ 11,457       | -0.00%|
|sets-bytes            | 48,379,815,792 | 47,586,523,600 | ↘ 793,292,192  | -1.64%|
|sets-elements         | 2,840,072,218  | 2,790,496,848  | ↘ 49,575,370   | -1.75%|
|sets-number           | 183,666,269    | 183,660,877    | ↘ 5,392        | -0.00%|
|sizes-Attr            | 16             | 16             | 0              |       |
|sizes-Bindings        | 16             | 16             | 0              |       |
|sizes-Env             | 16             | 16             | 0              |       |
|sizes-Value           | 24             | 24             | 0              |       |
|symbols-bytes         | 3,454,822      | 3,454,838      | ↗ 16           | 0.00% |
|symbols-number        | 188,756        | 188,757        | ↗ 1            | 0.00% |
|values-bytes          | 38,132,032,032 | 38,131,756,776 | ↘ 275,256      | -0.00%|
|values-number         | 1,588,834,668  | 1,588,823,199  | ↘ 11,469       | -0.00%|

The table was formatted manually from stats copied from ofborg(I forgot how to do it properly), so it may
look a bit wonky