### PR TITLE
splice.nix: remove toplevel {build,host,target}Platform in `__splicedPackages`

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -1,7 +1,6 @@
 { stdenv, lib, fetchpatch
 , recompressTarball
 , buildPackages
-, buildPlatform
 , pkgsBuildBuild
 # Channel data:
 , channel, upstream-info

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,9 +1,9 @@
-{ hostPlatform, callPackage }:
+{ stdenv, callPackage }:
 {
   signal-desktop =
-    if hostPlatform.system == "aarch64-linux" then
+    if stdenv.hostPlatform.system == "aarch64-linux" then
       callPackage ./signal-desktop-aarch64.nix { }
-    else if hostPlatform.isDarwin then
+    else if stdenv.hostPlatform.isDarwin then
       callPackage ./signal-desktop-darwin.nix { }
     else
       callPackage ./signal-desktop.nix { };

--- a/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
+++ b/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
@@ -1,11 +1,11 @@
 { lib
 , fetchFromGitHub
-, hostPlatform
+, stdenv
 , lld
 }:
 
 let
-  arch = hostPlatform.qemuArch;
+  arch = stdenv.hostPlatform.qemuArch;
 
   target = ./. + "/${arch}-unknown-none.json";
 
@@ -15,7 +15,7 @@ assert lib.assertMsg (builtins.pathExists target) "Target spec not found";
 
 let
   cross = import ../../../.. {
-    system = hostPlatform.system;
+    system = stdenv.hostPlatform.system;
     crossSystem = lib.systems.examples."${arch}-embedded" // {
       rust.rustcTarget = "${arch}-unknown-none";
       rust.platform = lib.importJSON target;

--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  targetPlatform,
   fetchurl,
   python312,
   SDL2,
@@ -30,7 +29,7 @@ let
         hash = "sha256-o1Yg0C5k07NZzc9jQrHXR+kkQl8HZ55U9/fqcpe3Iyw=";
       };
     }
-    .${targetPlatform.system} or (throw "${targetPlatform.system} is unsupported.");
+    .${stdenv.targetPlatform.system} or (throw "${stdenv.targetPlatform.system} is unsupported.");
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "bombsquad";

--- a/pkgs/by-name/pu/pupdate/package.nix
+++ b/pkgs/by-name/pu/pupdate/package.nix
@@ -5,7 +5,6 @@
 , dotnetCorePackages
 , openssl
 , zlib
-, hostPlatform
 , nix-update-script
 }:
 
@@ -30,7 +29,7 @@ buildDotnetModule rec {
   patches = [ ./add-runtime-identifier.patch ];
   postPatch = ''
     substituteInPlace pupdate.csproj \
-      --replace @RuntimeIdentifier@ "${dotnetCorePackages.systemToDotnetRid hostPlatform.system}"
+      --replace @RuntimeIdentifier@ "${dotnetCorePackages.systemToDotnetRid stdenv.hostPlatform.system}"
   '';
 
   projectFile = "pupdate.csproj";

--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -3,12 +3,10 @@
   callPackage,
   writeText,
   symlinkJoin,
-  targetPlatform,
-  buildPlatform,
   darwin,
   clang,
   llvm,
-  tools ? callPackage ./tools.nix { inherit buildPlatform; },
+  tools ? callPackage ./tools.nix { },
   stdenv,
   stdenvNoCC,
   dart,
@@ -53,7 +51,7 @@ let
 
   expandDeps = deps: lib.flatten (map expandSingleDep deps);
 
-  constants = callPackage ./constants.nix { platform = targetPlatform; };
+  constants = callPackage ./constants.nix { platform = stdenv.targetPlatform; };
 
   python3 = if lib.versionAtLeast flutterVersion "3.20" then python312 else python39;
 
@@ -64,8 +62,6 @@ let
       version
       hashes
       url
-      targetPlatform
-      buildPlatform
       ;
   };
 
@@ -253,7 +249,7 @@ stdenv.mkDerivation (finalAttrs: {
       "--embedder-for-target"
       "--no-goma"
     ]
-    ++ lib.optionals (targetPlatform.isx86_64 == false) [
+    ++ lib.optionals (stdenv.targetPlatform.isx86_64 == false) [
       "--linux"
       "--linux-cpu ${constants.alt-arch}"
     ]
@@ -278,7 +274,7 @@ stdenv.mkDerivation (finalAttrs: {
         --out-dir $out \
         --target-sysroot $toolchain \
         --target-dir $outName \
-        --target-triple ${targetPlatform.config} \
+        --target-triple ${stdenv.targetPlatform.config} \
         --enable-fontconfig
 
       runHook postConfigure

--- a/pkgs/development/compilers/flutter/engine/tools.nix
+++ b/pkgs/development/compilers/flutter/engine/tools.nix
@@ -5,8 +5,6 @@
   fetchurl,
   writeText,
   runCommand,
-  buildPlatform,
-  hostPlatform,
   darwin,
   writeShellScriptBin,
   depot_toolsCommit ? "7d95eb2eb054447592585c73a8ff7adad97ecba1",
@@ -31,8 +29,8 @@
   },
 }:
 let
-  constants = callPackage ./constants.nix { platform = buildPlatform; };
-  host-constants = callPackage ./constants.nix { platform = hostPlatform; };
+  constants = callPackage ./constants.nix { platform = stdenv.buildPlatform; };
+  host-constants = callPackage ./constants.nix { platform = stdenv.hostPlatform; };
   stdenv-constants = callPackage ./constants.nix { platform = stdenv.hostPlatform; };
 in
 {

--- a/pkgs/development/compilers/zig/cc.nix
+++ b/pkgs/development/compilers/zig/cc.nix
@@ -3,7 +3,7 @@
   wrapCCWith,
   makeWrapper,
   runCommand,
-  targetPlatform,
+  stdenv,
   targetPackages,
   zig,
 }:
@@ -34,9 +34,9 @@ wrapCCWith {
   nixSupport.cc-cflags =
     [
       "-target"
-      "${targetPlatform.parsed.cpu.name}-${targetPlatform.parsed.kernel.name}-${targetPlatform.parsed.abi.name}"
+      "${stdenv.targetPlatform.parsed.cpu.name}-${stdenv.targetPlatform.parsed.kernel.name}-${stdenv.targetPlatform.parsed.abi.name}"
     ]
     ++ lib.optional (
-      targetPlatform.isLinux && !(targetPackages.isStatic or false)
+      stdenv.targetPlatform.isLinux && !(targetPackages.isStatic or false)
     ) "-Wl,-dynamic-linker=${targetPackages.stdenv.cc.bintools.dynamicLinker}";
 }

--- a/pkgs/development/python-modules/conda/default.nix
+++ b/pkgs/development/python-modules/conda/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  hostPlatform,
+  stdenv,
   fetchFromGitHub,
   # build dependencies
   hatchling,
@@ -72,7 +72,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "conda" ];
 
   # menuinst is currently not packaged
-  pythonRemoveDeps = lib.optionals (!hostPlatform.isWindows) [ "menuinst" ];
+  pythonRemoveDeps = lib.optionals (!stdenv.hostPlatform.isWindows) [ "menuinst" ];
 
   meta = {
     description = "OS-agnostic, system-level binary package manager";

--- a/pkgs/tools/networking/rosenpass/default.nix
+++ b/pkgs/tools/networking/rosenpass/default.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , nixosTests
 , rustPlatform
-, hostPlatform
+, stdenv
 , installShellFiles
 , cmake
 , libsodium
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
 
   # nix defaults to building for aarch64 _without_ the armv8-a
   # crypto extensions, but liboqs depends on these
-  preBuild = lib.optionalString hostPlatform.isAarch64 ''
+  preBuild = lib.optionalString stdenv.hostPlatform.isAarch64 ''
     NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -march=armv8-a+crypto"
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25964,9 +25964,11 @@ with pkgs;
     fetchurl = import ../build-support/fetchurl/boot.nix {
       inherit (stdenv.buildPlatform) system;
     };
-    checkMeta = callPackage ../stdenv/generic/check-meta.nix { };
+    checkMeta = callPackage ../stdenv/generic/check-meta.nix { inherit (stdenv) hostPlatform; };
   });
-  minimal-bootstrap-sources = callPackage ../os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix { };
+  minimal-bootstrap-sources = callPackage ../os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix {
+    inherit (stdenv) hostPlatform;
+  };
   make-minimal-bootstrap-sources = callPackage ../os-specific/linux/minimal-bootstrap/stage0-posix/make-bootstrap-sources.nix {
     inherit (stdenv) hostPlatform;
   };

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -119,7 +119,6 @@ let
       pkgsTargetTarget
       buildPackages pkgs targetPackages
       ;
-    inherit (pkgs.stdenv) buildPlatform targetPlatform hostPlatform;
   };
 
   splicedPackagesWithXorg = splicedPackages // builtins.removeAttrs splicedPackages.xorg [


### PR DESCRIPTION
These should have been removed in ecab3ede but were not discovered.

Since these were only in `__splicedPackages` they were only available in `callPackage`, now that they are removed the entries in aliases.nix will take over.

https://www.github.com/NixOS/nixpkgs/blob/e056730f13ab6ed6d8325d4343752f7f9b9bf60b/pkgs/top-level/aliases.nix#L1817


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
