### PR TITLE
nixos/nginx: add strictTransportSecurity options

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -209,15 +209,16 @@ let
               # https://ssl-config.mozilla.org/#server=nginx&config=intermediate that
               # isn't already handled by some other option.
               ''
-              ssl_ecdh_curve X25519:prime256v1:secp384r1;
-              ssl_session_timeout 1d;
-              ssl_session_cache shared:SSL:10m;
-              # Breaks forward secrecy: https://github.com/mozilla/server-side-tls/issues/135
-              ssl_session_tickets off;
-              # We don't enable insecure ciphers by default, so this allows
-              # clients to pick the most performant, per https://github.com/mozilla/server-side-tls/issues/260
-              ssl_prefer_server_ciphers off;
-            ''}
+                ssl_ecdh_curve X25519:prime256v1:secp384r1;
+                ssl_session_timeout 1d;
+                ssl_session_cache shared:SSL:10m;
+                # Breaks forward secrecy: https://github.com/mozilla/server-side-tls/issues/135
+                ssl_session_tickets off;
+                # We don't enable insecure ciphers by default, so this allows
+                # clients to pick the most performant, per https://github.com/mozilla/server-side-tls/issues/260
+                ssl_prefer_server_ciphers off;
+              ''
+            }
 
             ${optionalString cfg.recommendedBrotliSettings ''
               brotli on;
@@ -449,12 +450,11 @@ let
               ''}
             '';
 
-        hstsValue =
-          concatStringsSep "; " (
-            [ "max-age=${toString vhost.strictTransportSecurity.seconds}" ]
-            ++ optional vhost.strictTransportSecurity.includeSubdomains "includeSubdomains"
-            ++ optional vhost.strictTransportSecurity.preload "preload"
-          );
+        hstsValue = concatStringsSep "; " (
+          [ "max-age=${toString vhost.strictTransportSecurity.seconds}" ]
+          ++ optional vhost.strictTransportSecurity.includeSubdomains "includeSubdomains"
+          ++ optional vhost.strictTransportSecurity.preload "preload"
+        );
       in
       ''
         ${optionalString vhost.forceSSL ''

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -267,10 +267,8 @@ with lib;
         type = types.int;
         default = 63072000;
         description = ''
-          If HTTP Strict Transport Security (HSTS) is enabled by
-          `strictTransportSecurity.enable`, this is how long the browser is
-          instructed to retain the setting, in seconds. 2 years (63072000 seconds)
-          is recommended, but if you're introducing HSTS for the first time on an
+          This is how long the browser is instructed to retain the HSTS setting in seconds.
+          2 years (63072000 seconds) is recommended, but if you're introducing HSTS for the first time on an
           existing site you may want to ramp up the value gradually, or set it to
           0 to tell clients to drop their HSTS config for this domain.
         '';
@@ -280,12 +278,12 @@ with lib;
         type = types.bool;
         default = false;
         description = ''
-          If HTTP Strict Transport Security (HSTS) is enabled by
-          `strictTransportSecurity.enable`, also specify the `includeSubdomains`
-          directive, so that e.g. if the vhost is https://www.website.example it
-          also sets the HSTS policy for https://sub.www.website.example. (Note
-          that "sibling" domains like https://mail.website.example are not
-          affected.)
+          Also specify the `includeSubdomains` directive, so that e.g. if the virtual host is `https://www.example.com` it
+          also sets the HSTS policy for `https://sub.www.example.com`
+          
+          ::: {.note}
+          "Sibling" domains like https://mail.example.com are not affected.
+          :::
         '';
       };
 
@@ -295,9 +293,7 @@ with lib;
         # default
         default = false;
         description = ''
-          If HTTP Strict Transport Security (HSTS) is enabled by
-          `strictTransportSecurity.enable`, also specify the (non-standard, but
-          widely recognised) `preload` directive. This allows submitting your
+          Also specify the `preload` directive. This allows submitting your
           site to https://hstspreload.org/ to be added to the HSTS preload list
           used by all major browsers, so that it is not necessary to visit your
           site even once to enable HSTS.

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -239,11 +239,10 @@ with lib;
         default = false;
         description = ''
           Whether to enable HTTP Strict Transport Security (HSTS). This sends
-          the header "strict-transport-security: max-age=63072000" on all
+          the header "strict-transport-security: max-age=N" on all
           responses, which tells clients to refuse to use an insecure HTTP
-          connection for this host for the next 63072000 seconds (approximately
-          2 years), or for the duration specified by
-          `strictTransportSecurity.seconds` if set. This helps protects against
+          connection for this host for the next N seconds, where N is specified
+          by `strictTransportSecurity.seconds`. This helps protects against
           man-in-the-middle attacks that e.g. block HTTPS connections in the
           hope that the client will fall back to an insecure HTTP connection,
           which can be intercepted and modified.

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -264,13 +264,14 @@ with lib;
       };
 
       seconds = mkOption {
-        type = types.int;
+        type = types.ints.unsigned;
         default = 63072000;
         description = ''
-          This is how long the browser is instructed to retain the HSTS setting in seconds.
-          2 years (63072000 seconds) is recommended, but if you're introducing HSTS for the first time on an
-          existing site you may want to ramp up the value gradually, or set it to
-          0 to tell clients to drop their HSTS config for this domain.
+          This is how long the browser is instructed to retain the HSTS setting
+          in seconds. 2 years (63072000 seconds) is recommended, but if you're
+          introducing HSTS for the first time on an existing site you may want
+          to ramp up the value gradually, or set it to 0 to tell clients to drop
+          their HSTS config for this domain.
         '';
       };
 
@@ -278,9 +279,10 @@ with lib;
         type = types.bool;
         default = false;
         description = ''
-          Also specify the `includeSubdomains` directive, so that e.g. if the virtual host is `https://www.example.com` it
-          also sets the HSTS policy for `https://sub.www.example.com`
-          
+          Also specify the `includeSubdomains` directive in the HSTS header, so
+          that e.g. if the virtual host is `https://www.example.com` it also
+          sets the HSTS policy for `https://sub.www.example.com`.
+
           ::: {.note}
           "Sibling" domains like https://mail.example.com are not affected.
           :::

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -278,7 +278,7 @@ with lib;
 
       includeSubdomains = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           If HTTP Strict Transport Security (HSTS) is enabled by
           `strictTransportSecurity.enable`, also specify the `includeSubdomains`

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -282,6 +282,11 @@ with lib;
           that e.g. if the virtual host is `https://www.example.com` it also
           sets the HSTS policy for `https://sub.www.example.com`.
 
+          This can be especially helpful if you have rarely-visited subdomains
+          of a frequently-visited parent domain, but it can also be hazardous
+          since it can enable HSTS for a subdomain which doesn't actually
+          support HTTPS, which would make it fully inaccessible.
+
           ::: {.note}
           "Sibling" domains like https://mail.example.com are not affected.
           :::


### PR DESCRIPTION
Let me know if this needs a changelog entry, I wasn't sure whether it was significant enough.

This is my first nontrivial nixpkgs PR, so sorry about any mess :) I didn't `nixfmt` these modules because it would change a lot more than what I touched.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
