### PR TITLE
minion: init at 3.0.12

### DIFF
--- a/pkgs/by-name/mi/minion/package.nix
+++ b/pkgs/by-name/mi/minion/package.nix
@@ -1,0 +1,76 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+  openjfx21,
+  openjdk21,
+  makeDesktopItem,
+  wrapGAppsHook3,
+  makeBinaryWrapper,
+}:
+
+let
+  openjfx_jdk = openjfx21.override { withWebKit = true; };
+  openjdk = openjdk21.override {
+    enableJavaFX = true;
+    inherit openjfx_jdk;
+  };
+
+  jvmArgs = [
+    "-cp $out/share/minion/lib"
+    "--add-exports=javafx.graphics/com.sun.javafx.css=ALL-UNNAMED"
+    "--add-exports=javafx.graphics/javafx.scene.image=ALL-UNNAMED"
+    "--add-opens=javafx.graphics/javafx.scene.image=ALL-UNNAMED"
+    "--add-opens=java.base/java.lang=ALL-UNNAMED"
+  ];
+in
+stdenvNoCC.mkDerivation rec {
+  version = "3.0.12";
+  pname = "minion";
+
+  src = fetchzip {
+    url = "https://cdn.mmoui.com/minion/v3/Minion${version}-java.zip";
+    hash = "sha256-KjSj3TBMY3y5kgIywtIDeil0L17dau/Rb2HuXAulSO8=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    wrapGAppsHook3
+  ];
+
+  dontWrapGApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D Minion-jfx.jar "$out/share/minion/Minion-jfx.jar"
+    cp -r ./lib "$out/share/minion/"
+
+    makeWrapper ${lib.getExe openjdk} $out/bin/minion \
+      "''${gappsWrapperArgs[@]}" \
+      --add-flags "${lib.concatStringsSep " " jvmArgs} -jar $out/share/minion/Minion-jfx.jar"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "minion";
+      exec = "minion";
+      comment = "MMO Addon manager for Elder Scrolls Online and World of Warcraft";
+      desktopName = "Minion";
+      categories = [ "Game" ];
+    })
+  ];
+
+  meta = {
+    description = "Addon manager for World of Warcraft and The Elder Scrolls Online";
+    homepage = "https://minion.mmoui.com/";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    mainProgram = "minion";
+    maintainers = with lib.maintainers; [ patrickdag ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+  };
+}


### PR DESCRIPTION
New package minion a MMO Addon manager for WOW and ESO from https://minion.mmoui.com/.
Close #142868

Adapted from @Vodurden, big thanks, and if you want to be credited somehow lmk.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
