### PR TITLE
libhv: 1.3.2 → 1.3.3

### DIFF
--- a/pkgs/by-name/li/libhv/package.nix
+++ b/pkgs/by-name/li/libhv/package.nix
@@ -5,7 +5,7 @@
   cmake,
   curl,
   openssl,
-  Security,
+  darwin,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     curl
     openssl
-  ] ++ lib.optional stdenv.hostPlatform.isDarwin Security;
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Security;
 
   cmakeFlags = [
     "-DENABLE_UDS=ON"

--- a/pkgs/development/libraries/libhv/default.nix
+++ b/pkgs/development/libraries/libhv/default.nix
@@ -1,25 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, curl, openssl, Security }:
+{ lib, stdenv, fetchFromGitHub, cmake, curl, openssl, Security }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libhv";
-  version = "1.3.2";
+  version = "1.3.3";
 
   src = fetchFromGitHub {
     owner = "ithewei";
     repo = "libhv";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-tVuQwj2HvAhp51urGCuNPjBEIaTu9yR031Ih/5or9Pk=";
+    hash = "sha256-N2YD84eORA5nDpeeqy9jCvRx86PkRaKLzI6LF1AnHtU=";
   };
-
-  patches = [
-    # Fix build failure on gcc-13:
-    #   https://github.com/ithewei/libhv/pull/490
-    (fetchpatch {
-      name = "gcc-13.patch";
-      url = "https://github.com/ithewei/libhv/commit/b3e61519fbdbbb956fed275c0a849ba5d4d6e45c.patch";
-      hash = "sha256-fuYI+B3qZkSAbLZc0p6/0fnqaHx6w9N9vhTEE2t6UUs=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/libraries/libhv/default.nix
+++ b/pkgs/development/libraries/libhv/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, cmake, curl, openssl, Security }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  curl,
+  openssl,
+  Security,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libhv";
@@ -13,7 +21,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ curl openssl ] ++ lib.optional stdenv.hostPlatform.isDarwin Security;
+  buildInputs = [
+    curl
+    openssl
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin Security;
 
   cmakeFlags = [
     "-DENABLE_UDS=ON"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21012,10 +21012,6 @@ with pkgs;
 
   libhugetlbfs = callPackage ../development/libraries/libhugetlbfs { };
 
-  libhv = callPackage ../development/libraries/libhv {
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
-
   libhwy = callPackage ../development/libraries/libhwy { };
 
   libHX = callPackage ../development/libraries/libHX { };


### PR DESCRIPTION
https://github.com/ithewei/libhv/releases/tag/v1.3.3
Fixes CVE-2023-26146, CVE-2023-26147, CVE-2023-26148

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
