### PR TITLE
python312Packages.httpx-ws: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/development/python-modules/httpx-ws/default.nix
+++ b/pkgs/development/python-modules/httpx-ws/default.nix
@@ -1,17 +1,17 @@
 {
   lib,
+  anyio,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   hatchling,
-  anyio,
   httpcore,
   httpx,
-  wsproto,
   pytestCheckHook,
+  pythonOlder,
   starlette,
   trio,
   uvicorn,
+  wsproto,
 }:
 
 buildPythonPackage rec {
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   version = "0.6.2";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "frankie567";
@@ -46,14 +46,14 @@ buildPythonPackage rec {
     wsproto
   ];
 
-  pythonImportsCheck = [ "httpx_ws" ];
-
   nativeCheckInputs = [
     pytestCheckHook
     starlette
     trio
     uvicorn
   ];
+
+  pythonImportsCheck = [ "httpx_ws" ];
 
   disabledTestPaths = [
     # hang
@@ -63,6 +63,8 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "WebSocket support for HTTPX";
     homepage = "https://github.com/frankie567/httpx-ws";
+    changelog = "https://github.com/frankie567/httpx-ws/releases/tag/v${version}";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/httpx-ws/default.nix
+++ b/pkgs/development/python-modules/httpx-ws/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "httpx-ws";
-  version = "0.6.1";
+  version = "0.6.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "frankie567";
     repo = "httpx-ws";
     rev = "refs/tags/v${version}";
-    hash = "sha256-mynr07px+rQb7x8GepQoUgBbh0720S0K2RJrboOoJXA=";
+    hash = "sha256-VsIYOGNEdX4rxjEa01M77arA3ddJS3cPFxXlf13QTuE=";
   };
 
   # we don't need to use the hatch-regex-commit plugin


### PR DESCRIPTION
Diff: https://github.com/frankie567/httpx-ws/compare/refs/tags/v0.6.1...v0.6.2

Changelog: https://github.com/frankie567/httpx-ws/releases/tag/v0.6.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
