### PR TITLE
versatiles: init at 0.12.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23072,6 +23072,13 @@
     githubId = 1215623;
     keys = [ { fingerprint = "DA03 D6C6 3F58 E796 AD26  E99B 366A 2940 479A 06FC"; } ];
   };
+  wilhelmines = {
+    email = "mail@aesz.org";
+    matrix = "@wilhelmines:matrix.org";
+    name = "Ronja Schwarz";
+    github = "wilhelmines";
+    githubId = 71409721;
+  };
   willbush = {
     email = "git@willbush.dev";
     matrix = "@willbush:matrix.org";

--- a/pkgs/by-name/ve/versatiles/package.nix
+++ b/pkgs/by-name/ve/versatiles/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "versatiles";
+  version = "0.12.10"; # When updating: Replace with current version
+
+  src = fetchFromGitHub {
+    owner = "versatiles-org";
+    repo = "versatiles-rs";
+    rev = "refs/tags/v${version}"; # When updating: Replace with long commit hash of new version
+    hash = "sha256-LKUpxsAy39dX8hESlUEVs4rkOpYsd7kbATfnU1QYd9Q="; # When updating: Use `lib.fakeHash` for recomputing the hash once. Run: 'nix-build -A versatiles'. Swap with new hash and proceed.
+  };
+
+  cargoHash = "sha256-dkFnoQY1+VNNrjS+o5Y0cvhWKoHt38KJKyNhCQ0dGaY="; # When updating: Same as above
+
+  # Testing only necessary for the `bins` and `lib` features
+  cargoTestFlags = [
+    "--bins"
+    "--lib"
+  ];
+
+  # Skip tests that require network access
+  checkFlags = [
+    "--skip tools::convert::tests::test_remote1"
+    "--skip tools::convert::tests::test_remote2"
+    "--skip tools::probe::tests::test_remote"
+    "--skip tools::serve::tests::test_remote"
+    "--skip utils::io::data_reader_http"
+    "--skip utils::io::data_reader_http::tests::read_range_git"
+    "--skip utils::io::data_reader_http::tests::read_range_googleapis"
+  ];
+
+  meta = {
+    description = "Toolbox for converting, checking and serving map tiles in various formats";
+    longDescription = ''
+      VersaTiles is a Rust-based project designed for processing and serving tile data efficiently.
+      It supports multiple tile formats and offers various functionalities for handling tile data.
+    '';
+    homepage = "https://versatiles.org/";
+    downloadPage = "https://github.com/versatiles-org/versatiles-rs";
+    changelog = "https://github.com/versatiles-org/versatiles-rs/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wilhelmines ];
+    mainProgram = "versatiles";
+    platforms = with lib.platforms; linux ++ darwin ++ windows;
+  };
+}


### PR DESCRIPTION
## VersaTiles

This is a pull request to add VersaTiles to nixpkgs.


The short description from the github repo:
VersaTiles - A toolbox for converting, checking and serving map tiles in various formats.
VersaTiles is a Rust-based project designed for processing and serving tile data efficiently. It supports multiple tile formats and offers various functionalities for handling tile data.

More information can be found on the project's website https://versatiles.org as well as on the GitHub repo: https://github.com/versatiles-org/versatiles-rs

Currently, I'm not included in the development of VersaTiles, but have decided to create the package based on a wish on their contributing page. I plan to be the package maintainer. The lead developer knows about my effort and helped me with fixing related bugs.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

