### PR TITLE
postgresqlPackages.sqlite_fdw: init at 2.4.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/default.nix
+++ b/pkgs/servers/sql/postgresql/ext/default.nix
@@ -107,6 +107,8 @@ self: super: {
 
     rum = super.callPackage ./rum.nix { };
 
+    sqlite_fdw = super.callPackage ./sqlite_fdw.nix { };
+
     tsja = super.callPackage ./tsja.nix { };
 
     wal2json = super.callPackage ./wal2json.nix { };

--- a/pkgs/servers/sql/postgresql/ext/sqlite_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/sqlite_fdw.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  sqlite,
+  postgresql,
+  buildPostgresqlExtension,
+}:
+
+buildPostgresqlExtension rec {
+  pname = "sqlite_fdw";
+  # TODO: Check whether PostgreSQL 17 is still broken after next update.
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "pgspider";
+    repo = "sqlite_fdw";
+    rev = "v${version}";
+    hash = "sha256-u51rcKUH2nZyZbI2g3crzHt5jiacbTq4xmfP3JgqnnM=";
+  };
+
+  buildInputs = [ sqlite ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  meta = {
+    description = "SQLite Foreign Data Wrapper for PostgreSQL";
+    homepage = "https://github.com/pgspider/sqlite_fdw";
+    changelog = "https://github.com/pgspider/sqlite_fdw/releases/tag/v${version}";
+    maintainers = with lib.maintainers; [ apfelkuchen6 ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.postgresql;
+    broken = lib.versionAtLeast postgresql.version "17";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
