### PR TITLE
[Backport release-24.05] factorio: 1.1.110 -> 2.0.7

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -29,7 +29,8 @@
 
 assert releaseType == "alpha"
   || releaseType == "headless"
-  || releaseType == "demo";
+  || releaseType == "demo"
+  || releaseType == "expansion";
 
 let
 
@@ -272,6 +273,7 @@ let
         cp -a doc-html $out/share/factorio
       '';
     };
+    expansion = alpha;
   };
 
 in

--- a/pkgs/games/factorio/update.py
+++ b/pkgs/games/factorio/update.py
@@ -55,6 +55,7 @@ SYSTEMS = [
 
 RELEASE_TYPES = [
     ReleaseType("alpha", needs_auth=True),
+    ReleaseType("expansion", needs_auth=True),
     ReleaseType("demo"),
     ReleaseType("headless"),
 ]

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,20 +2,20 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.107.tar.xz",
+        "name": "factorio_alpha_x64-2.0.7.tar.xz",
         "needsAuth": true,
-        "sha256": "16hkyfwp02zcijka4yslifz62ry6hrvk0w9960618kqdw3gr7p82",
+        "sha256": "14gsl01j06d0cfii2zsp0njak3hf8kgb9ig9i3prbch507bmfw6q",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/alpha/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/2.0.7/alpha/linux64",
+        "version": "2.0.7"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.107.tar.xz",
+        "name": "factorio_alpha_x64-2.0.7.tar.xz",
         "needsAuth": true,
-        "sha256": "16hkyfwp02zcijka4yslifz62ry6hrvk0w9960618kqdw3gr7p82",
+        "sha256": "14gsl01j06d0cfii2zsp0njak3hf8kgb9ig9i3prbch507bmfw6q",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/alpha/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/2.0.7/alpha/linux64",
+        "version": "2.0.7"
       }
     },
     "demo": {
@@ -38,20 +38,20 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.107.tar.xz",
+        "name": "factorio_headless_x64-2.0.7.tar.xz",
         "needsAuth": false,
-        "sha256": "10ds1nz9sbx9xz1lyypf16wncc6323vpm7l5p11d6iy4cha85wsw",
+        "sha256": "0qi7vypm4iy3cp9qyl3cvvm606g9g37sa2pls4y7glxiwng4m9p6",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/headless/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/2.0.7/headless/linux64",
+        "version": "2.0.7"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.107.tar.xz",
+        "name": "factorio_headless_x64-2.0.7.tar.xz",
         "needsAuth": false,
-        "sha256": "10ds1nz9sbx9xz1lyypf16wncc6323vpm7l5p11d6iy4cha85wsw",
+        "sha256": "0qi7vypm4iy3cp9qyl3cvvm606g9g37sa2pls4y7glxiwng4m9p6",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/headless/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/2.0.7/headless/linux64",
+        "version": "2.0.7"
       }
     }
   }

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -36,6 +36,24 @@
         "version": "1.1.107"
       }
     },
+    "expansion": {
+      "experimental": {
+        "name": "factorio_expansion_x64-2.0.7.tar.xz",
+        "needsAuth": true,
+        "sha256": "1zvk1skkm37kyikq4l1q285l8zhxc6lqvs1x2y2ccxwd4cdm6r96",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/2.0.7/expansion/linux64",
+        "version": "2.0.7"
+      },
+      "stable": {
+        "name": "factorio_expansion_x64-2.0.7.tar.xz",
+        "needsAuth": true,
+        "sha256": "1zvk1skkm37kyikq4l1q285l8zhxc6lqvs1x2y2ccxwd4cdm6r96",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/2.0.7/expansion/linux64",
+        "version": "2.0.7"
+      }
+    },
     "headless": {
       "experimental": {
         "name": "factorio_headless_x64-2.0.7.tar.xz",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36637,6 +36637,10 @@ with pkgs;
 
   factorio-demo = factorio.override { releaseType = "demo"; };
 
+  factorio-space-age = factorio.override { releaseType = "expansion"; };
+
+  factorio-space-age-experimental = factorio.override { releaseType = "expansion"; experimental = true; };
+
   factorio-mods = callPackage ../games/factorio/mods.nix { };
 
   factorio-utils = callPackage ../games/factorio/utils.nix { };


### PR DESCRIPTION
- backport of #350214

I just followed the [commands](https://github.com/NixOS/nixpkgs/pull/350214#issuecomment-2427840535) that the bot failed to complete and then resolved all the merge conflicts in favour of new.

I built and ran the full game and the headless server. Caveat that I did not use the "specify your token and have Nix download the binary for you", since I never managed to get that working before.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
    - only normal client + headless so far 
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
