### PR TITLE
rcodesign: 0.22.0 -> 0.27.0

### DIFF
--- a/pkgs/development/tools/rcodesign/default.nix
+++ b/pkgs/development/tools/rcodesign/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , rustPlatform
 , fetchFromGitHub
-, darwin
+, apple-sdk_11
 , uutils-coreutils
 }:
 
@@ -17,9 +17,6 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-F6Etl3Zbpmh3A/VeCcSXIy3W1WYFg8WUSJBJV/akCxU=";
   };
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk_11_0.frameworks.Security
-  ];
   cargoPatches = [
     # Update time to a version that is compatible with Rust 1.80
     ./update-time-rs-in-cargo-lock.patch
@@ -34,6 +31,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-VrexypkCW58asvzXo3wj/Rgi72tiGuchA31BkEZoYpI=";
 
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_11 ];
 
   cargoBuildFlags = [
     # Only build the binary we want

--- a/pkgs/development/tools/rcodesign/default.nix
+++ b/pkgs/development/tools/rcodesign/default.nix
@@ -7,20 +7,25 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rcodesign";
-  version = "0.22.0";
+  version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "indygreg";
     repo = "apple-platform-rs";
     rev = "apple-codesign/${version}";
-    hash = "sha256-ndbDBGtTOfHHUquKrETe4a+hB5Za9samlnXwVGVvWy4=";
+    hash = "sha256-F6Etl3Zbpmh3A/VeCcSXIy3W1WYFg8WUSJBJV/akCxU=";
   };
-
-  cargoHash = "sha256-cpQBdxTw/ge4VtzjdL2a2xgSeCT22fMIjuKu5UEedhI=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.apple_sdk_11_0.frameworks.Security
   ];
+  cargoPatches = [
+    # Update time to a version that is compatible with Rust 1.80
+    ./update-time-rs-in-cargo-lock.patch
+  ];
+
+  cargoHash = "sha256-VrexypkCW58asvzXo3wj/Rgi72tiGuchA31BkEZoYpI=";
+
 
   cargoBuildFlags = [
     # Only build the binary we want

--- a/pkgs/development/tools/rcodesign/disable-sign-for-notarization-test.patch
+++ b/pkgs/development/tools/rcodesign/disable-sign-for-notarization-test.patch
@@ -1,0 +1,14 @@
+diff --git a/apple-codesign/tests/cli_tests.rs b/apple-codesign/tests/cli_tests.rs
+index 22166712ec..8721a92753 100644
+--- a/apple-codesign/tests/cli_tests.rs
++++ b/apple-codesign/tests/cli_tests.rs
+@@ -271,6 +271,9 @@
+ 
+     cases.case("tests/cmd/*.trycmd").case("tests/cmd/*.toml");
+ 
++    // Disable in nixpkgs because it requires network access
++    cases.skip("tests/cmd/sign-for-notarization.trycmd");
++
+     // Help output breaks without notarize feature.
+     if cfg!(not(feature = "notarize")) {
+         cases.skip("tests/cmd/encode-app-store-connect-api-key.trycmd");

--- a/pkgs/development/tools/rcodesign/fix-verbosity-level.patch
+++ b/pkgs/development/tools/rcodesign/fix-verbosity-level.patch
@@ -1,0 +1,19 @@
+diff --git a/apple-codesign/src/cli/mod.rs b/apple-codesign/src/cli/mod.rs
+index 53e9649271..82d4d061a6 100644
+--- a/apple-codesign/src/cli/mod.rs
++++ b/apple-codesign/src/cli/mod.rs
+@@ -2499,9 +2499,11 @@
+         _ => LevelFilter::Trace,
+     };
+ 
+-    let mut builder = env_logger::Builder::from_env(
+-        env_logger::Env::default().default_filter_or(log_level.as_str()),
+-    );
++    let mut builder = env_logger::Builder::new();
++
++    builder
++        .filter_level(log_level)
++        .parse_default_env();
+ 
+     // Disable log context except at higher log levels.
+     if log_level <= LevelFilter::Info {

--- a/pkgs/development/tools/rcodesign/update-time-rs-in-cargo-lock.patch
+++ b/pkgs/development/tools/rcodesign/update-time-rs-in-cargo-lock.patch
@@ -1,0 +1,47 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 3a5dd6d244..787b048829 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2257,6 +2257,12 @@
+ ]
+ 
+ [[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
++[[package]]
+ name = "num-integer"
+ version = "0.1.45"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -3605,12 +3611,13 @@
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.31"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
++ "num-conv",
+  "powerfmt",
+  "serde",
+  "time-core",
+@@ -3625,10 +3632,11 @@
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.16"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18207,7 +18207,7 @@ with pkgs;
 
   hammer = callPackage ../development/tools/parsing/hammer { };
 
-  rcodesign = darwin.apple_sdk_11_0.callPackage ../development/tools/rcodesign {};
+  rcodesign = callPackage ../development/tools/rcodesign { };
 
   rdocker = callPackage ../development/tools/rdocker { };
 


### PR DESCRIPTION
Fixes build of rcodesign on staging-next https://github.com/NixOS/nixpkgs/pull/348827.

- https://hydra.nixos.org/build/276135762

The verbosity patch has been upstreamed as https://github.com/indygreg/apple-platform-rs/pull/162.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
