### PR TITLE
flashlabel-yxwl: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1575,6 +1575,13 @@
     githubId = 7644264;
     name = "Andrew Gazelka";
   };
+  AndrewKvalheim = {
+    email = "andrew@kvalhe.im";
+    github = "AndrewKvalheim";
+    githubId = 1844746;
+    matrix = "@andrew:kvalhe.im";
+    name = "Andrew Kvalheim";
+  };
   andrewrk = {
     email = "superjoe30@gmail.com";
     github = "andrewrk";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1293,6 +1293,13 @@
     githubId = 45176912;
     name = "Tomasz Hołubowicz";
   };
+  altsalt = {
+    email = "salt@sal.td";
+    github = "altsalt";
+    githubId = 2441328;
+    matrix = "@salt:sal.td";
+    name = "Wm Salt Hale";
+  };
   alunduil = {
     email = "alunduil@gmail.com";
     github = "alunduil";

--- a/pkgs/by-name/fl/flashlabel-yxwl/package.nix
+++ b/pkgs/by-name/fl/flashlabel-yxwl/package.nix
@@ -1,0 +1,87 @@
+{
+  autoPatchelfHook,
+  cups,
+  lib,
+  requireFile,
+  stdenv,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "flashlabel-yxwl";
+  version = "1.2.1";
+
+  # The source URL currently redirects through “pCloud”, a file storage service
+  # that resists direct downloads.
+  src = requireFile {
+    name = "A4_Linux_Driver_Ver${version}.run";
+    url = "https://flashlabel.net/YXWL-A4driver-linux";
+    hash = "sha256-qkc3NJ1dK0nJf+Q7xL7f1/+X0COWSWMEbH4luzaFARc=";
+  };
+
+  # The driver is distributed as a self-extracting executable consisting of a
+  # shell script concatenated with a gzipped tar archive. The script hard codes
+  # its length in the `lines` variable, which we read to locate the archive.
+  unpackPhase = ''
+    lines="$(sed 's/^lines=//; t; d' "$src")"
+    tail --lines "+$lines" "$src" | tar --extract --gzip --strip-components=1
+  '';
+
+  patchPhase = ''
+    runHook prePatch
+
+    # Remove model from manufacturer name
+    sed --in-place 's/\(^\*Manufacturer: "YXWL\) [^"]*\("$\)/\1\2/' *.ppd
+
+    runHook postPatch
+  '';
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ cups ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir --parents $out/lib/cups/filter
+    mv {A80,A80H} $out/lib/cups/filter
+
+    mkdir --parents $out/share/cups/model
+    mv *.ppd $out/share/cups/model
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    gzip --best $out/share/cups/model/*.ppd
+  '';
+
+  meta = {
+    description = "CUPS driver for FlashLabel A4 thermal printers";
+    longDescription = ''
+      Supported models:
+
+        - A80
+        - A80H
+        - A81
+        - A81H
+        - C80
+        - C80H
+        - D80
+        - D80 Pro
+        - Y8
+        - Y8 Pro
+        - Y80
+    '';
+    homepage = "https://help.flashlabel.com/support/solutions/articles/150000191214";
+    downloadPage = "https://flashlabel.net/YXWL-A4driver-linux";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      altsalt
+      AndrewKvalheim
+    ];
+  };
+}


### PR DESCRIPTION
This is the proprietary CUPS driver for [FlashLabel A4 thermal printers](https://help.flashlabel.com/support/solutions/150000213895), internally named “YXWL”. Tested using an [Aixiqee A80](https://www.amazon.com/dp/B0C81DZTX4).

> ![screenshot of driver selection screen](https://github.com/user-attachments/assets/2bc47219-1924-456d-9571-262ee5465fda)

I’m not confident in the best way to package this and would appreciate feedback especially on the unpacking.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
