### PR TITLE
factorio: 2.0.7 -> 2.0.8

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,20 +2,20 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-2.0.7.tar.xz",
+        "name": "factorio_alpha_x64-2.0.8.tar.xz",
         "needsAuth": true,
-        "sha256": "14gsl01j06d0cfii2zsp0njak3hf8kgb9ig9i3prbch507bmfw6q",
+        "sha256": "11g1fgfm0lki9j2jsfmvlxzisbyx7482ia2qf7gnjcqhp6jkdsll",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/alpha/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/alpha/linux64",
+        "version": "2.0.8"
       },
       "stable": {
-        "name": "factorio_alpha_x64-2.0.7.tar.xz",
+        "name": "factorio_alpha_x64-2.0.8.tar.xz",
         "needsAuth": true,
-        "sha256": "14gsl01j06d0cfii2zsp0njak3hf8kgb9ig9i3prbch507bmfw6q",
+        "sha256": "11g1fgfm0lki9j2jsfmvlxzisbyx7482ia2qf7gnjcqhp6jkdsll",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/alpha/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/alpha/linux64",
+        "version": "2.0.8"
       }
     },
     "demo": {
@@ -37,39 +37,31 @@
       }
     },
     "expansion": {
-      "experimental": {
-        "name": "factorio_expansion_x64-2.0.7.tar.xz",
-        "needsAuth": true,
-        "sha256": "1zvk1skkm37kyikq4l1q285l8zhxc6lqvs1x2y2ccxwd4cdm6r96",
-        "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/expansion/linux64",
-        "version": "2.0.7"
-      },
       "stable": {
-        "name": "factorio_expansion_x64-2.0.7.tar.xz",
+        "name": "factorio_expansion_x64-2.0.8.tar.xz",
         "needsAuth": true,
-        "sha256": "1zvk1skkm37kyikq4l1q285l8zhxc6lqvs1x2y2ccxwd4cdm6r96",
+        "sha256": "0q3abb01ld1mlbp21lgzpa62j1gybs982yzan5j1axma9n1ax3j0",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/expansion/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/expansion/linux64",
+        "version": "2.0.8"
       }
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-2.0.7.tar.xz",
+        "name": "factorio_headless_x64-2.0.8.tar.xz",
         "needsAuth": false,
-        "sha256": "0qi7vypm4iy3cp9qyl3cvvm606g9g37sa2pls4y7glxiwng4m9p6",
+        "sha256": "1jp1vlc4indicgy0xnrxq87h32wcv9s4g2hqbfb4ygiaam6lqnfr",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/headless/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/headless/linux64",
+        "version": "2.0.8"
       },
       "stable": {
-        "name": "factorio_headless_x64-2.0.7.tar.xz",
+        "name": "factorio_headless_x64-2.0.8.tar.xz",
         "needsAuth": false,
-        "sha256": "0qi7vypm4iy3cp9qyl3cvvm606g9g37sa2pls4y7glxiwng4m9p6",
+        "sha256": "1jp1vlc4indicgy0xnrxq87h32wcv9s4g2hqbfb4ygiaam6lqnfr",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/headless/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/headless/linux64",
+        "version": "2.0.8"
       }
     }
   }


### PR DESCRIPTION
Note that this also effectively deletes factorio-space-age-experimental; this is left in top-level/all-packages.nix for now since I don't know if they plan to bring it back. Longer term we should make it resolve to stable if it doesn't exist, probably.

### Bugfixes

* Fixed a crash when changing decider combinator conditions or outputs in latency in some cases.
* Fixed a crash when sending a platform with no thrust to a planet and then removing the stop. ([more](https://forums.factorio.com/116133))
* Fixed a crash when robots try to station in a full roboport because their stack size changed.
* Fixed a crash in path finder when migrating 1.0 save files to 2.0.
* Fixed orbital drop slots not counting towards Item count wait condition.
* Fixed space platforms not respecting peaceful and no enemy modes.
* Fixed a crash when downloading multiple mods fails.
* Fixed a crash when clicking "play" while the map preview was running. ([more](https://forums.factorio.com/116202))
* Fixed a crash when drawing a spider leg with length 0. ([more](https://forums.factorio.com/116034))
* Fixed error in loading 1.1 version of blueprint library would prevent starting new map or loading a save. ([more](https://forums.factorio.com/116217))
* Fixed crashes around the Explore Mods GUI with intermittent network connectivity.
* Fixed a crash when viewing a single-product recipe with no main product in Factoriopedia.
* Fixed a crash when pathfinding with a rotated bounding box. ([more](https://forums.factorio.com/115524))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
