### PR TITLE
[Backport release-24.05] factorio_2 + factorio-space-age: init at 2.0.8

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -29,7 +29,8 @@
 
 assert releaseType == "alpha"
   || releaseType == "headless"
-  || releaseType == "demo";
+  || releaseType == "demo"
+  || releaseType == "expansion";
 
 let
 
@@ -272,6 +273,7 @@ let
         cp -a doc-html $out/share/factorio
       '';
     };
+    expansion = alpha;
   };
 
 in

--- a/pkgs/games/factorio/update.py
+++ b/pkgs/games/factorio/update.py
@@ -55,6 +55,7 @@ SYSTEMS = [
 
 RELEASE_TYPES = [
     ReleaseType("alpha", needs_auth=True),
+    ReleaseType("expansion", needs_auth=True),
     ReleaseType("demo"),
     ReleaseType("headless"),
 ]

--- a/pkgs/games/factorio/versions-1.json
+++ b/pkgs/games/factorio/versions-1.json
@@ -1,0 +1,58 @@
+{
+  "x86_64-linux": {
+    "alpha": {
+      "experimental": {
+        "name": "factorio_alpha_x64-1.1.110.tar.xz",
+        "needsAuth": true,
+        "sha256": "0ndhb94lh47n09a7wshm2inv52fd6rjfa7fk7nk9b7zzh84i7f4x",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/1.1.110/alpha/linux64",
+        "version": "1.1.110"
+      },
+      "stable": {
+        "name": "factorio_alpha_x64-1.1.110.tar.xz",
+        "needsAuth": true,
+        "sha256": "0ndhb94lh47n09a7wshm2inv52fd6rjfa7fk7nk9b7zzh84i7f4x",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/1.1.110/alpha/linux64",
+        "version": "1.1.110"
+      }
+    },
+    "demo": {
+      "experimental": {
+        "name": "factorio_demo_x64-1.1.110.tar.xz",
+        "needsAuth": false,
+        "sha256": "0dasxgrybl00vrabgrlarsvg0hdg5rvn3y4hsljhqc4zpbf93nxx",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/1.1.110/demo/linux64",
+        "version": "1.1.110"
+      },
+      "stable": {
+        "name": "factorio_demo_x64-1.1.110.tar.xz",
+        "needsAuth": false,
+        "sha256": "0dasxgrybl00vrabgrlarsvg0hdg5rvn3y4hsljhqc4zpbf93nxx",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/1.1.110/demo/linux64",
+        "version": "1.1.110"
+      }
+    },
+    "headless": {
+      "experimental": {
+        "name": "factorio_headless_x64-1.1.110.tar.xz",
+        "needsAuth": false,
+        "sha256": "0sk4g9y051xjhiwdhj1yz808308zwsbpq3nps1ywvpp56vdycps8",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/1.1.110/headless/linux64",
+        "version": "1.1.110"
+      },
+      "stable": {
+        "name": "factorio_headless_x64-1.1.110.tar.xz",
+        "needsAuth": false,
+        "sha256": "0sk4g9y051xjhiwdhj1yz808308zwsbpq3nps1ywvpp56vdycps8",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/1.1.110/headless/linux64",
+        "version": "1.1.110"
+      }
+    }
+  }
+}

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -36,6 +36,24 @@
         "version": "1.1.110"
       }
     },
+    "expansion": {
+      "experimental": {
+        "name": "factorio_expansion_x64-2.0.7.tar.xz",
+        "needsAuth": true,
+        "sha256": "1zvk1skkm37kyikq4l1q285l8zhxc6lqvs1x2y2ccxwd4cdm6r96",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/2.0.7/expansion/linux64",
+        "version": "2.0.7"
+      },
+      "stable": {
+        "name": "factorio_expansion_x64-2.0.7.tar.xz",
+        "needsAuth": true,
+        "sha256": "1zvk1skkm37kyikq4l1q285l8zhxc6lqvs1x2y2ccxwd4cdm6r96",
+        "tarDirectory": "x64",
+        "url": "https://factorio.com/get-download/2.0.7/expansion/linux64",
+        "version": "2.0.7"
+      }
+    },
     "headless": {
       "experimental": {
         "name": "factorio_headless_x64-2.0.7.tar.xz",

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,20 +2,20 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.110.tar.xz",
+        "name": "factorio_alpha_x64-2.0.7.tar.xz",
         "needsAuth": true,
-        "sha256": "0ndhb94lh47n09a7wshm2inv52fd6rjfa7fk7nk9b7zzh84i7f4x",
+        "sha256": "14gsl01j06d0cfii2zsp0njak3hf8kgb9ig9i3prbch507bmfw6q",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.110/alpha/linux64",
-        "version": "1.1.110"
+        "url": "https://factorio.com/get-download/2.0.7/alpha/linux64",
+        "version": "2.0.7"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.110.tar.xz",
+        "name": "factorio_alpha_x64-2.0.7.tar.xz",
         "needsAuth": true,
-        "sha256": "0ndhb94lh47n09a7wshm2inv52fd6rjfa7fk7nk9b7zzh84i7f4x",
+        "sha256": "14gsl01j06d0cfii2zsp0njak3hf8kgb9ig9i3prbch507bmfw6q",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.110/alpha/linux64",
-        "version": "1.1.110"
+        "url": "https://factorio.com/get-download/2.0.7/alpha/linux64",
+        "version": "2.0.7"
       }
     },
     "demo": {
@@ -38,20 +38,20 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.110.tar.xz",
+        "name": "factorio_headless_x64-2.0.7.tar.xz",
         "needsAuth": false,
-        "sha256": "0sk4g9y051xjhiwdhj1yz808308zwsbpq3nps1ywvpp56vdycps8",
+        "sha256": "0qi7vypm4iy3cp9qyl3cvvm606g9g37sa2pls4y7glxiwng4m9p6",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.110/headless/linux64",
-        "version": "1.1.110"
+        "url": "https://factorio.com/get-download/2.0.7/headless/linux64",
+        "version": "2.0.7"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.110.tar.xz",
+        "name": "factorio_headless_x64-2.0.7.tar.xz",
         "needsAuth": false,
-        "sha256": "0sk4g9y051xjhiwdhj1yz808308zwsbpq3nps1ywvpp56vdycps8",
+        "sha256": "0qi7vypm4iy3cp9qyl3cvvm606g9g37sa2pls4y7glxiwng4m9p6",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.110/headless/linux64",
-        "version": "1.1.110"
+        "url": "https://factorio.com/get-download/2.0.7/headless/linux64",
+        "version": "2.0.7"
       }
     }
   }

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,20 +2,20 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-2.0.7.tar.xz",
+        "name": "factorio_alpha_x64-2.0.8.tar.xz",
         "needsAuth": true,
-        "sha256": "14gsl01j06d0cfii2zsp0njak3hf8kgb9ig9i3prbch507bmfw6q",
+        "sha256": "11g1fgfm0lki9j2jsfmvlxzisbyx7482ia2qf7gnjcqhp6jkdsll",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/alpha/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/alpha/linux64",
+        "version": "2.0.8"
       },
       "stable": {
-        "name": "factorio_alpha_x64-2.0.7.tar.xz",
+        "name": "factorio_alpha_x64-2.0.8.tar.xz",
         "needsAuth": true,
-        "sha256": "14gsl01j06d0cfii2zsp0njak3hf8kgb9ig9i3prbch507bmfw6q",
+        "sha256": "11g1fgfm0lki9j2jsfmvlxzisbyx7482ia2qf7gnjcqhp6jkdsll",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/alpha/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/alpha/linux64",
+        "version": "2.0.8"
       }
     },
     "demo": {
@@ -37,39 +37,31 @@
       }
     },
     "expansion": {
-      "experimental": {
-        "name": "factorio_expansion_x64-2.0.7.tar.xz",
-        "needsAuth": true,
-        "sha256": "1zvk1skkm37kyikq4l1q285l8zhxc6lqvs1x2y2ccxwd4cdm6r96",
-        "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/expansion/linux64",
-        "version": "2.0.7"
-      },
       "stable": {
-        "name": "factorio_expansion_x64-2.0.7.tar.xz",
+        "name": "factorio_expansion_x64-2.0.8.tar.xz",
         "needsAuth": true,
-        "sha256": "1zvk1skkm37kyikq4l1q285l8zhxc6lqvs1x2y2ccxwd4cdm6r96",
+        "sha256": "0q3abb01ld1mlbp21lgzpa62j1gybs982yzan5j1axma9n1ax3j0",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/expansion/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/expansion/linux64",
+        "version": "2.0.8"
       }
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-2.0.7.tar.xz",
+        "name": "factorio_headless_x64-2.0.8.tar.xz",
         "needsAuth": false,
-        "sha256": "0qi7vypm4iy3cp9qyl3cvvm606g9g37sa2pls4y7glxiwng4m9p6",
+        "sha256": "1jp1vlc4indicgy0xnrxq87h32wcv9s4g2hqbfb4ygiaam6lqnfr",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/headless/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/headless/linux64",
+        "version": "2.0.8"
       },
       "stable": {
-        "name": "factorio_headless_x64-2.0.7.tar.xz",
+        "name": "factorio_headless_x64-2.0.8.tar.xz",
         "needsAuth": false,
-        "sha256": "0qi7vypm4iy3cp9qyl3cvvm606g9g37sa2pls4y7glxiwng4m9p6",
+        "sha256": "1jp1vlc4indicgy0xnrxq87h32wcv9s4g2hqbfb4ygiaam6lqnfr",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.7/headless/linux64",
-        "version": "2.0.7"
+        "url": "https://factorio.com/get-download/2.0.8/headless/linux64",
+        "version": "2.0.8"
       }
     }
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36654,9 +36654,9 @@ with pkgs;
 
   # there is no factorio_2-demo
 
-  factorio-space-age = factorio.override { releaseType = "expansion"; };
+  factorio-space-age = factorio_2.override { releaseType = "expansion"; };
 
-  factorio-space-age-experimental = factorio.override { releaseType = "expansion"; experimental = true; };
+  factorio-space-age-experimental = factorio_2.override { releaseType = "expansion"; experimental = true; };
 
   factorio-mods = callPackage ../games/factorio/mods.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36654,6 +36654,10 @@ with pkgs;
 
   # there is no factorio_2-demo
 
+  factorio-space-age = factorio.override { releaseType = "expansion"; };
+
+  factorio-space-age-experimental = factorio.override { releaseType = "expansion"; experimental = true; };
+
   factorio-mods = callPackage ../games/factorio/mods.nix { };
 
   factorio-utils = callPackage ../games/factorio/utils.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36621,7 +36621,10 @@ with pkgs;
     fltk = fltk-minimal;
   };
 
-  factorio = callPackage ../games/factorio { releaseType = "alpha"; };
+  factorio = callPackage ../games/factorio {
+    releaseType = "alpha";
+    versionsJson = ../games/factorio/versions-1.json;
+  };
 
   factorio-experimental = factorio.override { releaseType = "alpha"; experimental = true; };
 
@@ -36630,6 +36633,26 @@ with pkgs;
   factorio-headless-experimental = factorio.override { releaseType = "headless"; experimental = true; };
 
   factorio-demo = factorio.override { releaseType = "demo"; };
+
+  factorio_1 = factorio;
+
+  factorio_1-experimental = factorio-experimental;
+
+  factorio_1-headless = factorio-headless;
+
+  factorio_1-headless-experimental = factorio-headless-experimental;
+
+  factorio_1-demo = factorio-demo;
+
+  factorio_2 = factorio.override { versionsJson = ../games/factorio/versions.json; };
+
+  factorio_2-experimental = factorio-experimental.override { versionsJson = ../games/factorio/versions.json; };
+
+  factorio_2-headless = factorio-headless.override { versionsJson = ../games/factorio/versions.json; };
+
+  factorio_2-headless-experimental = factorio-headless-experimental.override { versionsJson = ../games/factorio/versions.json; };
+
+  # there is no factorio_2-demo
 
   factorio-mods = callPackage ../games/factorio/mods.nix { };
 


### PR DESCRIPTION
- supersedes #350371 which I messed up

edit: the final version of this PR backported:
- #350214 
- #350377

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
    - not all, just headless and the expansion binary
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
