### PR TITLE
bant: 0.1.7 fix changed hash of fixed derivation.

### DIFF
--- a/pkgs/by-name/ba/bant/package.nix
+++ b/pkgs/by-name/ba/bant/package.nix
@@ -15,7 +15,8 @@ let
     rev = "40bc9ad53e5a59d596935839e7c072679e706266";
     hash = "sha256-CL0YMQd1ck6/dlvJCLxt9jYyqDuk+iAWfdBOMj864u8=";
   };
-in buildBazelPackage rec {
+in
+buildBazelPackage rec {
   pname = "bant";
   version = "0.1.7";
 
@@ -26,17 +27,22 @@ in buildBazelPackage rec {
     hash = "sha256-QbxPosjlrpxbz6gQKUKccF2Gu/i5xvqh2gwfABYE8kE=";
   };
 
-  bazelFlags = ["--registry" "file://${registry}"];
+  bazelFlags = [
+    "--registry"
+    "file://${registry}"
+  ];
 
   postPatch = ''
     patchShebangs scripts/create-workspace-status.sh
   '';
 
   fetchAttrs = {
-    sha256 = {
-      aarch64-linux = "sha256-09RL0tj6xsGEmuv11V81eAtqLc9nAaE8Il3d6ueS0UQ=";
-      x86_64-linux = "sha256-6mlaJ/kT14vKvlJjxqBK/lESjjxbcYxApi7+eiiI37M=";
-    }.${system} or (throw "No hash for system: ${system}");
+    hash =
+      {
+        aarch64-linux = "sha256-LNca4h4yceSgve9GYUoXqlODKPjLAa71kh1BWXqRYtk=";
+        x86_64-linux = "sha256-bRFIfaVbsU2WroXR/i0E7J4rWeaNEoum93r8qOMXXvc=";
+      }
+      .${system} or (throw "No hash for system: ${system}");
   };
 
   nativeBuildInputs = [
@@ -58,7 +64,10 @@ in buildBazelPackage rec {
     description = "Bazel/Build Analysis and Navigation Tool";
     homepage = "http://bant.build/";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ hzeller lromor ];
+    maintainers = with maintainers; [
+      hzeller
+      lromor
+    ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
The hash of the fixed derivation changed

If the old derivation with the hash was cached on the system, the build failed with:

```
ERROR: /build/output/external/googletest~1.14.0.bcr.1/BUILD.bazel:80:11: Compiling googletest/src/gtest.cc failed: The include path '/nix/store/p5w6cmwqfvhyaf4vjr7jb18a90icrrr2-openjdk-21.0.3+9/include' references a path outside of the execution root.
ERROR: /build/output/external/abseil-cpp~20240116.2/absl/base/BUILD.bazel:755:11: Compiling absl/base/internal/strerror.cc failed: The include path '/nix/store/p5w6cmwqfvhyaf4vjr7jb18a90icrrr2-openjdk-21.0.3+9/include' references a path outside of the execution root.
```

This indicates that the derivation also bakes in the path of the used JDK, which apparently changed since last time. Quick fix for now: adapt hash, but hopefully there could be a more long-term solution.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
