### PR TITLE
hyprlock: 0.4.1 -> 0.5.0; sdbus-cpp_2: init at 2.0.0

### DIFF
--- a/pkgs/by-name/hy/hyprlock/package.nix
+++ b/pkgs/by-name/hy/hyprlock/package.nix
@@ -9,6 +9,8 @@
   hyprlang,
   hyprutils,
   pam,
+  sdbus-cpp_2,
+  systemdLibs,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -24,13 +26,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprlock";
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprlock";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-w+AyYuqlZ/uWEimiptlHjtDFECm/JlUOD2ciCw8/+/8=";
+    hash = "sha256-sUIsjWpZLplSJXWyJcDZdvDweksXLH5r9GSkwg0kgBw=";
   };
 
   strictDeps = true;
@@ -54,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
     mesa
     pam
     pango
+    sdbus-cpp_2
+    systemdLibs
     wayland
     wayland-protocols
   ];

--- a/pkgs/development/libraries/sdbus-cpp/default.nix
+++ b/pkgs/development/libraries/sdbus-cpp/default.nix
@@ -1,53 +1,71 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, expat
-, pkg-config
-, systemd
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  expat,
+  pkg-config,
+  systemdLibs,
 }:
+let
+  generic =
+    {
+      version,
+      rev ? "v${version}",
+      hash,
+    }:
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "sdbus-cpp";
+      inherit version;
 
-stdenv.mkDerivation rec {
-  pname = "sdbus-cpp";
-  version = "1.5.0";
+      src = fetchFromGitHub {
+        owner = "kistler-group";
+        repo = "sdbus-cpp";
+        inherit rev hash;
+      };
 
-  src = fetchFromGitHub {
-    owner = "kistler-group";
-    repo = "sdbus-cpp";
-    rev = "v${version}";
+      nativeBuildInputs = [
+        cmake
+        pkg-config
+      ];
+
+      buildInputs = [
+        expat
+        systemdLibs
+      ];
+
+      cmakeFlags = [
+        (lib.cmakeBool "BUILD_CODE_GEN" true)
+      ];
+
+      meta = {
+        homepage = "https://github.com/Kistler-Group/sdbus-cpp";
+        changelog = "https://github.com/Kistler-Group/sdbus-cpp/blob/v${version}/ChangeLog";
+        description = "High-level C++ D-Bus library designed to provide easy-to-use yet powerful API";
+        longDescription = ''
+          sdbus-c++ is a high-level C++ D-Bus library for Linux designed to provide
+          expressive, easy-to-use API in modern C++.
+          It adds another layer of abstraction on top of sd-bus, a nice, fresh C
+          D-Bus implementation by systemd.
+          It's been written primarily as a replacement of dbus-c++, which currently
+          suffers from a number of (unresolved) bugs, concurrency issues and
+          inherent design complexities and limitations.
+        '';
+        license = lib.licenses.lgpl2Only;
+        maintainers = [ ];
+        platforms = lib.platforms.linux;
+        mainProgram = "sdbus-c++-xml2cpp";
+      };
+    });
+in
+{
+  sdbus-cpp = generic {
+    version = "1.5.0";
     hash = "sha256-oO8QNffwNI245AEPdutOGqxj4qyusZYK3bZWLh2Lcag=";
   };
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-  ];
-
-  buildInputs = [
-    expat
-    systemd
-  ];
-
-  cmakeFlags = [
-    "-DBUILD_CODE_GEN=ON"
-  ];
-
-  meta = {
-    homepage = "https://github.com/Kistler-Group/sdbus-cpp";
-    changelog = "https://github.com/Kistler-Group/sdbus-cpp/blob/v${version}/ChangeLog";
-    description = "High-level C++ D-Bus library designed to provide easy-to-use yet powerful API";
-    longDescription = ''
-      sdbus-c++ is a high-level C++ D-Bus library for Linux designed to provide
-      expressive, easy-to-use API in modern C++.
-      It adds another layer of abstraction on top of sd-bus, a nice, fresh C
-      D-Bus implementation by systemd.
-      It's been written primarily as a replacement of dbus-c++, which currently
-      suffers from a number of (unresolved) bugs, concurrency issues and
-      inherent design complexities and limitations.
-    '';
-    license = lib.licenses.lgpl2Only;
-    maintainers = [ ];
-    platforms = lib.platforms.linux;
-    mainProgram = "sdbus-c++-xml2cpp";
+  sdbus-cpp_2 = generic {
+    version = "2.0.0";
+    hash = "sha256-W8V5FRhV3jtERMFrZ4gf30OpIQLYoj2yYGpnYOmH2+g=";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1906,7 +1906,7 @@ with pkgs;
 
   scarab = callPackage ../tools/games/scarab { };
 
-  sdbus-cpp = callPackage ../development/libraries/sdbus-cpp { };
+  inherit (callPackage ../development/libraries/sdbus-cpp { }) sdbus-cpp sdbus-cpp_2;
 
   sdlookup = callPackage ../tools/security/sdlookup { };
 


### PR DESCRIPTION
Diff: https://github.com/hyprwm/hyprlock/compare/v0.4.1...v0.5.0
Changelog: https://github.com/hyprwm/hyprlock/releases/tag/v0.5.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Now requires sdbus-cpp >= 2.0.0, but bumping sdbus-cpp to 2.0 breaks the following other packages:

> dnf5 dnf5.man gummy hypridle jami xdg-desktop-portal-hyprland

I'm not sure if the override is the correct approach to resolve this.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
