### PR TITLE
nushellPlugins.file: init at 0.13.0

### DIFF
--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -10,6 +10,7 @@ lib.makeScope newScope (self: with self; {
   highlight = callPackage ./highlight.nix { inherit IOKit Foundation; };
   dbus = callPackage ./dbus.nix { inherit dbus; nushell_plugin_dbus = self.dbus; };
   skim = callPackage ./skim.nix { inherit IOKit CoreFoundation; };
+  file = callPackage ./file.nix { inherit IOKit CoreFoundation; };
 } // lib.optionalAttrs config.allowAliases {
   regex = throw "`nu_plugin_regex` is no longer compatible with the current Nushell release.";
 })

--- a/pkgs/shells/nushell/plugins/file.nix
+++ b/pkgs/shells/nushell/plugins/file.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  pkg-config,
+  nix-update-script,
+  fetchFromGitHub,
+  CoreFoundation,
+  IOKit,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nushell_plugin_file";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    repo = "nu_plugin_file";
+    owner = "fdncred";
+    tag = "v${version}";
+    hash = "sha256-cMDkhNPIfkJb01fBSt2fCCdg/acdzak66qMRp0zuJzc=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-s2Sw8NDVJZoZsnNeGGCXb64WFb3ivO9TxBYFcjLVOZI=";
+
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    CoreFoundation
+    IOKit
+  ];
+  cargoBuildFlags = [ "--package nu_plugin_file" ];
+
+  checkPhase = ''
+    cargo test
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A nushell plugin that will inspect a file and return information based on it's magic number.";
+    mainProgram = "nu_plugin_file";
+    homepage = "https://github.com/fdncred/nu_plugin_file";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.mgttlinger ];
+    platforms = lib.platforms.all;
+    changelog = "https://github.com/fdncred/nu_plugin_file/releases/tag/v${version}/CHANGELOG.md";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added new nutshell plugin `file` replacing the equally named command with a nu native implementation. See https://github.com/fdncred/nu_plugin_file

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
