### PR TITLE
nixos/wakapi; fix logical errors; add NixOS test

### DIFF
--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -196,7 +196,7 @@ in
     ];
 
     warnings = [
-      (lib.optionalString (cfg.db.createLocall -> cfg.db.dialect != "postgres") ''
+      (lib.optionalString (cfg.db.createLocally -> cfg.db.dialect != "postgres") ''
         You have enabled automatic database configuration, but the database dialect is not set to "posgres".
 
         The Wakapi module only supports for PostgreSQL. Please set `services.wakapi.database.createLocally`

--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -182,11 +182,11 @@ in
         message = "Either `services.wakapi.passwordSalt` or `services.wakapi.passwordSaltFile` must be set.";
       }
       {
-        assertion = cfg.passwordSalt != null -> cfg.passwordSaltFile != null;
+        assertion = !(cfg.passwordSalt != null && cfg.passwordSaltFile != null);
         message = "Both `services.wakapi.passwordSalt` `services.wakapi.passwordSaltFile` should not be set at the same time.";
       }
       {
-        assertion = cfg.smtpPassword != null -> cfg.smtpPasswordFile != null;
+        assertion = !(cfg.smtpPassword != null && cfg.smtpPasswordFile != null);
         message = "Both `services.wakapi.smtpPassword` `services.wakapi.smtpPasswordFile` should not be set at the same time.";
       }
       {

--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -190,13 +190,13 @@ in
         message = "Both `services.wakapi.smtpPassword` `services.wakapi.smtpPasswordFile` should not be set at the same time.";
       }
       {
-        assertion = cfg.db.createLocally -> cfg.db.dialect != null;
+        assertion = cfg.database.createLocally -> cfg.settings.db.dialect != null;
         message = "`services.wakapi.database.createLocally` is true, but a database dialect is not set!";
       }
     ];
 
     warnings = [
-      (lib.optionalString (cfg.db.createLocally -> cfg.db.dialect != "postgres") ''
+      (lib.optionalString (cfg.database.createLocally -> cfg.settings.db.dialect != "postgres") ''
         You have enabled automatic database configuration, but the database dialect is not set to "posgres".
 
         The Wakapi module only supports for PostgreSQL. Please set `services.wakapi.database.createLocally`

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1108,6 +1108,7 @@ in {
   vscode-remote-ssh = handleTestOn ["x86_64-linux"] ./vscode-remote-ssh.nix {};
   vscodium = discoverTests (import ./vscodium.nix);
   vsftpd = handleTest ./vsftpd.nix {};
+  wakapi = handleTest ./wakapi.nix {};
   warzone2100 = handleTest ./warzone2100.nix {};
   wasabibackend = handleTest ./wasabibackend.nix {};
   wastebin = handleTest ./wastebin.nix {};

--- a/nixos/tests/wakapi.nix
+++ b/nixos/tests/wakapi.nix
@@ -1,0 +1,40 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+  {
+    name = "Wakapi";
+
+    nodes.machine = {
+      services.wakapi = {
+        enable = true;
+        settings = {
+          server.port = 3000; # upstream default, set explicitly in case upstream changes it
+
+          db = {
+            dialect = "postgres"; # `createLocally` only supports postgres
+            host = "/run/postgresql";
+            port = 5432; # service will fail if port is not set
+            name = "wakapi";
+            user = "wakapi";
+          };
+        };
+
+        database.createLocally = true;
+
+        # Created with `cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1`
+        # Prefer passwordSaltFile in production.
+        passwordSalt = "NpqCY7eY7fMoIWYmPx5mAgr6YoSlXSuI";
+      };
+    };
+
+    # Test that the service is running and that it is reachable.
+    # This is not very comprehensive for a test, but it should
+    # catch very basic mistakes in the module.
+    testScript = ''
+      machine.wait_for_unit("wakapi.service")
+      machine.wait_for_open_port(3000)
+      machine.succeed("curl --fail http://localhost:3000")
+    '';
+
+    meta.maintainers = [ lib.maintainers.NotAShelf ];
+  }
+)


### PR DESCRIPTION
- **nixos/wakapi: fix typo in warning conditional**
- **nixos/wakapi: fix failing assertions**
- **nixos/wakapi: fix incorrect assertion conditions**
- **nixos/tests: add wakapi**

Adds basic NixOS tests for the Wakapi module. Also fixes a few typos and logical errors.
The tests are very basic, but it is better than nothing imho. If more test cases arise, we may support them accordingly.

CC: @isabelroses for review and testing.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
