### PR TITLE
weblate: 5.7.2 -> 5.8.3

### DIFF
--- a/pkgs/by-name/we/weblate/package.nix
+++ b/pkgs/by-name/we/weblate/package.nix
@@ -15,9 +15,7 @@
 let
   python = python3.override {
     packageOverrides = final: prev: {
-      django = prev.django_5.overridePythonAttrs (old: {
-        dependencies = old.dependencies ++ prev.django_5.optional-dependencies.argon2;
-      });
+      django = prev.django_5;
       sentry-sdk = prev.sentry-sdk_2;
       djangorestframework = prev.djangorestframework.overridePythonAttrs (old: {
         # https://github.com/encode/django-rest-framework/discussions/9342
@@ -28,9 +26,11 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "weblate";
-  version = "5.7.2";
+  version = "5.8.3";
 
   pyproject = true;
+
+  disabled = python.pythonOlder "3.11";
 
   outputs = [
     "out"
@@ -41,17 +41,8 @@ python.pkgs.buildPythonApplication rec {
     owner = "WeblateOrg";
     repo = "weblate";
     rev = "refs/tags/weblate-${version}";
-    hash = "sha256-cIwCNYXbg7l6z9OAkMAGJ783QI/nCOyrhLPURDcDv+Y=";
+    hash = "sha256-Kmna23jhhFRJ0ExplYNPFEaIAJxmwHU2azivfKHHnjs=";
   };
-
-  pythonRelaxDeps = [
-    # https://github.com/WeblateOrg/weblate/commit/9695f912b0d24ae999d9442bb49719b4bb552696
-    "qrcode"
-    # https://github.com/WeblateOrg/weblate/commit/1cf2a423b20fcd2dde18a43277311334e38208e7
-    "rapidfuzz"
-    # https://github.com/WeblateOrg/weblate/commit/3e34566fd7c151e1983586586bd7651cefe79585
-    "redis"
-  ];
 
   patches = [
     # FIXME This shouldn't be necessary and probably has to do with some dependency mismatch.
@@ -93,6 +84,7 @@ python.pkgs.buildPythonApplication rec {
       cssselect
       cython
       cyrtranslit
+      dateparser
       diff-match-patch
       django-appconf
       django-celery-beat
@@ -105,6 +97,7 @@ python.pkgs.buildPythonApplication rec {
       django-otp-webauthn
       django
       djangorestframework
+      drf-spectacular
       filelock
       fluent-syntax
       gitpython
@@ -142,8 +135,10 @@ python.pkgs.buildPythonApplication rec {
       weblate-language-data
       weblate-schemas
     ]
+    ++ django.optional-dependencies.argon2
     ++ python-redis-lock.optional-dependencies.django
-    ++ celery.optional-dependencies.redis;
+    ++ celery.optional-dependencies.redis
+    ++ drf-spectacular.optional-dependencies.sidecar;
 
   optional-dependencies = {
     postgres = with python.pkgs; [ psycopg ];

--- a/pkgs/development/python-modules/diff-match-patch/default.nix
+++ b/pkgs/development/python-modules/diff-match-patch/default.nix
@@ -8,15 +8,16 @@
 
 buildPythonPackage rec {
   pname = "diff-match-patch";
-  version = "20230430";
-  format = "pyproject";
+  version = "20241021";
+  pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-lTAZzbnJ0snke1sSvP889HRvxFmOtAYHb6H8J+ah8Vw=";
+    pname = "diff_match_patch";
+    inherit version;
+    hash = "sha256-vq5XqZ+kgIRTKTXuKWi4Zh24YYYuyCxvIfSs3W2DUHM=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  dependencies = [ flit-core ];
 
   nativeCheckInputs = [ unittestCheckHook ];
 

--- a/pkgs/development/python-modules/django-otp-webauthn/default.nix
+++ b/pkgs/development/python-modules/django-otp-webauthn/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "django-otp-webauthn";
-  version = "0.3.0";
+  version = "0.4.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "django_otp_webauthn";
-    hash = "sha256-+Y46/PDeXL9zayoZykaU63faQmnLHzYPmqJJeRBx+hs=";
+    hash = "sha256-BXwIjQjynTjFK+bNML5i35qxQ7TJeb4Xc+duS6Y+5Fk=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/drf-spectacular/default.nix
+++ b/pkgs/development/python-modules/drf-spectacular/default.nix
@@ -93,6 +93,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "drf_spectacular" ];
 
+  optional-dependencies.sidecar = [ drf-spectacular-sidecar ];
+
   meta = with lib; {
     description = "Sane and flexible OpenAPI 3 schema generation for Django REST framework";
     homepage = "https://github.com/tfranzel/drf-spectacular";

--- a/pkgs/development/python-modules/translate-toolkit/default.nix
+++ b/pkgs/development/python-modules/translate-toolkit/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "translate-toolkit";
-  version = "3.13.4";
+  version = "3.14.1";
 
   pyproject = true;
   build-system = [ setuptools-scm ];
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "translate_toolkit";
     inherit version;
-    hash = "sha256-d0q4xpN37xeLSmQMBrDGZlGjAj4hHfkazGUHzl89UHI=";
+    hash = "sha256-IUjEN8Up1Or4nFo71WkDduq+6Xw8ObfUgkABp88zPoY=";
   };
 
   dependencies = [


### PR DESCRIPTION
- [x] Depends on some stuff cherry-picked from `python-updates`
- [x] Requires further adaptations to the module

Changelogs:

- `translate-toolkit`
  - https://github.com/translate/translate/releases/tag/3.13.5
  - https://github.com/translate/translate/releases/tag/3.14.0
  - https://github.com/translate/translate/releases/tag/3.14.1
- `diff-match-patch`:
  - https://github.com/diff-match-patch-python/diff-match-patch/releases/tag/v20241021
- `django-otp-webauthn`:
  - https://github.com/Stormbase/django-otp-webauthn/releases/tag/v0.4.0
- `weblate`:
  - https://github.com/WeblateOrg/weblate/releases/tag/weblate-5.8
  - https://github.com/WeblateOrg/weblate/releases/tag/weblate-5.8.1
  - https://github.com/WeblateOrg/weblate/releases/tag/weblate-5.8.2
  - https://github.com/WeblateOrg/weblate/releases/tag/weblate-5.8.3
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
