### PR TITLE
nixos/mautrix-whatsapp: upgrade default config to 0.11.0

### DIFF
--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -14,26 +14,30 @@
 
   mkDefaults = lib.mapAttrsRecursive (n: v: lib.mkDefault v);
   defaultConfig = {
+    database = {
+      type = "sqlite3-fk-wal";
+      uri = "file:${dataDir}/mautrix-whatsapp.db?_txlock=immediate";
+    };
     homeserver.address = "http://localhost:8448";
     appservice = {
       hostname = "[::]";
       port = appservicePort;
-      database.type = "sqlite3";
-      database.uri = "${dataDir}/mautrix-whatsapp.db";
       id = "whatsapp";
       bot.username = "whatsappbot";
       bot.displayname = "WhatsApp Bridge Bot";
       as_token = "";
       hs_token = "";
-    };
-    bridge = {
       username_template = "whatsapp_{{.}}";
-      displayname_template = "{{if .BusinessName}}{{.BusinessName}}{{else if .PushName}}{{.PushName}}{{else}}{{.JID}}{{end}} (WA)";
-      double_puppet_server_map = {};
-      login_shared_secret_map = {};
+    };
+    network.displayname_template = "{{if .BusinessName}}{{.BusinessName}}{{else if .PushName}}{{.PushName}}{{else}}{{.JID}}{{end}} (WA)";
+    bridge = {
       command_prefix = "!wa";
       permissions."*" = "relay";
       relay.enabled = true;
+    };
+    double_puppet = {
+      servers = {};
+      secrets = {};
     };
     logging = {
       min_level = "info";
@@ -60,31 +64,32 @@ in {
         instead of this world-readable attribute set.
       '';
       example = {
+        database = {
+          type = "postgres";
+          uri = "postgresql:///mautrix_whatsapp?host=/run/postgresql";
+        };
         appservice = {
-          database = {
-            type = "postgres";
-            uri = "postgresql:///mautrix_whatsapp?host=/run/postgresql";
-          };
           id = "whatsapp";
           ephemeral_events = false;
         };
-        bridge = {
+        network = {
           history_sync = {
             request_full_sync = true;
           };
+        };
+        bridge = {
           private_chat_portal_meta = true;
-          mute_bridging = true;
-          encryption = {
-            allow = true;
-            default = true;
-            require = true;
-          };
-          provisioning = {
-            shared_secret = "disable";
-          };
           permissions = {
             "example.com" = "user";
           };
+        };
+        provisioning = {
+          shared_secret = "disable";
+        };
+        encryption = {
+          allow = true;
+          default = true;
+          require = true;
         };
       };
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

mautrix-whatsapp 0.11.0 (merged in #349492) includes some config format changes due to a backend rewrite ([changelog](https://github.com/mautrix/whatsapp/releases/tag/v0.11.0)). mautrix-whatsapp will automatically upgrade legacy configs at runtime ([here](https://github.com/mautrix/go/blob/v0.21.1/bridgev2/bridgeconfig/upgrade.go) and [here](https://github.com/mautrix/go/blob/v0.21.1/bridgev2/bridgeconfig/legacymigrate.go)), so the change is not breaking. But of course the nixos module should be up to date. The proposed changes in this PR correspond to the automated changes within mautrix-whatsapp/mautrix-go.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
