### PR TITLE
strawberry-graphql: adding typer to CLI optional deps

### DIFF
--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -1,46 +1,10 @@
-{
-  lib,
-  aiohttp,
-  asgiref,
-  buildPythonPackage,
-  chalice,
-  channels,
-  daphne,
-  django,
-  email-validator,
-  fastapi,
-  fetchFromGitHub,
-  fetchpatch,
-  flask,
-  freezegun,
-  graphql-core,
-  inline-snapshot,
-  libcst,
-  opentelemetry-api,
-  opentelemetry-sdk,
-  poetry-core,
-  pydantic,
-  pygments,
-  pyinstrument,
-  pytest-aiohttp,
-  pytest-asyncio,
-  pytest-django,
-  pytest-emoji,
-  pytest-flask,
-  pytest-mock,
-  pytest-snapshot,
-  pytestCheckHook,
-  python-dateutil,
-  python-multipart,
-  pythonOlder,
-  rich,
-  sanic,
-  sanic-testing,
-  starlette,
-  typing-extensions,
-  uvicorn,
-  typer,
-  graphlib-backport
+{ lib, aiohttp, asgiref, buildPythonPackage, chalice, channels, daphne, django
+, email-validator, fastapi, fetchFromGitHub, fetchpatch, flask, freezegun
+, graphql-core, inline-snapshot, libcst, opentelemetry-api, opentelemetry-sdk
+, poetry-core, pydantic, pygments, pyinstrument, pytest-aiohttp, pytest-asyncio
+, pytest-django, pytest-emoji, pytest-flask, pytest-mock, pytest-snapshot
+, pytestCheckHook, python-dateutil, python-multipart, pythonOlder, rich, sanic
+, sanic-testing, starlette, typing-extensions, uvicorn, typer, graphlib-backport
 }:
 
 buildPythonPackage rec {
@@ -61,7 +25,8 @@ buildPythonPackage rec {
     (fetchpatch {
       # https://github.com/strawberry-graphql/strawberry/pull/2199
       name = "switch-to-poetry-core.patch";
-      url = "https://github.com/strawberry-graphql/strawberry/commit/710bb96f47c244e78fc54c921802bcdb48f5f421.patch";
+      url =
+        "https://github.com/strawberry-graphql/strawberry/commit/710bb96f47c244e78fc54c921802bcdb48f5f421.patch";
       hash = "sha256-ekUZ2hDPCqwXp9n0YjBikwSkhCmVKUzQk7LrPECcD7Y=";
     })
   ];
@@ -73,65 +38,23 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  dependencies = [
-    graphql-core
-    python-dateutil
-    typing-extensions
-  ];
+  dependencies = [ graphql-core python-dateutil typing-extensions ];
 
   optional-dependencies = {
-    aiohttp = [
-      aiohttp
-      pytest-aiohttp
-    ];
-    asgi = [
-      starlette
-      python-multipart
-    ];
-    debug = [
-      rich
-      libcst
-    ];
-    debug-server = [
-      typer
-      libcst
-      pygments
-      python-multipart
-      rich
-      starlette
-      uvicorn
-    ];
-    django = [
-      django
-      pytest-django
-      asgiref
-    ];
-    channels = [
-      channels
-      asgiref
-    ];
-    flask = [
-      flask
-      pytest-flask
-    ];
-    opentelemetry = [
-      opentelemetry-api
-      opentelemetry-sdk
-    ];
+    aiohttp = [ aiohttp pytest-aiohttp ];
+    asgi = [ starlette python-multipart ];
+    debug = [ rich libcst ];
+    debug-server =
+      [ typer libcst pygments python-multipart rich starlette uvicorn ];
+    django = [ django pytest-django asgiref ];
+    channels = [ channels asgiref ];
+    flask = [ flask pytest-flask ];
+    opentelemetry = [ opentelemetry-api opentelemetry-sdk ];
     pydantic = [ pydantic ];
     sanic = [ sanic ];
-    fastapi = [
-      fastapi
-      python-multipart
-    ];
+    fastapi = [ fastapi python-multipart ];
     chalice = [ chalice ];
-    cli = [
-      pygments
-      rich
-      libcst
-      typer
-      graphlib-backport
-    ];
+    cli = [ pygments rich libcst typer graphlib-backport ];
     # starlite = [ starlite ];
     # litestar = [ litestar ];
     pyinstrument = [ pyinstrument ];
@@ -173,7 +96,8 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "GraphQL library for Python that leverages type annotations";
     homepage = "https://strawberry.rocks";
-    changelog = "https://github.com/strawberry-graphql/strawberry/blob/${version}/CHANGELOG.md";
+    changelog =
+      "https://github.com/strawberry-graphql/strawberry/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ izorkin ];
     mainProgram = "strawberry";

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -5,7 +5,6 @@
   buildPythonPackage,
   chalice,
   channels,
-  click,
   daphne,
   django,
   email-validator,
@@ -40,6 +39,8 @@
   starlette,
   typing-extensions,
   uvicorn,
+  typer,
+  graphlib-backport
 }:
 
 buildPythonPackage rec {
@@ -92,7 +93,7 @@ buildPythonPackage rec {
       libcst
     ];
     debug-server = [
-      click
+      typer
       libcst
       pygments
       python-multipart

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -1,10 +1,46 @@
-{ lib, aiohttp, asgiref, buildPythonPackage, chalice, channels, daphne, django
-, email-validator, fastapi, fetchFromGitHub, fetchpatch, flask, freezegun
-, graphql-core, inline-snapshot, libcst, opentelemetry-api, opentelemetry-sdk
-, poetry-core, pydantic, pygments, pyinstrument, pytest-aiohttp, pytest-asyncio
-, pytest-django, pytest-emoji, pytest-flask, pytest-mock, pytest-snapshot
-, pytestCheckHook, python-dateutil, python-multipart, pythonOlder, rich, sanic
-, sanic-testing, starlette, typing-extensions, uvicorn, typer, graphlib-backport
+{
+  lib,
+  aiohttp,
+  asgiref,
+  buildPythonPackage,
+  chalice,
+  channels,
+  daphne,
+  django,
+  email-validator,
+  fastapi,
+  fetchFromGitHub,
+  fetchpatch,
+  flask,
+  freezegun,
+  graphql-core,
+  inline-snapshot,
+  libcst,
+  opentelemetry-api,
+  opentelemetry-sdk,
+  poetry-core,
+  pydantic,
+  pygments,
+  pyinstrument,
+  pytest-aiohttp,
+  pytest-asyncio,
+  pytest-django,
+  pytest-emoji,
+  pytest-flask,
+  pytest-mock,
+  pytest-snapshot,
+  pytestCheckHook,
+  python-dateutil,
+  python-multipart,
+  pythonOlder,
+  rich,
+  sanic,
+  sanic-testing,
+  starlette,
+  typing-extensions,
+  uvicorn,
+  typer,
+  graphlib-backport,
 }:
 
 buildPythonPackage rec {
@@ -25,8 +61,7 @@ buildPythonPackage rec {
     (fetchpatch {
       # https://github.com/strawberry-graphql/strawberry/pull/2199
       name = "switch-to-poetry-core.patch";
-      url =
-        "https://github.com/strawberry-graphql/strawberry/commit/710bb96f47c244e78fc54c921802bcdb48f5f421.patch";
+      url = "https://github.com/strawberry-graphql/strawberry/commit/710bb96f47c244e78fc54c921802bcdb48f5f421.patch";
       hash = "sha256-ekUZ2hDPCqwXp9n0YjBikwSkhCmVKUzQk7LrPECcD7Y=";
     })
   ];
@@ -38,23 +73,65 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  dependencies = [ graphql-core python-dateutil typing-extensions ];
+  dependencies = [
+    graphql-core
+    python-dateutil
+    typing-extensions
+  ];
 
   optional-dependencies = {
-    aiohttp = [ aiohttp pytest-aiohttp ];
-    asgi = [ starlette python-multipart ];
-    debug = [ rich libcst ];
-    debug-server =
-      [ typer libcst pygments python-multipart rich starlette uvicorn ];
-    django = [ django pytest-django asgiref ];
-    channels = [ channels asgiref ];
-    flask = [ flask pytest-flask ];
-    opentelemetry = [ opentelemetry-api opentelemetry-sdk ];
+    aiohttp = [
+      aiohttp
+      pytest-aiohttp
+    ];
+    asgi = [
+      starlette
+      python-multipart
+    ];
+    debug = [
+      rich
+      libcst
+    ];
+    debug-server = [
+      typer
+      libcst
+      pygments
+      python-multipart
+      rich
+      starlette
+      uvicorn
+    ];
+    django = [
+      django
+      pytest-django
+      asgiref
+    ];
+    channels = [
+      channels
+      asgiref
+    ];
+    flask = [
+      flask
+      pytest-flask
+    ];
+    opentelemetry = [
+      opentelemetry-api
+      opentelemetry-sdk
+    ];
     pydantic = [ pydantic ];
     sanic = [ sanic ];
-    fastapi = [ fastapi python-multipart ];
+    fastapi = [
+      fastapi
+      python-multipart
+    ];
     chalice = [ chalice ];
-    cli = [ pygments rich libcst typer graphlib-backport ];
+    cli = [
+      pygments
+      rich
+      libcst
+      typer
+      graphlib-backport
+    ];
     # starlite = [ starlite ];
     # litestar = [ litestar ];
     pyinstrument = [ pyinstrument ];
@@ -96,8 +173,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "GraphQL library for Python that leverages type annotations";
     homepage = "https://strawberry.rocks";
-    changelog =
-      "https://github.com/strawberry-graphql/strawberry/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/strawberry-graphql/strawberry/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ izorkin ];
     mainProgram = "strawberry";

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -129,6 +129,7 @@ buildPythonPackage rec {
       pygments
       rich
       libcst
+      typer
     ];
     # starlite = [ starlite ];
     # litestar = [ litestar ];

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -125,11 +125,11 @@ buildPythonPackage rec {
     ];
     chalice = [ chalice ];
     cli = [
-      click
       pygments
       rich
       libcst
       typer
+      graphlib-backport
     ];
     # starlite = [ starlite ];
     # litestar = [ litestar ];


### PR DESCRIPTION
Based on [this](https://github.com/strawberry-graphql/strawberry/blob/main/CHANGELOG.md#01841---2023-06-13) changelog, and [line 139](https://github.com/strawberry-graphql/strawberry/blob/main/pyproject.toml) of the optional dependencies config file, the CLI optional dep as been migrated to Typer, but the dependencie was not added in the current nix file.
Unused deps for this option as been removed and new ones as been added.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
