### PR TITLE
gtuber: init at 0-unstable-2024-10-11

### DIFF
--- a/pkgs/applications/video/clapper/default.nix
+++ b/pkgs/applications/video/clapper/default.nix
@@ -17,6 +17,8 @@
 , vala
 , cmake
 , libmicrodns
+, gtuber
+, glib-networking
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -49,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-good
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-plugins-ugly
+    gtuber
+    glib-networking # for TLS support
     gtk4
     libGL
     libadwaita

--- a/pkgs/by-name/gt/gtuber/package.nix
+++ b/pkgs/by-name/gt/gtuber/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  gobject-introspection,
+  vala,
+  glib,
+  libsoup_3,
+  json-glib,
+  libxml2,
+  gst_all_1,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation {
+  pname = "gtuber";
+  version = "0-unstable-2024-10-11";
+
+  src = fetchFromGitHub {
+    owner = "Rafostar";
+    repo = "gtuber";
+    rev = "468bf02a8adcf69b1bd6dd7b5dbcdcc0bfdb6922";
+    hash = "sha256-pEiHqcxkrxZRD9xW/R9DNDdp5foxaHK2SAuzmPNegaY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection # For g-ir-scanner
+    vala # For vapigen
+  ];
+  buildInputs = [
+    glib
+    libsoup_3
+    json-glib
+    libxml2
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+  ];
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = {
+    description = "GStreamer plugin for streaming videos from websites";
+    homepage = "https://rafostar.github.io/gtuber/";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ chuangzhu ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Package [gtuber](https://github.com/Rafostar/gtuber) and add gtuber support to `clapper`. This allows clapper to play YouTube URLs directly

![Add youtube URI](https://github.com/user-attachments/assets/5a0b8ecb-24e1-42ac-8177-b775f3c94c4d)

![Video playing](https://github.com/user-attachments/assets/4c2cacf3-475e-46a6-a1d6-41c08f660812)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
