### PR TITLE
factorio: give advice on how to retain source tarball

### DIFF
--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -70,6 +70,15 @@ let
       nix-prefetch-url file://\''$HOME/Downloads/factorio_\''${releaseType}_x64_\''${version}.tar.xz --name factorio_\''${releaseType}_x64-\''${version}.tar.xz
 
     Note the ultimate "_" is replaced with "-" in the --name arg!
+
+    If you go this route you might want to tell nix to explicitly hold on to the
+    source tarball. Otherwise it could get GC'd from the nix store and you'd
+    have to redownload it next time the package wants to rebuild to use a newer
+    dependency. E.g. if you're using nixos:
+
+      system.extraDependencies = [
+        factorio.src
+      ];
   '';
 
   desktopItem = makeDesktopItem {

--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -71,10 +71,10 @@ let
 
     Note the ultimate "_" is replaced with "-" in the --name arg!
 
-    If you go this route you might want to tell nix to explicitly hold on to the
-    source tarball. Otherwise it could get GC'd from the nix store and you'd
+    If you go this route you might want to tell Nix to explicitly hold on to the
+    source tarball. Otherwise it could get GC'd from the Nix store and you'd
     have to redownload it next time the package wants to rebuild to use a newer
-    dependency. E.g. if you're using nixos:
+    dependency. E.g. if you're using NixOS:
 
       system.extraDependencies = [
         factorio.src


### PR DESCRIPTION
[edit: following discussion I changed approach of this PR, but retaining the original PR description for posterity)

This option artificially makes the source tarball a runtime dependency of the final derivation by symlinking it into the share directory. This is to ensure it doesn't get GC'd, which otherwise can mean you need to manually redownload it every time some unrelated dependency of the package updates.

I've been using this personally for a while. I think it's a pretty janky solution, so I'd be very interested to hear more idiomatic ways to achieve the same thing, but I'm also happy for this to be merged if other folks are ok with it.

Note that even though I only really care about this option in the `needsAuth` cases, it seemed least confusing to just make it always do the same thing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
    - I only tried this with the expansion client, but I don't expect the others to be any different
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
