### PR TITLE
python312Packages.torchmetrics: 1.4.3 -> 1.6.1

### DIFF
--- a/pkgs/development/python-modules/torchmetrics/default.nix
+++ b/pkgs/development/python-modules/torchmetrics/default.nix
@@ -7,59 +7,48 @@
   numpy,
   lightning-utilities,
   packaging,
-  pretty-errors,
 
   # buildInputs
   torch,
 
   # tests
-  cloudpickle,
-  psutil,
   pytestCheckHook,
   pytest-doctestplus,
   pytest-xdist,
   pytorch-lightning,
   scikit-image,
-  scikit-learn,
 
   # passthru
   torchmetrics,
 }:
 
-let
+buildPythonPackage rec {
   pname = "torchmetrics";
-  version = "1.4.3";
-in
-buildPythonPackage {
-  inherit pname version;
+  version = "1.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Lightning-AI";
     repo = "torchmetrics";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-527cHPFdFw/JajHe7Kkz7+zl4EfePaLx77I2OTjjxaA=";
+    tag = "v${version}";
+    hash = "sha256-itLFJB920hQGX2VLOLolHhmXFVHAOkfRRFtUGB9neKM=";
   };
 
   dependencies = [
     numpy
     lightning-utilities
     packaging
-    pretty-errors
   ];
 
   # Let the user bring their own instance
   buildInputs = [ torch ];
 
   nativeCheckInputs = [
-    cloudpickle
-    psutil
     pytestCheckHook
     pytest-doctestplus
     pytest-xdist
     pytorch-lightning
     scikit-image
-    scikit-learn
   ];
 
   # A cyclic dependency in: integrations/test_lightning.py
@@ -73,15 +62,19 @@ buildPythonPackage {
     dontInstall = true;
   });
 
-  disabledTests = [
-    # `IndexError: list index out of range`
-    "test_metric_lightning_log"
-  ];
-
   disabledTestPaths = [
     # These require too many "leftpad-level" dependencies
     # Also too cross-dependent
     "tests/unittests"
+
+    # AttributeError: partially initialized module 'pesq' has no attribute 'pesq' (most likely due to a circular import)
+    "examples/audio/pesq.py"
+
+    # Require internet access
+    "examples/text/bertscore.py"
+    "examples/image/clip_score.py"
+    "examples/text/perplexity.py"
+    "examples/text/rouge.py"
 
     # A trillion import path mismatch errors
     "src/torchmetrics"


### PR DESCRIPTION
## Things done

Changelogs:
- https://github.com/Lightning-AI/torchmetrics/releases/tag/v1.5.0
- https://github.com/Lightning-AI/torchmetrics/releases/tag/v1.5.1
- https://github.com/Lightning-AI/torchmetrics/releases/tag/v1.6.0
- https://github.com/Lightning-AI/torchmetrics/releases/tag/v1.6.1

cc @SomeoneSerge 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
