### PR TITLE
python312Packages.pesq: init at 0.0.4

### DIFF
--- a/pkgs/development/python-modules/pesq/default.nix
+++ b/pkgs/development/python-modules/pesq/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cython,
+  numpy,
+  setuptools,
+
+  # tests
+  pytestCheckHook,
+  scipy,
+}:
+
+buildPythonPackage rec {
+  pname = "pesq";
+  version = "0.0.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ludlows";
+    repo = "PESQ";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-JuwZ+trFKGMetS3cC3pEQsV+wbj6+klFnC3THOd8bPE=";
+  };
+
+  postPatch =
+    # pythonRemoveDeps does not work for removing pytest-runner
+    ''
+      substituteInPlace setup.py \
+        --replace-fail ", 'pytest-runner'" ""
+    ''
+    # Flaky tests: numerical equality is not satisfied on ARM platforms
+    + ''
+      substituteInPlace tests/test_pesq.py \
+        --replace-fail \
+          "assert score == 1.6072081327438354" \
+          "assert abs(score - 1.6072081327438354) < 1e-5" \
+        --replace-fail \
+          "assert score == [1.6072081327438354]" \
+          "assert np.allclose(np.array(score), np.array([1.6072081327438354]))"
+    '';
+
+  build-system = [
+    cython
+    setuptools
+    numpy
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  pythonImportsCheck = [
+    "pesq"
+    "pesq.cypesq"
+  ];
+
+  # Prevents importing the `pesq` module from the source files (which lack the cypesq extension)
+  preCheck = ''
+    rm -rf pesq
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    scipy
+  ];
+
+  meta = {
+    description = "PESQ (Perceptual Evaluation of Speech Quality) Wrapper for Python Users";
+    homepage = "https://github.com/ludlows/PESQ";
+    changelog = "https://github.com/ludlows/PESQ/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9890,6 +9890,8 @@ self: super: with self; {
 
   pescea = callPackage ../development/python-modules/pescea { };
 
+  pesq = callPackage ../development/python-modules/pesq { };
+
   pex = callPackage ../development/python-modules/pex { };
 
   pexif = callPackage ../development/python-modules/pexif { };


### PR DESCRIPTION
## Things done

Add [pesq](https://github.com/ludlows/PESQ), a python package to compute the PESQ metric.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
