### PR TITLE
surfer: build on darwin

### DIFF
--- a/pkgs/by-name/su/surfer/package.nix
+++ b/pkgs/by-name/su/surfer/package.nix
@@ -11,8 +11,11 @@
   libX11,
   libXcursor,
   libXi,
+  libiconv,
   stdenv,
   makeWrapper,
+  darwin,
+  writeDarwinBundle,
   zenity,
 }:
 rustPlatform.buildRustPackage rec {
@@ -29,14 +32,31 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    autoPatchelfHook
     makeWrapper
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
   ];
 
   buildInputs = [
     openssl
     stdenv.cc.cc.lib
-  ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin (
+    [ libiconv ]
+    ++ (with darwin.apple_sdk.frameworks; [
+      SystemConfiguration
+      Security
+      AppKit
+      Foundation
+      CoreFoundation
+      OpenGL
+      CoreServices
+      QuartzCore
+      ApplicationServices
+      CoreGraphics
+      CoreVideo
+      Carbon
+      CoreData
+    ]));
 
   # Wayland and X11 libs are required at runtime since winit uses dlopen
   runtimeDependencies = [
@@ -60,9 +80,17 @@ rustPlatform.buildRustPackage rec {
   # Avoid the network attempt from skia. See: https://github.com/cargo2nix/cargo2nix/issues/318
   doCheck = false;
 
-  postFixup = ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     wrapProgram $out/bin/surfer \
       --prefix PATH : ${lib.makeBinPath [ zenity ]}
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p "$out/Applications/Surfer.app/Contents/MacOS"
+
+    ${writeDarwinBundle}/bin/write-darwin-bundle "$out" "Surfer" "unused"
+    mv $out/bin/surfer $out/Applications/Surfer.app/Contents/MacOS/Surfer
+    wrapProgram $out/Applications/Surfer.app/Contents/MacOS/Surfer \
+      --prefix PATH : ${lib.makeBinPath [ zenity ]}
+    ln -s $out/Applications/Surfer.app/Contents/MacOS/Surfer $out/bin/surfer
   '';
 
   meta = {
@@ -71,7 +99,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://gitlab.com/surfer-project/surfer/-/releases/v${version}";
     license = lib.licenses.eupl12;
     maintainers = with lib.maintainers; [ hakan-demirli ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     mainProgram = "surfer";
   };
 }


### PR DESCRIPTION
Darwin is well supported upstream, it's just a matter of what system libraries need to be passed to the linker.
Tested with local waveforms and over server mode without issue.

The usage of `writeDarwinBundle`, while quite unorthodox (there isn't even an icon to convert besides the default from egui), is meant to solve the issue of programs on Darwin leaking wrapper information in the GUI.
This is far from an elegant solution, but is (in my view) worth it for a smoother UX.
See also #350494.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
