### PR TITLE
waybar-mpris: fix updateScript; unstable-2022-01-27 -> 0.1.0-unstable-2022-01-27

### DIFF
--- a/pkgs/by-name/wa/waybar-mpris/package.nix
+++ b/pkgs/by-name/wa/waybar-mpris/package.nix
@@ -1,7 +1,8 @@
-{ lib
-, fetchgit
-, buildGoModule
-, unstableGitUpdater
+{
+  lib,
+  fetchgit,
+  buildGoModule,
+  unstableGitUpdater,
 }:
 
 buildGoModule {

--- a/pkgs/by-name/wa/waybar-mpris/package.nix
+++ b/pkgs/by-name/wa/waybar-mpris/package.nix
@@ -7,7 +7,7 @@
 
 buildGoModule {
   pname = "waybar-mpris";
-  version = "unstable-2022-01-27";
+  version = "0.1.0-unstable-2022-01-27";
 
   src = fetchgit {
     url = "https://git.hrfee.pw/hrfee/waybar-mpris";

--- a/pkgs/by-name/wa/waybar-mpris/package.nix
+++ b/pkgs/by-name/wa/waybar-mpris/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchgit,
   buildGoModule,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 buildGoModule {
@@ -22,7 +22,7 @@ buildGoModule {
     "-w"
   ];
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = with lib; {
     description = "Waybar component/utility for displaying and controlling MPRIS2 compliant media players individually";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Fix update script that was crashing and version to use expected unstable versioning to make sure update detection is done correctly.
https://nixpkgs-update-logs.nix-community.org/waybar-mpris/2024-10-07.log

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
