### PR TITLE
nixos/auto-cpufreq: init vm test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -141,6 +141,7 @@ in {
   audiobookshelf = handleTest ./audiobookshelf.nix {};
   auth-mysql = handleTest ./auth-mysql.nix {};
   authelia = handleTest ./authelia.nix {};
+  auto-cpufreq = handleTest ./auto-cpufreq.nix {};
   avahi = handleTest ./avahi.nix {};
   avahi-with-resolved = handleTest ./avahi.nix { networkd = true; };
   ayatana-indicators = runTest ./ayatana-indicators.nix;

--- a/nixos/tests/auto-cpufreq.nix
+++ b/nixos/tests/auto-cpufreq.nix
@@ -1,0 +1,33 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+
+  {
+    name = "auto-cpufreq-server";
+
+    nodes = {
+      machine =
+        { pkgs, ... }:
+        {
+          # service will still start but since vm inside qemu cpufreq adjustments
+          # cannot be made. This will resource in the following error but the service
+          # remains up:
+          #   ERROR:
+          #   Couldn't find any of the necessary scaling governors.
+          services.auto-cpufreq = {
+            enable = true;
+            settings = {
+              charger = {
+                turbo = "auto";
+              };
+            };
+          };
+        };
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("auto-cpufreq.service")
+      machine.succeed("auto-cpufreq --force reset")
+    '';
+  }
+)

--- a/pkgs/by-name/au/auto-cpufreq/package.nix
+++ b/pkgs/by-name/au/auto-cpufreq/package.nix
@@ -7,6 +7,7 @@
   wrapGAppsHook3,
   gtk3,
   getent,
+  nixosTests,
 }:
 python3Packages.buildPythonPackage rec {
   pname = "auto-cpufreq";
@@ -92,6 +93,10 @@ python3Packages.buildPythonPackage rec {
     mkdir -p $out/share/polkit-1/actions
     cp scripts/org.auto-cpufreq.pkexec.policy $out/share/polkit-1/actions
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) auto-cpufreq;
+  };
 
   meta = {
     mainProgram = "auto-cpufreq";


### PR DESCRIPTION
Include a vm test for the [auto-cpufreq nixos module](https://github.com/NixOS/nixpkgs/blob/2e8caf6ac6fcca24d61f4d30ac507215b64e7c8d/nixos/modules/services/hardware/auto-cpufreq.nix)

Even though cpufreq cannot be adjusted within qemu this test is still
useful to ensure that the service is running and the auto-cpufreq cli is
able to interact with the auto-cpufreq service.

This helped me troubleshoot the existing errors raised in: https://github.com/NixOS/nixpkgs/issues/347804

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
