### PR TITLE
unvanquished: 0.54.1 -> 0.55.0

### DIFF
--- a/pkgs/games/unvanquished/default.nix
+++ b/pkgs/games/unvanquished/default.nix
@@ -32,7 +32,7 @@
 }:
 
 let
-  version = "0.54.1";
+  version = "0.55.0";
   binary-deps-version = "10";
 
   src = fetchFromGitHub {
@@ -40,7 +40,7 @@ let
     repo = "Unvanquished";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-F8U9UBFCe0PcFYZ2DThQwhouO22jKyWb0/ABhprHXCU=";
+    hash = "sha256-4ONge+GnrpV/FHKuA66o7uK7jIygBYizZl8JAUr8x/0=";
   };
 
   unvanquished-binary-deps = stdenv.mkDerivation rec {
@@ -50,7 +50,7 @@ let
 
     src = fetchzip {
       url = "https://dl.unvanquished.net/deps/linux-amd64-default_${version}.tar.xz ";
-      sha256 = "sha256-5n8gRvTuke4e7EaZ/5G+dtCG6qmnawhtA1IXIFQPkzA=";
+      hash = "sha256-5n8gRvTuke4e7EaZ/5G+dtCG6qmnawhtA1IXIFQPkzA=";
     };
 
     dontPatchELF = true;
@@ -118,7 +118,7 @@ let
     pname = "unvanquished-assets";
     inherit version src;
 
-    outputHash = "sha256-xb8gKQHSyscWM29r0BWK0YsALull9uYjX7e+l1DHFPg=";
+    outputHash = "sha256-FDDhwBvmv4EvmSh5g6Cb0HYLuY9T++k7q8egxzo04J8=";
     outputHashMode = "recursive";
 
     nativeBuildInputs = [ aria2 cacert ];


### PR DESCRIPTION
Maintainer upload: new release of unvanquished. Upgrading this package is mandatory to keep playing online.

Release notes: https://unvanquished.net/unvanquished-0-55-awesomeness-has-arrived/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux (not supported by the package yet)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
