### PR TITLE
linuxPackages.nvidiaPackages.beta: 560.31.02 -> 565.57.01

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -58,12 +58,12 @@ rec {
   });
 
   beta = selectHighestVersion latest (generic {
-    version = "560.31.02";
-    sha256_64bit = "sha256-0cwgejoFsefl2M6jdWZC+CKc58CqOXDjSi4saVPNKY0=";
-    sha256_aarch64 = "sha256-m7da+/Uc2+BOYj6mGON75h03hKlIWItHORc5+UvXBQc=";
-    openSha256 = "sha256-X5UzbIkILvo0QZlsTl9PisosgPj/XRmuuMH+cDohdZQ=";
-    settingsSha256 = "sha256-A3SzGAW4vR2uxT1Cv+Pn+Sbm9lLF5a/DGzlnPhxVvmE=";
-    persistencedSha256 = "sha256-BDtdpH5f9/PutG3Pv9G4ekqHafPm3xgDYdTcQumyMtg=";
+    version = "565.57.01";
+    sha256_64bit = "sha256-buvpTlheOF6IBPWnQVLfQUiHv4GcwhvZW3Ks0PsYLHo=";
+    sha256_aarch64 = "sha256-aDVc3sNTG4O3y+vKW87mw+i9AqXCY29GVqEIUlsvYfE=";
+    openSha256 = "sha256-/tM3n9huz1MTE6KKtTCBglBMBGGL/GOHi5ZSUag4zXA=";
+    settingsSha256 = "sha256-H7uEe34LdmUFcMcS6bz7sbpYhg9zPCb/5AmZZFTx1QA=";
+    persistencedSha256 = "sha256-hdszsACWNqkCh8G4VBNitDT85gk9gJe1BlQ8LdrYIkg=";
   });
 
   # Vulkan developer beta driver


### PR DESCRIPTION
- Fixed a bug that could cause suspend/resume to fail when using the NVreg_PreserveVideoMemoryAllocations option: https://github.com/NVIDIA/open-gpu-kernel-modules/issues/472
- Fixed a bug that caused the cursor image to be truncated on Gamescope: https://github.com/ValveSoftware/gamescope/issues/1099
- Re-enabled GLX_EXT_buffer_age on Xwayland. This extension had been previously disabled on Xwayland due to a bug which is now fixed.
- Added support for mmap of exported DMA-BUF objects.
- Reduced some cases of stutter with OpenGL syncing to vblank while using GSP firmware.
- Fixed a regression that could cause some applications to exit due to resource exhaustion on some GPUs while using GSP firmware.
- Added several new per-plane and per-CRTC vendor-specific properties to nvidia-drm. These properties may be used by Wayland compositors to program the GPU's color pipeline for HDR hardware acceleration.
- Introduced a driver optimization to mitigate the performance loss from the 'd3d9.floatEmulation' option in DXVK.
- Fixed a bug that caused FarCry 5 running through DXVK to display a black screen.
- Updated the framelock settings page of the nvidia-settings control panel to use the GTK3 theme text color rather than defaulting to white for the text color, improving legibility with some themes.
- Fixed some performance regressions that were observed with Vkd3d 2.9.
- Fixed a bug that could cause flickering in some applications when using Unified Back Buffer (UBB).
- Fixed a bug which could cause incorrect and/or washed out colors to be displayed with HDR scanout: https://bugs.kde.org/show_bug.cgi?id=482780
- Implemented support for VK_EXT_depth_clamp_control.
- Fixed a bug which could cause applications using GBM to crash when running with nvidia-drm.modeset=0.
- Fixed a bug that could cause kernel crashes upon attempting KMS operations through DRM when nvidia_drm was loaded with modeset=0.
- https://github.com/NVIDIA/open-gpu-kernel-modules/compare/560.35.03...565.57.01
- ~Draft pending auxiliary programs~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
