### PR TITLE
lutris: fix Dolphin and RPCS3 AppImage; add rapiteanu to maintainer list

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -138,6 +138,7 @@ buildPythonApplication rec {
   dontWrapGApps = true;
   makeWrapperArgs = [
     "--prefix PATH : ${lib.makeBinPath requiredTools}"
+    "--prefix APPIMAGE_EXTRACT_AND_RUN : 1"
     "\${gappsWrapperArgs[@]}"
   ];
 

--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -146,7 +146,7 @@ buildPythonApplication rec {
     homepage = "https://lutris.net";
     description = "Open Source gaming platform for GNU/Linux";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ Madouura ];
+    maintainers = with maintainers; [ Madouura rapiteanu ];
     platforms = platforms.linux;
     mainProgram = "lutris";
   };

--- a/pkgs/applications/misc/lutris/fhsenv.nix
+++ b/pkgs/applications/misc/lutris/fhsenv.nix
@@ -7,6 +7,7 @@
 let
 
   qt5Deps = pkgs: with pkgs.qt5; [ qtbase qtmultimedia ];
+  qt6Deps = pkgs: with pkgs.qt6; [ qtbase ];
   gnomeDeps = pkgs: with pkgs; [ zenity gtksourceview gnome-desktop libgnome-keyring webkitgtk_4_0 ];
   xorgDeps = pkgs: with pkgs.xorg; [
     libX11 libXrender libXrandr libxcb libXmu libpthreadstubs libXext libXdmcp
@@ -52,8 +53,8 @@ in buildFHSEnv {
     # DGen // TODO: libarchive is broken
 
     # Dolphin
-    bluez ffmpeg gettext portaudio miniupnpc mbedtls_2 lzo sfml gsm
-    wavpack orc nettle gmp pcre vulkan-loader
+    bluez ffmpeg_6 gettext portaudio miniupnpc mbedtls_2 lzo sfml gsm
+    wavpack orc nettle gmp pcre vulkan-loader zstd
 
     # DOSBox
     SDL_net SDL_sound
@@ -110,6 +111,7 @@ in buildFHSEnv {
     # ZDOOM
     soundfont-fluid bzip2 game-music-emu
   ] ++ qt5Deps pkgs
+    ++ qt6Deps pkgs
     ++ gnomeDeps pkgs
     ++ lib.optional steamSupport pkgs.steam
     ++ extraPkgs pkgs;
@@ -117,7 +119,7 @@ in buildFHSEnv {
   multiPkgs = pkgs: with pkgs; [
     # Common
     libsndfile libtheora libogg libvorbis libopus libGLU libpcap libpulseaudio
-    libao libevdev udev libgcrypt libxml2 libusb-compat-0_1 libpng libmpeg2 libv4l
+    libao libevdev udev libgcrypt libxml2 libusb1 libpng libmpeg2 libv4l
     libjpeg libxkbcommon libass libcdio libjack2 libsamplerate libzip libmad libaio
     libcap libtiff libva libgphoto2 libxslt libsndfile giflib zlib glib
     alsa-lib zziplib bash dbus keyutils zip cabextract freetype unzip coreutils

--- a/pkgs/applications/misc/lutris/fhsenv.nix
+++ b/pkgs/applications/misc/lutris/fhsenv.nix
@@ -34,6 +34,9 @@ in buildFHSEnv {
   targetPkgs = pkgs: with pkgs; [
     lutris-unwrapped
 
+    # Appimages
+    fuse
+
     # Adventure Game Studio
     allegro dumb
 
@@ -86,9 +89,8 @@ in buildFHSEnv {
 
     # Redream // "redream is not available for the x86_64 architecture"
 
-
-    # rpcs3 // TODO: "error while loading shared libraries: libz.so.1..."
-    llvm
+    # RPCS3
+    llvm e2fsprogs libgpg-error
 
     # ScummVM
     nasm sndio


### PR DESCRIPTION
1. Made Lutris able to run the implicit AppImages
A lot of runners are AppImages and these due to their fuse + FHS dependencies, won't work as expected in Nix. This commit implements a workaround that Lutris also employes for flatpaks where they unpack the image and then they run it. This is done via an environment variable passed to the Lutris executable.
This commit also brings all dependencies needed for RPCS3 emulator to work as expected.
2. Fix all dependencies for Dolphin to run as expected.
3. Add rapiteanu to maintainer list

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
