### PR TITLE
autofs: enable NIS support

### DIFF
--- a/pkgs/by-name/au/autofs5/package.nix
+++ b/pkgs/by-name/au/autofs5/package.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, flex, bison, linuxHeaders, libtirpc, mount, umount, nfs-utils, e2fsprogs
 , libxml2, libkrb5, kmod, openldap, sssd, cyrus_sasl, openssl, rpcsvc-proto, pkgconf
-, fetchpatch
+, fetchpatch, libnsl
 }:
 
 stdenv.mkDerivation rec {
@@ -48,9 +48,9 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ linuxHeaders libtirpc libxml2 libkrb5 kmod openldap sssd
-                  openssl cyrus_sasl rpcsvc-proto ];
+                  openssl cyrus_sasl rpcsvc-proto libnsl ];
 
-  nativeBuildInputs = [ flex bison pkgconf ];
+  nativeBuildInputs = [ flex bison pkgconf libnsl.dev ];
 
   meta = {
     description = "Kernel-based automounter";


### PR DESCRIPTION
The current autofs package does not support automounter maps from [NIS](https://en.wikipedia.org/wiki/Network_Information_Service).
The configure script of autofs searches for the header file `rpcsvc/ypclnt.h` file and enables NIS support when it finds it.
Adding the `libnsl.dev` package to `buildInputs` makes the header available during the build process.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Tested against NFS shares from a real NIS server