### PR TITLE
python3Packages.dirsearch: init at 0.4.3

### DIFF
--- a/pkgs/development/python-modules/dirsearch/default.nix
+++ b/pkgs/development/python-modules/dirsearch/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  python,
+  # deps
+  /*
+    ntlm-auth is in the requirements.txt, however nixpkgs tells me
+    > ntlm-auth has been removed, because it relies on the md4 implementation provided by openssl. Use pyspnego instead.
+    Not sure if pyspnego is a drop in replacement.
+    The simple functionality dirsearch seems not to depend on this package.
+  */
+  #ntlm-auth,
+  #pyspnego,
+  beautifulsoup4,
+  certifi,
+  cffi,
+  chardet,
+  charset-normalizer,
+  colorama,
+  cryptography,
+  defusedxml,
+  idna,
+  jinja2,
+  markupsafe,
+  pyopenssl,
+  pyparsing,
+  pysocks,
+  requests,
+  requests-ntlm,
+  setuptools,
+  urllib3,
+}:
+
+buildPythonPackage rec {
+  pname = "dirsearch";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "maurosoria";
+    repo = "dirsearch";
+    rev = "v${version}";
+    hash = "sha256-eXB103qUB3m7V/9hlq2xv3Y3bIz89/pGJsbPZQ+AZXs=";
+  };
+
+  # setup.py does some weird stuff with mktemp
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'os.chdir(env_dir)' "" \
+      --replace-fail 'shutil.copytree(os.path.abspath(os.getcwd()), os.path.join(env_dir, "dirsearch"))' ""
+  '';
+
+  dependencies = [
+    # maybe needed, see above
+    #pyspnego
+    #ntlm-auth
+    beautifulsoup4
+    certifi
+    cffi
+    chardet
+    charset-normalizer
+    colorama
+    cryptography
+    defusedxml
+    idna
+    jinja2
+    markupsafe
+    pyopenssl
+    pyparsing
+    pysocks
+    requests
+    requests-ntlm
+    setuptools
+    urllib3
+  ];
+
+  # the library files get installed in the wrong location
+  # and dirsearch.py, __init__.py and db/ are missing
+  postInstall = ''
+    dirsearchpath=$out/lib/python${lib.versions.majorMinor python.version}/site-packages/
+    mkdir -p $dirsearchpath/dirsearch
+    mv $dirsearchpath/{lib,dirsearch}
+    cp $src/{dirsearch,__init__}.py $dirsearchpath/dirsearch
+    cp -r $src/db $dirsearchpath/dirsearch
+  '';
+
+  meta = {
+    changelog = "https://github.com/maurosoria/dirsearch/releases/tag/${version}";
+    description = "command-line tool for brute-forcing directories and files in webservers, AKA a web path scanner";
+    homepage = "https://github.com/maurosoria/dirsearch";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "dirsearch";
+    maintainers = with lib.maintainers; [ quantenzitrone ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3194,6 +3194,8 @@ self: super: with self; {
 
   dirigera = callPackage ../development/python-modules/dirigera { };
 
+  dirsearch = callPackage ../development/python-modules/dirsearch { };
+
   dirty-equals = callPackage ../development/python-modules/dirty-equals { };
 
   dirtyjson = callPackage ../development/python-modules/dirtyjson { };


### PR DESCRIPTION
closes #191097


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
    - python 3.13, 3.11 and 3.10 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
