### PR TITLE
catalyst-browser: init at 3.9.4

### DIFF
--- a/pkgs/by-name/ca/catalyst-browser/package.nix
+++ b/pkgs/by-name/ca/catalyst-browser/package.nix
@@ -1,0 +1,85 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  appimageTools,
+  makeWrapper,
+  electron_33,
+  electronPackage ? electron_33,
+  asar,
+}:
+
+let
+  electron = electronPackage;
+in
+stdenv.mkDerivation rec {
+  pname = "catalyst-browser";
+  version = "3.9.4";
+
+  src = fetchurl {
+    url = "https://github.com/CatalystDevOrg/Catalyst/releases/download/v${version}/catalyst-${version}.AppImage";
+    hash = "sha256-6t1RAxmRc/1fAQT4Qnd42kh3cxgRZr74k8gwebTb0Ic=";
+    name = "catalyst-${version}.AppImage";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname src version;
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    asar
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/catalyst $out/share/applications
+    mkdir -p $out/share/catalyst/resources/
+
+    cp -a ${appimageContents}/locales $out/share/catalyst
+    cp -a ${appimageContents}/catalyst.desktop $out/share/applications/catalyst.desktop
+    mkdir -p $out/share/pixmaps
+    cp -r ${appimageContents}/usr/share/icons/hicolor/0x0/apps/catalyst.png $out/share/pixmaps/
+    asar extract ${appimageContents}/resources/app.asar resources/
+    rm -rf resources/.github
+    rm -rf resources/.vscode
+    rm -rf resources/.eslintrc.json
+    rm -rf resources/.gitignore
+    rm -rf resources/.pnpm-debug.log
+    rm -rf resources/contributing.md
+    rm -rf resources/pnpm-lock.yaml
+    rm -rf resources/README.md
+    rm -rf resources/CODE_OF_CONDUCT.md
+    rm -rf *.nix
+    substituteInPlace resources/src/index.html \
+      --replace-fail 'catalyst-default-distrib' 'catalyst-default-nixpkgs'
+
+    substituteInPlace $out/share/applications/catalyst.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${meta.mainProgram}'
+
+    asar pack resources/ $out/share/catalyst/resources/app.asar
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${electron}/bin/electron $out/bin/${meta.mainProgram} \
+      --add-flags $out/share/catalyst/resources/app.asar \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc ]}"
+  '';
+
+  meta = {
+    description = "Minimal, functional, and customizable user-focused FOSS web browser based on Chromium";
+    homepage = "https://getcatalyst.eu.org";
+    license = lib.licenses.mit;
+    mainProgram = "catalyst";
+    maintainers = with lib.maintainers; [ jdev082 ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Adds [Catalyst](https://getcatalyst.eu.org) to the package repository.

Source code is [here](https://github.com/CatalystDevOrg/Catalyst)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
