### PR TITLE
p4{,d,v}: upgrade, use GitHub as a mirror

### DIFF
--- a/pkgs/applications/version-management/p4/default.nix
+++ b/pkgs/applications/version-management/p4/default.nix
@@ -33,12 +33,12 @@ let
 in
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "p4";
-  version = "2024.1/2596294";
+  version = "2024.1.2655224";
 
   src = fetchurl {
     # Upstream replaces minor versions, so use archived URL.
-    url = "https://web.archive.org/web/20240526153453id_/https://ftp.perforce.com/perforce/r24.1/bin.tools/p4source.tgz";
-    sha256 = "sha256-6+DOJPeVzP4x0UsN9MlZRAyusapBTICX0BuyvVBQBC8=";
+    url = "https://github.com/impl/nix-p4-archive/releases/download/p4-${version}/p4source-${version}.tgz";
+    hash = "sha256-+ftxoN5Ln9uCl8YnqX3tmbyUTZWONsG0iHz7IpIbodQ=";
   };
 
   nativeBuildInputs = [ jam ];
@@ -60,11 +60,13 @@ stdenv.mkDerivation (finalAttrs: rec {
     ++ lib.optionals stdenv.cc.isClang [ "-sOSCOMP=clang" "-sCLANGVER=${stdenv.cc.cc.version}" ]
     ++ lib.optionals stdenv.cc.isGNU [ "-sOSCOMP=gcc" "-sGCCVER=${stdenv.cc.cc.version}" ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ "-sOSVER=26" ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [ "-sOSPLAT=aarch64" ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       "-sOSVER=1013"
       "-sMACOSX_SDK=${emptyDirectory}"
       "-sLIBC++DIR=${lib.getLib stdenv.cc.libcxx}/lib"
-    ];
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [ "-sOSPLAT=arm64" ];
 
   CCFLAGS =
     # The file contrib/optimizations/slide_hash_neon.h is missing from the

--- a/pkgs/applications/version-management/p4d/default.nix
+++ b/pkgs/applications/version-management/p4d/default.nix
@@ -5,21 +5,31 @@
 }:
 
 let
+  version = "2024.1.2661979";
+
   # Upstream replaces minor versions, so use cached URLs.
   srcs = {
+    "aarch64-linux" = fetchurl {
+      url = "https://github.com/impl/nix-p4-archive/releases/download/p4d-${version}/helix-core-server-${version}-linux26aarch64.tgz";
+      hash = "sha256-LBTUO3hElgNWeDDFX9GF6Me4ZHwoGsjgdrRJMeqPpnw=";
+    };
     "x86_64-linux" = fetchurl {
-      url = "https://web.archive.org/web/20231109221336id_/https://ftp.perforce.com/perforce/r23.1/bin.linux26x86_64/helix-core-server.tgz";
-      sha256 = "b68c4907cf9258ab47102e8f0e489c11d528a8f614bfa45e3a2fa198639e2362";
+      url = "https://github.com/impl/nix-p4-archive/releases/download/p4d-${version}/helix-core-server-${version}-linux26x86_64.tgz";
+      hash = "sha256-m8Qsbx5JDsiahKpcbXRzK6BCT+AyGnrf8xeUBMbb6Ic=";
+    };
+    "aarch64-darwin" = fetchurl {
+      url = "https://github.com/impl/nix-p4-archive/releases/download/p4d-${version}/helix-core-server-${version}-macosx12arm64.tgz";
+      hash = "sha256-rZ5Za/Cb/O6no49hWD256G6vTINgNVU0KqcLvujYFAw=";
     };
     "x86_64-darwin" = fetchurl {
-      url = "https://web.archive.org/web/20231109221937id_/https://ftp.perforce.com/perforce/r23.1/bin.macosx1015x86_64/helix-core-server.tgz";
-      sha256 = "fcbf09787ffc29f7237839711447bf19a37ae18a8a7e19b2d30deb3715ae2c11";
+      url = "https://github.com/impl/nix-p4-archive/releases/download/p4d-${version}/helix-core-server-${version}-macosx1015x86_64.tgz";
+      hash = "sha256-/BmXiGRVzZBf25ra8rB2DXV/bArrfXOY5BCdHK2DDbE=";
     };
   };
 in
 stdenv.mkDerivation {
   pname = "p4d";
-  version = "2023.1.2513900";
+  inherit version;
 
   src =
     assert lib.assertMsg (builtins.hasAttr stdenv.hostPlatform.system srcs) "p4d is not available for ${stdenv.hostPlatform.system}";
@@ -30,6 +40,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
   dontBuild = true;
+
+  # Unnecessary, and seems to segfault on aarch64-darwin.
+  dontStrip = true;
 
   installPhase = ''
     install -D -t $out/bin p4broker p4d p4p

--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -6,15 +6,17 @@
 }:
 
 let
+  version = "2024.3.2656785";
+
   # Upstream replaces minor versions, so use archived URLs.
   srcs = rec {
     x86_64-linux = fetchurl {
-      url = "https://web.archive.org/web/20240612193642id_/https://ftp.perforce.com/perforce/r24.2/bin.linux26x86_64/p4v.tgz";
-      sha256 = "sha256-HA99fHcmgli/vVnr0M8ZJEsaZ2ZLzpG3M8S77oDYJyE=";
+      url = "https://github.com/impl/nix-p4-archive/releases/download/p4v-${version}/p4v-${version}-linux26x86_64.tgz";
+      hash = "sha256-Jmj14DMP9tyo+QPyyWTNdEjAcYT06mkIvM+FrJgVIz4=";
     };
     aarch64-darwin = fetchurl {
-      url = "https://web.archive.org/web/20240612194532id_/https://ftp.perforce.com/perforce/r24.2/bin.macosx12u/P4V.dmg";
-      sha256 = "sha256-PS7gfDdWspyL//YWLkrsGi5wh6SIeAry2yef1/V0d6o=";
+      url = "https://github.com/impl/nix-p4-archive/releases/download/p4v-${version}/p4v-${version}-macosx12u.dmg";
+      hash = "sha256-bQw6Lu/MQKWkfBwe6ZHu0O+JEbVM+2UjRXLs4njHGe0=";
     };
     # this is universal
     x86_64-darwin = aarch64-darwin;
@@ -25,7 +27,7 @@ let
     else qt6Packages.callPackage ./linux.nix { };
 in mkDerivation {
   pname = "p4v";
-  version = "2024.2/2606884";
+  inherit version;
 
   src = srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 


### PR DESCRIPTION
With the Internet Archive's recent struggles, making these packages reliably available (because they're unfree and don't get cached) has been more challenging than usual.

This change upgrades them to the latest version from the Perforce FTP site and uses a GitHub repository as a mirror instead of the Internet Archive.

Release notes:

* https://www.perforce.com/perforce/doc.current/user/relnotes.txt
* https://www.perforce.com/perforce/doc.current/user/p4vnotes.txt


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
