### PR TITLE
nushellPlugins.strutils: init at 0.10.0

### DIFF
--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -25,6 +25,7 @@ lib.makeScope newScope (
       nushell_plugin_dbus = self.dbus;
     };
     skim = callPackage ./skim.nix { inherit IOKit CoreFoundation; };
+    strutils = callPackage ./strutils.nix { inherit IOKit CoreFoundation; };
   }
   // lib.optionalAttrs config.allowAliases {
     regex = throw "`nu_plugin_regex` is no longer compatible with the current Nushell release.";

--- a/pkgs/shells/nushell/plugins/strutils.nix
+++ b/pkgs/shells/nushell/plugins/strutils.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  runCommand,
+  lib,
+  rustPlatform,
+  nix-update-script,
+  fetchFromGitHub,
+  IOKit,
+  CoreFoundation,
+  nushell,
+  strutils,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "nu_plugin_strutils";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "fdncred";
+    repo = pname;
+    tag = version;
+    hash = "sha256-JXlxQtTNOAYf+ZSsiwKe4jKdj2eF0QLslhTRI5rwf+s=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-9bUGg5dqky20wwWjUMo99FuueFNzxDs15wz6HV2yB3I=";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ rustPlatform.bindgenHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    IOKit
+    CoreFoundation
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.check =
+      let
+        nu = lib.getExe nushell;
+        plugin = lib.getExe strutils;
+      in
+      runCommand "${pname}-test" { } ''
+        touch $out
+        ${nu} -n -c "plugin add --plugin-config $out ${plugin}"
+        ${nu} -n -c "plugin use --plugin-config $out strutils"
+      '';
+  };
+
+  meta = with lib; {
+    description = "A nushell plugin that implements additional string utilities beyond the built-in commands";
+    mainProgram = "nu_plugin_strutils";
+    homepage = "https://github.com/fdncred/nu_plugin_strutils";
+    license = licenses.mit;
+    maintainers = [ maintainers.aftix ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
Added package for [nu_plugin_strutils](https://github.com/fdncred/nu_plugin_strutils). It includes a simple test that the passed in nushell can load the plugin.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
