### PR TITLE
Mumps: keep parallel with Debian mumps-seq

### DIFF
--- a/pkgs/by-name/ca/casadi/package.nix
+++ b/pkgs/by-name/ca/casadi/package.nix
@@ -71,11 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
         "<ocp/" \
         "<fatrop/ocp/"
 
-      # fix mumps lib name. No idea where this comes from.
-      substituteInPlace cmake/FindMUMPS.cmake --replace-fail \
-        "mumps_seq" \
-        "mumps"
-
       # help casadi find its own libs
       substituteInPlace casadi/core/casadi_os.cpp --replace-fail \
         "std::vector<std::string> search_paths;" \

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp Make.inc/Makefile.debian.SEQ ./Makefile.inc
   '';
 
+  enableParallelBuilding = true;
+
   makeFlags =
     lib.optionals stdenv.hostPlatform.isDarwin [
       "SONAME="

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -61,9 +61,11 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir $out
     cp -r include lib $out
 
+    # Install mumps_seq headers
+    install -Dm 444 -t $out/include/mumps_seq libseq/*.h
+
     # Add some compatibility with coin-or-mumps
-    ln -s $out/include $out/include/mumps
-    cp libseq/mumps_mpi.h $out/include
+    ln -s $out/include/mumps_seq/mpi.h $out/include/mumps_mpi.h
   '';
 
   nativeBuildInputs = [ gfortran ];

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -18,25 +18,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ZnIfAuvOBJDYqCtKGlWs0r39nG6X2lAVRuUmeIJenZw=";
   };
 
-  patches = [
-    # Compatibility with coin-or-mumps version
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/coin-or-tools/ThirdParty-Mumps/bd0bdf9baa3f3677bd34fb36ce63b2b32cc6cc7d/mumps_mpi.patch";
-      hash = "sha256-70qZUKBVBpJOSRxYxng5Y6ct1fdCUQUGur3chDhGabQ=";
-    })
-  ];
-
-  postPatch =
-    ''
-      # Compatibility with coin-or-mumps version
-      # https://github.com/coin-or-tools/ThirdParty-Mumps/blob/stable/3.0/get.Mumps#L66
-      cp libseq/mpi.h libseq/mumps_mpi.h
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace src/Makefile --replace-fail \
-        "-Wl,\''$(SONAME),libmumps_common" \
-        "-Wl,-install_name,$out/lib/libmumps_common"
-    '';
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/Makefile --replace-fail \
+      "-Wl,\''$(SONAME),libmumps_common" \
+      "-Wl,-install_name,$out/lib/libmumps_common"
+  '';
 
   configurePhase = ''
     cp Make.inc/Makefile.debian.SEQ ./Makefile.inc


### PR DESCRIPTION
## Motivation
This pr install header files in libseq to $out/include/mumps_seq to keep parrallel with Debian and Archlinux.
See 
    - https://sources.debian.org/src/mumps/5.7.3-2/debian/libmumps-headers-dev.install
    - https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mumps-seq
Also remove unnecessary patch from coin-or-mumps. Tested building mumps and ipopt succcessfully.

@nim65s
@abbradar

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
