### PR TITLE
webcord-vencord: switch to electron_31

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33371,7 +33371,7 @@ with pkgs;
 
   webcord = callPackage ../by-name/we/webcord/package.nix { electron = electron_32; };
 
-  webcord-vencord = callPackage ../by-name/we/webcord-vencord/package.nix { electron = electron_30; };
+  webcord-vencord = callPackage ../by-name/we/webcord-vencord/package.nix { electron = electron_31; };
 
   webex = callPackage ../applications/networking/instant-messengers/webex { };
 


### PR DESCRIPTION
- **webcord-vencord: switch to electron_31**

Replaces electron override of `webcord-vencord` to `electron_31` from
`electron_30`.

I wanted to switch to 32 to save some time inbetween manual bumps, but
unfortunately Electron 32 is not supported - this is annoying, but we have
always remained behind the regular Webcord package due to (classic) Electron
issues, so nothing new.

P.S. I wish to be free of Electron one day.

P.P.S. I've only tested with x86_64-linux, for which `webcord-vencord` builds and runs.

See: #350549
