### PR TITLE
antares: modernize; remove electron override

### DIFF
--- a/pkgs/by-name/an/antares/package.nix
+++ b/pkgs/by-name/an/antares/package.nix
@@ -15,7 +15,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "antares-sql";
     repo = "antares";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-3zgr3Eefx3WDUW9/1NOaneUbFy3GTnJ3tGgivtW1K/g=";
   };
 
@@ -66,10 +66,11 @@ buildNpmPackage rec {
     })
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Modern, fast and productivity driven SQL client with a focus in UX";
     homepage = "https://github.com/antares-sql/antares";
-    license = licenses.mit;
-    maintainers = with maintainers; [ eymeric ];
+    changelog = "https://github.com/antares-sql/antares/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eymeric ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16853,10 +16853,6 @@ with pkgs;
 
   ansible-lint = callPackage ../tools/admin/ansible/lint.nix { };
 
-  antares = callPackage ../by-name/an/antares/package.nix {
-    electron = electron_30;
-  };
-
   antlr2 = callPackage ../development/tools/parsing/antlr/2.7.7.nix { };
   antlr3_4 = callPackage ../development/tools/parsing/antlr/3.4.nix { };
   antlr3_5 = callPackage ../development/tools/parsing/antlr/3.5.nix { };


### PR DESCRIPTION
- **antares: modernize derivation**
- **antares: remove redundant Electron override**

Removes the Electron override for antares in `all-packages.nix`. While I was
looking at the derivation, I also updated some parts to better reflect current
nixpkgs standards and added changelog.

See: #350549
