### PR TITLE
morgen: bump electron version to electron_32

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10104,7 +10104,7 @@ with pkgs;
   mole = callPackage ../tools/networking/mole { };
 
   morgen = callPackage ../applications/office/morgen {
-    electron = electron_30;
+    electron = electron_32;
   };
 
   mosh = callPackage ../tools/networking/mosh { };


### PR DESCRIPTION
- **morgen: bump electron version to electron_32**

Bump Electron version of morgen from Electron 30 to Electron 32. Tested, but the app never launches for me - not with E30, nor with E32. Likely cause is Wayland, but unsure.

See: #350549
