### PR TITLE
ruff: move to buildPythonPackage

### DIFF
--- a/pkgs/by-name/ru/ruff/package.nix
+++ b/pkgs/by-name/ru/ruff/package.nix
@@ -4,16 +4,24 @@
   fetchFromGitHub,
   installShellFiles,
   stdenv,
+  python3Packages,
   darwin,
   rust-jemalloc-sys,
   ruff-lsp,
   nix-update-script,
   versionCheckHook,
+  libiconv,
 }:
 
-rustPlatform.buildRustPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "ruff";
   version = "0.7.0";
+  pyproject = true;
+
+  outputs = [
+    "bin"
+    "out"
+  ];
 
   src = fetchFromGitHub {
     owner = "astral-sh";
@@ -22,7 +30,15 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-//ayB5ayYM5FqiSXDDns2tIL+PJ0Osvkp8+MEEL0L+8=";
   };
 
-  cargoLock = {
+  # Do not rely on path lookup at runtime to find the ruff binary
+  postPatch = ''
+    substituteInPlace python/ruff/__main__.py \
+      --replace-fail \
+        'ruff_exe = "ruff" + sysconfig.get_config_var("EXE")' \
+        'return "${placeholder "bin"}/bin/ruff"'
+  '';
+
+  cargoDeps = rustPlatform.importCargoLock {
     lockFile = ./Cargo.lock;
     outputHashes = {
       "lsp-types-0.95.1" = "sha256-8Oh299exWXVi6A39pALOISNfp8XBya8z+KT/Z7suRxQ=";
@@ -30,18 +46,35 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs =
+    [ installShellFiles ]
+    ++ (with rustPlatform; [
+      cargoSetupHook
+      maturinBuildHook
+      cargoCheckHook
+    ]);
 
-  buildInputs = [
-    rust-jemalloc-sys
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.CoreServices ];
+  buildInputs =
+    [
+      rust-jemalloc-sys
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.apple_sdk.frameworks.CoreServices
+      libiconv
+    ];
 
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd ruff \
-      --bash <($out/bin/ruff generate-shell-completion bash) \
-      --fish <($out/bin/ruff generate-shell-completion fish) \
-      --zsh <($out/bin/ruff generate-shell-completion zsh)
-  '';
+  postInstall =
+    ''
+      mkdir -p $bin/bin
+      mv $out/bin/ruff $bin/bin/
+      rmdir $out/bin
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd ruff \
+        --bash <($bin/bin/ruff generate-shell-completion bash) \
+        --fish <($bin/bin/ruff generate-shell-completion fish) \
+        --zsh <($bin/bin/ruff generate-shell-completion zsh)
+    '';
 
   passthru = {
     tests = {
@@ -49,6 +82,12 @@ rustPlatform.buildRustPackage rec {
     };
     updateScript = nix-update-script { };
   };
+
+  # Run cargo tests
+  cargoCheckType = "debug";
+  postInstallCheck = ''
+    cargoCheckHook
+  '';
 
   # Failing on darwin for an unclear reason.
   # According to the maintainers, those tests are from an experimental crate that isn't actually
@@ -73,11 +112,12 @@ rustPlatform.buildRustPackage rec {
     "--skip=unix::symlink_inside_workspace"
   ];
 
-  nativeInstallCheckInputs = [
+  nativeCheckInputs = [
     versionCheckHook
   ];
   versionCheckProgramArg = [ "--version" ];
-  doInstallCheck = true;
+
+  pythonImportsCheck = [ "ruff" ];
 
   meta = {
     description = "Extremely fast Python linter";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13913,6 +13913,10 @@ self: super: with self; {
 
   rubymarshal = callPackage ../development/python-modules/rubymarshal { };
 
+  ruff = toPythonModule (pkgs.ruff.override {
+    python3Packages = self;
+  });
+
   ruff-api = callPackage ../development/python-modules/ruff-api { };
 
   ruffus = callPackage ../development/python-modules/ruffus { };


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/350608

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
