### PR TITLE
{fakeroute,magnetico}: update source url 

### DIFF
--- a/pkgs/applications/networking/p2p/magnetico/default.nix
+++ b/pkgs/applications/networking/p2p/magnetico/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   version = "0.12.1";
 
   src = fetchFromGitea {
-    domain = "maxwell.ydns.eu/git";
+    domain = "maxwell.eurofusion.eu/git";
     owner  = "rnhmjoj";
     repo   = "magnetico";
     rev    = "v${version}";
@@ -31,7 +31,7 @@ buildGoModule rec {
 
   meta = with lib; {
     description  = "Autonomous (self-hosted) BitTorrent DHT search engine suite";
-    homepage     = "https://maxwell.ydns.eu/git/rnhmjoj/magnetico";
+    homepage     = "https://maxwell.eurofusion.eu/git/rnhmjoj/magnetico";
     license      = licenses.agpl3Only;
     badPlatforms = platforms.darwin;
     maintainers  = with maintainers; [ rnhmjoj ];

--- a/pkgs/tools/networking/fakeroute/default.nix
+++ b/pkgs/tools/networking/fakeroute/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.3";
 
   src = fetchurl {
-    url = "https://maxwell.ydns.eu/git/rnhmjoj/fakeroute/releases/download/v${version}/fakeroute-${version}.tar.gz";
+    url = "https://maxwell.eurofusion.eu/git/rnhmjoj/fakeroute/releases/download/v${version}/fakeroute-${version}.tar.gz";
     hash = "sha256-DoXGJm8vOlAD6ZuvVAt6bkgfahc8WgyYIXCrgqzfiWg=";
   };
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     description = ''
       Make your machine appears to be anywhere on the internet in a traceroute
     '';
-    homepage = "https://maxwell.ydns.eu/git/rnhmjoj/fakeroute";
+    homepage = "https://maxwell.eurofusion.eu/git/rnhmjoj/fakeroute";
     license = licenses.bsd3;
     platforms = platforms.linux;
     mainProgram = "fakeroute";


### PR DESCRIPTION
Update the url of my repositories in Nixpkgs

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested with
  - [x] `magnetico.src`
  - [x] `fakeroute.src`
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
