### PR TITLE
ytt: refactor

### DIFF
--- a/pkgs/development/tools/ytt/default.nix
+++ b/pkgs/development/tools/ytt/default.nix
@@ -1,12 +1,18 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
-
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  testers,
+  ytt,
+}:
 buildGoModule rec {
   pname = "ytt";
   version = "0.50.0";
 
   src = fetchFromGitHub {
-    owner = "vmware-tanzu";
-    repo = "carvel-ytt";
+    owner = "carvel-dev";
+    repo = "ytt";
     rev = "v${version}";
     sha256 = "sha256-57SCBlA2IoBy0iygqunFPBS/nyLtl7e7GlA3vB+ED/4=";
   };
@@ -16,10 +22,10 @@ buildGoModule rec {
   nativeBuildInputs = [ installShellFiles ];
 
   ldflags = [
-    "-X github.com/vmware-tanzu/carvel-ytt/pkg/version.Version=${version}"
+    "-s"
+    "-w"
+    "-X carvel.dev/ytt/pkg/version.Version=${version}"
   ];
-
-  subPackages = [ "cmd/ytt" ];
 
   postInstall = ''
     installShellCompletion --cmd ytt \
@@ -28,11 +34,27 @@ buildGoModule rec {
       --zsh <($out/bin/ytt completion zsh)
   '';
 
+  # Once `__structuredArgs` is introduced, integrate checks and
+  # set some regexes `checkFlags = [ "-skip=TestDataValues.*" ]`
+  # etc. So far we dont test because passing '*' chars through the Go builder
+  # is flawed.
+  doCheck = false;
+
+  passthru.tests.version = testers.testVersion {
+    package = ytt;
+    command = "ytt --version";
+    inherit version;
+  };
+
   meta = with lib; {
     description = "YAML templating tool that allows configuration of complex software via reusable templates with user-provided values";
     mainProgram = "ytt";
     homepage = "https://get-ytt.io";
     license = licenses.asl20;
-    maintainers = with maintainers; [ brodes techknowlogick ];
+    maintainers = with maintainers; [
+      brodes
+      techknowlogick
+      gabyx
+    ];
   };
 }


### PR DESCRIPTION

- Add version test, since it was not correct.
- Use the new correct URL to `carvel-dev` github repo.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
