### PR TITLE
mpv: clean‐ups and Darwin improvements

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -81,7 +81,7 @@
   rubberbandSupport ? true,
   sdl2Support ? !stdenv.hostPlatform.isDarwin,
   sixelSupport ? false,
-  vaapiSupport ? x11Support || waylandSupport,
+  vaapiSupport ? !stdenv.hostPlatform.isDarwin && (x11Support || waylandSupport),
   vapoursynthSupport ? false,
   vdpauSupport ? true,
   vulkanSupport ? true,

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -131,7 +131,6 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     (lib.mesonOption "default_library" "shared")
     (lib.mesonBool "libmpv" true)
-    (lib.mesonEnable "libarchive" archiveSupport)
     (lib.mesonEnable "manpage-build" true)
     (lib.mesonEnable "cdda" cddaSupport)
     (lib.mesonEnable "dvbin" dvbinSupport)

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -79,7 +79,7 @@
   pipewireSupport ? stdenv.hostPlatform.isLinux,
   pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
   rubberbandSupport ? true,
-  sdl2Support ? !stdenv.hostPlatform.isDarwin,
+  sdl2Support ? false,
   sixelSupport ? false,
   vaapiSupport ? !stdenv.hostPlatform.isDarwin && (x11Support || waylandSupport),
   vapoursynthSupport ? false,

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -75,8 +75,8 @@
   jackaudioSupport ? false,
   javascriptSupport ? true,
   openalSupport ? true,
-  pipewireSupport ? stdenv.hostPlatform.isLinux,
-  pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
+  pipewireSupport ? !stdenv.hostPlatform.isDarwin,
+  pulseSupport ? config.pulseaudio or (!stdenv.hostPlatform.isDarwin),
   rubberbandSupport ? true,
   sdl2Support ? false,
   sixelSupport ? false,
@@ -84,8 +84,8 @@
   vapoursynthSupport ? false,
   vdpauSupport ? true,
   vulkanSupport ? true,
-  waylandSupport ? stdenv.hostPlatform.isLinux,
-  x11Support ? stdenv.hostPlatform.isLinux,
+  waylandSupport ? !stdenv.hostPlatform.isDarwin,
+  x11Support ? !stdenv.hostPlatform.isDarwin,
   zimgSupport ? true,
 }:
 

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -90,7 +90,6 @@
   sdl2Support ? !stdenv.hostPlatform.isDarwin,
   sixelSupport ? false,
   speexSupport ? true,
-  swiftSupport ? stdenv.hostPlatform.isDarwin,
   theoraSupport ? true,
   vaapiSupport ? x11Support || waylandSupport,
   vapoursynthSupport ? false,
@@ -143,29 +142,21 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Ensure we reference 'lib' (not 'out') of Swift.
-  preConfigure = lib.optionalString swiftSupport ''
+  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
     export SWIFT_LIB_DYNAMIC="${lib.getLib swift.swift}/lib/swift/macosx"
   '';
 
-  mesonFlags =
-    [
-      (lib.mesonOption "default_library" "shared")
-      (lib.mesonBool "libmpv" true)
-      (lib.mesonEnable "libarchive" archiveSupport)
-      (lib.mesonEnable "manpage-build" true)
-      (lib.mesonEnable "cdda" cddaSupport)
-      (lib.mesonEnable "dvbin" dvbinSupport)
-      (lib.mesonEnable "dvdnav" dvdnavSupport)
-      (lib.mesonEnable "openal" openalSupport)
-      (lib.mesonEnable "sdl2" sdl2Support)
-      # Disable whilst Swift isn't supported
-      (lib.mesonEnable "swift-build" swiftSupport)
-      (lib.mesonEnable "macos-cocoa-cb" swiftSupport)
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # Toggle explicitly because it fails on darwin
-      (lib.mesonEnable "videotoolbox-pl" vulkanSupport)
-    ];
+  mesonFlags = [
+    (lib.mesonOption "default_library" "shared")
+    (lib.mesonBool "libmpv" true)
+    (lib.mesonEnable "libarchive" archiveSupport)
+    (lib.mesonEnable "manpage-build" true)
+    (lib.mesonEnable "cdda" cddaSupport)
+    (lib.mesonEnable "dvbin" dvbinSupport)
+    (lib.mesonEnable "dvdnav" dvdnavSupport)
+    (lib.mesonEnable "openal" openalSupport)
+    (lib.mesonEnable "sdl2" sdl2Support)
+  ];
 
   mesonAutoFeatures = "auto";
 
@@ -179,8 +170,8 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       buildPackages.darwin.sigtool
+      swift
     ]
-    ++ lib.optionals swiftSupport [ swift ]
     ++ lib.optionals waylandSupport [ wayland-scanner ];
 
   buildInputs =
@@ -250,8 +241,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals xineramaSupport [ libXinerama ]
     ++ lib.optionals xvSupport [ libXv ]
     ++ lib.optionals zimgSupport [ zimg ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ nv-codec-headers-11 ]
-    ;
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ nv-codec-headers-11 ];
 
   postBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
     pushd .. # Must be run from the source dir because it uses relative paths

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -19,7 +19,6 @@
   libXext,
   libXpresent,
   libXrandr,
-  libXv,
   libarchive,
   libass,
   libbluray,
@@ -87,7 +86,6 @@
   vulkanSupport ? true,
   waylandSupport ? stdenv.hostPlatform.isLinux,
   x11Support ? stdenv.hostPlatform.isLinux,
-  xvSupport ? stdenv.hostPlatform.isLinux,
   zimgSupport ? true,
 }:
 
@@ -217,7 +215,6 @@ stdenv.mkDerivation (finalAttrs: {
       libXpresent
       libXScrnSaver
     ]
-    ++ lib.optionals xvSupport [ libXv ]
     ++ lib.optionals zimgSupport [ zimg ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ nv-codec-headers-11 ];
 

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -38,7 +38,6 @@
   libpthreadstubs,
   libpulseaudio,
   libsixel,
-  libtheora,
   libuchardet,
   libva,
   libvdpau,
@@ -88,7 +87,6 @@
   screenSaverSupport ? true,
   sdl2Support ? !stdenv.hostPlatform.isDarwin,
   sixelSupport ? false,
-  theoraSupport ? true,
   vaapiSupport ? x11Support || waylandSupport,
   vapoursynthSupport ? false,
   vdpauSupport ? true,
@@ -207,7 +205,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals screenSaverSupport [ libXScrnSaver ]
     ++ lib.optionals sdl2Support [ SDL2 ]
     ++ lib.optionals sixelSupport [ libsixel ]
-    ++ lib.optionals theoraSupport [ libtheora ]
     ++ lib.optionals vaapiSupport [ libva ]
     ++ lib.optionals vapoursynthSupport [ vapoursynth ]
     ++ lib.optionals vdpauSupport [ libvdpau ]

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -38,6 +38,7 @@
   libvdpau,
   libxkbcommon,
   lua,
+  makeWrapper,
   mesa,
   meson,
   mujs,
@@ -152,6 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       buildPackages.darwin.sigtool
       swift
+      makeWrapper
     ]
     ++ lib.optionals waylandSupport [ wayland-scanner ];
 
@@ -244,6 +246,13 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p $out/Applications
       cp -r mpv.app $out/Applications
+
+      # On macOS, many things won’t work properly unless `mpv(1)` is
+      # executed from the app bundle, such as spatial audio with
+      # `--ao=avfoundation`. This wrapper ensures that those features
+      # work reliably and also avoids shipping two copies of the entire
+      # `mpv` executable.
+      makeWrapper $out/Applications/mpv.app/Contents/MacOS/mpv $out/bin/mpv
     '';
 
   # Set RUNPATH so that libcuda in /run/opengl-driver(-32)/lib can be found.

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -56,7 +56,6 @@
   python3,
   rubberband,
   shaderc, # instead of spirv-cross
-  speex,
   stdenv,
   swift,
   testers,
@@ -89,7 +88,6 @@
   screenSaverSupport ? true,
   sdl2Support ? !stdenv.hostPlatform.isDarwin,
   sixelSupport ? false,
-  speexSupport ? true,
   theoraSupport ? true,
   vaapiSupport ? x11Support || waylandSupport,
   vapoursynthSupport ? false,
@@ -209,7 +207,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals screenSaverSupport [ libXScrnSaver ]
     ++ lib.optionals sdl2Support [ SDL2 ]
     ++ lib.optionals sixelSupport [ libsixel ]
-    ++ lib.optionals speexSupport [ speex ]
     ++ lib.optionals theoraSupport [ libtheora ]
     ++ lib.optionals vaapiSupport [ libva ]
     ++ lib.optionals vapoursynthSupport [ vapoursynth ]

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -18,7 +18,6 @@
   libX11,
   libXScrnSaver,
   libXext,
-  libXinerama,
   libXpresent,
   libXrandr,
   libXv,
@@ -90,7 +89,6 @@
   vulkanSupport ? true,
   waylandSupport ? stdenv.hostPlatform.isLinux,
   x11Support ? stdenv.hostPlatform.isLinux,
-  xineramaSupport ? stdenv.hostPlatform.isLinux,
   xvSupport ? stdenv.hostPlatform.isLinux,
   zimgSupport ? true,
 }:
@@ -223,7 +221,6 @@ stdenv.mkDerivation (finalAttrs: {
       libXpresent
       libXScrnSaver
     ]
-    ++ lib.optionals xineramaSupport [ libXinerama ]
     ++ lib.optionals xvSupport [ libXv ]
     ++ lib.optionals zimgSupport [ zimg ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ nv-codec-headers-11 ];

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -72,7 +72,7 @@
   cmsSupport ? true,
   drmSupport ? stdenv.hostPlatform.isLinux,
   dvbinSupport ? stdenv.hostPlatform.isLinux,
-  dvdnavSupport ? stdenv.hostPlatform.isLinux,
+  dvdnavSupport ? true,
   jackaudioSupport ? false,
   javascriptSupport ? true,
   openalSupport ? true,

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -141,11 +141,6 @@ stdenv.mkDerivation (finalAttrs: {
     ''
   ];
 
-  # Ensure we reference 'lib' (not 'out') of Swift.
-  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    export SWIFT_LIB_DYNAMIC="${lib.getLib swift.swift}/lib/swift/macosx"
-  '';
-
   mesonFlags = [
     (lib.mesonOption "default_library" "shared")
     (lib.mesonBool "libmpv" true)

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -82,7 +82,6 @@
   pipewireSupport ? stdenv.hostPlatform.isLinux,
   pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
   rubberbandSupport ? true,
-  screenSaverSupport ? true,
   sdl2Support ? !stdenv.hostPlatform.isDarwin,
   sixelSupport ? false,
   vaapiSupport ? x11Support || waylandSupport,
@@ -199,7 +198,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals pipewireSupport [ pipewire ]
     ++ lib.optionals pulseSupport [ libpulseaudio ]
     ++ lib.optionals rubberbandSupport [ rubberband ]
-    ++ lib.optionals screenSaverSupport [ libXScrnSaver ]
     ++ lib.optionals sdl2Support [ SDL2 ]
     ++ lib.optionals sixelSupport [ libsixel ]
     ++ lib.optionals vaapiSupport [ libva ]
@@ -223,6 +221,7 @@ stdenv.mkDerivation (finalAttrs: {
       libXxf86vm
       libXrandr
       libXpresent
+      libXScrnSaver
     ]
     ++ lib.optionals xineramaSupport [ libXinerama ]
     ++ lib.optionals xvSupport [ libXv ]

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -94,7 +94,7 @@
   vaapiSupport ? x11Support || waylandSupport,
   vapoursynthSupport ? false,
   vdpauSupport ? true,
-  vulkanSupport ? stdenv.hostPlatform.isLinux,
+  vulkanSupport ? true,
   waylandSupport ? stdenv.hostPlatform.isLinux,
   x11Support ? stdenv.hostPlatform.isLinux,
   xineramaSupport ? stdenv.hostPlatform.isLinux,

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -21,7 +21,6 @@
   libXpresent,
   libXrandr,
   libXv,
-  libXxf86vm,
   libarchive,
   libass,
   libbluray,
@@ -216,7 +215,6 @@ stdenv.mkDerivation (finalAttrs: {
       libXext
       libGLU
       libGL
-      libXxf86vm
       libXrandr
       libXpresent
       libXScrnSaver

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -34,7 +34,6 @@
   libdvdnav,
   libjack2,
   libplacebo,
-  libpng,
   libpthreadstubs,
   libpulseaudio,
   libsixel,
@@ -79,7 +78,6 @@
   dvdnavSupport ? stdenv.hostPlatform.isLinux,
   jackaudioSupport ? false,
   javascriptSupport ? true,
-  libpngSupport ? true,
   openalSupport ? true,
   pipewireSupport ? stdenv.hostPlatform.isLinux,
   pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
@@ -197,7 +195,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals jackaudioSupport [ libjack2 ]
     ++ lib.optionals javascriptSupport [ mujs ]
-    ++ lib.optionals libpngSupport [ libpng ]
     ++ lib.optionals openalSupport [ openalSoft ]
     ++ lib.optionals pipewireSupport [ pipewire ]
     ++ lib.optionals pulseSupport [ libpulseaudio ]

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -14,7 +14,6 @@
   freetype,
   lcms2,
   libGL,
-  libGLU,
   libX11,
   libXScrnSaver,
   libXext,
@@ -213,7 +212,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals x11Support [
       libX11
       libXext
-      libGLU
       libGL
       libXrandr
       libXpresent

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -162,7 +162,7 @@ stdenv'.mkDerivation (finalAttrs: {
     ''
       substituteInPlace meson.build \
         --replace-fail "conf_data.set_quoted('CONFIGURATION', configuration)" \
-                       "conf_data.set_quoted('CONFIGURATION', '<ommited>')"
+                       "conf_data.set_quoted('CONFIGURATION', '<omitted>')"
     ''
     # A trick to patchShebang everything except mpv_identify.sh
     ''

--- a/pkgs/by-name/mo/moltenvk/package.nix
+++ b/pkgs/by-name/mo/moltenvk/package.nix
@@ -108,6 +108,10 @@ stdenv.mkDerivation (finalAttrs: {
       "-isystem ${lib.getDev libcxx}/include/c++/v1"
       "-I${lib.getDev spirv-cross}/include/spirv_cross"
       "-I${lib.getDev spirv-headers}/include/spirv/unified1"
+
+      # MoltenVK prints a lot of verbose output to the console out of
+      # the box; we adjust this to match Homebrew’s default log level.
+      "-DMVK_CONFIG_LOG_LEVEL=MVK_CONFIG_LOG_LEVEL_NONE"
     ]
     ++ lib.optional enablePrivateAPIUsage "-DMVK_USE_METAL_PRIVATE_API=1"
   );

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31183,7 +31183,6 @@ with pkgs;
 
   mpv-unwrapped = darwin.apple_sdk_11_0.callPackage ../applications/video/mpv {
     stdenv = if stdenv.hostPlatform.isDarwin then swiftPackages.stdenv else stdenv;
-    inherit lua;
   };
 
   # Wrap avoiding rebuild

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31181,7 +31181,7 @@ with pkgs;
     libdvdnav = libdvdnav_4_2_1;
   } // (config.mplayer or {}));
 
-  mpv-unwrapped = darwin.apple_sdk_11_0.callPackage ../applications/video/mpv {
+  mpv-unwrapped = callPackage ../applications/video/mpv {
     stdenv = if stdenv.hostPlatform.isDarwin then swiftPackages.stdenv else stdenv;
   };
 


### PR DESCRIPTION
This ports mpv over to the new SDK format from https://github.com/NixOS/nixpkgs/pull/346043 (so much less cruft! yay!), enables the new upstream default of Vulkan on Darwin, and cleans up a bunch of flags and dependencies, including removing flags that had no effect, broke the build to toggle, or are just obsolete, and adjusting some defaults to be less Linux‐specific or more inline with upstream and other distros.

There are still things to investigate with the macOS build (e.g. VideoToolbox seems to support fewer pixel output formats compared to their official CI binaries), but I wanted to get this batch with the theoretically‐breaking changes posted before the freeze.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
