### PR TITLE
[Backport release-24.05] factorio 1.1.107 -> 1.1.110

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,56 +2,56 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.109.tar.xz",
+        "name": "factorio_alpha_x64-1.1.110.tar.xz",
         "needsAuth": true,
-        "sha256": "1fmgh5b4sq9lcbjz0asvq5zcwf25cqdn5jc2ickind2lnkhd557h",
+        "sha256": "0ndhb94lh47n09a7wshm2inv52fd6rjfa7fk7nk9b7zzh84i7f4x",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.109/alpha/linux64",
-        "version": "1.1.109"
+        "url": "https://factorio.com/get-download/1.1.110/alpha/linux64",
+        "version": "1.1.110"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.109.tar.xz",
+        "name": "factorio_alpha_x64-1.1.110.tar.xz",
         "needsAuth": true,
-        "sha256": "1fmgh5b4sq9lcbjz0asvq5zcwf25cqdn5jc2ickind2lnkhd557h",
+        "sha256": "0ndhb94lh47n09a7wshm2inv52fd6rjfa7fk7nk9b7zzh84i7f4x",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.109/alpha/linux64",
-        "version": "1.1.109"
+        "url": "https://factorio.com/get-download/1.1.110/alpha/linux64",
+        "version": "1.1.110"
       }
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.109.tar.xz",
+        "name": "factorio_demo_x64-1.1.110.tar.xz",
         "needsAuth": false,
-        "sha256": "1222jg22dmj4pby9y5axybqv0dmwxh8r9h2507f87za3jsv15fsx",
+        "sha256": "0dasxgrybl00vrabgrlarsvg0hdg5rvn3y4hsljhqc4zpbf93nxx",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.109/demo/linux64",
-        "version": "1.1.109"
+        "url": "https://factorio.com/get-download/1.1.110/demo/linux64",
+        "version": "1.1.110"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.1.109.tar.xz",
+        "name": "factorio_demo_x64-1.1.110.tar.xz",
         "needsAuth": false,
-        "sha256": "1222jg22dmj4pby9y5axybqv0dmwxh8r9h2507f87za3jsv15fsx",
+        "sha256": "0dasxgrybl00vrabgrlarsvg0hdg5rvn3y4hsljhqc4zpbf93nxx",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.109/demo/linux64",
-        "version": "1.1.109"
+        "url": "https://factorio.com/get-download/1.1.110/demo/linux64",
+        "version": "1.1.110"
       }
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.109.tar.xz",
+        "name": "factorio_headless_x64-1.1.110.tar.xz",
         "needsAuth": false,
-        "sha256": "0gxzfz074833fjm4s3528y05c5n1jf7zxfdj5xpfcvwi7i9khnhh",
+        "sha256": "0sk4g9y051xjhiwdhj1yz808308zwsbpq3nps1ywvpp56vdycps8",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.109/headless/linux64",
-        "version": "1.1.109"
+        "url": "https://factorio.com/get-download/1.1.110/headless/linux64",
+        "version": "1.1.110"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.109.tar.xz",
+        "name": "factorio_headless_x64-1.1.110.tar.xz",
         "needsAuth": false,
-        "sha256": "0gxzfz074833fjm4s3528y05c5n1jf7zxfdj5xpfcvwi7i9khnhh",
+        "sha256": "0sk4g9y051xjhiwdhj1yz808308zwsbpq3nps1ywvpp56vdycps8",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.109/headless/linux64",
-        "version": "1.1.109"
+        "url": "https://factorio.com/get-download/1.1.110/headless/linux64",
+        "version": "1.1.110"
       }
     }
   }

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,56 +2,56 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.107.tar.xz",
+        "name": "factorio_alpha_x64-1.1.109.tar.xz",
         "needsAuth": true,
-        "sha256": "16hkyfwp02zcijka4yslifz62ry6hrvk0w9960618kqdw3gr7p82",
+        "sha256": "1fmgh5b4sq9lcbjz0asvq5zcwf25cqdn5jc2ickind2lnkhd557h",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/alpha/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/1.1.109/alpha/linux64",
+        "version": "1.1.109"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.107.tar.xz",
+        "name": "factorio_alpha_x64-1.1.109.tar.xz",
         "needsAuth": true,
-        "sha256": "16hkyfwp02zcijka4yslifz62ry6hrvk0w9960618kqdw3gr7p82",
+        "sha256": "1fmgh5b4sq9lcbjz0asvq5zcwf25cqdn5jc2ickind2lnkhd557h",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/alpha/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/1.1.109/alpha/linux64",
+        "version": "1.1.109"
       }
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.107.tar.xz",
+        "name": "factorio_demo_x64-1.1.109.tar.xz",
         "needsAuth": false,
-        "sha256": "0qc36n6h4wcbnj9rnq162bsml4x3ag1dkjmywqz8f4ydaf86gyjw",
+        "sha256": "1222jg22dmj4pby9y5axybqv0dmwxh8r9h2507f87za3jsv15fsx",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/demo/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/1.1.109/demo/linux64",
+        "version": "1.1.109"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.1.107.tar.xz",
+        "name": "factorio_demo_x64-1.1.109.tar.xz",
         "needsAuth": false,
-        "sha256": "0qc36n6h4wcbnj9rnq162bsml4x3ag1dkjmywqz8f4ydaf86gyjw",
+        "sha256": "1222jg22dmj4pby9y5axybqv0dmwxh8r9h2507f87za3jsv15fsx",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/demo/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/1.1.109/demo/linux64",
+        "version": "1.1.109"
       }
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.107.tar.xz",
+        "name": "factorio_headless_x64-1.1.109.tar.xz",
         "needsAuth": false,
-        "sha256": "10ds1nz9sbx9xz1lyypf16wncc6323vpm7l5p11d6iy4cha85wsw",
+        "sha256": "0gxzfz074833fjm4s3528y05c5n1jf7zxfdj5xpfcvwi7i9khnhh",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/headless/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/1.1.109/headless/linux64",
+        "version": "1.1.109"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.107.tar.xz",
+        "name": "factorio_headless_x64-1.1.109.tar.xz",
         "needsAuth": false,
-        "sha256": "10ds1nz9sbx9xz1lyypf16wncc6323vpm7l5p11d6iy4cha85wsw",
+        "sha256": "0gxzfz074833fjm4s3528y05c5n1jf7zxfdj5xpfcvwi7i9khnhh",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.107/headless/linux64",
-        "version": "1.1.107"
+        "url": "https://factorio.com/get-download/1.1.109/headless/linux64",
+        "version": "1.1.109"
       }
     }
   }


### PR DESCRIPTION
- backports #324227 and #338300
- the hopefully uncontroversial / straightforward fragment of #350379 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
