### PR TITLE
nixos/clatd: add enableNetworkManagerIntegration option

### DIFF
--- a/nixos/modules/services/networking/clatd.nix
+++ b/nixos/modules/services/networking/clatd.nix
@@ -13,6 +13,11 @@ in
 
       package = lib.mkPackageOption pkgs "clatd" { };
 
+      enableNetworkManagerIntegration = lib.mkEnableOption "NetworkManager integration" // {
+        default = config.networking.networkmanager.enable;
+        defaultText = "config.networking.networkmanager.enable";
+      };
+
       settings = lib.mkOption {
         type = lib.types.submodule ({ name, ... }: {
           freeformType = settingsFormat.type;
@@ -75,5 +80,17 @@ in
         ];
       };
     };
+
+    networking.networkmanager.dispatcherScripts = cfg.enableNetworkManagerIntegration [
+      {
+        type = "basic";
+        # https://github.com/toreanderson/clatd/blob/master/scripts/clatd.networkmanager
+        source = pkgs.writeShellScript "restart-clatd" ''
+          [ "$DEVICE_IFACE" = "clat" ] && exit 0
+          [ "$2" != "up" ] && [ "$2" != "down" ] && exit 0
+          ${pkgs.systemd}/bin/systemctl restart clatd.service
+        '';
+      }
+    ];
   };
 }


### PR DESCRIPTION
Added an option `services.clatd.enableNetworkManagerIntegration` to restart clatd.service when a NM-managed interface toggles. This follows the upstream NM integration: https://github.com/toreanderson/clatd/blob/master/scripts/clatd.networkmanager

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
