### PR TITLE
keepassxc: add mainProgram attribute

### DIFF
--- a/pkgs/applications/misc/keepassxc/default.nix
+++ b/pkgs/applications/misc/keepassxc/default.nix
@@ -146,6 +146,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://keepassxc.org/";
     license = licenses.gpl2Plus;
+    mainProgram = "keepassxc";
     maintainers = with maintainers; [ blankparticle ];
     platforms = platforms.linux ++ platforms.darwin;
   };


### PR DESCRIPTION
Adding `mainProgram` attribute to get rid of evaluation warning with `getExe`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
