### PR TITLE
virtualbox: 7.0.20 -> 7.0.22

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -78,8 +78,8 @@ let
   buildType = "release";
   # Use maintainers/scripts/update.nix to update the version and all related hashes or
   # change the hashes in extpack.nix and guest-additions/default.nix as well manually.
-  virtualboxVersion = "7.0.20";
-  virtualboxSha256 = "5cf5979bef66ebab3fcd495796b215a940e8a07c469d4bc56d064de44222dd02";
+  virtualboxVersion = "7.0.22";
+  virtualboxSha256 = "cf3ddf633ca410f1b087b0722413e83247cda4f14d33323dc122a4a42ff61981";
 
   kvmPatchVersion = "20240828";
   kvmPatchHash = "sha256-g0esJbB1IGyLGZMLFJIY8ZYdHWuiM5IZtLMHZvCY6bs=";

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -14,7 +14,7 @@ fetchurl rec {
     # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
     # Checksums can also be found at https://www.virtualbox.org/download/hashes/${version}/SHA256SUMS
     let
-      value = "d750fb17688d70e0cb2d7b06f1ad3a661303793f4d1ac39cfa9a54806b89da25";
+      value = "6b0c16074dde1ea273b15e091336034368217ba569e09359a63c4d32af558886";
     in
     assert (builtins.stringLength value) == 64;
     value;

--- a/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
@@ -9,7 +9,7 @@ let
 in
 fetchurl {
   url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-  sha256 = "4c7523fa6d17436e3b7788f62956674270572cfefa340d03111b85f8517d5981";
+  sha256 = "486f90cbfe9ed4bf2b12d726ebf54a839758a237e967aa65fc2c92d90a963021";
   meta = {
     description = "Guest additions ISO for VirtualBox";
     longDescription = ''

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -28,11 +28,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "VirtualBox-GuestAdditions-builder-${kernel.version}";
-  version = "7.0.20";
+  version = "7.0.22";
 
   src = fetchurl {
     url = "https://download.virtualbox.org/virtualbox/${finalAttrs.version}/VirtualBox-${finalAttrs.version}.tar.bz2";
-    sha256 = "5cf5979bef66ebab3fcd495796b215a940e8a07c469d4bc56d064de44222dd02";
+    sha256 = "cf3ddf633ca410f1b087b0722413e83247cda4f14d33323dc122a4a42ff61981";
   };
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";


### PR DESCRIPTION
Fixes CVE-2024-21248, CVE-2024-21253, CVE-2024-21259, CVE-2024-21263 and CVE-2024-21273.

Changelog:
https://www.virtualbox.org/wiki/Changelog-7.0#v22


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 350707`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_4_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_4_hardened.virtualboxGuestAdditions</li>
  </ul>
</details>
<details>
  <summary>:x: 7 packages failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_15_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_15_hardened.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_6_1_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_6_1_hardened.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_hardened.virtualbox (linuxKernel.packages.linux_6_6_hardened.virtualbox)</li>
    <li>linuxKernel.packages.linux_hardened.virtualboxGuestAdditions (linuxKernel.packages.linux_6_6_hardened.virtualboxGuestAdditions)</li>
    <li>virtualboxKvm</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 37 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_10.virtualbox</li>
    <li>linuxKernel.packages.linux_5_10.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_5_10_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_10_hardened.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_5_15.virtualbox</li>
    <li>linuxKernel.packages.linux_5_15.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_5_4.virtualbox</li>
    <li>linuxKernel.packages.linux_5_4.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_6_1.virtualbox</li>
    <li>linuxKernel.packages.linux_6_1.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_6_10.virtualbox</li>
    <li>linuxKernel.packages.linux_6_10.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_6_11.virtualbox</li>
    <li>linuxKernel.packages.linux_6_11.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_6_6.virtualbox</li>
    <li>linuxKernel.packages.linux_6_6.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_latest_libre.virtualbox</li>
    <li>linuxKernel.packages.linux_latest_libre.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_libre.virtualbox</li>
    <li>linuxKernel.packages.linux_libre.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_lqx.virtualbox</li>
    <li>linuxKernel.packages.linux_lqx.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_xanmod.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_xanmod_latest.virtualbox (linuxKernel.packages.linux_xanmod_stable.virtualbox)</li>
    <li>linuxKernel.packages.linux_xanmod_latest.virtualboxGuestAdditions (linuxKernel.packages.linux_xanmod_stable.virtualboxGuestAdditions)</li>
    <li>linuxKernel.packages.linux_zen.virtualbox</li>
    <li>linuxKernel.packages.linux_zen.virtualboxGuestAdditions</li>
    <li>virtualbox</li>
    <li>virtualbox.modsrc</li>
    <li>virtualboxExtpack</li>
    <li>virtualboxHardened</li>
    <li>virtualboxHardened.modsrc</li>
    <li>virtualboxHeadless</li>
    <li>virtualboxHeadless.modsrc</li>
    <li>virtualboxWithExtpack</li>
    <li>virtualboxWithExtpack.modsrc</li>
  </ul>
</details>
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
