### PR TITLE
factorio: 2.0.8 -> 2.0.9

### DIFF
--- a/pkgs/by-name/fa/factorio/versions.json
+++ b/pkgs/by-name/fa/factorio/versions.json
@@ -14,14 +14,14 @@
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio_linux_2.0.8.tar.xz"
+          "factorio_linux_2.0.9.tar.xz"
         ],
-        "name": "factorio_alpha_x64-2.0.8.tar.xz",
+        "name": "factorio_alpha_x64-2.0.9.tar.xz",
         "needsAuth": true,
-        "sha256": "94ea36a5b9103369df7158a8281039dd2f1d7fa7bb3a2d854c715250dd73e185",
+        "sha256": "34c21cd3cbe91b65483786ccb4467b5d4766c748cbbddd2ce3b30d319d163e3b",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.8/alpha/linux64",
-        "version": "2.0.8"
+        "url": "https://factorio.com/get-download/2.0.9/alpha/linux64",
+        "version": "2.0.9"
       }
     },
     "demo": {
@@ -62,14 +62,14 @@
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio-space-age_linux_2.0.8.tar.xz"
+          "factorio-space-age_linux_2.0.9.tar.xz"
         ],
-        "name": "factorio_expansion_x64-2.0.8.tar.xz",
+        "name": "factorio_expansion_x64-2.0.9.tar.xz",
         "needsAuth": true,
-        "sha256": "408eae824daa761564b1ea7b81925efe05298cbaffd120eea235341ac05a6a60",
+        "sha256": "6369d23550a7a721d3de1d34253e8321ee601fa759d1fb5efac9abc28aa7509d",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.8/expansion/linux64",
-        "version": "2.0.8"
+        "url": "https://factorio.com/get-download/2.0.9/expansion/linux64",
+        "version": "2.0.9"
       }
     },
     "headless": {
@@ -87,15 +87,15 @@
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio-headless_linux_2.0.8.tar.xz",
-          "factorio_headless_x64_2.0.8.tar.xz"
+          "factorio-headless_linux_2.0.9.tar.xz",
+          "factorio_headless_x64_2.0.9.tar.xz"
         ],
-        "name": "factorio_headless_x64-2.0.8.tar.xz",
+        "name": "factorio_headless_x64-2.0.9.tar.xz",
         "needsAuth": false,
-        "sha256": "d9594c4d552a3e4f965b188a4774da8c8b010fc23ddb0efc63b1d94818dde1ca",
+        "sha256": "f499077b3e2c1313452c350f1faf17db31cae2a0fa738f69166e97c3caa3c86d",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.8/headless/linux64",
-        "version": "2.0.8"
+        "url": "https://factorio.com/get-download/2.0.9/headless/linux64",
+        "version": "2.0.9"
       }
     }
   }


### PR DESCRIPTION
This brings `factorio`, `factorio-headless`, and `factorio-space-age` up to date with their -experimental variants.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
