### PR TITLE
ruff-lsp: ruff is now a python package

### DIFF
--- a/pkgs/by-name/ru/ruff-lsp/package.nix
+++ b/pkgs/by-name/ru/ruff-lsp/package.nix
@@ -3,9 +3,6 @@
   python3Packages,
   fetchFromGitHub,
 
-  # nativeCheckInputs
-  ruff,
-
   # tests
   versionCheckHook,
 
@@ -25,17 +22,13 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-TB4OcKkaUGYAmiGNJRnfRmiXTyTQL4sFoBrzxT6DWec=";
   };
 
-  postPatch = ''
-    # ruff binary added to PATH in wrapper so it's not needed
-    sed -i '/"ruff>=/d' pyproject.toml
-  '';
-
   build-system = with python3Packages; [ hatchling ];
 
   dependencies = with python3Packages; [
     packaging
     pygls
     lsprotocol
+    ruff
     typing-extensions
   ];
 
@@ -43,15 +36,14 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
     pytest-asyncio
     python-lsp-jsonrpc
-    ruff
+    ruff.bin
     versionCheckHook
   ];
   versionCheckProgramArg = [ "--version" ];
 
   makeWrapperArgs = [
     # prefer ruff from user's PATH, that's usually desired behavior
-    "--suffix PATH : ${lib.makeBinPath [ ruff ]}"
-
+    "--suffix PATH : ${lib.makeBinPath (with python3Packages; [ ruff ])}"
     # Unset ambient PYTHONPATH in the wrapper, so ruff-lsp only ever runs with
     # its own, isolated set of dependencies. This works because the correct
     # PYTHONPATH is set in the Python script, which runs after the wrapper.


### PR DESCRIPTION
Followup on #350654

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
