### PR TITLE
whoogle-search: init at 0.9.0, add module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -34,6 +34,8 @@
 
 - [Bat](https://github.com/sharkdp/bat), a {manpage}`cat(1)` clone with wings. Available as [programs.bat](options.html#opt-programs.bat).
 
+- [Whoogle Search](https://github.com/benbusby/whoogle-search), a self-hosted, ad-free, privacy-respecting metasearch engine. Available as [services.whoogle-search](options.html#opt-services.whoogle-search.enable).
+
 - [agorakit](https://github.com/agorakit/agorakit), an organization tool for citizens' collectives. Available with [services.agorakit](options.html#opt-services.agorakit.enable).
 
 - [waagent](https://github.com/Azure/WALinuxAgent), the Microsoft Azure Linux Agent (waagent) manages Linux provisioning and VM interaction with the Azure Fabric Controller. Available with [services.waagent](options.html#opt-services.waagent.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1291,6 +1291,7 @@
   ./services/networking/websockify.nix
   ./services/networking/wg-access-server.nix
   ./services/networking/wg-netmanager.nix
+  ./services/networking/whoogle-search.nix
   ./services/networking/wvdial.nix
   ./services/networking/webhook.nix
   ./services/networking/wg-quick.nix

--- a/nixos/modules/services/networking/whoogle-search.nix
+++ b/nixos/modules/services/networking/whoogle-search.nix
@@ -1,0 +1,70 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.whoogle-search;
+in
+{
+  options = {
+    services.whoogle-search = {
+      enable = lib.mkEnableOption "Whoogle, a metasearch engine";
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 5000;
+        description = "Port to listen on.";
+      };
+
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = "Address to listen on for the web interface.";
+      };
+
+      extraEnv = lib.mkOption {
+        type = with lib.types; attrsOf str;
+        default = { };
+        description = ''
+          Extra environment variables to pass to Whoogle, see
+          https://github.com/benbusby/whoogle-search?tab=readme-ov-file#environment-variables
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    systemd.services.whoogle-search = {
+      description = "Whoogle Search";
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.whoogle-search ];
+
+      environment = {
+        CONFIG_VOLUME = "/var/lib/whoogle-search";
+      } // cfg.extraEnv;
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart =
+          "${lib.getExe pkgs.whoogle-search}"
+          + " --host '${cfg.listenAddress}'"
+          + " --port '${builtins.toString cfg.port}'";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        StateDirectory = "whoogle-search";
+        StateDirectoryMode = "0750";
+        DynamicUser = true;
+        PrivateTmp = true;
+        ProtectSystem = true;
+        ProtectHome = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+
+    meta.maintainers = with lib.maintainers; [ malte-v ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1149,6 +1149,7 @@ in {
   webhook = runTest ./webhook.nix;
   weblate = handleTest ./web-apps/weblate.nix {};
   whisparr = handleTest ./whisparr.nix {};
+  whoogle-search = handleTest ./whoogle-search.nix {};
   wiki-js = handleTest ./wiki-js.nix {};
   wine = handleTest ./wine.nix {};
   wireguard = handleTest ./wireguard {};

--- a/nixos/tests/whoogle-search.nix
+++ b/nixos/tests/whoogle-search.nix
@@ -1,0 +1,24 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+  {
+    name = "whoogle-search";
+    meta.maintainers = with lib.maintainers; [ malte-v ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.whoogle-search = {
+          enable = true;
+          port = 5000;
+          listenAddress = "127.0.0.1";
+        };
+      };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("whoogle-search.service")
+      machine.wait_for_open_port(5000)
+      machine.wait_until_succeeds("curl --fail --show-error --silent --location localhost:5000/")
+    '';
+  }
+)

--- a/pkgs/by-name/wh/whoogle-search/package.nix
+++ b/pkgs/by-name/wh/whoogle-search/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+  nixosTests,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "whoogle-search";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "whoogle_search";
+    inherit version;
+    hash = "sha256-JpTvt7A81gisijWaXu0Rh/vPwjA95hvmpzRBwjvByiI=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    attrs
+    beautifulsoup4
+    brotli
+    cachelib
+    certifi
+    cffi
+    chardet
+    click
+    cryptography
+    cssutils
+    defusedxml
+    flask
+    idna
+    itsdangerous
+    jinja2
+    markupsafe
+    more-itertools
+    packaging
+    pluggy
+    pycodestyle
+    pycparser
+    pyopenssl
+    pyparsing
+    pysocks
+    python-dateutil
+    requests
+    soupsieve
+    stem
+    urllib3
+    validators
+    waitress
+    wcwidth
+    werkzeug
+    python-dotenv
+  ];
+
+  postInstall = ''
+    # This creates renamed versions of the static files for cache busting,
+    # without which whoogle will not run. If we don't do this here, whoogle
+    # will attempt to create them on startup, which fails since the nix store
+    # is read-only.
+    python3 $out/${python3Packages.python.sitePackages}/app/__init__.py
+  '';
+
+  passthru.tests = {
+    inherit (nixosTests) whoogle-search;
+  };
+
+  meta = {
+    homepage = "https://github.com/benbusby/whoogle-search";
+    description = "A self-hosted, ad-free, privacy-respecting metasearch engine";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ malte-v ];
+    mainProgram = "whoogle-search";
+  };
+}


### PR DESCRIPTION
[Whoogle](https://github.com/benbusby/whoogle-search)

Closes #167245

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
