### PR TITLE
cbconvert: init at 1.0.4

### DIFF
--- a/pkgs/by-name/cb/cbconvert/gui.nix
+++ b/pkgs/by-name/cb/cbconvert/gui.nix
@@ -1,0 +1,48 @@
+{
+  buildGoModule,
+  cbconvert,
+  gtk3,
+  wrapGAppsHook3,
+}:
+
+buildGoModule rec {
+  pname = "cbconvert-gui";
+
+  inherit (cbconvert)
+    patches
+    proxyVendor
+    src
+    tags
+    version
+    ;
+
+  nativeBuildInputs = cbconvert.nativeBuildInputs ++ [
+    wrapGAppsHook3
+  ];
+  buildInputs = cbconvert.buildInputs ++ [ gtk3 ];
+
+  vendorHash = "sha256-vvCvKecPszhNCQdgm3mQMb5+486BGZ9sz3R0b70eLeQ=";
+  modRoot = "cmd/cbconvert-gui";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.appVersion=${version}"
+  ];
+
+  postInstall = ''
+    install -D --mode=0644 --target-directory=$out/share/applications/ dist/linux/cbconvert.desktop
+    install -D --mode=0644 --target-directory=$out/icons/hicolor/256x256/apps dist/linux/cbconvert.png
+    install -D --mode=0644 --target-directory=$out/share/thumbnailers dist/linux/cbconvert.thumbnailer
+    install -D --mode=0644 dist/linux/flatpak/io.github.gen2brain.cbconvert.metainfo.xml $out/share/metainfo/cbconvert.metainfo.xml
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/share/metainfo/cbconvert.metainfo.xml \
+      --replace-fail "io.github.gen2brain.cbconvert" "cbconvert"
+  '';
+
+  meta = cbconvert.meta // {
+    mainProgram = "cbconvert-gui";
+  };
+}

--- a/pkgs/by-name/cb/cbconvert/package.nix
+++ b/pkgs/by-name/cb/cbconvert/package.nix
@@ -1,0 +1,87 @@
+{
+  buildGoModule,
+  bzip2,
+  callPackage,
+  cbconvert,
+  fetchFromGitHub,
+  fetchpatch2,
+  imagemagick,
+  lib,
+  libunarr,
+  mupdf-headless,
+  nix-update-script,
+  pkg-config,
+  testers,
+  zlib,
+}:
+
+buildGoModule rec {
+  pname = "cbconvert";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "gen2brain";
+    repo = "cbconvert";
+    rev = "v${version}";
+    hash = "sha256-9x7RXyiQoV2nIVFnG1XHcYfTQiMZ88Ck7uuY7NLK8CA=";
+  };
+
+  # Update dependencies in order to use the extlib tag.
+  patches = [
+    (fetchpatch2 {
+      name = "update-dependencies-1.patch";
+      url = "https://github.com/gen2brain/cbconvert/commit/1a36ec17b2c012f278492d60d469b8e8457a6110.patch";
+      hash = "sha256-E+HWYPz9FtU3JAktzIRflF/pHdLfoaciBmjb7UOQYLo=";
+    })
+    (fetchpatch2 {
+      name = "update-dependencies-2.patch";
+      url = "https://github.com/gen2brain/cbconvert/commit/74c5de699413e95133f97666b64a1866f88fedd5.patch";
+      hash = "sha256-rrJsYJHcfNWF90vwUAT3J/gqg22e1gk6I48LsTrYbmU=";
+    })
+  ];
+
+  vendorHash = "sha256-aVInsWvygNH+/h7uQs4hAPOO2gsSkBx+tI+TK77M/hg=";
+  modRoot = "cmd/cbconvert";
+
+  proxyVendor = true;
+
+  # The extlib tag forces the github.com/gen2brain/go-unarr module to use external libraries instead of bundled ones.
+  tags = [ "extlib" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.appVersion=${version}"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    bzip2
+    imagemagick
+    libunarr
+    mupdf-headless
+    zlib
+  ];
+
+  passthru = {
+    gui = callPackage ./gui.nix { };
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = cbconvert;
+      command = "cbconvert version";
+    };
+  };
+
+  meta = {
+    description = "Comic Book converter";
+    homepage = "https://github.com/gen2brain/cbconvert";
+    changelog = "https://github.com/gen2brain/cbconvert/releases/tag/v${version}";
+    license = with lib.licenses; [ gpl3Only ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ jwillikers ];
+    mainProgram = "cbconvert";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28410,6 +28410,8 @@ with pkgs;
 
   cbc = callPackage ../applications/science/math/cbc { };
 
+  cbconvert-gui = cbconvert.gui;
+
   cddiscid = callPackage ../applications/audio/cd-discid {
     inherit (darwin) IOKit;
   };


### PR DESCRIPTION
Add [cbconvert](https://github.com/gen2brain/cbconvert), a comic book converter. It provides two packages, one for the CLI and one for the GUI. Patches were included from the upstream which allow building one of the dependencies using external libraries instead of bundled libraries.

Fixes #294569.

I'm not sure how to best organize this since it technically provides two packages built from separate Go modules in the same source repository, `cbconvert` and `cbconvert-gui`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
