### PR TITLE
gtk4: compute DPI properly when Xft options are not used

### DIFF
--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -84,6 +84,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-LsU+B9GMnwA7OeSmqDgFTZJZ4Ei2xMBdgMDQWqch2UQ=";
   };
 
+  patches = [
+    ./patches/4.0-Xft-setting-fallback-compute-DPI-properly.patch
+  ];
+
   depsBuildBuild = [
     pkg-config
   ];

--- a/pkgs/development/libraries/gtk/patches/4.0-Xft-setting-fallback-compute-DPI-properly.patch
+++ b/pkgs/development/libraries/gtk/patches/4.0-Xft-setting-fallback-compute-DPI-properly.patch
@@ -1,0 +1,16 @@
+--- a/gdk/x11/gdkxftdefaults.c
++++ b/gdk/x11/gdkxftdefaults.c
+@@ -185,8 +185,11 @@ init_xft_settings (GdkX11Screen *x11_screen)
+   if (!get_integer_default (x11_screen, "rgba", &x11_screen->xft_rgba))
+     x11_screen->xft_rgba = FC_RGBA_UNKNOWN;
+ 
+-  if (!get_double_default (x11_screen, "dpi", &dpi_double))
+-    dpi_double = 96.0;
++  if (!get_double_default (x11_screen, "dpi", &dpi_double)) {
++    Display *xdisplay = GDK_SCREEN_XDISPLAY (x11_screen);
++    dpi_double = (DisplayHeight(xdisplay, x11_screen->screen_num)*25.4)/
++                   DisplayHeightMM(xdisplay, x11_screen->screen_num);
++  }
+ 
+   x11_screen->xft_dpi = (int)(0.5 + PANGO_SCALE * dpi_double);
+ }


### PR DESCRIPTION
This is a port of 88105ee01863d3905ee926975b4ad92bdb961bcf to gtk4, it makes gtk4 respect the `DisplaySize` set in the monitor section of my xorg config, since I don't have `Xft.dpi` set.

built pwvucontrol on master on x86_64-linux (tested) and aarch64-linux (untested), built libadwaita on master on {aarch64,x86_64}-darwin


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
