### PR TITLE
hugo: 0.135.0 -> 0.136.4

### DIFF
--- a/pkgs/by-name/hu/hugo/package.nix
+++ b/pkgs/by-name/hu/hugo/package.nix
@@ -1,25 +1,27 @@
-{ stdenv
-, lib
-, buildGoModule
-, fetchFromGitHub
-, installShellFiles
-, buildPackages
-, testers
-, hugo
+{
+  stdenv,
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  buildPackages,
+  testers,
+  nix-update-script,
+  hugo,
 }:
 
 buildGoModule rec {
   pname = "hugo";
-  version = "0.135.0";
+  version = "0.136.4";
 
   src = fetchFromGitHub {
     owner = "gohugoio";
     repo = "hugo";
     rev = "refs/tags/v${version}";
-    hash = "sha256-WCWaEVD2HON6feOev9HBfpqBWYIFmfevu6LH0OMtv2Q=";
+    hash = "sha256-wCv0lZqvJNOwL/naFuGb6k0Xyk58NpgH1mkhoNnkSno=";
   };
 
-  vendorHash = "sha256-XIFgmT0VyhRrUNfwy85Ac7YIO9fij0KqVmqb/s3IDVg=";
+  vendorHash = "sha256-KqDsa7MlSONyn7AYOepQ95q1CEM83AhWk23iYSQ4twU=";
 
   doCheck = false;
 
@@ -31,16 +33,24 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  ldflags = [ "-s" "-w" "-X github.com/gohugoio/hugo/common/hugo.vendorInfo=nixpkgs" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/gohugoio/hugo/common/hugo.vendorInfo=nixpkgs"
+  ];
 
-  postInstall = let emulator = stdenv.hostPlatform.emulator buildPackages; in ''
-    ${emulator} $out/bin/hugo gen man
-    installManPage man/*
-    installShellCompletion --cmd hugo \
-      --bash <(${emulator} $out/bin/hugo completion bash) \
-      --fish <(${emulator} $out/bin/hugo completion fish) \
-      --zsh  <(${emulator} $out/bin/hugo completion zsh)
-  '';
+  postInstall =
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      ${emulator} $out/bin/hugo gen man
+      installManPage man/*
+      installShellCompletion --cmd hugo \
+        --bash <(${emulator} $out/bin/hugo completion bash) \
+        --fish <(${emulator} $out/bin/hugo completion fish) \
+        --zsh  <(${emulator} $out/bin/hugo completion zsh)
+    '';
 
   passthru.tests.version = testers.testVersion {
     package = hugo;
@@ -48,12 +58,18 @@ buildGoModule rec {
     version = "v${version}";
   };
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     changelog = "https://github.com/gohugoio/hugo/releases/tag/v${version}";
     description = "Fast and modern static website engine";
     homepage = "https://gohugo.io";
     license = lib.licenses.asl20;
     mainProgram = "hugo";
-    maintainers = with lib.maintainers; [ schneefux Br1ght0ne Frostman ];
+    maintainers = with lib.maintainers; [
+      schneefux
+      Br1ght0ne
+      Frostman
+    ];
   };
 }


### PR DESCRIPTION
Updated to [0.136.4](https://github.com/gohugoio/hugo/releases/tag/v0.136.4):

- Added `passthru.updateScript`
- Ran update script
- Formatted to RFC style

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
