### PR TITLE
python3Packages.{langchain,langchain-core,langchain-community,langchain-openai} update to latest 20241023

### DIFF
--- a/pkgs/development/python-modules/langchain-aws/default.nix
+++ b/pkgs/development/python-modules/langchain-aws/default.nix
@@ -45,6 +45,11 @@ buildPythonPackage rec {
     numpy
   ];
 
+  pythonRelaxDeps = [
+    # Boto @ 1.35 has outstripped the version requirement
+    "boto3"
+  ];
+
   nativeCheckInputs = [
     langchain-standard-tests
     pytest-asyncio

--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -38,14 +38,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-community";
-  version = "0.3.1";
+  version = "0.3.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     rev = "refs/tags/langchain-community==${version}";
-    hash = "sha256-h7+89w8PkSpFxGGQKFC6FuB6Q2B27EYgLk0aiPqwp4s=";
+    hash = "sha256-xWr4v+4gL8LAegqerQc1SdAynPk5X8qLlPF211+OBvY=";
   };
 
   sourceRoot = "${src.name}/libs/community";

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "0.3.7";
+  version = "0.3.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     rev = "refs/tags/langchain-core==${version}";
-    hash = "sha256-s2tqBJpWJNy0SnHWt0RQowmRbBD+7zqFEeDuFrUzr2U=";
+    hash = "sha256-WWzEIP/JirA4btYVy4+U7PSg6S8VnkZqxPLgLriWbTY=";
   };
 
   sourceRoot = "${src.name}/libs/core";
@@ -119,6 +119,15 @@ buildPythonPackage rec {
       # TypeError: exceptions must be derived from Warning, not <class 'NoneType'>
       "test_chat_prompt_template_variable_names"
       "test_create_model_v2"
+
+      # Comparison with magic strings
+      "test_prompt_with_chat_model"
+      "test_prompt_with_chat_model_async"
+      "test_prompt_with_llm"
+      "test_prompt_with_llm_parser"
+      "test_prompt_with_llm_and_async_lambda"
+      "test_prompt_with_chat_model_and_parser"
+      "test_combining_sequences"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # Langchain-core the following tests due to the test comparing execution time with magic values.

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-openai";
-  version = "0.2.1";
+  version = "0.2.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     rev = "refs/tags/langchain-openai==${version}";
-    hash = "sha256-M1gyw0Nmh+aLU9scbuqmK2kPyfwtaFaCfue+T8PLguQ=";
+    hash = "sha256-ENQOKvp9XJTTC34UoNO4LLvcBwfFRcbOAvX/qtzln6k=";
   };
 
   sourceRoot = "${src.name}/libs/partners/openai";

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -42,14 +42,14 @@
 
 buildPythonPackage rec {
   pname = "langchain";
-  version = "0.3.1";
+  version = "0.3.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     rev = "refs/tags/langchain==${version}";
-    hash = "sha256-Zg+9ZwzTDKCyfz4T/tVIGfRUUmkE939hocxSWpFRngQ=";
+    hash = "sha256-MRpXR4nQDobzofhzkU5Y2OiEsi+VdjCcF/vcxcG/144=";
   };
 
   sourceRoot = "${src.name}/libs/langchain";


### PR DESCRIPTION
1. Updated via update script:
- python3Packages.langchain 0.3.1 -> 0.3.4 [diff](https://github.com/langchain-ai/langchain/compare/refs/tags/langchain==0.3.1...langchain==0.3.4)
- python3Packages.langchain-core 0.3.7->0.3.12 [diff](https://github.com/langchain-ai/langchain/compare/refs/tags/langchain-core==0.3.7...langchain-core==0.3.12)
- python3Packages.langchain-community 0.3.1->0.3.3 [diff](https://github.com/langchain-ai/langchain/compare/refs/tags/langchain-community==0.3.1...langchain-community==0.3.3)
- python3Packages.langchain-openai 0.2.1->0.2.3 [diff](https://github.com/langchain-ai/langchain/compare/refs/tags/langchain-openai==0.2.1...langchain-openai==0.2.3)
2. Relaxed boto3 dep in `langchain-aws`.
3. Disabled new langchain-core integration tests that aren't quite as cross-platform as expected.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
