### PR TITLE
python3Packages.{langgraph->0.2.39, langgraph-sdk->0.1.33,langgraph-checkpoint->2.0.1, langgraph-checkpoint-postgres->2.0.1}

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-postgres";
-  version = "2.0.0";
+  version = "2.0.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/checkpointpostgres==${version}";
-    hash = "sha256-piBWr6F1YWML9D8+Bk4KvReQJhgb1Z7Xf5q8bcVUeEQ=";
+    hash = "sha256-5gKgCd0hl2iPLBfh94n8kMojECknhd0r+W4gt3m4g+M=";
   };
 
   postgresqlTestSetupPost = ''

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint";
-  version = "2.0.0";
+  version = "2.0.1";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/checkpoint==${version}";
-    hash = "sha256-LBIQyDWKmT89OgYUk3LFIZ5VDXX9KQXFkR9A8XHOCBQ=";
+    hash = "sha256-BDuc6PpziOFIsPpDets7OM2Z+VJ6ekxKpkAuoavDdmI=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint";

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-sdk";
-  version = "0.1.32";
+  version = "0.1.33";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/sdk==${version}";
-    hash = "sha256-qOxtrRbdK0M4aFWJX0SFn7U27rvAyqu53iCbYZX3s8A=";
+    hash = "sha256-oSkF82AvIycGaw0Pb2tldtvjyG9HkXPlSE6onRbDDPE=";
   };
 
   sourceRoot = "${src.name}/libs/sdk-py";
@@ -40,12 +40,11 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "langgraph_sdk" ];
 
   passthru = {
-    # python3Packages.langgraph-sdk depends on python3Packages.langgraph. langgraph-cli is independent of both.
     updateScript = writeScript "update.sh" ''
       #!/usr/bin/env nix-shell
       #!nix-shell -i bash -p nix-update
 
-      set -eu -o pipefail
+      set -eu -o pipefail +e
       nix-update --commit --version-regex '(.*)' python3Packages.langgraph
       nix-update --commit --version-regex 'sdk==(.*)' python3Packages.langgraph-sdk
       nix-update --commit --version-regex 'checkpoint==(.*)' python3Packages.langgraph-checkpoint

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -10,6 +10,7 @@
   # dependencies
   langchain-core,
   langgraph-checkpoint,
+  langgraph-sdk,
 
   # tests
   aiosqlite,
@@ -29,21 +30,18 @@
   syrupy,
   postgresql,
   postgresqlTestHook,
-
-  # passthru
-  langgraph-sdk,
 }:
 
 buildPythonPackage rec {
   pname = "langgraph";
-  version = "0.2.34";
+  version = "0.2.39";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     rev = "refs/tags/${version}";
-    hash = "sha256-5Suyj6pEslgR383MkYGGz7IC2A0A++02YooZmi8YtyM=";
+    hash = "sha256-VZRGlE3MSOzur1TWC6swQjf/o5M62LsYncx2g8dtS+o=";
   };
 
   postgresqlTestSetupPost = ''
@@ -58,6 +56,7 @@ buildPythonPackage rec {
   dependencies = [
     langchain-core
     langgraph-checkpoint
+    langgraph-sdk
   ];
 
   pythonImportsCheck = [ "langgraph" ];


### PR DESCRIPTION
1. Fixed update script to not error out if a package update wasn't found. (In this case, the sqlite checkpointer didn't have a recent release.)
2. `python3Packages.langchain` now depends on the langchain-sdk. Added dependency.
3. Ran update script:
- langgraph 0.2.34 -> 0.2.39
- langgraph-sdk 0.1.32 -> 0.1.33
- langgraph-checkpoint 2.0.0 -> 2.0.1
- langgraph-checkpoint-postgres 2.0.0 -> 2.0.1


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
