### PR TITLE
grimblast: patch shebang in `.grimblast-wrapped`

### DIFF
--- a/pkgs/by-name/gr/grimblast/package.nix
+++ b/pkgs/by-name/gr/grimblast/package.nix
@@ -11,6 +11,7 @@
 , libnotify
 , slurp
 , wl-clipboard
+, bash
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -30,6 +31,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper
     scdoc
   ];
+
+  buildInputs = [ bash ];
 
   makeFlags = [
     "PREFIX=$(out)"


### PR DESCRIPTION
`strictDeps` is used so `bash` is not in `buildInputs` just because it's in
`common-path.nix`
